### PR TITLE
fix(control-plane): replace silent exception swallowing with logging in coordinator core.py (#5423)

### DIFF
--- a/aragora/control_plane/coordinator/core.py
+++ b/aragora/control_plane/coordinator/core.py
@@ -80,7 +80,7 @@ try:
 
     HAS_WATCHDOG = True
 except ImportError:
-    pass
+    pass  # Optional dependency: watchdog features disabled when module unavailable
 
 logger = get_logger(__name__)
 
@@ -197,7 +197,7 @@ class ControlPlaneCoordinator:
                 )
                 self._state_manager.set_km_adapter(adapter)
             except ImportError:
-                pass
+                logger.debug("ControlPlaneAdapter not available; skipping KM adapter setup")
 
         # Initialize scheduler bridge (with backward compatibility for scheduler param)
         self._scheduler_bridge = scheduler_bridge or SchedulerBridge(

--- a/aragora/control_plane/coordinator/core.py
+++ b/aragora/control_plane/coordinator/core.py
@@ -60,7 +60,7 @@ DeliberationOutcome: Any = None
 DELIBERATION_TASK_TYPE = "deliberation"
 try:
     from aragora.control_plane.arena_bridge import ArenaControlPlaneBridge
-    from aragora.control_plane.deliberation import (
+    from aragora.control_plane.deliberation import ( # type: ignore[no-redef]
         DELIBERATION_TASK_TYPE as _DELIBERATION_TASK_TYPE,
         DeliberationOutcome,
         DeliberationTask,

--- a/aragora/control_plane/coordinator/core.py
+++ b/aragora/control_plane/coordinator/core.py
@@ -59,7 +59,7 @@ DeliberationTask: Any = None
 DeliberationOutcome: Any = None
 DELIBERATION_TASK_TYPE = "deliberation"
 try:
-    from aragora.control_plane.arena_bridge import ArenaControlPlaneBridge
+    from aragora.control_plane.arena_bridge import ArenaControlPlaneBridge  # type: ignore[no-redef]
     from aragora.control_plane.deliberation import ( # type: ignore[no-redef]
         DELIBERATION_TASK_TYPE as _DELIBERATION_TASK_TYPE,
         DeliberationOutcome,

--- a/aragora/control_plane/coordinator/core.py
+++ b/aragora/control_plane/coordinator/core.py
@@ -76,7 +76,7 @@ except ImportError:
 HAS_WATCHDOG = False
 IssueSeverityType: Any = None
 try:
-    from aragora.control_plane.watchdog import IssueSeverity as IssueSeverityType
+    from aragora.control_plane.watchdog import IssueSeverity as IssueSeverityType  # type: ignore[no-redef]
 
     HAS_WATCHDOG = True
 except ImportError:


### PR DESCRIPTION
Replace bare `except ImportError: pass` in KM adapter setup with debug
logging so failures are visible during troubleshooting. The module-level
watchdog import retains `pass` with a justification comment since the
logger is not yet initialized at that point.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 586dea3684e73eaf4246657d81ec0293e13af43e)
