### PR TITLE
fix(scripts): block dirty worktrees from cleanup

### DIFF
--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -22,6 +22,9 @@ class WorktreeInspection:
     branch: str | None
     active_session: bool
     lock_files: list[str]
+    dirty: bool
+    unique_commits_ahead: int
+    ahead_lookup_failed: bool
     open_prs: list[dict[str, Any]]
     pr_lookup_failed: bool
     blockers: list[str]
@@ -97,6 +100,36 @@ def _lookup_open_prs(repo_root: Path, branch: str | None) -> tuple[list[dict[str
     return payload, False
 
 
+def _worktree_is_dirty(path: Path) -> bool:
+    if not path.exists():
+        return False
+    proc = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return False
+    return bool(proc.stdout.strip())
+
+
+def _unique_commits_ahead_of_main(
+    repo_root: Path,
+    branch: str | None,
+) -> tuple[int, bool]:
+    if not branch:
+        return 0, False
+    proc = autopilot._run_git(repo_root, "rev-list", "--count", f"origin/main..{branch}")
+    if proc.returncode != 0:
+        return 0, True
+    try:
+        return int(proc.stdout.strip() or "0"), False
+    except ValueError:
+        return 0, True
+
+
 def inspect_worktree(
     repo_root: Path, path: Path, *, branch_override: str | None = None
 ) -> WorktreeInspection:
@@ -107,6 +140,8 @@ def inspect_worktree(
     branch = branch_override or _branch_for_path(path, entry)
     active_session = exists and autopilot._has_active_session(path)
     lock_files = _active_lock_files(path) if exists else []
+    dirty = _worktree_is_dirty(path) if exists else False
+    unique_commits_ahead, ahead_lookup_failed = _unique_commits_ahead_of_main(repo_root, branch)
     open_prs, pr_lookup_failed = _lookup_open_prs(repo_root, branch)
 
     blockers: list[str] = []
@@ -114,8 +149,16 @@ def inspect_worktree(
         blockers.append("missing_path")
     if active_session:
         blockers.append("active_session")
+    if lock_files:
+        blockers.append("session_lock_present")
+    if dirty:
+        blockers.append("dirty_worktree")
+    if unique_commits_ahead > 0:
+        blockers.append("branch_ahead_of_origin_main")
     if open_prs:
         blockers.append("open_pr")
+    if branch and ahead_lookup_failed:
+        blockers.append("ahead_lookup_failed")
     if branch and pr_lookup_failed:
         blockers.append("pr_lookup_failed")
 
@@ -126,6 +169,9 @@ def inspect_worktree(
         branch=branch,
         active_session=active_session,
         lock_files=lock_files,
+        dirty=dirty,
+        unique_commits_ahead=unique_commits_ahead,
+        ahead_lookup_failed=ahead_lookup_failed,
         open_prs=open_prs,
         pr_lookup_failed=pr_lookup_failed,
         blockers=blockers,
@@ -146,6 +192,10 @@ def _print_inspection(inspection: WorktreeInspection, *, as_json: bool) -> None:
     print(f"active_session: {inspection.active_session}")
     if inspection.lock_files:
         print(f"lock_files: {', '.join(inspection.lock_files)}")
+    print(f"dirty: {inspection.dirty}")
+    if inspection.branch:
+        print(f"unique_commits_ahead: {inspection.unique_commits_ahead}")
+        print(f"ahead_lookup_failed: {inspection.ahead_lookup_failed}")
     print(f"open_prs: {len(inspection.open_prs)}")
     if inspection.open_prs:
         for pr in inspection.open_prs:

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -35,6 +35,8 @@ def test_inspect_reports_open_pr_blocker(tmp_path: Path, monkeypatch: pytest.Mon
         lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/test")],
     )
     monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(mod, "_worktree_is_dirty", lambda _path: False)
+    monkeypatch.setattr(mod, "_unique_commits_ahead_of_main", lambda _repo, _branch: (0, False))
     monkeypatch.setattr(
         mod,
         "_lookup_open_prs",
@@ -48,6 +50,8 @@ def test_inspect_reports_open_pr_blocker(tmp_path: Path, monkeypatch: pytest.Mon
 
     assert inspection.tracked_worktree is True
     assert inspection.branch == "codex/test"
+    assert inspection.dirty is False
+    assert inspection.unique_commits_ahead == 0
     assert inspection.blockers == ["open_pr"]
 
 
@@ -68,6 +72,9 @@ def test_remove_refuses_blocked_worktree_without_force(
         branch="codex/test",
         active_session=False,
         lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
         open_prs=[{"number": 1361, "title": "Open PR", "url": "https://example.com/pr/1361"}],
         pr_lookup_failed=False,
         blockers=["open_pr"],
@@ -108,6 +115,8 @@ def test_inspect_accepts_branch_override_for_orphaned_path(
 
     monkeypatch.setattr(mod.autopilot, "_get_worktree_entries", lambda _repo: [])
     monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(mod, "_worktree_is_dirty", lambda _path: False)
+    monkeypatch.setattr(mod, "_unique_commits_ahead_of_main", lambda _repo, _branch: (0, False))
     monkeypatch.setattr(
         mod,
         "_lookup_open_prs",
@@ -155,6 +164,9 @@ def test_remove_purges_residual_path_after_failed_git_remove(
         branch="codex/test",
         active_session=False,
         lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
         open_prs=[],
         pr_lookup_failed=False,
         blockers=[],
@@ -203,6 +215,9 @@ def test_remove_deletes_branch_when_requested(
         branch="codex/test",
         active_session=False,
         lock_files=[],
+        dirty=False,
+        unique_commits_ahead=0,
+        ahead_lookup_failed=False,
         open_prs=[],
         pr_lookup_failed=False,
         blockers=[],
@@ -229,3 +244,60 @@ def test_remove_deletes_branch_when_requested(
 
     assert result["branch_deleted"] is True
     assert result["status"] == "purged"
+
+
+def test_inspect_blocks_dirty_and_ahead_worktrees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(
+        mod.autopilot,
+        "_get_worktree_entries",
+        lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/test")],
+    )
+    monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(mod, "_worktree_is_dirty", lambda _path: True)
+    monkeypatch.setattr(mod, "_unique_commits_ahead_of_main", lambda _repo, _branch: (2, False))
+    monkeypatch.setattr(mod, "_lookup_open_prs", lambda _repo, _branch: ([], False))
+
+    inspection = mod.inspect_worktree(repo_root, worktree)
+
+    assert inspection.dirty is True
+    assert inspection.unique_commits_ahead == 2
+    assert inspection.blockers == ["dirty_worktree", "branch_ahead_of_origin_main"]
+
+
+def test_inspect_blocks_lock_files_and_history_lookup_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".codex_session_active").write_text("active\n")
+
+    monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(
+        mod.autopilot,
+        "_get_worktree_entries",
+        lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/test")],
+    )
+    monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(mod, "_worktree_is_dirty", lambda _path: False)
+    monkeypatch.setattr(mod, "_unique_commits_ahead_of_main", lambda _repo, _branch: (0, True))
+    monkeypatch.setattr(mod, "_lookup_open_prs", lambda _repo, _branch: ([], False))
+
+    inspection = mod.inspect_worktree(repo_root, worktree)
+
+    assert inspection.lock_files == [".codex_session_active"]
+    assert inspection.ahead_lookup_failed is True
+    assert inspection.blockers == ["session_lock_present", "ahead_lookup_failed"]


### PR DESCRIPTION
## Summary
- make safe_worktree_cleanup inspect fail closed on dirty worktrees, local commits ahead of origin/main, and lingering session lock files
- expose the new inspection facts in JSON/plain output so audits can distinguish cleanup-safe paths from harvest candidates
- add focused regression tests for dirty, ahead-of-main, and stale-lock cases

## Validation
- python3 -m pytest tests/scripts/test_safe_worktree_cleanup.py -q
- ruff check scripts/safe_worktree_cleanup.py tests/scripts/test_safe_worktree_cleanup.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/safe_worktree_cleanup.py inspect --json /Users/armand/Development/aragora/.worktrees/pr-5277-fix
