### PR TITLE
docs: operationalize wedge-first execution backlog

### DIFF
--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -38,6 +38,16 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 
 Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining gate is production guard proof, not inflating the benchmark story.
 
+## Current 30-Day Execution Set
+
+Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
+
+- Do now: `RS-07`, `BC-01`, `BC-03`, `BC-02`, `TW-01`, `TW-02`, `TW-03`, `CS-01..03`
+- Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
+- Top 3 boss-ready next: `RS-07`, `BC-01`, `BC-03`
+- GitHub coverage for those top 3 remains epic-level only through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issues exist yet
+
 ## Epic 1 — Reliability Substrate
 
 **Outcome:** make bounded unattended execution trustworthy on real multi-host backlogs.
@@ -57,8 +67,8 @@ Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort
 ### Milestone 1.3 — Contract-Aware Preflight `[30-90d]`
 
 - [ ] **RS-07** Build `aragora swarm preflight run --contract ...` _(Partial as of 2026-04-13: module preflight plus scratch/draft-PR validation exist, but the top-level operator surface is still incomplete)_
-- [ ] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path
-- [ ] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers
+- [x] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
+- [x] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
 
 ### Milestone 1.4 — Ledger & Self-Heal `[90d]`
 
@@ -80,7 +90,7 @@ Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort
 
 - [x] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined _(Done 2026-04-12)_
 - [x] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch _(Done 2026-04-13)_
-- [ ] **BC-06** Preserve original versus sanitized task text for audit
+- [x] **BC-06** Preserve original versus sanitized task text for audit _(Done 2026-04-13 via [#5113](https://github.com/synaptent/aragora/pull/5113), [#5190](https://github.com/synaptent/aragora/pull/5190), and [#5305](https://github.com/synaptent/aragora/pull/5305))_
 
 ### Milestone 2.3 — Truthful Lane / Integrator State `[90d]`
 

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -10,7 +10,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to finish `RS-08/09` and `BC-01..03`, then prove the `B2` guard on the safest execution classes across the current execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to finish `RS-07` and `BC-01..03`, then prove the `B2` guard on the safest execution classes across the current execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -22,14 +22,16 @@ What is already true:
 - the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
 - launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
+- scratch and remote-publish preflight validation now run through the production preflight path and emit canonical terminal truth on `main`
 - task sanitizer outcomes and success-rate filtering are shaping safer boss-loop intake
+- original versus sanitized task text is already preserved for audit on `main`
 
 What is still missing:
 
 - production-equivalent preflight through the operator surface on the safest classes
 - resumable session state, retry context, and precise blocker evidence on the live swarm loop
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
-- broader repair-loop coverage and persisted original-versus-sanitized task audit
+- broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”
@@ -45,7 +47,66 @@ The 30-day target is intentionally narrow:
 
 Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; truthful guard completion is.
 
+Primary truth metric:
+
+- issue-level truth success remains `mergeable_pr OR merged_pr`
+- merged-only rate is a secondary truth metric, not the primary gate
+- PR-signal counts and iteration counts are proxies only
+
 If a task does not improve that metric, it is not first-tranche work.
+
+## 30-Day Canonical Backlog
+
+This is the executable backlog for the next 30 days. Keep it to one bounded lane at a time for a founder budget of 5-10 hours per week.
+
+| Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
+|---|---|---|---|---|---|---|
+| 1 | `RS-07` | The remaining guard gap is the top-level operator preflight surface, not the module substrate. | `aragora swarm preflight run --contract ...` (or the canonical operator equivalent) uses the same receipt-backed production preflight path and fails closed on the safe classes. | At least one guarded admission path is live through the operator surface with receipt-backed success and failure. | substrate | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 2 | `BC-01` | Session persistence is the prerequisite for truthful repair, retry, and operator control. | Session state survives `explore -> plan -> edit -> verify -> repair -> publish` and survives process restart. | Benchmark retry lanes show resumed state instead of cold restarts. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 3 | `BC-03` | Founder time is wasted when a failed run does not say exactly what broke and what to try next. | Failed runs emit precise blocker evidence, canonical blocker class, and repair transcript or next-step evidence. | `100%` of failed bounded runs include receipt-backed blocker evidence mapped to canonical terminal truth. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 4 | `BC-02` | Retry without state reuse just repeats prompt cost and rescue labor. | Retry resumes from prior state, contract, and repair evidence instead of re-prompting from scratch. | Retried runs emit resume-from-stage evidence and show lower repeated-rescue incidence on the same class. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 5 | `TW-01` | The wedge only becomes real if the benchmark corpus keeps proving `prompt -> spec -> code -> verify -> PR` loops on bounded work. | A fixed benchmark corpus runs repeatedly on current `main` without ad hoc issue swapping. | Repeated benchmark runs report issue-level truth outcomes on the same bounded corpus. | trust | Covered by [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
+| 6 | `TW-02` | The project needs issue-level truth, not PR-count or iteration-count vanity metrics. | Weekly truth reporting uses `mergeable_pr OR merged_pr`, distinguishes proxy from truth, and stays linked from status docs. | Fresh `origin/main` truth reports publish issue-level truth success and no-rescue truth success. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
+| 7 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
+| 8 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+
+## Do Now / Delay / Avoid
+
+### Do now
+
+- `RS-07`
+- `BC-01`
+- `BC-03`
+- `BC-02`
+- `TW-01`
+- `TW-02`
+- `TW-03`
+- `CS-01..03`
+
+### Delay
+
+- `BC-07..09` until the repair loop is truthful and resumable
+- `RS-10..12` until the operator-surface guard is real
+- `TW-07..09` until the bounded execution wedge is boringly reliable
+- `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
+- `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
+
+### Avoid in this tranche
+
+- `UDW-07..12`
+- `MCF-04..12`
+- `CS-04..12`
+- broad provider-surface expansion
+- heavy DAG workbench work that is not backed by live runtime truth
+- generalized memory fabric work that is not directly improving the execution wedge
+
+## Top 3 Boss-Ready Next
+
+1. `RS-07` because it closes the last missing guard on the live operator path.
+2. `BC-01` because retries and repair loops cannot become truthful until session state survives restarts.
+3. `BC-03` because founder leverage depends on precise blocker evidence before more retry logic is added.
+
+There is no dedicated open GitHub issue yet for those three codes. Existing issue coverage is still at the epic level through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806). Do not invent duplicate roadmap issues in this tranche unless the canonical docs stop being enough to drive bounded execution.
 
 ## Reverse-Staged Rocket Bootstrap
 


### PR DESCRIPTION
## Summary
- operationalize the wedge-first roadmap into one executable 30-day canonical backlog
- correct stale status for RS-08, RS-09, and BC-06 on current origin/main
- mark the top 3 boss-ready next items and explicitly separate do-now, delay, and avoid

## Notes
- doc-only change
- current truth metric remains issue-level truth success = mergeable_pr OR merged_pr
- no new coding lanes or duplicate roadmap issues created in this PR