### PR TITLE
feat(swarm): add blocker evidence to metrics and status (BC-03)

### DIFF
--- a/aragora/server/fastapi/routes/swarm_status.py
+++ b/aragora/server/fastapi/routes/swarm_status.py
@@ -55,8 +55,10 @@ def swarm_status_summary(
 
     terminal_classes: Counter[str] = Counter()
     outcomes: Counter[str] = Counter()
+    failure_reasons: Counter[str] = Counter()
     issues_attempted: set[int] = set()
     issues_succeeded: set[int] = set()
+    recent_blockers: list[dict[str, Any]] = []
     latest_tick: dict[str, Any] = {}
 
     for row in rows:
@@ -74,6 +76,21 @@ def swarm_status_summary(
             if tc and tc.startswith("success"):
                 issues_succeeded.add(issue_num)
 
+        # Collect failure reasons and blocker evidence (BC-03)
+        failure_reason = str(row.get("failure_reason", "")).strip()
+        if failure_reason:
+            failure_reasons[failure_reason] += 1
+        if tc and not tc.startswith("success") and not tc.startswith("deliverable"):
+            recent_blockers.append(
+                {
+                    "issue_number": issue_num,
+                    "terminal_class": tc,
+                    "failure_reason": failure_reason or None,
+                    "blocker_kind": str(row.get("blocker_kind", "")).strip() or None,
+                    "issue_title": str(row.get("issue_title", "")).strip()[:80] or None,
+                }
+            )
+
         latest_tick = row
 
     success_count = sum(v for k, v in terminal_classes.items() if k.startswith("success"))
@@ -88,6 +105,8 @@ def swarm_status_summary(
         "success_rate": round(success_count / len(rows), 3) if rows else 0,
         "terminal_class_distribution": dict(terminal_classes.most_common(10)),
         "outcome_distribution": dict(outcomes.most_common(10)),
+        "failure_reason_distribution": dict(failure_reasons.most_common(10)),
+        "recent_blockers": recent_blockers[-10:],
         "latest_tick": {
             "timestamp": latest_tick.get("timestamp", ""),
             "issue_number": latest_tick.get("issue_number"),

--- a/aragora/swarm/boss_loop_outcome.py
+++ b/aragora/swarm/boss_loop_outcome.py
@@ -62,9 +62,18 @@ def append_iteration_metrics(
                     prompt_chars += int(wo.get("prompt_chars", 0) or 0)
                     enriched_context_chars += int(wo.get("enriched_context_chars", 0) or 0)
 
+        # Extract failure/blocker evidence for operator visibility (BC-03)
+        failure_reason = str(worker_result.get("failure_reason", "")).strip() or None
+        blocker_kind = str(worker_result.get("blocker_kind", "")).strip() or None
+        needs_human_reasons = worker_result.get("reasons")
+        if isinstance(needs_human_reasons, list) and needs_human_reasons:
+            if not failure_reason:
+                failure_reason = str(needs_human_reasons[0]).strip()[:200]
+
         payload = {
             "iteration": int(iteration),
             "issue_number": issue_number,
+            "issue_title": issue_title[:120] if issue_title else None,
             "worker_status": str(worker_result.get("status", "")).strip() or "unknown",
             "worker_outcome": str(worker_result.get("outcome", "")).strip() or None,
             "elapsed_seconds": float(elapsed_seconds or 0.0),
@@ -81,6 +90,8 @@ def append_iteration_metrics(
             "cohort_tag": cohort_tag,
             "has_deliverable": bool(worker_result.get("deliverable")),
             "publish_action": publish_action,
+            "failure_reason": failure_reason,
+            "blocker_kind": blocker_kind,
             "category_success_rates": category_success_rates,
         }
 


### PR DESCRIPTION
## Summary

- Boss loop tick JSONL now includes `failure_reason`, `blocker_kind`, and `issue_title`
- Swarm status endpoint surfaces `recent_blockers` and `failure_reason_distribution`

Addresses #5349

## Test plan

- [x] `python3 scripts/measure_b0_scorecard.py` — valid scorecard
- [x] `ruff check` — clean
- [x] preflight — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)