### PR TITLE
feat(scripts): persist agent bridge lane registry

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -45,9 +45,11 @@ except ModuleNotFoundError:
 
 AGENT_BRIDGE_DIR = Path.home() / ".aragora" / "agent-bridge"
 SESSION_SNAPSHOT_FILE = AGENT_BRIDGE_DIR / "sessions.json"
+LANE_REGISTRY_FILE = AGENT_BRIDGE_DIR / "lanes.json"
 TMUX_SESSIONS_DIR = Path.home() / ".aragora" / "tmux-sessions"
 TMUX_SESSION = "aragora"
 REPO_ROOT = Path(__file__).resolve().parents[1]
+ACTIVE_LANE_STATUSES = {"active", "running", "pending", "queued", "claimed"}
 
 
 @dataclass
@@ -64,6 +66,42 @@ class Session:
 
     def to_dict(self) -> dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v}
+
+
+@dataclass
+class LaneRecord:
+    lane_id: str
+    owner_session: str
+    goal: str = ""
+    source: str = ""
+    status: str = "active"
+    next_action: str = ""
+    updated_at: str = ""
+    branch: str = ""
+    worktree: str = ""
+    pr_number: int | None = None
+    conflict_session: str = ""
+    conflict_reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v not in ("", None)}
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "LaneRecord":
+        return cls(
+            lane_id=str(payload.get("lane_id", "")),
+            owner_session=str(payload.get("owner_session", "")),
+            goal=str(payload.get("goal", "")),
+            source=str(payload.get("source", "")),
+            status=str(payload.get("status", "active")),
+            next_action=str(payload.get("next_action", "")),
+            updated_at=str(payload.get("updated_at", "")),
+            branch=str(payload.get("branch", "")),
+            worktree=str(payload.get("worktree", "")),
+            pr_number=payload.get("pr_number"),
+            conflict_session=str(payload.get("conflict_session", "")),
+            conflict_reason=str(payload.get("conflict_reason", "")),
+        )
 
 
 def discover() -> list[Session]:
@@ -144,6 +182,104 @@ def _write_session_snapshot(sessions: list[Session]) -> None:
     tmp_path = SESSION_SNAPSHOT_FILE.with_suffix(".json.tmp")
     tmp_path.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
     tmp_path.replace(SESSION_SNAPSHOT_FILE)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _load_lane_registry() -> list[LaneRecord]:
+    if not LANE_REGISTRY_FILE.exists():
+        return []
+    try:
+        payload = json.loads(LANE_REGISTRY_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [LaneRecord.from_dict(item) for item in payload if isinstance(item, dict)]
+
+
+def _write_lane_registry(records: list[LaneRecord]) -> None:
+    AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    tmp_path = LANE_REGISTRY_FILE.with_suffix(".json.tmp")
+    tmp_path.write_text(
+        json.dumps([record.to_dict() for record in records], indent=2) + "\n",
+        encoding="utf-8",
+    )
+    tmp_path.replace(LANE_REGISTRY_FILE)
+
+
+def _find_lane_record(records: list[LaneRecord], lane_id: str) -> LaneRecord | None:
+    for record in records:
+        if record.lane_id == lane_id:
+            return record
+    return None
+
+
+def _sync_lane_records(records: list[LaneRecord], sessions: list[Session]) -> list[LaneRecord]:
+    session_map = {session.name: session for session in sessions}
+    for record in records:
+        live = session_map.get(record.owner_session)
+        if live is not None:
+            record.branch = live.branch
+            record.worktree = live.worktree
+            record.pr_number = live.pr_number
+    return records
+
+
+def _lane_conflict(
+    records: list[LaneRecord],
+    lane_id: str,
+    owner_session: str,
+) -> LaneRecord | None:
+    record = _find_lane_record(records, lane_id)
+    if record is None:
+        return None
+    if record.owner_session == owner_session:
+        return None
+    if record.status not in ACTIVE_LANE_STATUSES:
+        return None
+    return record
+
+
+def _persist_lane_claim(
+    records: list[LaneRecord],
+    lane_id: str,
+    session: Session,
+    *,
+    goal: str,
+    source: str,
+    status: str,
+    next_action: str,
+    allow_conflict: bool,
+) -> None:
+    existing = _find_lane_record(records, lane_id)
+    conflict = _lane_conflict(records, lane_id, session.name)
+    if conflict is not None and allow_conflict:
+        conflict.status = "conflict"
+        conflict.conflict_session = session.name
+        conflict.conflict_reason = f"conflicting active owner claim from {session.name}"
+        conflict.next_action = next_action or "resolve ambiguous lane ownership"
+        conflict.updated_at = _now_iso()
+        _write_lane_registry(records)
+        return
+
+    record = existing or LaneRecord(lane_id=lane_id, owner_session=session.name)
+    record.owner_session = session.name
+    record.goal = goal or record.goal
+    record.source = source or record.source
+    record.status = status or record.status
+    record.next_action = next_action or record.next_action
+    record.updated_at = _now_iso()
+    record.branch = session.branch
+    record.worktree = session.worktree
+    record.pr_number = session.pr_number
+    record.conflict_session = ""
+    record.conflict_reason = ""
+    if existing is None:
+        records.append(record)
+    _write_lane_registry(records)
 
 
 def _find_session(sessions: list[Session], target: str) -> Session | None:
@@ -292,6 +428,7 @@ def cmd_sessions(args: argparse.Namespace) -> int:
 
 def cmd_send(args: argparse.Namespace) -> int:
     sessions = discover()
+    _enrich_prs(sessions)
     session = _find_session(sessions, args.name)
     if not session:
         print(f"No session matching '{args.name}'", file=sys.stderr)
@@ -304,7 +441,28 @@ def cmd_send(args: argparse.Namespace) -> int:
     if not target:
         print(f"No tmux target for '{session.name}'", file=sys.stderr)
         return 1
+    records = _sync_lane_records(_load_lane_registry(), sessions)
+    lane_id = str(getattr(args, "lane", "") or "").strip()
+    if lane_id:
+        conflict = _lane_conflict(records, lane_id, session.name)
+        if conflict is not None and not getattr(args, "allow_conflict", False):
+            print(
+                f"Lane '{lane_id}' already owned by active session '{conflict.owner_session}'",
+                file=sys.stderr,
+            )
+            return 1
     if _send_tmux(target, prompt):
+        if lane_id:
+            _persist_lane_claim(
+                records,
+                lane_id,
+                session,
+                goal=str(getattr(args, "goal", "") or "").strip(),
+                source=str(getattr(args, "source", "") or "").strip(),
+                status=str(getattr(args, "status", "") or "active").strip(),
+                next_action=str(getattr(args, "next_action", "") or "").strip(),
+                allow_conflict=bool(getattr(args, "allow_conflict", False)),
+            )
         print(f"Sent to '{session.name}' ({len(prompt)} chars)")
         return 0
     print(f"Send failed for '{session.name}'", file=sys.stderr)
@@ -380,6 +538,27 @@ def cmd_lanes(args: argparse.Namespace) -> int:
     sessions = discover()
     _enrich_prs(sessions)
     _write_session_snapshot(sessions)
+    records = _sync_lane_records(_load_lane_registry(), sessions)
+    if records:
+        _write_lane_registry(records)
+        if args.json:
+            print(json.dumps([record.to_dict() for record in records], indent=2))
+            return 0
+        print(f"{'LANE':<22} {'OWNER':<24} {'STATUS':<10} {'BRANCH':<26} {'PR':>5} NEXT ACTION")
+        print("-" * 120)
+        for record in records:
+            branch = record.branch[:24] if record.branch else "-"
+            pr = f"#{record.pr_number}" if record.pr_number else "-"
+            next_action = (
+                record.next_action[:40] + "..."
+                if len(record.next_action) > 40
+                else record.next_action
+            ) or "-"
+            print(
+                f"{record.lane_id:<22} {record.owner_session:<24} {record.status:<10} "
+                f"{branch:<26} {pr:>5} {next_action}"
+            )
+        return 0
     if args.json:
         print(json.dumps([s.to_dict() for s in sessions], indent=2))
         return 0
@@ -435,6 +614,16 @@ def main() -> int:
     send_p.add_argument("name")
     send_p.add_argument("prompt", nargs="*")
     send_p.add_argument("--file", help="Prompt file")
+    send_p.add_argument("--lane", help="Lane identifier to claim/update")
+    send_p.add_argument("--goal", default="", help="Lane goal summary")
+    send_p.add_argument("--source", default="", help="Source issue or PR reference")
+    send_p.add_argument("--status", default="active", help="Lane status")
+    send_p.add_argument("--next-action", default="", help="Next action for the lane")
+    send_p.add_argument(
+        "--allow-conflict",
+        action="store_true",
+        help="Mark an explicit conflict instead of rejecting a second active owner",
+    )
 
     approve_p = sub.add_parser("approve", help="Approve Codex permission")
     approve_p.add_argument("name")

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1,0 +1,249 @@
+"""Tests for scripts/agent_bridge.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+def _patch_bridge_paths(mod, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bridge_dir = tmp_path / "bridge"
+    monkeypatch.setattr(mod, "AGENT_BRIDGE_DIR", bridge_dir)
+    monkeypatch.setattr(mod, "SESSION_SNAPSHOT_FILE", bridge_dir / "sessions.json")
+    monkeypatch.setattr(mod, "LANE_REGISTRY_FILE", bridge_dir / "lanes.json")
+
+
+def test_cmd_send_persists_lane_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    session = mod.Session(
+        name="codex-strategic",
+        agent="codex",
+        status="alive",
+        tmux_target="aragora:codex-strategic",
+        branch="codex/issue-5320",
+        worktree="/tmp/aragora-5320",
+    )
+    monkeypatch.setattr(mod, "discover", lambda: [session])
+    monkeypatch.setattr(mod, "_resolve_tmux_target", lambda _session: "aragora:codex-strategic")
+    monkeypatch.setattr(mod, "_send_tmux", lambda _target, _prompt: True)
+
+    def _enrich_prs(sessions):
+        sessions[0].pr_number = 5401
+
+    monkeypatch.setattr(mod, "_enrich_prs", _enrich_prs)
+
+    args = argparse.Namespace(
+        name="codex-strategic",
+        prompt=["Continue", "#5320"],
+        file=None,
+        lane="bridge-hardening",
+        goal="Persist lane registry",
+        source="#5320",
+        status="active",
+        next_action="open PR",
+        allow_conflict=False,
+    )
+    rc = mod.cmd_send(args)
+
+    assert rc == 0
+    payload = json.loads(mod.LANE_REGISTRY_FILE.read_text(encoding="utf-8"))
+    assert payload == [
+        {
+            "lane_id": "bridge-hardening",
+            "owner_session": "codex-strategic",
+            "goal": "Persist lane registry",
+            "source": "#5320",
+            "status": "active",
+            "next_action": "open PR",
+            "updated_at": payload[0]["updated_at"],
+            "branch": "codex/issue-5320",
+            "worktree": "/tmp/aragora-5320",
+            "pr_number": 5401,
+        }
+    ]
+
+
+def test_cmd_send_rejects_active_lane_owner_conflict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "bridge-hardening",
+                    "owner_session": "other-session",
+                    "status": "active",
+                    "updated_at": "2026-04-13T21:20:00+00:00",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    session = mod.Session(name="codex-strategic", agent="codex", status="alive")
+    monkeypatch.setattr(mod, "discover", lambda: [session])
+    monkeypatch.setattr(mod, "_resolve_tmux_target", lambda _session: "aragora:codex-strategic")
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+
+    def _unexpected_send(_target, _prompt):
+        raise AssertionError("send should not run when lane ownership conflicts")
+
+    monkeypatch.setattr(mod, "_send_tmux", _unexpected_send)
+
+    args = argparse.Namespace(
+        name="codex-strategic",
+        prompt=["Continue"],
+        file=None,
+        lane="bridge-hardening",
+        goal="",
+        source="",
+        status="active",
+        next_action="",
+        allow_conflict=False,
+    )
+    rc = mod.cmd_send(args)
+
+    assert rc == 1
+    assert "already owned by active session 'other-session'" in capsys.readouterr().err
+    payload = json.loads(mod.LANE_REGISTRY_FILE.read_text(encoding="utf-8"))
+    assert payload[0]["owner_session"] == "other-session"
+    assert payload[0]["status"] == "active"
+
+
+def test_cmd_send_allow_conflict_marks_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "bridge-hardening",
+                    "owner_session": "other-session",
+                    "goal": "Persist lane registry",
+                    "source": "#5320",
+                    "status": "active",
+                    "updated_at": "2026-04-13T21:20:00+00:00",
+                    "branch": "codex/old",
+                    "worktree": "/tmp/old",
+                    "pr_number": 5399,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    session = mod.Session(
+        name="codex-strategic",
+        agent="codex",
+        status="alive",
+        tmux_target="aragora:codex-strategic",
+        branch="codex/issue-5320",
+        worktree="/tmp/aragora-5320",
+    )
+    monkeypatch.setattr(mod, "discover", lambda: [session])
+    monkeypatch.setattr(mod, "_resolve_tmux_target", lambda _session: "aragora:codex-strategic")
+    monkeypatch.setattr(mod, "_send_tmux", lambda _target, _prompt: True)
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+
+    args = argparse.Namespace(
+        name="codex-strategic",
+        prompt=["Continue"],
+        file=None,
+        lane="bridge-hardening",
+        goal="",
+        source="",
+        status="active",
+        next_action="triage conflicting ownership",
+        allow_conflict=True,
+    )
+    rc = mod.cmd_send(args)
+
+    assert rc == 0
+    payload = json.loads(mod.LANE_REGISTRY_FILE.read_text(encoding="utf-8"))
+    assert payload[0]["owner_session"] == "other-session"
+    assert payload[0]["status"] == "conflict"
+    assert payload[0]["conflict_session"] == "codex-strategic"
+    assert payload[0]["conflict_reason"] == "conflicting active owner claim from codex-strategic"
+    assert payload[0]["next_action"] == "triage conflicting ownership"
+
+
+def test_cmd_lanes_json_prefers_registry_and_syncs_live_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "bridge-hardening",
+                    "owner_session": "codex-strategic",
+                    "goal": "Persist lane registry",
+                    "source": "#5320",
+                    "status": "active",
+                    "updated_at": "2026-04-13T21:20:00+00:00",
+                    "branch": "stale-branch",
+                    "worktree": "/tmp/stale",
+                    "pr_number": 5300,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    session = mod.Session(
+        name="codex-strategic",
+        agent="codex",
+        status="alive",
+        branch="codex/issue-5320",
+        worktree="/tmp/aragora-5320",
+    )
+    monkeypatch.setattr(mod, "discover", lambda: [session])
+
+    def _enrich_prs(sessions):
+        sessions[0].pr_number = 5402
+
+    monkeypatch.setattr(mod, "_enrich_prs", _enrich_prs)
+
+    rc = mod.cmd_lanes(argparse.Namespace(json=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == [
+        {
+            "lane_id": "bridge-hardening",
+            "owner_session": "codex-strategic",
+            "goal": "Persist lane registry",
+            "source": "#5320",
+            "status": "active",
+            "updated_at": payload[0]["updated_at"],
+            "branch": "codex/issue-5320",
+            "worktree": "/tmp/aragora-5320",
+            "pr_number": 5402,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add a durable  registry for lane ownership metadata
- enforce one active owner per lane in , with an explicit conflict path when requested
- surface registry-backed lane -> session -> branch -> PR state in  and cover send/conflict/sync flows with focused tests

## Validation
- python3 -m pytest -q tests/scripts/test_agent_bridge.py
- ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5320