### PR TITLE
feat(scripts): add agent bridge session inventory

### DIFF
--- a/scripts/agent_bridge_sessions.py
+++ b/scripts/agent_bridge_sessions.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""List Codex/Claude session state for a repository.
+
+This is a read-only bridge inventory tool. It combines:
+- tmux-managed session metadata/logs under ``~/.aragora/tmux-sessions``
+- Claude Code transcript tails under ``~/.claude/projects/.../*.jsonl``
+
+The goal is to give a small supervisor process one machine-readable view of:
+- which sessions exist
+- which repo/lane they appear to be working on
+- their latest visible local output / conversation turn
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from dataclasses import asdict
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+TAIL_BYTES = 256 * 1024
+ANSI_RE = re.compile(
+    r"\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b[@-_]",
+)
+TAG_RE = re.compile(
+    r"<(?:system-reminder|task-notification|command-[^>]+|local-command-[^>]+)>.*?</(?:system-reminder|task-notification|command-[^>]+|local-command-[^>]+)>",
+    re.DOTALL,
+)
+SEPARATOR_RE = re.compile(r"^[\s\-\u2500-\u257f=]+$")
+MODEL_STATUS_RE = re.compile(
+    r"^(?:gpt|claude|codex|openai|gemini)-[^\s]+(?:\s+\S+)?\s+·\s+.+$",
+    re.I,
+)
+
+
+@dataclass(slots=True)
+class SessionRecord:
+    source: str
+    session_id: str
+    name: str
+    agent: str
+    status: str
+    updated_at: str | None
+    branch: str | None
+    cwd: str | None
+    prompt_file: str | None
+    summary: str
+    log_file: str | None = None
+    transcript_file: str | None = None
+    last_role: str | None = None
+    last_user_text: str | None = None
+    last_assistant_text: str | None = None
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _run_git(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def resolve_canonical_repo_root(path: Path) -> Path:
+    """Resolve the shared repo root even when running from a linked worktree."""
+    common_dir_proc = _run_git(path, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    if common_dir_proc.returncode == 0:
+        common_dir = common_dir_proc.stdout.strip()
+        if common_dir.endswith("/.git"):
+            return Path(common_dir).resolve().parent
+
+    root_proc = _run_git(path, "rev-parse", "--show-toplevel")
+    if root_proc.returncode == 0 and root_proc.stdout.strip():
+        return Path(root_proc.stdout.strip()).resolve()
+    return path.resolve()
+
+
+def _claude_project_slug(repo_root: Path) -> str:
+    normalized = str(repo_root.resolve()).replace("\\", "/").replace(":", "-")
+    return normalized.replace("/", "-")
+
+
+def _repo_match(candidate_root: Path | None, repo_root: Path) -> bool:
+    if candidate_root is None:
+        return False
+    try:
+        if candidate_root == repo_root:
+            return True
+        candidate_root.relative_to(repo_root)
+        return True
+    except ValueError:
+        return False
+
+
+def _safe_repo_root(candidate: str | None) -> Path | None:
+    if not candidate:
+        return None
+    path = Path(candidate).expanduser()
+    try:
+        return resolve_canonical_repo_root(path)
+    except (OSError, RuntimeError, ValueError):
+        if path.exists():
+            return path.resolve()
+        return path
+
+
+def _tail_lines(path: Path, *, max_bytes: int = TAIL_BYTES) -> list[str]:
+    if not path.exists():
+        return []
+    data = path.read_bytes()
+    if len(data) > max_bytes:
+        data = data[-max_bytes:]
+        newline = data.find(b"\n")
+        if newline >= 0:
+            data = data[newline + 1 :]
+    return data.decode("utf-8", errors="replace").splitlines()
+
+
+def _collapse(text: str, *, max_chars: int = 160) -> str:
+    text = ANSI_RE.sub("", text).replace("\r", "")
+    text = TAG_RE.sub(" ", text)
+    text = "".join(ch if ch >= " " or ch in "\n\t" else " " for ch in text)
+    collapsed = " ".join(part.strip() for part in text.splitlines() if part.strip())
+    if len(collapsed) <= max_chars:
+        return collapsed
+    return collapsed[: max_chars - 3] + "..."
+
+
+def _clean_display_line(text: str, *, max_chars: int = 220) -> str:
+    text = ANSI_RE.sub("", text).replace("\r", "")
+    text = TAG_RE.sub(" ", text)
+    text = text.replace("…", "...")
+    text = "".join(ch if ch >= " " or ch in "\t" else " " for ch in text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"^[•›■]+\s*", "", text)
+    text = re.sub(r"\s*·\s*(?:gpt|claude|openai|gemini|codex)-.*$", "", text, flags=re.I)
+    if MODEL_STATUS_RE.match(text):
+        return ""
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3] + "..."
+
+
+def _summary_score(text: str) -> int:
+    if not text or SEPARATOR_RE.fullmatch(text):
+        return -100
+
+    lower = text.lower()
+    if lower.startswith("conversation interrupted"):
+        return -100
+    if lower.startswith("/"):
+        return -50
+
+    score = 0
+    if len(text) >= 20:
+        score += 1
+    if lower.startswith(("i’m ", "i'm ", "i am ", "hold ", "stay ", "no additional prs")):
+        score += 3
+    if lower.startswith(("pr #", "the commit/push", "next ", "working", "blocked")):
+        score += 2
+    if any(
+        needle in lower
+        for needle in (
+            "pr #",
+            "opened",
+            "pushed",
+            "push ",
+            "merge",
+            "blocked",
+            "passed",
+            "failed",
+            "waiting",
+            "monitor",
+            "parked",
+            "next",
+        )
+    ):
+        score += 2
+    if lower.startswith(("ran ", "explored", "read ", "search ", "waited for background terminal")):
+        score -= 2
+    return score
+
+
+def _select_summary(lines: list[str]) -> str:
+    fallback = ""
+    for raw in reversed(lines):
+        cleaned = _clean_display_line(raw)
+        if not cleaned:
+            continue
+        if not fallback:
+            fallback = cleaned
+        if _summary_score(cleaned) > 0:
+            return cleaned
+    return fallback
+
+
+def _extract_text(content: Any) -> str:
+    if isinstance(content, str):
+        return _collapse(content)
+    if not isinstance(content, list):
+        return ""
+
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, str):
+            if item.strip():
+                parts.append(item)
+            continue
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text":
+            text = str(item.get("text", "")).strip()
+            if text:
+                parts.append(text)
+    return _collapse("\n".join(parts))
+
+
+def _extract_recent_claude_turns(path: Path) -> dict[str, Any] | None:
+    last_user_text: str | None = None
+    last_assistant_text: str | None = None
+    last_role: str | None = None
+    last_text: str | None = None
+    updated_at: str | None = None
+    cwd: str | None = None
+    branch: str | None = None
+    session_id = path.stem
+
+    for raw in reversed(_tail_lines(path)):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if cwd is None:
+            raw_cwd = payload.get("cwd")
+            if isinstance(raw_cwd, str) and raw_cwd.strip():
+                cwd = raw_cwd
+        if branch is None:
+            raw_branch = payload.get("gitBranch")
+            if isinstance(raw_branch, str) and raw_branch.strip():
+                branch = raw_branch
+        if updated_at is None:
+            raw_ts = payload.get("timestamp")
+            if isinstance(raw_ts, str) and raw_ts.strip():
+                updated_at = raw_ts
+
+        entry_type = payload.get("type")
+        if entry_type not in {"user", "assistant"}:
+            continue
+
+        message = payload.get("message")
+        if not isinstance(message, dict):
+            continue
+        text = _extract_text(message.get("content"))
+        if not text:
+            continue
+
+        if last_role is None:
+            last_role = str(entry_type)
+            last_text = text
+        if entry_type == "user" and last_user_text is None:
+            last_user_text = text
+        elif entry_type == "assistant" and last_assistant_text is None:
+            last_assistant_text = text
+
+        if last_user_text and last_assistant_text and last_role and updated_at:
+            break
+
+    if last_role is None or last_text is None:
+        return None
+
+    return {
+        "session_id": session_id,
+        "updated_at": updated_at or datetime.fromtimestamp(path.stat().st_mtime, UTC).isoformat(),
+        "cwd": cwd,
+        "branch": branch,
+        "last_role": last_role,
+        "last_text": last_text,
+        "last_user_text": last_user_text,
+        "last_assistant_text": last_assistant_text,
+    }
+
+
+def _tmux_alive(name: str, *, session_name: str = "aragora") -> str:
+    has_session = subprocess.run(
+        ["tmux", "has-session", "-t", session_name],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if has_session.returncode != 0:
+        return "dead"
+
+    windows = subprocess.run(
+        ["tmux", "list-windows", "-t", session_name, "-F", "#{window_name}"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if windows.returncode != 0:
+        return "unknown"
+    return "alive" if name in windows.stdout.splitlines() else "dead"
+
+
+def _capture_tmux_summary(name: str, *, session_name: str = "aragora") -> str:
+    captured = subprocess.run(
+        ["tmux", "capture-pane", "-t", f"{session_name}:{name}", "-p", "-S", "-120"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if captured.returncode != 0 or not captured.stdout.strip():
+        return ""
+    return _select_summary(captured.stdout.splitlines())
+
+
+def _latest_log_line(log_file: Path) -> str:
+    return _select_summary(_tail_lines(log_file, max_bytes=64 * 1024))
+
+
+def load_tmux_sessions(*, repo_root: Path, tmux_dir: Path) -> list[SessionRecord]:
+    records: list[SessionRecord] = []
+    if not tmux_dir.exists():
+        return records
+
+    for meta_path in sorted(tmux_dir.glob("*.meta.json")):
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(meta, dict):
+            continue
+
+        candidate_root = _safe_repo_root(str(meta.get("repo_root", "") or ""))
+        if not _repo_match(candidate_root, repo_root):
+            continue
+
+        name = meta_path.stem.removesuffix(".meta")
+        log_file = Path(str(meta.get("log_file", "") or "")).expanduser()
+        updated_at = None
+        if log_file.exists():
+            updated_at = datetime.fromtimestamp(log_file.stat().st_mtime, UTC).isoformat()
+        else:
+            started = meta.get("started")
+            if isinstance(started, str) and started.strip():
+                updated_at = started
+
+        status = _tmux_alive(name)
+        summary = _capture_tmux_summary(name) if status == "alive" else ""
+        if not summary and log_file.exists():
+            summary = _latest_log_line(log_file)
+
+        records.append(
+            SessionRecord(
+                source="tmux",
+                session_id=name,
+                name=name,
+                agent=str(meta.get("agent", "unknown") or "unknown"),
+                status=status,
+                updated_at=updated_at,
+                branch=None,
+                cwd=str(candidate_root) if candidate_root else None,
+                prompt_file=str(meta.get("prompt_file", "") or "") or None,
+                summary=summary,
+                log_file=str(log_file) if log_file else None,
+            )
+        )
+    return records
+
+
+def _candidate_claude_logs(*, repo_root: Path, projects_root: Path) -> list[Path]:
+    preferred = projects_root / _claude_project_slug(repo_root)
+    if preferred.exists():
+        return sorted(preferred.glob("*.jsonl"))
+
+    candidates: list[Path] = []
+    for path in projects_root.glob("*/*.jsonl"):
+        transcript = _extract_recent_claude_turns(path)
+        if transcript is None:
+            continue
+        cwd = transcript.get("cwd")
+        if isinstance(cwd, str) and _repo_match(_safe_repo_root(cwd), repo_root):
+            candidates.append(path)
+    return sorted(candidates)
+
+
+def load_claude_sessions(*, repo_root: Path, projects_root: Path) -> list[SessionRecord]:
+    records: list[SessionRecord] = []
+    for jsonl_path in _candidate_claude_logs(repo_root=repo_root, projects_root=projects_root):
+        transcript = _extract_recent_claude_turns(jsonl_path)
+        if transcript is None:
+            continue
+        cwd = transcript.get("cwd")
+        if isinstance(cwd, str) and not _repo_match(_safe_repo_root(cwd), repo_root):
+            continue
+
+        session_id = str(transcript["session_id"])
+        branch = transcript.get("branch")
+        records.append(
+            SessionRecord(
+                source="claude_jsonl",
+                session_id=session_id,
+                name=f"claude-{session_id[:8]}",
+                agent="claude",
+                status="unknown",
+                updated_at=str(transcript.get("updated_at") or ""),
+                branch=str(branch) if branch else None,
+                cwd=str(cwd) if cwd else None,
+                prompt_file=None,
+                summary=str(transcript["last_text"]),
+                transcript_file=str(jsonl_path),
+                last_role=str(transcript.get("last_role") or ""),
+                last_user_text=(
+                    str(transcript["last_user_text"]) if transcript.get("last_user_text") else None
+                ),
+                last_assistant_text=(
+                    str(transcript["last_assistant_text"])
+                    if transcript.get("last_assistant_text")
+                    else None
+                ),
+            )
+        )
+    return records
+
+
+def collect_sessions(
+    *,
+    repo_root: Path,
+    tmux_dir: Path,
+    claude_projects_root: Path,
+    source: str = "all",
+    limit: int = 100,
+    resolve_repo: bool = True,
+) -> list[SessionRecord]:
+    normalized_repo = (
+        resolve_canonical_repo_root(repo_root) if resolve_repo else repo_root.resolve()
+    )
+    records: list[SessionRecord] = []
+    if source in {"all", "tmux"}:
+        records.extend(load_tmux_sessions(repo_root=normalized_repo, tmux_dir=tmux_dir))
+    if source in {"all", "claude"}:
+        records.extend(
+            load_claude_sessions(repo_root=normalized_repo, projects_root=claude_projects_root)
+        )
+    records.sort(key=lambda item: item.updated_at or "", reverse=True)
+    return records[:limit]
+
+
+def _print_table(repo_root: Path, sessions: list[SessionRecord]) -> None:
+    print(f"repo_root: {repo_root}")
+    print(f"sessions: {len(sessions)}")
+    print("")
+    header = f"{'source':<13} {'name':<24} {'agent':<8} {'status':<8} {'branch':<28} summary"
+    print(header)
+    print("-" * len(header))
+    for row in sessions:
+        branch = row.branch or "-"
+        print(
+            f"{row.source:<13} {row.name[:24]:<24} {row.agent[:8]:<8} {row.status[:8]:<8} "
+            f"{branch[:28]:<28} {row.summary}"
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="List local Codex/Claude sessions for a repo")
+    parser.add_argument("--repo", default=".", help="Repo path or worktree path (default: cwd)")
+    parser.add_argument(
+        "--source",
+        choices=("all", "tmux", "claude"),
+        default="all",
+        help="Which local session sources to read",
+    )
+    parser.add_argument("--limit", type=int, default=100, help="Maximum sessions to return")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument(
+        "--tmux-dir",
+        default=str(Path.home() / ".aragora" / "tmux-sessions"),
+        help="tmux metadata/log directory",
+    )
+    parser.add_argument(
+        "--claude-projects-root",
+        default=str(Path.home() / ".claude" / "projects"),
+        help="Claude project transcript root",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    repo_root = resolve_canonical_repo_root(Path(args.repo).expanduser())
+    sessions = collect_sessions(
+        repo_root=repo_root,
+        tmux_dir=Path(args.tmux_dir).expanduser(),
+        claude_projects_root=Path(args.claude_projects_root).expanduser(),
+        source=args.source,
+        limit=max(1, int(args.limit)),
+        resolve_repo=False,
+    )
+
+    payload = {
+        "generated_at": _utc_now_iso(),
+        "repo_root": str(repo_root),
+        "count": len(sessions),
+        "sessions": [asdict(item) for item in sessions],
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        _print_table(repo_root, sessions)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_agent_bridge_sessions.py
+++ b/tests/scripts/test_agent_bridge_sessions.py
@@ -1,0 +1,325 @@
+"""Tests for scripts/agent_bridge_sessions.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+def test_claude_project_slug_uses_canonical_absolute_path():
+    import agent_bridge_sessions as mod
+
+    slug = mod._claude_project_slug(Path("/Users/armand/Development/aragora"))
+    assert slug == "-Users-armand-Development-aragora"
+
+
+def test_collect_sessions_merges_tmux_and_claude_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge_sessions as mod
+
+    repo_root = tmp_path / "aragora"
+    repo_root.mkdir()
+    tmux_dir = tmp_path / "tmux"
+    tmux_dir.mkdir()
+    claude_projects_root = tmp_path / "claude-projects"
+    project_dir = claude_projects_root / "-tmp-pytest-of-root-aragora"
+    project_dir.mkdir(parents=True)
+
+    log_file = tmux_dir / "codex-strategic.log"
+    log_file.write_text("starting\nPR #5297 opened\n", encoding="utf-8")
+    (tmux_dir / "codex-strategic.meta.json").write_text(
+        json.dumps(
+            {
+                "name": "codex-strategic",
+                "agent": "codex",
+                "started": "2026-04-13T18:00:00Z",
+                "log_file": str(log_file),
+                "repo_root": str(repo_root),
+                "prompt_file": "/tmp/5282.md",
+                "has_prompt": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    claude_log = project_dir / "1431bd39-6ab6-41e0-9ead-05f91680e1df.jsonl"
+    claude_log.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "timestamp": "2026-04-13T18:01:00Z",
+                        "cwd": str(repo_root / ".claude" / "worktrees" / "board"),
+                        "gitBranch": "worktree-sessions-1-3-impl",
+                        "sessionId": "1431bd39-6ab6-41e0-9ead-05f91680e1df",
+                        "message": {
+                            "content": [
+                                {"type": "text", "text": "Track PR #5294 and #5295 tonight."}
+                            ]
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "timestamp": "2026-04-13T18:02:00Z",
+                        "cwd": str(repo_root / ".claude" / "worktrees" / "board"),
+                        "gitBranch": "worktree-sessions-1-3-impl",
+                        "sessionId": "1431bd39-6ab6-41e0-9ead-05f91680e1df",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "I’m watching #5294 and #5295; #5295 is closest to merge.",
+                                }
+                            ]
+                        },
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(mod, "_tmux_alive", lambda _name: "alive")
+    monkeypatch.setattr(mod, "_capture_tmux_summary", lambda _name: "")
+    monkeypatch.setattr(
+        mod, "_claude_project_slug", lambda _repo_root: "-tmp-pytest-of-root-aragora"
+    )
+
+    sessions = mod.collect_sessions(
+        repo_root=repo_root,
+        tmux_dir=tmux_dir,
+        claude_projects_root=claude_projects_root,
+        resolve_repo=False,
+    )
+
+    assert len(sessions) == 2
+    assert {item.source for item in sessions} == {"tmux", "claude_jsonl"}
+
+    tmux_session = next(item for item in sessions if item.source == "tmux")
+    assert tmux_session.name == "codex-strategic"
+    assert tmux_session.agent == "codex"
+    assert tmux_session.status == "alive"
+    assert tmux_session.summary == "PR #5297 opened"
+    assert tmux_session.prompt_file == "/tmp/5282.md"
+
+    claude_session = next(item for item in sessions if item.source == "claude_jsonl")
+    assert claude_session.name == "claude-1431bd39"
+    assert claude_session.branch == "worktree-sessions-1-3-impl"
+    assert claude_session.last_role == "assistant"
+    assert claude_session.last_user_text == "Track PR #5294 and #5295 tonight."
+    assert (
+        claude_session.last_assistant_text
+        == "I’m watching #5294 and #5295; #5295 is closest to merge."
+    )
+    assert claude_session.summary == "I’m watching #5294 and #5295; #5295 is closest to merge."
+
+
+def test_collect_sessions_filters_tmux_sessions_to_matching_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge_sessions as mod
+
+    repo_root = tmp_path / "aragora"
+    repo_root.mkdir()
+    other_repo_root = tmp_path / "other"
+    other_repo_root.mkdir()
+    tmux_dir = tmp_path / "tmux"
+    tmux_dir.mkdir()
+
+    for name, repo in (("keep", repo_root), ("skip", other_repo_root)):
+        log_file = tmux_dir / f"{name}.log"
+        log_file.write_text(f"{name}\n", encoding="utf-8")
+        (tmux_dir / f"{name}.meta.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "agent": "codex",
+                    "started": "2026-04-13T18:00:00Z",
+                    "log_file": str(log_file),
+                    "repo_root": str(repo),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(mod, "_tmux_alive", lambda _name: "dead")
+
+    sessions = mod.collect_sessions(
+        repo_root=repo_root,
+        tmux_dir=tmux_dir,
+        claude_projects_root=tmp_path / "claude-projects",
+        source="tmux",
+        resolve_repo=False,
+    )
+
+    assert len(sessions) == 1
+    assert sessions[0].name == "keep"
+
+
+def test_extract_recent_claude_turns_skips_tool_only_user_entries(tmp_path: Path) -> None:
+    import agent_bridge_sessions as mod
+
+    log = tmp_path / "session.jsonl"
+    log.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "timestamp": "2026-04-13T18:00:00Z",
+                        "cwd": "/tmp/repo",
+                        "gitBranch": "main",
+                        "message": {"content": [{"type": "tool_result", "content": "hook output"}]},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "timestamp": "2026-04-13T18:00:10Z",
+                        "cwd": "/tmp/repo",
+                        "gitBranch": "main",
+                        "message": {
+                            "content": [{"type": "text", "text": "Ready for the next step."}]
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "user",
+                        "timestamp": "2026-04-13T18:00:20Z",
+                        "cwd": "/tmp/repo",
+                        "gitBranch": "main",
+                        "message": {"content": [{"type": "text", "text": "Please continue."}]},
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    transcript = mod._extract_recent_claude_turns(log)
+    assert transcript is not None
+    assert transcript["last_role"] == "user"
+    assert transcript["last_text"] == "Please continue."
+    assert transcript["last_assistant_text"] == "Ready for the next step."
+
+
+def test_select_summary_prefers_meaningful_recent_line() -> None:
+    import agent_bridge_sessions as mod
+
+    summary = mod._select_summary(
+        [
+            "• Ran git push origin HEAD:codex/branch",
+            "────────────────────────────────────",
+            "• I’m refreshing #5297 onto current main locally before I report the updated CI state.",
+            "gpt-5.4 xhigh · ~/Development/aragora",
+        ]
+    )
+
+    assert (
+        summary
+        == "I’m refreshing #5297 onto current main locally before I report the updated CI state."
+    )
+
+
+def test_load_tmux_sessions_prefers_live_capture_over_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge_sessions as mod
+
+    repo_root = tmp_path / "aragora"
+    repo_root.mkdir()
+    tmux_dir = tmp_path / "tmux"
+    tmux_dir.mkdir()
+    log_file = tmux_dir / "codex-strategic.log"
+    log_file.write_text("noisy fallback\n", encoding="utf-8")
+    (tmux_dir / "codex-strategic.meta.json").write_text(
+        json.dumps(
+            {
+                "name": "codex-strategic",
+                "agent": "codex",
+                "started": "2026-04-13T18:00:00Z",
+                "log_file": str(log_file),
+                "repo_root": str(repo_root),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(mod, "_tmux_alive", lambda _name: "alive")
+    monkeypatch.setattr(
+        mod,
+        "_capture_tmux_summary",
+        lambda _name: "Hold on #5297. I am refreshing that branch onto current main locally.",
+    )
+
+    sessions = mod.load_tmux_sessions(repo_root=repo_root, tmux_dir=tmux_dir)
+
+    assert len(sessions) == 1
+    assert (
+        sessions[0].summary
+        == "Hold on #5297. I am refreshing that branch onto current main locally."
+    )
+
+
+def test_main_json_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import agent_bridge_sessions as mod
+
+    repo_root = tmp_path / "aragora"
+    repo_root.mkdir()
+
+    monkeypatch.setattr(mod, "resolve_canonical_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(
+        mod,
+        "collect_sessions",
+        lambda **_kwargs: [
+            mod.SessionRecord(
+                source="tmux",
+                session_id="codex-strategic",
+                name="codex-strategic",
+                agent="codex",
+                status="alive",
+                updated_at="2026-04-13T18:00:00Z",
+                branch="codex/issue-5282",
+                cwd=str(repo_root),
+                prompt_file="/tmp/5282.md",
+                summary="PR #5297 opened",
+            )
+        ],
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent_bridge_sessions.py",
+            "--repo",
+            str(repo_root),
+            "--json",
+        ],
+    )
+    rc = mod.main()
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["repo_root"] == str(repo_root)
+    assert payload["count"] == 1
+    assert payload["sessions"][0]["name"] == "codex-strategic"


### PR DESCRIPTION
## Summary
- add `scripts/agent_bridge_sessions.py` to inventory local Codex and Claude sessions for a repo
- merge tmux session metadata/logs with Claude Code transcript tails into one table or JSON view
- prefer rendered tmux pane capture for live session summaries and fall back to logs when a tmux window is gone

## Validation
- `pytest tests/scripts/test_agent_bridge_sessions.py -q`
- `ruff check scripts/agent_bridge_sessions.py tests/scripts/test_agent_bridge_sessions.py`
- `python3 scripts/agent_bridge_sessions.py --repo /Users/armand/Development/aragora --limit 5`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
