### PR TITLE
fix: improve exception logging visibility in auto_scaling.py

### DIFF
--- a/aragora/control_plane/auto_scaling.py
+++ b/aragora/control_plane/auto_scaling.py
@@ -274,7 +274,7 @@ class AutoScaler:
             except asyncio.CancelledError:
                 break
             except (RuntimeError, ValueError, OSError) as e:
-                logger.error("Error in scaling loop: %s", e)
+                logger.error("Error in scaling loop iteration", exc_info=e)
 
     def _cooldown_passed(self) -> bool:
         """Check if cooldown period has passed since last scaling action."""


### PR DESCRIPTION
Use exc_info parameter in scaling loop error handler to include full
traceback, improving debuggability without changing behavior.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit f107c87377a44731a3bb3308f3e216f14d96b7f1)
