### PR TITLE
feat(swarm): salvage conductor lane

### DIFF
--- a/aragora/swarm/conductor.py
+++ b/aragora/swarm/conductor.py
@@ -17,7 +17,7 @@ import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from aragora.swarm.ping_pong import build_handoff_prompt
 from aragora.swarm.terminal_truth import (
@@ -27,6 +27,9 @@ from aragora.swarm.terminal_truth import (
 )
 
 NextAction = Literal["retry_same", "retry_different_agent", "decompose", "escalate", "done"]
+_VALID_NEXT_ACTIONS = frozenset(
+    {"retry_same", "retry_different_agent", "decompose", "escalate", "done"}
+)
 
 _ALREADY_DONE_MARKERS = (
     "already implemented",
@@ -106,6 +109,13 @@ def _truncate(text: str, *, limit: int = 1600) -> str:
     return normalized[: limit - 3].rstrip() + "..."
 
 
+def _coerce_next_action(value: Any) -> NextAction:
+    action = _text(value)
+    if action in _VALID_NEXT_ACTIONS:
+        return cast(NextAction, action)
+    return "escalate"
+
+
 def _git_common_dir(repo_root: Path) -> Path | None:
     try:
         result = subprocess.run(
@@ -158,7 +168,7 @@ class ConductorStep:
             changed_files=[
                 _text(item) for item in list(data.get("changed_files", []) or []) if _text(item)
             ],
-            next_action=str(data.get("next_action", "escalate")),
+            next_action=_coerce_next_action(data.get("next_action")),
             next_prompt=_text(data.get("next_prompt")),
         )
 

--- a/aragora/swarm/conductor.py
+++ b/aragora/swarm/conductor.py
@@ -1,0 +1,715 @@
+"""Autonomous conductor substrate for swarm worker follow-ups.
+
+This module decides what to do after a worker finishes:
+
+- classify the terminal state
+- determine whether to retry, switch agents, decompose, escalate, or stop
+- generate the next prompt without manual copy-paste
+- persist issue/session history so the next attempt has context
+
+It is intentionally standalone for now and is not wired into ``boss_loop.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from aragora.swarm.ping_pong import build_handoff_prompt
+from aragora.swarm.terminal_truth import (
+    TerminalClass,
+    classify_from_metrics,
+    extract_run_worker_outcome,
+)
+
+NextAction = Literal["retry_same", "retry_different_agent", "decompose", "escalate", "done"]
+
+_ALREADY_DONE_MARKERS = (
+    "already implemented",
+    "already exists",
+    "no changes needed",
+    "nothing to commit",
+)
+_AUTH_MARKERS = (
+    "auth",
+    "authentication",
+    "unauthorized",
+    "permission denied",
+    "credentials",
+    "token",
+    "login",
+    "forbidden",
+    "403",
+    "401",
+)
+_RUNNER_MARKERS = (
+    "no runner",
+    "runner unavailable",
+    "agent unavailable",
+    "worker type blocked",
+    "command not found",
+)
+_SCOPE_MARKERS = (
+    "too broad",
+    "split",
+    "decompose",
+    "decomposition",
+    "multiple concerns",
+    "multiple files",
+    "too many files",
+    "out of scope",
+    "scope too large",
+)
+_VALIDATION_MARKERS = (
+    "pytest",
+    "test failed",
+    "tests failed",
+    "assertionerror",
+    "typecheck",
+    "mypy",
+    "ruff",
+    "lint",
+    "verification failed",
+)
+_TIMEOUT_MARKERS = ("timed out", "timeout", "no progress")
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw in values:
+        value = _text(raw)
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def _contains_any(text: str, markers: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in markers)
+
+
+def _truncate(text: str, *, limit: int = 1600) -> str:
+    normalized = _text(text)
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 3].rstrip() + "..."
+
+
+def _git_common_dir(repo_root: Path) -> Path | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    path_text = _text(result.stdout)
+    if result.returncode != 0 or not path_text:
+        return None
+    path = Path(path_text)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    return path if path.exists() else None
+
+
+@dataclass(slots=True)
+class ConductorStep:
+    issue_number: int
+    session_id: str
+    worker_output: str
+    terminal_class: TerminalClass
+    changed_files: list[str]
+    next_action: NextAction
+    next_prompt: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "issue_number": self.issue_number,
+            "session_id": self.session_id,
+            "worker_output": self.worker_output,
+            "terminal_class": self.terminal_class.value,
+            "changed_files": list(self.changed_files),
+            "next_action": self.next_action,
+            "next_prompt": self.next_prompt,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ConductorStep":
+        return cls(
+            issue_number=int(data.get("issue_number", 0) or 0),
+            session_id=_text(data.get("session_id")) or "unknown-session",
+            worker_output=_text(data.get("worker_output")),
+            terminal_class=TerminalClass(_text(data.get("terminal_class"))),
+            changed_files=[
+                _text(item) for item in list(data.get("changed_files", []) or []) if _text(item)
+            ],
+            next_action=str(data.get("next_action", "escalate")),
+            next_prompt=_text(data.get("next_prompt")),
+        )
+
+
+class SessionStateStore:
+    """Small JSON-backed issue/session history for conductor retries."""
+
+    def __init__(self, repo_root: Path):
+        self.repo_root = Path(repo_root).resolve()
+        git_common = _git_common_dir(self.repo_root)
+        self.storage_dir = (
+            git_common / "aragora_conductor"
+            if git_common is not None
+            else self.repo_root / ".aragora_conductor"
+        )
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+
+    def _issue_path(self, issue_number: int) -> Path:
+        return self.storage_dir / f"issue-{int(issue_number)}.json"
+
+    def load_steps(self, issue_number: int) -> list[ConductorStep]:
+        path = self._issue_path(issue_number)
+        if not path.exists():
+            return []
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return []
+        if not isinstance(payload, list):
+            return []
+        steps: list[ConductorStep] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            try:
+                steps.append(ConductorStep.from_dict(item))
+            except (TypeError, ValueError):
+                continue
+        return steps
+
+    def append_step(self, step: ConductorStep) -> None:
+        steps = self.load_steps(step.issue_number)
+        steps.append(step)
+        path = self._issue_path(step.issue_number)
+        path.write_text(
+            json.dumps([item.to_dict() for item in steps], indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+    def latest_step(self, issue_number: int) -> ConductorStep | None:
+        steps = self.load_steps(issue_number)
+        return steps[-1] if steps else None
+
+    def latest_session_id(self, issue_number: int) -> str | None:
+        latest = self.latest_step(issue_number)
+        if latest is None:
+            return None
+        return latest.session_id
+
+
+class Conductor:
+    def __init__(self, repo_root: Path):
+        self.repo_root = Path(repo_root).resolve()
+        self._session_store = SessionStateStore(self.repo_root)
+
+    def evaluate_worker_output(
+        self, issue_number: int, worker_result: dict[str, Any]
+    ) -> ConductorStep:
+        """Read worker output and decide what to do next."""
+        history = self._session_store.load_steps(issue_number)
+        worker_output = self._extract_worker_output(worker_result)
+        changed_files = self._extract_changed_files(worker_result)
+        terminal_class = self._classify_terminal(worker_result, worker_output, changed_files)
+        session_id = self._extract_session_id(issue_number, worker_result, history)
+        failure_reason = self._failure_reason(worker_result, worker_output, terminal_class)
+
+        if self._is_done(worker_result, worker_output, terminal_class):
+            next_action: NextAction = "done"
+            next_prompt = ""
+        else:
+            next_action = self._choose_next_action(
+                terminal_class=terminal_class,
+                failure_reason=failure_reason,
+                worker_output=worker_output,
+                changed_files=changed_files,
+                history=history,
+            )
+            if next_action == "retry_same":
+                next_prompt = self.generate_retry_prompt(
+                    issue_number, worker_output, failure_reason
+                )
+            elif next_action == "retry_different_agent":
+                next_prompt = self._build_different_agent_prompt(
+                    issue_number=issue_number,
+                    worker_result=worker_result,
+                    worker_output=worker_output,
+                    failure_reason=failure_reason,
+                    changed_files=changed_files,
+                    history=history,
+                )
+            elif next_action == "decompose":
+                next_prompt = self._build_decomposition_prompt(
+                    issue_number=issue_number,
+                    worker_output=worker_output,
+                    failure_reason=failure_reason,
+                    changed_files=changed_files,
+                    terminal_class=terminal_class,
+                )
+            else:
+                next_prompt = self._build_escalation_prompt(
+                    issue_number=issue_number,
+                    worker_output=worker_output,
+                    failure_reason=failure_reason,
+                    terminal_class=terminal_class,
+                )
+
+        step = ConductorStep(
+            issue_number=issue_number,
+            session_id=session_id,
+            worker_output=worker_output,
+            terminal_class=terminal_class,
+            changed_files=changed_files,
+            next_action=next_action,
+            next_prompt=next_prompt,
+        )
+        self._session_store.append_step(step)
+        return step
+
+    def generate_retry_prompt(
+        self, issue_number: int, prior_output: str, failure_reason: str
+    ) -> str:
+        """Generate a targeted retry prompt based on what failed."""
+        steps = self._session_store.load_steps(issue_number)
+        lines = [f"# Retry issue #{issue_number}", "", "## What was tried"]
+
+        if steps:
+            start = max(0, len(steps) - 3)
+            for index, step in enumerate(steps[start:], start=start + 1):
+                lines.append(
+                    f"- Attempt {index}: terminal={step.terminal_class.value}, "
+                    f"conductor_action={step.next_action}"
+                )
+        else:
+            lines.append("- No prior conductor attempts recorded.")
+
+        excerpt = _truncate(prior_output, limit=1800) or "(no worker output captured)"
+        lines.extend(
+            [
+                "",
+                "Most recent worker output:",
+                excerpt,
+                "",
+                "## Why it failed",
+                failure_reason or "unknown",
+                "",
+                "## What to try differently",
+            ]
+        )
+
+        for item in self._repair_guidance(failure_reason=failure_reason, prior_output=prior_output):
+            lines.append(f"- {item}")
+
+        lines.extend(
+            [
+                "",
+                "## Constraints",
+                "- Reuse any correct partial progress instead of starting over blindly.",
+                "- Keep the attempt bounded and end with a concrete deliverable or an exact blocker.",
+            ]
+        )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _extract_session_id(
+        issue_number: int,
+        worker_result: dict[str, Any],
+        history: list[ConductorStep],
+    ) -> str:
+        for key in ("session_id", "run_id", "receipt_id"):
+            value = _text(worker_result.get(key))
+            if value:
+                return value
+        if history:
+            return history[-1].session_id
+        return f"issue-{issue_number}"
+
+    @staticmethod
+    def _extract_worker_output(worker_result: dict[str, Any]) -> str:
+        parts: list[str] = []
+        for key in (
+            "worker_output",
+            "error",
+            "stdout",
+            "stderr",
+            "stdout_tail",
+            "stderr_tail",
+            "transcript",
+            "log_tail",
+        ):
+            value = _text(worker_result.get(key))
+            if value:
+                parts.append(value)
+
+        for item in list(worker_result.get("reasons", []) or []):
+            value = _text(item)
+            if value:
+                parts.append(value)
+
+        run_dict = worker_result.get("run")
+        if isinstance(run_dict, dict):
+            for work_order in run_dict.get("work_orders", []):
+                if not isinstance(work_order, dict):
+                    continue
+                for key in (
+                    "stdout_tail",
+                    "stderr_tail",
+                    "transcript",
+                    "log_tail",
+                    "failure_reason",
+                    "blocking_question",
+                ):
+                    value = _text(work_order.get(key))
+                    if value:
+                        parts.append(value)
+
+        return "\n\n".join(_ordered_unique(parts))
+
+    @staticmethod
+    def _extract_changed_files(worker_result: dict[str, Any]) -> list[str]:
+        files: list[str] = []
+        for key in ("changed_files", "changed_paths"):
+            value = worker_result.get(key)
+            if isinstance(value, list):
+                files.extend(_text(item) for item in value if _text(item))
+
+        deliverable = worker_result.get("deliverable")
+        if isinstance(deliverable, dict):
+            changed_paths = deliverable.get("changed_paths")
+            if isinstance(changed_paths, list):
+                files.extend(_text(item) for item in changed_paths if _text(item))
+
+        run_dict = worker_result.get("run")
+        if isinstance(run_dict, dict):
+            for work_order in run_dict.get("work_orders", []):
+                if not isinstance(work_order, dict):
+                    continue
+                changed_paths = work_order.get("changed_paths")
+                if isinstance(changed_paths, list):
+                    files.extend(_text(item) for item in changed_paths if _text(item))
+
+        return _ordered_unique(files)
+
+    def _classify_terminal(
+        self,
+        worker_result: dict[str, Any],
+        worker_output: str,
+        changed_files: list[str],
+    ) -> TerminalClass:
+        raw_terminal = worker_result.get("terminal_class")
+        if isinstance(raw_terminal, TerminalClass):
+            return raw_terminal
+        raw_terminal_text = _text(raw_terminal)
+        if raw_terminal_text:
+            try:
+                return TerminalClass(raw_terminal_text)
+            except ValueError:
+                pass
+
+        outcome = _text(worker_result.get("outcome")).lower()
+        deliverable = worker_result.get("deliverable")
+        deliverable_type = _text(deliverable.get("type")) if isinstance(deliverable, dict) else ""
+
+        if outcome == "pr_adopted" or deliverable_type in {"pr", "adopted_pr"}:
+            return TerminalClass.DELIVERABLE_PR_CREATED
+        if outcome == "deliverable_created":
+            return TerminalClass.DELIVERABLE_BRANCH_PUSHED
+        if outcome == "issue_already_resolved" or (
+            not changed_files and _contains_any(worker_output, _ALREADY_DONE_MARKERS)
+        ):
+            return TerminalClass.ISSUE_ALREADY_RESOLVED
+
+        run_dict = worker_result.get("run")
+        worker_outcome = outcome
+        if not worker_outcome and isinstance(run_dict, dict):
+            worker_outcome = _text(extract_run_worker_outcome(run_dict)).lower()
+
+        if not worker_outcome and _contains_any(worker_output, _TIMEOUT_MARKERS):
+            worker_outcome = "timeout"
+        elif not worker_outcome and _contains_any(worker_output, _AUTH_MARKERS):
+            worker_outcome = "auth_failure"
+        elif not worker_outcome and _contains_any(worker_output, _RUNNER_MARKERS):
+            worker_outcome = "no_fresh_runner"
+        elif not worker_outcome and _contains_any(worker_output, _SCOPE_MARKERS):
+            worker_outcome = "blocked"
+
+        metrics_row = {
+            "worker_status": _text(worker_result.get("status")).lower(),
+            "worker_outcome": worker_outcome,
+            "publish_action": _text(
+                worker_result.get("publish_action")
+                or ((worker_result.get("publish_result") or {}).get("action"))
+            ).lower(),
+            "files_changed": len(changed_files),
+            "elapsed_seconds": float(worker_result.get("elapsed_seconds", 0.0) or 0.0),
+            "has_deliverable": bool(outcome == "deliverable_created"),
+        }
+        return classify_from_metrics(metrics_row)
+
+    def _is_done(
+        self,
+        worker_result: dict[str, Any],
+        worker_output: str,
+        terminal_class: TerminalClass,
+    ) -> bool:
+        if terminal_class.is_success:
+            return True
+        outcome = _text(worker_result.get("outcome")).lower()
+        if outcome in {"deliverable_created", "pr_adopted", "issue_already_resolved"}:
+            return True
+        return not self._extract_changed_files(worker_result) and _contains_any(
+            worker_output, _ALREADY_DONE_MARKERS
+        )
+
+    def _failure_reason(
+        self,
+        worker_result: dict[str, Any],
+        worker_output: str,
+        terminal_class: TerminalClass,
+    ) -> str:
+        candidates: list[str] = []
+        for key in ("failure_reason", "error", "blocked_reason"):
+            value = _text(worker_result.get(key))
+            if value:
+                candidates.append(value)
+
+        for item in list(worker_result.get("reasons", []) or []):
+            value = _text(item)
+            if value:
+                candidates.append(value)
+
+        run_dict = worker_result.get("run")
+        if isinstance(run_dict, dict):
+            for work_order in run_dict.get("work_orders", []):
+                if not isinstance(work_order, dict):
+                    continue
+                for key in ("failure_reason", "blocking_question", "dispatch_error"):
+                    value = _text(work_order.get(key))
+                    if value:
+                        candidates.append(value)
+
+        for value in candidates:
+            if value:
+                return value
+
+        if _contains_any(worker_output, _AUTH_MARKERS):
+            return "auth_failure"
+        if _contains_any(worker_output, _RUNNER_MARKERS):
+            return "no_runner"
+        if _contains_any(worker_output, _VALIDATION_MARKERS):
+            return "verification_failed"
+        if _contains_any(worker_output, _SCOPE_MARKERS):
+            return "task_too_broad"
+        if _contains_any(worker_output, _TIMEOUT_MARKERS):
+            return "worker_timeout"
+        return terminal_class.value
+
+    def _choose_next_action(
+        self,
+        *,
+        terminal_class: TerminalClass,
+        failure_reason: str,
+        worker_output: str,
+        changed_files: list[str],
+        history: list[ConductorStep],
+    ) -> NextAction:
+        if terminal_class in {
+            TerminalClass.BLOCKED_AUTH_FAILURE,
+            TerminalClass.BLOCKED_NO_RUNNER,
+            TerminalClass.BLOCKED_VALIDATION_TARGET_MISSING,
+            TerminalClass.BLOCKED_DECOMPOSITION_LIMIT,
+            TerminalClass.RESCUE_PUBLISH_DEFERRED,
+        }:
+            return "escalate"
+
+        if terminal_class in {
+            TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED,
+            TerminalClass.BLOCKED_SANITATION_FAILED,
+        }:
+            if self._decomposition_would_help(failure_reason, worker_output, changed_files):
+                return "decompose"
+            return "escalate"
+
+        if terminal_class == TerminalClass.RESCUE_TIMEOUT:
+            return "retry_same"
+
+        if terminal_class == TerminalClass.RESCUE_VERIFICATION_FAILED:
+            return "retry_different_agent"
+
+        if terminal_class == TerminalClass.RESCUE_WORKER_CRASH:
+            if self._is_infrastructure_failure(failure_reason, worker_output):
+                return "escalate"
+            if history and not changed_files:
+                return "retry_different_agent"
+            return "retry_same"
+
+        if terminal_class == TerminalClass.RESCUE_NO_DELIVERABLE:
+            if self._decomposition_would_help(failure_reason, worker_output, changed_files):
+                return "decompose"
+            if history or changed_files:
+                return "retry_different_agent"
+            return "retry_same"
+
+        return "retry_same"
+
+    @staticmethod
+    def _decomposition_would_help(
+        failure_reason: str,
+        worker_output: str,
+        changed_files: list[str],
+    ) -> bool:
+        combined = "\n".join([failure_reason, worker_output])
+        if _contains_any(combined, _SCOPE_MARKERS):
+            return True
+        mentioned_files = re.findall(r"\b[\w./-]+\.(?:py|ts|tsx|js|jsx|md)\b", combined)
+        return len(_ordered_unique(changed_files + mentioned_files)) >= 4
+
+    @staticmethod
+    def _is_infrastructure_failure(failure_reason: str, worker_output: str) -> bool:
+        combined = "\n".join([failure_reason, worker_output])
+        return _contains_any(combined, _AUTH_MARKERS + _RUNNER_MARKERS)
+
+    def _build_different_agent_prompt(
+        self,
+        *,
+        issue_number: int,
+        worker_result: dict[str, Any],
+        worker_output: str,
+        failure_reason: str,
+        changed_files: list[str],
+        history: list[ConductorStep],
+    ) -> str:
+        previous_agent = (
+            _text(worker_result.get("agent"))
+            or _text(worker_result.get("target_agent"))
+            or _text((worker_result.get("receipt_metadata") or {}).get("requested_target_agent"))
+            or "previous_worker"
+        )
+        handoff = build_handoff_prompt(
+            goal=f"Repair issue #{issue_number} without repeating the failed approach.",
+            previous_transcript=worker_output or failure_reason or "(no transcript captured)",
+            previous_agent=previous_agent,
+            next_agent="different_agent",
+            round_number=len(history) + 1,
+            files_changed=changed_files,
+            remaining_issues=[failure_reason] if failure_reason else [],
+        )
+        return (
+            handoff + "\n\n## Additional guidance\n"
+            "- Start by verifying the failure independently.\n"
+            "- Keep any correct partial edits, but do not trust the prior approach blindly."
+        )
+
+    @staticmethod
+    def _build_decomposition_prompt(
+        *,
+        issue_number: int,
+        worker_output: str,
+        failure_reason: str,
+        changed_files: list[str],
+        terminal_class: TerminalClass,
+    ) -> str:
+        lines = [
+            f"# Decompose issue #{issue_number}",
+            "",
+            "The last autonomous attempt should not be retried as a single bounded worker task.",
+            "",
+            "## Why decomposition is needed",
+            f"- terminal_class: {terminal_class.value}",
+            f"- failure_reason: {failure_reason or 'unknown'}",
+        ]
+        if changed_files:
+            lines.append(f"- files involved: {', '.join(changed_files[:10])}")
+        excerpt = _truncate(worker_output, limit=1400)
+        if excerpt:
+            lines.extend(["", "## Worker evidence", excerpt])
+        lines.extend(
+            [
+                "",
+                "## Your task",
+                "Split the issue into 2-5 bounded subtasks.",
+                "Each subtask must include file scope, validation, and a single concrete deliverable.",
+            ]
+        )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _build_escalation_prompt(
+        *,
+        issue_number: int,
+        worker_output: str,
+        failure_reason: str,
+        terminal_class: TerminalClass,
+    ) -> str:
+        lines = [
+            f"# Escalate issue #{issue_number}",
+            "",
+            "The conductor is stopping autonomous retries until an external blocker is cleared.",
+            "",
+            "## Escalation summary",
+            f"- terminal_class: {terminal_class.value}",
+            f"- failure_reason: {failure_reason or 'unknown'}",
+        ]
+        excerpt = _truncate(worker_output, limit=1200)
+        if excerpt:
+            lines.extend(["", "## Worker evidence", excerpt])
+        lines.extend(
+            [
+                "",
+                "## Next owner",
+                "Route this to a human or infrastructure owner, clear the blocker, then re-queue.",
+            ]
+        )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _repair_guidance(*, failure_reason: str, prior_output: str) -> list[str]:
+        combined = "\n".join([failure_reason, prior_output]).lower()
+        guidance: list[str] = []
+
+        if _contains_any(combined, _VALIDATION_MARKERS):
+            guidance.append(
+                "Reproduce the failing verification first and fix the smallest failing assertion, lint, or type error."
+            )
+        if _contains_any(combined, _TIMEOUT_MARKERS):
+            guidance.append(
+                "Avoid full-suite validation or broad searches; stay within the files already implicated."
+            )
+        if "crash" in combined or "traceback" in combined:
+            guidance.append(
+                "Start by reproducing the crashing command or traceback before changing more code."
+            )
+        if _contains_any(combined, _SCOPE_MARKERS):
+            guidance.append(
+                "Choose one bounded slice and explicitly defer any remaining scope instead of widening the task."
+            )
+        if not guidance:
+            guidance.append(
+                "Change the approach, not just the wording: verify the failure, make the smallest bounded edit, then validate."
+            )
+        guidance.append("Do not repeat the same command sequence unless you learned something new.")
+        return _ordered_unique(guidance)
+
+
+__all__ = ["Conductor", "ConductorStep", "SessionStateStore"]

--- a/tests/swarm/test_conductor.py
+++ b/tests/swarm/test_conductor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from aragora.swarm.conductor import Conductor
+from aragora.swarm.conductor import Conductor, ConductorStep
 from aragora.swarm.terminal_truth import TerminalClass
 
 
@@ -256,6 +256,22 @@ def test_generate_retry_prompt_includes_required_sections(tmp_path: Path) -> Non
     assert "## Why it failed" in prompt
     assert "## What to try differently" in prompt
     assert "verification_failed" in prompt
+
+
+def test_conductor_step_from_dict_coerces_unknown_next_action() -> None:
+    step = ConductorStep.from_dict(
+        {
+            "issue_number": 114,
+            "session_id": "sess-114",
+            "worker_output": "needs a manual retry",
+            "terminal_class": TerminalClass.RESCUE_NO_DELIVERABLE.value,
+            "changed_files": ["aragora/swarm/conductor.py"],
+            "next_action": "retry_later",
+            "next_prompt": "Escalate to a human.",
+        }
+    )
+
+    assert step.next_action == "escalate"
 
 
 def test_generate_retry_prompt_references_prior_attempts_from_store(tmp_path: Path) -> None:

--- a/tests/swarm/test_conductor.py
+++ b/tests/swarm/test_conductor.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from aragora.swarm.conductor import Conductor
+from aragora.swarm.terminal_truth import TerminalClass
+
+
+def _result(
+    *,
+    session_id: str | None = "sess-1",
+    status: str = "needs_human",
+    outcome: str = "",
+    terminal_class: TerminalClass | str | None = None,
+    worker_output: str = "",
+    error: str = "",
+    reasons: list[str] | None = None,
+    changed_files: list[str] | None = None,
+    work_order_changed: list[str] | None = None,
+    worker_outcome: str = "",
+    agent: str = "codex",
+    deliverable: dict[str, object] | None = None,
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "status": status,
+        "outcome": outcome,
+        "agent": agent,
+        "run": {
+            "work_orders": [
+                {
+                    "worker_outcome": worker_outcome,
+                    "stdout_tail": worker_output,
+                    "stderr_tail": error,
+                    "changed_paths": list(work_order_changed or []),
+                }
+            ]
+        },
+    }
+    if session_id is not None:
+        result["session_id"] = session_id
+    if terminal_class is not None:
+        result["terminal_class"] = (
+            terminal_class.value if isinstance(terminal_class, TerminalClass) else terminal_class
+        )
+    if worker_output:
+        result["worker_output"] = worker_output
+    if error:
+        result["error"] = error
+    if reasons is not None:
+        result["reasons"] = list(reasons)
+    if changed_files is not None:
+        result["changed_files"] = list(changed_files)
+    if deliverable is not None:
+        result["deliverable"] = dict(deliverable)
+    return result
+
+
+def test_done_on_deliverable_created(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        101,
+        _result(
+            status="completed",
+            outcome="deliverable_created",
+            changed_files=["aragora/swarm/conductor.py"],
+        ),
+    )
+
+    assert step.next_action == "done"
+    assert step.terminal_class == TerminalClass.DELIVERABLE_BRANCH_PUSHED
+    assert step.next_prompt == ""
+
+
+def test_done_on_pr_adopted(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        102,
+        _result(
+            status="completed",
+            outcome="pr_adopted",
+            deliverable={"type": "pr", "pr_url": "https://github.com/org/repo/pull/12"},
+        ),
+    )
+
+    assert step.next_action == "done"
+    assert step.terminal_class == TerminalClass.DELIVERABLE_PR_CREATED
+
+
+def test_done_on_already_resolved_marker_without_changes(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        103,
+        _result(
+            worker_output="Already implemented; nothing to commit.",
+            worker_outcome="clean_exit_no_effect",
+        ),
+    )
+
+    assert step.next_action == "done"
+    assert step.terminal_class == TerminalClass.ISSUE_ALREADY_RESOLVED
+
+
+def test_timeout_retries_same_agent(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        104,
+        _result(terminal_class=TerminalClass.RESCUE_TIMEOUT, worker_output="Worker timed out"),
+    )
+
+    assert step.next_action == "retry_same"
+    assert "## What was tried" in step.next_prompt
+    assert "## What to try differently" in step.next_prompt
+
+
+def test_verification_failure_retries_different_agent(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        105,
+        _result(
+            terminal_class=TerminalClass.RESCUE_VERIFICATION_FAILED,
+            worker_output="pytest tests/swarm/test_x.py -q\nAssertionError: boom",
+            changed_files=["aragora/swarm/x.py"],
+        ),
+    )
+
+    assert step.next_action == "retry_different_agent"
+    assert "## Context" in step.next_prompt
+    assert "different_agent" in step.next_prompt
+    assert "aragora/swarm/x.py" in step.next_prompt
+
+
+def test_worker_crash_retries_same_agent(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        106,
+        _result(
+            terminal_class=TerminalClass.RESCUE_WORKER_CRASH,
+            worker_output="Traceback: ValueError",
+            error="worker crashed while parsing diff",
+        ),
+    )
+
+    assert step.next_action == "retry_same"
+    assert "ValueError" in step.worker_output
+
+
+def test_worker_crash_escalates_on_auth_failure(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        107,
+        _result(
+            terminal_class=TerminalClass.RESCUE_WORKER_CRASH,
+            worker_output="gh auth failed: permission denied",
+        ),
+    )
+
+    assert step.next_action == "escalate"
+    assert "permission denied" in step.next_prompt
+
+
+def test_blocked_scope_broadness_decomposes(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        108,
+        _result(
+            terminal_class=TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED,
+            worker_output=(
+                "Task is too broad and should be split. "
+                "It touches aragora/swarm/a.py, aragora/swarm/b.py, "
+                "tests/swarm/test_a.py, tests/swarm/test_b.py."
+            ),
+        ),
+    )
+
+    assert step.next_action == "decompose"
+    assert "Split the issue into 2-5 bounded subtasks" in step.next_prompt
+
+
+def test_blocked_auth_failure_escalates(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        109,
+        _result(terminal_class="blocked_auth_failure", worker_output="401 unauthorized"),
+    )
+
+    assert step.next_action == "escalate"
+    assert step.terminal_class == TerminalClass.BLOCKED_AUTH_FAILURE
+
+
+def test_blocked_decomposition_limit_escalates(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        110,
+        _result(terminal_class=TerminalClass.BLOCKED_DECOMPOSITION_LIMIT),
+    )
+
+    assert step.next_action == "escalate"
+
+
+def test_no_deliverable_decomposes_when_output_requests_split(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        111,
+        _result(
+            terminal_class=TerminalClass.RESCUE_NO_DELIVERABLE,
+            worker_output="Please decompose this; it spans auth, billing, and CLI setup.",
+        ),
+    )
+
+    assert step.next_action == "decompose"
+
+
+def test_no_deliverable_retries_different_agent_after_prior_history(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+    first = conductor.evaluate_worker_output(
+        112,
+        _result(
+            terminal_class=TerminalClass.RESCUE_NO_DELIVERABLE,
+            worker_output="Tried one approach but produced no deliverable.",
+        ),
+    )
+    second = conductor.evaluate_worker_output(
+        112,
+        _result(
+            session_id=None,
+            terminal_class=TerminalClass.RESCUE_NO_DELIVERABLE,
+            worker_output="Still no deliverable after retry.",
+        ),
+    )
+
+    assert first.next_action == "retry_same"
+    assert second.next_action == "retry_different_agent"
+
+
+def test_generate_retry_prompt_includes_required_sections(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    prompt = conductor.generate_retry_prompt(
+        113,
+        "pytest tests/swarm/test_conductor.py -q\nAssertionError: boom",
+        "verification_failed",
+    )
+
+    assert "## What was tried" in prompt
+    assert "## Why it failed" in prompt
+    assert "## What to try differently" in prompt
+    assert "verification_failed" in prompt
+
+
+def test_generate_retry_prompt_references_prior_attempts_from_store(tmp_path: Path) -> None:
+    Conductor(tmp_path).evaluate_worker_output(
+        114,
+        _result(terminal_class=TerminalClass.RESCUE_TIMEOUT, worker_output="timed out"),
+    )
+
+    prompt = Conductor(tmp_path).generate_retry_prompt(
+        114,
+        "timed out again",
+        "worker_timeout",
+    )
+
+    assert "Attempt 1" in prompt
+    assert "rescue_timeout" in prompt
+
+
+def test_session_persistence_round_trips_across_instances(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+    conductor.evaluate_worker_output(
+        115,
+        _result(
+            terminal_class=TerminalClass.RESCUE_TIMEOUT,
+            worker_output="worker timed out after narrow diff",
+        ),
+    )
+
+    restored = Conductor(tmp_path)
+    steps = restored._session_store.load_steps(115)
+
+    assert len(steps) == 1
+    assert steps[0].terminal_class == TerminalClass.RESCUE_TIMEOUT
+    assert restored._session_store.latest_session_id(115) == "sess-1"
+
+
+def test_explicit_terminal_class_string_is_respected(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        116,
+        _result(terminal_class="blocked_no_runner", worker_output="No runner available"),
+    )
+
+    assert step.terminal_class == TerminalClass.BLOCKED_NO_RUNNER
+    assert step.next_action == "escalate"
+
+
+def test_extracts_changed_files_from_run_work_orders(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        117,
+        _result(
+            terminal_class=TerminalClass.RESCUE_VERIFICATION_FAILED,
+            changed_files=["aragora/swarm/conductor.py"],
+            work_order_changed=["aragora/swarm/conductor.py", "tests/swarm/test_conductor.py"],
+        ),
+    )
+
+    assert step.changed_files == [
+        "aragora/swarm/conductor.py",
+        "tests/swarm/test_conductor.py",
+    ]
+
+
+def test_session_id_falls_back_to_existing_issue_session(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+    conductor.evaluate_worker_output(
+        118,
+        _result(session_id="session-keep", terminal_class=TerminalClass.RESCUE_TIMEOUT),
+    )
+
+    step = conductor.evaluate_worker_output(
+        118,
+        _result(session_id=None, terminal_class=TerminalClass.RESCUE_TIMEOUT),
+    )
+
+    assert step.session_id == "session-keep"
+
+
+def test_retry_prompt_uses_validation_specific_guidance(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    prompt = conductor.generate_retry_prompt(
+        119,
+        "pytest -q tests/swarm/test_conductor.py\nAssertionError: expected 1 == 2",
+        "verification_failed",
+    )
+
+    assert "Reproduce the failing verification first" in prompt
+
+
+def test_publish_deferred_escalates(tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+
+    step = conductor.evaluate_worker_output(
+        120,
+        _result(
+            terminal_class=TerminalClass.RESCUE_PUBLISH_DEFERRED,
+            worker_output="Deliverable exists but publish was deferred by gate.",
+        ),
+    )
+
+    assert step.next_action == "escalate"


### PR DESCRIPTION
Salvages the uncommitted conductor lane from the stale `conductor-s3` worktree onto current `origin/main`.

Scope:
- add `aragora/swarm/conductor.py`
- add `tests/swarm/test_conductor.py`

Validation:
- `python -m pytest -q tests/swarm/test_conductor.py`
- `python -m ruff check aragora/swarm/conductor.py tests/swarm/test_conductor.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
