### PR TITLE
test(swarm): add edge case tests for RescueEvent ledger (#5394)

### DIFF
--- a/tests/swarm/test_rescue_events.py
+++ b/tests/swarm/test_rescue_events.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -82,6 +83,59 @@ class TestRescueEventLedger:
         assert ledger.count_by_type() == {}
         assert ledger.repeated_classes() == []
 
+    def test_concurrent_writes(self, ledger: RescueEventLedger) -> None:
+        """Two threads writing in rapid succession should not lose events."""
+        barrier = threading.Barrier(2)
+
+        def _write(idx: int) -> None:
+            barrier.wait()
+            ledger.record(RescueEvent(event_type="other", reason=f"thread-{idx}"))
+
+        threads = [threading.Thread(target=_write, args=(i,)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        events = ledger.recent()
+        assert len(events) == 2
+        reasons = {e.reason for e in events}
+        assert reasons == {"thread-0", "thread-1"}
+
+    def test_malformed_jsonl_lines_skipped(self, ledger: RescueEventLedger) -> None:
+        """Malformed lines in the JSONL file should be silently skipped."""
+        ledger.record(RescueEvent(event_type="followup_prompt", reason="good"))
+        # Inject malformed lines directly into the file
+        with ledger.path.open("a", encoding="utf-8") as f:
+            f.write("NOT VALID JSON\n")
+            f.write("{}\n")  # missing required fields — still parseable
+            f.write('{"event_type": "other", "reason": "also good"}\n')
+        events = ledger.recent()
+        # First good event + empty-dict event (defaults) + last good event
+        assert any(e.reason == "good" for e in events)
+        assert any(e.reason == "also good" for e in events)
+
+    def test_large_ledger_performance(self, ledger: RescueEventLedger) -> None:
+        """Ledger with 1000+ events should still return results correctly."""
+        count = 1200
+        # Write all events in bulk for speed
+        ledger.path.parent.mkdir(parents=True, exist_ok=True)
+        with ledger.path.open("a", encoding="utf-8") as f:
+            for i in range(count):
+                import json as _json
+
+                evt = RescueEvent(event_type="other", reason=f"evt-{i}")
+                f.write(_json.dumps(evt.to_dict(), sort_keys=True) + "\n")
+
+        # Default limit 50
+        events = ledger.recent()
+        assert len(events) == 50
+        assert events[-1].reason == f"evt-{count - 1}"
+
+        # Explicit large limit
+        all_events = ledger.recent(limit=2000)
+        assert len(all_events) == count
+
 
 class TestRecordRescueConvenience:
     def test_convenience_function(self, tmp_path: Path) -> None:
@@ -103,3 +157,27 @@ class TestRescueEventType:
     def test_enum_values(self) -> None:
         assert RescueEventType.FOLLOWUP_PROMPT.value == "followup_prompt"
         assert RescueEventType.COPY_PASTE_RELAY.value == "copy_paste_relay"
+
+    def test_enum_completeness(self) -> None:
+        """All expected rescue event types should be present."""
+        expected = {
+            "followup_prompt",
+            "permission_approval",
+            "issue_rewrite",
+            "issue_requeue",
+            "session_restart",
+            "session_kill",
+            "pr_shepherd",
+            "blocked_escalate",
+            "manual_merge",
+            "worktree_cleanup",
+            "copy_paste_relay",
+            "other",
+        }
+        actual = {member.value for member in RescueEventType}
+        assert actual == expected
+
+    def test_enum_is_str_subclass(self) -> None:
+        """RescueEventType members should be usable as plain strings."""
+        assert isinstance(RescueEventType.OTHER, str)
+        assert RescueEventType.OTHER == "other"


### PR DESCRIPTION
Add tests for concurrent writes, malformed JSONL handling, large ledger
performance (1200 events), enum completeness, and str subclass behavior.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 85fc2058f1f8d8386f0b21baa650a2ee71f6ed27)
