### PR TITLE
fix(control-plane): replace silent exception pass with debug logging in state_manager.py (#5442)

### DIFF
--- a/aragora/control_plane/coordinator/state_manager.py
+++ b/aragora/control_plane/coordinator/state_manager.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
         ControlPlaneAdapter,
     )
 
+logger = get_logger(__name__)
+
 # Optional KM integration
 HAS_KM_ADAPTER = False
 # Pre-declare optional import with Any to avoid no-redef errors
@@ -49,7 +51,7 @@ try:
 
     HAS_KM_ADAPTER = True
 except ImportError:
-    pass
+    logger.debug("KM adapter not available, TaskOutcome import skipped")
 
 # Optional Watchdog support (Gastown three-tier monitoring)
 ThreeTierWatchdog: Any = None
@@ -92,8 +94,6 @@ try:
     HAS_REDIS_HA = True
 except ImportError:
     HAS_REDIS_HA = False
-
-logger = get_logger(__name__)
 
 # Retry configuration for control plane operations
 _CP_RETRY_CONFIG = PROVIDER_RETRY_POLICIES["control_plane"]

--- a/aragora/control_plane/coordinator/state_manager.py
+++ b/aragora/control_plane/coordinator/state_manager.py
@@ -47,7 +47,7 @@ HAS_KM_ADAPTER = False
 # Pre-declare optional import with Any to avoid no-redef errors
 TaskOutcome: Any = None
 try:
-    from aragora.knowledge.mound.adapters.control_plane_adapter import TaskOutcome
+    from aragora.knowledge.mound.adapters.control_plane_adapter import TaskOutcome  # type: ignore[no-redef]
 
     HAS_KM_ADAPTER = True
 except ImportError:
@@ -76,7 +76,7 @@ except ImportError:
 AgentFactory: Any = None
 get_agent_factory: Any = None
 try:
-    from aragora.control_plane.agent_factory import (
+    from aragora.control_plane.agent_factory import (  # type: ignore[no-redef]
         AgentFactory,
         get_agent_factory,
     )
@@ -89,7 +89,7 @@ except ImportError:
 RedisHASettings: Any = None
 get_redis_ha_config: Any = None
 try:
-    from aragora.config.redis import RedisHASettings, get_redis_ha_config
+    from aragora.config.redis import RedisHASettings, get_redis_ha_config  # type: ignore[no-redef]
 
     HAS_REDIS_HA = True
 except ImportError:
@@ -580,7 +580,7 @@ class StateManager:
         # Get KM recommendations
         try:
             cap_strings = [str(c) for c in capabilities]
-            recommendations = await self._km_adapter.get_agent_recommendations_for_task(
+            recommendations = await self._km_adapter.get_agent_recommendations_for_task(  # type: ignore[union-attr]
                 task_type=task_type,
                 available_agents=agent_ids,
                 required_capabilities=cap_strings,

--- a/aragora/control_plane/coordinator/state_manager.py
+++ b/aragora/control_plane/coordinator/state_manager.py
@@ -60,7 +60,7 @@ WatchdogTier: Any = None
 WatchdogIssue: Any = None
 get_watchdog: Any = None
 try:
-    from aragora.control_plane.watchdog import (
+    from aragora.control_plane.watchdog import ( # type: ignore[no-redef]
         ThreeTierWatchdog,
         WatchdogConfig,
         WatchdogTier,


### PR DESCRIPTION
Move logger initialization earlier so optional import guards can log
when dependencies are unavailable instead of silently passing.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit d8d99f54f011683fed512422a5c923708c708566)
