### PR TITLE
fix: add justification comment to CancelledError pass in integration.py

### DIFF
--- a/aragora/control_plane/integration.py
+++ b/aragora/control_plane/integration.py
@@ -107,7 +107,7 @@ class IntegratedControlPlane:
             try:
                 await self._sync_task
             except asyncio.CancelledError:
-                pass
+                pass  # Expected during graceful shutdown
         logger.info("IntegratedControlPlane stopped")
 
     async def _sync_loop(self) -> None:


### PR DESCRIPTION
The except CancelledError: pass pattern in stop() is idiomatic for
graceful asyncio task shutdown. Added inline comment to document this
intent per the no-bare-pass-without-justification policy.

Closes #5444 (partial)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 21aaf1cd570d93081acb4f7b62fc6e5962c9c83c)
