### PR TITLE
fix(autopilot): reject drifted reusable worktrees

### DIFF
--- a/scripts/codex_worktree_autopilot.py
+++ b/scripts/codex_worktree_autopilot.py
@@ -874,40 +874,43 @@ def cmd_ensure(args: argparse.Namespace) -> int:
         entries = _get_worktree_entries(repo_root)
         active_paths = _active_path_set(entries)
     else:
-        session["last_seen_at"] = _utc_now().isoformat()
-        if args.reconcile:
-            session_path = Path(session["path"])
-            metadata = _annotate_session(
+        session_path = Path(session["path"])
+        status = _worktree_status(repo_root, session_path, args.base)
+        needs_replacement = bool(status["dirty"]) or int(status["ahead"]) > 0
+
+        if args.reconcile and not needs_replacement and int(status["behind"]) > 0:
+            ok, reconcile_status = _integrate_worktree(
                 repo_root,
-                session,
-                active_paths=active_paths,
-                ttl=ttl,
-                base_branch=args.base,
+                session_path,
+                args.base,
+                args.strategy,
             )
-            if metadata["lifecycle_state"] == "active":
-                ok, status = True, "skipped_active_session"
-            elif metadata["lifecycle_state"] == "grace":
-                ok, status = True, "skipped_grace"
-            else:
-                ok, status = _integrate_worktree(
-                    repo_root,
-                    session_path,
-                    args.base,
-                    args.strategy,
-                )
-            session["reconcile_status"] = status
+            session["reconcile_status"] = reconcile_status
             if not ok:
-                # Fallback: auto-create replacement worktree if integration fails.
-                session = _create_managed_worktree(
-                    repo_root,
-                    managed_root,
-                    agent=args.agent,
-                    base=args.base,
-                    session_id=None,
+                needs_replacement = True
+            else:
+                status = _worktree_status(repo_root, session_path, args.base)
+                needs_replacement = (
+                    bool(status["dirty"]) or int(status["ahead"]) > 0 or int(status["behind"]) > 0
                 )
-                created = True
-                entries = _get_worktree_entries(repo_root)
-                active_paths = _active_path_set(entries)
+                if needs_replacement:
+                    session["reconcile_status"] = "rejected_not_clean_after_reconcile"
+
+        if needs_replacement:
+            if "reconcile_status" not in session:
+                session["reconcile_status"] = "rejected_drifted_reusable_session"
+            session = _create_managed_worktree(
+                repo_root,
+                managed_root,
+                agent=args.agent,
+                base=args.base,
+                session_id=None,
+            )
+            created = True
+            entries = _get_worktree_entries(repo_root)
+            active_paths = _active_path_set(entries)
+        else:
+            session["last_seen_at"] = _utc_now().isoformat()
 
     _annotate_session(
         repo_root,

--- a/tests/scripts/test_codex_worktree_autopilot.py
+++ b/tests/scripts/test_codex_worktree_autopilot.py
@@ -904,6 +904,114 @@ def test_cmd_ensure_refreshes_active_paths_for_new_worktree(
     assert saved_state["sessions"][0]["lifecycle_state"] == "grace"
 
 
+def test_cmd_ensure_replaces_ahead_reusable_session_with_fresh_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import codex_worktree_autopilot as mod
+
+    now = datetime(2026, 4, 13, 16, 30, tzinfo=timezone.utc)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    drifted_path = tmp_path / "managed" / "swarm-5d9f0302-micro-2"
+    created_path = tmp_path / "managed" / "swarm-clean"
+    drifted_path.mkdir(parents=True)
+    created_path.mkdir(parents=True)
+    state = {
+        "sessions": [
+            {
+                "session_id": "swarm-5d9f0302-micro-2",
+                "agent": "codex",
+                "branch": "codex/swarm-5d9f0302-micro-2",
+                "path": str(drifted_path),
+                "base_branch": "main",
+                "created_at": now.isoformat(),
+                "last_seen_at": now.isoformat(),
+            }
+        ]
+    }
+    saved_state: dict[str, object] = {}
+
+    entries_iter = iter(
+        [
+            [mod.WorktreeEntry(path=drifted_path, branch="codex/swarm-5d9f0302-micro-2")],
+            [
+                mod.WorktreeEntry(path=drifted_path, branch="codex/swarm-5d9f0302-micro-2"),
+                mod.WorktreeEntry(path=created_path, branch="codex/swarm-clean"),
+            ],
+        ]
+    )
+
+    def _worktree_status(_repo: Path, path: Path, _base: str) -> dict[str, int | bool]:
+        if path == drifted_path:
+            return {"dirty": False, "ahead": 1, "behind": 0}
+        if path == created_path:
+            return {"dirty": False, "ahead": 0, "behind": 0}
+        raise AssertionError(f"unexpected worktree path: {path}")
+
+    monkeypatch.setattr(mod, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(mod, "_get_worktree_entries", lambda _repo: next(entries_iter))
+    monkeypatch.setattr(mod, "_load_state", lambda _state_file: state)
+    monkeypatch.setattr(
+        mod,
+        "_create_managed_worktree",
+        lambda *_args, **_kwargs: {
+            "session_id": "swarm-clean",
+            "agent": "codex",
+            "branch": "codex/swarm-clean",
+            "path": str(created_path),
+            "base_branch": "main",
+            "created_at": now.isoformat(),
+            "last_seen_at": now.isoformat(),
+        },
+    )
+    monkeypatch.setattr(mod, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(
+        mod,
+        "_lease_snapshot",
+        lambda _repo_root, _path: {
+            "lease_id": None,
+            "lease_status": None,
+            "last_heartbeat_at": None,
+            "lease_expires_at": None,
+            "owner_agent": None,
+            "owner_session_id": None,
+            "branch": None,
+            "title": None,
+            "has_live_lease": False,
+            "lookup_failed": False,
+        },
+    )
+    monkeypatch.setattr(mod, "_worktree_status", _worktree_status)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_args, **_kwargs: "abc123")
+    monkeypatch.setattr(mod, "_branch_ahead_count", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(
+        mod, "_save_state", lambda _state_file, payload: saved_state.update(payload)
+    )
+
+    args = argparse.Namespace(
+        repo=".",
+        managed_dir=".worktrees/codex-auto",
+        agent="codex",
+        base="main",
+        session_id=None,
+        force_new=False,
+        reconcile=True,
+        strategy="ff-only",
+        print_path=False,
+        json=True,
+    )
+    rc = mod.cmd_ensure(args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["created"] is True
+    assert payload["session"]["path"] == str(created_path)
+    assert payload["session"]["branch"] == "codex/swarm-clean"
+    assert saved_state["sessions"][0]["reconcile_status"] == "rejected_drifted_reusable_session"
+    assert saved_state["sessions"][1]["path"] == str(created_path)
+
+
 def test_create_managed_worktree_retries_when_branch_is_created_concurrently(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- reject reusable managed worktrees that are ahead of or dirty relative to the base branch
- create a fresh managed worktree when reconcile cannot return the session to a clean reusable state
- cover the drifted-session replacement path with focused autopilot tests

## Validation
- python3 -m pytest tests/scripts/test_codex_worktree_autopilot.py -q
- ruff check scripts/codex_worktree_autopilot.py tests/scripts/test_codex_worktree_autopilot.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
Harvested from local branch codex/autopilot-ensure-clean-managed-20260413-v2.
