### PR TITLE
feat(swarm): dispatch conductor prompts via tmux

### DIFF
--- a/aragora/swarm/conductor.py
+++ b/aragora/swarm/conductor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -296,6 +297,90 @@ class Conductor:
         )
         self._session_store.append_step(step)
         return step
+
+    def dispatch_step_to_tmux(
+        self,
+        step: ConductorStep,
+        *,
+        session_name: str,
+        wait_seconds: int = 0,
+        harvest_lines: int = 200,
+    ) -> dict[str, Any]:
+        """Send a generated follow-up prompt to a tmux-managed agent session.
+
+        This stays intentionally thin: it reuses the already-landed shell
+        transport scripts instead of reimplementing pane control here.
+        """
+        prompt_text = _text(step.next_prompt)
+        if not prompt_text:
+            return {
+                "sent": False,
+                "reason": "no_prompt",
+                "session_name": session_name,
+                "next_action": step.next_action,
+            }
+
+        send_script = self.repo_root / "scripts" / "tmux_send_prompt.sh"
+        harvest_script = self.repo_root / "scripts" / "tmux_harvest.sh"
+        if not send_script.exists():
+            raise FileNotFoundError(f"tmux send script not found: {send_script}")
+
+        prompt_path = self._write_dispatch_prompt_file(step, prompt_text)
+        try:
+            send_cmd = [
+                str(send_script),
+                "--name",
+                session_name,
+                "--prompt-file",
+                str(prompt_path),
+            ]
+            if wait_seconds > 0:
+                send_cmd.extend(["--wait", str(wait_seconds)])
+            send_result = subprocess.run(
+                send_cmd,
+                cwd=self.repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            prompt_path.unlink(missing_ok=True)
+
+        if send_result.returncode != 0:
+            detail = _text(send_result.stderr) or _text(send_result.stdout) or "tmux send failed"
+            raise RuntimeError(detail)
+
+        harvest_output = ""
+        harvest_error = ""
+        if harvest_lines > 0 and harvest_script.exists():
+            harvest_result = subprocess.run(
+                [
+                    str(harvest_script),
+                    "--name",
+                    session_name,
+                    "--lines",
+                    str(harvest_lines),
+                ],
+                cwd=self.repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if harvest_result.returncode == 0:
+                harvest_output = _text(harvest_result.stdout)
+            else:
+                harvest_error = _text(harvest_result.stderr) or _text(harvest_result.stdout)
+
+        return {
+            "sent": True,
+            "session_name": session_name,
+            "next_action": step.next_action,
+            "prompt_chars": len(prompt_text),
+            "wait_seconds": max(wait_seconds, 0),
+            "harvest_lines": max(harvest_lines, 0),
+            "harvest_output": harvest_output,
+            "harvest_error": harvest_error,
+        }
 
     def generate_retry_prompt(
         self, issue_number: int, prior_output: str, failure_reason: str
@@ -720,6 +805,19 @@ class Conductor:
             )
         guidance.append("Do not repeat the same command sequence unless you learned something new.")
         return _ordered_unique(guidance)
+
+    def _write_dispatch_prompt_file(self, step: ConductorStep, prompt_text: str) -> Path:
+        temp = tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix=f"conductor-issue-{step.issue_number}-",
+            suffix=".md",
+            dir=self._session_store.storage_dir,
+            delete=False,
+        )
+        with temp:
+            temp.write(prompt_text)
+        return Path(temp.name)
 
 
 __all__ = ["Conductor", "ConductorStep", "SessionStateStore"]

--- a/tests/swarm/test_conductor.py
+++ b/tests/swarm/test_conductor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 from aragora.swarm.conductor import Conductor, ConductorStep
 from aragora.swarm.terminal_truth import TerminalClass
@@ -53,6 +54,13 @@ def _result(
     if deliverable is not None:
         result["deliverable"] = dict(deliverable)
     return result
+
+
+def _install_tmux_scripts(repo_root: Path) -> None:
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "tmux_send_prompt.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (scripts_dir / "tmux_harvest.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
 
 
 def test_done_on_deliverable_created(tmp_path: Path) -> None:
@@ -377,3 +385,109 @@ def test_publish_deferred_escalates(tmp_path: Path) -> None:
     )
 
     assert step.next_action == "escalate"
+
+
+def test_dispatch_step_to_tmux_sends_prompt_and_harvests_output(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _install_tmux_scripts(tmp_path)
+    conductor = Conductor(tmp_path)
+    step = conductor.evaluate_worker_output(
+        121,
+        _result(
+            terminal_class=TerminalClass.RESCUE_VERIFICATION_FAILED,
+            worker_output="pytest tests/swarm/test_conductor.py -q\nAssertionError: boom",
+        ),
+    )
+    seen_prompt_path: Path | None = None
+
+    def fake_run(cmd: list[str], **kwargs) -> SimpleNamespace:  # noqa: ANN003
+        nonlocal seen_prompt_path
+        if cmd[0].endswith("tmux_send_prompt.sh"):
+            prompt_index = cmd.index("--prompt-file") + 1
+            seen_prompt_path = Path(cmd[prompt_index])
+            assert seen_prompt_path.exists()
+            assert seen_prompt_path.read_text(encoding="utf-8") == step.next_prompt
+            return SimpleNamespace(returncode=0, stdout="Prompt sent", stderr="")
+        if cmd[0].endswith("tmux_harvest.sh"):
+            return SimpleNamespace(returncode=0, stdout="--- session ---\nagent output", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr("aragora.swarm.conductor.subprocess.run", fake_run)
+
+    result = conductor.dispatch_step_to_tmux(
+        step,
+        session_name="codex-conductor",
+        wait_seconds=5,
+        harvest_lines=80,
+    )
+
+    assert result["sent"] is True
+    assert result["session_name"] == "codex-conductor"
+    assert result["next_action"] == "retry_different_agent"
+    assert result["prompt_chars"] == len(step.next_prompt)
+    assert result["wait_seconds"] == 5
+    assert result["harvest_lines"] == 80
+    assert result["harvest_output"] == "--- session ---\nagent output"
+    assert seen_prompt_path is not None
+    assert not seen_prompt_path.exists()
+
+
+def test_dispatch_step_to_tmux_skips_done_steps(monkeypatch, tmp_path: Path) -> None:
+    conductor = Conductor(tmp_path)
+    step = conductor.evaluate_worker_output(
+        122,
+        _result(
+            status="completed",
+            outcome="deliverable_created",
+            changed_files=["aragora/swarm/conductor.py"],
+        ),
+    )
+
+    def fail_run(cmd: list[str], **kwargs) -> SimpleNamespace:  # noqa: ANN003
+        raise AssertionError(f"subprocess should not be invoked: {cmd}")
+
+    monkeypatch.setattr("aragora.swarm.conductor.subprocess.run", fail_run)
+
+    result = conductor.dispatch_step_to_tmux(step, session_name="codex-conductor")
+
+    assert result == {
+        "sent": False,
+        "reason": "no_prompt",
+        "session_name": "codex-conductor",
+        "next_action": "done",
+    }
+
+
+def test_dispatch_step_to_tmux_raises_and_cleans_prompt_file(monkeypatch, tmp_path: Path) -> None:
+    _install_tmux_scripts(tmp_path)
+    conductor = Conductor(tmp_path)
+    step = conductor.evaluate_worker_output(
+        123,
+        _result(
+            terminal_class=TerminalClass.RESCUE_TIMEOUT,
+            worker_output="Worker timed out before finishing.",
+        ),
+    )
+    seen_prompt_path: Path | None = None
+
+    def fake_run(cmd: list[str], **kwargs) -> SimpleNamespace:  # noqa: ANN003
+        nonlocal seen_prompt_path
+        if cmd[0].endswith("tmux_send_prompt.sh"):
+            prompt_index = cmd.index("--prompt-file") + 1
+            seen_prompt_path = Path(cmd[prompt_index])
+            assert seen_prompt_path.exists()
+            return SimpleNamespace(returncode=1, stdout="", stderr="Window not found")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr("aragora.swarm.conductor.subprocess.run", fake_run)
+
+    try:
+        conductor.dispatch_step_to_tmux(step, session_name="missing-session")
+    except RuntimeError as exc:
+        assert str(exc) == "Window not found"
+    else:
+        raise AssertionError("Expected dispatch_step_to_tmux to raise on send failure")
+
+    assert seen_prompt_path is not None
+    assert not seen_prompt_path.exists()


### PR DESCRIPTION
## Summary
- add a thin conductor hook that sends generated retry, handoff, or escalation prompts through the merged tmux transport scripts
- optionally harvest recent session output after dispatch for operator visibility
- cover send, skip, and failure cleanup behavior with focused conductor tests

## Validation
- python3 -m pytest tests/swarm/test_conductor.py -q
- python3 -m ruff check aragora/swarm/conductor.py tests/swarm/test_conductor.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD