### PR TITLE
fix(connectors): replace silent CancelledError pass with debug log in sqlserver.py (#5421)

### DIFF
--- a/aragora/connectors/enterprise/database/sqlserver.py
+++ b/aragora/connectors/enterprise/database/sqlserver.py
@@ -717,7 +717,7 @@ class SQLServerConnector(EnterpriseConnector):
             try:
                 await self._cdc_task
             except asyncio.CancelledError:
-                pass
+                logger.debug("[SQL Server CDC/CT] Polling task cancelled during shutdown")
             self._cdc_task = None
 
         logger.info("[SQL Server CDC/CT] Stopped polling for %s", self.database)


### PR DESCRIPTION
Replace bare `except CancelledError: pass` in stop_cdc_polling() with
a debug log message for better observability during shutdown.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 229d997ba142e9bbcc2d56d1e258cec179108837)
