### PR TITLE
fix(swarm): claim issues before boss dispatch (#5391)

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -52,6 +52,10 @@ from aragora.swarm.boss_feed import (  # noqa: F401
     scope_entries_overlap,
 )
 from aragora.swarm.boss_freshness import RunnerFreshnessResult, check_runner_freshness  # noqa: F401
+from aragora.swarm.boss_loop_claims import (
+    ISSUE_CLAIM_TTL_SECONDS,
+    issue_claim_path as _issue_claim_path_impl,
+)
 from aragora.swarm.boss_validation import (  # noqa: F401
     _compose_issue_dispatch_goal,
     _should_replace_with_focused_tests,
@@ -83,6 +87,7 @@ _ALREADY_DONE_MARKERS = (
     "there's nothing to commit",
 )
 _BOSS_PUBLISH_COMMENT_MARKER = "<!-- aragora-boss-loop-publish -->"
+_ISSUE_CLAIM_TTL_SECONDS = ISSUE_CLAIM_TTL_SECONDS
 
 
 def _strict_bool(value: Any) -> bool | None:
@@ -815,6 +820,10 @@ class BossLoop:
         from aragora.swarm.boss_loop_claims import filter_claimed_issues
 
         return filter_claimed_issues(issues, self.run_id)
+
+    @staticmethod
+    def _issue_claim_path(issue_number: int) -> Path:
+        return _issue_claim_path_impl(issue_number)
 
     def _claim_issue_dispatch(self, issue_number: int) -> tuple[bool, str | None]:
         from aragora.swarm.boss_loop_claims import claim_issue

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 import re
-import socket
 import subprocess
 import sys
 import tempfile
@@ -84,7 +83,6 @@ _ALREADY_DONE_MARKERS = (
     "there's nothing to commit",
 )
 _BOSS_PUBLISH_COMMENT_MARKER = "<!-- aragora-boss-loop-publish -->"
-_ISSUE_CLAIM_TTL_SECONDS = 30 * 60
 
 
 def _strict_bool(value: Any) -> bool | None:
@@ -810,219 +808,29 @@ class BossLoop:
 
         return blocked
 
-    @staticmethod
-    def _issue_claims_dir() -> Path:
-        return Path.cwd() / ".aragora" / "issue_claims"
-
-    def _issue_claim_path(self, issue_number: int) -> Path:
-        return self._issue_claims_dir() / f"{int(issue_number)}.lock"
-
-    @staticmethod
-    def _read_issue_claim_payload(path: Path) -> dict[str, Any] | None:
-        try:
-            raw = path.read_text(encoding="utf-8").strip()
-        except OSError:
-            return None
-        if not raw:
-            return None
-        try:
-            payload = json.loads(raw)
-        except (TypeError, ValueError):
-            return None
-        return payload if isinstance(payload, dict) else None
-
-    @staticmethod
-    def _issue_claim_owner_pid(payload: dict[str, Any] | None) -> int | None:
-        if not isinstance(payload, dict):
-            return None
-        try:
-            pid = int(payload.get("pid", 0) or 0)
-        except (TypeError, ValueError):
-            return None
-        return pid if pid > 0 else None
-
-    def _issue_claim_owned_by_self(self, payload: dict[str, Any] | None) -> bool:
-        return (
-            isinstance(payload, dict)
-            and str(payload.get("run_id", "")).strip() == self.run_id
-            and self._issue_claim_owner_pid(payload) == os.getpid()
-        )
-
-    def _reap_stale_issue_claim(
-        self,
-        issue_number: int,
-        path: Path,
-        payload: dict[str, Any] | None,
-    ) -> bool:
-        try:
-            stat = path.stat()
-        except FileNotFoundError:
-            return True
-        except OSError:
-            return False
-
-        stale_reason: str | None = None
-        age_seconds = max(0.0, time.time() - stat.st_mtime)
-        if age_seconds > _ISSUE_CLAIM_TTL_SECONDS:
-            stale_reason = "expired"
-        else:
-            owner_pid = self._issue_claim_owner_pid(payload)
-            owner_host = str((payload or {}).get("host", "")).strip()
-            if owner_pid is not None and (not owner_host or owner_host == socket.gethostname()):
-                try:
-                    os.kill(owner_pid, 0)
-                except ProcessLookupError:
-                    stale_reason = "owner_dead"
-                except PermissionError:
-                    stale_reason = None
-
-        if stale_reason is None:
-            return False
-
-        try:
-            path.unlink()
-        except FileNotFoundError:
-            return True
-        except OSError:
-            logger.debug("Failed to remove stale boss issue claim %s", path, exc_info=True)
-            return False
-
-        logger.info("boss_loop_reaped_issue_claim issue=#%s reason=%s", issue_number, stale_reason)
-        return True
-
-    def _issue_has_active_foreign_claim(self, issue_number: int) -> bool:
-        path = self._issue_claim_path(issue_number)
-        if not path.exists():
-            return False
-        payload = self._read_issue_claim_payload(path)
-        if self._issue_claim_owned_by_self(payload):
-            return False
-        if self._reap_stale_issue_claim(issue_number, path, payload):
-            return False
-        return True
-
     def _filter_issues_with_active_claims(
         self,
         issues: list[GitHubIssue],
     ) -> list[GitHubIssue]:
-        filtered: list[GitHubIssue] = []
-        for issue in issues:
-            if self._issue_has_active_foreign_claim(issue.number):
-                logger.info("boss_loop_skip_claimed_issue issue=#%s", issue.number)
-                continue
-            filtered.append(issue)
-        return filtered
+        from aragora.swarm.boss_loop_claims import filter_claimed_issues
+
+        return filter_claimed_issues(issues, self.run_id)
 
     def _claim_issue_dispatch(self, issue_number: int) -> tuple[bool, str | None]:
-        path = self._issue_claim_path(issue_number)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "issue_number": int(issue_number),
-            "run_id": self.run_id,
-            "pid": os.getpid(),
-            "host": socket.gethostname(),
-            "claimed_at": datetime.now(UTC).isoformat(),
-        }
-        serialized = json.dumps(payload, sort_keys=True)
+        from aragora.swarm.boss_loop_claims import claim_issue
 
-        while True:
-            try:
-                fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-            except FileExistsError:
-                existing = self._read_issue_claim_payload(path)
-                if self._issue_claim_owned_by_self(existing):
-                    return True, None
-                if self._reap_stale_issue_claim(issue_number, path, existing):
-                    continue
-                owner_parts: list[str] = []
-                if isinstance(existing, dict):
-                    existing_run_id = str(existing.get("run_id", "")).strip()
-                    if existing_run_id:
-                        owner_parts.append(existing_run_id)
-                    existing_pid = self._issue_claim_owner_pid(existing)
-                    if existing_pid is not None:
-                        owner_parts.append(f"pid {existing_pid}")
-                    existing_host = str(existing.get("host", "")).strip()
-                    if existing_host:
-                        owner_parts.append(existing_host)
-                owner_text = ", ".join(owner_parts) if owner_parts else "another boss loop"
-                return False, f"Issue #{issue_number} is already claimed by {owner_text}."
-            except OSError as exc:
-                return False, f"Failed to claim issue #{issue_number}: {exc}"
-
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                    handle.write(serialized)
-                    handle.write("\n")
-            except OSError as exc:
-                try:
-                    path.unlink()
-                except OSError:
-                    logger.debug(
-                        "Failed to clean up partial boss issue claim %s", path, exc_info=True
-                    )
-                return False, f"Failed to persist issue claim for #{issue_number}: {exc}"
-            return True, None
+        return claim_issue(issue_number, self.run_id)
 
     def _release_issue_dispatch_claim(self, issue_number: int) -> None:
-        path = self._issue_claim_path(issue_number)
-        payload = self._read_issue_claim_payload(path)
-        if payload is not None and not self._issue_claim_owned_by_self(payload):
-            return
-        try:
-            path.unlink()
-        except FileNotFoundError:
-            return
-        except OSError:
-            logger.debug("Failed to release boss issue claim %s", path, exc_info=True)
+        from aragora.swarm.boss_loop_claims import release_claim
 
-    def _extract_iteration_metrics(self, worker_result: dict[str, Any]) -> tuple[int, int, int]:
-        """Summarize changed files and test verification from a worker run."""
-        run_dict = worker_result.get("run")
-        if not isinstance(run_dict, dict):
-            return 0, 0, 0
+        release_claim(issue_number, self.run_id)
 
-        changed_files: list[str] = []
-        tests_run: list[str] = []
-        tests_passed = 0
-        saw_verification_results = False
+    @staticmethod
+    def _extract_iteration_metrics(worker_result: dict[str, Any]) -> tuple[int, int, int]:
+        from aragora.swarm.boss_loop_outcome import extract_iteration_metrics
 
-        for work_order in run_dict.get("work_orders", []):
-            if not isinstance(work_order, dict):
-                continue
-
-            changed_files.extend(
-                str(path).strip()
-                for path in work_order.get("changed_paths", [])
-                if str(path).strip()
-            )
-            tests_run.extend(
-                str(command).strip()
-                for command in work_order.get("tests_run", [])
-                if str(command).strip()
-            )
-
-            verification_results = work_order.get("verification_results", [])
-            if not isinstance(verification_results, list):
-                continue
-
-            for verification in verification_results:
-                if not isinstance(verification, dict):
-                    continue
-                saw_verification_results = True
-                if verification.get("passed") is True:
-                    tests_passed += 1
-
-        unique_changed_files = list(dict.fromkeys(changed_files))
-        unique_tests_run = list(dict.fromkeys(tests_run))
-        if (
-            not saw_verification_results
-            and unique_tests_run
-            and str(worker_result.get("status", "")).strip().lower() == "completed"
-        ):
-            tests_passed = len(unique_tests_run)
-
-        return len(unique_changed_files), len(unique_tests_run), tests_passed
+        return extract_iteration_metrics(worker_result)
 
     def _append_iteration_metrics(
         self,

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import socket
 import subprocess
 import sys
 import tempfile
@@ -83,6 +84,7 @@ _ALREADY_DONE_MARKERS = (
     "there's nothing to commit",
 )
 _BOSS_PUBLISH_COMMENT_MARKER = "<!-- aragora-boss-loop-publish -->"
+_ISSUE_CLAIM_TTL_SECONDS = 30 * 60
 
 
 def _strict_bool(value: Any) -> bool | None:
@@ -807,6 +809,172 @@ class BossLoop:
             logger.debug("Failed to collect active fleet claim scopes", exc_info=True)
 
         return blocked
+
+    @staticmethod
+    def _issue_claims_dir() -> Path:
+        return Path.cwd() / ".aragora" / "issue_claims"
+
+    def _issue_claim_path(self, issue_number: int) -> Path:
+        return self._issue_claims_dir() / f"{int(issue_number)}.lock"
+
+    @staticmethod
+    def _read_issue_claim_payload(path: Path) -> dict[str, Any] | None:
+        try:
+            raw = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        if not raw:
+            return None
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    @staticmethod
+    def _issue_claim_owner_pid(payload: dict[str, Any] | None) -> int | None:
+        if not isinstance(payload, dict):
+            return None
+        try:
+            pid = int(payload.get("pid", 0) or 0)
+        except (TypeError, ValueError):
+            return None
+        return pid if pid > 0 else None
+
+    def _issue_claim_owned_by_self(self, payload: dict[str, Any] | None) -> bool:
+        return (
+            isinstance(payload, dict)
+            and str(payload.get("run_id", "")).strip() == self.run_id
+            and self._issue_claim_owner_pid(payload) == os.getpid()
+        )
+
+    def _reap_stale_issue_claim(
+        self,
+        issue_number: int,
+        path: Path,
+        payload: dict[str, Any] | None,
+    ) -> bool:
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+
+        stale_reason: str | None = None
+        age_seconds = max(0.0, time.time() - stat.st_mtime)
+        if age_seconds > _ISSUE_CLAIM_TTL_SECONDS:
+            stale_reason = "expired"
+        else:
+            owner_pid = self._issue_claim_owner_pid(payload)
+            owner_host = str((payload or {}).get("host", "")).strip()
+            if owner_pid is not None and (not owner_host or owner_host == socket.gethostname()):
+                try:
+                    os.kill(owner_pid, 0)
+                except ProcessLookupError:
+                    stale_reason = "owner_dead"
+                except PermissionError:
+                    stale_reason = None
+
+        if stale_reason is None:
+            return False
+
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return True
+        except OSError:
+            logger.debug("Failed to remove stale boss issue claim %s", path, exc_info=True)
+            return False
+
+        logger.info("boss_loop_reaped_issue_claim issue=#%s reason=%s", issue_number, stale_reason)
+        return True
+
+    def _issue_has_active_foreign_claim(self, issue_number: int) -> bool:
+        path = self._issue_claim_path(issue_number)
+        if not path.exists():
+            return False
+        payload = self._read_issue_claim_payload(path)
+        if self._issue_claim_owned_by_self(payload):
+            return False
+        if self._reap_stale_issue_claim(issue_number, path, payload):
+            return False
+        return True
+
+    def _filter_issues_with_active_claims(
+        self,
+        issues: list[GitHubIssue],
+    ) -> list[GitHubIssue]:
+        filtered: list[GitHubIssue] = []
+        for issue in issues:
+            if self._issue_has_active_foreign_claim(issue.number):
+                logger.info("boss_loop_skip_claimed_issue issue=#%s", issue.number)
+                continue
+            filtered.append(issue)
+        return filtered
+
+    def _claim_issue_dispatch(self, issue_number: int) -> tuple[bool, str | None]:
+        path = self._issue_claim_path(issue_number)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "issue_number": int(issue_number),
+            "run_id": self.run_id,
+            "pid": os.getpid(),
+            "host": socket.gethostname(),
+            "claimed_at": datetime.now(UTC).isoformat(),
+        }
+        serialized = json.dumps(payload, sort_keys=True)
+
+        while True:
+            try:
+                fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            except FileExistsError:
+                existing = self._read_issue_claim_payload(path)
+                if self._issue_claim_owned_by_self(existing):
+                    return True, None
+                if self._reap_stale_issue_claim(issue_number, path, existing):
+                    continue
+                owner_parts: list[str] = []
+                if isinstance(existing, dict):
+                    existing_run_id = str(existing.get("run_id", "")).strip()
+                    if existing_run_id:
+                        owner_parts.append(existing_run_id)
+                    existing_pid = self._issue_claim_owner_pid(existing)
+                    if existing_pid is not None:
+                        owner_parts.append(f"pid {existing_pid}")
+                    existing_host = str(existing.get("host", "")).strip()
+                    if existing_host:
+                        owner_parts.append(existing_host)
+                owner_text = ", ".join(owner_parts) if owner_parts else "another boss loop"
+                return False, f"Issue #{issue_number} is already claimed by {owner_text}."
+            except OSError as exc:
+                return False, f"Failed to claim issue #{issue_number}: {exc}"
+
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(serialized)
+                    handle.write("\n")
+            except OSError as exc:
+                try:
+                    path.unlink()
+                except OSError:
+                    logger.debug(
+                        "Failed to clean up partial boss issue claim %s", path, exc_info=True
+                    )
+                return False, f"Failed to persist issue claim for #{issue_number}: {exc}"
+            return True, None
+
+    def _release_issue_dispatch_claim(self, issue_number: int) -> None:
+        path = self._issue_claim_path(issue_number)
+        payload = self._read_issue_claim_payload(path)
+        if payload is not None and not self._issue_claim_owned_by_self(payload):
+            return
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return
+        except OSError:
+            logger.debug("Failed to release boss issue claim %s", path, exc_info=True)
 
     def _extract_iteration_metrics(self, worker_result: dict[str, Any]) -> tuple[int, int, int]:
         """Summarize changed files and test verification from a worker run."""
@@ -3695,6 +3863,7 @@ class BossLoop:
         candidate_issues = [
             i for i in issues if i.number in pending_issue_numbers or i.number not in already_maxed
         ]
+        candidate_issues = self._filter_issues_with_active_claims(candidate_issues)
         eligibility_report = build_issue_eligibility_report(
             candidate_issues,
             skip_labels=self.config.skip_labels,
@@ -3845,6 +4014,26 @@ class BossLoop:
         if existing_pr_status is not None:
             return existing_pr_status
 
+        issue_claimed, issue_claim_reason = self._claim_issue_dispatch(selected.number)
+        if not issue_claimed:
+            issue_dict = self._issue_payload(selected)
+            return BossIterationStatus(
+                iteration=iteration,
+                run_id=self.run_id,
+                timestamp=now,
+                runner_freshness=freshness_dict,
+                selected_issue=issue_dict,
+                worker_status="skipped",
+                stop_reason=None,
+                needs_human_reasons=[],
+                next_actions=[
+                    issue_claim_reason
+                    or f"Issue #{selected.number} is already claimed by another boss loop."
+                ],
+                elapsed_seconds=time.monotonic() - iter_start,
+                worker_outcome="issue_claimed",
+            )
+
         # Step 4: Dispatch supervised work for this issue
         issue_dict = self._issue_payload(selected)
         self._attempted_issues.append(issue_dict)
@@ -3876,7 +4065,10 @@ class BossLoop:
             ),
         )
 
-        worker_result = await self._dispatch_issue(selected, freshness)
+        try:
+            worker_result = await self._dispatch_issue(selected, freshness)
+        finally:
+            self._release_issue_dispatch_claim(selected.number)
         return self._finalize_worker_result(
             iteration=iteration,
             timestamp=now,
@@ -3930,6 +4122,7 @@ class BossLoop:
         candidate_issues = [
             i for i in issues if i.number in pending_issue_numbers or i.number not in already_maxed
         ]
+        candidate_issues = self._filter_issues_with_active_claims(candidate_issues)
         eligibility_report = build_issue_eligibility_report(
             candidate_issues,
             skip_labels=self.config.skip_labels,
@@ -4051,6 +4244,27 @@ class BossLoop:
         while pending_issues and len(active_tasks) < parallel_limit:
             issue = pending_issues.pop(0)
             issue_dict = self._issue_payload(issue)
+            issue_claimed, issue_claim_reason = self._claim_issue_dispatch(issue.number)
+            if not issue_claimed:
+                statuses.append(
+                    BossIterationStatus(
+                        iteration=iteration,
+                        run_id=self.run_id,
+                        timestamp=now,
+                        runner_freshness=freshness_dict,
+                        selected_issue=issue_dict,
+                        worker_status="skipped",
+                        stop_reason=None,
+                        needs_human_reasons=[],
+                        next_actions=[
+                            issue_claim_reason
+                            or f"Issue #{issue.number} is already claimed by another boss loop."
+                        ],
+                        elapsed_seconds=time.monotonic() - iter_start,
+                        worker_outcome="issue_claimed",
+                    )
+                )
+                continue
             self._attempted_issues.append(issue_dict)
             self._issue_attempt_counts[issue.number] = (
                 self._issue_attempt_counts.get(issue.number, 0) + 1
@@ -4079,7 +4293,7 @@ class BossLoop:
                     elapsed_seconds=time.monotonic() - iter_start,
                 ),
             )
-            task = asyncio.create_task(self._dispatch_issue(issue, freshness))
+            task = asyncio.create_task(self._dispatch_issue_under_claim(issue, freshness))
             active_tasks[task] = (issue, issue_dict, time.monotonic())
 
         while active_tasks:
@@ -5097,6 +5311,16 @@ class BossLoop:
             if error:
                 logger.warning("Boss dispatch failed for issue #%d: %s", issue.number, error)
         return result
+
+    async def _dispatch_issue_under_claim(
+        self,
+        issue: GitHubIssue,
+        freshness: RunnerFreshnessResult,
+    ) -> dict[str, Any]:
+        try:
+            return await self._dispatch_issue(issue, freshness)
+        finally:
+            self._release_issue_dispatch_claim(issue.number)
 
     @staticmethod
     def _load_resume_context(issue_number: int | None) -> str:

--- a/aragora/swarm/boss_loop_claims.py
+++ b/aragora/swarm/boss_loop_claims.py
@@ -1,0 +1,195 @@
+"""Issue dispatch claim lock for parallel boss loop safety.
+
+Prevents two boss loop instances from dispatching the same issue by
+writing a claim file to .aragora/issue_claims/{issue_number}.lock.
+Claims auto-expire after TTL or when the owning process dies.
+
+Extracted from boss_loop.py to keep it under the LOC ratchet.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+UTC = timezone.utc
+
+ISSUE_CLAIM_TTL_SECONDS = 30 * 60
+
+
+def issue_claims_dir() -> Path:
+    return Path.cwd() / ".aragora" / "issue_claims"
+
+
+def issue_claim_path(issue_number: int) -> Path:
+    return issue_claims_dir() / f"{int(issue_number)}.lock"
+
+
+def read_issue_claim_payload(path: Path) -> dict[str, Any] | None:
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def issue_claim_owner_pid(payload: dict[str, Any] | None) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    try:
+        pid = int(payload.get("pid", 0) or 0)
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def claim_owned_by(payload: dict[str, Any] | None, run_id: str) -> bool:
+    return (
+        isinstance(payload, dict)
+        and str(payload.get("run_id", "")).strip() == run_id
+        and issue_claim_owner_pid(payload) == os.getpid()
+    )
+
+
+def reap_stale_claim(
+    issue_number: int,
+    path: Path,
+    payload: dict[str, Any] | None,
+    run_id: str,
+) -> bool:
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+
+    stale_reason: str | None = None
+    age_seconds = max(0.0, time.time() - stat.st_mtime)
+    if age_seconds > ISSUE_CLAIM_TTL_SECONDS:
+        stale_reason = "expired"
+    else:
+        owner_pid = issue_claim_owner_pid(payload)
+        owner_host = str((payload or {}).get("host", "")).strip()
+        if owner_pid is not None and (not owner_host or owner_host == socket.gethostname()):
+            try:
+                os.kill(owner_pid, 0)
+            except ProcessLookupError:
+                stale_reason = "owner_dead"
+            except PermissionError:
+                stale_reason = None
+
+    if stale_reason is None:
+        return False
+
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return True
+    except OSError:
+        logger.debug("Failed to remove stale boss issue claim %s", path, exc_info=True)
+        return False
+
+    logger.info("boss_loop_reaped_issue_claim issue=#%s reason=%s", issue_number, stale_reason)
+    return True
+
+
+def has_active_foreign_claim(issue_number: int, run_id: str) -> bool:
+    path = issue_claim_path(issue_number)
+    if not path.exists():
+        return False
+    payload = read_issue_claim_payload(path)
+    if claim_owned_by(payload, run_id):
+        return False
+    if reap_stale_claim(issue_number, path, payload, run_id):
+        return False
+    return True
+
+
+def filter_claimed_issues(
+    issues: list[Any],
+    run_id: str,
+) -> list[Any]:
+    filtered: list[Any] = []
+    for issue in issues:
+        if has_active_foreign_claim(issue.number, run_id):
+            logger.info("boss_loop_skip_claimed_issue issue=#%s", issue.number)
+            continue
+        filtered.append(issue)
+    return filtered
+
+
+def claim_issue(issue_number: int, run_id: str) -> tuple[bool, str | None]:
+    path = issue_claim_path(issue_number)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "issue_number": int(issue_number),
+        "run_id": run_id,
+        "pid": os.getpid(),
+        "host": socket.gethostname(),
+        "claimed_at": datetime.now(UTC).isoformat(),
+    }
+    serialized = json.dumps(payload, sort_keys=True)
+
+    while True:
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            existing = read_issue_claim_payload(path)
+            if claim_owned_by(existing, run_id):
+                return True, None
+            if reap_stale_claim(issue_number, path, existing, run_id):
+                continue
+            owner_parts: list[str] = []
+            if isinstance(existing, dict):
+                existing_run_id = str(existing.get("run_id", "")).strip()
+                if existing_run_id:
+                    owner_parts.append(existing_run_id)
+                existing_pid = issue_claim_owner_pid(existing)
+                if existing_pid is not None:
+                    owner_parts.append(f"pid {existing_pid}")
+                existing_host = str(existing.get("host", "")).strip()
+                if existing_host:
+                    owner_parts.append(existing_host)
+            owner_text = ", ".join(owner_parts) if owner_parts else "another boss loop"
+            return False, f"Issue #{issue_number} is already claimed by {owner_text}."
+        except OSError as exc:
+            return False, f"Failed to claim issue #{issue_number}: {exc}"
+
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(serialized)
+                handle.write("\n")
+        except OSError as exc:
+            try:
+                path.unlink()
+            except OSError:
+                logger.debug("Failed to clean up partial boss issue claim %s", path, exc_info=True)
+            return False, f"Failed to persist issue claim for #{issue_number}: {exc}"
+        return True, None
+
+
+def release_claim(issue_number: int, run_id: str) -> None:
+    path = issue_claim_path(issue_number)
+    payload = read_issue_claim_payload(path)
+    if payload is not None and not claim_owned_by(payload, run_id):
+        return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        logger.debug("Failed to release boss issue claim %s", path, exc_info=True)

--- a/aragora/swarm/boss_loop_outcome.py
+++ b/aragora/swarm/boss_loop_outcome.py
@@ -14,6 +14,53 @@ from aragora.swarm.terminal_truth import TerminalClass, classify_from_metrics
 logger = logging.getLogger(__name__)
 
 
+def extract_iteration_metrics(worker_result: dict[str, Any]) -> tuple[int, int, int]:
+    """Summarize changed files and test verification from a worker run.
+
+    Returns (files_changed, tests_run, tests_passed).
+    """
+    run_dict = worker_result.get("run")
+    if not isinstance(run_dict, dict):
+        return 0, 0, 0
+
+    changed_files: list[str] = []
+    tests_run: list[str] = []
+    tests_passed = 0
+    saw_verification_results = False
+
+    for work_order in run_dict.get("work_orders", []):
+        if not isinstance(work_order, dict):
+            continue
+        changed_files.extend(
+            str(path).strip() for path in work_order.get("changed_paths", []) if str(path).strip()
+        )
+        tests_run.extend(
+            str(command).strip()
+            for command in work_order.get("tests_run", [])
+            if str(command).strip()
+        )
+        verification_results = work_order.get("verification_results", [])
+        if not isinstance(verification_results, list):
+            continue
+        for verification in verification_results:
+            if not isinstance(verification, dict):
+                continue
+            saw_verification_results = True
+            if verification.get("passed") is True:
+                tests_passed += 1
+
+    unique_changed_files = list(dict.fromkeys(changed_files))
+    unique_tests_run = list(dict.fromkeys(tests_run))
+    if (
+        not saw_verification_results
+        and unique_tests_run
+        and str(worker_result.get("status", "")).strip().lower() == "completed"
+    ):
+        tests_passed = len(unique_tests_run)
+
+    return len(unique_changed_files), len(unique_tests_run), tests_passed
+
+
 def append_iteration_metrics(
     *,
     metrics_jsonl_path: str | None,

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -17,6 +17,8 @@ import argparse
 import asyncio
 import json
 import os
+import socket
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -27,6 +29,7 @@ import pytest
 
 from aragora.swarm.boss_loop import (
     _should_replace_with_focused_tests,
+    _ISSUE_CLAIM_TTL_SECONDS,
     build_issue_eligibility_report,
     BossIterationStatus,
     BossLoop,
@@ -440,6 +443,111 @@ class TestBatchIssueSelection:
 
         assert seen["numbers"] == [2]
         assert [issue.number for issue in selected] == [2]
+
+    @pytest.mark.asyncio
+    async def test_run_iteration_filters_active_foreign_issue_claim(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        claim_dir = tmp_path / ".aragora" / "issue_claims"
+        claim_dir.mkdir(parents=True)
+        (claim_dir / "1.lock").write_text(
+            json.dumps(
+                {
+                    "issue_number": 1,
+                    "run_id": "boss-other",
+                    "pid": os.getpid(),
+                    "host": socket.gethostname(),
+                    "claimed_at": datetime.now(UTC).isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        issue_one = _make_issue(1, "Claimed elsewhere")
+        issue_two = _make_issue(2, "Dispatch me instead")
+        feed = MagicMock()
+        feed.fetch.return_value = [issue_one, issue_two]
+        loop = BossLoop(
+            _boss_config(max_iterations=1),
+            issue_feed=feed,
+            freshness_checker=lambda **_: _fresh_result(fresh=True),
+        )
+        loop._existing_open_pr_skip_status = lambda **_: None
+        loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+
+        status = await loop._run_iteration(1)
+
+        assert status.worker_status == "completed"
+        assert status.selected_issue["number"] == 2
+        loop._dispatch_issue.assert_awaited_once_with(issue_two, ANY)
+
+    @pytest.mark.asyncio
+    async def test_run_iteration_skips_issue_when_claim_taken_before_dispatch(self):
+        issue = _make_issue(1, "Race on issue claim")
+        feed = MagicMock()
+        feed.fetch.return_value = [issue]
+        loop = BossLoop(
+            _boss_config(max_iterations=1),
+            issue_feed=feed,
+            freshness_checker=lambda **_: _fresh_result(fresh=True),
+        )
+        loop._existing_open_pr_skip_status = lambda **_: None
+        loop._claim_issue_dispatch = lambda issue_number: (
+            False,
+            f"Issue #{issue_number} is already claimed by boss-other.",
+        )
+        loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+
+        status = await loop._run_iteration(1)
+
+        assert status.worker_status == "skipped"
+        assert status.worker_outcome == "issue_claimed"
+        assert status.selected_issue["number"] == 1
+        loop._dispatch_issue.assert_not_awaited()
+
+    def test_claim_issue_dispatch_reaps_expired_claim(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        claim_dir = tmp_path / ".aragora" / "issue_claims"
+        claim_dir.mkdir(parents=True)
+        claim_path = claim_dir / "42.lock"
+        claim_path.write_text(
+            json.dumps(
+                {
+                    "issue_number": 42,
+                    "run_id": "boss-old",
+                    "pid": 999999,
+                    "host": socket.gethostname(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        expired = time.time() - (_ISSUE_CLAIM_TTL_SECONDS + 5)
+        os.utime(claim_path, (expired, expired))
+
+        loop = BossLoop(_boss_config(max_iterations=1))
+
+        claimed, reason = loop._claim_issue_dispatch(42)
+
+        assert claimed is True
+        assert reason is None
+        payload = json.loads(claim_path.read_text(encoding="utf-8"))
+        assert payload["run_id"] == loop.run_id
+        assert payload["pid"] == os.getpid()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_issue_under_claim_releases_issue_lock(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        loop = BossLoop(_boss_config(max_iterations=1))
+        issue = _make_issue(77, "Release claim after dispatch")
+        claimed, reason = loop._claim_issue_dispatch(issue.number)
+        assert claimed is True
+        assert reason is None
+
+        loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+
+        result = await loop._dispatch_issue_under_claim(issue, _fresh_result(fresh=True))
+
+        assert result["status"] == "completed"
+        assert not loop._issue_claim_path(issue.number).exists()
 
     def test_skips_issues_with_skip_labels(self):
         issues = [


### PR DESCRIPTION
## Summary
- filter out actively claimed issues before boss selection so foreign in-flight work is skipped instead of redispatched
- add an atomic per-issue claim file under `.aragora/issue_claims` with stale-claim reaping for dead or expired owners
- release issue claims after dispatch and cover selection, race, expiry, and release behavior with focused boss-loop tests

## Validation
- python3 -m pytest tests/swarm/test_boss_loop.py -q -k "issue_claim or parallel_selection or skips_issues_with_skip_labels"
- ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5391