### PR TITLE
fix(control-plane): reconcile coordinator type imports

### DIFF
--- a/aragora/control_plane/coordinator/core.py
+++ b/aragora/control_plane/coordinator/core.py
@@ -45,42 +45,58 @@ from aragora.control_plane.coordinator.scheduler_bridge import SchedulerBridge
 if TYPE_CHECKING:
     import asyncio
 
+    from aragora.control_plane.arena_bridge import ArenaControlPlaneBridge
+    from aragora.control_plane.deliberation import (
+        DeliberationOutcome,
+        DeliberationTask,
+    )
     from aragora.control_plane.policy import ControlPlanePolicyManager
     from aragora.control_plane.registry import AgentRegistry
     from aragora.control_plane.scheduler import TaskScheduler
     from aragora.control_plane.health import HealthMonitor
     from aragora.knowledge.mound.adapters.control_plane_adapter import ControlPlaneAdapter
+    from aragora.control_plane.watchdog import IssueSeverity as IssueSeverityType
     from aragora.control_plane.watchdog import ThreeTierWatchdog, WatchdogIssue
     from aragora.control_plane.agent_factory import AgentFactory
+else:
+    ArenaControlPlaneBridge = Any
+    DeliberationTask = Any
+    DeliberationOutcome = Any
+    IssueSeverityType = Any
 
 # Optional Arena Bridge
-ArenaControlPlaneBridge: Any = None
-DeliberationTask: Any = None
-DeliberationOutcome: Any = None
 DELIBERATION_TASK_TYPE = "deliberation"
-try:
-    from aragora.control_plane.arena_bridge import ArenaControlPlaneBridge
-    from aragora.control_plane.deliberation import (
-        DELIBERATION_TASK_TYPE as _DELIBERATION_TASK_TYPE,
-        DeliberationOutcome,
-        DeliberationTask,
-    )
+HAS_ARENA_BRIDGE = False
+if not TYPE_CHECKING:
+    try:
+        from aragora.control_plane.arena_bridge import (
+            ArenaControlPlaneBridge as _ArenaControlPlaneBridge,
+        )
+        from aragora.control_plane.deliberation import (
+            DELIBERATION_TASK_TYPE as _DELIBERATION_TASK_TYPE,
+            DeliberationOutcome as _DeliberationOutcome,
+            DeliberationTask as _DeliberationTask,
+        )
 
-    DELIBERATION_TASK_TYPE = _DELIBERATION_TASK_TYPE  # Use real value if available
+        ArenaControlPlaneBridge = _ArenaControlPlaneBridge
+        DeliberationOutcome = _DeliberationOutcome
+        DeliberationTask = _DeliberationTask
+        DELIBERATION_TASK_TYPE = _DELIBERATION_TASK_TYPE  # Use real value if available
 
-    HAS_ARENA_BRIDGE = True
-except ImportError:
-    HAS_ARENA_BRIDGE = False
+        HAS_ARENA_BRIDGE = True
+    except ImportError:
+        pass
 
 # Optional Watchdog
 HAS_WATCHDOG = False
-IssueSeverityType: Any = None
-try:
-    from aragora.control_plane.watchdog import IssueSeverity as IssueSeverityType
+if not TYPE_CHECKING:
+    try:
+        from aragora.control_plane.watchdog import IssueSeverity as _IssueSeverityType
 
-    HAS_WATCHDOG = True
-except ImportError:
-    pass
+        IssueSeverityType = _IssueSeverityType
+        HAS_WATCHDOG = True
+    except ImportError:
+        pass
 
 logger = get_logger(__name__)
 

--- a/aragora/control_plane/coordinator/scheduler_bridge.py
+++ b/aragora/control_plane/coordinator/scheduler_bridge.py
@@ -30,7 +30,10 @@ from aragora.resilience.retry import (
 if TYPE_CHECKING:
     from aragora.control_plane.coordinator.state_manager import StateManager, ControlPlaneConfig
     from aragora.control_plane.coordinator.policy_enforcer import PolicyEnforcer
+    from aragora.control_plane.policy import EnforcementLevel as EnforcementLevelType
     from aragora.control_plane.policy import ControlPlanePolicyManager
+else:
+    EnforcementLevelType = Any
 
 # Optional KM integration
 HAS_KM_ADAPTER = False
@@ -43,13 +46,14 @@ except ImportError:
 
 # Optional Policy
 HAS_POLICY = False
-EnforcementLevelType: Any = None
-try:
-    from aragora.control_plane.policy import EnforcementLevel as EnforcementLevelType
+if not TYPE_CHECKING:
+    try:
+        from aragora.control_plane.policy import EnforcementLevel as _EnforcementLevelType
 
-    HAS_POLICY = True
-except ImportError:
-    pass
+        EnforcementLevelType = _EnforcementLevelType
+        HAS_POLICY = True
+    except ImportError:
+        pass
 
 logger = get_logger(__name__)
 

--- a/aragora/control_plane/coordinator/state_manager.py
+++ b/aragora/control_plane/coordinator/state_manager.py
@@ -38,60 +38,96 @@ from aragora.resilience.retry import (
 if TYPE_CHECKING:
     from aragora.knowledge.mound.adapters.control_plane_adapter import (
         ControlPlaneAdapter,
+        TaskOutcome,
     )
-
-# Optional KM integration
-HAS_KM_ADAPTER = False
-# Pre-declare optional import with Any to avoid no-redef errors
-TaskOutcome: Any = None
-try:
-    from aragora.knowledge.mound.adapters.control_plane_adapter import TaskOutcome
-
-    HAS_KM_ADAPTER = True
-except ImportError:
-    pass
-
-# Optional Watchdog support (Gastown three-tier monitoring)
-ThreeTierWatchdog: Any = None
-WatchdogConfig: Any = None
-WatchdogTier: Any = None
-WatchdogIssue: Any = None
-get_watchdog: Any = None
-try:
     from aragora.control_plane.watchdog import (
         ThreeTierWatchdog,
         WatchdogConfig,
-        WatchdogTier,
         WatchdogIssue,
+        WatchdogTier,
         get_watchdog,
     )
-
-    HAS_WATCHDOG = True
-except ImportError:
-    HAS_WATCHDOG = False
-
-# Optional AgentFactory for auto-creating agents from registry
-AgentFactory: Any = None
-get_agent_factory: Any = None
-try:
     from aragora.control_plane.agent_factory import (
         AgentFactory,
         get_agent_factory,
     )
+    from aragora.config.redis import RedisHASettings, get_redis_ha_config
+else:
+    ControlPlaneAdapter = Any
+    TaskOutcome = Any
+    ThreeTierWatchdog = Any
+    WatchdogConfig = Any
+    WatchdogTier = Any
+    WatchdogIssue = Any
+    get_watchdog = lambda: None
+    AgentFactory = Any
+    get_agent_factory = lambda: None
+    RedisHASettings = Any
+    get_redis_ha_config = lambda: None
 
-    HAS_AGENT_FACTORY = True
-except ImportError:
-    HAS_AGENT_FACTORY = False
+# Optional KM integration
+HAS_KM_ADAPTER = False
+if not TYPE_CHECKING:
+    try:
+        from aragora.knowledge.mound.adapters.control_plane_adapter import (
+            TaskOutcome as _TaskOutcome,
+        )
+
+        TaskOutcome = _TaskOutcome
+        HAS_KM_ADAPTER = True
+    except ImportError:
+        pass
+
+# Optional Watchdog support (Gastown three-tier monitoring)
+HAS_WATCHDOG = False
+if not TYPE_CHECKING:
+    try:
+        from aragora.control_plane.watchdog import (
+            ThreeTierWatchdog as _ThreeTierWatchdog,
+            WatchdogConfig as _WatchdogConfig,
+            WatchdogTier as _WatchdogTier,
+            WatchdogIssue as _WatchdogIssue,
+            get_watchdog as _get_watchdog,
+        )
+
+        ThreeTierWatchdog = _ThreeTierWatchdog
+        WatchdogConfig = _WatchdogConfig
+        WatchdogTier = _WatchdogTier
+        WatchdogIssue = _WatchdogIssue
+        get_watchdog = _get_watchdog
+        HAS_WATCHDOG = True
+    except ImportError:
+        pass
+
+# Optional AgentFactory for auto-creating agents from registry
+HAS_AGENT_FACTORY = False
+if not TYPE_CHECKING:
+    try:
+        from aragora.control_plane.agent_factory import (
+            AgentFactory as _AgentFactory,
+            get_agent_factory as _get_agent_factory,
+        )
+
+        AgentFactory = _AgentFactory
+        get_agent_factory = _get_agent_factory
+        HAS_AGENT_FACTORY = True
+    except ImportError:
+        pass
 
 # Optional Redis HA support
-RedisHASettings: Any = None
-get_redis_ha_config: Any = None
-try:
-    from aragora.config.redis import RedisHASettings, get_redis_ha_config
+HAS_REDIS_HA = False
+if not TYPE_CHECKING:
+    try:
+        from aragora.config.redis import (
+            RedisHASettings as _RedisHASettings,
+            get_redis_ha_config as _get_redis_ha_config,
+        )
 
-    HAS_REDIS_HA = True
-except ImportError:
-    HAS_REDIS_HA = False
+        RedisHASettings = _RedisHASettings
+        get_redis_ha_config = _get_redis_ha_config
+        HAS_REDIS_HA = True
+    except ImportError:
+        pass
 
 logger = get_logger(__name__)
 
@@ -576,11 +612,18 @@ class StateManager:
         # Deduplicate
         agent_map = {a.agent_id: a for a in available_agents}
         agent_ids = list(agent_map.keys())
+        km_adapter = self._km_adapter
+        if km_adapter is None:
+            return await self._registry.select_agent(
+                capabilities=capabilities,
+                strategy="least_loaded",
+                exclude=exclude,
+            )
 
         # Get KM recommendations
         try:
             cap_strings = [str(c) for c in capabilities]
-            recommendations = await self._km_adapter.get_agent_recommendations_for_task(
+            recommendations = await km_adapter.get_agent_recommendations_for_task(
                 task_type=task_type,
                 available_agents=agent_ids,
                 required_capabilities=cap_strings,


### PR DESCRIPTION
## Summary
- reconcile the unpublished coordinator typecheck and mypy fixes into one bounded branch
- move optional control-plane imports behind TYPE_CHECKING with runtime alias assignment
- fall back to registry selection when KM is unavailable instead of dereferencing a null adapter

## Validation
- ruff check aragora/control_plane/coordinator/core.py aragora/control_plane/coordinator/scheduler_bridge.py aragora/control_plane/coordinator/state_manager.py
- python3 -m mypy --follow-imports=skip --ignore-missing-imports aragora/control_plane/coordinator/core.py aragora/control_plane/coordinator/scheduler_bridge.py aragora/control_plane/coordinator/state_manager.py
- python3 -m pytest tests/control_plane -q -k 'coordinator or state_manager or scheduler_bridge'
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
Harvested from unpublished branches codex/codex-20260414-091659-6b89e62b and codex/codex-20260414-111809-b27e21c5.
