### PR TITLE
feat(swarm): add OpenRouter-backed RescuePlanner (RS-11b)

### DIFF
--- a/aragora/swarm/rescue_planner.py
+++ b/aragora/swarm/rescue_planner.py
@@ -1,0 +1,231 @@
+"""OpenRouter-backed RescuePlanner with typed next-action output.
+
+Consumes session state, blocker evidence, PR truth, and rescue history
+to propose bounded recovery actions. Returns schema-validated JSON that
+the active supervisor can execute if policy allows.
+
+The planner is read-only by default — it recommends actions, not executes.
+Action execution is a separate policy-gated step.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_JSON_OBJECT_RE = re.compile(r"\{[^{}]*\}", re.DOTALL)
+
+
+class RescueAction(str, Enum):
+    """Bounded set of recovery actions the planner can recommend."""
+
+    WAIT_FOR_CI = "wait_for_ci"
+    SEND_FOLLOWUP = "send_followup"
+    APPROVE_PROMPT = "approve_prompt"
+    RESTART_FROM_STATE = "restart_from_state"
+    REWRITE_ISSUE = "rewrite_issue"
+    SPLIT_ISSUE = "split_issue"
+    ESCALATE = "escalate"
+
+
+@dataclass
+class ActionPlan:
+    """Schema-validated recovery recommendation."""
+
+    action: str
+    reason: str
+    confidence: float = 0.0
+    required_policy: str = ""
+    proposed_prompt: str = ""
+    expected_receipt: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# Default model for rescue planning — cheap and fast
+_DEFAULT_MODEL = "anthropic/claude-haiku-4-5-20251001"
+_FALLBACK_MODEL = "deepseek/deepseek-chat"
+
+_SYSTEM_PROMPT = """\
+You are a rescue planner for an autonomous software execution system.
+Given a stuck or failed lane, recommend ONE bounded recovery action.
+
+Return ONLY valid JSON with these exact fields:
+{
+  "action": "wait_for_ci|send_followup|approve_prompt|restart_from_state|rewrite_issue|split_issue|escalate",
+  "reason": "brief explanation",
+  "confidence": 0.0 to 1.0,
+  "required_policy": "what permission is needed",
+  "proposed_prompt": "exact text to send if action is send_followup"
+}
+
+Rules:
+- Only recommend actions you are confident about (>0.5)
+- If unsure, recommend "escalate"
+- Keep proposed_prompt under 500 chars
+- Do not recommend actions outside the allowed set
+"""
+
+_VALID_ACTIONS = frozenset(a.value for a in RescueAction)
+
+
+def plan_rescue(
+    *,
+    session_summary: str = "",
+    blocker_evidence: str = "",
+    pr_state: str = "",
+    rescue_history: str = "",
+    lane_metadata: str = "",
+    model: str | None = None,
+    api_key: str | None = None,
+) -> ActionPlan:
+    """Call OpenRouter to classify a stuck lane and propose recovery.
+
+    Returns an ActionPlan with the recommended next action. Falls back
+    to ESCALATE if the LLM response is malformed or confidence is low.
+    """
+    context_parts = []
+    if session_summary:
+        context_parts.append(f"## Session Summary\n{session_summary}")
+    if blocker_evidence:
+        context_parts.append(f"## Blocker Evidence\n{blocker_evidence}")
+    if pr_state:
+        context_parts.append(f"## PR State\n{pr_state}")
+    if rescue_history:
+        context_parts.append(f"## Rescue History\n{rescue_history}")
+    if lane_metadata:
+        context_parts.append(f"## Lane Metadata\n{lane_metadata}")
+
+    if not context_parts:
+        return ActionPlan(
+            action=RescueAction.ESCALATE.value,
+            reason="No context provided for rescue planning.",
+            confidence=0.0,
+        )
+
+    user_prompt = "\n\n".join(context_parts)
+    resolved_key = api_key or os.environ.get("OPENROUTER_API_KEY", "")
+    resolved_model = model or _DEFAULT_MODEL
+
+    if not resolved_key:
+        return ActionPlan(
+            action=RescueAction.ESCALATE.value,
+            reason="No OpenRouter API key available for rescue planning.",
+            confidence=0.0,
+        )
+
+    try:
+        raw = _call_openrouter(
+            system=_SYSTEM_PROMPT,
+            user=user_prompt,
+            model=resolved_model,
+            api_key=resolved_key,
+        )
+        return _parse_action_plan(raw)
+    except Exception as exc:
+        logger.debug("RescuePlanner call failed: %s", exc)
+        return ActionPlan(
+            action=RescueAction.ESCALATE.value,
+            reason=f"Rescue planning failed: {type(exc).__name__}",
+            confidence=0.0,
+        )
+
+
+def _call_openrouter(
+    *,
+    system: str,
+    user: str,
+    model: str,
+    api_key: str,
+) -> str:
+    """Make a single OpenRouter chat completion call."""
+    import httpx
+
+    response = httpx.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user[:4000]},
+            ],
+            "max_tokens": 500,
+            "temperature": 0.1,
+        },
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    data = response.json()
+    choices = data.get("choices", [])
+    if not choices:
+        raise ValueError("No choices in OpenRouter response")
+    return str(choices[0].get("message", {}).get("content", "")).strip()
+
+
+def _parse_action_plan(raw: str) -> ActionPlan:
+    """Parse and validate an ActionPlan from LLM output."""
+    if not raw.strip():
+        return ActionPlan(
+            action=RescueAction.ESCALATE.value,
+            reason="Empty response from rescue planner.",
+            confidence=0.0,
+        )
+
+    # Try direct JSON parse first
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        match = _JSON_OBJECT_RE.search(raw)
+        if not match:
+            return ActionPlan(
+                action=RescueAction.ESCALATE.value,
+                reason="Could not parse JSON from rescue planner response.",
+                confidence=0.0,
+            )
+        data = json.loads(match.group())
+
+    if not isinstance(data, dict):
+        return ActionPlan(
+            action=RescueAction.ESCALATE.value,
+            reason="Rescue planner returned non-object JSON.",
+            confidence=0.0,
+        )
+
+    action = str(data.get("action", "")).strip().lower()
+    if action not in _VALID_ACTIONS:
+        action = RescueAction.ESCALATE.value
+
+    confidence = 0.0
+    try:
+        confidence = max(0.0, min(1.0, float(data.get("confidence", 0))))
+    except (TypeError, ValueError):
+        pass
+
+    # Fail closed on low confidence
+    if confidence < 0.3 and action != RescueAction.ESCALATE.value:
+        return ActionPlan(
+            action=RescueAction.ESCALATE.value,
+            reason=f"Low confidence ({confidence:.2f}) on {action}; escalating.",
+            confidence=confidence,
+        )
+
+    return ActionPlan(
+        action=action,
+        reason=str(data.get("reason", "")).strip()[:500],
+        confidence=confidence,
+        required_policy=str(data.get("required_policy", "")).strip()[:200],
+        proposed_prompt=str(data.get("proposed_prompt", "")).strip()[:500],
+        expected_receipt=str(data.get("expected_receipt", "")).strip()[:200],
+    )

--- a/tests/swarm/test_rescue_planner.py
+++ b/tests/swarm/test_rescue_planner.py
@@ -1,0 +1,141 @@
+"""Tests for the OpenRouter-backed RescuePlanner."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from aragora.swarm.rescue_planner import (
+    ActionPlan,
+    RescueAction,
+    _parse_action_plan,
+    plan_rescue,
+)
+
+
+class TestParseActionPlan:
+    def test_valid_json(self) -> None:
+        raw = json.dumps(
+            {
+                "action": "send_followup",
+                "reason": "session stalled after test failure",
+                "confidence": 0.85,
+                "proposed_prompt": "Check the test output and fix the assertion.",
+            }
+        )
+        plan = _parse_action_plan(raw)
+        assert plan.action == "send_followup"
+        assert plan.confidence == 0.85
+        assert "stalled" in plan.reason
+
+    def test_json_embedded_in_prose(self) -> None:
+        raw = 'Here is my recommendation:\n{"action": "restart_from_state", "reason": "worker crashed", "confidence": 0.7}\nDone.'
+        plan = _parse_action_plan(raw)
+        assert plan.action == "restart_from_state"
+        assert plan.confidence == 0.7
+
+    def test_invalid_action_falls_back_to_escalate(self) -> None:
+        raw = json.dumps({"action": "delete_everything", "reason": "bad", "confidence": 0.9})
+        plan = _parse_action_plan(raw)
+        assert plan.action == "escalate"
+
+    def test_low_confidence_escalates(self) -> None:
+        raw = json.dumps({"action": "send_followup", "reason": "maybe", "confidence": 0.1})
+        plan = _parse_action_plan(raw)
+        assert plan.action == "escalate"
+        assert "Low confidence" in plan.reason
+
+    def test_empty_response_escalates(self) -> None:
+        plan = _parse_action_plan("")
+        assert plan.action == "escalate"
+
+    def test_non_json_escalates(self) -> None:
+        plan = _parse_action_plan("I don't know what to do.")
+        assert plan.action == "escalate"
+
+    def test_escalate_at_low_confidence_is_kept(self) -> None:
+        raw = json.dumps({"action": "escalate", "reason": "genuinely stuck", "confidence": 0.1})
+        plan = _parse_action_plan(raw)
+        assert plan.action == "escalate"
+        assert plan.reason == "genuinely stuck"
+
+    def test_proposed_prompt_truncated(self) -> None:
+        raw = json.dumps(
+            {
+                "action": "send_followup",
+                "reason": "needs fix",
+                "confidence": 0.8,
+                "proposed_prompt": "x" * 1000,
+            }
+        )
+        plan = _parse_action_plan(raw)
+        assert len(plan.proposed_prompt) <= 500
+
+
+class TestPlanRescue:
+    def test_no_context_escalates(self) -> None:
+        plan = plan_rescue()
+        assert plan.action == "escalate"
+        assert "No context" in plan.reason
+
+    def test_no_api_key_escalates(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            plan = plan_rescue(session_summary="worker stalled")
+        assert plan.action == "escalate"
+        assert "API key" in plan.reason
+
+    def test_successful_call(self) -> None:
+        mock_response = json.dumps(
+            {
+                "action": "send_followup",
+                "reason": "test failure needs fix",
+                "confidence": 0.9,
+                "proposed_prompt": "Fix the failing assertion in test_foo.py",
+            }
+        )
+        with (
+            patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}),
+            patch(
+                "aragora.swarm.rescue_planner._call_openrouter",
+                return_value=mock_response,
+            ),
+        ):
+            plan = plan_rescue(
+                session_summary="Worker ran tests, 1 failed",
+                blocker_evidence="AssertionError in test_foo.py:42",
+            )
+        assert plan.action == "send_followup"
+        assert plan.confidence == 0.9
+
+    def test_api_error_escalates(self) -> None:
+        with (
+            patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}),
+            patch(
+                "aragora.swarm.rescue_planner._call_openrouter",
+                side_effect=ConnectionError("network down"),
+            ),
+        ):
+            plan = plan_rescue(session_summary="stuck")
+        assert plan.action == "escalate"
+        assert "ConnectionError" in plan.reason
+
+
+class TestActionPlan:
+    def test_to_dict(self) -> None:
+        plan = ActionPlan(
+            action="send_followup",
+            reason="test",
+            confidence=0.8,
+        )
+        d = plan.to_dict()
+        assert d["action"] == "send_followup"
+        assert d["confidence"] == 0.8
+
+
+class TestRescueAction:
+    def test_all_actions_have_values(self) -> None:
+        assert len(RescueAction) == 7
+        assert RescueAction.WAIT_FOR_CI.value == "wait_for_ci"
+        assert RescueAction.ESCALATE.value == "escalate"


### PR DESCRIPTION
## Summary

Frontier LLM rescue classifier. Consumes session state + blocker evidence, returns schema-validated ActionPlan with 7 bounded actions. Fails closed on malformed output. 14 tests. Part of #5375.

Addresses #5378

🤖 Generated with [Claude Code](https://claude.com/claude-code)