### PR TITLE
feat(swarm): close queue, preflight, and benchmark truth gaps

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -1208,30 +1208,83 @@ def cmd_swarm(args: argparse.Namespace) -> None:
     autonomy_level = autonomy_map.get(autonomy_str, AutonomyLevel.PROPOSE_APPROVE)
 
     if action == "preflight":
-        from aragora.swarm.preflight import run_preflight
+        from aragora.swarm.credential_envelope import CredentialEnvelope
+        from aragora.swarm.preflight import (
+            evaluate_preflight_receipt_gate,
+            run_contract_preflight_receipt,
+            run_preflight,
+        )
 
         repo_root = resolve_repo_root(Path.cwd())
         contract_arg = getattr(args, "contract", None)
-        result = run_preflight(
-            repo_root=repo_root,
-            agent=str(getattr(args, "worker_model", "claude") or "claude"),
-            base_ref=str(target_branch or "main"),
-            skip_publication=skip_publication,
-            contract_path=Path(str(contract_arg)).expanduser() if contract_arg else None,
-        )
-        payload = {"mode": "swarm-preflight", **result.to_dict()}
+        if contract_arg:
+            contract_path = Path(str(contract_arg)).expanduser()
+            envelope = CredentialEnvelope.from_environment(os.environ)
+            receipt = run_contract_preflight_receipt(
+                repo_root=repo_root,
+                agent=str(getattr(args, "worker_model", "claude") or "claude"),
+                base_ref=str(target_branch or "main"),
+                skip_publication=skip_publication,
+                contract_path=contract_path,
+                envelope=envelope,
+            )
+            expected_contract_checksum = str(
+                receipt.artifacts.get("expected_contract_checksum", "") or ""
+            ).strip()
+            admission_gate = evaluate_preflight_receipt_gate(
+                receipt,
+                repo_root=repo_root,
+                envelope=envelope,
+                check_type="scratch" if skip_publication else "remote_publish",
+                base_ref=str(target_branch or "main"),
+                expected_contract_checksum=expected_contract_checksum,
+            )
+            failure_terminal_class = receipt.failure_terminal_class
+            payload = {
+                "mode": "swarm-preflight",
+                "receipt": receipt.to_dict(),
+                "admission_gate": admission_gate.to_dict(),
+                "failure_terminal_class": (
+                    failure_terminal_class.value if failure_terminal_class is not None else None
+                ),
+            }
+        else:
+            result = run_preflight(
+                repo_root=repo_root,
+                agent=str(getattr(args, "worker_model", "claude") or "claude"),
+                base_ref=str(target_branch or "main"),
+                skip_publication=skip_publication,
+                contract_path=None,
+            )
+            payload = {"mode": "swarm-preflight", **result.to_dict()}
         if as_json:
             print(json.dumps(payload, indent=2))
         else:
-            print("swarm preflight: ok")
-            print(f"repo_root={payload['repo_root']}")
-            print(f"agent={payload['agent']}")
-            print(f"base_ref={payload['base_ref']}")
-            print(f"branch={payload['branch']}")
-            worker = payload.get("worker", {})
-            checksum = str(worker.get("worker_contract_checksum", "")).strip()
-            if checksum:
-                print(f"worker_contract_checksum={checksum}")
+            if contract_arg:
+                receipt_payload = dict(payload.get("receipt", {}) or {})
+                gate_payload = dict(payload.get("admission_gate", {}) or {})
+                print(f"swarm preflight: {gate_payload.get('verdict', 'blocked')}")
+                print(f"receipt_id={receipt_payload.get('receipt_id', '')}")
+                print(f"check_type={receipt_payload.get('check_type', '')}")
+                print(f"passed={receipt_payload.get('passed', False)}")
+                print(f"expires_at={receipt_payload.get('expires_at', '')}")
+                failure_terminal_class = str(
+                    payload.get("failure_terminal_class", "") or ""
+                ).strip()
+                if failure_terminal_class:
+                    print(f"failure_terminal_class={failure_terminal_class}")
+            else:
+                print("swarm preflight: ok")
+                print(f"repo_root={payload['repo_root']}")
+                print(f"agent={payload['agent']}")
+                print(f"base_ref={payload['base_ref']}")
+                print(f"branch={payload['branch']}")
+                worker = payload.get("worker", {})
+                checksum = str(worker.get("worker_contract_checksum", "")).strip()
+                if checksum:
+                    print(f"worker_contract_checksum={checksum}")
+        if contract_arg and payload["admission_gate"]["verdict"] != "pass":
+            raise SystemExit(2)
         return
 
     if action in {"coord", "assign", "claim-pr", "report", "findings"}:

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -28,6 +28,7 @@ from aragora.swarm.boss_loop_outcome import append_iteration_metrics
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
 from aragora.swarm.dispatch_contract_gate import dispatch_contract_gate
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.roadmap_priority import load_roadmap_priority_policy
 from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
 from aragora.swarm.terminal_truth import (
     extract_run_deliverable,
@@ -1447,6 +1448,20 @@ class BossLoop:
             return
 
         lineage_root, decomposition_depth = self._decomposition_lineage(issue)
+        roadmap_priority = self._roadmap_priority_match_for_issue_lineage(
+            issue=issue,
+            issues=issues,
+            lineage_root=lineage_root,
+        )
+        if roadmap_priority is not None and roadmap_priority.priority.blocks_boss_ready:
+            blocked_codes = ", ".join(roadmap_priority.blocked_codes) or "delayed roadmap refs"
+            self._label_boss_stuck(
+                issue_number,
+                repo,
+                "Auto-decomposition skipped because the issue lineage references "
+                f"{blocked_codes}, which is outside the canonical do-now set.",
+            )
+            return
         if decomposition_depth >= self.config.max_decomposition_depth:
             self._label_boss_stuck(
                 issue_number,
@@ -1758,6 +1773,39 @@ class BossLoop:
             depth = 0
 
         return root_issue, depth
+
+    def _fetch_issue_by_number(self, issue_number: int) -> GitHubIssue | None:
+        fetch_issue = getattr(self._feed, "_fetch_issue", None)
+        if not callable(fetch_issue):
+            return None
+        try:
+            issue = fetch_issue(issue_number, allow_closed=True)
+        except TypeError:
+            try:
+                issue = fetch_issue(issue_number)
+            except Exception:
+                return None
+        except Exception:
+            return None
+        return issue if isinstance(issue, GitHubIssue) else None
+
+    def _roadmap_priority_match_for_issue_lineage(
+        self,
+        *,
+        issue: GitHubIssue,
+        issues: list[GitHubIssue],
+        lineage_root: int,
+    ) -> Any:
+        policy = load_roadmap_priority_policy(Path.cwd())
+        if policy is None:
+            return None
+        root_issue = next((item for item in issues if item.number == lineage_root), None)
+        if root_issue is None and lineage_root != int(issue.number):
+            root_issue = self._fetch_issue_by_number(lineage_root)
+        texts = [issue.title, issue.body or ""]
+        if root_issue is not None and int(root_issue.number) != int(issue.number):
+            texts.extend([root_issue.title, root_issue.body or ""])
+        return policy.priority_for_text(*texts)
 
     @staticmethod
     def _decomposition_scope_entries(

--- a/aragora/swarm/decomposition_bridge.py
+++ b/aragora/swarm/decomposition_bridge.py
@@ -32,6 +32,7 @@ from aragora.swarm.boss_validation import (
 from aragora.swarm.issue_scanner import BossIssueCandidate, infer_issue_category_from_title
 from aragora.swarm.micro_decomposer import build_micro_work_orders
 from aragora.swarm.prompt_refiner import refine_worker_prompt
+from aragora.swarm.roadmap_priority import load_roadmap_priority_policy
 from aragora.swarm.spec import SwarmSpec
 from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
 
@@ -129,6 +130,7 @@ class DecompositionBridge:
         self.repo_root = Path(repo_root).resolve()
         self._task_decomposer = TaskDecomposer()
         self._task_sanitizer = TaskSanitizer(repo_root=self.repo_root)
+        self._priority_policy = load_roadmap_priority_policy(self.repo_root)
 
     async def decompose_issue(
         self,
@@ -150,6 +152,14 @@ class DecompositionBridge:
     ) -> DecompositionOutcome:
         if max_children <= 0:
             return DecompositionOutcome(children=[], stats=DecompositionStats())
+        if self._priority_policy is not None:
+            priority = self._priority_policy.priority_for_text(title, body)
+            if priority.priority.blocks_boss_ready:
+                logger.info(
+                    "Skipping decomposition for delayed/avoided roadmap refs: %s",
+                    ", ".join(priority.blocked_codes),
+                )
+                return DecompositionOutcome(children=[], stats=DecompositionStats())
 
         spec = self._build_parent_spec(title, body)
         parent_category = infer_issue_category_from_title(title) or "decomposed_issue"

--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -994,6 +994,263 @@ def run_remote_publish_validation_receipt(
     return receipt
 
 
+def _dispatch_gate_detail(dispatch_gate: dict[str, Any]) -> str:
+    gate = dict(dispatch_gate or {})
+    parts: list[str] = []
+    verdict = str(gate.get("verdict", "") or "").strip()
+    if verdict:
+        parts.append(f"verdict={verdict}")
+    failure_classes = [
+        str(item).strip() for item in list(gate.get("failure_classes") or []) if str(item).strip()
+    ]
+    if failure_classes:
+        parts.append(f"failure_classes={','.join(failure_classes)}")
+    notes = str(gate.get("notes", "") or "").strip()
+    if notes:
+        parts.append(notes)
+    return " | ".join(parts) or "dispatch gate unavailable"
+
+
+def _checks_from_contract_preflight_result(
+    result: PreflightResult,
+    *,
+    expected_contract_checksum: str,
+    skip_publication: bool,
+) -> list[dict[str, Any]]:
+    checks = [dict(item) for item in list(result.checks or [])]
+    worker = dict(result.worker or {})
+    worker_checksum = str(worker.get("worker_contract_checksum", "") or "").strip()
+    checks.append(
+        {
+            "name": "dispatch_gate",
+            "passed": str(result.dispatch_gate.get("verdict", "")).strip()
+            == GateVerdict.PASS.value,
+            "detail": _dispatch_gate_detail(result.dispatch_gate),
+        }
+    )
+    checks.append(
+        {
+            "name": "worker_contract_checksum",
+            "passed": bool(worker_checksum) and worker_checksum == expected_contract_checksum,
+            "detail": worker_checksum or "missing worker_contract_checksum",
+        }
+    )
+    commit_shas = [
+        str(item).strip() for item in list(worker.get("commit_shas") or []) if str(item).strip()
+    ]
+    checks.append(
+        {
+            "name": "worker_commit",
+            "passed": bool(commit_shas),
+            "detail": ",".join(commit_shas) if commit_shas else "worker produced no commit",
+        }
+    )
+    if not skip_publication:
+        checks.append(
+            {
+                "name": "publication_flow",
+                "passed": bool(result.published)
+                and bool(result.pull_request_created)
+                and bool(result.pull_request_closed),
+                "detail": (
+                    f"published={result.published} "
+                    f"pr_created={result.pull_request_created} "
+                    f"pr_closed={result.pull_request_closed}"
+                ),
+            }
+        )
+    return checks
+
+
+def run_contract_preflight_receipt(
+    *,
+    repo_root: Path,
+    agent: str | None = None,
+    base_ref: str = "main",
+    skip_publication: bool = False,
+    contract_path: Path,
+    envelope: CredentialEnvelope | None = None,
+) -> PreflightReceipt:
+    resolved_repo_root = repo_root.resolve()
+    normalized_base_ref = str(base_ref or "main").strip() or "main"
+    normalized_contract_path = contract_path.expanduser().resolve()
+    normalized_check_type = "scratch" if skip_publication else "remote_publish"
+    resolved_envelope = envelope or CredentialEnvelope.from_environment(os.environ)
+    started_at = _utc_now()
+    checks: list[dict[str, Any]] = []
+    artifacts: dict[str, Any] = {
+        "target_ref": normalized_base_ref,
+        "contract_path": str(normalized_contract_path),
+        "skip_publication": bool(skip_publication),
+        "expected_contract_checksum": "",
+    }
+    try:
+        _, expected_contract_checksum = _load_contract_payload(normalized_contract_path)
+        artifacts["expected_contract_checksum"] = expected_contract_checksum
+    except Exception as exc:
+        checks.append({"name": "contract_payload", "passed": False, "detail": str(exc)})
+        finished_at = _utc_now()
+        receipt = _finalize_preflight_receipt(
+            repo_root=resolved_repo_root,
+            envelope=resolved_envelope,
+            check_type=normalized_check_type,
+            base_ref=normalized_base_ref,
+            started_at=started_at,
+            finished_at=finished_at,
+            checks=checks,
+            artifacts=artifacts,
+        )
+        _save_preflight_receipt(resolved_repo_root, receipt)
+        return receipt
+
+    try:
+        result = run_preflight(
+            repo_root=resolved_repo_root,
+            agent=agent,
+            base_ref=normalized_base_ref,
+            skip_publication=skip_publication,
+            contract_path=normalized_contract_path,
+        )
+    except Exception as exc:
+        checks.append({"name": "contract_preflight", "passed": False, "detail": str(exc)})
+    else:
+        checks.extend(
+            _checks_from_contract_preflight_result(
+                result,
+                expected_contract_checksum=expected_contract_checksum,
+                skip_publication=skip_publication,
+            )
+        )
+        artifacts.update(
+            {
+                "branch": str(result.branch or "").strip(),
+                "worktree_path": str(result.worktree_path or "").strip(),
+                "agent": str(result.agent or "").strip(),
+                "published": bool(result.published),
+                "pull_request_created": bool(result.pull_request_created),
+                "pull_request_closed": bool(result.pull_request_closed),
+                "cleanup_worktree_removed": bool(result.cleanup_worktree_removed),
+                "cleanup_branch_removed": bool(result.cleanup_branch_removed),
+                "dispatch_gate": dict(result.dispatch_gate),
+                "worker_contract_checksum": str(
+                    (result.worker or {}).get("worker_contract_checksum", "") or ""
+                ).strip(),
+                "commit_shas": [
+                    str(item).strip()
+                    for item in list((result.worker or {}).get("commit_shas") or [])
+                    if str(item).strip()
+                ],
+            }
+        )
+
+    finished_at = _utc_now()
+    receipt = _finalize_preflight_receipt(
+        repo_root=resolved_repo_root,
+        envelope=resolved_envelope,
+        check_type=normalized_check_type,
+        base_ref=normalized_base_ref,
+        started_at=started_at,
+        finished_at=finished_at,
+        checks=checks,
+        artifacts=artifacts,
+    )
+    _save_preflight_receipt(resolved_repo_root, receipt)
+    return receipt
+
+
+def evaluate_preflight_receipt_gate(
+    receipt: PreflightReceipt | None,
+    *,
+    repo_root: Path,
+    envelope: CredentialEnvelope,
+    check_type: str,
+    base_ref: str = "main",
+    expected_contract_checksum: str = "",
+    now: datetime | None = None,
+) -> GateEvaluation:
+    normalized = _validate_check_type(check_type)
+    current_time = now or _utc_now()
+    normalized_base_ref = str(base_ref or "main").strip() or "main"
+    required_evidence = ["preflight_receipt"]
+    if receipt is None:
+        return GateEvaluation(
+            gate_type=GateType.DISPATCH_READY.value,
+            verdict=GateVerdict.BLOCKED.value,
+            failure_classes=["receipt_missing"],
+            required_evidence=required_evidence,
+            notes="Preflight admission blocked: receipt missing.",
+        )
+    if str(receipt.check_type or "").strip() != normalized:
+        return GateEvaluation(
+            gate_type=GateType.DISPATCH_READY.value,
+            verdict=GateVerdict.BLOCKED.value,
+            failure_classes=["receipt_check_type_mismatch"],
+            required_evidence=required_evidence,
+            notes=(
+                "Preflight admission blocked: receipt check type "
+                f"`{receipt.check_type}` does not match expected `{normalized}`."
+            ),
+        )
+    if str(receipt.envelope_seal or "").strip() != envelope.preflight_cache_seal():
+        return GateEvaluation(
+            gate_type=GateType.DISPATCH_READY.value,
+            verdict=GateVerdict.BLOCKED.value,
+            failure_classes=["receipt_envelope_mismatch"],
+            required_evidence=required_evidence,
+            notes="Preflight admission blocked: credential envelope no longer matches the receipt.",
+        )
+    if _parse_isoformat_utc(receipt.expires_at) <= current_time:
+        return GateEvaluation(
+            gate_type=GateType.DISPATCH_READY.value,
+            verdict=GateVerdict.BLOCKED.value,
+            failure_classes=["receipt_expired"],
+            required_evidence=required_evidence,
+            notes="Preflight admission blocked: receipt expired.",
+        )
+    if normalized == "remote_publish":
+        target_ref = str(receipt.artifacts.get("target_ref", "") or "").strip() or "main"
+        if target_ref != normalized_base_ref:
+            return GateEvaluation(
+                gate_type=GateType.DISPATCH_READY.value,
+                verdict=GateVerdict.BLOCKED.value,
+                failure_classes=["receipt_target_ref_mismatch"],
+                required_evidence=required_evidence,
+                notes=(
+                    "Preflight admission blocked: receipt target ref "
+                    f"`{target_ref}` does not match expected `{normalized_base_ref}`."
+                ),
+            )
+    if expected_contract_checksum:
+        actual_contract_checksum = str(
+            receipt.artifacts.get("expected_contract_checksum", "") or ""
+        ).strip()
+        if actual_contract_checksum != expected_contract_checksum:
+            return GateEvaluation(
+                gate_type=GateType.DISPATCH_READY.value,
+                verdict=GateVerdict.BLOCKED.value,
+                failure_classes=["receipt_contract_mismatch"],
+                required_evidence=required_evidence,
+                notes="Preflight admission blocked: receipt contract checksum mismatch.",
+            )
+    if not receipt.passed:
+        failure_class = receipt.failure_terminal_class
+        return GateEvaluation(
+            gate_type=GateType.DISPATCH_READY.value,
+            verdict=GateVerdict.BLOCKED.value,
+            failure_classes=[
+                failure_class.value if failure_class is not None else "preflight_failed"
+            ],
+            required_evidence=required_evidence,
+            notes="Preflight admission blocked: receipt recorded a failed preflight.",
+        )
+    return GateEvaluation(
+        gate_type=GateType.DISPATCH_READY.value,
+        verdict=GateVerdict.PASS.value,
+        required_evidence=required_evidence,
+        notes=f"Preflight receipt verified: {receipt.receipt_id}",
+    )
+
+
 def _branch_name() -> str:
     stamp = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
     return f"preflight/{stamp}"

--- a/aragora/swarm/roadmap_priority.py
+++ b/aragora/swarm/roadmap_priority.py
@@ -1,0 +1,141 @@
+"""Canonical roadmap-priority helpers for boss-ready issue governance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+import re
+
+_SECTION_DO_NOW = "do_now"
+_SECTION_DELAY = "delay"
+_SECTION_AVOID = "avoid"
+_SECTION_NAMES = {
+    "### Do now": _SECTION_DO_NOW,
+    "### Delay": _SECTION_DELAY,
+    "### Avoid in this tranche": _SECTION_AVOID,
+}
+_CODE_RE = re.compile(r"\b([A-Z]+-\d+(?:\.\.\d+)?)\b")
+_RANGE_RE = re.compile(r"^(?P<prefix>[A-Z]+)-(?P<start>\d+)\.\.(?P<end>\d+)$")
+
+
+class RoadmapPriority(str, Enum):
+    DO_NOW = "do_now"
+    DELAY = "delay"
+    AVOID = "avoid"
+    UNKNOWN = "unknown"
+
+    @property
+    def blocks_boss_ready(self) -> bool:
+        return self in {self.DELAY, self.AVOID}
+
+
+@dataclass(frozen=True)
+class RoadmapPriorityMatch:
+    priority: RoadmapPriority
+    codes: tuple[str, ...]
+    blocked_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RoadmapPriorityPolicy:
+    do_now: frozenset[str]
+    delay: frozenset[str]
+    avoid: frozenset[str]
+
+    def priority_for_codes(
+        self, codes: list[str] | tuple[str, ...] | set[str]
+    ) -> RoadmapPriorityMatch:
+        ordered = tuple(dict.fromkeys(str(code).strip() for code in codes if str(code).strip()))
+        blocked: list[str] = []
+        if any(code in self.avoid for code in ordered):
+            blocked = [code for code in ordered if code in self.avoid]
+            return RoadmapPriorityMatch(RoadmapPriority.AVOID, ordered, tuple(blocked))
+        if any(code in self.delay for code in ordered):
+            blocked = [code for code in ordered if code in self.delay]
+            return RoadmapPriorityMatch(RoadmapPriority.DELAY, ordered, tuple(blocked))
+        if any(code in self.do_now for code in ordered):
+            return RoadmapPriorityMatch(RoadmapPriority.DO_NOW, ordered, ())
+        return RoadmapPriorityMatch(RoadmapPriority.UNKNOWN, ordered, ())
+
+    def priority_for_text(self, *texts: str) -> RoadmapPriorityMatch:
+        codes: list[str] = []
+        for text in texts:
+            codes.extend(extract_roadmap_codes(text))
+        return self.priority_for_codes(codes)
+
+    def allows_boss_ready(self, *texts: str) -> bool:
+        return not self.priority_for_text(*texts).priority.blocks_boss_ready
+
+
+def _canonical_path(repo_root: Path | str) -> Path:
+    return Path(repo_root) / "docs" / "status" / "NEXT_STEPS_CANONICAL.md"
+
+
+def load_roadmap_priority_policy(repo_root: Path | str) -> RoadmapPriorityPolicy | None:
+    path = _canonical_path(repo_root)
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8")
+    buckets = {
+        _SECTION_DO_NOW: set(),
+        _SECTION_DELAY: set(),
+        _SECTION_AVOID: set(),
+    }
+    current_section = ""
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("### "):
+            current_section = _SECTION_NAMES.get(line, "")
+            continue
+        if not current_section or not line.startswith("- "):
+            continue
+        for token in _CODE_RE.findall(line):
+            buckets[current_section].update(expand_roadmap_token(token))
+    return RoadmapPriorityPolicy(
+        do_now=frozenset(buckets[_SECTION_DO_NOW]),
+        delay=frozenset(buckets[_SECTION_DELAY]),
+        avoid=frozenset(buckets[_SECTION_AVOID]),
+    )
+
+
+def expand_roadmap_token(token: str) -> tuple[str, ...]:
+    normalized = str(token or "").strip()
+    if not normalized:
+        return ()
+    match = _RANGE_RE.match(normalized)
+    if not match:
+        return (normalized,)
+    prefix = match.group("prefix")
+    start_text = match.group("start")
+    end_text = match.group("end")
+    start = int(start_text)
+    end = int(end_text)
+    width = len(start_text)
+    if end < start:
+        return (normalized,)
+    return tuple(f"{prefix}-{value:0{width}d}" for value in range(start, end + 1))
+
+
+def extract_roadmap_codes(text: str) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for raw in _CODE_RE.findall(str(text or "")):
+        for code in expand_roadmap_token(raw):
+            if code in seen:
+                continue
+            seen.add(code)
+            ordered.append(code)
+    return tuple(ordered)
+
+
+__all__ = [
+    "RoadmapPriority",
+    "RoadmapPriorityMatch",
+    "RoadmapPriorityPolicy",
+    "expand_roadmap_token",
+    "extract_roadmap_codes",
+    "load_roadmap_priority_policy",
+]

--- a/aragora/swarm/strategic_issue_bridge.py
+++ b/aragora/swarm/strategic_issue_bridge.py
@@ -25,6 +25,7 @@ from aragora.swarm.mission import (
     RepairPolicy,
     normalize_context_policies,
 )
+from aragora.swarm.roadmap_priority import load_roadmap_priority_policy
 from aragora.swarm.spec import SwarmSpec
 
 logger = logging.getLogger(__name__)
@@ -450,6 +451,13 @@ class StrategicIssueBridge:
         context = self.load_context()
         active_text = context.get("active_execution", "")
         roadmap_items, priority_order = self.parse_roadmap_items(active_text)
+        priority_policy = load_roadmap_priority_policy(self.repo_root)
+        if priority_policy is not None:
+            roadmap_items = [
+                item
+                for item in roadmap_items
+                if priority_policy.priority_for_codes([item.code]).priority.value == "do_now"
+            ]
 
         llm_candidates: list[StrategicIssueCandidate] = []
         if self.config.enable_llm and not self.config.heuristic_only:

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -45,6 +45,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 - Do now: `RS-07`, `BC-01`, `BC-03`, `BC-02`, `TW-01`, `TW-02`, `TW-03`, `CS-01..03`
 - Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
+- Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
 - Top 3 boss-ready next: `RS-07`, `BC-01`, `BC-03`
 - GitHub coverage for those top 3 remains epic-level only through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issues exist yet
 
@@ -66,7 +67,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 ### Milestone 1.3 — Contract-Aware Preflight `[30-90d]`
 
-- [ ] **RS-07** Build `aragora swarm preflight run --contract ...` _(Partial as of 2026-04-13: module preflight plus scratch/draft-PR validation exist, but the top-level operator surface is still incomplete)_
+- [ ] **RS-07** Build `aragora swarm preflight run --contract ...` _(In progress as of 2026-04-13: the operator surface now has a contract-backed receipt path with persisted `PreflightReceipt` output and fail-closed admission verdicts; remaining follow-through is to make that receipt the default admission truth everywhere that consumes preflight.)_
 - [x] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
 - [x] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
 
@@ -83,7 +84,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 ### Milestone 2.1 — Interactive Sessions & Repair Journal `[90d]`
 
 - [ ] **BC-01** Persist session state across `explore -> plan -> edit -> verify -> repair -> publish`
-- [ ] **BC-02** Resume retries from prior session state instead of fresh prompts
+- [x] **BC-02** Resume retries from prior session state instead of fresh prompts _(Done 2026-04-13 via [#5384](https://github.com/synaptent/aragora/pull/5384))_
 - [ ] **BC-03** Emit precise blocker evidence and repair transcripts for failed runs
 
 ### Milestone 2.2 — Task Sanitizer & Admission Gate `[30-90d]`
@@ -110,8 +111,8 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 ### Milestone 3.1 — Autonomous Software Execution Benchmark `[30d]`
 
-- [ ] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues
-- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate
+- [ ] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Partial as of 2026-04-13: the frozen corpus manifest is checked in at `docs/benchmarks/corpus.json`; the remaining gap is recurring execution against that fixed revision.)_
+- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Partial as of 2026-04-13: diffable truth-artifact generation exists, including truth/no-rescue/failure-class/rescue-type reporting; the remaining gap is recurring publication and status linkage.)_
 - [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -10,7 +10,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to finish `RS-07` and `BC-01..03`, then prove the `B2` guard on the safest execution classes across the current execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to finish `RS-07`, close the remaining truthful repair gaps in `BC-01/03`, and keep `TW-01/TW-02` publishing recurring truth artifacts before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -25,17 +25,24 @@ What is already true:
 - scratch and remote-publish preflight validation now run through the production preflight path and emit canonical terminal truth on `main`
 - task sanitizer outcomes and success-rate filtering are shaping safer boss-loop intake
 - original versus sanitized task text is already preserved for audit on `main`
+- retry dispatch now carries prior session resume context on `main` via [#5384](https://github.com/synaptent/aragora/pull/5384)
+- the rescue loop can now record interventions, plan bounded recovery, and execute safe followups on `main` via [#5379](https://github.com/synaptent/aragora/pull/5379), [#5380](https://github.com/synaptent/aragora/pull/5380), and [#5383](https://github.com/synaptent/aragora/pull/5383)
 
 What is still missing:
 
-- receipt-backed contract preflight on the operator admission path — the module-level preflight exists but nothing yet returns a signed receipt that the supervisor can use as an admission gate for safe classes ([#5327](https://github.com/synaptent/aragora/issues/5327))
-- resumable session state, retry context, and precise blocker evidence on the live swarm loop
-- a checked-in frozen benchmark corpus and recurring no-rescue scorecard that meets the TW-01/TW-02 spec ([#5329](https://github.com/synaptent/aragora/issues/5329))
+- the last `RS-07` step is to make receipt-backed contract preflight the default operator admission truth everywhere, not just a substrate primitive — contract in, persisted receipt out, fail-closed on any mismatch ([#5327](https://github.com/synaptent/aragora/issues/5327))
+- broader repair truth on the live swarm loop still depends on full `BC-01` persistence and precise `BC-03` blocker evidence
+- recurring scheduled use of the frozen corpus and diffable truth artifact still needs to become routine status output ([#5329](https://github.com/synaptent/aragora/issues/5329))
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
 - broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”
+
+Queue rule for this tranche:
+
+- only roadmap codes in the **Do now** set may carry or be auto-created with `boss-ready`
+- delayed-track issues may stay open for planning truth, but restock and auto-decomposition should strip them from the live dispatch queue
 
 ## 30-Day Success Metric
 
@@ -62,7 +69,7 @@ If a task does not improve that metric, it is not first-tranche work.
 
 ### Benchmark corpus requirements (TW-01)
 
-- The corpus is a fixed, versioned list of bounded issues checked into the repo (e.g. `benchmarks/corpus.json`).
+- The corpus is a fixed, versioned list of bounded issues checked into the repo (e.g. `docs/benchmarks/corpus.json`).
 - Issues in the corpus are not swapped ad hoc between runs; additions and removals are tracked as explicit corpus revisions.
 - Each corpus entry includes: issue identifier, expected execution class, and any known constraints.
 - The corpus runs against current `main` on a recurring basis (at minimum weekly) using the existing benchmark scoring lane.
@@ -92,7 +99,9 @@ Scorecard output rules:
 
 - Terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are on `main`.
 - The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
-- What is missing: a checked-in frozen corpus definition and a recurring scorecard output that meets the format above.
+- The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
+- The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
+- What remains is recurring scheduled use of that artifact path, not inventing a second benchmark definition.
 
 ## 30-Day Canonical Backlog
 
@@ -141,7 +150,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ## Top 3 Boss-Ready Next
 
-1. `RS-07` ([#5327](https://github.com/synaptent/aragora/issues/5327)) because it closes the last missing guard on the live operator path — contract in, receipt out, fail-closed admission.
+1. `RS-07` ([#5327](https://github.com/synaptent/aragora/issues/5327)) because it closes the last missing guard on the live operator path and turns preflight into the admission truth the operator can actually trust.
 2. `BC-01` because retries and repair loops cannot become truthful until session state survives restarts.
 3. `BC-03` because founder leverage depends on precise blocker evidence before more retry logic is added.
 

--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Build a corpus-linked benchmark truth artifact for TW-01/TW-02."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.terminal_truth import TerminalClass  # noqa: E402
+from scripts.reconcile_b0_pr_truth import (  # noqa: E402
+    DEFAULT_METRICS_PATH,
+    GitHubTruthClient,
+    IssueMetricsAggregate,
+    reconcile_issue_truth,
+    report_to_json as _unused_report_to_json,
+    resolve_metrics_path,
+    resolve_terminal_class,
+    load_metrics_rows,
+)
+
+DEFAULT_CORPUS_PATH = REPO_ROOT / "docs" / "benchmarks" / "corpus.json"
+
+
+def load_corpus(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Corpus at {path} must be a JSON object")
+    issues = payload.get("issues")
+    if not isinstance(issues, list) or not issues:
+        raise ValueError(f"Corpus at {path} must contain a non-empty 'issues' list")
+    return payload
+
+
+def aggregate_corpus_issues(
+    rows: list[dict[str, Any]],
+    corpus: dict[str, Any],
+) -> list[IssueMetricsAggregate]:
+    by_issue: dict[int, IssueMetricsAggregate] = {}
+    corpus_issues = [item for item in list(corpus.get("issues") or []) if isinstance(item, dict)]
+    for item in corpus_issues:
+        issue_number = int(item.get("issue_id", 0) or 0)
+        if issue_number <= 0:
+            continue
+        by_issue[issue_number] = IssueMetricsAggregate(
+            issue_number=issue_number,
+            title=str(item.get("title") or "").strip(),
+            row_count=0,
+            proxy_pr_signal=False,
+            had_rescue=False,
+        )
+
+    corpus_issue_numbers = set(by_issue)
+    for row in rows:
+        issue_number = row.get("issue_number")
+        if not isinstance(issue_number, int) or issue_number not in corpus_issue_numbers:
+            continue
+        aggregate = by_issue[issue_number]
+        aggregate.row_count += 1
+        terminal_class = resolve_terminal_class(row)
+        publish_action = str(row.get("publish_action", "") or "").strip().lower()
+        worker_outcome = str(row.get("worker_outcome", "") or "").strip().lower()
+        if (
+            terminal_class is TerminalClass.DELIVERABLE_PR_CREATED
+            or publish_action in {"pr_created", "existing_pr", "discovered_after_push"}
+            or worker_outcome in {"pr_adopted"}
+        ):
+            aggregate.proxy_pr_signal = True
+        if terminal_class.value.startswith("rescue_"):
+            aggregate.had_rescue = True
+    return [by_issue[number] for number in sorted(by_issue)]
+
+
+def _failure_distributions(
+    rows: list[dict[str, Any]],
+    *,
+    corpus_issue_numbers: set[int],
+) -> tuple[dict[str, int], dict[str, int]]:
+    failure_counts: Counter[str] = Counter()
+    rescue_counts: Counter[str] = Counter()
+    for row in rows:
+        issue_number = row.get("issue_number")
+        if not isinstance(issue_number, int) or issue_number not in corpus_issue_numbers:
+            continue
+        terminal_class = resolve_terminal_class(row).value
+        if terminal_class.startswith("deliverable_") or terminal_class == "issue_already_resolved":
+            continue
+        failure_counts[terminal_class] += 1
+        if terminal_class.startswith("rescue_"):
+            rescue_counts[terminal_class] += 1
+    return dict(sorted(failure_counts.items())), dict(sorted(rescue_counts.items()))
+
+
+def build_benchmark_truth_artifact(
+    *,
+    repo: str,
+    metrics_file: Path,
+    corpus_path: Path,
+    client: GitHubTruthClient | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    rows = load_metrics_rows(metrics_file)
+    corpus = load_corpus(corpus_path)
+    aggregates = aggregate_corpus_issues(rows, corpus)
+    truth_client = client or GitHubTruthClient()
+    records = [reconcile_issue_truth(repo, aggregate, truth_client) for aggregate in aggregates]
+    corpus_issue_count = len(aggregates)
+    attempted_issue_count = sum(1 for aggregate in aggregates if aggregate.row_count > 0)
+    truth_success_issue_count = sum(1 for record in records if record.truth_success)
+    no_rescue_truth_success_issue_count = sum(
+        1 for record in records if record.no_rescue_truth_success
+    )
+    merged_issue_count = sum(1 for record in records if record.truth_state == "merged_pr")
+    proxy_pr_signal_issue_count = sum(1 for aggregate in aggregates if aggregate.proxy_pr_signal)
+    failure_class_distribution, rescue_counts_by_type = _failure_distributions(
+        rows,
+        corpus_issue_numbers={aggregate.issue_number for aggregate in aggregates},
+    )
+    return {
+        "generated_at": generated_at or dt.datetime.now(dt.UTC).isoformat(),
+        "repo": repo,
+        "metrics_file": str(metrics_file),
+        "corpus": {
+            "path": str(corpus_path),
+            "corpus_id": str(corpus.get("corpus_id") or "").strip(),
+            "revision": int(corpus.get("revision", 0) or 0),
+            "recorded_on": str(corpus.get("recorded_on") or "").strip(),
+            "success_contract": str(corpus.get("success_contract") or "").strip(),
+            "issue_count": corpus_issue_count,
+        },
+        "primary_metrics": {
+            "truth_success_rate": round(truth_success_issue_count / corpus_issue_count, 4)
+            if corpus_issue_count
+            else 0.0,
+            "no_rescue_truth_success_rate": round(
+                no_rescue_truth_success_issue_count / corpus_issue_count,
+                4,
+            )
+            if corpus_issue_count
+            else 0.0,
+            "merged_only_rate": round(merged_issue_count / corpus_issue_count, 4)
+            if corpus_issue_count
+            else 0.0,
+        },
+        "proxy_metrics": {
+            "attempted_issue_count": attempted_issue_count,
+            "proxy_pr_signal_issue_count": proxy_pr_signal_issue_count,
+            "proxy_pr_signal_issue_rate": round(
+                proxy_pr_signal_issue_count / corpus_issue_count,
+                4,
+            )
+            if corpus_issue_count
+            else 0.0,
+            "note": "Proxy metrics are secondary. Truth metrics remain mergeable_pr OR merged_pr.",
+        },
+        "failure_class_distribution": failure_class_distribution,
+        "rescue_counts_by_type": rescue_counts_by_type,
+        "issues": [record.to_dict() for record in records],
+    }
+
+
+def write_artifact(path: Path, artifact: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="synaptent/aragora", help="GitHub repo owner/name")
+    parser.add_argument(
+        "--metrics-file",
+        type=Path,
+        default=DEFAULT_METRICS_PATH,
+        help=f"Metrics JSONL file (default: {DEFAULT_METRICS_PATH})",
+    )
+    parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=DEFAULT_CORPUS_PATH,
+        help=f"Benchmark corpus manifest (default: {DEFAULT_CORPUS_PATH})",
+    )
+    parser.add_argument("--output", type=Path, default=None, help="Optional artifact output path")
+    parser.add_argument("--json", action="store_true", help="Emit JSON to stdout")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    metrics_file = resolve_metrics_path(args.metrics_file)
+    corpus_path = args.corpus.resolve()
+    if not metrics_file.exists():
+        raise SystemExit(f"metrics file not found: {metrics_file}")
+    if not corpus_path.exists():
+        raise SystemExit(f"corpus file not found: {corpus_path}")
+    artifact = build_benchmark_truth_artifact(
+        repo=str(args.repo),
+        metrics_file=metrics_file,
+        corpus_path=corpus_path,
+    )
+    if args.output is not None:
+        output_path = write_artifact(args.output.resolve(), artifact)
+        print(str(output_path))
+    if args.json or args.output is None:
+        print(json.dumps(artifact, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from aragora.swarm.decomposition_bridge import DecompositionBridge  # noqa: E402
 from aragora.swarm.issue_scanner import BossIssueCandidate, scan_all  # noqa: E402
 from aragora.swarm.issue_upgrader import upgrade_issue_heuristic  # noqa: E402
+from aragora.swarm.roadmap_priority import load_roadmap_priority_policy  # noqa: E402
 
 _GENERIC_PARENT_PHRASES: tuple[str, ...] = (
     "read the module and identify all public functions",
@@ -483,6 +484,8 @@ def main() -> None:
     skipped_dup = 0
     skipped_pr = 0
     skipped_val = 0
+    skipped_priority = 0
+    priority_policy = load_roadmap_priority_policy(repo_root)
 
     for candidate in candidates:
         if len(filtered) >= args.max_issues * 2:
@@ -501,6 +504,16 @@ def main() -> None:
             continue
 
         body = format_boss_ready_body(candidate)
+        if args.label == "boss-ready" and priority_policy is not None:
+            priority = priority_policy.priority_for_text(candidate.title, body)
+            if priority.priority.blocks_boss_ready:
+                skipped_priority += 1
+                if args.verbose:
+                    print(
+                        "  SKIP (canonical priority): "
+                        f"{candidate.title} [{', '.join(priority.blocked_codes)}]"
+                    )
+                continue
         ok, reason = validate_body(body)
         if not ok:
             skipped_val += 1
@@ -512,7 +525,11 @@ def main() -> None:
 
     print(f"\nFiltered to {len(filtered)} valid candidates")
     print(
-        f"  Skipped: {skipped_dup} duplicates, {skipped_pr} PR conflicts, {skipped_val} validation failures"
+        "  Skipped: "
+        f"{skipped_dup} duplicates, "
+        f"{skipped_pr} PR conflicts, "
+        f"{skipped_priority} canonical priority blocks, "
+        f"{skipped_val} validation failures"
     )
 
     # 5. Trim to max

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -544,12 +544,12 @@ class TestSwarmParser:
         assert config.auto_continue_on_needs_human is True
         assert '"mode": "boss-loop"' in capsys.readouterr().out
 
-    def test_cmd_swarm_preflight_routes_to_module(self, capsys):
+    def test_cmd_swarm_preflight_routes_to_module_without_contract(self, capsys):
         args = _swarm_args(
             swarm_action_or_goal="preflight",
             worker_model="codex",
             target_branch="origin/main",
-            contract="/tmp/worker-contract.json",
+            contract=None,
             skip_publication=True,
             json=True,
         )
@@ -578,11 +578,109 @@ class TestSwarmParser:
         assert kwargs["agent"] == "codex"
         assert kwargs["base_ref"] == "origin/main"
         assert kwargs["skip_publication"] is True
-        assert kwargs["contract_path"] == Path("/tmp/worker-contract.json")
+        assert kwargs["contract_path"] is None
         assert isinstance(kwargs["repo_root"], Path)
         out = capsys.readouterr().out
         assert '"mode": "swarm-preflight"' in out
         assert '"worker_contract_checksum": "abc123"' in out
+
+    def test_cmd_swarm_preflight_contract_path_emits_receipt_and_gate(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="preflight",
+            worker_model="codex",
+            target_branch="origin/main",
+            contract="/tmp/worker-contract.json",
+            skip_publication=True,
+            json=True,
+        )
+        fake_receipt = SimpleNamespace(
+            to_dict=lambda: {
+                "receipt_id": "preflight-scratch-1234",
+                "check_type": "scratch",
+                "passed": True,
+                "expires_at": "2026-04-14T03:00:00Z",
+                "artifacts": {"expected_contract_checksum": "abc123"},
+            },
+            failure_terminal_class=None,
+            artifacts={"expected_contract_checksum": "abc123"},
+        )
+        fake_gate = SimpleNamespace(
+            to_dict=lambda: {
+                "gate_type": "dispatch_ready",
+                "verdict": "pass",
+                "failure_classes": [],
+                "notes": "receipt verified",
+            }
+        )
+
+        with (
+            patch(
+                "aragora.swarm.preflight.run_contract_preflight_receipt",
+                return_value=fake_receipt,
+            ) as run_contract_preflight_receipt,
+            patch(
+                "aragora.swarm.preflight.evaluate_preflight_receipt_gate",
+                return_value=fake_gate,
+            ) as evaluate_preflight_receipt_gate,
+        ):
+            cmd_swarm(args)
+
+        kwargs = run_contract_preflight_receipt.call_args.kwargs
+        assert kwargs["agent"] == "codex"
+        assert kwargs["base_ref"] == "origin/main"
+        assert kwargs["skip_publication"] is True
+        assert kwargs["contract_path"] == Path("/tmp/worker-contract.json")
+        assert isinstance(kwargs["repo_root"], Path)
+        gate_kwargs = evaluate_preflight_receipt_gate.call_args.kwargs
+        assert gate_kwargs["check_type"] == "scratch"
+        out = capsys.readouterr().out
+        assert '"receipt_id": "preflight-scratch-1234"' in out
+        assert '"verdict": "pass"' in out
+
+    def test_cmd_swarm_preflight_contract_path_fails_closed(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="preflight",
+            worker_model="codex",
+            target_branch="main",
+            contract="/tmp/worker-contract.json",
+            skip_publication=True,
+            json=True,
+        )
+        fake_receipt = SimpleNamespace(
+            to_dict=lambda: {
+                "receipt_id": "preflight-scratch-1234",
+                "check_type": "scratch",
+                "passed": False,
+                "expires_at": "2026-04-14T03:00:00Z",
+                "artifacts": {"expected_contract_checksum": "abc123"},
+            },
+            failure_terminal_class=SimpleNamespace(value="blocked_not_dispatch_bounded"),
+            artifacts={"expected_contract_checksum": "abc123"},
+        )
+        fake_gate = SimpleNamespace(
+            to_dict=lambda: {
+                "gate_type": "dispatch_ready",
+                "verdict": "blocked",
+                "failure_classes": ["blocked_not_dispatch_bounded"],
+                "notes": "receipt failed",
+            }
+        )
+
+        with (
+            patch(
+                "aragora.swarm.preflight.run_contract_preflight_receipt",
+                return_value=fake_receipt,
+            ),
+            patch(
+                "aragora.swarm.preflight.evaluate_preflight_receipt_gate",
+                return_value=fake_gate,
+            ),
+            pytest.raises(SystemExit, match="2"),
+        ):
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"failure_terminal_class": "blocked_not_dispatch_bounded"' in out
 
     def test_swarm_integrator_parser(self):
         from aragora.cli.parser import build_parser

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import build_benchmark_truth_artifact as mod  # noqa: E402
+
+
+class FakeGitHubTruthClient:
+    def __init__(self, *, issues: dict[int, dict], prs: dict[int, dict]) -> None:
+        self.issues = issues
+        self.prs = prs
+
+    def get_issue(self, repo: str, number: int) -> dict:
+        return self.issues[number]
+
+    def get_pr(self, repo: str, number: int) -> dict:
+        return self.prs[number]
+
+    def get_cross_referenced_pr_numbers(self, repo: str, number: int) -> list[int]:
+        return []
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_build_benchmark_truth_artifact_links_corpus_revision_and_truth_metrics(
+    tmp_path: Path,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "issue_number": 1064,
+                        "issue_title": "Dependency bump",
+                        "terminal_class": "deliverable_pr_created",
+                        "publish_action": "pr_created",
+                        "worker_outcome": "pr_adopted",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "issue_number": 2712,
+                        "issue_title": "Boolean parsing fix",
+                        "terminal_class": "rescue_worker_crash",
+                        "worker_outcome": "crash",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 3,
+            "recorded_on": "2026-04-13",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [
+                {"issue_id": 1064, "title": "Dependency bump"},
+                {"issue_id": 2712, "title": "Boolean parsing fix"},
+            ],
+        },
+    )
+    client = FakeGitHubTruthClient(
+        issues={
+            1064: {
+                "title": "Dependency bump",
+                "comments": [{"body": "PR: https://github.com/synaptent/aragora/pull/6001"}],
+            },
+            2712: {"title": "Boolean parsing fix", "comments": []},
+        },
+        prs={
+            6001: {
+                "number": 6001,
+                "title": "merged fix",
+                "url": "https://github.com/synaptent/aragora/pull/6001",
+                "state": "MERGED",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": "2026-04-13T12:00:00Z",
+                "isDraft": False,
+            }
+        },
+    )
+
+    artifact = mod.build_benchmark_truth_artifact(
+        repo="synaptent/aragora",
+        metrics_file=metrics_path,
+        corpus_path=corpus_path,
+        client=client,
+        generated_at="2026-04-13T20:00:00Z",
+    )
+
+    assert artifact["corpus"]["corpus_id"] == "tw-01-bounded-execution-v1"
+    assert artifact["corpus"]["revision"] == 3
+    assert artifact["primary_metrics"]["truth_success_rate"] == 0.5
+    assert artifact["primary_metrics"]["no_rescue_truth_success_rate"] == 0.5
+    assert artifact["primary_metrics"]["merged_only_rate"] == 0.5
+    assert artifact["failure_class_distribution"] == {"rescue_worker_crash": 1}
+    assert artifact["rescue_counts_by_type"] == {"rescue_worker_crash": 1}
+    assert artifact["proxy_metrics"]["attempted_issue_count"] == 2
+    assert [issue["truth_state"] for issue in artifact["issues"]] == ["merged_pr", "no_linked_pr"]
+
+
+def test_write_artifact_emits_diffable_json(tmp_path: Path) -> None:
+    payload = {
+        "generated_at": "2026-04-13T20:00:00Z",
+        "corpus": {"corpus_id": "tw-01", "revision": 1, "issue_count": 1},
+        "primary_metrics": {"truth_success_rate": 1.0},
+    }
+    output = tmp_path / "artifact.json"
+
+    written = mod.write_artifact(output, payload)
+
+    assert written == output
+    parsed = json.loads(output.read_text(encoding="utf-8"))
+    assert parsed["corpus"]["revision"] == 1
+    assert parsed["primary_metrics"]["truth_success_rate"] == 1.0

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -50,6 +50,7 @@ from aragora.swarm.boss_loop import (
     sanitize_issue_body_for_dispatch,
     select_eligible_issue,
 )
+from aragora.swarm.roadmap_priority import RoadmapPriorityPolicy
 from aragora.swarm.task_sanitizer import SanitizationOutcome
 
 UTC = timezone.utc
@@ -4482,6 +4483,39 @@ def test_auto_decompose_stops_at_body_lineage_depth_limit() -> None:
         loop._auto_decompose_stuck_issue(4475, [issue])
 
     mock_label_stuck.assert_called_once()
+    mock_decomposer.assert_not_called()
+
+
+def test_auto_decompose_skips_delayed_root_issue_lineage() -> None:
+    issue = _make_issue(
+        5400,
+        "[from #5390] Define operator state model",
+        body=("## Decomposition Lineage\n- Root issue: #5331\n- Parent issue: #5390\n- Depth: 2\n"),
+        labels=["boss-ready"],
+    )
+    root_issue = _make_issue(
+        5331,
+        "BC-07 Unify lane, host, runner, and publication state into one operator model",
+        body="Refs: docs/status/NEXT_STEPS_CANONICAL.md (`BC-07`)",
+        labels=[],
+    )
+    loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
+    policy = RoadmapPriorityPolicy(
+        do_now=frozenset({"RS-07"}),
+        delay=frozenset({"BC-07", "BC-08", "BC-09"}),
+        avoid=frozenset(),
+    )
+
+    with (
+        patch("aragora.swarm.boss_loop.load_roadmap_priority_policy", return_value=policy),
+        patch.object(loop, "_fetch_issue_by_number", return_value=root_issue),
+        patch.object(loop, "_label_boss_stuck") as mock_label_stuck,
+        patch("aragora.nomic.task_decomposer.TaskDecomposer") as mock_decomposer,
+    ):
+        loop._auto_decompose_stuck_issue(5400, [issue])
+
+    mock_label_stuck.assert_called_once()
+    assert "BC-07" in mock_label_stuck.call_args.args[2]
     mock_decomposer.assert_not_called()
 
 

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -358,6 +358,207 @@ def test_run_preflight_rejects_emitted_contract_drift(monkeypatch, tmp_path: Pat
     assert cleanup_commands[0][:4] == ["git", "worktree", "remove", "--force"]
 
 
+def test_run_contract_preflight_receipt_persists_and_returns_receipt(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    contract_payload = _worker(branch="preflight/20260413-contract").worker_contract
+    contract_path = tmp_path / "worker_contract.json"
+    contract_path.write_text(json.dumps(contract_payload), encoding="utf-8")
+    fake_result = mod.PreflightResult(
+        repo_root=str(repo_root),
+        base_ref="main",
+        branch="preflight/20260413-contract",
+        worktree_path=str(repo_root / ".worktrees" / "preflight-contract"),
+        agent="codex",
+        published=False,
+        pull_request_created=False,
+        pull_request_closed=False,
+        cleanup_worktree_removed=True,
+        cleanup_branch_removed=True,
+        dispatch_gate={
+            "gate_type": GateType.DISPATCH_READY.value,
+            "verdict": GateVerdict.PASS.value,
+            "failure_classes": [],
+            "notes": "dispatch ready",
+        },
+        worker=_worker(branch="preflight/20260413-contract").to_dict(),
+        passed=True,
+    )
+
+    monkeypatch.setattr(mod, "run_preflight", lambda **_: fake_result)
+    receipt = mod.run_contract_preflight_receipt(
+        repo_root=repo_root,
+        agent="codex",
+        base_ref="main",
+        skip_publication=True,
+        contract_path=contract_path,
+        envelope=envelope,
+    )
+
+    expected_checksum = checksum_contract_payload(contract_payload)
+    assert receipt.passed is True
+    assert receipt.check_type == "scratch"
+    assert receipt.artifacts["expected_contract_checksum"] == expected_checksum
+    assert receipt.artifacts["worker_contract_checksum"] == expected_checksum
+    assert any(check["name"] == "dispatch_gate" for check in receipt.checks)
+    receipt_path = (
+        repo_root / ".aragora" / "receipts" / "preflight" / f"scratch-{receipt.cache_key}.json"
+    )
+    assert receipt_path.exists()
+
+
+def test_run_contract_preflight_receipt_persists_failure_on_preflight_error(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    contract_payload = _worker(branch="preflight/20260413-contract-bad").worker_contract
+    contract_path = tmp_path / "worker_contract_bad.json"
+    contract_path.write_text(json.dumps(contract_payload), encoding="utf-8")
+
+    monkeypatch.setattr(
+        mod,
+        "run_preflight",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("worker contract checksum mismatch")),
+    )
+
+    receipt = mod.run_contract_preflight_receipt(
+        repo_root=repo_root,
+        agent="codex",
+        base_ref="main",
+        skip_publication=True,
+        contract_path=contract_path,
+        envelope=envelope,
+    )
+
+    assert receipt.passed is False
+    assert "checksum mismatch" in receipt.checks[0]["detail"]
+    assert receipt.failure_terminal_class == TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED
+
+
+def test_evaluate_preflight_receipt_gate_blocks_missing_receipt(tmp_path: Path) -> None:
+    gate = mod.evaluate_preflight_receipt_gate(
+        None,
+        repo_root=tmp_path,
+        envelope=_envelope(),
+        check_type="scratch",
+    )
+
+    assert gate.verdict == GateVerdict.BLOCKED.value
+    assert gate.failure_classes == ["receipt_missing"]
+
+
+def test_evaluate_preflight_receipt_gate_blocks_expired_and_failed_receipts(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    now = datetime(2026, 4, 13, 2, 0, 0, tzinfo=timezone.utc)
+    expired_receipt = mod.PreflightReceipt(
+        receipt_id="preflight-scratch-expired",
+        envelope_seal=envelope.preflight_cache_seal(),
+        repo_root=str(repo_root),
+        check_type="scratch",
+        started_at="2026-04-13T00:00:00Z",
+        finished_at="2026-04-13T00:05:00Z",
+        passed=True,
+        checks=[{"name": "dispatch_gate", "passed": True, "detail": "ok"}],
+        cache_key="cache-1",
+        ttl_seconds=60,
+        expires_at="2026-04-13T00:06:00Z",
+        artifacts={},
+    )
+    expired_gate = mod.evaluate_preflight_receipt_gate(
+        expired_receipt,
+        repo_root=repo_root,
+        envelope=envelope,
+        check_type="scratch",
+        now=now,
+    )
+    assert expired_gate.failure_classes == ["receipt_expired"]
+
+    failed_receipt = mod.PreflightReceipt(
+        receipt_id="preflight-scratch-failed",
+        envelope_seal=envelope.preflight_cache_seal(),
+        repo_root=str(repo_root),
+        check_type="scratch",
+        started_at="2026-04-13T00:00:00Z",
+        finished_at="2026-04-13T00:05:00Z",
+        passed=False,
+        checks=[{"name": "dispatch_gate", "passed": False, "detail": "bounded dispatch blocked"}],
+        cache_key="cache-2",
+        ttl_seconds=3600,
+        expires_at="2026-04-13T03:00:00Z",
+        artifacts={},
+    )
+    failed_gate = mod.evaluate_preflight_receipt_gate(
+        failed_receipt,
+        repo_root=repo_root,
+        envelope=envelope,
+        check_type="scratch",
+        now=now,
+    )
+    assert failed_gate.verdict == GateVerdict.BLOCKED.value
+    assert failed_gate.failure_classes == [TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED.value]
+
+
+def test_evaluate_preflight_receipt_gate_blocks_envelope_and_contract_mismatch(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    receipt = mod.PreflightReceipt(
+        receipt_id="preflight-remote-valid",
+        envelope_seal=envelope.preflight_cache_seal(),
+        repo_root=str(repo_root),
+        check_type="remote_publish",
+        started_at="2026-04-13T00:00:00Z",
+        finished_at="2026-04-13T00:05:00Z",
+        passed=True,
+        checks=[{"name": "dispatch_gate", "passed": True, "detail": "ok"}],
+        cache_key="cache-3",
+        ttl_seconds=3600,
+        expires_at="2026-04-13T03:00:00Z",
+        artifacts={
+            "target_ref": "main",
+            "expected_contract_checksum": "expected-1",
+        },
+    )
+
+    changed_envelope = CredentialEnvelope.from_environment(
+        {
+            "ARAGORA_CLAUDE_PROFILE": "different",
+            "GITHUB_TOKEN": "token",
+            "OPENAI_API_KEY": "key",
+        }
+    )
+    envelope_gate = mod.evaluate_preflight_receipt_gate(
+        receipt,
+        repo_root=repo_root,
+        envelope=changed_envelope,
+        check_type="remote_publish",
+        base_ref="main",
+        expected_contract_checksum="expected-1",
+        now=datetime(2026, 4, 13, 2, 0, 0, tzinfo=timezone.utc),
+    )
+    assert envelope_gate.failure_classes == ["receipt_envelope_mismatch"]
+
+    checksum_gate = mod.evaluate_preflight_receipt_gate(
+        receipt,
+        repo_root=repo_root,
+        envelope=envelope,
+        check_type="remote_publish",
+        base_ref="main",
+        expected_contract_checksum="expected-2",
+        now=datetime(2026, 4, 13, 2, 0, 0, tzinfo=timezone.utc),
+    )
+    assert checksum_gate.failure_classes == ["receipt_contract_mismatch"]
+
+
 def test_run_scratch_validation_receipt_persists_success(monkeypatch, tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()

--- a/tests/swarm/test_roadmap_priority.py
+++ b/tests/swarm/test_roadmap_priority.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from aragora.swarm.roadmap_priority import (
+    RoadmapPriority,
+    expand_roadmap_token,
+    extract_roadmap_codes,
+    load_roadmap_priority_policy,
+)
+
+
+def test_expand_roadmap_token_handles_ranges() -> None:
+    assert expand_roadmap_token("BC-07..09") == ("BC-07", "BC-08", "BC-09")
+    assert expand_roadmap_token("CS-01..03") == ("CS-01", "CS-02", "CS-03")
+    assert expand_roadmap_token("RS-07") == ("RS-07",)
+
+
+def test_extract_roadmap_codes_deduplicates_and_expands() -> None:
+    text = "Refs: (`RS-07`), delayed `BC-07..08`, plus repeated `RS-07`."
+    assert extract_roadmap_codes(text) == ("RS-07", "BC-07", "BC-08")
+
+
+def test_load_priority_policy_parses_canonical_sections(tmp_path: Path) -> None:
+    docs = tmp_path / "docs" / "status"
+    docs.mkdir(parents=True)
+    (docs / "NEXT_STEPS_CANONICAL.md").write_text(
+        "\n".join(
+            [
+                "## Do Now / Delay / Avoid",
+                "",
+                "### Do now",
+                "- `RS-07`",
+                "- `TW-01`",
+                "",
+                "### Delay",
+                "- `BC-07..09` until truth exists",
+                "",
+                "### Avoid in this tranche",
+                "- `UDW-07..08`",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    policy = load_roadmap_priority_policy(tmp_path)
+
+    assert policy is not None
+    assert policy.priority_for_text("Refs: (`RS-07`)").priority == RoadmapPriority.DO_NOW
+    blocked = policy.priority_for_text("Refs: (`BC-07`) and (`TW-01`)")
+    assert blocked.priority == RoadmapPriority.DELAY
+    assert blocked.blocked_codes == ("BC-07",)
+    avoid = policy.priority_for_text("Refs: (`UDW-08`)")
+    assert avoid.priority == RoadmapPriority.AVOID

--- a/tests/swarm/test_strategic_issue_bridge.py
+++ b/tests/swarm/test_strategic_issue_bridge.py
@@ -142,6 +142,54 @@ def test_generate_candidates_can_filter_by_theme() -> None:
     assert all(candidate.metadata["theme"] == "BC" for candidate in candidates)
 
 
+def test_generate_candidates_honors_canonical_do_now_filter(tmp_path: Path) -> None:
+    docs_status = tmp_path / "docs" / "status"
+    docs_status.mkdir(parents=True)
+    (tmp_path / "docs" / "CANONICAL_GOALS.md").write_text("canonical\n", encoding="utf-8")
+    (tmp_path / "ROADMAP.md").write_text("roadmap\n", encoding="utf-8")
+    (docs_status / "ACTIVE_EXECUTION_ISSUES.md").write_text(
+        "\n".join(
+            [
+                "1. **Reliability Substrate**",
+                "2. **Bounded Autonomy Control Plane**",
+                "## Epic 1 - Reliability Substrate",
+                "### Milestone 1.1 - Guard",
+                "- [ ] **RS-07** Receipt-backed preflight",
+                "## Epic 2 - Bounded Autonomy Control Plane",
+                "### Milestone 2.1 - Multi",
+                "- [ ] **BC-07** Unified operator model",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (docs_status / "NEXT_STEPS_CANONICAL.md").write_text(
+        "\n".join(
+            [
+                "## Do Now / Delay / Avoid",
+                "",
+                "### Do now",
+                "- `RS-07`",
+                "",
+                "### Delay",
+                "- `BC-07..09` until the repair loop is truthful and resumable",
+                "",
+                "### Avoid in this tranche",
+                "- `UDW-07..12`",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = StrategicIssueBridgeConfig(max_issues=5, heuristic_only=True, enable_scanner=False)
+    bridge = StrategicIssueBridge(repo_root=tmp_path, config=config)
+
+    candidates = bridge.generate_candidates()
+
+    refs = {candidate.roadmap_refs[0] for candidate in candidates if candidate.roadmap_refs}
+    assert "RS-07" in refs
+    assert "BC-07" not in refs
+
+
 def test_llm_fallback_without_keys(monkeypatch) -> None:
     for key in (
         "ANTHROPIC_API_KEY",


### PR DESCRIPTION
## Summary
- enforce canonical do-now/delay gating across boss issue restock and auto-decomposition
- add a receipt-backed `swarm preflight --contract` operator path with fail-closed admission evaluation
- add a diffable benchmark truth artifact builder and reconcile roadmap/status docs to match live queue policy

## Validation
- `python3 -m pytest tests/swarm/test_roadmap_priority.py tests/swarm/test_strategic_issue_bridge.py tests/swarm/test_boss_loop.py -q -k 'auto_decompose_skips_delayed_root_issue_lineage or auto_decompose_carries_lineage_and_removes_ready_label or roadmap_priority or strategic_issue_bridge'`
- `python3 -m pytest tests/swarm/test_preflight.py tests/cli/test_swarm_command.py -q -k 'preflight'`
- `python3 -m pytest tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_reconcile_b0_pr_truth.py -q`
- `ruff check aragora/swarm/roadmap_priority.py aragora/swarm/strategic_issue_bridge.py aragora/swarm/decomposition_bridge.py aragora/swarm/boss_loop.py aragora/swarm/preflight.py aragora/cli/commands/swarm.py scripts/generate_boss_issues.py scripts/build_benchmark_truth_artifact.py tests/swarm/test_roadmap_priority.py tests/swarm/test_strategic_issue_bridge.py tests/swarm/test_boss_loop.py tests/swarm/test_preflight.py tests/cli/test_swarm_command.py tests/scripts/test_build_benchmark_truth_artifact.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Refs
- #5327
- #5329
