### PR TITLE
test(swarm): add test for modify-annotation false positive with 'add' keyword

### DIFF
--- a/tests/swarm/test_task_sanitizer.py
+++ b/tests/swarm/test_task_sanitizer.py
@@ -244,6 +244,16 @@ class TestContradictoryScope:
         body = "## Allowed Write Set\n- `tests/swarm/test_task_sanitizer.py` (create)\n"
         assert sanitizer._check_contradictory_scope(body) is None
 
+    def test_contradictory_scope_ignores_modify_with_add_in_description(
+        self, sanitizer: TaskSanitizer
+    ) -> None:
+        """Modify annotations should not false-positive when descriptive text contains 'add'."""
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (modify) — add a helper for scope dedup\n"
+        )
+        assert sanitizer._check_contradictory_scope(body) is None
+
 
 class TestRewriteMissingValidation:
     def test_rewrite_missing_validation_appends_section(self, sanitizer: TaskSanitizer) -> None:


### PR DESCRIPTION
Covers the scenario where explicit (modify) annotations should not be
misread as create+modify when descriptive text contains create-related
keywords like 'add', verifying the _create_is_subordinate guard works.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 2a0dbf2b1b45a025944cd359261c4db260400fb3)
