### PR TITLE
fix(scripts): make launchd services choose a usable python

### DIFF
--- a/scripts/install_boss_loop_launchd.sh
+++ b/scripts/install_boss_loop_launchd.sh
@@ -67,6 +67,45 @@ trim_text() {
     printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
 
+resolve_python_bin() {
+    local candidates=()
+    local candidate=""
+    local python_cmd=""
+
+    if [[ -n "${ARAGORA_PYTHON:-}" ]]; then
+        candidates+=("${ARAGORA_PYTHON}")
+    fi
+    if [[ -x "${REPO_ROOT}/.venv/bin/python3" ]]; then
+        candidates+=("${REPO_ROOT}/.venv/bin/python3")
+    fi
+    if python_cmd="$(command -v python3 2>/dev/null)"; then
+        candidates+=("${python_cmd}")
+    fi
+    if python_cmd="$(command -v python 2>/dev/null)"; then
+        candidates+=("${python_cmd}")
+    fi
+    for candidate in "${candidates[@]}"; do
+        if [[ -z "${candidate}" || ! -x "${candidate}" ]]; then
+            continue
+        fi
+        if "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+
+    if command -v pyenv >/dev/null 2>&1; then
+        candidate="$(pyenv which python3 2>/dev/null || true)"
+        if [[ -n "${candidate}" && -x "${candidate}" ]] && "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    fi
+
+    echo "No usable python interpreter with pydantic found for boss-loop launchd install." >&2
+    exit 2
+}
+
 validate_integer() {
     local label="$1"
     local value="$2"
@@ -211,8 +250,9 @@ mkdir -p "$(dirname "${PLIST_PATH}")"
 mkdir -p "$(dirname "${LOG_PATH}")"
 mkdir -p "${REPO_ROOT}/.aragora/overnight"
 
-VENV_ACTIVATE="${REPO_ROOT}/.venv/bin/activate"
-command_string="cd \"${REPO_ROOT}\" && export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\" && source \"${VENV_ACTIVATE}\""
+PYTHON_BIN="$(resolve_python_bin)"
+PYTHON_DIR="$(dirname "${PYTHON_BIN}")"
+command_string="cd \"${REPO_ROOT}\" && export PATH=\"${PYTHON_DIR}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\" && export ARAGORA_PYTHON=\"${PYTHON_BIN}\""
 if [[ -n "${ARAGORA_CLAUDE_PROFILE}" ]]; then
     command_string="${command_string} && export ARAGORA_CLAUDE_PROFILE=\"${ARAGORA_CLAUDE_PROFILE}\""
 fi
@@ -269,5 +309,6 @@ launchctl load "${PLIST_PATH}"
 echo "Installed launchd job: ${LABEL}"
 echo "Plist: ${PLIST_PATH}"
 echo "Log: ${LOG_PATH}"
+echo "Python: ${PYTHON_BIN}"
 echo "Boss repo: ${BOSS_REPO}"
 echo "Labels: ${LABELS[*]}"

--- a/scripts/install_merge_arbiter_launchd.sh
+++ b/scripts/install_merge_arbiter_launchd.sh
@@ -38,6 +38,45 @@ Options:
 EOF
 }
 
+resolve_python_bin() {
+    local candidates=()
+    local candidate=""
+    local python_cmd=""
+
+    if [[ -n "${ARAGORA_PYTHON:-}" ]]; then
+        candidates+=("${ARAGORA_PYTHON}")
+    fi
+    if [[ -x "${REPO_ROOT}/.venv/bin/python3" ]]; then
+        candidates+=("${REPO_ROOT}/.venv/bin/python3")
+    fi
+    if python_cmd="$(command -v python3 2>/dev/null)"; then
+        candidates+=("${python_cmd}")
+    fi
+    if python_cmd="$(command -v python 2>/dev/null)"; then
+        candidates+=("${python_cmd}")
+    fi
+    for candidate in "${candidates[@]}"; do
+        if [[ -z "${candidate}" || ! -x "${candidate}" ]]; then
+            continue
+        fi
+        if "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+
+    if command -v pyenv >/dev/null 2>&1; then
+        candidate="$(pyenv which python3 2>/dev/null || true)"
+        if [[ -n "${candidate}" && -x "${candidate}" ]] && "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    fi
+
+    echo "No usable python interpreter with pydantic found for merge-arbiter launchd install." >&2
+    exit 2
+}
+
 validate_integer() {
     local label="$1"
     local value="$2"
@@ -117,8 +156,9 @@ mkdir -p "$(dirname "${PLIST_PATH}")"
 mkdir -p "$(dirname "${LOG_PATH}")"
 mkdir -p "${REPO_ROOT}/.aragora/overnight"
 
-VENV_ACTIVATE="${REPO_ROOT}/.venv/bin/activate"
-command_string="cd \"${REPO_ROOT}\" && export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\" && source \"${VENV_ACTIVATE}\" && exec python3 -u -m aragora.cli.main swarm merge-arbiter --boss-repo \"${BOSS_REPO}\" --branch-prefix \"${BRANCH_PREFIXES}\" --interval \"${INTERVAL_SECONDS}\" --max-hours \"${MAX_HOURS}\" --max-consecutive-failures \"${MAX_CONSECUTIVE_FAILURES}\""
+PYTHON_BIN="$(resolve_python_bin)"
+PYTHON_DIR="$(dirname "${PYTHON_BIN}")"
+command_string="cd \"${REPO_ROOT}\" && export PATH=\"${PYTHON_DIR}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:\$PATH\" && export ARAGORA_USER_ID=\"${ARAGORA_USER_ID}\" && export ARAGORA_WORKSPACE_ID=\"${ARAGORA_WORKSPACE_ID}\" && export ARAGORA_PYTHON=\"${PYTHON_BIN}\" && exec \"${PYTHON_BIN}\" -u -m aragora.cli.main swarm merge-arbiter --boss-repo \"${BOSS_REPO}\" --branch-prefix \"${BRANCH_PREFIXES}\" --interval \"${INTERVAL_SECONDS}\" --max-hours \"${MAX_HOURS}\" --max-consecutive-failures \"${MAX_CONSECUTIVE_FAILURES}\""
 if [[ "${DRY_RUN}" == true ]]; then
     command_string="${command_string} --dry-run"
 fi
@@ -160,4 +200,5 @@ launchctl load "${PLIST_PATH}"
 echo "Installed launchd job: ${LABEL}"
 echo "Plist: ${PLIST_PATH}"
 echo "Log: ${LOG_PATH}"
+echo "Python: ${PYTHON_BIN}"
 echo "Branch prefixes: ${BRANCH_PREFIXES}"

--- a/scripts/run_boss_cycle.sh
+++ b/scripts/run_boss_cycle.sh
@@ -9,6 +9,49 @@ POST_LOOP_LABEL="${ARAGORA_POST_LOOP_LABEL:-}"
 boss_repo=""
 boss_label=""
 
+resolve_python_bin() {
+    local candidates=()
+    local candidate=""
+    local python_cmd=""
+
+    if [[ -n "${ARAGORA_PYTHON:-}" ]]; then
+        if [[ -x "${ARAGORA_PYTHON}" ]]; then
+            printf '%s\n' "${ARAGORA_PYTHON}"
+            return 0
+        fi
+        echo "ARAGORA_PYTHON is set but not executable: ${ARAGORA_PYTHON}" >&2
+    fi
+    if [[ -x "${REPO_ROOT}/.venv/bin/python3" ]]; then
+        candidates+=("${REPO_ROOT}/.venv/bin/python3")
+    fi
+    if python_cmd="$(command -v python3 2>/dev/null)"; then
+        candidates+=("${python_cmd}")
+    fi
+    if python_cmd="$(command -v python 2>/dev/null)"; then
+        candidates+=("${python_cmd}")
+    fi
+    for candidate in "${candidates[@]}"; do
+        if [[ -z "${candidate}" || ! -x "${candidate}" ]]; then
+            continue
+        fi
+        if "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+
+    if command -v pyenv >/dev/null 2>&1; then
+        candidate="$(pyenv which python3 2>/dev/null || true)"
+        if [[ -n "${candidate}" && -x "${candidate}" ]] && "${candidate}" -c 'import pydantic' >/dev/null 2>&1; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    fi
+
+    echo "No usable python interpreter with pydantic found for boss-loop runtime." >&2
+    return 1
+}
+
 args=("$@")
 for ((i = 0; i < ${#args[@]}; i++)); do
     case "${args[$i]}" in
@@ -27,12 +70,14 @@ done
 
 boss_repo="${boss_repo:-synaptent/aragora}"
 boss_label="${POST_LOOP_LABEL:-${boss_label:-boss-ready}}"
+PYTHON_BIN="$(resolve_python_bin)"
 
 cd "${REPO_ROOT}"
 
 echo "Starting boss-loop cycle for ${boss_repo} (label=${boss_label})..."
+echo "Using Python interpreter: ${PYTHON_BIN}"
 set +e
-python3 -u -m aragora.cli.main swarm boss-loop "${args[@]}"
+"${PYTHON_BIN}" -u -m aragora.cli.main swarm boss-loop "${args[@]}"
 boss_status=$?
 set -e
 echo "Boss loop exited with status ${boss_status}."
@@ -48,7 +93,7 @@ if [[ "${boss_status}" -ne 0 ]]; then
 fi
 
 refill_cmd=(
-    python3
+    "${PYTHON_BIN}"
     scripts/generate_boss_issues.py
     --repo
     "${boss_repo}"


### PR DESCRIPTION
## Summary
- stop launchd installers from assuming a repo-local .venv exists
- export a concrete python path into the launchd jobs and reuse it in the boss-cycle wrapper
- keep a runtime fallback in run_boss_cycle.sh so post-loop refill uses the same interpreter

## Validation
- bash -n scripts/run_boss_cycle.sh scripts/install_boss_loop_launchd.sh scripts/install_merge_arbiter_launchd.sh
- manual launchd reinstall on macOS confirmed a live boss-loop python process and a live merge-arbiter process
