### PR TITLE
fix(connectors): replace silent CancelledError pass with debug log in outlook_sync.py (#5417)

### DIFF
--- a/aragora/connectors/email/outlook_sync.py
+++ b/aragora/connectors/email/outlook_sync.py
@@ -394,7 +394,7 @@ class OutlookSyncService:
             try:
                 await self._renewal_task
             except asyncio.CancelledError:
-                pass
+                logger.debug("[OutlookSync] Renewal task cancelled during stop")
 
         # Delete subscription
         if self._state and self._state.subscription_id:


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 249e404a9a5bd7576054157647988449b060cf6c)
