### PR TITLE
fix(gmail): replace silent CancelledError pass with debug log in watch.py (#5418)

### DIFF
--- a/aragora/connectors/enterprise/communication/gmail/watch.py
+++ b/aragora/connectors/enterprise/communication/gmail/watch.py
@@ -265,7 +265,7 @@ class GmailWatchMixin(GmailBaseMethods):
                     if inspect.isawaitable(self._watch_task):
                         await self._watch_task
                 except asyncio.CancelledError:
-                    pass
+                    logger.debug("[Gmail] Watch renewal task cancelled during stop_watch")
                 self._watch_task = None
 
         try:


### PR DESCRIPTION
Replace the bare `except CancelledError: pass` in stop_watch() with a
debug log message to add visibility into task cancellation events.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit fb5eddee9a295d4d79c6100f8c0806090177fe87)
