### PR TITLE
feat(swarm): add tmux session transport

### DIFF
--- a/aragora/swarm/session_mux.py
+++ b/aragora/swarm/session_mux.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import shlex
+import subprocess
+from typing import Any
+import uuid
+
+_REGISTRY_SCHEMA_VERSION = 1
+_PROMPT_MARKER_PREFIX = "=== ARAGORA_SESSION_MUX_PROMPT "
+
+
+def resolve_repo_root(path_hint: Path | None = None) -> Path:
+    candidate = (path_hint or Path.cwd()).resolve()
+    proc = subprocess.run(
+        ["git", "-C", str(candidate), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 0 and proc.stdout.strip():
+        return Path(proc.stdout.strip()).resolve()
+    return candidate
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _isoformat_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _sanitize_session_name(name: str) -> str:
+    cleaned = "".join(
+        char if char.isalnum() or char in {"-", "_"} else "-" for char in name.strip()
+    )
+    normalized = cleaned.strip("-_")
+    if not normalized:
+        raise ValueError("Session name must contain at least one alphanumeric character")
+    return normalized
+
+
+def _registry_dir(repo_root: Path) -> Path:
+    return repo_root / ".aragora" / "session_mux"
+
+
+def _registry_path(repo_root: Path) -> Path:
+    return _registry_dir(repo_root) / "registry.json"
+
+
+def _logs_dir(repo_root: Path) -> Path:
+    return _registry_dir(repo_root) / "logs"
+
+
+def _session_log_path(repo_root: Path, session_name: str) -> Path:
+    safe_name = _sanitize_session_name(session_name)
+    return _logs_dir(repo_root) / f"{safe_name}.log"
+
+
+def _tail_text(text: str, line_count: int) -> str:
+    if line_count <= 0:
+        return text
+    lines = text.splitlines()
+    return "\n".join(lines[-line_count:])
+
+
+def prompt_marker(prompt_id: str, *, at: datetime | None = None) -> str:
+    return f"{_PROMPT_MARKER_PREFIX}{prompt_id} {_isoformat_utc(at or _utc_now())}"
+
+
+def append_prompt_marker(log_path: Path, *, prompt_id: str, at: datetime | None = None) -> str:
+    marker = prompt_marker(prompt_id, at=at)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{marker}\n")
+    return marker
+
+
+def extract_output_after_marker(text: str, *, prompt_id: str | None) -> str:
+    if not prompt_id:
+        return text
+    prefix = f"{_PROMPT_MARKER_PREFIX}{prompt_id} "
+    marker_index = -1
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith(prefix):
+            marker_index = index
+    if marker_index < 0:
+        return text
+    return "\n".join(lines[marker_index + 1 :])
+
+
+@dataclass(slots=True)
+class SessionRecord:
+    name: str
+    tmux_session: str
+    tmux_window: str
+    tmux_pane: str
+    launcher_command: str
+    started_at: str
+    log_path: str
+    last_prompt_at: str | None = None
+    last_prompt_id: str | None = None
+    worktree_path: str | None = None
+    branch: str | None = None
+    launcher_log_path: str | None = None
+    meta_path: str | None = None
+
+    @property
+    def tmux_target(self) -> str:
+        return f"{self.tmux_session}:{self.tmux_window}.{self.tmux_pane}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "tmux_session": self.tmux_session,
+            "tmux_window": self.tmux_window,
+            "tmux_pane": self.tmux_pane,
+            "launcher_command": self.launcher_command,
+            "started_at": self.started_at,
+            "last_prompt_at": self.last_prompt_at,
+            "last_prompt_id": self.last_prompt_id,
+            "worktree_path": self.worktree_path,
+            "branch": self.branch,
+            "log_path": self.log_path,
+            "launcher_log_path": self.launcher_log_path,
+            "meta_path": self.meta_path,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "SessionRecord":
+        return cls(
+            name=str(payload.get("name", "") or ""),
+            tmux_session=str(payload.get("tmux_session", "") or ""),
+            tmux_window=str(payload.get("tmux_window", "") or "0"),
+            tmux_pane=str(payload.get("tmux_pane", "") or "0"),
+            launcher_command=str(payload.get("launcher_command", "") or ""),
+            started_at=str(payload.get("started_at", "") or ""),
+            log_path=str(payload.get("log_path", "") or ""),
+            last_prompt_at=str(payload.get("last_prompt_at"))
+            if payload.get("last_prompt_at")
+            else None,
+            last_prompt_id=str(payload.get("last_prompt_id"))
+            if payload.get("last_prompt_id")
+            else None,
+            worktree_path=str(payload.get("worktree_path"))
+            if payload.get("worktree_path")
+            else None,
+            branch=str(payload.get("branch")) if payload.get("branch") else None,
+            launcher_log_path=(
+                str(payload.get("launcher_log_path")) if payload.get("launcher_log_path") else None
+            ),
+            meta_path=str(payload.get("meta_path")) if payload.get("meta_path") else None,
+        )
+
+
+class SessionMuxRegistry:
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root.resolve()
+        self.path = _registry_path(self.repo_root)
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"schema_version": _REGISTRY_SCHEMA_VERSION, "sessions": {}}
+        payload = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"Invalid session mux registry payload: {self.path}")
+        payload.setdefault("schema_version", _REGISTRY_SCHEMA_VERSION)
+        payload.setdefault("sessions", {})
+        return payload
+
+    def _save(self, payload: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def list(self) -> list[SessionRecord]:
+        payload = self._load()
+        sessions = payload.get("sessions", {})
+        if not isinstance(sessions, dict):
+            return []
+        return [
+            SessionRecord.from_dict(dict(item))
+            for _, item in sorted(sessions.items(), key=lambda pair: str(pair[0]))
+            if isinstance(item, dict)
+        ]
+
+    def get(self, name: str) -> SessionRecord | None:
+        payload = self._load()
+        sessions = payload.get("sessions", {})
+        if not isinstance(sessions, dict):
+            return None
+        raw = sessions.get(name)
+        if not isinstance(raw, dict):
+            return None
+        return SessionRecord.from_dict(raw)
+
+    def upsert(self, record: SessionRecord) -> None:
+        payload = self._load()
+        sessions = payload.setdefault("sessions", {})
+        if not isinstance(sessions, dict):
+            sessions = {}
+            payload["sessions"] = sessions
+        sessions[record.name] = record.to_dict()
+        self._save(payload)
+
+
+def build_tmux_new_session_cmd(*, tmux_session: str, cwd: Path, command: str) -> list[str]:
+    return ["tmux", "new-session", "-d", "-s", tmux_session, "-c", str(cwd), command]
+
+
+def build_tmux_list_panes_cmd(tmux_session: str) -> list[str]:
+    return [
+        "tmux",
+        "list-panes",
+        "-t",
+        tmux_session,
+        "-F",
+        "#{window_index}\t#{pane_index}\t#{pane_current_path}",
+    ]
+
+
+def build_tmux_pipe_pane_cmd(*, target: str, log_path: Path) -> list[str]:
+    sink = f"cat >> {shlex.quote(str(log_path))}"
+    return ["tmux", "pipe-pane", "-o", "-t", target, sink]
+
+
+def build_tmux_load_buffer_cmd() -> list[str]:
+    return ["tmux", "load-buffer", "-"]
+
+
+def build_tmux_paste_buffer_cmd(*, target: str) -> list[str]:
+    return ["tmux", "paste-buffer", "-d", "-t", target]
+
+
+def build_tmux_send_enter_cmd(*, target: str) -> list[str]:
+    return ["tmux", "send-keys", "-t", target, "Enter"]
+
+
+def build_tmux_capture_pane_cmd(*, target: str, line_count: int) -> list[str]:
+    return ["tmux", "capture-pane", "-p", "-t", target, "-S", f"-{max(line_count, 1)}"]
+
+
+def _run_tmux(cmd: list[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _tmux_session_exists(tmux_session: str) -> bool:
+    result = _run_tmux(["tmux", "has-session", "-t", tmux_session])
+    return result.returncode == 0
+
+
+def _primary_pane(tmux_session: str) -> dict[str, str]:
+    result = _run_tmux(build_tmux_list_panes_cmd(tmux_session))
+    if result.returncode != 0 or not result.stdout.strip():
+        raise RuntimeError(
+            f"Unable to inspect tmux panes for session {tmux_session}: {result.stderr.strip()}"
+        )
+    line = result.stdout.strip().splitlines()[0]
+    parts = line.split("\t")
+    if len(parts) != 3:
+        raise RuntimeError(f"Unexpected tmux pane format for session {tmux_session}: {line}")
+    window, pane, current_path = parts
+    return {
+        "window": window,
+        "pane": pane,
+        "current_path": current_path,
+    }
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _codex_meta_candidates(repo_root: Path) -> list[Path]:
+    worktrees_root = repo_root / ".worktrees"
+    if not worktrees_root.exists():
+        return []
+    return sorted(worktrees_root.rglob(".codex_session_meta.json"))
+
+
+def _best_codex_meta(repo_root: Path, *, agent_name: str) -> dict[str, Any]:
+    matched: list[dict[str, Any]] = []
+    for path in _codex_meta_candidates(repo_root):
+        payload = _read_json(path)
+        if str(payload.get("agent", "") or "") != agent_name:
+            continue
+        payload["meta_path"] = str(path)
+        matched.append(payload)
+    if not matched:
+        return {}
+    matched.sort(key=lambda item: str(item.get("started_at", "")))
+    return matched[-1]
+
+
+def _git_branch(path: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def refresh_session_record(repo_root: Path, record: SessionRecord) -> SessionRecord:
+    refreshed = SessionRecord.from_dict(record.to_dict())
+    if _tmux_session_exists(refreshed.tmux_session):
+        pane = _primary_pane(refreshed.tmux_session)
+        refreshed.tmux_window = pane["window"]
+        refreshed.tmux_pane = pane["pane"]
+        current_path = pane["current_path"].strip()
+        if current_path:
+            refreshed.worktree_path = current_path
+            if refreshed.branch is None:
+                refreshed.branch = _git_branch(Path(current_path))
+    meta = _best_codex_meta(repo_root, agent_name=refreshed.name)
+    if meta:
+        worktree_path = str(meta.get("worktree_path", "") or "").strip()
+        refreshed.worktree_path = worktree_path or refreshed.worktree_path
+        refreshed.branch = str(meta.get("branch", "") or "").strip() or refreshed.branch
+        refreshed.launcher_log_path = (
+            str(meta.get("log_path", "") or "").strip() or refreshed.launcher_log_path
+        )
+        refreshed.meta_path = str(meta.get("meta_path", "") or "").strip() or refreshed.meta_path
+    return refreshed
+
+
+def session_status(repo_root: Path, *, name: str) -> dict[str, Any]:
+    registry = SessionMuxRegistry(repo_root)
+    record = registry.get(name)
+    if record is None:
+        raise KeyError(f"Unknown session: {name}")
+    record = refresh_session_record(repo_root, record)
+    registry.upsert(record)
+    running = _tmux_session_exists(record.tmux_session)
+    payload = record.to_dict()
+    payload["running"] = running
+    payload["tmux_target"] = record.tmux_target
+    return payload
+
+
+def list_sessions(repo_root: Path) -> list[dict[str, Any]]:
+    registry = SessionMuxRegistry(repo_root)
+    statuses: list[dict[str, Any]] = []
+    for record in registry.list():
+        refreshed = refresh_session_record(repo_root, record)
+        registry.upsert(refreshed)
+        status = refreshed.to_dict()
+        status["running"] = _tmux_session_exists(refreshed.tmux_session)
+        status["tmux_target"] = refreshed.tmux_target
+        statuses.append(status)
+    return statuses
+
+
+def launch_session(repo_root: Path, *, name: str, command: str) -> dict[str, Any]:
+    if not command.strip():
+        raise ValueError("Launch command must not be empty")
+    registry = SessionMuxRegistry(repo_root)
+    existing = registry.get(name)
+    if existing is not None and _tmux_session_exists(existing.tmux_session):
+        raise ValueError(f"Session already running: {name}")
+
+    tmux_session = _sanitize_session_name(name)
+    if _tmux_session_exists(tmux_session):
+        raise ValueError(f"tmux session already exists: {tmux_session}")
+
+    started_at = _isoformat_utc(_utc_now())
+    log_path = _session_log_path(repo_root, name)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("", encoding="utf-8")
+
+    create_result = _run_tmux(
+        build_tmux_new_session_cmd(tmux_session=tmux_session, cwd=repo_root, command=command)
+    )
+    if create_result.returncode != 0:
+        raise RuntimeError(create_result.stderr.strip() or f"tmux launch failed for {name}")
+
+    pane = _primary_pane(tmux_session)
+    base_record = SessionRecord(
+        name=name,
+        tmux_session=tmux_session,
+        tmux_window=pane["window"],
+        tmux_pane=pane["pane"],
+        launcher_command=command,
+        started_at=started_at,
+        worktree_path=pane["current_path"].strip() or None,
+        branch=_git_branch(Path(pane["current_path"])) if pane["current_path"].strip() else None,
+        log_path=str(log_path),
+    )
+    pipe_result = _run_tmux(
+        build_tmux_pipe_pane_cmd(target=base_record.tmux_target, log_path=log_path)
+    )
+    if pipe_result.returncode != 0:
+        raise RuntimeError(pipe_result.stderr.strip() or f"tmux pipe-pane failed for {name}")
+
+    record = refresh_session_record(repo_root, base_record)
+    registry.upsert(record)
+    payload = record.to_dict()
+    payload["running"] = True
+    payload["tmux_target"] = record.tmux_target
+    return payload
+
+
+def send_prompt(
+    repo_root: Path,
+    *,
+    name: str,
+    text: str | None = None,
+    file_path: Path | None = None,
+) -> dict[str, Any]:
+    if not text and file_path is None:
+        raise ValueError("Provide either text or file_path")
+    if text and file_path is not None:
+        raise ValueError("Provide either text or file_path, not both")
+
+    registry = SessionMuxRegistry(repo_root)
+    record = registry.get(name)
+    if record is None:
+        raise KeyError(f"Unknown session: {name}")
+    record = refresh_session_record(repo_root, record)
+    if not _tmux_session_exists(record.tmux_session):
+        raise RuntimeError(f"tmux session is not running: {name}")
+
+    prompt_text = text if text is not None else file_path.read_text(encoding="utf-8")
+    prompt_id = uuid.uuid4().hex[:8]
+    prompt_at = _utc_now()
+    append_prompt_marker(Path(record.log_path), prompt_id=prompt_id, at=prompt_at)
+
+    load_result = _run_tmux(build_tmux_load_buffer_cmd(), input_text=prompt_text)
+    if load_result.returncode != 0:
+        raise RuntimeError(load_result.stderr.strip() or f"tmux load-buffer failed for {name}")
+    paste_result = _run_tmux(build_tmux_paste_buffer_cmd(target=record.tmux_target))
+    if paste_result.returncode != 0:
+        raise RuntimeError(paste_result.stderr.strip() or f"tmux paste-buffer failed for {name}")
+    enter_result = _run_tmux(build_tmux_send_enter_cmd(target=record.tmux_target))
+    if enter_result.returncode != 0:
+        raise RuntimeError(enter_result.stderr.strip() or f"tmux send-keys failed for {name}")
+
+    record.last_prompt_id = prompt_id
+    record.last_prompt_at = _isoformat_utc(prompt_at)
+    registry.upsert(record)
+    payload = record.to_dict()
+    payload["running"] = True
+    payload["tmux_target"] = record.tmux_target
+    return payload
+
+
+def capture_output(repo_root: Path, *, name: str, tail_lines: int = 200) -> str:
+    registry = SessionMuxRegistry(repo_root)
+    record = registry.get(name)
+    if record is None:
+        raise KeyError(f"Unknown session: {name}")
+    log_path = Path(record.log_path)
+    text = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+    captured = extract_output_after_marker(text, prompt_id=record.last_prompt_id)
+    return _tail_text(captured, tail_lines).rstrip()
+
+
+def tail_output(repo_root: Path, *, name: str, line_count: int = 200) -> str:
+    registry = SessionMuxRegistry(repo_root)
+    record = registry.get(name)
+    if record is None:
+        raise KeyError(f"Unknown session: {name}")
+    record = refresh_session_record(repo_root, record)
+    registry.upsert(record)
+
+    if _tmux_session_exists(record.tmux_session):
+        result = _run_tmux(
+            build_tmux_capture_pane_cmd(target=record.tmux_target, line_count=line_count)
+        )
+        if result.returncode == 0:
+            return result.stdout.rstrip()
+    log_path = Path(record.log_path)
+    if not log_path.exists():
+        return ""
+    return _tail_text(log_path.read_text(encoding="utf-8"), line_count).rstrip()

--- a/scripts/swarm_session_mux.py
+++ b/scripts/swarm_session_mux.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from aragora.swarm import session_mux
+
+
+def _repo_root() -> Path:
+    return session_mux.resolve_repo_root(Path.cwd())
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="tmux-backed session transport for Aragora")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    launch = subparsers.add_parser("launch", help="launch a named session under tmux")
+    launch.add_argument("--name", required=True)
+    launch.add_argument("--cmd", required=True)
+
+    list_parser = subparsers.add_parser("list", help="list registered sessions")
+    list_parser.add_argument("--json", action="store_true")
+
+    status = subparsers.add_parser("status", help="show status for one session")
+    status.add_argument("--name", required=True)
+    status.add_argument("--json", action="store_true")
+
+    send = subparsers.add_parser("send", help="send text or file contents to a session")
+    send.add_argument("--name", required=True)
+    group = send.add_mutually_exclusive_group(required=True)
+    group.add_argument("--text")
+    group.add_argument("--file", dest="file_path")
+
+    capture = subparsers.add_parser("capture", help="capture output since the last prompt marker")
+    capture.add_argument("--name", required=True)
+    capture.add_argument("--tail", type=int, default=200)
+
+    tail = subparsers.add_parser("tail", help="tail recent output for a session")
+    tail.add_argument("--name", required=True)
+    tail.add_argument("--lines", type=int, default=200)
+    return parser
+
+
+def _print_json(payload: object) -> None:
+    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _print_status_text(status: dict[str, object]) -> None:
+    line = (
+        f"{status['name']}: running={status['running']} "
+        f"tmux={status['tmux_target']} branch={status.get('branch') or '-'} "
+        f"worktree={status.get('worktree_path') or '-'}"
+    )
+    sys.stdout.write(f"{line}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    repo_root = _repo_root()
+
+    try:
+        if args.command == "launch":
+            payload = session_mux.launch_session(repo_root, name=args.name, command=args.cmd)
+            _print_json(payload)
+            return 0
+        if args.command == "list":
+            payload = session_mux.list_sessions(repo_root)
+            if args.json:
+                _print_json(payload)
+            else:
+                for item in payload:
+                    _print_status_text(item)
+            return 0
+        if args.command == "status":
+            payload = session_mux.session_status(repo_root, name=args.name)
+            if args.json:
+                _print_json(payload)
+            else:
+                _print_status_text(payload)
+            return 0
+        if args.command == "send":
+            file_path = Path(args.file_path).resolve() if args.file_path else None
+            payload = session_mux.send_prompt(
+                repo_root,
+                name=args.name,
+                text=args.text,
+                file_path=file_path,
+            )
+            _print_json(payload)
+            return 0
+        if args.command == "capture":
+            text = session_mux.capture_output(repo_root, name=args.name, tail_lines=args.tail)
+            sys.stdout.write(f"{text}\n" if text else "")
+            return 0
+        if args.command == "tail":
+            text = session_mux.tail_output(repo_root, name=args.name, line_count=args.lines)
+            sys.stdout.write(f"{text}\n" if text else "")
+            return 0
+    except (FileNotFoundError, KeyError, RuntimeError, ValueError) as exc:
+        parser.exit(status=1, message=f"{exc}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_swarm_session_mux.py
+++ b/tests/scripts/test_swarm_session_mux.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import scripts.swarm_session_mux as cli
+from aragora.swarm import session_mux
+
+
+def _completed(*, returncode: int = 0, stdout: str = "", stderr: str = "") -> SimpleNamespace:
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_launch_command_creates_registry_entry(monkeypatch, tmp_path: Path, capsys) -> None:
+    state = {"exists": False}
+
+    def fake_run(cmd: list[str], **kwargs) -> SimpleNamespace:  # noqa: ANN003
+        if cmd[:3] == ["tmux", "has-session", "-t"]:
+            return _completed(returncode=0 if state["exists"] else 1)
+        if cmd[:2] == ["tmux", "new-session"]:
+            state["exists"] = True
+            return _completed()
+        if cmd[:2] == ["tmux", "list-panes"]:
+            return _completed(stdout="0\t0\t/tmp/codex-worktree\n")
+        if cmd[:2] == ["tmux", "pipe-pane"]:
+            return _completed()
+        if cmd[:3] == ["git", "-C", "/tmp/codex-worktree"]:
+            return _completed(stdout="codex/demo\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(cli, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(session_mux.subprocess, "run", fake_run)
+
+    exit_code = cli.main(
+        [
+            "launch",
+            "--name",
+            "codex-1",
+            "--cmd",
+            "./scripts/codex_session.sh --agent codex-1 -- zsh -l",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = capsys.readouterr().out
+    assert '"name": "codex-1"' in payload
+    record = session_mux.SessionMuxRegistry(tmp_path).get("codex-1")
+    assert record is not None
+    assert record.branch == "codex/demo"
+
+
+def test_list_command_prints_json(monkeypatch, tmp_path: Path, capsys) -> None:
+    registry = session_mux.SessionMuxRegistry(tmp_path)
+    registry.upsert(
+        session_mux.SessionRecord(
+            name="codex-1",
+            tmux_session="codex-1",
+            tmux_window="0",
+            tmux_pane="0",
+            launcher_command="codex",
+            started_at="2026-04-13T18:00:00Z",
+            log_path=str(tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"),
+        )
+    )
+
+    def fake_run(cmd: list[str], **kwargs) -> SimpleNamespace:  # noqa: ANN003
+        if cmd[:3] == ["tmux", "has-session", "-t"]:
+            return _completed(returncode=0)
+        if cmd[:2] == ["tmux", "list-panes"]:
+            return _completed(stdout="0\t0\t/tmp/codex-worktree\n")
+        if cmd[:3] == ["git", "-C", "/tmp/codex-worktree"]:
+            return _completed(stdout="codex/demo\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(cli, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(session_mux.subprocess, "run", fake_run)
+
+    exit_code = cli.main(["list", "--json"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert '"name": "codex-1"' in output
+    assert '"running": true' in output
+
+
+def test_send_command_updates_prompt_marker(monkeypatch, tmp_path: Path, capsys) -> None:
+    log_path = tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"
+    registry = session_mux.SessionMuxRegistry(tmp_path)
+    registry.upsert(
+        session_mux.SessionRecord(
+            name="codex-1",
+            tmux_session="codex-1",
+            tmux_window="0",
+            tmux_pane="0",
+            launcher_command="codex",
+            started_at="2026-04-13T18:00:00Z",
+            log_path=str(log_path),
+        )
+    )
+
+    def fake_run(cmd: list[str], **kwargs) -> SimpleNamespace:  # noqa: ANN003
+        if cmd[:3] == ["tmux", "has-session", "-t"]:
+            return _completed(returncode=0)
+        if cmd[:2] == ["tmux", "list-panes"]:
+            return _completed(stdout="0\t0\t/tmp/codex-worktree\n")
+        if cmd[:3] == ["git", "-C", "/tmp/codex-worktree"]:
+            return _completed(stdout="codex/demo\n")
+        if cmd[:2] == ["tmux", "load-buffer"]:
+            assert kwargs["input"] == "hello from mux"
+            return _completed()
+        if cmd[:2] == ["tmux", "paste-buffer"]:
+            return _completed()
+        if cmd[:2] == ["tmux", "send-keys"]:
+            return _completed()
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(cli, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(session_mux.subprocess, "run", fake_run)
+
+    exit_code = cli.main(["send", "--name", "codex-1", "--text", "hello from mux"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert '"last_prompt_id":' in output
+    saved = session_mux.SessionMuxRegistry(tmp_path).get("codex-1")
+    assert saved is not None
+    assert saved.last_prompt_id is not None
+    assert saved.last_prompt_at is not None
+    assert "ARAGORA_SESSION_MUX_PROMPT" in log_path.read_text(encoding="utf-8")
+
+
+def test_capture_command_reads_log_since_last_prompt(monkeypatch, tmp_path: Path, capsys) -> None:
+    log_path = tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text(
+        "\n".join(
+            [
+                "boot",
+                session_mux.prompt_marker("old"),
+                "before",
+                session_mux.prompt_marker("fresh"),
+                "captured line",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    registry = session_mux.SessionMuxRegistry(tmp_path)
+    registry.upsert(
+        session_mux.SessionRecord(
+            name="codex-1",
+            tmux_session="codex-1",
+            tmux_window="0",
+            tmux_pane="0",
+            launcher_command="codex",
+            started_at="2026-04-13T18:00:00Z",
+            log_path=str(log_path),
+            last_prompt_id="fresh",
+        )
+    )
+
+    monkeypatch.setattr(cli, "_repo_root", lambda: tmp_path)
+
+    exit_code = cli.main(["capture", "--name", "codex-1", "--tail", "20"])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out.strip() == "captured line"

--- a/tests/swarm/test_session_mux.py
+++ b/tests/swarm/test_session_mux.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aragora.swarm import session_mux as mod
+
+
+def test_registry_round_trip(tmp_path: Path) -> None:
+    registry = mod.SessionMuxRegistry(tmp_path)
+    record = mod.SessionRecord(
+        name="codex-1",
+        tmux_session="codex-1",
+        tmux_window="0",
+        tmux_pane="0",
+        launcher_command="./scripts/codex_session.sh --agent codex-1 -- zsh -l",
+        started_at="2026-04-13T18:00:00Z",
+        log_path=str(tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"),
+        worktree_path="/tmp/worktree",
+        branch="codex/demo",
+    )
+
+    registry.upsert(record)
+
+    loaded = registry.get("codex-1")
+    assert loaded is not None
+    assert loaded.to_dict() == record.to_dict()
+    payload = json.loads((tmp_path / ".aragora" / "session_mux" / "registry.json").read_text())
+    assert payload["schema_version"] == 1
+
+
+def test_extract_output_after_marker_uses_latest_matching_boundary() -> None:
+    old_marker = mod.prompt_marker("old")
+    new_marker = mod.prompt_marker("new")
+    text = "\n".join(
+        [
+            "before",
+            old_marker,
+            "old output",
+            new_marker,
+            "line a",
+            "line b",
+        ]
+    )
+
+    assert mod.extract_output_after_marker(text, prompt_id="new") == "line a\nline b"
+
+
+def test_build_tmux_commands_are_stable(tmp_path: Path) -> None:
+    new_session = mod.build_tmux_new_session_cmd(
+        tmux_session="codex-1",
+        cwd=tmp_path,
+        command="./scripts/codex_session.sh --agent codex-1 -- zsh -l",
+    )
+    pipe_pane = mod.build_tmux_pipe_pane_cmd(
+        target="codex-1:0.0",
+        log_path=tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log",
+    )
+
+    assert new_session == [
+        "tmux",
+        "new-session",
+        "-d",
+        "-s",
+        "codex-1",
+        "-c",
+        str(tmp_path),
+        "./scripts/codex_session.sh --agent codex-1 -- zsh -l",
+    ]
+    assert pipe_pane[:5] == ["tmux", "pipe-pane", "-o", "-t", "codex-1:0.0"]
+    assert "cat >>" in pipe_pane[5]
+
+
+def test_refresh_session_record_harvests_codex_metadata(monkeypatch, tmp_path: Path) -> None:
+    meta_path = tmp_path / ".worktrees" / "codex-auto" / "codex-1" / ".codex_session_meta.json"
+    meta_path.parent.mkdir(parents=True)
+    meta_path.write_text(
+        json.dumps(
+            {
+                "agent": "codex-1",
+                "branch": "codex/branch",
+                "worktree_path": "/tmp/codex-worktree",
+                "log_path": "/tmp/codex-worktree/.codex_session.log",
+                "started_at": "2026-04-13T18:30:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    record = mod.SessionRecord(
+        name="codex-1",
+        tmux_session="codex-1",
+        tmux_window="0",
+        tmux_pane="0",
+        launcher_command="codex",
+        started_at="2026-04-13T18:00:00Z",
+        log_path=str(tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"),
+    )
+    monkeypatch.setattr(mod, "_tmux_session_exists", lambda _: False)
+
+    refreshed = mod.refresh_session_record(tmp_path, record)
+
+    assert refreshed.worktree_path == "/tmp/codex-worktree"
+    assert refreshed.branch == "codex/branch"
+    assert refreshed.launcher_log_path == "/tmp/codex-worktree/.codex_session.log"
+    assert refreshed.meta_path == str(meta_path)
+
+
+def test_capture_output_uses_last_prompt_marker(tmp_path: Path) -> None:
+    log_path = tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text(
+        "\n".join(
+            [
+                "boot",
+                mod.prompt_marker("older"),
+                "stale",
+                mod.prompt_marker("fresh"),
+                "recent line 1",
+                "recent line 2",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    registry = mod.SessionMuxRegistry(tmp_path)
+    registry.upsert(
+        mod.SessionRecord(
+            name="codex-1",
+            tmux_session="codex-1",
+            tmux_window="0",
+            tmux_pane="0",
+            launcher_command="codex",
+            started_at="2026-04-13T18:00:00Z",
+            log_path=str(log_path),
+            last_prompt_id="fresh",
+        )
+    )
+
+    captured = mod.capture_output(tmp_path, name="codex-1", tail_lines=1)
+
+    assert captured == "recent line 2"


### PR DESCRIPTION
## Summary
- add a tmux-backed session transport with registry, log markers, and Codex metadata harvesting
- add a thin CLI for launch/list/status/send/capture/tail
- cover registry, marker parsing, tmux command construction, and CLI smoke paths with focused tests

## Validation
- python3 -m pytest tests/swarm/test_session_mux.py tests/scripts/test_swarm_session_mux.py -q
- python3 -m ruff check aragora/swarm/session_mux.py scripts/swarm_session_mux.py tests/swarm/test_session_mux.py tests/scripts/test_swarm_session_mux.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD