### PR TITLE
[codex] Wire OutcomeLearner snapshot into boss loop tick metrics

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -284,6 +284,7 @@ class BossLoopConfig:
 
     status_report_interval: int = 5  # every N iterations
     metrics_jsonl_path: str | None = ".aragora/overnight/boss_metrics.jsonl"
+    outcome_learner_window: int = 500
 
 
 # ---------------------------------------------------------------------------
@@ -832,6 +833,7 @@ class BossLoop:
         files_changed, tests_run, tests_passed = self._extract_iteration_metrics(worker_result)
         append_iteration_metrics(
             metrics_jsonl_path=self.config.metrics_jsonl_path,
+            outcome_learner_window=self.config.outcome_learner_window,
             deferred_queue_depth=len(self._deferred_publish_queue),
             iteration=iteration,
             issue_number=issue_number,

--- a/aragora/swarm/boss_loop_outcome.py
+++ b/aragora/swarm/boss_loop_outcome.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.outcome_learner import load_category_success_rates
 from aragora.swarm.terminal_truth import TerminalClass, classify_from_metrics
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,7 @@ logger = logging.getLogger(__name__)
 def append_iteration_metrics(
     *,
     metrics_jsonl_path: str | None,
+    outcome_learner_window: int,
     deferred_queue_depth: int,
     iteration: int,
     issue_number: int | None,
@@ -48,6 +50,7 @@ def append_iteration_metrics(
         publish_action = (
             str((worker_result.get("publish_result") or {}).get("action", "")).strip() or None
         )
+        category_success_rates = load_category_success_rates(window_size=outcome_learner_window)
         sanitizer_outcome = str(worker_result.get("sanitizer_outcome", "")).strip() or None
         checks_failed = (
             raw_checks if isinstance(raw_checks := worker_result.get("checks_failed"), list) else []
@@ -78,6 +81,7 @@ def append_iteration_metrics(
             "cohort_tag": cohort_tag,
             "has_deliverable": bool(worker_result.get("deliverable")),
             "publish_action": publish_action,
+            "category_success_rates": category_success_rates,
         }
 
         try:


### PR DESCRIPTION
Issue: #5282

This wires OutcomeLearner calibration into boss-loop tick metrics by importing
`load_category_success_rates`, adding an `outcome_learner_window` knob to
`BossLoopConfig`, and emitting the learned category success-rate snapshot with
each finalized iteration metric row.

The user-facing effect is that downstream metrics consumers now have the latest
OutcomeLearner category calibration available alongside the existing tick
telemetry without changing dispatch behavior or boss-loop control flow.

Validation:
- `pytest tests/swarm/test_boss_loop.py -x --timeout=30`
  - Fails on this branch.
  - Also fails on a clean `origin/main` baseline worktree, so this is a
    pre-existing red suite rather than a regression from this patch.
  - Branch example failure: `TestPublishedPrTerminal::test_needs_human_with_pr_url_is_terminal_completed`
  - Baseline example failure: `TestBossLoop::test_successful_completion_resets_consecutive_failures`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
  - Passed

Risks and assumptions:
- The new metrics field is additive and should be ignored by existing readers
  that only consume known keys.
- OutcomeLearner category rates continue to default to `{}` when the signal log
  is absent or unreadable.
