### PR TITLE
fix(auto_scaling): document justified CancelledError pass pattern

### DIFF
--- a/aragora/control_plane/auto_scaling.py
+++ b/aragora/control_plane/auto_scaling.py
@@ -253,7 +253,7 @@ class AutoScaler:
             try:
                 await self._task
             except asyncio.CancelledError:
-                pass
+                pass  # Expected when stopping — task was intentionally cancelled
             self._task = None
 
         logger.info("Auto-scaler stopped")


### PR DESCRIPTION
Add inline justification comment to the only remaining bare `pass`
in auto_scaling.py — the standard asyncio task cancellation pattern
in AutoScaler.stop(). All other exception handlers already use proper
logging (addressed in prior commits 9dbb9e92, 47883f5f).

Closes part of #5422

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit c3e551e99fdb99d42ed8432c4abf395bf8c06301)
