### PR TITLE
feat(swarm): add __all__ exports to rescue_events.py

### DIFF
--- a/aragora/swarm/rescue_events.py
+++ b/aragora/swarm/rescue_events.py
@@ -20,6 +20,14 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+__all__ = [
+    "DEFAULT_RESCUE_LEDGER_PATH",
+    "RescueEvent",
+    "RescueEventLedger",
+    "RescueEventType",
+    "record_rescue",
+]
+
 logger = logging.getLogger(__name__)
 UTC = timezone.utc
 


### PR DESCRIPTION
Adds explicit __all__ list exporting the public API: DEFAULT_RESCUE_LEDGER_PATH,
RescueEvent, RescueEventLedger, RescueEventType, and record_rescue.

Part of #5427.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit fa5cf8bd577e4e170326d278b89e24e6fbbc9a44)
