### PR TITLE
fix(auth): add justification comment to CancelledError pass in mfa_drift_monitor.py

### DIFF
--- a/aragora/auth/mfa_drift_monitor.py
+++ b/aragora/auth/mfa_drift_monitor.py
@@ -301,7 +301,7 @@ class MFADriftMonitor:
             try:
                 await self._task
             except asyncio.CancelledError:
-                pass
+                pass  # Expected: we just cancelled the task above
             self._task = None
         logger.info("MFADriftMonitor stopped")
 


### PR DESCRIPTION
The only except-pass pattern in this file is the standard asyncio
CancelledError handling after task.cancel(). Added an inline comment
explaining why the pass is intentional. All other broad except blocks
already log via logger.exception().

Refs: #5409

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 5672a87a0d0b191969d2883b6aea2b4740428d2a)
