### PR TITLE
fix(benchmarks): fail closed on partial corpus coverage (#5487)

### DIFF
--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -98,6 +98,14 @@ def _failure_distributions(
     return dict(sorted(failure_counts.items())), dict(sorted(rescue_counts.items()))
 
 
+def _missing_corpus_issue_numbers(aggregates: list[IssueMetricsAggregate]) -> list[int]:
+    return [
+        aggregate.issue_number
+        for aggregate in aggregates
+        if aggregate.issue_number > 0 and aggregate.row_count <= 0
+    ]
+
+
 def build_benchmark_truth_artifact(
     *,
     repo: str,
@@ -119,6 +127,8 @@ def build_benchmark_truth_artifact(
     )
     merged_issue_count = sum(1 for record in records if record.truth_state == "merged_pr")
     proxy_pr_signal_issue_count = sum(1 for aggregate in aggregates if aggregate.proxy_pr_signal)
+    missing_issue_numbers = _missing_corpus_issue_numbers(aggregates)
+    run_complete = not missing_issue_numbers
     failure_class_distribution, rescue_counts_by_type = _failure_distributions(
         rows,
         corpus_issue_numbers={aggregate.issue_number for aggregate in aggregates},
@@ -134,6 +144,14 @@ def build_benchmark_truth_artifact(
             "recorded_on": str(corpus.get("recorded_on") or "").strip(),
             "success_contract": str(corpus.get("success_contract") or "").strip(),
             "issue_count": corpus_issue_count,
+        },
+        "run_status": "complete" if run_complete else "incomplete",
+        "coverage": {
+            "attempted_issue_count": attempted_issue_count,
+            "missing_issue_count": len(missing_issue_numbers),
+            "missing_issue_numbers": missing_issue_numbers,
+            "is_complete": run_complete,
+            "status": "complete" if run_complete else "incomplete",
         },
         "primary_metrics": {
             "truth_success_rate": round(truth_success_issue_count / corpus_issue_count, 4)
@@ -189,6 +207,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--output", type=Path, default=None, help="Optional artifact output path")
     parser.add_argument("--json", action="store_true", help="Emit JSON to stdout")
+    parser.add_argument(
+        "--fail-incomplete",
+        action="store_true",
+        help="Exit non-zero when the artifact does not cover every corpus issue",
+    )
     return parser
 
 
@@ -210,6 +233,16 @@ def main(argv: list[str] | None = None) -> int:
         print(str(output_path))
     if args.json or args.output is None:
         print(json.dumps(artifact, indent=2, sort_keys=True))
+    if args.fail_incomplete and artifact.get("run_status") != "complete":
+        missing_issue_numbers = list(
+            (artifact.get("coverage") or {}).get("missing_issue_numbers") or []
+        )
+        missing_suffix = ", ".join(str(item) for item in missing_issue_numbers) or "unknown"
+        print(
+            f"incomplete corpus coverage: missing issue numbers {missing_suffix}",
+            file=sys.stderr,
+        )
+        return 2
     return 0
 
 

--- a/tests/fixtures/swarm/sample_boss_metrics.jsonl
+++ b/tests/fixtures/swarm/sample_boss_metrics.jsonl
@@ -1,0 +1,2 @@
+{"issue_number": 1064, "issue_title": "Dependency bump", "terminal_class": "deliverable_pr_created", "publish_action": "pr_created", "worker_outcome": "pr_adopted"}
+{"issue_number": 2712, "issue_title": "Boolean parsing fix", "terminal_class": "rescue_worker_crash", "worker_outcome": "crash"}

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -105,6 +105,10 @@ def test_build_benchmark_truth_artifact_links_corpus_revision_and_truth_metrics(
 
     assert artifact["corpus"]["corpus_id"] == "tw-01-bounded-execution-v1"
     assert artifact["corpus"]["revision"] == 3
+    assert artifact["run_status"] == "complete"
+    assert artifact["coverage"]["attempted_issue_count"] == 2
+    assert artifact["coverage"]["missing_issue_numbers"] == []
+    assert artifact["coverage"]["is_complete"] is True
     assert artifact["primary_metrics"]["truth_success_rate"] == 0.5
     assert artifact["primary_metrics"]["no_rescue_truth_success_rate"] == 0.5
     assert artifact["primary_metrics"]["merged_only_rate"] == 0.5
@@ -112,6 +116,151 @@ def test_build_benchmark_truth_artifact_links_corpus_revision_and_truth_metrics(
     assert artifact["rescue_counts_by_type"] == {"rescue_worker_crash": 1}
     assert artifact["proxy_metrics"]["attempted_issue_count"] == 2
     assert [issue["truth_state"] for issue in artifact["issues"]] == ["merged_pr", "no_linked_pr"]
+
+
+def test_build_benchmark_truth_artifact_marks_partial_corpus_runs_incomplete(
+    tmp_path: Path,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        json.dumps(
+            {
+                "issue_number": 1064,
+                "issue_title": "Dependency bump",
+                "terminal_class": "deliverable_pr_created",
+                "publish_action": "pr_created",
+                "worker_outcome": "pr_adopted",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 4,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [
+                {"issue_id": 1064, "title": "Dependency bump"},
+                {"issue_id": 873, "title": "ESLint bump"},
+            ],
+        },
+    )
+    client = FakeGitHubTruthClient(
+        issues={
+            1064: {
+                "title": "Dependency bump",
+                "comments": [{"body": "PR: https://github.com/synaptent/aragora/pull/6001"}],
+            },
+            873: {"title": "ESLint bump", "comments": []},
+        },
+        prs={
+            6001: {
+                "number": 6001,
+                "title": "merged fix",
+                "url": "https://github.com/synaptent/aragora/pull/6001",
+                "state": "MERGED",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": "2026-04-13T12:00:00Z",
+                "isDraft": False,
+            }
+        },
+    )
+
+    artifact = mod.build_benchmark_truth_artifact(
+        repo="synaptent/aragora",
+        metrics_file=metrics_path,
+        corpus_path=corpus_path,
+        client=client,
+        generated_at="2026-04-14T01:00:00Z",
+    )
+
+    assert artifact["run_status"] == "incomplete"
+    assert artifact["coverage"]["attempted_issue_count"] == 1
+    assert artifact["coverage"]["missing_issue_count"] == 1
+    assert artifact["coverage"]["missing_issue_numbers"] == [873]
+    assert artifact["coverage"]["is_complete"] is False
+    assert artifact["primary_metrics"]["truth_success_rate"] == 0.5
+
+
+def test_main_fail_incomplete_returns_nonzero_and_emits_artifact(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        json.dumps(
+            {
+                "issue_number": 1064,
+                "issue_title": "Dependency bump",
+                "terminal_class": "deliverable_pr_created",
+                "publish_action": "pr_created",
+                "worker_outcome": "pr_adopted",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 5,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [
+                {"issue_id": 1064, "title": "Dependency bump"},
+                {"issue_id": 873, "title": "ESLint bump"},
+            ],
+        },
+    )
+    fake_client = FakeGitHubTruthClient(
+        issues={
+            1064: {
+                "title": "Dependency bump",
+                "comments": [{"body": "PR: https://github.com/synaptent/aragora/pull/6001"}],
+            },
+            873: {"title": "ESLint bump", "comments": []},
+        },
+        prs={
+            6001: {
+                "number": 6001,
+                "title": "merged fix",
+                "url": "https://github.com/synaptent/aragora/pull/6001",
+                "state": "MERGED",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": "2026-04-13T12:00:00Z",
+                "isDraft": False,
+            }
+        },
+    )
+
+    monkeypatch.setattr(mod, "GitHubTruthClient", lambda: fake_client)
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            "synaptent/aragora",
+            "--metrics-file",
+            str(metrics_path),
+            "--corpus",
+            str(corpus_path),
+            "--json",
+            "--fail-incomplete",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 2
+    assert payload["run_status"] == "incomplete"
+    assert payload["coverage"]["missing_issue_numbers"] == [873]
+    assert "incomplete corpus coverage" in captured.err
 
 
 def test_write_artifact_emits_diffable_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add explicit corpus coverage state and missing issue numbers to the benchmark truth artifact
- add a --fail-incomplete flag so CI can fail closed on partial fixed-corpus runs while still emitting the artifact
- add the sample boss metrics fixture referenced by the validation flow and extend artifact tests for complete and incomplete runs

## Validation
- python3 -m pytest tests/scripts/test_build_benchmark_truth_artifact.py -q
- python3 -m ruff check scripts/build_benchmark_truth_artifact.py tests/scripts/test_build_benchmark_truth_artifact.py
- python3 scripts/build_benchmark_truth_artifact.py --json --corpus docs/benchmarks/corpus.json --metrics-file tests/fixtures/swarm/sample_boss_metrics.jsonl
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5487