### PR TITLE
fix(server): restore legacy-safe cloud storage route ids

### DIFF
--- a/aragora/server/handlers/cloud_storage.py
+++ b/aragora/server/handlers/cloud_storage.py
@@ -83,8 +83,14 @@ CLOUD_STORAGE_CB_COOLDOWN_SECONDS = 30
 # Safe filename pattern
 SAFE_FILENAME_PATTERN = re.compile(r"^[\w\-. ]+$")
 SAFE_BUCKET_PATTERN = re.compile(r"^[a-z0-9][a-z0-9\-]{1,61}[a-z0-9]$")
-SAFE_FILE_ID_PATTERN = re.compile(r"^file_[0-9a-f]{16}$")
-SAFE_BUCKET_ID_PATTERN = re.compile(r"^(?:default|bucket_[0-9a-f]{12})$")
+# Accept current generated IDs (`file_<hex>`) and older safe slug IDs used in
+# tests and existing in-memory metadata. Route handlers still reject traversal
+# and malformed path segments because only simple URL-safe slugs are allowed.
+SAFE_FILE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+# Bucket IDs are internal route keys, not bucket names. Accept the current
+# generated IDs and older safe slug IDs while still rejecting traversal and
+# malformed path segments.
+SAFE_BUCKET_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
 
 
 class StorageProvider(str, Enum):
@@ -666,7 +672,7 @@ class CloudStorageHandler(BaseHandler):
                 parts = path.split("/")
                 # Path: /api/v2/storage/files/:file_id/presign -> ["", "api", "v2", "storage", "files", file_id, "presign"]
                 if len(parts) != 7:
-                    return error_response("Invalid file path", 400)
+                    return None
 
                 file_id = parts[5]
                 valid_file_id, file_id_error = self._validate_file_id(file_id)
@@ -677,7 +683,7 @@ class CloudStorageHandler(BaseHandler):
                 if parts[6] == "presign":
                     return await self._generate_presigned_url(file_id, body, handler)
 
-                return error_response("Invalid file path", 400)
+                return None
 
             return None
 

--- a/tests/handlers/test_cloud_storage.py
+++ b/tests/handlers/test_cloud_storage.py
@@ -359,6 +359,30 @@ class TestUtilityMethods:
         ids = {handler._generate_file_id() for _ in range(100)}
         assert len(ids) == 100
 
+    def test_validate_file_id_accepts_generated_and_legacy_safe_ids(self, handler):
+        for file_id in ("file_del", "file_berr", "nonexistent", handler._generate_file_id()):
+            valid, err = handler._validate_file_id(file_id)
+            assert valid is True
+            assert err == ""
+
+    def test_validate_file_id_rejects_malformed_or_traversal_ids(self, handler):
+        for file_id in ("", "../etc/passwd", "file bad", "file/segment", ".hidden"):
+            valid, err = handler._validate_file_id(file_id)
+            assert valid is False
+            assert err == "Invalid file ID"
+
+    def test_validate_bucket_id_accepts_default_generated_and_legacy_safe_ids(self, handler):
+        for bucket_id in ("default", "b123", "b_del", handler._generate_bucket_id()):
+            valid, err = handler._validate_bucket_id(bucket_id)
+            assert valid is True
+            assert err == ""
+
+    def test_validate_bucket_id_rejects_malformed_or_traversal_ids(self, handler):
+        for bucket_id in ("", "../etc/passwd", "bucket bad", "bucket/segment", ".hidden"):
+            valid, err = handler._validate_bucket_id(bucket_id)
+            assert valid is False
+            assert err == "Invalid bucket ID"
+
     def test_generate_bucket_id(self, handler):
         bid = handler._generate_bucket_id()
         assert bid.startswith("bucket_")


### PR DESCRIPTION
## Summary

- relax cloud storage file and bucket route-id validation to accept legacy-safe slug IDs as well as generated IDs
- restore `POST /api/v2/storage/files/:id` without `/presign` to fall through instead of returning a spurious 400
- add focused validation coverage for safe vs malformed route IDs

## Why

Recent fail-closed validation tightened the route-id regexes so far that ordinary existing IDs like `file_del`, `file_berr`, `b_del`, and even `nonexistent` short-circuited as `400 Invalid file ID` / `400 Invalid bucket ID` before the handler could perform normal lookup behavior. That poisoned unrelated CI runs with baseline handler failures.

## Validation

- `python3 -m pytest tests/handlers/test_cloud_storage.py -q`
- `ruff check aragora/server/handlers/cloud_storage.py tests/handlers/test_cloud_storage.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`