### PR TITLE
fix(preflight): block operator state snapshots from being committed

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -45,7 +45,7 @@ fi
 echo "preflight: checking whitespace"
 git diff --check "${BASE_REF}...${HEAD_REF}"
 
-forbidden_regex='(^|/)(\.codex_session_active|\.claude-session-active|\.nomic-session-active|\.codex_session_meta\.json|\.swarm_worker_stdout\.log|\.swarm_worker_stderr\.log|\.swarm_worker_status\.json|\.swarm_repair_journal\.json)$|(^|/)(\.aragora_events|\.pytest_cache|__pycache__)/'
+forbidden_regex='(^|/)(\.codex_session_active|\.claude-session-active|\.nomic-session-active|\.codex_session_meta\.json|\.swarm_worker_stdout\.log|\.swarm_worker_stderr\.log|\.swarm_worker_status\.json|\.swarm_repair_journal\.json|\.operator_state\.json|\.operator_snapshot\.json)$|(^|/)(\.aragora_events|\.pytest_cache|__pycache__)/'
 forbidden_files="$(printf '%s\n' "${changed_files}" | grep -E "${forbidden_regex}" || true)"
 if [[ -n "${forbidden_files}" ]]; then
     echo "preflight: automation/session artifacts must not be committed:" >&2


### PR DESCRIPTION
Add .operator_state.json and .operator_snapshot.json to the forbidden
artifacts regex in automation_pr_preflight.sh. These are runtime
artifacts produced by the OperatorStateModel and should never be
committed to the repository.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 1e017762174e8a84c64914b86f48c111d486029f)
