### PR TITLE
fix(health): replace silent CancelledError pass with debug log

### DIFF
--- a/aragora/control_plane/health.py
+++ b/aragora/control_plane/health.py
@@ -162,7 +162,7 @@ class HealthMonitor:
             try:
                 await self._monitor_task
             except asyncio.CancelledError:
-                pass
+                logger.debug("HealthMonitor task cancelled during shutdown")
 
         logger.info("HealthMonitor stopped")
 


### PR DESCRIPTION
Replace the bare `except CancelledError: pass` in HealthMonitor.stop()
with a debug log message for observability, per issue #5443.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 83cac03e3b30aa9147abe4e645c6e496a52ee702)
