### PR TITLE
fix: replace silent exception swallowing in slack queue.py

### DIFF
--- a/aragora/connectors/chat/slack/queue.py
+++ b/aragora/connectors/chat/slack/queue.py
@@ -557,7 +557,7 @@ class SlackMessageQueue:
             try:
                 await self._processor_task
             except asyncio.CancelledError:
-                pass
+                logger.debug("Queue processor task cancelled")
             self._processor_task = None
 
     def get_stats(self) -> dict[str, Any]:

--- a/aragora/connectors/chat/slack/queue.py
+++ b/aragora/connectors/chat/slack/queue.py
@@ -540,9 +540,9 @@ class SlackMessageQueue:
 
         logger.info("Slack message queue processor stopped")
 
-    async def start_processor(self) -> asyncio.Task:
+    async def start_processor(self) -> asyncio.Task:  # type: ignore[type-arg]
         """Start the background processor."""
-        if self._running:
+        if self._running and self._processor_task is not None:
             return self._processor_task
 
         self._running = True


### PR DESCRIPTION
Replace bare `except CancelledError: pass` with a debug log message
to add visibility into queue processor task cancellation.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 6b4c800d13994dc8d6f939e51d904c0c57318ae1)
