### PR TITLE
fix(control-plane): replace silent exception pass with debug logging in scheduler_bridge.py (#5441)

### DIFF
--- a/aragora/control_plane/coordinator/scheduler_bridge.py
+++ b/aragora/control_plane/coordinator/scheduler_bridge.py
@@ -47,7 +47,7 @@ except ImportError:
 HAS_POLICY = False
 EnforcementLevelType: Any = None
 try:
-    from aragora.control_plane.policy import EnforcementLevel as EnforcementLevelType
+    from aragora.control_plane.policy import EnforcementLevel as EnforcementLevelType # type: ignore[no-redef]
 
     HAS_POLICY = True
 except ImportError:

--- a/aragora/control_plane/coordinator/scheduler_bridge.py
+++ b/aragora/control_plane/coordinator/scheduler_bridge.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     from aragora.control_plane.coordinator.policy_enforcer import PolicyEnforcer
     from aragora.control_plane.policy import ControlPlanePolicyManager
 
+logger = get_logger(__name__)
+
 # Optional KM integration
 HAS_KM_ADAPTER = False
 try:
@@ -49,9 +51,9 @@ try:
 
     HAS_POLICY = True
 except ImportError:
-    pass
+    # EnforcementLevel unavailable; SLA compliance checks will be skipped
+    logger.debug("control_plane.policy not available; SLA enforcement disabled")
 
-logger = get_logger(__name__)
 
 # Retry configuration for control plane operations
 _CP_RETRY_CONFIG = PROVIDER_RETRY_POLICIES["control_plane"]


### PR DESCRIPTION
Replace bare `except ImportError: pass` with a debug log message when
the optional EnforcementLevel import fails, providing visibility into
why SLA enforcement is disabled. Moved logger initialization before
optional import blocks to support this.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 86f15dc9fb0e8c05ba1200ba87673dc905393c81)
