### PR TITLE
feat(swarm): add work chain DAG validation and wave executor

### DIFF
--- a/aragora/swarm/chain_executor.py
+++ b/aragora/swarm/chain_executor.py
@@ -17,7 +17,6 @@ from datetime import timezone
 from typing import Any
 
 from aragora.swarm.work_chain import (
-    ChainStatus,
     ExecutionWave,
     StepStatus,
     WorkChain,
@@ -25,6 +24,7 @@ from aragora.swarm.work_chain import (
 
 logger = logging.getLogger(__name__)
 UTC = timezone.utc
+_TERMINAL_STEP_STATUSES = frozenset({StepStatus.COMPLETED, StepStatus.FAILED, StepStatus.SKIPPED})
 
 
 @dataclass(slots=True)
@@ -155,21 +155,18 @@ class ChainExecutor:
         Skips steps whose predecessors have failed.
         """
         self._propagate_failures()
-
-        ready = self._chain.ready_steps()
-        if not ready:
+        if self._active_wave_index() is not None:
             return None
 
-        # Determine wave index from the chain's wave structure
-        ready_ids = {step.step_id for step in ready}
-        wave_index = 0
-        for wave in self._chain.waves:
-            if any(sid in ready_ids for sid in wave.step_ids):
-                wave_index = wave.wave_index
-                break
+        wave = self._next_dispatchable_wave()
+        if wave is None:
+            return None
 
         dispatches: list[StepDispatch] = []
-        for step in ready:
+        for step_id in wave.step_ids:
+            step = self._chain.step_by_id(step_id)
+            if step is None or step.status != StepStatus.PENDING:
+                continue
             predecessor_outputs: dict[str, StepOutcome] = {}
             for dep_id in step.depends_on:
                 if dep_id in self._outcomes:
@@ -180,13 +177,15 @@ class ChainExecutor:
                     step_id=step.step_id,
                     work_order_id=step.work_order_id,
                     title=step.title,
-                    wave_index=wave_index,
+                    wave_index=wave.wave_index,
                     predecessor_outputs=predecessor_outputs,
                 )
             )
             self._chain.mark_step(step.step_id, StepStatus.RUNNING)
 
-        return WaveDispatchPlan(wave_index=wave_index, dispatches=dispatches)
+        if not dispatches:
+            return None
+        return WaveDispatchPlan(wave_index=wave.wave_index, dispatches=dispatches)
 
     def record_outcome(self, outcome: StepOutcome) -> None:
         """Record the result of a step execution."""
@@ -242,7 +241,31 @@ class ChainExecutor:
         return dispatches
 
     def is_complete(self) -> bool:
-        return self._chain.status in (ChainStatus.COMPLETED, ChainStatus.FAILED)
+        return all(step.status in _TERMINAL_STEP_STATUSES for step in self._chain.steps)
+
+    def _active_wave_index(self) -> int | None:
+        for wave in self._chain.waves:
+            if any(
+                (step := self._chain.step_by_id(step_id)) is not None
+                and step.status == StepStatus.RUNNING
+                for step_id in wave.step_ids
+            ):
+                return wave.wave_index
+        return None
+
+    def _next_dispatchable_wave(self) -> ExecutionWave | None:
+        for wave in self._chain.waves:
+            statuses = [
+                step.status
+                for step_id in wave.step_ids
+                if (step := self._chain.step_by_id(step_id)) is not None
+            ]
+            if not statuses:
+                continue
+            if all(status in _TERMINAL_STEP_STATUSES for status in statuses):
+                continue
+            return wave
+        return None
 
     def summary(self) -> dict[str, Any]:
         """Return a summary of the chain execution."""

--- a/aragora/swarm/work_chain.py
+++ b/aragora/swarm/work_chain.py
@@ -22,6 +22,7 @@ from enum import Enum
 from typing import Any
 
 UTC = timezone.utc
+_DEPENDENCY_ALIAS_KEYS = ("work_order_id", "pipeline_task_id", "task_key")
 
 
 class ChainStatus(str, Enum):
@@ -43,6 +44,9 @@ class StepStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     SKIPPED = "skipped"
+
+
+_TERMINAL_STEP_STATUSES = frozenset({StepStatus.COMPLETED, StepStatus.FAILED, StepStatus.SKIPPED})
 
 
 @dataclass
@@ -167,11 +171,7 @@ class WorkChain:
 
     def ready_steps(self) -> list[ChainStep]:
         """Return steps whose dependencies are all completed."""
-        completed = {
-            step.step_id
-            for step in self.steps
-            if step.status in (StepStatus.COMPLETED, StepStatus.SKIPPED)
-        }
+        completed = {step.step_id for step in self.steps if step.status == StepStatus.COMPLETED}
         return [
             step
             for step in self.steps
@@ -188,14 +188,25 @@ class WorkChain:
 
     def _update_chain_status(self) -> None:
         statuses = {step.status for step in self.steps}
-        if all(s in (StepStatus.COMPLETED, StepStatus.SKIPPED) for s in statuses):
-            self.status = ChainStatus.COMPLETED
-        elif StepStatus.FAILED in statuses:
-            self.status = ChainStatus.FAILED
-        elif StepStatus.RUNNING in statuses or StepStatus.READY in statuses:
+        if statuses and all(status in _TERMINAL_STEP_STATUSES for status in statuses):
+            self.status = (
+                ChainStatus.FAILED if StepStatus.FAILED in statuses else ChainStatus.COMPLETED
+            )
+            return
+        if statuses and any(
+            status
+            in {
+                StepStatus.RUNNING,
+                StepStatus.READY,
+                StepStatus.COMPLETED,
+                StepStatus.FAILED,
+                StepStatus.SKIPPED,
+            }
+            for status in statuses
+        ):
             self.status = ChainStatus.RUNNING
-        else:
-            self.status = ChainStatus.PENDING
+            return
+        self.status = ChainStatus.PENDING
 
     def fingerprint(self) -> str:
         """Stable hash over chain structure for dedup."""
@@ -287,6 +298,7 @@ def build_chain_from_work_orders(
     """
     steps: list[ChainStep] = []
     wo_to_step: dict[str, str] = {}
+    alias_to_step: dict[str, str] = {}
 
     for wo in work_orders:
         wo_id = str(wo.get("work_order_id", "")).strip()
@@ -294,17 +306,33 @@ def build_chain_from_work_orders(
             continue
         step_id = wo_id
         wo_to_step[wo_id] = step_id
+        for key in _DEPENDENCY_ALIAS_KEYS:
+            alias = str(wo.get(key, "")).strip()
+            if not alias:
+                continue
+            existing = alias_to_step.get(alias)
+            if existing is not None and existing != step_id:
+                raise ValueError(f"Dependency alias '{alias}' maps to multiple work orders")
+            alias_to_step[alias] = step_id
 
     for wo in work_orders:
         wo_id = str(wo.get("work_order_id", "")).strip()
         if wo_id not in wo_to_step:
             continue
         raw_deps = wo.get("dependency_ids", [])
-        depends_on = [
-            wo_to_step[dep]
-            for dep in (raw_deps if isinstance(raw_deps, list) else [])
-            if str(dep or "").strip() in wo_to_step
-        ]
+        if not isinstance(raw_deps, list):
+            raw_deps = []
+        depends_on: list[str] = []
+        for raw_dep in raw_deps:
+            dependency_id = str(raw_dep or "").strip()
+            if not dependency_id:
+                continue
+            resolved = alias_to_step.get(dependency_id)
+            if resolved is None:
+                raise ValueError(
+                    f"Unknown dependency id '{dependency_id}' for work order '{wo_id}'"
+                )
+            depends_on.append(resolved)
         steps.append(
             ChainStep(
                 step_id=wo_to_step[wo_id],

--- a/tests/swarm/test_chain_executor.py
+++ b/tests/swarm/test_chain_executor.py
@@ -63,6 +63,18 @@ def _parallel_chain() -> WorkChain:
     )
 
 
+def _wide_wave_chain() -> WorkChain:
+    return WorkChain(
+        chain_id="wide-wave",
+        title="Wide wave chain",
+        steps=[
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B"),
+            ChainStep(step_id="c", work_order_id="wo-c", title="C", depends_on=["a"]),
+        ],
+    )
+
+
 class TestChainExecutorPlan:
     def test_plan_linear_chain(self) -> None:
         executor = ChainExecutor(_linear_chain())
@@ -150,6 +162,22 @@ class TestNextWave:
         assert executor.next_wave() is None
         assert executor.is_complete()
 
+    def test_next_wave_waits_for_all_steps_in_current_wave(self) -> None:
+        executor = ChainExecutor(_wide_wave_chain())
+        wave = executor.next_wave()
+        assert wave is not None
+        assert sorted(d.step_id for d in wave.dispatches) == ["a", "b"]
+
+        executor.record_outcome(StepOutcome(step_id="a", status=StepStatus.COMPLETED))
+
+        assert executor.next_wave() is None
+        assert executor.is_complete() is False
+
+        executor.record_outcome(StepOutcome(step_id="b", status=StepStatus.COMPLETED))
+        next_wave = executor.next_wave()
+        assert next_wave is not None
+        assert [d.step_id for d in next_wave.dispatches] == ["c"]
+
 
 class TestFailurePropagation:
     def test_failed_step_skips_dependents(self) -> None:
@@ -186,6 +214,22 @@ class TestFailurePropagation:
         assert step_join is not None
         assert step_join.status == StepStatus.SKIPPED
 
+    def test_failure_does_not_make_chain_complete_while_peer_is_still_running(self) -> None:
+        executor = ChainExecutor(_parallel_chain())
+        wave = executor.next_wave()
+        assert wave is not None
+
+        executor.record_outcome(StepOutcome(step_id="a", status=StepStatus.FAILED))
+
+        assert executor.is_complete() is False
+        assert executor.chain.status == ChainStatus.RUNNING
+
+        executor.record_outcome(StepOutcome(step_id="b", status=StepStatus.COMPLETED))
+        executor.record_outcome(StepOutcome(step_id="c", status=StepStatus.COMPLETED))
+
+        assert executor.is_complete() is True
+        assert executor.chain.status == ChainStatus.FAILED
+
 
 class TestSummary:
     def test_summary_after_full_execution(self) -> None:
@@ -211,6 +255,7 @@ class TestSummary:
         executor.record_outcome(StepOutcome(step_id="a", status=StepStatus.COMPLETED))
 
         summary = executor.summary()
+        assert summary["chain_status"] == "running"
         assert summary["completed"] == 1
         assert summary["remaining"] == 2
 

--- a/tests/swarm/test_work_chain.py
+++ b/tests/swarm/test_work_chain.py
@@ -170,6 +170,17 @@ class TestReadySteps:
         assert len(ready) == 1
         assert ready[0].step_id == "b"
 
+    def test_skipped_predecessor_does_not_make_successor_ready(self) -> None:
+        steps = [
+            ChainStep(step_id="a", work_order_id="wo-a", title="A"),
+            ChainStep(step_id="b", work_order_id="wo-b", title="B", depends_on=["a"]),
+        ]
+        chain = WorkChain(chain_id="test", title="Sequence", steps=steps)
+
+        chain.mark_step("a", StepStatus.SKIPPED)
+
+        assert chain.ready_steps() == []
+
 
 class TestChainStatus:
     def test_all_completed_makes_chain_completed(self) -> None:
@@ -182,13 +193,15 @@ class TestChainStatus:
         chain.mark_step("b", StepStatus.COMPLETED)
         assert chain.status == ChainStatus.COMPLETED
 
-    def test_any_failed_makes_chain_failed(self) -> None:
+    def test_any_failed_makes_chain_failed_once_all_steps_are_terminal(self) -> None:
         steps = [
             ChainStep(step_id="a", work_order_id="wo-a", title="A"),
             ChainStep(step_id="b", work_order_id="wo-b", title="B"),
         ]
         chain = WorkChain(chain_id="test", title="Test", steps=steps)
         chain.mark_step("a", StepStatus.FAILED)
+        assert chain.status == ChainStatus.RUNNING
+        chain.mark_step("b", StepStatus.COMPLETED)
         assert chain.status == ChainStatus.FAILED
 
     def test_skipped_counts_as_done(self) -> None:
@@ -262,6 +275,28 @@ class TestBuildFromWorkOrders:
         assert chain.topological_order[0] == "wo-1"
         assert chain.topological_order[1] == "wo-2"
 
+    def test_resolves_dependency_ids_via_pipeline_task_id(self) -> None:
+        work_orders = [
+            {
+                "work_order_id": "wo-1",
+                "pipeline_task_id": "task-1",
+                "title": "Create module",
+            },
+            {
+                "work_order_id": "wo-2",
+                "pipeline_task_id": "task-2",
+                "title": "Add tests",
+                "dependency_ids": ["task-1"],
+            },
+        ]
+
+        chain = build_chain_from_work_orders("Test chain", work_orders)
+
+        assert len(chain.steps) == 2
+        assert chain.step_by_id("wo-2") is not None
+        assert chain.step_by_id("wo-2").depends_on == ["wo-1"]
+        assert chain.topological_order == ["wo-1", "wo-2"]
+
     def test_skips_empty_work_order_ids(self) -> None:
         work_orders = [
             {"work_order_id": "", "title": "Empty"},
@@ -270,7 +305,7 @@ class TestBuildFromWorkOrders:
         chain = build_chain_from_work_orders("Test", work_orders)
         assert len(chain.steps) == 1
 
-    def test_ignores_dangling_dependency_ids(self) -> None:
+    def test_raises_on_dangling_dependency_ids(self) -> None:
         work_orders = [
             {
                 "work_order_id": "wo-1",
@@ -278,9 +313,8 @@ class TestBuildFromWorkOrders:
                 "dependency_ids": ["nonexistent"],
             },
         ]
-        chain = build_chain_from_work_orders("Test", work_orders)
-        assert len(chain.steps) == 1
-        assert chain.steps[0].depends_on == []
+        with pytest.raises(ValueError, match="Unknown dependency id"):
+            build_chain_from_work_orders("Test", work_orders)
 
 
 class TestComplexDAGPatterns:


### PR DESCRIPTION
## Summary
- add work-chain DAG validation and wave-based execution support
- reject unknown dependency aliases and wait for an active wave to fully settle before dispatching the next wave
- cover the executor and chain behavior with focused tests

## Validation
- python3 -m pytest tests/swarm/test_chain_executor.py tests/swarm/test_work_chain.py -q
- ruff check aragora/swarm/chain_executor.py aragora/swarm/work_chain.py tests/swarm/test_chain_executor.py tests/swarm/test_work_chain.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
Includes follow-up fixes on top of local branch codex/pr-5277-fix to prevent premature next-wave dispatch and to make dependency alias resolution fail closed.
