### PR TITLE
fix(server): count deliverables in swarm status

### DIFF
--- a/aragora/server/fastapi/routes/swarm_status.py
+++ b/aragora/server/fastapi/routes/swarm_status.py
@@ -17,6 +17,12 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_METRICS_PATH = Path(".aragora/overnight/boss_metrics.jsonl")
 DEFAULT_WINDOW = 50
+SUCCESS_TERMINAL_PREFIXES = ("success", "deliverable")
+
+
+def _is_success_terminal_class(terminal_class: str) -> bool:
+    """Return whether a terminal class counts as a truthful success."""
+    return terminal_class.startswith(SUCCESS_TERMINAL_PREFIXES)
 
 
 def _tail_jsonl(path: Path, max_lines: int) -> list[dict[str, Any]]:
@@ -73,7 +79,7 @@ def swarm_status_summary(
         issue_num = row.get("issue_number")
         if isinstance(issue_num, int):
             issues_attempted.add(issue_num)
-            if tc and tc.startswith("success"):
+            if tc and _is_success_terminal_class(tc):
                 issues_succeeded.add(issue_num)
 
         # Collect failure reasons and blocker evidence (BC-03)
@@ -93,7 +99,7 @@ def swarm_status_summary(
 
         latest_tick = row
 
-    success_count = sum(v for k, v in terminal_classes.items() if k.startswith("success"))
+    success_count = sum(v for k, v in terminal_classes.items() if _is_success_terminal_class(k))
 
     return {
         "status": "active",

--- a/tests/server/fastapi/routes/test_swarm_status.py
+++ b/tests/server/fastapi/routes/test_swarm_status.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+
+os.environ.setdefault("ARAGORA_USE_SECRETS_MANAGER", "0")
+
+from aragora.server.fastapi.routes import swarm_status
+from aragora.swarm.preflight import PreflightReceipt
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+
+def test_swarm_status_summary_counts_deliverables_as_success(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    _write_jsonl(
+        metrics_path,
+        [
+            {
+                "timestamp": "2026-04-14T02:20:00Z",
+                "issue_number": 101,
+                "terminal_class": "deliverable_pr_created",
+                "outcome": "completed",
+                "elapsed_seconds": 12,
+            },
+            {
+                "timestamp": "2026-04-14T02:21:00Z",
+                "issue_number": 102,
+                "terminal_class": "success_pr_created",
+                "outcome": "completed",
+                "elapsed_seconds": 18,
+            },
+        ],
+    )
+
+    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path)
+
+    assert summary["status"] == "active"
+    assert summary["total_ticks"] == 2
+    assert summary["unique_issues_attempted"] == 2
+    assert summary["unique_issues_succeeded"] == 2
+    assert summary["success_rate"] == 1.0
+    assert summary["terminal_class_distribution"] == {
+        "deliverable_pr_created": 1,
+        "success_pr_created": 1,
+    }
+    assert summary["latest_tick"]["issue_number"] == 102
+
+
+def test_preflight_check_returns_receipt_dict() -> None:
+    fake_receipt = MagicMock()
+    fake_receipt.to_dict.return_value = {"receipt_id": "receipt-1", "passed": True}
+
+    with (
+        patch(
+            "aragora.swarm.credential_envelope.CredentialEnvelope.from_environment",
+            return_value=object(),
+        ) as from_environment,
+        patch("aragora.swarm.preflight.run_preflight", return_value=fake_receipt) as run_preflight,
+    ):
+        result = swarm_status.preflight_check(
+            agent="codex",
+            base_ref="origin/main",
+            skip_publication=False,
+        )
+
+    assert result == {"receipt_id": "receipt-1", "passed": True}
+    from_environment.assert_called_once()
+    assert run_preflight.call_args.kwargs["repo_root"] == Path.cwd()
+    assert run_preflight.call_args.kwargs["agent"] == "codex"
+    assert run_preflight.call_args.kwargs["base_ref"] == "origin/main"
+    assert run_preflight.call_args.kwargs["skip_publication"] is False
+
+
+def test_list_preflight_receipts_returns_empty_without_receipt_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert swarm_status.list_preflight_receipts() == []
+
+
+def test_list_preflight_receipts_reads_valid_receipts(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    receipt_dir = tmp_path / ".aragora" / "receipts" / "preflight"
+    receipt_dir.mkdir(parents=True)
+
+    receipt = PreflightReceipt(
+        receipt_id="preflight-scratch-1",
+        envelope_seal="seal-1",
+        repo_root=str(tmp_path),
+        check_type="scratch_validation",
+        started_at="2026-04-14T02:20:00Z",
+        finished_at="2026-04-14T02:21:00Z",
+        passed=True,
+        cache_key="scratch-key",
+        ttl_seconds=600,
+        expires_at="2026-04-14T02:31:00Z",
+    )
+    (receipt_dir / "receipt-ok.json").write_text(
+        json.dumps(receipt.to_dict()),
+        encoding="utf-8",
+    )
+    (receipt_dir / "receipt-bad.json").write_text("{not-json", encoding="utf-8")
+
+    receipts = swarm_status.list_preflight_receipts()
+
+    assert receipts == [
+        {
+            "receipt_id": "preflight-scratch-1",
+            "check_type": "scratch_validation",
+            "passed": True,
+            "started_at": "2026-04-14T02:20:00Z",
+            "finished_at": "2026-04-14T02:21:00Z",
+            "expires_at": "2026-04-14T02:31:00Z",
+            "cache_key": "scratch-key",
+        }
+    ]
+
+
+def test_register_routes_adds_swarm_status_endpoints() -> None:
+    app = FastAPI()
+
+    swarm_status.register_routes(app)
+
+    route_paths = {route.path for route in app.routes}
+    assert "/api/v1/swarm/status" in route_paths
+    assert "/api/v1/swarm/preflight" in route_paths
+    assert "/api/v1/swarm/preflight/receipts" in route_paths


### PR DESCRIPTION
## Summary
- count deliverable terminal classes as successful outcomes in the swarm status route
- align the operator-facing success rate with the benchmark truth model
- add focused FastAPI route coverage for the swarm status and preflight endpoints

## Validation
- python3 -m pytest tests/server/fastapi/routes/test_swarm_status.py -q -o cache_dir=/tmp/pytest-swarm-status
- python3 -m ruff check aragora/server/fastapi/routes/swarm_status.py tests/server/fastapi/routes/test_swarm_status.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
