### PR TITLE
fix(tranche): keep original issue text in audit metadata

### DIFF
--- a/aragora/swarm/tranche.py
+++ b/aragora/swarm/tranche.py
@@ -65,6 +65,8 @@ def _issue_text_metadata(result: dict[str, Any]) -> dict[str, Any]:
     payload: dict[str, Any] = {}
     if kept_body is not None:
         payload["sanitized_body"] = kept_body
+    if changed and original_body is not None:
+        payload["original_body"] = original_body
     payload["changed"] = changed
     if sanitizer_outcome is not None:
         payload["sanitizer_outcome"] = sanitizer_outcome

--- a/tests/swarm/test_tranche.py
+++ b/tests/swarm/test_tranche.py
@@ -808,7 +808,9 @@ async def test_artifact_from_run_result_persists_receipt_and_lease_ids(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_artifact_from_run_result_omits_raw_issue_text_when_sanitized(tmp_path: Path) -> None:
+async def test_artifact_from_run_result_preserves_original_issue_text_when_sanitized(
+    tmp_path: Path,
+) -> None:
     repo = _init_repo(tmp_path)
     manifest = TrancheManifest.from_dict(
         {
@@ -872,12 +874,12 @@ async def test_artifact_from_run_result_omits_raw_issue_text_when_sanitized(tmp_
     )
 
     assert artifact.metadata["issue_text"] == {
+        "original_body": "raw body",
         "sanitized_body": "rewritten body",
         "changed": True,
         "sanitizer_outcome": "rewritten",
         "checks_failed": ["missing_validation"],
     }
-    assert "original_body" not in artifact.metadata["issue_text"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve the original issue body in tranche audit metadata when sanitization rewrites the task text
- keep unchanged issue bodies compact by storing only a single copy
- update tranche regression coverage for both rewritten and unchanged issue text

## Validation
- python3 -m pytest tests/swarm/test_tranche.py -q -k 'preserves_original_issue_text_when_sanitized or keeps_single_copy_when_text_is_unchanged' -o cache_dir=/tmp/pytest-tranche-focus-2
- python3 -m pytest tests/swarm/test_tranche.py -q -k 'not test_run_disables_managed_session_script_by_default and not test_run_allows_explicit_managed_session_script_override' -o cache_dir=/tmp/pytest-tranche-file-minus-gh
- ruff check aragora/swarm/tranche.py tests/swarm/test_tranche.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD