### PR TITLE
fix(scripts): handle multi-line prompts in tmux launcher metadata

### DIFF
--- a/scripts/tmux_harvest.sh
+++ b/scripts/tmux_harvest.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Harvest output from tmux-managed agent sessions.
+#
+# Usage:
+#   ./scripts/tmux_harvest.sh --name codex-conductor              # last 50 lines
+#   ./scripts/tmux_harvest.sh --name codex-conductor --lines 200  # last 200 lines
+#   ./scripts/tmux_harvest.sh --name codex-conductor --full        # full log
+#   ./scripts/tmux_harvest.sh --all                                # summary of all sessions
+#   ./scripts/tmux_harvest.sh --name codex-conductor --since "5 minutes ago"
+#   ./scripts/tmux_harvest.sh --name codex-conductor --grep "error\|FAIL\|passed"
+
+set -euo pipefail
+
+LOG_DIR="${HOME}/.aragora/tmux-sessions"
+TMUX_SESSION="aragora"
+NAME=""
+LINES=50
+FULL=false
+ALL=false
+SINCE=""
+GREP_PATTERN=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --name)   NAME="$2"; shift 2 ;;
+        --lines)  LINES="$2"; shift 2 ;;
+        --full)   FULL=true; shift ;;
+        --all)    ALL=true; shift ;;
+        --since)  SINCE="$2"; shift 2 ;;
+        --grep)   GREP_PATTERN="$2"; shift 2 ;;
+        *)        echo "Unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+_strip_ansi() {
+    # Strip ANSI escape codes for cleaner output
+    sed 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\][^\x07]*\x07//g; s/\r//g'
+}
+
+# --- all sessions summary ---
+if [[ "${ALL}" == "true" ]]; then
+    echo "=== Aragora Agent Sessions ==="
+    echo ""
+
+    for meta in "${LOG_DIR}"/*.meta.json; do
+        [[ -f "${meta}" ]] || continue
+        session_name=$(basename "${meta}" .meta.json)
+        log_file="${LOG_DIR}/${session_name}.log"
+
+        # Read metadata
+        agent=$(python3 -c "import json; print(json.load(open('${meta}')).get('agent','-'))" 2>/dev/null || echo "-")
+        started=$(python3 -c "import json; print(json.load(open('${meta}')).get('started','-'))" 2>/dev/null || echo "-")
+
+        # Check if tmux window is alive
+        alive="dead"
+        if tmux has-session -t "${TMUX_SESSION}" 2>/dev/null; then
+            window_id=$(tmux list-windows -t "${TMUX_SESSION}" -F '#{window_index} #{window_name}' \
+                | awk -v name="${session_name}" '$2 == name { print $1; exit }')
+            [[ -n "${window_id}" ]] && alive="alive"
+        fi
+
+        # Log size
+        log_size="0"
+        if [[ -f "${log_file}" ]]; then
+            log_size=$(wc -l < "${log_file}" | tr -d ' ')
+        fi
+
+        # Last meaningful line
+        last_line=""
+        if [[ -f "${log_file}" ]]; then
+            last_line=$(tail -5 "${log_file}" | _strip_ansi | grep -v '^$' | tail -1 | head -c 80)
+        fi
+
+        printf "%-20s  %-8s  %-5s  %6s lines  %s\n" "${session_name}" "${agent}" "${alive}" "${log_size}" "${last_line}"
+    done
+
+    exit 0
+fi
+
+# --- single session harvest ---
+if [[ -z "${NAME}" ]]; then
+    echo "Usage: --name <session-name> [--lines N] [--full] [--grep pattern]" >&2
+    echo "   or: --all" >&2
+    exit 1
+fi
+
+LOG_FILE="${LOG_DIR}/${NAME}.log"
+
+if [[ ! -f "${LOG_FILE}" ]]; then
+    echo "No log file for '${NAME}' at ${LOG_FILE}" >&2
+    exit 1
+fi
+
+# Apply filters
+if [[ "${FULL}" == "true" ]]; then
+    if [[ -n "${GREP_PATTERN}" ]]; then
+        _strip_ansi < "${LOG_FILE}" | grep -iE "${GREP_PATTERN}"
+    else
+        _strip_ansi < "${LOG_FILE}"
+    fi
+elif [[ -n "${SINCE}" ]]; then
+    # Use find to check if file was modified since the given time
+    # Then show all lines (best effort — log files don't have per-line timestamps)
+    echo "--- ${NAME} output (last ${LINES} lines, since '${SINCE}') ---"
+    tail -n "${LINES}" "${LOG_FILE}" | _strip_ansi
+elif [[ -n "${GREP_PATTERN}" ]]; then
+    echo "--- ${NAME} output (matching '${GREP_PATTERN}') ---"
+    _strip_ansi < "${LOG_FILE}" | grep -iE "${GREP_PATTERN}" | tail -n "${LINES}"
+else
+    echo "--- ${NAME} output (last ${LINES} lines) ---"
+    tail -n "${LINES}" "${LOG_FILE}" | _strip_ansi
+fi

--- a/scripts/tmux_send_prompt.sh
+++ b/scripts/tmux_send_prompt.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Send a prompt to a named tmux pane in the aragora session.
+#
+# Usage:
+#   ./scripts/tmux_send_prompt.sh --name codex-conductor --prompt "Fix the bug in spec.py"
+#   ./scripts/tmux_send_prompt.sh --name codex-conductor --prompt-file /tmp/prompt.md
+#   ./scripts/tmux_send_prompt.sh --name codex-conductor --prompt-file /tmp/prompt.md --wait 30
+#
+# The prompt is sent line-by-line via tmux send-keys. For multi-line prompts
+# from a file, the content is piped through tmux's paste buffer to avoid
+# shell interpretation issues.
+
+set -euo pipefail
+
+TMUX_SESSION="aragora"
+NAME=""
+PROMPT=""
+PROMPT_FILE=""
+WAIT_SECONDS=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --name)        NAME="$2"; shift 2 ;;
+        --prompt)      PROMPT="$2"; shift 2 ;;
+        --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
+        --wait)        WAIT_SECONDS="$2"; shift 2 ;;
+        *)             echo "Unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "${NAME}" ]]; then
+    echo "Usage: --name <pane-name> --prompt <text> | --prompt-file <path>" >&2
+    exit 1
+fi
+
+# Resolve prompt content
+if [[ -n "${PROMPT_FILE}" && -f "${PROMPT_FILE}" ]]; then
+    PROMPT="$(cat "${PROMPT_FILE}")"
+fi
+
+if [[ -z "${PROMPT}" ]]; then
+    echo "No prompt specified. Use --prompt or --prompt-file." >&2
+    exit 1
+fi
+
+# Verify the tmux window exists
+if ! tmux has-session -t "${TMUX_SESSION}" 2>/dev/null; then
+    echo "No aragora tmux session. Launch one first with tmux_session_launcher.sh" >&2
+    exit 1
+fi
+
+window_id=$(tmux list-windows -t "${TMUX_SESSION}" -F '#{window_index} #{window_name}' \
+    | awk -v name="${NAME}" '$2 == name { print $1; exit }')
+
+if [[ -z "${window_id}" ]]; then
+    echo "Window '${NAME}' not found in tmux session '${TMUX_SESSION}'." >&2
+    echo "Available windows:"
+    tmux list-windows -t "${TMUX_SESSION}" -F '  #{window_name}' 2>/dev/null
+    exit 1
+fi
+
+TARGET="${TMUX_SESSION}:${window_id}"
+
+# For multi-line prompts, use tmux paste buffer to avoid shell escaping issues
+if [[ "$(echo "${PROMPT}" | wc -l)" -gt 1 ]]; then
+    tmux set-buffer -b "aragora-prompt" "${PROMPT}"
+    tmux paste-buffer -b "aragora-prompt" -t "${TARGET}"
+    tmux send-keys -t "${TARGET}" "" Enter
+    tmux delete-buffer -b "aragora-prompt" 2>/dev/null || true
+else
+    tmux send-keys -t "${TARGET}" "${PROMPT}" Enter
+fi
+
+echo "Prompt sent to '${NAME}' (${#PROMPT} chars)"
+
+# Optional wait + tail
+if [[ "${WAIT_SECONDS}" -gt 0 ]]; then
+    LOG_FILE="${HOME}/.aragora/tmux-sessions/${NAME}.log"
+    if [[ -f "${LOG_FILE}" ]]; then
+        echo "Waiting ${WAIT_SECONDS}s, tailing output..."
+        timeout "${WAIT_SECONDS}" tail -f "${LOG_FILE}" 2>/dev/null || true
+    else
+        echo "Log file not found at ${LOG_FILE}, sleeping ${WAIT_SECONDS}s..."
+        sleep "${WAIT_SECONDS}"
+    fi
+fi

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Launch a Codex or Claude session inside a named tmux pane.
+#
+# Usage:
+#   ./scripts/tmux_session_launcher.sh --name codex-conductor --agent codex --prompt-file /tmp/prompt.md
+#   ./scripts/tmux_session_launcher.sh --name claude-review --agent claude
+#   ./scripts/tmux_session_launcher.sh --name codex-qa --agent codex --prompt "Fix the tests in aragora/swarm/"
+#   ./scripts/tmux_session_launcher.sh --list
+#   ./scripts/tmux_session_launcher.sh --kill codex-conductor
+#
+# Each session gets:
+#   - a dedicated tmux window in the "aragora" session
+#   - an isolated git worktree (via codex_session.sh or claude-wt)
+#   - output logged to ~/.aragora/tmux-sessions/<name>.log
+#   - a metadata file at ~/.aragora/tmux-sessions/<name>.meta.json
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TMUX_SESSION="aragora"
+LOG_DIR="${HOME}/.aragora/tmux-sessions"
+mkdir -p "${LOG_DIR}"
+
+# --- argument parsing ---
+NAME=""
+AGENT="codex"
+PROMPT=""
+PROMPT_FILE=""
+ACTION="launch"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --name)     NAME="$2"; shift 2 ;;
+        --agent)    AGENT="$2"; shift 2 ;;
+        --prompt)   PROMPT="$2"; shift 2 ;;
+        --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
+        --list)     ACTION="list"; shift ;;
+        --kill)     ACTION="kill"; NAME="$2"; shift 2 ;;
+        --status)   ACTION="status"; shift ;;
+        *)          echo "Unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+# --- list action ---
+if [[ "${ACTION}" == "list" || "${ACTION}" == "status" ]]; then
+    if ! tmux has-session -t "${TMUX_SESSION}" 2>/dev/null; then
+        echo "No aragora tmux session running."
+        exit 0
+    fi
+    echo "=== Aragora tmux panes ==="
+    tmux list-windows -t "${TMUX_SESSION}" -F '#{window_index} #{window_name} #{pane_current_command}' 2>/dev/null || true
+
+    echo ""
+    echo "=== Session metadata ==="
+    for meta in "${LOG_DIR}"/*.meta.json; do
+        [[ -f "${meta}" ]] || continue
+        basename "${meta}" .meta.json
+        python3 -c "
+import json, sys
+d = json.load(open('${meta}'))
+print(f\"  agent={d.get('agent','-')} started={d.get('started','-')} pid={d.get('pane_pid','-')}\")
+" 2>/dev/null || true
+    done
+    exit 0
+fi
+
+# --- kill action ---
+if [[ "${ACTION}" == "kill" ]]; then
+    if [[ -z "${NAME}" ]]; then
+        echo "Usage: --kill <name>" >&2; exit 1
+    fi
+    if tmux has-session -t "${TMUX_SESSION}" 2>/dev/null; then
+        # Find and kill the window by name
+        window_id=$(tmux list-windows -t "${TMUX_SESSION}" -F '#{window_index} #{window_name}' \
+            | awk -v name="${NAME}" '$2 == name { print $1; exit }')
+        if [[ -n "${window_id}" ]]; then
+            tmux kill-window -t "${TMUX_SESSION}:${window_id}"
+            echo "Killed tmux window: ${NAME}"
+        else
+            echo "Window '${NAME}' not found."
+        fi
+    fi
+    rm -f "${LOG_DIR}/${NAME}.meta.json"
+    exit 0
+fi
+
+# --- launch action ---
+if [[ -z "${NAME}" ]]; then
+    NAME="${AGENT}-$(date +%H%M%S)"
+fi
+
+LOG_FILE="${LOG_DIR}/${NAME}.log"
+META_FILE="${LOG_DIR}/${NAME}.meta.json"
+
+# Ensure tmux session exists
+if ! tmux has-session -t "${TMUX_SESSION}" 2>/dev/null; then
+    tmux new-session -d -s "${TMUX_SESSION}" -n "_control" -x 200 -y 50
+    echo "Created tmux session: ${TMUX_SESSION}"
+fi
+
+# Build the launch command
+if [[ "${AGENT}" == "codex" ]]; then
+    LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/codex_session.sh --agent codex --base main"
+elif [[ "${AGENT}" == "claude" ]]; then
+    LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/claude-wt"
+else
+    echo "Unknown agent: ${AGENT}. Use 'codex' or 'claude'." >&2
+    exit 1
+fi
+
+# If a prompt file is specified, we'll feed it after launch
+if [[ -n "${PROMPT_FILE}" && -f "${PROMPT_FILE}" ]]; then
+    PROMPT="$(cat "${PROMPT_FILE}")"
+fi
+
+# Create new tmux window with logging
+tmux new-window -t "${TMUX_SESSION}" -n "${NAME}"
+tmux pipe-pane -t "${TMUX_SESSION}:${NAME}" -o "cat >> '${LOG_FILE}'"
+
+# Send the launch command
+tmux send-keys -t "${TMUX_SESSION}:${NAME}" "${LAUNCH_CMD}" Enter
+
+# Write metadata
+python3 -c "
+import json, datetime
+meta = {
+    'name': '${NAME}',
+    'agent': '${AGENT}',
+    'started': datetime.datetime.now().isoformat(),
+    'log_file': '${LOG_FILE}',
+    'repo_root': '${REPO_ROOT}',
+    'prompt_file': '${PROMPT_FILE}' or None,
+    'has_prompt': bool('${PROMPT}'),
+}
+with open('${META_FILE}', 'w') as f:
+    json.dump(meta, f, indent=2)
+"
+
+echo "Launched '${NAME}' (${AGENT}) in tmux session '${TMUX_SESSION}'"
+echo "  Log: ${LOG_FILE}"
+echo "  Meta: ${META_FILE}"
+
+# If there's a prompt to send, wait for the session to initialize then send it
+if [[ -n "${PROMPT}" ]]; then
+    echo "Waiting 5s for session init before sending prompt..."
+    sleep 5
+    "${SCRIPT_DIR}/tmux_send_prompt.sh" --name "${NAME}" --prompt "${PROMPT}"
+fi

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -121,21 +121,22 @@ tmux pipe-pane -t "${TMUX_SESSION}:${NAME}" -o "cat >> '${LOG_FILE}'"
 # Send the launch command
 tmux send-keys -t "${TMUX_SESSION}:${NAME}" "${LAUNCH_CMD}" Enter
 
-# Write metadata
-python3 -c "
-import json, datetime
+# Write metadata (avoid embedding prompt content in Python literal)
+python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" <<'PYEOF'
+import json, datetime, sys
+name, agent, log_file, repo_root, prompt_file, meta_file, has_prompt = sys.argv[1:8]
 meta = {
-    'name': '${NAME}',
-    'agent': '${AGENT}',
-    'started': datetime.datetime.now().isoformat(),
-    'log_file': '${LOG_FILE}',
-    'repo_root': '${REPO_ROOT}',
-    'prompt_file': '${PROMPT_FILE}' or None,
-    'has_prompt': bool('${PROMPT}'),
+    "name": name,
+    "agent": agent,
+    "started": datetime.datetime.now().isoformat(),
+    "log_file": log_file,
+    "repo_root": repo_root,
+    "prompt_file": prompt_file or None,
+    "has_prompt": bool(has_prompt),
 }
-with open('${META_FILE}', 'w') as f:
+with open(meta_file, "w") as f:
     json.dump(meta, f, indent=2)
-"
+PYEOF
 
 echo "Launched '${NAME}' (${AGENT}) in tmux session '${TMUX_SESSION}'"
 echo "  Log: ${LOG_FILE}"


### PR DESCRIPTION
## Summary

- Fix tmux_session_launcher.sh metadata writer that broke on multi-line prompt files
- Root cause: prompt content was interpolated into a Python string literal
- Fix: pass values as sys.argv with heredoc Python script

## Test plan

- [x] `./scripts/tmux_session_launcher.sh --name test --agent codex --prompt-file /tmp/aragora-prompts/overnight-strategic.md` — launches successfully
- [x] Metadata file written correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)