### PR TITLE
fix(ci): install missing mypy stubs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -374,7 +374,7 @@ jobs:
       - name: Install mypy and type stubs
         run: |
           "${{ steps.typecheck_python.outputs.python_bin }}" -m pip install --user -e .
-          "${{ steps.typecheck_python.outputs.python_bin }}" -m pip install --user mypy types-requests types-redis types-python-dateutil types-setuptools
+          "${{ steps.typecheck_python.outputs.python_bin }}" -m pip install --user mypy types-requests types-redis types-python-dateutil types-setuptools types-jsonschema types-PyYAML
 
       - name: Resolve phase-1 typecheck plan
         id: typecheck_plan
@@ -493,7 +493,7 @@ jobs:
       - name: Install mypy and dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install mypy types-requests types-redis types-python-dateutil types-setuptools
+          python -m pip install mypy types-requests types-redis types-python-dateutil types-setuptools types-jsonschema types-PyYAML
           python -m pip install -e .
 
       - name: Typecheck core modules (REQUIRED)

--- a/scripts/ci_install_project.sh
+++ b/scripts/ci_install_project.sh
@@ -46,6 +46,8 @@ LEGACY_CONTROL_PLANE_DEV_DEPS=(
   "ruff>=0.1,<1.0"
   "bandit>=1.7,<2.0"
   "mypy>=1.8,<2.0"
+  "types-jsonschema"
+  "types-PyYAML"
   "mutmut>=3.0,<4.0"
   "pre-commit>=3.6,<5.0"
   "datamodel-code-generator==0.54.0"


### PR DESCRIPTION
## Summary
- install types-jsonschema and types-PyYAML in the lint workflow mypy jobs
- add the same stub packages to the shared CI dev dependency helper
- remove avoidable import-untyped failures from yaml/jsonschema users without relaxing the type gate

## Validation
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/lint.yml').read_text(encoding='utf-8')); print('lint.yml ok')"
- python3 -m venv /private/tmp/aragora-type-stubs-venv-14b3de76 && /private/tmp/aragora-type-stubs-venv-14b3de76/bin/python -m pip install --upgrade pip >/dev/null && /private/tmp/aragora-type-stubs-venv-14b3de76/bin/pip install mypy PyYAML jsonschema types-PyYAML types-jsonschema >/dev/null && /private/tmp/aragora-type-stubs-venv-14b3de76/bin/python -m mypy --ignore-missing-imports --follow-imports=skip scripts/generate_openapi.py aragora/gauntlet/api/schema.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD