### PR TITLE
fix(handlers): validate request bodies across blocked endpoints

### DIFF
--- a/aragora/server/handlers/admin/system.py
+++ b/aragora/server/handlers/admin/system.py
@@ -460,10 +460,12 @@ class SystemHandler(BaseHandler):
             return error_response("Invalid JSON body", 400)
 
         token = body.get("token")
-        if not token:
+        if not isinstance(token, str) or not token.strip():
             return error_response("Token is required", 400)
 
         reason = body.get("reason", "")
+        if not isinstance(reason, str):
+            return error_response("Reason must be a string", 400)
 
         # Revoke the token using both in-memory and persistent backends
         success = auth_config.revoke_token(token, reason)

--- a/aragora/server/handlers/autonomous/improve.py
+++ b/aragora/server/handlers/autonomous/improve.py
@@ -130,7 +130,9 @@ class AutonomousImproveHandler(SecureEndpointMixin, SecureHandler):  # type: ign
         path = strip_version_prefix(path)
 
         if path == "/api/autonomous/improve":
-            body = self.read_json_body(handler) or {}
+            body, error = self.read_json_object_or_error(handler)
+            if error:
+                return error
             return await self._start_run(body)
 
         return None

--- a/aragora/server/handlers/autonomous_learning.py
+++ b/aragora/server/handlers/autonomous_learning.py
@@ -570,7 +570,6 @@ class AutonomousLearningHandler(BaseHandler):
         handler: Any,
     ) -> HandlerResult | None:
         """Route POST requests to appropriate handler method."""
-        body = self.read_json_body(handler) or {}
         query_params = query_params or {}
 
         try:
@@ -585,18 +584,30 @@ class AutonomousLearningHandler(BaseHandler):
 
             # Create session
             if path == "/api/v2/learning/sessions":
+                body, error = self.read_json_object_or_error(handler)
+                if error:
+                    return error
                 return await self._create_session(body, handler)
 
             # Submit feedback
             if path == "/api/v2/learning/feedback":
+                body, error = self.read_json_object_or_error(handler)
+                if error:
+                    return error
                 return await self._submit_feedback(body, handler)
 
             # Trigger knowledge extraction
             if path == "/api/v2/learning/knowledge/extract":
+                body, error = self.read_json_object_or_error(handler)
+                if error:
+                    return error
                 return await self._extract_knowledge(body, handler)
 
             # Trigger calibration
             if path == "/api/v2/learning/calibrate":
+                body, error = self.read_json_object_or_error(handler)
+                if error:
+                    return error
                 return await self._calibrate(body, handler)
 
             # Session-specific POST routes
@@ -622,6 +633,9 @@ class AutonomousLearningHandler(BaseHandler):
                 pattern_id = parts[5]
 
                 if parts[6] == "validate":
+                    body, error = self.read_json_object_or_error(handler)
+                    if error:
+                        return error
                     return await self._validate_pattern(pattern_id, body, handler)
 
             return None
@@ -708,10 +722,20 @@ class AutonomousLearningHandler(BaseHandler):
             return error_response("Session name is required", 400)
 
         mode_str = body.get("mode", "supervised")
+        if not isinstance(mode_str, str):
+            return error_response("mode must be a string", 400)
         try:
             mode = LearningMode(mode_str)
         except ValueError:
             return error_response(f"Invalid learning mode: {mode_str}", 400)
+
+        config = body.get("config", {})
+        if not isinstance(config, dict):
+            return error_response("config must be a JSON object", 400)
+
+        total_epochs = body.get("total_epochs", 100)
+        if isinstance(total_epochs, bool) or not isinstance(total_epochs, int) or total_epochs <= 0:
+            return error_response("total_epochs must be a positive integer", 400)
 
         # Check max active sessions
         active_sessions = sum(
@@ -738,8 +762,8 @@ class AutonomousLearningHandler(BaseHandler):
             status=SessionStatus.PENDING,
             created_at=now,
             owner_id=owner_id,
-            config=body.get("config", {}),
-            total_epochs=body.get("total_epochs", 100),
+            config=config,
+            total_epochs=total_epochs,
         )
 
         # Automatically start the session
@@ -997,8 +1021,16 @@ class AutonomousLearningHandler(BaseHandler):
     ) -> HandlerResult:
         """Trigger knowledge extraction from debates."""
         debate_ids = body.get("debate_ids", [])
+        if not isinstance(debate_ids, list) or not all(
+            isinstance(debate_id, str) and debate_id.strip() for debate_id in debate_ids
+        ):
+            return error_response("debate_ids is required and must be a list of strings", 400)
         if not debate_ids:
             return error_response("debate_ids is required", 400)
+
+        topics = body.get("topics", ["general"])
+        if not isinstance(topics, list) or not all(isinstance(topic, str) for topic in topics):
+            return error_response("topics must be a list of strings", 400)
 
         # Simulate knowledge extraction
         knowledge_id = self._generate_knowledge_id()
@@ -1012,7 +1044,7 @@ class AutonomousLearningHandler(BaseHandler):
             source_debates=debate_ids,
             confidence=random.uniform(0.7, 0.95),  # noqa: S311 -- simulated metric
             extracted_at=now,
-            topics=body.get("topics", ["general"]),
+            topics=topics,
         )
 
         self._knowledge[knowledge_id] = knowledge
@@ -1051,6 +1083,10 @@ class AutonomousLearningHandler(BaseHandler):
         if target_type not in ("session", "pattern", "knowledge"):
             return error_response(f"Invalid target_type: {target_type}", 400)
 
+        rating = body.get("rating")
+        if rating is not None and not isinstance(rating, int | float):
+            return error_response("rating must be numeric", 400)
+
         user = self.get_current_user(handler)
         submitted_by = user.user_id if user else "anonymous"
 
@@ -1065,7 +1101,7 @@ class AutonomousLearningHandler(BaseHandler):
             comment=comment,
             submitted_by=submitted_by,
             submitted_at=now,
-            rating=body.get("rating"),
+            rating=rating,
         )
 
         self._feedback.append(feedback)
@@ -1215,6 +1251,12 @@ class AutonomousLearningHandler(BaseHandler):
         """Trigger model calibration."""
         agent_ids = body.get("agent_ids", [])
         force = body.get("force", False)
+        if not isinstance(agent_ids, list) or not all(
+            isinstance(agent_id, str) for agent_id in agent_ids
+        ):
+            return error_response("agent_ids must be a list of strings", 400)
+        if not isinstance(force, bool):
+            return error_response("force must be a boolean", 400)
 
         # Simulate calibration
         now = datetime.now(timezone.utc)

--- a/aragora/server/handlers/autonomous_learning.py
+++ b/aragora/server/handlers/autonomous_learning.py
@@ -1084,8 +1084,9 @@ class AutonomousLearningHandler(BaseHandler):
             return error_response(f"Invalid target_type: {target_type}", 400)
 
         rating = body.get("rating")
-        if rating is not None and not isinstance(rating, int | float):
-            return error_response("rating must be numeric", 400)
+        if rating is not None:
+            if isinstance(rating, bool) or not isinstance(rating, int):
+                return error_response("rating must be an integer", 400)
 
         user = self.get_current_user(handler)
         submitted_by = user.user_id if user else "anonymous"

--- a/aragora/server/handlers/base.py
+++ b/aragora/server/handlers/base.py
@@ -1233,6 +1233,34 @@ class BaseHandler:
 
         return body, None
 
+    def read_json_object_or_error(
+        self,
+        handler: Any,
+        *,
+        allow_empty: bool = True,
+        max_size: int | None = None,
+        invalid_error: str = "Invalid JSON body",
+        empty_error: str = "Request body must be a non-empty JSON object",
+    ) -> tuple[dict[str, Any] | None, HandlerResult | None]:
+        """Read a JSON object body and convert parsing failures into 400 responses.
+
+        Args:
+            handler: The HTTP request handler with headers and rfile.
+            allow_empty: Whether an empty JSON object/no body is accepted.
+            max_size: Maximum body size to accept.
+            invalid_error: Error message when parsing fails.
+            empty_error: Error message when an empty object is disallowed.
+
+        Returns:
+            Tuple of (parsed_dict, None) on success or (None, HandlerResult) on failure.
+        """
+        body = self.read_json_body(handler, max_size)
+        if body is None:
+            return None, error_response(invalid_error, 400)
+        if not allow_empty and not body:
+            return None, error_response(empty_error, 400)
+        return body, None
+
     def handle(
         self, path: str, query_params: dict[str, Any], handler: Any
     ) -> MaybeAsyncHandlerResult:

--- a/aragora/server/handlers/bots/base.py
+++ b/aragora/server/handlers/bots/base.py
@@ -339,7 +339,18 @@ class BotHandlerMixin:
             return None, error_response("Empty request body", 400, code=BotErrorCode.EMPTY_BODY)
 
         try:
-            return json.loads(body.decode("utf-8")), None
+            parsed = json.loads(body.decode("utf-8"))
+            if not isinstance(parsed, dict):
+                logger.error("Non-object JSON in %s %s", self.bot_platform, context)
+                return (
+                    None,
+                    error_response(
+                        "Request body must be a JSON object",
+                        400,
+                        code=BotErrorCode.VALIDATION_ERROR,
+                    ),
+                )
+            return parsed, None
         except json.JSONDecodeError as e:
             logger.error("Invalid JSON in %s %s: %s", self.bot_platform, context, e)
             return None, error_response("Invalid JSON", 400, code=BotErrorCode.INVALID_JSON)

--- a/aragora/server/handlers/bots/discord.py
+++ b/aragora/server/handlers/bots/discord.py
@@ -305,6 +305,8 @@ class DiscordHandler(BotHandlerMixin, SecureHandler):
             interaction, err = self._parse_json_body(body, "Discord interaction")
             if err:
                 return err
+            if interaction is None:
+                return error_response("Discord interaction body must be a JSON object", 400)
 
             interaction_type = interaction.get("type")
             if isinstance(interaction_type, bool) or not isinstance(interaction_type, int):

--- a/aragora/server/handlers/bots/discord.py
+++ b/aragora/server/handlers/bots/discord.py
@@ -307,6 +307,11 @@ class DiscordHandler(BotHandlerMixin, SecureHandler):
                 return err
 
             interaction_type = interaction.get("type")
+            if isinstance(interaction_type, bool) or not isinstance(interaction_type, int):
+                return error_response(
+                    "Discord interaction body must include an integer 'type' field",
+                    400,
+                )
 
             # Handle PING (type 1) - required for URL verification
             if interaction_type == 1:

--- a/aragora/server/handlers/bots/slack/handler.py
+++ b/aragora/server/handlers/bots/slack/handler.py
@@ -291,6 +291,8 @@ class SlackHandler(BotHandlerMixin, SecureHandler):
                 timestamp = handler.headers.get("X-Slack-Request-Timestamp", "")
                 signature = handler.headers.get("X-Slack-Signature", "")
                 body = handler.rfile.read(int(handler.headers.get("Content-Length", 0)))
+                if not body:
+                    return error_response("Empty request body", 400)
                 # Reset the file position for later reads
                 handler.rfile.seek(0)
 

--- a/aragora/server/handlers/bots/teams/handler.py
+++ b/aragora/server/handlers/bots/teams/handler.py
@@ -902,6 +902,9 @@ class TeamsHandler(SecureEndpointMixin, BotHandlerMixin, SecureHandler):  # type
 
             if not activity:
                 return error_response("Empty activity", 400)
+            activity_type = activity.get("type")
+            if not isinstance(activity_type, str) or not activity_type.strip():
+                return error_response("Teams activity must include a non-empty 'type' field", 400)
 
             auth_header = handler.headers.get("Authorization", "")
 

--- a/aragora/server/handlers/bots/whatsapp.py
+++ b/aragora/server/handlers/bots/whatsapp.py
@@ -245,6 +245,8 @@ class WhatsAppHandler(BotHandlerMixin, SecureHandler):
             payload, err = self._parse_json_body(body, "WhatsApp webhook")
             if err:
                 return err
+            if payload is None:
+                return error_response("WhatsApp webhook body must be a JSON object", 400)
 
             entries = payload.get("entry")
             if not isinstance(entries, list):

--- a/aragora/server/handlers/bots/whatsapp.py
+++ b/aragora/server/handlers/bots/whatsapp.py
@@ -246,8 +246,14 @@ class WhatsAppHandler(BotHandlerMixin, SecureHandler):
             if err:
                 return err
 
+            entries = payload.get("entry")
+            if not isinstance(entries, list):
+                return error_response("WhatsApp webhook body must include an 'entry' list", 400)
+
             # Process webhook entries
-            for entry in payload.get("entry", []):
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    return error_response("WhatsApp webhook entries must be JSON objects", 400)
                 for change in entry.get("changes", []):
                     if change.get("field") == "messages":
                         self._process_messages(change.get("value", {}))

--- a/aragora/server/handlers/bots/zoom.py
+++ b/aragora/server/handlers/bots/zoom.py
@@ -204,6 +204,8 @@ class ZoomHandler(BotHandlerMixin, SecureHandler):
             event, err = self._parse_json_body(body, "Zoom event")
             if err:
                 return err
+            if event is None:
+                return error_response("Zoom event body must be a JSON object", 400)
 
             event_type = event.get("event", "")
             if not isinstance(event_type, str) or not event_type.strip():
@@ -220,6 +222,8 @@ class ZoomHandler(BotHandlerMixin, SecureHandler):
                 import hmac
 
                 payload = event.get("payload", {})
+                if not isinstance(payload, dict):
+                    return error_response("Zoom URL validation payload must be a JSON object", 400)
                 plain_token = payload.get("plainToken", "")
 
                 encrypted = hmac.new(
@@ -262,6 +266,10 @@ class ZoomHandler(BotHandlerMixin, SecureHandler):
             # RBAC: check permission for chat-related events
             if event_type == "bot_notification":
                 payload = event.get("payload", {})
+                if not isinstance(payload, dict):
+                    return error_response(
+                        "Zoom bot notification payload must be a JSON object", 400
+                    )
                 user_jid = payload.get("userJid", "")
                 try:
                     self._check_bot_permission(

--- a/aragora/server/handlers/bots/zoom.py
+++ b/aragora/server/handlers/bots/zoom.py
@@ -206,6 +206,8 @@ class ZoomHandler(BotHandlerMixin, SecureHandler):
                 return err
 
             event_type = event.get("event", "")
+            if not isinstance(event_type, str) or not event_type.strip():
+                return error_response("Zoom event body must include a non-empty 'event' field", 400)
             logger.info("Zoom event received: %s", event_type)
 
             # Handle URL validation - requires ZOOM_SECRET_TOKEN

--- a/aragora/server/handlers/cloud_storage.py
+++ b/aragora/server/handlers/cloud_storage.py
@@ -27,6 +27,7 @@ Stability: STABLE
 
 from __future__ import annotations
 
+import binascii
 import hashlib
 import logging
 import mimetypes
@@ -931,7 +932,7 @@ class CloudStorageHandler(BaseHandler):
 
         try:
             data = base64.b64decode(content_b64, validate=True)
-        except (ValueError, TypeError, base64.binascii.Error):
+        except (ValueError, TypeError, binascii.Error):
             return error_response("Invalid base64 content", 400)
 
         # Check file size

--- a/aragora/server/handlers/cloud_storage.py
+++ b/aragora/server/handlers/cloud_storage.py
@@ -638,13 +638,6 @@ class CloudStorageHandler(BaseHandler):
         handler: Any,
     ) -> HandlerResult | None:
         """Route POST requests to appropriate handler method."""
-        raw_body = self.read_json_body(handler)
-        if raw_body is None:
-            body: dict[str, Any] = {}
-        elif isinstance(raw_body, dict):
-            body = raw_body
-        else:
-            return error_response("Request body must be a JSON object", 400)
         query_params, query_params_error = self._validate_query_params(query_params)
         if query_params_error:
             return error_response(query_params_error, 400)
@@ -661,10 +654,16 @@ class CloudStorageHandler(BaseHandler):
 
             # Upload file
             if path == "/api/v2/storage/files":
+                body, error = self.read_json_object_or_error(handler)
+                if error:
+                    return error
                 return await self._upload_file(body, handler)
 
             # Create bucket
             if path == "/api/v2/storage/buckets":
+                body, error = self.read_json_object_or_error(handler)
+                if error:
+                    return error
                 return await self._create_bucket(body, handler)
 
             # File-specific POST routes
@@ -681,6 +680,9 @@ class CloudStorageHandler(BaseHandler):
 
                 # Presigned URL endpoint
                 if parts[6] == "presign":
+                    body, error = self.read_json_object_or_error(handler)
+                    if error:
+                        return error
                     return await self._generate_presigned_url(file_id, body, handler)
 
                 return None

--- a/aragora/server/handlers/compliance_eu_ai_act.py
+++ b/aragora/server/handlers/compliance_eu_ai_act.py
@@ -166,6 +166,8 @@ class EUAIActComplianceHandler(BaseHandler):
         body, error = self.read_json_object_or_error(handler)
         if error:
             return error
+        if body is None:
+            return error_response("JSON object body is required", 400)
 
         debate_id = body.get("debate_id")
         scope = body.get("scope")

--- a/aragora/server/handlers/compliance_eu_ai_act.py
+++ b/aragora/server/handlers/compliance_eu_ai_act.py
@@ -163,10 +163,18 @@ class EUAIActComplianceHandler(BaseHandler):
         if path != "/api/v1/compliance/eu-ai-act/bundles":
             return None
 
-        body = self.read_json_body(handler) or {}
+        body, error = self.read_json_object_or_error(handler)
+        if error:
+            return error
+
         debate_id = body.get("debate_id")
         scope = body.get("scope")
         articles = body.get("articles")
+
+        if debate_id is not None and not isinstance(debate_id, str):
+            return error_response("'debate_id' must be a string", 400)
+        if scope is not None and not isinstance(scope, str):
+            return error_response("'scope' must be a string", 400)
 
         # Validate articles parameter
         if articles is not None:

--- a/aragora/server/handlers/compliance_reports.py
+++ b/aragora/server/handlers/compliance_reports.py
@@ -64,13 +64,20 @@ class ComplianceReportHandler(BaseHandler):
         if path != "/api/v1/compliance/reports/generate":
             return None
 
-        body = self.read_json_body(handler) or {}
+        body, error = self.read_json_object_or_error(handler)
+        if error:
+            return error
+
         framework = body.get("framework", "general")
         debate_id = body.get("debate_id")
         scope = body.get("scope", {})
 
-        if not debate_id:
+        if not isinstance(debate_id, str) or not debate_id.strip():
             return error_response("debate_id is required", 400)
+        if not isinstance(framework, str):
+            return error_response("framework must be a string", 400)
+        if not isinstance(scope, dict):
+            return error_response("scope must be a JSON object", 400)
 
         valid_frameworks = {"soc2", "gdpr", "hipaa", "iso27001", "general", "custom"}
         if framework not in valid_frameworks:
@@ -92,7 +99,7 @@ class ComplianceReportHandler(BaseHandler):
             storage = self.ctx.get("storage")
             debate_data = None
             if storage:
-                debate_data = storage.get_debate(debate_id)
+                debate_data = storage.get_debate(debate_id.strip())
 
             if debate_data is None:
                 return error_response(f"Debate '{debate_id}' not found", 404)
@@ -110,7 +117,7 @@ class ComplianceReportHandler(BaseHandler):
 
             report = generator.generate(
                 debate_result=debate_result,
-                debate_id=debate_id,
+                debate_id=debate_id.strip(),
                 framework=framework_enum,
                 include_evidence=scope.get("include_evidence", True),
                 include_chain=scope.get("include_chain", True),

--- a/aragora/server/handlers/compliance_reports.py
+++ b/aragora/server/handlers/compliance_reports.py
@@ -67,6 +67,8 @@ class ComplianceReportHandler(BaseHandler):
         body, error = self.read_json_object_or_error(handler)
         if error:
             return error
+        if body is None:
+            return error_response("JSON object body is required", 400)
 
         framework = body.get("framework", "general")
         debate_id = body.get("debate_id")

--- a/aragora/server/handlers/computer_use_handler.py
+++ b/aragora/server/handlers/computer_use_handler.py
@@ -345,16 +345,21 @@ class ComputerUseHandler(BaseHandler):
         if not orchestrator:
             return error_response("Orchestrator not available", 503)
 
-        body = self.read_json_body(handler)
-        if body is None:
-            return error_response("Invalid JSON body", 400)
+        body, error = self.read_json_object_or_error(handler)
+        if error:
+            return error
 
         goal = body.get("goal")
-        if not goal:
-            return error_response("goal is required", 400)
+        if not isinstance(goal, str) or not goal.strip():
+            return error_response("goal is required and must be a non-empty string", 400)
 
         max_steps = body.get("max_steps", 10)
+        if isinstance(max_steps, bool) or not isinstance(max_steps, int) or max_steps <= 0:
+            return error_response("max_steps must be a positive integer", 400)
+
         dry_run = body.get("dry_run", False)
+        if not isinstance(dry_run, bool):
+            return error_response("dry_run must be a boolean", 400)
 
         # Get auth context for metadata
         auth_ctx = self._get_auth_context(handler)
@@ -399,9 +404,11 @@ class ComputerUseHandler(BaseHandler):
                         "roles": list(getattr(auth_ctx, "roles", [])),
                     }
                 receipt_id = body.get("receipt_id")
+                if receipt_id is not None and not isinstance(receipt_id, str):
+                    return error_response("receipt_id must be a string", 400)
                 result: Any = run_async(
                     orchestrator.run_task(
-                        goal=goal,
+                        goal=goal.strip(),
                         max_steps=max_steps,
                         metadata=metadata,
                         receipt_id=receipt_id,
@@ -535,13 +542,27 @@ class ComputerUseHandler(BaseHandler):
         if error := self._check_rbac_permission(handler, "computer_use:policies:create"):
             return error
 
-        body = self.read_json_body(handler)
-        if body is None:
-            return error_response("Invalid JSON body", 400)
+        body, error = self.read_json_object_or_error(handler)
+        if error:
+            return error
 
         name = body.get("name")
-        if not name:
-            return error_response("name is required", 400)
+        if not isinstance(name, str) or not name.strip():
+            return error_response("name is required and must be a non-empty string", 400)
+
+        allowed_actions = body.get(
+            "allowed_actions", ["screenshot", "click", "type", "scroll", "key"]
+        )
+        if not isinstance(allowed_actions, list) or not all(
+            isinstance(action, str) for action in allowed_actions
+        ):
+            return error_response("allowed_actions must be a list of strings", 400)
+
+        blocked_domains = body.get("blocked_domains", [])
+        if not isinstance(blocked_domains, list) or not all(
+            isinstance(domain, str) for domain in blocked_domains
+        ):
+            return error_response("blocked_domains must be a list of strings", 400)
 
         policy_id = f"policy-{uuid.uuid4().hex[:8]}"
 
@@ -552,12 +573,10 @@ class ComputerUseHandler(BaseHandler):
         # Create policy record
         policy_data = {
             "policy_id": policy_id,
-            "name": name,
+            "name": name.strip(),
             "description": body.get("description", ""),
-            "allowed_actions": body.get(
-                "allowed_actions", ["screenshot", "click", "type", "scroll", "key"]
-            ),
-            "blocked_domains": body.get("blocked_domains", []),
+            "allowed_actions": allowed_actions,
+            "blocked_domains": blocked_domains,
             "tenant_id": tenant_id,
         }
 
@@ -639,8 +658,12 @@ class ComputerUseHandler(BaseHandler):
 
         auth_ctx = self._get_auth_context(handler)
         approver_id: str = getattr(auth_ctx, "user_id", "system") if auth_ctx else "system"
-        body = self.read_json_body(handler) or {}
+        body, error = self.read_json_object_or_error(handler)
+        if error:
+            return error
         reason = body.get("reason")
+        if reason is not None and not isinstance(reason, str):
+            return error_response("reason must be a string", 400)
 
         approved = run_async(workflow.approve(request_id, approver_id, reason))
         if not approved:
@@ -664,8 +687,12 @@ class ComputerUseHandler(BaseHandler):
 
         auth_ctx = self._get_auth_context(handler)
         approver_id: str = getattr(auth_ctx, "user_id", "system") if auth_ctx else "system"
-        body = self.read_json_body(handler) or {}
+        body, error = self.read_json_object_or_error(handler)
+        if error:
+            return error
         reason = body.get("reason")
+        if reason is not None and not isinstance(reason, str):
+            return error_response("reason must be a string", 400)
 
         denied = run_async(workflow.deny(request_id, approver_id, reason))
         if not denied:

--- a/aragora/server/handlers/computer_use_handler.py
+++ b/aragora/server/handlers/computer_use_handler.py
@@ -45,66 +45,51 @@ from aragora.server.http_utils import run_async
 from aragora.server.validation.query_params import safe_query_int
 
 if TYPE_CHECKING:
-    from aragora.rbac import AuthorizationContext
+    from aragora.rbac import AuthorizationContext as AuthorizationContextType
     from aragora.computer_use import (
-        ComputerUseOrchestrator,
+        ComputerUseOrchestrator as ComputerUseOrchestratorType,
     )
-
-# RBAC imports - runtime fallback
-_AuthorizationContext: Any = None
-_check_permission: Any = None
-_extract_user_from_request: Any = None
+else:
+    AuthorizationContextType = Any
+    ComputerUseOrchestratorType = Any
 
 try:
     from aragora.rbac import (
-        AuthorizationContext as _AuthorizationContext,
-        check_permission as _check_permission,
+        AuthorizationContext,
+        check_permission,
     )
     from aragora.billing.jwt_auth import (
-        extract_user_from_request as _extract_user_from_request,
+        extract_user_from_request,
     )
 
     RBAC_AVAILABLE = True
 except ImportError:
     RBAC_AVAILABLE = False
+    AuthorizationContext = None  # type: ignore[misc,assignment]
+    check_permission = None  # type: ignore[assignment]
+    extract_user_from_request = None  # type: ignore[assignment]
 
 from aragora.server.handlers.utils.rbac_guard import rbac_fail_closed
 
-# Expose RBAC symbols for patching in tests
-AuthorizationContext = _AuthorizationContext  # type: ignore[misc]
-check_permission = _check_permission
-extract_user_from_request = _extract_user_from_request
-
-# Computer Use imports - runtime fallback
-_ComputerUseOrchestrator: Any = None
-_ComputerUseConfig: Any = None
-_ComputerPolicy: Any = None
-_create_default_computer_policy: Any = None
-_TaskResult: Any = None
-_TaskStatus: Any = None
-_ApprovalStatus: Any = None
-
 try:
     from aragora.computer_use import (
-        ComputerUseOrchestrator as _ComputerUseOrchestrator,
-        ComputerUseConfig as _ComputerUseConfig,
-        create_default_computer_policy as _create_default_computer_policy,
+        ComputerUseOrchestrator,
+        ComputerUseConfig,
+        create_default_computer_policy,
     )
     from aragora.computer_use.orchestrator import (
-        TaskStatus as _TaskStatus,
+        TaskStatus,
     )
-    from aragora.computer_use.approval import ApprovalStatus as _ApprovalStatus
+    from aragora.computer_use.approval import ApprovalStatus
 
     COMPUTER_USE_AVAILABLE = True
 except ImportError:
     COMPUTER_USE_AVAILABLE = False
-
-# Expose computer-use symbols for patching in tests
-ComputerUseOrchestrator = _ComputerUseOrchestrator  # type: ignore[misc]
-ComputerUseConfig = _ComputerUseConfig
-create_default_computer_policy = _create_default_computer_policy
-TaskStatus = _TaskStatus
-ApprovalStatus = _ApprovalStatus
+    ComputerUseOrchestrator = None  # type: ignore[misc,assignment]
+    ComputerUseConfig = None  # type: ignore[assignment]
+    create_default_computer_policy = None  # type: ignore[assignment]
+    TaskStatus = None  # type: ignore[assignment]
+    ApprovalStatus = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +116,7 @@ class ComputerUseHandler(BaseHandler):
 
     def __init__(self, server_context: Any) -> None:
         super().__init__(server_context)
-        self._orchestrator: ComputerUseOrchestrator | None = None
+        self._orchestrator: ComputerUseOrchestratorType | None = None
         self._storage: ComputerUseStorage | None = None
         self._approval_workflow: Any | None = None
 
@@ -141,7 +126,7 @@ class ComputerUseHandler(BaseHandler):
             self._storage = get_computer_use_storage()
         return self._storage
 
-    def _get_orchestrator(self) -> ComputerUseOrchestrator | None:
+    def _get_orchestrator(self) -> ComputerUseOrchestratorType | None:
         """Get or create computer use orchestrator."""
         if not COMPUTER_USE_AVAILABLE:
             return None
@@ -165,7 +150,7 @@ class ComputerUseHandler(BaseHandler):
         """Get user store from context."""
         return self.ctx.get("user_store")
 
-    def _get_auth_context(self, handler: Any) -> AuthorizationContext | None:
+    def _get_auth_context(self, handler: Any) -> AuthorizationContextType | None:
         """Build AuthorizationContext from request."""
         if not RBAC_AVAILABLE or AuthorizationContext is None:
             # Fail closed in production - caller must handle None with rbac_fail_closed()
@@ -348,6 +333,8 @@ class ComputerUseHandler(BaseHandler):
         body, error = self.read_json_object_or_error(handler)
         if error:
             return error
+        if body is None:
+            return error_response("JSON object body is required", 400)
 
         goal = body.get("goal")
         if not isinstance(goal, str) or not goal.strip():
@@ -545,6 +532,8 @@ class ComputerUseHandler(BaseHandler):
         body, error = self.read_json_object_or_error(handler)
         if error:
             return error
+        if body is None:
+            return error_response("JSON object body is required", 400)
 
         name = body.get("name")
         if not isinstance(name, str) or not name.strip():
@@ -661,6 +650,8 @@ class ComputerUseHandler(BaseHandler):
         body, error = self.read_json_object_or_error(handler)
         if error:
             return error
+        if body is None:
+            return error_response("JSON object body is required", 400)
         reason = body.get("reason")
         if reason is not None and not isinstance(reason, str):
             return error_response("reason must be a string", 400)
@@ -690,6 +681,8 @@ class ComputerUseHandler(BaseHandler):
         body, error = self.read_json_object_or_error(handler)
         if error:
             return error
+        if body is None:
+            return error_response("JSON object body is required", 400)
         reason = body.get("reason")
         if reason is not None and not isinstance(reason, str):
             return error_response("reason must be a string", 400)

--- a/aragora/server/handlers/connectors/management.py
+++ b/aragora/server/handlers/connectors/management.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
 from typing import Any
 
 from aragora.connectors.runtime_registry import (
@@ -134,6 +135,27 @@ class ConnectorManagementHandler(BaseHandler):
 
         # POST /api/v1/connectors/<name>/test
         if len(parts) == 2 and parts[1] == "test":
+            headers = getattr(handler, "headers", None)
+            content_length = 0
+            if isinstance(headers, Mapping):
+                try:
+                    content_length = int(headers.get("Content-Length", 0))
+                except (TypeError, ValueError):
+                    content_length = 0
+
+            request = getattr(handler, "request", None)
+            has_explicit_body = any(
+                isinstance(raw_body, (bytes, bytearray, str))
+                for raw_body in (
+                    getattr(handler, "body", None),
+                    getattr(request, "body", None) if request is not None else None,
+                )
+            )
+
+            if has_explicit_body or content_length > 0:
+                _, body_error = self.read_json_object_or_error(handler)
+                if body_error:
+                    return body_error
             return self._handle_test(parts[0])
 
         return None

--- a/aragora/server/handlers/coordination.py
+++ b/aragora/server/handlers/coordination.py
@@ -162,27 +162,27 @@ class CoordinationHandler(BaseHandler):
         normalized = path.rstrip("/")
 
         if normalized.endswith("/coordination/workspaces"):
-            body = self.read_json_body(handler)
-            if body is None:
-                return error_response("Invalid JSON body", 400)
+            body, error = self.read_json_object_or_error(handler)
+            if error:
+                return error
             return self._handle_register_workspace(body)
 
         if normalized.endswith("/coordination/federation"):
-            body = self.read_json_body(handler)
-            if body is None:
-                return error_response("Invalid JSON body", 400)
+            body, error = self.read_json_object_or_error(handler)
+            if error:
+                return error
             return self._handle_create_policy(body)
 
         if normalized.endswith("/coordination/execute"):
-            body = self.read_json_body(handler)
-            if body is None:
-                return error_response("Invalid JSON body", 400)
+            body, error = self.read_json_object_or_error(handler)
+            if error:
+                return error
             return self._handle_execute(body)
 
         if normalized.endswith("/coordination/consent"):
-            body = self.read_json_body(handler)
-            if body is None:
-                return error_response("Invalid JSON body", 400)
+            body, error = self.read_json_object_or_error(handler)
+            if error:
+                return error
             return self._handle_grant_consent(body)
 
         # POST /api/v1/coordination/approve/{id}
@@ -196,9 +196,9 @@ class CoordinationHandler(BaseHandler):
                     break
             if not request_id:
                 return error_response("Missing request ID", 400)
-            body = self.read_json_body(handler)
-            if body is None:
-                body = {}
+            body, error = self.read_json_object_or_error(handler)
+            if error:
+                return error
             return self._handle_approve(request_id, body)
 
         return None

--- a/tests/handlers/bots/test_base.py
+++ b/tests/handlers/bots/test_base.py
@@ -771,14 +771,16 @@ class TestParseJsonBody:
         assert error is None
         assert data["outer"]["inner"]["deep"] is True
 
-    def test_json_array(self, bot):
-        """Arrays are valid JSON but not dicts - still parses."""
+    def test_json_array_rejected(self, bot):
+        """Non-object JSON payloads should be rejected for webhook handlers."""
         body = b"[1, 2, 3]"
 
         data, error = bot._parse_json_body(body)
 
-        assert error is None
-        assert data == [1, 2, 3]
+        assert data is None
+        assert error is not None
+        assert _status(error) == 400
+        assert "json object" in _body(error)["error"]["message"].lower()
 
     def test_unicode_body(self, bot):
         body = json.dumps({"emoji": "hello"}).encode("utf-8")

--- a/tests/handlers/connectors/test_management.py
+++ b/tests/handlers/connectors/test_management.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import time
+from io import BytesIO
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -558,6 +559,14 @@ class TestTestConnectivity:
     def test_test_invalid_name(self, handler, mock_http_handler, mock_registry):
         result = handler.handle_post(_PREFIX + "/bad-name/test", {}, mock_http_handler)
         assert _status(result) == 400
+
+    def test_test_invalid_json_returns_400(self, handler, mock_registry):
+        bad_http_handler = MagicMock()
+        bad_http_handler.headers = {"Content-Length": "8"}
+        bad_http_handler.rfile = BytesIO(b"not-json")
+        result = handler.handle_post(_PREFIX + "/slack/test", {}, bad_http_handler)
+        assert _status(result) == 400
+        assert "json" in _body(result).get("error", "").lower()
 
     def test_test_unknown_status_connector(self, handler, mock_http_handler, mock_registry):
         connector = _make_connector(

--- a/tests/handlers/test_autonomous_improve.py
+++ b/tests/handlers/test_autonomous_improve.py
@@ -265,6 +265,16 @@ class TestCreateRun:
         assert _status(result) == 400
 
     @pytest.mark.asyncio
+    async def test_invalid_json_returns_400(self, handler_with_store, mock_http_handler):
+        """Malformed JSON should fail before semantic validation."""
+        http = mock_http_handler(method="POST")
+        http.rfile.read.return_value = b"not-json"
+        http.headers = {"Content-Length": "8"}
+        result = await handler_with_store.handle_post("/api/v1/autonomous/improve", {}, http)
+        assert _status(result) == 400
+        assert "json" in _body(result).get("error", "").lower()
+
+    @pytest.mark.asyncio
     async def test_budget_limit_accepted(self, handler_with_store, mock_store, mock_http_handler):
         """POST with valid budget_limit succeeds."""
         mock_run = SelfImproveRun(run_id="budg-1", goal="test", budget_limit_usd=5.0)

--- a/tests/handlers/test_autonomous_learning.py
+++ b/tests/handlers/test_autonomous_learning.py
@@ -282,6 +282,21 @@ class TestCanHandle:
     def test_performance(self, handler):
         assert handler.can_handle("/api/v2/learning/performance", "GET")
 
+
+class TestPostBodyValidation:
+    """Focused regression tests for POST body parsing."""
+
+    @pytest.mark.asyncio
+    async def test_create_session_invalid_json_returns_400(self, handler):
+        mock_http = MockHTTPHandler(method="POST")
+        mock_http.rfile.read.return_value = b"not-json"
+        mock_http.headers["Content-Length"] = "8"
+
+        result = await handler.handle_post("/api/v2/learning/sessions", {}, mock_http)
+
+        assert _status(result) == 400
+        assert "json" in _body(result).get("error", "").lower()
+
     def test_calibrate(self, handler):
         assert handler.can_handle("/api/v2/learning/calibrate", "POST")
 

--- a/tests/handlers/test_cloud_storage.py
+++ b/tests/handlers/test_cloud_storage.py
@@ -645,6 +645,15 @@ class TestUploadFile:
         assert "required" in _body(result).get("error", "").lower()
 
     @pytest.mark.asyncio
+    async def test_upload_invalid_json_returns_400(self, handler):
+        h = _make_handler(method="POST")
+        h.rfile.read.return_value = b"not-json"
+        h.headers = {"Content-Length": "8"}
+        result = await handler.handle_post("/api/v2/storage/files", {}, h)
+        assert _status(result) == 400
+        assert "json" in _body(result).get("error", "").lower()
+
+    @pytest.mark.asyncio
     async def test_upload_empty_filename(self, handler):
         body = {"filename": "", "content": _sample_b64_content()}
         h = _make_handler(body=body, method="POST")

--- a/tests/handlers/test_compliance_eu_ai_act.py
+++ b/tests/handlers/test_compliance_eu_ai_act.py
@@ -263,6 +263,23 @@ class TestPostBundle:
 
         assert result is None
 
+    def test_invalid_json_returns_400(self, handler, _tmp_db):
+        """Malformed JSON should fail before bundle generation logic."""
+        from aragora.compliance.eu_ai_act import EUAIActBundleGenerator
+
+        gen = EUAIActBundleGenerator(db_path=_tmp_db)
+        with patch(
+            "aragora.server.handlers.compliance_eu_ai_act._get_bundle_generator",
+            return_value=gen,
+        ):
+            mock_http = _MockHTTPHandler("POST")
+            mock_http.rfile.read.return_value = b"not-json"
+            mock_http.headers = {"Content-Length": "8"}
+            result = handler.handle_post("/api/v1/compliance/eu-ai-act/bundles", {}, mock_http)
+
+        assert _status(result) == 400
+        assert "json" in _body(result).get("error", "").lower()
+
 
 # ---------------------------------------------------------------------------
 # Test: GET /api/v1/compliance/eu-ai-act/bundles/{bundle_id}

--- a/tests/handlers/test_compliance_reports.py
+++ b/tests/handlers/test_compliance_reports.py
@@ -862,6 +862,15 @@ class TestHandlePostRouting:
         result = handler.handle_post("/api/v1/compliance/reports/generate", {}, mock_h)
         assert _status(result) == 400
 
+    def test_correct_path_with_invalid_json_returns_400(self, handler):
+        """Malformed JSON should fail before debate_id validation."""
+        mock_h = _MockHTTPHandler("POST")
+        mock_h.rfile.read.return_value = b"not-json"
+        mock_h.headers = {"Content-Length": "8"}
+        result = handler.handle_post("/api/v1/compliance/reports/generate", {}, mock_h)
+        assert _status(result) == 400
+        assert "json" in _body(result).get("error", "").lower()
+
     def test_case_sensitive_path(self, handler):
         """Path matching is case-sensitive."""
         mock_h = _MockHTTPHandler("POST", body={"debate_id": "d1"})

--- a/tests/handlers/test_coordination_handler.py
+++ b/tests/handlers/test_coordination_handler.py
@@ -686,6 +686,15 @@ class TestApprove:
         result = handler.handle_post("/api/v1/coordination/approve/req-77", {}, mock_handler)
         assert _status(result) == 200
 
+    def test_approve_invalid_json_returns_400(self, handler, coordinator):
+        """Approve endpoint rejects malformed JSON instead of silently defaulting to {}."""
+        mock_handler = MagicMock()
+        mock_handler.headers = {"Content-Length": "7"}
+        mock_handler.rfile = BytesIO(b"not-json")
+        result = handler.handle_post("/api/v1/coordination/approve/req-88", {}, mock_handler)
+        assert _status(result) == 400
+        assert "json" in _body(result).get("error", "").lower()
+
 
 # ===================================================================
 # Stats endpoint

--- a/tests/server/handlers/test_computer_use_handler.py
+++ b/tests/server/handlers/test_computer_use_handler.py
@@ -369,6 +369,22 @@ class TestCreateTask:
         assert result is not None
         assert result.status_code == 400
 
+    def test_create_task_invalid_json_returns_400(self, handler):
+        """Malformed JSON should fail before task validation."""
+        mock_handler = MockRequestHandler()
+
+        with patch.object(handler, "_check_rbac_permission", return_value=None):
+            with patch.object(handler, "read_json_body", return_value=None):
+                result = handler.handle_post(
+                    "/api/v1/computer-use/tasks",
+                    {},
+                    mock_handler,
+                )
+
+        assert result is not None
+        assert result.status_code == 400
+        assert "json" in json.loads(result.body)["error"].lower()
+
 
 class TestCancelTask:
     """Test cancel task endpoint."""


### PR DESCRIPTION
## Summary
- add a shared JSON-object body helper for HTTP handlers and use it across the bounced needs-human routes
- reject malformed or non-object payloads for coordination, computer-use, compliance, storage, autonomous, connector, and bot endpoints without changing their successful flows
- add focused regression coverage for the invalid-body cases that were previously falling through

## Validation
- `ruff check aragora/server/handlers/base.py aragora/server/handlers/coordination.py aragora/server/handlers/computer_use_handler.py aragora/server/handlers/compliance_reports.py aragora/server/handlers/compliance_eu_ai_act.py aragora/server/handlers/autonomous_learning.py aragora/server/handlers/autonomous/improve.py aragora/server/handlers/admin/system.py aragora/server/handlers/connectors/management.py aragora/server/handlers/cloud_storage.py aragora/server/handlers/bots/base.py aragora/server/handlers/bots/discord.py aragora/server/handlers/bots/slack/handler.py aragora/server/handlers/bots/teams/handler.py aragora/server/handlers/bots/whatsapp.py aragora/server/handlers/bots/zoom.py tests/handlers/bots/test_base.py tests/handlers/test_coordination_handler.py tests/server/handlers/test_computer_use_handler.py tests/handlers/test_autonomous_improve.py tests/handlers/test_autonomous_learning.py tests/handlers/test_compliance_reports.py tests/handlers/test_compliance_eu_ai_act.py tests/handlers/test_cloud_storage.py tests/handlers/connectors/test_management.py`
- `python3 -m pytest -q tests/handlers/bots/test_base.py tests/handlers/test_coordination_handler.py tests/server/handlers/test_computer_use_handler.py tests/handlers/test_autonomous_improve.py tests/handlers/test_autonomous_learning.py tests/handlers/test_compliance_reports.py tests/handlers/test_compliance_eu_ai_act.py tests/handlers/test_cloud_storage.py tests/handlers/connectors/test_management.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Closes #5459
Closes #5458
Closes #5457
Closes #5456
Closes #5455
Closes #5454
Closes #5453
Closes #5452
Closes #5451
Closes #5450
Closes #5449
Closes #5448
Closes #5447
Closes #5446
