### PR TITLE
feat(swarm): require receipt-backed dispatch admission

### DIFF
--- a/aragora/swarm/dispatch_contract_gate.py
+++ b/aragora/swarm/dispatch_contract_gate.py
@@ -9,6 +9,12 @@ from typing import Any, Mapping
 from aragora.swarm.boss_feed import GitHubIssue
 from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.preflight import (
+    PreflightReceipt,
+    run_remote_publish_validation_receipt,
+    run_scratch_validation_receipt,
+)
+from aragora.swarm.terminal_truth import TerminalClass, classify_preflight_failure
 from aragora.swarm.worker_contract import build_worker_contract
 from aragora.swarm.worker_process import LaunchConfig
 
@@ -203,6 +209,123 @@ def _gate_reason(
     return reasons, list(dict.fromkeys(next_actions))
 
 
+def _required_preflight_receipts(loop: Any) -> list[str]:
+    required = ["scratch"]
+    if bool(loop.config.auto_publish_deliverables):
+        required.append("remote_publish")
+    return required
+
+
+def _preflight_receipt_summary(receipt: PreflightReceipt) -> dict[str, Any]:
+    terminal_class = receipt.failure_terminal_class
+    return {
+        "check_type": receipt.check_type,
+        "receipt_id": receipt.receipt_id,
+        "passed": receipt.passed,
+        "expires_at": receipt.expires_at,
+        "failure_terminal_class": terminal_class.value if terminal_class else None,
+        "failed_checks": [
+            {
+                "name": str(item.get("name", "")).strip(),
+                "detail": str(item.get("detail", "")).strip(),
+            }
+            for item in receipt.checks
+            if isinstance(item, dict) and not bool(item.get("passed", False))
+        ],
+    }
+
+
+def _synthetic_preflight_summary(check_type: str, detail: str) -> dict[str, Any]:
+    terminal_class = classify_preflight_failure(
+        passed=False,
+        checks=[{"name": "preflight_receipt", "passed": False, "detail": detail}],
+        dispatch_gate=None,
+    )
+    return {
+        "check_type": check_type,
+        "receipt_id": "",
+        "passed": False,
+        "expires_at": "",
+        "failure_terminal_class": (
+            terminal_class.value
+            if terminal_class
+            else TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED.value
+        ),
+        "failed_checks": [{"name": "preflight_receipt", "detail": detail}],
+    }
+
+
+def _preflight_failure_outcome(summary: Mapping[str, Any]) -> str:
+    terminal_class = str(summary.get("failure_terminal_class", "") or "").strip()
+    if terminal_class == TerminalClass.BLOCKED_AUTH_FAILURE.value:
+        return "blocked_auth_failure"
+    if terminal_class == TerminalClass.BLOCKED_NO_RUNNER.value:
+        return "blocked_no_runner"
+    return "blocked"
+
+
+def _preflight_failure_reason(issue_number: int, summary: Mapping[str, Any]) -> str:
+    check_type = str(summary.get("check_type", "") or "").strip() or "scratch"
+    terminal_class = str(summary.get("failure_terminal_class", "") or "").strip() or "blocked"
+    failed_checks = [
+        item for item in list(summary.get("failed_checks", []) or []) if isinstance(item, Mapping)
+    ]
+    detail = "; ".join(
+        f"{str(item.get('name', '') or 'check').strip()}: "
+        f"{str(item.get('detail', '') or 'failed').strip()}"
+        for item in failed_checks[:2]
+    ).strip("; ")
+    if detail:
+        return (
+            f"Issue #{issue_number} failed `{check_type}` preflight receipt admission "
+            f"({terminal_class}): {detail}"
+        )
+    return f"Issue #{issue_number} failed `{check_type}` preflight receipt admission ({terminal_class})."
+
+
+def _preflight_next_action(summary: Mapping[str, Any]) -> str:
+    check_type = str(summary.get("check_type", "") or "").strip() or "scratch"
+    terminal_class = str(summary.get("failure_terminal_class", "") or "").strip()
+    if terminal_class == TerminalClass.BLOCKED_AUTH_FAILURE.value:
+        if check_type == "remote_publish":
+            return (
+                "Restore git/GitHub publish authentication and refresh the remote publish "
+                "preflight receipt before redispatch."
+            )
+        return "Restore the required runner/git credentials and refresh the scratch preflight receipt before redispatch."
+    if terminal_class == TerminalClass.BLOCKED_NO_RUNNER.value:
+        return "Ensure the selected runner CLI is installed and discoverable, then refresh the preflight receipt before redispatch."
+    if check_type == "remote_publish":
+        return "Fix the branch push or draft-PR path and refresh the remote publish preflight receipt before redispatch."
+    return "Fix the repo write/commit path and refresh the scratch preflight receipt before redispatch."
+
+
+def _run_dispatch_preflight_receipts(
+    loop: Any,
+    *,
+    repo_root: Path,
+    envelope: CredentialEnvelope,
+    preview_env: Mapping[str, str],
+) -> list[PreflightReceipt]:
+    receipts = [
+        run_scratch_validation_receipt(
+            repo_root=repo_root,
+            envelope=envelope,
+            env=preview_env,
+        )
+    ]
+    if bool(loop.config.auto_publish_deliverables):
+        receipts.append(
+            run_remote_publish_validation_receipt(
+                repo_root=repo_root,
+                envelope=envelope,
+                base_ref=str(loop.config.target_branch or "main"),
+                env=preview_env,
+            )
+        )
+    return receipts
+
+
 def dispatch_contract_gate(
     loop: Any,
     issue: GitHubIssue,
@@ -220,6 +343,8 @@ def dispatch_contract_gate(
     )
     envelope = CredentialEnvelope.from_environment(preview_env)
     missing_slices = _missing_slices(loop, envelope=envelope, target_agent=target_agent)
+    required_receipts: list[str] = []
+    preflight_receipts: list[dict[str, Any]] = []
     launch_config = LaunchConfig(
         base_branch=loop.config.target_branch,
         execution_mode=loop.config.execution_mode,
@@ -252,7 +377,23 @@ def dispatch_contract_gate(
             break
 
     if contract_valid and not missing_slices:
-        return None
+        required_receipts = _required_preflight_receipts(loop)
+        try:
+            receipt_payloads = _run_dispatch_preflight_receipts(
+                loop,
+                repo_root=Path.cwd(),
+                envelope=envelope,
+                preview_env=preview_env,
+            )
+        except Exception as exc:  # noqa: BLE001 - fail closed on receipt routing issues
+            detail = str(exc or "").strip() or "preflight receipt generation failed"
+            preflight_receipts = [_synthetic_preflight_summary(required_receipts[0], detail)]
+        else:
+            preflight_receipts = [
+                _preflight_receipt_summary(receipt) for receipt in receipt_payloads
+            ]
+            if all(bool(item.get("passed", False)) for item in preflight_receipts):
+                return None
 
     reasons, next_actions = _gate_reason(
         issue_number=issue.number,
@@ -260,17 +401,30 @@ def dispatch_contract_gate(
         missing_slices=missing_slices,
         contract_valid=contract_valid,
     )
+    failed_receipts = [
+        summary for summary in preflight_receipts if not bool(summary.get("passed", False))
+    ]
+    if failed_receipts:
+        reasons.extend(
+            _preflight_failure_reason(issue.number, summary) for summary in failed_receipts
+        )
+        next_actions.extend(_preflight_next_action(summary) for summary in failed_receipts)
+    outcome = "blocked_auth_failure" if missing_slices else "blocked"
+    if failed_receipts:
+        outcome = _preflight_failure_outcome(failed_receipts[0])
     if claimed_runner_id:
         loop._release_runner_claim(claimed_runner_id)
     return {
         "status": "needs_human",
-        "outcome": "blocked_auth_failure" if missing_slices else "blocked",
+        "outcome": outcome,
         "reasons": reasons,
-        "next_actions": next_actions,
+        "next_actions": list(dict.fromkeys(next_actions)),
         "dispatch_contract": {
             "target_agent": target_agent,
             "contract_valid": contract_valid,
             "missing_slices": missing_slices,
             "credential_envelope": envelope.preflight_cache_payload(),
+            "required_receipts": required_receipts,
+            "preflight_receipts": preflight_receipts,
         },
     }

--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -13,7 +13,7 @@ import sys
 import time
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.env_utils import git_safe_env
@@ -439,6 +439,7 @@ def _find_open_pr_by_branch(
     cwd: Path,
     branch: str,
     base_ref: str,
+    env: Mapping[str, str] | None = None,
 ) -> tuple[int | None, str]:
     result = subprocess.run(
         [
@@ -453,6 +454,7 @@ def _find_open_pr_by_branch(
             "number,url,isDraft,baseRefName",
         ],
         cwd=str(cwd),
+        env=dict(env) if env is not None else None,
         capture_output=True,
         text=True,
         timeout=60,
@@ -652,9 +654,11 @@ def run_scratch_validation_receipt(
     repo_root: Path,
     envelope: CredentialEnvelope,
     force_refresh: bool = False,
+    env: Mapping[str, str] | None = None,
 ) -> PreflightReceipt:
     resolved_repo_root = repo_root.resolve()
     normalized_base_ref = "main"
+    git_env = git_safe_env(env)
     if not force_refresh:
         cached = _load_cached_preflight_receipt(resolved_repo_root, envelope, "scratch")
         if cached is not None:
@@ -689,7 +693,7 @@ def run_scratch_validation_receipt(
                 normalized_base_ref,
             ],
             cwd=resolved_repo_root,
-            env=git_safe_env(),
+            env=git_env,
         )
         if worktree_result is not None and worktree_result.returncode == 0:
             worktree_created = True
@@ -706,7 +710,7 @@ def run_scratch_validation_receipt(
                 name="git_add",
                 cmd=["git", "add", str(scratch_file.relative_to(worktree_path))],
                 cwd=worktree_path,
-                env=git_safe_env(),
+                env=git_env,
             )
             if add_result is not None and add_result.returncode == 0:
                 _run_check(
@@ -714,7 +718,7 @@ def run_scratch_validation_receipt(
                     name="git_commit",
                     cmd=["git", "commit", "-m", "chore: preflight scratch validation"],
                     cwd=worktree_path,
-                    env=git_safe_env(),
+                    env=git_env,
                 )
     finally:
         if worktree_created:
@@ -723,12 +727,14 @@ def run_scratch_validation_receipt(
                 name="cleanup_worktree_remove",
                 cmd=["git", "worktree", "remove", "--force", str(worktree_path)],
                 cwd=resolved_repo_root,
+                env=git_env,
             )
             _run_check(
                 checks,
                 name="cleanup_branch_delete",
                 cmd=["git", "branch", "-D", branch],
                 cwd=resolved_repo_root,
+                env=git_env,
             )
 
     finished_at = _utc_now()
@@ -752,9 +758,12 @@ def run_remote_publish_validation_receipt(
     envelope: CredentialEnvelope,
     base_ref: str = "main",
     force_refresh: bool = False,
+    env: Mapping[str, str] | None = None,
 ) -> PreflightReceipt:
     resolved_repo_root = repo_root.resolve()
     normalized_base_ref = str(base_ref or "main").strip() or "main"
+    git_env = git_safe_env(env)
+    command_env = dict(env) if env is not None else None
     if not force_refresh:
         cached = _load_cached_preflight_receipt(
             resolved_repo_root,
@@ -790,7 +799,7 @@ def run_remote_publish_validation_receipt(
             name="git_worktree_add",
             cmd=["git", "worktree", "add", "-b", branch, str(worktree_path), "HEAD"],
             cwd=resolved_repo_root,
-            env=git_safe_env(),
+            env=git_env,
         )
         if worktree_result is not None and worktree_result.returncode == 0:
             worktree_created = True
@@ -807,7 +816,7 @@ def run_remote_publish_validation_receipt(
                 name="git_add",
                 cmd=["git", "add", str(scratch_file.relative_to(worktree_path))],
                 cwd=worktree_path,
-                env=git_safe_env(),
+                env=git_env,
             )
             if add_result is not None and add_result.returncode == 0:
                 commit_result = _run_check(
@@ -815,7 +824,7 @@ def run_remote_publish_validation_receipt(
                     name="git_commit",
                     cmd=["git", "commit", "-m", "chore: preflight remote publish validation"],
                     cwd=worktree_path,
-                    env=git_safe_env(),
+                    env=git_env,
                 )
                 if commit_result is not None and commit_result.returncode == 0:
                     push_result = _run_check(
@@ -823,7 +832,7 @@ def run_remote_publish_validation_receipt(
                         name="git_push",
                         cmd=["git", "push", "origin", "HEAD"],
                         cwd=worktree_path,
-                        env=git_safe_env(),
+                        env=git_env,
                     )
                     pushed = push_result is not None and push_result.returncode == 0
                     if pushed:
@@ -845,6 +854,7 @@ def run_remote_publish_validation_receipt(
                                 "--draft",
                             ],
                             cwd=worktree_path,
+                            env=command_env,
                         )
                         if pr_result is not None and pr_result.returncode == 0:
                             pr_number, pr_url = _parse_pr_create_output(
@@ -856,6 +866,7 @@ def run_remote_publish_validation_receipt(
                                     cwd=worktree_path if worktree_created else resolved_repo_root,
                                     branch=branch,
                                     base_ref=normalized_base_ref,
+                                    env=command_env,
                                 )
                             if pr_number is None or not pr_url:
                                 _append_check(
@@ -883,6 +894,7 @@ def run_remote_publish_validation_receipt(
                 cwd=worktree_path if worktree_created else resolved_repo_root,
                 branch=branch,
                 base_ref=normalized_base_ref,
+                env=command_env,
             )
             if pr_number is not None and pr_url:
                 draft_created = True
@@ -911,6 +923,7 @@ def run_remote_publish_validation_receipt(
                     "Preflight complete - closing.",
                 ],
                 cwd=worktree_path if worktree_created else resolved_repo_root,
+                env=command_env,
             )
             draft_close_succeeded = close_result is not None and close_result.returncode == 0
         elif pushed and unresolved_remote_pr_state:
@@ -941,7 +954,7 @@ def run_remote_publish_validation_receipt(
                 name="cleanup_remote_branch_delete",
                 cmd=["git", "push", "origin", "--delete", branch],
                 cwd=worktree_path if worktree_created else resolved_repo_root,
-                env=git_safe_env(),
+                env=git_env,
             )
         elif pushed and draft_created and not draft_close_succeeded:
             _append_check(
@@ -971,12 +984,14 @@ def run_remote_publish_validation_receipt(
                 name="cleanup_worktree_remove",
                 cmd=["git", "worktree", "remove", "--force", str(worktree_path)],
                 cwd=resolved_repo_root,
+                env=git_env,
             )
             _run_check(
                 checks,
                 name="cleanup_branch_delete",
                 cmd=["git", "branch", "-D", branch],
                 cwd=resolved_repo_root,
+                env=git_env,
             )
 
     finished_at = _utc_now()

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -25,6 +25,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 
+from aragora.swarm import preflight as preflight_mod
 from aragora.swarm.boss_loop import (
     _should_replace_with_focused_tests,
     build_issue_eligibility_report,
@@ -108,6 +109,35 @@ def _boss_config(**overrides: Any) -> BossLoopConfig:
     }
     defaults.update(overrides)
     return BossLoopConfig(**defaults)
+
+
+def _preflight_receipt(
+    *,
+    check_type: str = "scratch",
+    passed: bool = True,
+    checks: list[dict[str, Any]] | None = None,
+) -> preflight_mod.PreflightReceipt:
+    return preflight_mod.PreflightReceipt(
+        receipt_id=f"preflight-{check_type}-20260414T001900Z-test",
+        envelope_seal="seal",
+        repo_root="/tmp/repo",
+        check_type=check_type,
+        started_at="2026-04-14T00:19:00Z",
+        finished_at="2026-04-14T00:19:05Z",
+        passed=passed,
+        checks=checks
+        or [
+            {
+                "name": "receipt_check",
+                "passed": passed,
+                "detail": "ok" if passed else "failed",
+            }
+        ],
+        cache_key=f"{check_type}-cache",
+        ttl_seconds=3600,
+        expires_at="2026-04-14T01:19:05Z",
+        artifacts={"target_ref": "main"},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -3376,6 +3406,10 @@ async def test_dispatch_issue_contract_gate_allows_complete_cli_dispatch() -> No
             ),
         ),
         patch(
+            "aragora.swarm.dispatch_contract_gate.run_scratch_validation_receipt",
+            return_value=_preflight_receipt(),
+        ) as scratch_receipt,
+        patch(
             "aragora.swarm.boss_loop.dispatch_bounded_spec",
             new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
         ) as dispatch_mock,
@@ -3383,6 +3417,7 @@ async def test_dispatch_issue_contract_gate_allows_complete_cli_dispatch() -> No
         result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
 
     assert result["status"] == "completed"
+    scratch_receipt.assert_called_once()
     dispatch_mock.assert_awaited_once()
 
 
@@ -3436,6 +3471,65 @@ async def test_dispatch_issue_contract_gate_blocks_missing_publish_auth_slices()
 
 
 @pytest.mark.asyncio
+async def test_dispatch_issue_contract_gate_blocks_failed_scratch_preflight_receipt() -> None:
+    issue = _make_issue(2467, "Dispatch requires receipt-backed admission")
+    loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="codex"))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+    failed_receipt = _preflight_receipt(
+        passed=False,
+        checks=[
+            {
+                "name": "git_commit",
+                "passed": False,
+                "detail": "worktree has uncommitted changes",
+            }
+        ],
+    )
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch(
+            "aragora.swarm.dispatch_contract_gate._preview_env",
+            return_value=(
+                "codex",
+                {
+                    "ARAGORA_RUNNER_AUTH_MODE": "command",
+                    "CODEX_COMMAND": "/usr/local/bin/codex",
+                    "PYTEST_PATH": "/usr/local/bin/pytest",
+                    "RUFF_PATH": "/usr/local/bin/ruff",
+                },
+            ),
+        ),
+        patch(
+            "aragora.swarm.dispatch_contract_gate.run_scratch_validation_receipt",
+            return_value=failed_receipt,
+        ) as scratch_receipt,
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
+        ) as dispatch_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "blocked"
+    assert "failed `scratch` preflight receipt admission" in result["reasons"][0]
+    assert result["dispatch_contract"]["required_receipts"] == ["scratch"]
+    assert result["dispatch_contract"]["preflight_receipts"][0]["failure_terminal_class"] == (
+        "blocked_not_dispatch_bounded"
+    )
+    scratch_receipt.assert_called_once()
+    dispatch_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_issue_contract_gate_blocks_missing_provider_for_api_agent() -> None:
     issue = _make_issue(2466, "Dispatch requires provider auth")
     loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="openai-api"))
@@ -3473,6 +3567,79 @@ async def test_dispatch_issue_contract_gate_blocks_missing_provider_for_api_agen
     assert result["outcome"] == "blocked_auth_failure"
     assert result["dispatch_contract"]["missing_slices"] == ["provider"]
     assert "missing provider credentials" in result["reasons"][0]
+    dispatch_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_contract_gate_blocks_failed_remote_publish_receipt() -> None:
+    issue = _make_issue(2468, "Dispatch requires publish receipt")
+    loop = BossLoop(
+        config=_boss_config(
+            max_iterations=1,
+            default_target_agent="codex",
+            auto_publish_deliverables=True,
+        )
+    )
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+    remote_failure = _preflight_receipt(
+        check_type="remote_publish",
+        passed=False,
+        checks=[
+            {
+                "name": "gh_pr_create_draft",
+                "passed": False,
+                "detail": "requires authentication",
+            }
+        ],
+    )
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch(
+            "aragora.swarm.dispatch_contract_gate._preview_env",
+            return_value=(
+                "codex",
+                {
+                    "ARAGORA_RUNNER_AUTH_MODE": "command",
+                    "CODEX_COMMAND": "/usr/local/bin/codex",
+                    "PYTEST_PATH": "/usr/local/bin/pytest",
+                    "RUFF_PATH": "/usr/local/bin/ruff",
+                    "SSH_AUTH_SOCK": "/tmp/agent.sock",
+                    "GITHUB_TOKEN": "token",
+                },
+            ),
+        ),
+        patch(
+            "aragora.swarm.dispatch_contract_gate.run_scratch_validation_receipt",
+            return_value=_preflight_receipt(),
+        ) as scratch_receipt,
+        patch(
+            "aragora.swarm.dispatch_contract_gate.run_remote_publish_validation_receipt",
+            return_value=remote_failure,
+        ) as remote_receipt,
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
+        ) as dispatch_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "blocked_auth_failure"
+    assert result["dispatch_contract"]["required_receipts"] == ["scratch", "remote_publish"]
+    assert result["dispatch_contract"]["preflight_receipts"][1]["check_type"] == "remote_publish"
+    assert result["dispatch_contract"]["preflight_receipts"][1]["failure_terminal_class"] == (
+        "blocked_auth_failure"
+    )
+    scratch_receipt.assert_called_once()
+    remote_receipt.assert_called_once()
     dispatch_mock.assert_not_awaited()
 
 

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -799,12 +799,19 @@ def test_run_remote_publish_validation_receipt_records_pr_artifacts(
     envelope = _envelope()
     now = datetime(2026, 4, 12, 19, 50, 0, tzinfo=timezone.utc)
     commands: list[list[str]] = []
+    command_envs: list[tuple[list[str], dict[str, str]]] = []
+    dispatch_env = {
+        "GITHUB_TOKEN": "dispatch-token",
+        "SSH_AUTH_SOCK": "/tmp/custom-agent.sock",
+        "CUSTOM_FLAG": "1",
+    }
 
     monkeypatch.setattr(mod, "_utc_now", lambda: now)
     monkeypatch.setattr(mod, "_receipt_token", lambda: "ef56aa11")
 
     def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         commands.append(list(cmd))
+        command_envs.append((list(cmd), dict(kwargs.get("env") or {})))
         if cmd[:3] == ["git", "worktree", "add"]:
             Path(cmd[5]).mkdir(parents=True, exist_ok=True)
             return SimpleNamespace(returncode=0, stdout="", stderr="")
@@ -821,6 +828,7 @@ def test_run_remote_publish_validation_receipt_records_pr_artifacts(
     receipt = mod.run_remote_publish_validation_receipt(
         repo_root=repo_root,
         envelope=envelope,
+        env=dispatch_env,
     )
 
     assert receipt.check_type == "remote_publish"
@@ -832,6 +840,15 @@ def test_run_remote_publish_validation_receipt_records_pr_artifacts(
     assert any(check["name"] == "gh_pr_capture" for check in receipt.checks)
     assert ["git", "push", "origin", "HEAD"] in commands
     assert any(cmd[:3] == ["gh", "pr", "close"] for cmd in commands)
+    git_envs = [env for cmd, env in command_envs if cmd and cmd[0] == "git"]
+    gh_envs = [env for cmd, env in command_envs if cmd[:2] == ["gh", "pr"]]
+    assert git_envs
+    assert gh_envs
+    assert all(env.get("SSH_AUTH_SOCK") == "/tmp/custom-agent.sock" for env in git_envs)
+    assert all(env.get("CUSTOM_FLAG") == "1" for env in git_envs)
+    assert all("GITHUB_TOKEN" not in env for env in git_envs)
+    assert all(env.get("GITHUB_TOKEN") == "dispatch-token" for env in gh_envs)
+    assert all(env.get("CUSTOM_FLAG") == "1" for env in gh_envs)
 
 
 def test_run_remote_publish_validation_receipt_closes_draft_when_create_output_unparseable(


### PR DESCRIPTION
## Summary
- require a receipt-backed pre-dispatch admission path for scratch validation
- persist and surface dispatch-contract receipt metadata through preflight and boss-loop flows
- cover both receipt persistence and dispatch-gate blocking behavior with focused tests

## Validation
- ruff check aragora/swarm/dispatch_contract_gate.py aragora/swarm/preflight.py tests/swarm/test_boss_loop.py tests/swarm/test_preflight.py
- python3 -m pytest tests/swarm/test_preflight.py -q -k 'contract_preflight_receipt or evaluate_preflight_dispatch_gate or evaluate_preflight_receipt_gate'
- python3 -m pytest tests/swarm/test_boss_loop.py -q -k 'dispatch_issue_contract_gate'
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
Harvested from unpublished branch codex/codex-20260414-001903-4f22e790 and rebased onto current origin/main.
