### PR TITLE
fix: add RBAC guards to admin health helpers

### DIFF
--- a/aragora/server/handlers/admin/health/agent_health.py
+++ b/aragora/server/handlers/admin/health/agent_health.py
@@ -13,9 +13,42 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from aragora.rbac.checker import get_permission_checker
+from aragora.rbac.models import AuthorizationContext
+
 from ...base import HandlerResult, json_response
 
 logger = logging.getLogger(__name__)
+HEALTH_PERMISSION = "system.health.read"
+
+
+def _require_health_permission(handler: Any) -> HandlerResult | None:
+    """Honor an attached auth_context when these helpers are called directly.
+
+    The main health handler enforces `system.health.read` before routing into
+    this module. This secondary guard covers direct helper entrypoints that are
+    invoked with an AuthorizationContext-bearing handler object.
+    """
+    auth_context = getattr(handler, "_auth_context", None)
+    if not isinstance(auth_context, AuthorizationContext):
+        return None
+
+    decision = get_permission_checker().check_permission(auth_context, HEALTH_PERMISSION)
+    if decision.allowed:
+        return None
+
+    logger.warning(
+        "Permission denied for agent health helper: %s user=%s",
+        HEALTH_PERMISSION,
+        auth_context.user_id,
+    )
+    return json_response(
+        {
+            "error": "Permission denied",
+            "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
+        },
+        status=403,
+    )
 
 
 def _get_watchdog() -> Any | None:
@@ -38,6 +71,9 @@ def agent_health_summary(handler: Any) -> HandlerResult:
     Returns:
         JSON response with agent health summary
     """
+    if permission_error := _require_health_permission(handler):
+        return permission_error
+
     agents: list[dict[str, Any]] = []
     errors: list[str] = []
     watchdog_available = False
@@ -136,6 +172,9 @@ def agent_health_detail(handler: Any, agent_id: str) -> HandlerResult:
     Returns:
         JSON response with detailed agent health or 404 if not found
     """
+    if permission_error := _require_health_permission(handler):
+        return permission_error
+
     try:
         watchdog = _get_watchdog()
         if watchdog:
@@ -210,6 +249,9 @@ def agent_availability_status(handler: Any) -> HandlerResult:
     Returns:
         JSON response with availability data
     """
+    if permission_error := _require_health_permission(handler):
+        return permission_error
+
     available: list[dict[str, Any]] = []
     unavailable: list[dict[str, Any]] = []
     errors: list[str] = []

--- a/aragora/server/handlers/admin/health/metrics_health.py
+++ b/aragora/server/handlers/admin/health/metrics_health.py
@@ -11,9 +11,42 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from aragora.rbac.checker import get_permission_checker
+from aragora.rbac.models import AuthorizationContext
+
 from ...base import HandlerResult, json_response
 
 logger = logging.getLogger(__name__)
+HEALTH_PERMISSION = "system.health.read"
+
+
+def _require_health_permission(handler: Any) -> HandlerResult | None:
+    """Honor an attached auth_context when this helper is called directly.
+
+    The main health handler enforces `system.health.read` before routing into
+    this module. This helper closes the gap for direct invocations that pass an
+    AuthorizationContext-bearing handler object.
+    """
+    auth_context = getattr(handler, "_auth_context", None)
+    if not isinstance(auth_context, AuthorizationContext):
+        return None
+
+    decision = get_permission_checker().check_permission(auth_context, HEALTH_PERMISSION)
+    if decision.allowed:
+        return None
+
+    logger.warning(
+        "Permission denied for metrics health helper: %s user=%s",
+        HEALTH_PERMISSION,
+        auth_context.user_id,
+    )
+    return json_response(
+        {
+            "error": "Permission denied",
+            "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
+        },
+        status=403,
+    )
 
 
 def metrics_health(handler: Any) -> HandlerResult:
@@ -29,6 +62,9 @@ def metrics_health(handler: Any) -> HandlerResult:
     Returns:
         JSON response with metrics subsystem health
     """
+    if permission_error := _require_health_permission(handler):
+        return permission_error
+
     components: dict[str, Any] = {}
     issues: list[str] = []
 

--- a/tests/server/handlers/admin/test_server_handlers_admin_health_metrics_health.py
+++ b/tests/server/handlers/admin/test_server_handlers_admin_health_metrics_health.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from aragora.rbac.models import AuthorizationContext
+
 # Pre-stub Slack modules to prevent import chain failures
 _SLACK_ATTRS = [
     "SlackHandler",
@@ -73,6 +75,26 @@ class TestMetricsHealthBasic:
         result = metrics_health(MagicMock())
         data = _parse_body(result)
         assert data["status"] in {"healthy", "degraded", "disabled"}
+
+    def test_denies_direct_calls_without_system_health_permission(self):
+        handler = MagicMock()
+        handler._auth_context = AuthorizationContext(
+            user_id="user-123",
+            org_id="org-123",
+            roles=set(),
+            permissions=set(),
+        )
+        denied = MagicMock(allowed=False, reason="missing system.health.read")
+
+        with patch(
+            "aragora.server.handlers.admin.health.metrics_health.get_permission_checker"
+        ) as mock_checker:
+            mock_checker.return_value.check_permission.return_value = denied
+            result = metrics_health(handler)
+
+        data = _parse_body(result)
+        assert result.status_code == 403
+        assert data["error"] == "Permission denied"
 
 
 class TestMetricsHealthEnabled:

--- a/tests/server_handlers_admin_health_agent_health/test_server_handlers_admin_health_agent_health.py
+++ b/tests/server_handlers_admin_health_agent_health/test_server_handlers_admin_health_agent_health.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from aragora.rbac.models import AuthorizationContext
 from aragora.server.handlers.admin.health.agent_health import (
     _classify_agent_status,
     agent_availability_status,
@@ -196,6 +197,23 @@ class TestAgentHealthSummary:
         assert body["status"] == "unknown"
         assert body["summary"]["total_agents"] == 0
         assert "watchdog module not available" in body["errors"]
+
+    def test_denies_direct_calls_without_system_health_permission(self):
+        handler = _make_handler()
+        handler._auth_context = AuthorizationContext(
+            user_id="user-123",
+            org_id="org-123",
+            roles=set(),
+            permissions=set(),
+        )
+        denied = MagicMock(allowed=False, reason="missing system.health.read")
+
+        with patch(f"{_MOD}.get_permission_checker") as mock_checker:
+            mock_checker.return_value.check_permission.return_value = denied
+            result = agent_health_summary(handler)
+
+        assert _status(result) == 403
+        assert _body(result)["error"] == "Permission denied"
 
     def test_watchdog_returns_agents(self):
         healthy_agent = FakeAgentHealth(
@@ -438,6 +456,23 @@ class TestAgentHealthDetail:
         assert _status(result) == 404
         body = _body(result)
         assert "Agent not found" in body["error"]
+
+    def test_denies_direct_detail_calls_without_system_health_permission(self):
+        handler = _make_handler()
+        handler._auth_context = AuthorizationContext(
+            user_id="user-123",
+            org_id="org-123",
+            roles=set(),
+            permissions=set(),
+        )
+        denied = MagicMock(allowed=False, reason="missing system.health.read")
+
+        with patch(f"{_MOD}.get_permission_checker") as mock_checker:
+            mock_checker.return_value.check_permission.return_value = denied
+            result = agent_health_detail(handler, "claude-opus")
+
+        assert _status(result) == 403
+        assert _body(result)["error"] == "Permission denied"
 
     def test_watchdog_import_error(self):
         with patch(f"{_MOD}._get_watchdog", side_effect=ImportError):


### PR DESCRIPTION
Follow-up to merged #5272.

## What changed
- add direct-call RBAC guards to `agent_health.py` and `metrics_health.py` when a real `AuthorizationContext` is attached
- add focused denial tests for those helpers

## Validation
- `pytest -q tests/server_handlers_admin_health_agent_health/test_server_handlers_admin_health_agent_health.py tests/server/handlers/admin/test_server_handlers_admin_health_metrics_health.py tests/rbac/test_handler_enforcement.py::TestHandlerRBACEnforcement::test_all_handlers_have_authorization`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`