### PR TITLE
fix(connectors): replace silent CancelledError pass with debug log in mysql.py

### DIFF
--- a/aragora/connectors/enterprise/database/mysql.py
+++ b/aragora/connectors/enterprise/database/mysql.py
@@ -550,7 +550,7 @@ class MySQLConnector(EnterpriseConnector):
             try:
                 await self._cdc_task
             except asyncio.CancelledError:
-                pass
+                logger.debug("[MySQL CDC] Binlog CDC task cancelled")
 
         if self._binlog_stream:
             self._binlog_stream.close()


### PR DESCRIPTION
Replace bare `except CancelledError: pass` in stop_binlog_cdc with a
debug log message for visibility into CDC task cancellation.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 75619f51ebe954d56704ff4d1d01ef6f2b9555d1)
