### PR TITLE
feat(swarm): add work chain DAG validation and wave executor

### DIFF
--- a/aragora/swarm/chain_executor.py
+++ b/aragora/swarm/chain_executor.py
@@ -1,0 +1,270 @@
+"""Chain executor: wave-based execution of work chain DAGs.
+
+Consumes a validated WorkChain and drives execution wave by wave. Each wave
+dispatches its ready steps, waits for completion, then advances to the next
+wave. Failed steps cause dependent steps to be skipped automatically.
+
+The executor does not launch workers directly — it produces dispatch
+instructions that the supervisor can consume. This keeps the boundary clean:
+chain_executor plans, supervisor executes.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import timezone
+from typing import Any
+
+from aragora.swarm.work_chain import (
+    ChainStatus,
+    ExecutionWave,
+    StepStatus,
+    WorkChain,
+)
+
+logger = logging.getLogger(__name__)
+UTC = timezone.utc
+
+
+@dataclass(slots=True)
+class StepDispatch:
+    """Instruction to dispatch one chain step to a worker."""
+
+    step_id: str
+    work_order_id: str
+    title: str
+    wave_index: int
+    predecessor_outputs: dict[str, StepOutcome] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_id": self.step_id,
+            "work_order_id": self.work_order_id,
+            "title": self.title,
+            "wave_index": self.wave_index,
+            "predecessor_outputs": {k: v.to_dict() for k, v in self.predecessor_outputs.items()},
+        }
+
+
+@dataclass(slots=True)
+class StepOutcome:
+    """Result of one chain step execution."""
+
+    step_id: str
+    status: StepStatus
+    branch: str = ""
+    changed_files: list[str] = field(default_factory=list)
+    commit_shas: list[str] = field(default_factory=list)
+    error: str = ""
+    elapsed_seconds: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_id": self.step_id,
+            "status": self.status.value,
+            "branch": self.branch,
+            "changed_files": list(self.changed_files),
+            "commit_shas": list(self.commit_shas),
+            "error": self.error,
+            "elapsed_seconds": self.elapsed_seconds,
+        }
+
+
+@dataclass
+class ChainExecutionPlan:
+    """Complete execution plan for a work chain."""
+
+    chain_id: str
+    waves: list[WaveDispatchPlan]
+    total_steps: int
+    max_parallelism: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chain_id": self.chain_id,
+            "waves": [wave.to_dict() for wave in self.waves],
+            "total_steps": self.total_steps,
+            "max_parallelism": self.max_parallelism,
+        }
+
+
+@dataclass
+class WaveDispatchPlan:
+    """Dispatch plan for one execution wave."""
+
+    wave_index: int
+    dispatches: list[StepDispatch]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "wave_index": self.wave_index,
+            "dispatches": [d.to_dict() for d in self.dispatches],
+        }
+
+
+class ChainExecutor:
+    """Drives wave-by-wave execution of a WorkChain.
+
+    Usage::
+
+        executor = ChainExecutor(chain)
+        plan = executor.plan()
+
+        for wave_plan in plan.waves:
+            for dispatch in wave_plan.dispatches:
+                # Submit dispatch.work_order_id to supervisor
+                ...
+            # Collect results
+            for dispatch in wave_plan.dispatches:
+                executor.record_outcome(StepOutcome(...))
+
+        summary = executor.summary()
+    """
+
+    def __init__(self, chain: WorkChain) -> None:
+        if not chain.steps:
+            raise ValueError("Cannot execute an empty chain")
+        self._chain = chain
+        self._outcomes: dict[str, StepOutcome] = {}
+
+    @property
+    def chain(self) -> WorkChain:
+        return self._chain
+
+    def plan(self) -> ChainExecutionPlan:
+        """Generate the full execution plan without executing anything."""
+        wave_plans: list[WaveDispatchPlan] = []
+        max_parallelism = 0
+
+        for wave in self._chain.waves:
+            dispatches = self._dispatches_for_wave(wave)
+            wave_plans.append(WaveDispatchPlan(wave_index=wave.wave_index, dispatches=dispatches))
+            max_parallelism = max(max_parallelism, len(dispatches))
+
+        return ChainExecutionPlan(
+            chain_id=self._chain.chain_id,
+            waves=wave_plans,
+            total_steps=len(self._chain.steps),
+            max_parallelism=max_parallelism,
+        )
+
+    def next_wave(self) -> WaveDispatchPlan | None:
+        """Return the next wave of dispatches, or None if chain is done.
+
+        Skips steps whose predecessors have failed.
+        """
+        self._propagate_failures()
+
+        ready = self._chain.ready_steps()
+        if not ready:
+            return None
+
+        # Determine wave index from the chain's wave structure
+        ready_ids = {step.step_id for step in ready}
+        wave_index = 0
+        for wave in self._chain.waves:
+            if any(sid in ready_ids for sid in wave.step_ids):
+                wave_index = wave.wave_index
+                break
+
+        dispatches: list[StepDispatch] = []
+        for step in ready:
+            predecessor_outputs: dict[str, StepOutcome] = {}
+            for dep_id in step.depends_on:
+                if dep_id in self._outcomes:
+                    predecessor_outputs[dep_id] = self._outcomes[dep_id]
+
+            dispatches.append(
+                StepDispatch(
+                    step_id=step.step_id,
+                    work_order_id=step.work_order_id,
+                    title=step.title,
+                    wave_index=wave_index,
+                    predecessor_outputs=predecessor_outputs,
+                )
+            )
+            self._chain.mark_step(step.step_id, StepStatus.RUNNING)
+
+        return WaveDispatchPlan(wave_index=wave_index, dispatches=dispatches)
+
+    def record_outcome(self, outcome: StepOutcome) -> None:
+        """Record the result of a step execution."""
+        self._outcomes[outcome.step_id] = outcome
+        self._chain.mark_step(outcome.step_id, outcome.status)
+        logger.info("Chain step %s finished: %s", outcome.step_id, outcome.status.value)
+
+    def _propagate_failures(self) -> None:
+        """Skip steps whose predecessors have failed or been skipped.
+
+        Runs transitively: if A fails, B (depends on A) is skipped, then
+        C (depends on B) is also skipped.
+        """
+        changed = True
+        while changed:
+            changed = False
+            blocked_ids = {
+                step.step_id
+                for step in self._chain.steps
+                if step.status in (StepStatus.FAILED, StepStatus.SKIPPED)
+            }
+            if not blocked_ids:
+                return
+
+            for step in self._chain.steps:
+                if step.status != StepStatus.PENDING:
+                    continue
+                blocker = next((dep for dep in step.depends_on if dep in blocked_ids), None)
+                if blocker is not None:
+                    self._chain.mark_step(step.step_id, StepStatus.SKIPPED)
+                    logger.info(
+                        "Skipping step %s: predecessor %s blocked",
+                        step.step_id,
+                        blocker,
+                    )
+                    changed = True
+
+    def _dispatches_for_wave(self, wave: ExecutionWave) -> list[StepDispatch]:
+        """Build dispatch instructions for a wave (used by plan())."""
+        dispatches: list[StepDispatch] = []
+        for step_id in wave.step_ids:
+            step = self._chain.step_by_id(step_id)
+            if step is None:
+                continue
+            dispatches.append(
+                StepDispatch(
+                    step_id=step.step_id,
+                    work_order_id=step.work_order_id,
+                    title=step.title,
+                    wave_index=wave.wave_index,
+                )
+            )
+        return dispatches
+
+    def is_complete(self) -> bool:
+        return self._chain.status in (ChainStatus.COMPLETED, ChainStatus.FAILED)
+
+    def summary(self) -> dict[str, Any]:
+        """Return a summary of the chain execution."""
+        completed = sum(1 for s in self._chain.steps if s.status == StepStatus.COMPLETED)
+        failed = sum(1 for s in self._chain.steps if s.status == StepStatus.FAILED)
+        skipped = sum(1 for s in self._chain.steps if s.status == StepStatus.SKIPPED)
+        return {
+            "chain_id": self._chain.chain_id,
+            "chain_status": self._chain.status.value,
+            "total_steps": len(self._chain.steps),
+            "completed": completed,
+            "failed": failed,
+            "skipped": skipped,
+            "remaining": len(self._chain.steps) - completed - failed - skipped,
+            "outcomes": {k: v.to_dict() for k, v in self._outcomes.items()},
+        }
+
+
+__all__ = [
+    "ChainExecutionPlan",
+    "ChainExecutor",
+    "StepDispatch",
+    "StepOutcome",
+    "WaveDispatchPlan",
+]

--- a/aragora/swarm/work_chain.py
+++ b/aragora/swarm/work_chain.py
@@ -1,0 +1,329 @@
+"""Work chains: multi-step dependent work orders with DAG validation.
+
+A WorkChain groups related BoundedWorkOrders into a dependency DAG. It
+provides:
+- Cycle detection (Kahn's algorithm)
+- Topological ordering
+- Execution wave planning (maximal independent sets)
+- Chain-level status tracking
+
+The chain is a planning abstraction; actual execution is handled by
+ChainExecutor which feeds waves into the existing supervisor dispatch path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+UTC = timezone.utc
+
+
+class ChainStatus(str, Enum):
+    """Lifecycle status of a work chain."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class StepStatus(str, Enum):
+    """Lifecycle status of a single chain step."""
+
+    PENDING = "pending"
+    READY = "ready"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class ChainStep:
+    """One node in a work chain DAG.
+
+    Each step wraps a work order ID and declares its predecessors via
+    ``depends_on``.  The step itself does not carry the full work order
+    — it references one by ID so the chain stays lightweight.
+    """
+
+    step_id: str
+    work_order_id: str
+    title: str
+    depends_on: list[str] = field(default_factory=list)
+    status: StepStatus = StepStatus.PENDING
+    file_scope: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.step_id = str(self.step_id or "").strip() or str(uuid.uuid4())[:12]
+        self.work_order_id = str(self.work_order_id or "").strip()
+        self.depends_on = list(
+            dict.fromkeys(dep for dep in self.depends_on if str(dep or "").strip())
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_id": self.step_id,
+            "work_order_id": self.work_order_id,
+            "title": self.title,
+            "depends_on": list(self.depends_on),
+            "status": self.status.value,
+            "file_scope": list(self.file_scope),
+            "metadata": dict(self.metadata),
+        }
+
+
+class CycleDetectedError(ValueError):
+    """Raised when a work chain contains a dependency cycle."""
+
+    def __init__(self, involved_steps: list[str]) -> None:
+        self.involved_steps = involved_steps
+        super().__init__(f"Dependency cycle detected among steps: {', '.join(involved_steps)}")
+
+
+@dataclass
+class ExecutionWave:
+    """A group of steps that can execute concurrently.
+
+    All steps in a wave have their dependencies satisfied by earlier waves.
+    """
+
+    wave_index: int
+    step_ids: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"wave_index": self.wave_index, "step_ids": list(self.step_ids)}
+
+
+@dataclass
+class WorkChain:
+    """A DAG of dependent work order steps.
+
+    Construction validates the DAG is acyclic and computes topological order.
+    """
+
+    chain_id: str
+    title: str
+    steps: list[ChainStep] = field(default_factory=list)
+    status: ChainStatus = ChainStatus.PENDING
+    created_at: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    # Computed after validation
+    _topo_order: list[str] = field(default_factory=list, repr=False)
+    _waves: list[ExecutionWave] = field(default_factory=list, repr=False)
+
+    def __post_init__(self) -> None:
+        self.chain_id = str(self.chain_id or "").strip() or str(uuid.uuid4())[:12]
+        if not self.created_at:
+            self.created_at = datetime.now(UTC).isoformat()
+        if self.steps:
+            self.validate()
+
+    def validate(self) -> None:
+        """Validate DAG structure and compute topological order + waves.
+
+        Raises CycleDetectedError if the dependency graph contains a cycle.
+        Raises ValueError for dangling dependency references.
+        """
+        step_ids = {step.step_id for step in self.steps}
+
+        # Check for dangling references
+        for step in self.steps:
+            for dep in step.depends_on:
+                if dep not in step_ids:
+                    raise ValueError(f"Step '{step.step_id}' depends on unknown step '{dep}'")
+
+        self._topo_order = _topological_sort(self.steps)
+        self._waves = _compute_waves(self.steps, self._topo_order)
+
+    @property
+    def topological_order(self) -> list[str]:
+        """Step IDs in valid execution order."""
+        return list(self._topo_order)
+
+    @property
+    def waves(self) -> list[ExecutionWave]:
+        """Execution waves: groups of steps that can run concurrently."""
+        return list(self._waves)
+
+    @property
+    def num_waves(self) -> int:
+        return len(self._waves)
+
+    def step_by_id(self, step_id: str) -> ChainStep | None:
+        for step in self.steps:
+            if step.step_id == step_id:
+                return step
+        return None
+
+    def ready_steps(self) -> list[ChainStep]:
+        """Return steps whose dependencies are all completed."""
+        completed = {
+            step.step_id
+            for step in self.steps
+            if step.status in (StepStatus.COMPLETED, StepStatus.SKIPPED)
+        }
+        return [
+            step
+            for step in self.steps
+            if step.status == StepStatus.PENDING
+            and all(dep in completed for dep in step.depends_on)
+        ]
+
+    def mark_step(self, step_id: str, status: StepStatus) -> None:
+        step = self.step_by_id(step_id)
+        if step is None:
+            raise KeyError(f"Unknown step: {step_id}")
+        step.status = status
+        self._update_chain_status()
+
+    def _update_chain_status(self) -> None:
+        statuses = {step.status for step in self.steps}
+        if all(s in (StepStatus.COMPLETED, StepStatus.SKIPPED) for s in statuses):
+            self.status = ChainStatus.COMPLETED
+        elif StepStatus.FAILED in statuses:
+            self.status = ChainStatus.FAILED
+        elif StepStatus.RUNNING in statuses or StepStatus.READY in statuses:
+            self.status = ChainStatus.RUNNING
+        else:
+            self.status = ChainStatus.PENDING
+
+    def fingerprint(self) -> str:
+        """Stable hash over chain structure for dedup."""
+        parts = sorted(
+            f"{step.step_id}:{step.work_order_id}:{','.join(step.depends_on)}"
+            for step in self.steps
+        )
+        raw = f"{self.title}|{'|'.join(parts)}"
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chain_id": self.chain_id,
+            "title": self.title,
+            "steps": [step.to_dict() for step in self.steps],
+            "status": self.status.value,
+            "created_at": self.created_at,
+            "metadata": dict(self.metadata),
+            "topological_order": list(self._topo_order),
+            "waves": [wave.to_dict() for wave in self._waves],
+            "fingerprint": self.fingerprint(),
+        }
+
+
+def _topological_sort(steps: list[ChainStep]) -> list[str]:
+    """Kahn's algorithm for topological sorting with cycle detection."""
+    in_degree: dict[str, int] = {step.step_id: 0 for step in steps}
+    adjacency: dict[str, list[str]] = defaultdict(list)
+
+    for step in steps:
+        for dep in step.depends_on:
+            adjacency[dep].append(step.step_id)
+            in_degree[step.step_id] += 1
+
+    queue: deque[str] = deque(
+        step_id for step_id, degree in sorted(in_degree.items()) if degree == 0
+    )
+    order: list[str] = []
+
+    while queue:
+        current = queue.popleft()
+        order.append(current)
+        for neighbor in sorted(adjacency[current]):
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                queue.append(neighbor)
+
+    if len(order) != len(steps):
+        remaining = sorted(step_id for step_id, degree in in_degree.items() if degree > 0)
+        raise CycleDetectedError(remaining)
+
+    return order
+
+
+def _compute_waves(steps: list[ChainStep], topo_order: list[str]) -> list[ExecutionWave]:
+    """Assign each step to the earliest possible wave."""
+    step_map = {step.step_id: step for step in steps}
+    wave_assignment: dict[str, int] = {}
+
+    for step_id in topo_order:
+        step = step_map[step_id]
+        if not step.depends_on:
+            wave_assignment[step_id] = 0
+        else:
+            wave_assignment[step_id] = max(wave_assignment[dep] for dep in step.depends_on) + 1
+
+    if not wave_assignment:
+        return []
+
+    max_wave = max(wave_assignment.values())
+    waves: list[ExecutionWave] = []
+    for idx in range(max_wave + 1):
+        members = sorted(step_id for step_id, wave in wave_assignment.items() if wave == idx)
+        if members:
+            waves.append(ExecutionWave(wave_index=idx, step_ids=members))
+    return waves
+
+
+def build_chain_from_work_orders(
+    title: str,
+    work_orders: list[dict[str, Any]],
+    *,
+    chain_id: str = "",
+) -> WorkChain:
+    """Construct a WorkChain from a list of work order dicts.
+
+    Each work order dict must have ``work_order_id`` and optionally
+    ``dependency_ids``, ``title``, ``file_scope``.
+    """
+    steps: list[ChainStep] = []
+    wo_to_step: dict[str, str] = {}
+
+    for wo in work_orders:
+        wo_id = str(wo.get("work_order_id", "")).strip()
+        if not wo_id:
+            continue
+        step_id = wo_id
+        wo_to_step[wo_id] = step_id
+
+    for wo in work_orders:
+        wo_id = str(wo.get("work_order_id", "")).strip()
+        if wo_id not in wo_to_step:
+            continue
+        raw_deps = wo.get("dependency_ids", [])
+        depends_on = [
+            wo_to_step[dep]
+            for dep in (raw_deps if isinstance(raw_deps, list) else [])
+            if str(dep or "").strip() in wo_to_step
+        ]
+        steps.append(
+            ChainStep(
+                step_id=wo_to_step[wo_id],
+                work_order_id=wo_id,
+                title=str(wo.get("title", wo_id)),
+                depends_on=depends_on,
+                file_scope=list(wo.get("file_scope", [])),
+            )
+        )
+
+    return WorkChain(chain_id=chain_id or "", title=title, steps=steps)
+
+
+__all__ = [
+    "ChainStatus",
+    "ChainStep",
+    "CycleDetectedError",
+    "ExecutionWave",
+    "StepStatus",
+    "WorkChain",
+    "build_chain_from_work_orders",
+]

--- a/tests/swarm/test_chain_executor.py
+++ b/tests/swarm/test_chain_executor.py
@@ -1,0 +1,242 @@
+"""Tests for chain executor wave-based dispatch planning."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.swarm.chain_executor import (
+    ChainExecutionPlan,
+    ChainExecutor,
+    StepDispatch,
+    StepOutcome,
+    WaveDispatchPlan,
+)
+from aragora.swarm.work_chain import (
+    ChainStatus,
+    ChainStep,
+    StepStatus,
+    WorkChain,
+)
+
+
+def _linear_chain() -> WorkChain:
+    return WorkChain(
+        chain_id="linear",
+        title="Linear chain",
+        steps=[
+            ChainStep(step_id="a", work_order_id="wo-a", title="Step A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="Step B", depends_on=["a"]),
+            ChainStep(step_id="c", work_order_id="wo-c", title="Step C", depends_on=["b"]),
+        ],
+    )
+
+
+def _diamond_chain() -> WorkChain:
+    return WorkChain(
+        chain_id="diamond",
+        title="Diamond chain",
+        steps=[
+            ChainStep(step_id="root", work_order_id="wo-root", title="Root"),
+            ChainStep(step_id="left", work_order_id="wo-left", title="Left", depends_on=["root"]),
+            ChainStep(
+                step_id="right", work_order_id="wo-right", title="Right", depends_on=["root"]
+            ),
+            ChainStep(
+                step_id="join",
+                work_order_id="wo-join",
+                title="Join",
+                depends_on=["left", "right"],
+            ),
+        ],
+    )
+
+
+def _parallel_chain() -> WorkChain:
+    return WorkChain(
+        chain_id="parallel",
+        title="Parallel chain",
+        steps=[
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B"),
+            ChainStep(step_id="c", work_order_id="wo-c", title="C"),
+        ],
+    )
+
+
+class TestChainExecutorPlan:
+    def test_plan_linear_chain(self) -> None:
+        executor = ChainExecutor(_linear_chain())
+        plan = executor.plan()
+        assert plan.total_steps == 3
+        assert plan.max_parallelism == 1
+        assert len(plan.waves) == 3
+
+    def test_plan_diamond_chain(self) -> None:
+        executor = ChainExecutor(_diamond_chain())
+        plan = executor.plan()
+        assert plan.total_steps == 4
+        assert plan.max_parallelism == 2
+        assert len(plan.waves) == 3
+
+    def test_plan_parallel_chain(self) -> None:
+        executor = ChainExecutor(_parallel_chain())
+        plan = executor.plan()
+        assert plan.total_steps == 3
+        assert plan.max_parallelism == 3
+        assert len(plan.waves) == 1
+
+    def test_plan_to_dict(self) -> None:
+        executor = ChainExecutor(_linear_chain())
+        plan = executor.plan()
+        d = plan.to_dict()
+        assert d["chain_id"] == "linear"
+        assert len(d["waves"]) == 3
+
+    def test_empty_chain_raises(self) -> None:
+        chain = WorkChain(chain_id="empty", title="Empty")
+        with pytest.raises(ValueError, match="empty chain"):
+            ChainExecutor(chain)
+
+
+class TestNextWave:
+    def test_first_wave_dispatches_roots(self) -> None:
+        executor = ChainExecutor(_diamond_chain())
+        wave = executor.next_wave()
+        assert wave is not None
+        assert len(wave.dispatches) == 1
+        assert wave.dispatches[0].step_id == "root"
+
+    def test_completing_root_unlocks_second_wave(self) -> None:
+        executor = ChainExecutor(_diamond_chain())
+        wave = executor.next_wave()
+        assert wave is not None
+
+        executor.record_outcome(
+            StepOutcome(step_id="root", status=StepStatus.COMPLETED, branch="feat/root")
+        )
+        wave2 = executor.next_wave()
+        assert wave2 is not None
+        assert len(wave2.dispatches) == 2
+        dispatch_ids = sorted(d.step_id for d in wave2.dispatches)
+        assert dispatch_ids == ["left", "right"]
+
+    def test_predecessor_outputs_are_passed(self) -> None:
+        executor = ChainExecutor(_linear_chain())
+        wave1 = executor.next_wave()
+        assert wave1 is not None
+
+        executor.record_outcome(
+            StepOutcome(
+                step_id="a",
+                status=StepStatus.COMPLETED,
+                branch="feat/a",
+                changed_files=["mod.py"],
+            )
+        )
+        wave2 = executor.next_wave()
+        assert wave2 is not None
+        dispatch = wave2.dispatches[0]
+        assert "a" in dispatch.predecessor_outputs
+        assert dispatch.predecessor_outputs["a"].branch == "feat/a"
+
+    def test_no_more_waves_when_complete(self) -> None:
+        executor = ChainExecutor(_parallel_chain())
+        wave = executor.next_wave()
+        assert wave is not None
+
+        for d in wave.dispatches:
+            executor.record_outcome(StepOutcome(step_id=d.step_id, status=StepStatus.COMPLETED))
+
+        assert executor.next_wave() is None
+        assert executor.is_complete()
+
+
+class TestFailurePropagation:
+    def test_failed_step_skips_dependents(self) -> None:
+        executor = ChainExecutor(_linear_chain())
+        wave = executor.next_wave()
+        assert wave is not None
+
+        executor.record_outcome(
+            StepOutcome(step_id="a", status=StepStatus.FAILED, error="compile error")
+        )
+
+        # Next wave should return None because b and c are skipped
+        assert executor.next_wave() is None
+        assert executor.is_complete()
+        assert executor.chain.status == ChainStatus.FAILED
+
+    def test_diamond_partial_failure(self) -> None:
+        executor = ChainExecutor(_diamond_chain())
+
+        # Execute root
+        wave = executor.next_wave()
+        assert wave is not None
+        executor.record_outcome(StepOutcome(step_id="root", status=StepStatus.COMPLETED))
+
+        # Execute left+right: left succeeds, right fails
+        wave2 = executor.next_wave()
+        assert wave2 is not None
+        executor.record_outcome(StepOutcome(step_id="left", status=StepStatus.COMPLETED))
+        executor.record_outcome(StepOutcome(step_id="right", status=StepStatus.FAILED))
+
+        # Join should be skipped because right failed
+        assert executor.next_wave() is None
+        step_join = executor.chain.step_by_id("join")
+        assert step_join is not None
+        assert step_join.status == StepStatus.SKIPPED
+
+
+class TestSummary:
+    def test_summary_after_full_execution(self) -> None:
+        executor = ChainExecutor(_parallel_chain())
+        wave = executor.next_wave()
+        assert wave is not None
+
+        executor.record_outcome(StepOutcome(step_id="a", status=StepStatus.COMPLETED))
+        executor.record_outcome(StepOutcome(step_id="b", status=StepStatus.FAILED, error="oops"))
+        executor.record_outcome(StepOutcome(step_id="c", status=StepStatus.COMPLETED))
+
+        summary = executor.summary()
+        assert summary["chain_status"] == "failed"
+        assert summary["completed"] == 2
+        assert summary["failed"] == 1
+        assert summary["skipped"] == 0
+        assert summary["remaining"] == 0
+
+    def test_summary_mid_execution(self) -> None:
+        executor = ChainExecutor(_linear_chain())
+        wave = executor.next_wave()
+        assert wave is not None
+        executor.record_outcome(StepOutcome(step_id="a", status=StepStatus.COMPLETED))
+
+        summary = executor.summary()
+        assert summary["completed"] == 1
+        assert summary["remaining"] == 2
+
+
+class TestStepDispatchSerialization:
+    def test_dispatch_to_dict(self) -> None:
+        dispatch = StepDispatch(
+            step_id="a",
+            work_order_id="wo-a",
+            title="Step A",
+            wave_index=0,
+        )
+        d = dispatch.to_dict()
+        assert d["step_id"] == "a"
+        assert d["wave_index"] == 0
+        assert d["predecessor_outputs"] == {}
+
+    def test_outcome_to_dict(self) -> None:
+        outcome = StepOutcome(
+            step_id="a",
+            status=StepStatus.COMPLETED,
+            branch="feat/a",
+            changed_files=["mod.py"],
+            elapsed_seconds=45.2,
+        )
+        d = outcome.to_dict()
+        assert d["status"] == "completed"
+        assert d["branch"] == "feat/a"
+        assert d["elapsed_seconds"] == 45.2

--- a/tests/swarm/test_work_chain.py
+++ b/tests/swarm/test_work_chain.py
@@ -1,0 +1,298 @@
+"""Tests for work chain DAG validation and topological ordering."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.swarm.work_chain import (
+    ChainStatus,
+    ChainStep,
+    CycleDetectedError,
+    ExecutionWave,
+    StepStatus,
+    WorkChain,
+    build_chain_from_work_orders,
+)
+
+
+class TestChainStep:
+    def test_step_generates_id_when_empty(self) -> None:
+        step = ChainStep(step_id="", work_order_id="wo-1", title="Step 1")
+        assert step.step_id  # auto-generated
+        assert len(step.step_id) == 12
+
+    def test_step_preserves_explicit_id(self) -> None:
+        step = ChainStep(step_id="my-step", work_order_id="wo-1", title="Step 1")
+        assert step.step_id == "my-step"
+
+    def test_step_deduplicates_depends_on(self) -> None:
+        step = ChainStep(
+            step_id="s1",
+            work_order_id="wo-1",
+            title="Step 1",
+            depends_on=["a", "b", "a", "c", "b"],
+        )
+        assert step.depends_on == ["a", "b", "c"]
+
+    def test_step_strips_empty_depends_on(self) -> None:
+        step = ChainStep(
+            step_id="s1",
+            work_order_id="wo-1",
+            title="Step 1",
+            depends_on=["a", "", None, "b"],  # type: ignore[list-item]
+        )
+        assert step.depends_on == ["a", "b"]
+
+    def test_step_to_dict(self) -> None:
+        step = ChainStep(
+            step_id="s1",
+            work_order_id="wo-1",
+            title="Step 1",
+            depends_on=["s0"],
+            file_scope=["foo.py"],
+        )
+        d = step.to_dict()
+        assert d["step_id"] == "s1"
+        assert d["depends_on"] == ["s0"]
+        assert d["status"] == "pending"
+
+
+class TestWorkChainValidation:
+    def test_linear_chain_validates(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="Step A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="Step B", depends_on=["a"]),
+            ChainStep(step_id="c", work_order_id="wo-c", title="Step C", depends_on=["b"]),
+        ]
+        chain = WorkChain(chain_id="test", title="Linear chain", steps=steps)
+        assert chain.topological_order == ["a", "b", "c"]
+        assert chain.num_waves == 3
+
+    def test_diamond_chain_validates(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="Root"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="Left", depends_on=["a"]),
+            ChainStep(step_id="c", work_order_id="wo-c", title="Right", depends_on=["a"]),
+            ChainStep(step_id="d", work_order_id="wo-d", title="Join", depends_on=["b", "c"]),
+        ]
+        chain = WorkChain(chain_id="test", title="Diamond", steps=steps)
+        topo = chain.topological_order
+        assert topo.index("a") < topo.index("b")
+        assert topo.index("a") < topo.index("c")
+        assert topo.index("b") < topo.index("d")
+        assert topo.index("c") < topo.index("d")
+
+    def test_parallel_roots_form_single_wave(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B"),
+            ChainStep(step_id="c", work_order_id="wo-c", title="C"),
+        ]
+        chain = WorkChain(chain_id="test", title="Parallel", steps=steps)
+        assert chain.num_waves == 1
+        assert sorted(chain.waves[0].step_ids) == ["a", "b", "c"]
+
+    def test_cycle_detected(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A", depends_on=["c"]),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B", depends_on=["a"]),
+            ChainStep(step_id="c", work_order_id="wo-c", title="C", depends_on=["b"]),
+        ]
+        with pytest.raises(CycleDetectedError) as exc_info:
+            WorkChain(chain_id="test", title="Cycle", steps=steps)
+        assert set(exc_info.value.involved_steps) == {"a", "b", "c"}
+
+    def test_self_cycle_detected(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A", depends_on=["a"]),
+        ]
+        with pytest.raises(CycleDetectedError):
+            WorkChain(chain_id="test", title="Self-cycle", steps=steps)
+
+    def test_dangling_dependency_raises(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A", depends_on=["missing"]),
+        ]
+        with pytest.raises(ValueError, match="unknown step 'missing'"):
+            WorkChain(chain_id="test", title="Dangling", steps=steps)
+
+    def test_empty_chain_validates(self) -> None:
+        chain = WorkChain(chain_id="test", title="Empty")
+        assert chain.topological_order == []
+        assert chain.waves == []
+        assert chain.num_waves == 0
+
+
+class TestExecutionWaves:
+    def test_diamond_has_three_waves(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="Root"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="Left", depends_on=["a"]),
+            ChainStep(step_id="c", work_order_id="wo-c", title="Right", depends_on=["a"]),
+            ChainStep(step_id="d", work_order_id="wo-d", title="Join", depends_on=["b", "c"]),
+        ]
+        chain = WorkChain(chain_id="test", title="Diamond", steps=steps)
+        assert chain.num_waves == 3
+        assert chain.waves[0].step_ids == ["a"]
+        assert sorted(chain.waves[1].step_ids) == ["b", "c"]
+        assert chain.waves[2].step_ids == ["d"]
+
+    def test_wave_to_dict(self) -> None:
+        wave = ExecutionWave(wave_index=0, step_ids=["a", "b"])
+        d = wave.to_dict()
+        assert d["wave_index"] == 0
+        assert d["step_ids"] == ["a", "b"]
+
+
+class TestReadySteps:
+    def test_all_roots_are_ready_initially(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B"),
+            ChainStep(step_id="c", work_order_id="wo-c", title="C", depends_on=["a"]),
+        ]
+        chain = WorkChain(chain_id="test", title="Ready test", steps=steps)
+        ready = chain.ready_steps()
+        ready_ids = [step.step_id for step in ready]
+        assert sorted(ready_ids) == ["a", "b"]
+
+    def test_completing_predecessor_makes_successor_ready(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B", depends_on=["a"]),
+        ]
+        chain = WorkChain(chain_id="test", title="Sequence", steps=steps)
+        assert len(chain.ready_steps()) == 1
+        assert chain.ready_steps()[0].step_id == "a"
+
+        chain.mark_step("a", StepStatus.COMPLETED)
+        ready = chain.ready_steps()
+        assert len(ready) == 1
+        assert ready[0].step_id == "b"
+
+
+class TestChainStatus:
+    def test_all_completed_makes_chain_completed(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B"),
+        ]
+        chain = WorkChain(chain_id="test", title="Test", steps=steps)
+        chain.mark_step("a", StepStatus.COMPLETED)
+        chain.mark_step("b", StepStatus.COMPLETED)
+        assert chain.status == ChainStatus.COMPLETED
+
+    def test_any_failed_makes_chain_failed(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B"),
+        ]
+        chain = WorkChain(chain_id="test", title="Test", steps=steps)
+        chain.mark_step("a", StepStatus.FAILED)
+        assert chain.status == ChainStatus.FAILED
+
+    def test_skipped_counts_as_done(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B"),
+        ]
+        chain = WorkChain(chain_id="test", title="Test", steps=steps)
+        chain.mark_step("a", StepStatus.COMPLETED)
+        chain.mark_step("b", StepStatus.SKIPPED)
+        assert chain.status == ChainStatus.COMPLETED
+
+    def test_mark_unknown_step_raises(self) -> None:
+        chain = WorkChain(
+            chain_id="test",
+            title="Test",
+            steps=[
+                ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ],
+        )
+        with pytest.raises(KeyError, match="Unknown step"):
+            chain.mark_step("nonexistent", StepStatus.COMPLETED)
+
+
+class TestFingerprint:
+    def test_same_structure_same_fingerprint(self) -> None:
+        def make_chain() -> WorkChain:
+            return WorkChain(
+                chain_id="different-id",
+                title="Test chain",
+                steps=[
+                    ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+                    ChainStep(step_id="b", work_order_id="wo-b", title="B", depends_on=["a"]),
+                ],
+            )
+
+        assert make_chain().fingerprint() == make_chain().fingerprint()
+
+    def test_different_structure_different_fingerprint(self) -> None:
+        chain_a = WorkChain(
+            chain_id="test",
+            title="Test",
+            steps=[
+                ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ],
+        )
+        chain_b = WorkChain(
+            chain_id="test",
+            title="Test",
+            steps=[
+                ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+                ChainStep(step_id="b", work_order_id="wo-b", title="B"),
+            ],
+        )
+        assert chain_a.fingerprint() != chain_b.fingerprint()
+
+
+class TestBuildFromWorkOrders:
+    def test_builds_chain_from_work_order_dicts(self) -> None:
+        work_orders = [
+            {"work_order_id": "wo-1", "title": "Create module", "file_scope": ["mod.py"]},
+            {
+                "work_order_id": "wo-2",
+                "title": "Add tests",
+                "dependency_ids": ["wo-1"],
+                "file_scope": ["test_mod.py"],
+            },
+        ]
+        chain = build_chain_from_work_orders("Test chain", work_orders)
+        assert len(chain.steps) == 2
+        assert chain.topological_order[0] == "wo-1"
+        assert chain.topological_order[1] == "wo-2"
+
+    def test_skips_empty_work_order_ids(self) -> None:
+        work_orders = [
+            {"work_order_id": "", "title": "Empty"},
+            {"work_order_id": "wo-1", "title": "Real"},
+        ]
+        chain = build_chain_from_work_orders("Test", work_orders)
+        assert len(chain.steps) == 1
+
+    def test_ignores_dangling_dependency_ids(self) -> None:
+        work_orders = [
+            {
+                "work_order_id": "wo-1",
+                "title": "Step",
+                "dependency_ids": ["nonexistent"],
+            },
+        ]
+        chain = build_chain_from_work_orders("Test", work_orders)
+        assert len(chain.steps) == 1
+        assert chain.steps[0].depends_on == []
+
+
+class TestToDict:
+    def test_chain_roundtrip_serialization(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B", depends_on=["a"]),
+        ]
+        chain = WorkChain(chain_id="test-chain", title="Serialize test", steps=steps)
+        d = chain.to_dict()
+        assert d["chain_id"] == "test-chain"
+        assert len(d["steps"]) == 2
+        assert d["topological_order"] == ["a", "b"]
+        assert len(d["waves"]) == 2
+        assert isinstance(d["fingerprint"], str)


### PR DESCRIPTION
## Summary

- Add `work_chain.py`: WorkChain data model with ChainStep nodes, DAG validation via Kahn's algorithm, topological ordering, and execution wave planning (maximal independent sets)
- Add `chain_executor.py`: ChainExecutor drives wave-by-wave dispatch, passes predecessor outputs to dependent steps, propagates failures transitively (failed → skip all downstream)
- 41 tests covering cycle detection, diamond/linear/parallel DAGs, failure propagation, serialization, and build-from-work-orders convenience

## Test plan

- [x] `pytest tests/swarm/test_work_chain.py tests/swarm/test_chain_executor.py -v` — 41/41 pass
- [x] `bash scripts/automation_pr_preflight.sh origin/main HEAD` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)