### PR TITLE
feat(swarm): add RescueEvent ledger (RS-11a)

### DIFF
--- a/aragora/swarm/rescue_events.py
+++ b/aragora/swarm/rescue_events.py
@@ -1,0 +1,168 @@
+"""RescueEvent ledger for tracking low-value human interventions.
+
+Every time a human has to copy-paste, type "proceed", rewrite an issue,
+approve a permission prompt, or restart a stuck session, that intervention
+should be captured as a typed RescueEvent so the system can learn to
+absorb repeated rescue patterns autonomously.
+
+The ledger persists to ~/.aragora/rescue_events.jsonl and is designed
+to be consumed by the TW-03 rescue-class harvest loop and the RS-11b
+RescuePlanner.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+UTC = timezone.utc
+
+DEFAULT_RESCUE_LEDGER_PATH = Path.home() / ".aragora" / "rescue_events.jsonl"
+
+
+class RescueEventType(str, Enum):
+    """Types of low-value human interventions."""
+
+    FOLLOWUP_PROMPT = "followup_prompt"
+    PERMISSION_APPROVAL = "permission_approval"
+    ISSUE_REWRITE = "issue_rewrite"
+    ISSUE_REQUEUE = "issue_requeue"
+    SESSION_RESTART = "session_restart"
+    SESSION_KILL = "session_kill"
+    PR_SHEPHERD = "pr_shepherd"
+    BLOCKED_ESCALATE = "blocked_escalate"
+    MANUAL_MERGE = "manual_merge"
+    WORKTREE_CLEANUP = "worktree_cleanup"
+    COPY_PASTE_RELAY = "copy_paste_relay"
+    OTHER = "other"
+
+
+@dataclass
+class RescueEvent:
+    """A single recorded human intervention."""
+
+    event_type: str
+    reason: str
+    actor: str = "founder"
+    issue_number: int | None = None
+    lane_id: str = ""
+    run_id: str = ""
+    session_id: str = ""
+    pr_number: int | None = None
+    evidence: str = ""
+    outcome: str = ""
+    created_at: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.created_at:
+            self.created_at = datetime.now(UTC).isoformat()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+class RescueEventLedger:
+    """Append-only JSONL ledger for rescue events."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or DEFAULT_RESCUE_LEDGER_PATH
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def record(self, event: RescueEvent) -> None:
+        """Append a rescue event to the ledger."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(event.to_dict(), sort_keys=True))
+                f.write("\n")
+        except OSError:
+            logger.debug("Failed to write rescue event", exc_info=True)
+
+    def recent(self, limit: int = 50) -> list[RescueEvent]:
+        """Read the most recent rescue events."""
+        if not self._path.exists():
+            return []
+        events: list[RescueEvent] = []
+        try:
+            for line in self._path.read_text(encoding="utf-8", errors="replace").splitlines():
+                try:
+                    data = json.loads(line)
+                    events.append(_parse_event(data))
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    continue
+        except OSError:
+            return []
+        return events[-limit:]
+
+    def count_by_type(self) -> dict[str, int]:
+        """Count rescue events by type for pattern detection."""
+        from collections import Counter
+
+        counts: Counter[str] = Counter()
+        events = self.recent(limit=500)
+        for event in events:
+            counts[event.event_type] += 1
+        return dict(counts.most_common())
+
+    def repeated_classes(self, threshold: int = 2) -> list[dict[str, Any]]:
+        """Identify rescue event types that appear repeatedly.
+
+        These are candidates for absorption into playbooks or substrate fixes.
+        """
+        from collections import Counter
+
+        type_reasons: Counter[str] = Counter()
+        events = self.recent(limit=500)
+        for event in events:
+            key = f"{event.event_type}:{event.reason[:60]}"
+            type_reasons[key] += 1
+        return [
+            {"class": key, "count": count}
+            for key, count in type_reasons.most_common()
+            if count >= threshold
+        ]
+
+
+def _parse_event(data: dict[str, Any]) -> RescueEvent:
+    """Parse a rescue event from a JSONL row."""
+    fields = RescueEvent.__dataclass_fields__.keys()
+    return RescueEvent(**{k: v for k, v in data.items() if k in fields})
+
+
+def record_rescue(
+    event_type: str,
+    reason: str,
+    *,
+    actor: str = "founder",
+    issue_number: int | None = None,
+    lane_id: str = "",
+    session_id: str = "",
+    pr_number: int | None = None,
+    evidence: str = "",
+    outcome: str = "",
+    ledger_path: Path | None = None,
+) -> None:
+    """Convenience function to record a rescue event."""
+    ledger = RescueEventLedger(path=ledger_path)
+    ledger.record(
+        RescueEvent(
+            event_type=event_type,
+            reason=reason,
+            actor=actor,
+            issue_number=issue_number,
+            lane_id=lane_id,
+            session_id=session_id,
+            pr_number=pr_number,
+            evidence=evidence,
+            outcome=outcome,
+        )
+    )

--- a/tests/swarm/test_rescue_events.py
+++ b/tests/swarm/test_rescue_events.py
@@ -1,0 +1,105 @@
+"""Tests for the RescueEvent ledger."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm.rescue_events import (
+    RescueEvent,
+    RescueEventLedger,
+    RescueEventType,
+    record_rescue,
+)
+
+
+@pytest.fixture()
+def ledger(tmp_path: Path) -> RescueEventLedger:
+    return RescueEventLedger(path=tmp_path / "rescue_events.jsonl")
+
+
+class TestRescueEvent:
+    def test_event_has_timestamp(self) -> None:
+        event = RescueEvent(event_type="followup_prompt", reason="session stalled")
+        assert event.created_at
+        assert "T" in event.created_at
+
+    def test_event_to_dict(self) -> None:
+        event = RescueEvent(
+            event_type="issue_rewrite",
+            reason="sanitizer false positive",
+            issue_number=5348,
+        )
+        d = event.to_dict()
+        assert d["event_type"] == "issue_rewrite"
+        assert d["issue_number"] == 5348
+        assert "created_at" in d
+
+    def test_event_to_dict_omits_none(self) -> None:
+        event = RescueEvent(event_type="other", reason="test")
+        d = event.to_dict()
+        assert "issue_number" not in d
+        assert "pr_number" not in d
+
+
+class TestRescueEventLedger:
+    def test_record_and_read(self, ledger: RescueEventLedger) -> None:
+        ledger.record(RescueEvent(event_type="followup_prompt", reason="stalled"))
+        ledger.record(RescueEvent(event_type="permission_approval", reason="git fetch"))
+        events = ledger.recent()
+        assert len(events) == 2
+        assert events[0].event_type == "followup_prompt"
+        assert events[1].event_type == "permission_approval"
+
+    def test_recent_limits(self, ledger: RescueEventLedger) -> None:
+        for i in range(10):
+            ledger.record(RescueEvent(event_type="other", reason=f"reason {i}"))
+        events = ledger.recent(limit=3)
+        assert len(events) == 3
+        assert events[0].reason == "reason 7"
+
+    def test_count_by_type(self, ledger: RescueEventLedger) -> None:
+        ledger.record(RescueEvent(event_type="followup_prompt", reason="a"))
+        ledger.record(RescueEvent(event_type="followup_prompt", reason="b"))
+        ledger.record(RescueEvent(event_type="issue_rewrite", reason="c"))
+        counts = ledger.count_by_type()
+        assert counts["followup_prompt"] == 2
+        assert counts["issue_rewrite"] == 1
+
+    def test_repeated_classes(self, ledger: RescueEventLedger) -> None:
+        ledger.record(RescueEvent(event_type="followup_prompt", reason="session stalled"))
+        ledger.record(RescueEvent(event_type="followup_prompt", reason="session stalled"))
+        ledger.record(RescueEvent(event_type="followup_prompt", reason="session stalled"))
+        ledger.record(RescueEvent(event_type="issue_rewrite", reason="unique reason"))
+        repeated = ledger.repeated_classes(threshold=2)
+        assert len(repeated) == 1
+        assert repeated[0]["class"] == "followup_prompt:session stalled"
+        assert repeated[0]["count"] == 3
+
+    def test_empty_ledger_returns_empty(self, ledger: RescueEventLedger) -> None:
+        assert ledger.recent() == []
+        assert ledger.count_by_type() == {}
+        assert ledger.repeated_classes() == []
+
+
+class TestRecordRescueConvenience:
+    def test_convenience_function(self, tmp_path: Path) -> None:
+        path = tmp_path / "rescue.jsonl"
+        record_rescue(
+            "issue_requeue",
+            "sanitizer false positive on contradictory_scope",
+            issue_number=5348,
+            ledger_path=path,
+        )
+        ledger = RescueEventLedger(path=path)
+        events = ledger.recent()
+        assert len(events) == 1
+        assert events[0].event_type == "issue_requeue"
+        assert events[0].issue_number == 5348
+
+
+class TestRescueEventType:
+    def test_enum_values(self) -> None:
+        assert RescueEventType.FOLLOWUP_PROMPT.value == "followup_prompt"
+        assert RescueEventType.COPY_PASTE_RELAY.value == "copy_paste_relay"


### PR DESCRIPTION
## Summary

Typed RescueEvent ledger for capturing low-value human interventions. JSONL persistence, repeated_classes() for pattern detection, 10 focused tests. Foundation for self-healing rescue loop (#5375). Addresses #5377.

## Test plan

- [x] `pytest tests/swarm/test_rescue_events.py -v` — 10 passed
- [x] `ruff check` — clean
- [x] preflight — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)