### PR TITLE
feat(benchmarks): add ci output for b0 scorecard (#5424)

### DIFF
--- a/scripts/measure_b0_scorecard.py
+++ b/scripts/measure_b0_scorecard.py
@@ -14,6 +14,7 @@ Usage:
   python3 scripts/measure_b0_scorecard.py
   python3 scripts/measure_b0_scorecard.py --metrics .aragora/overnight/boss_metrics.jsonl
   python3 scripts/measure_b0_scorecard.py --json
+  python3 scripts/measure_b0_scorecard.py --ci --threshold 0.5
   python3 scripts/measure_b0_scorecard.py --window 100
 """
 
@@ -153,7 +154,26 @@ def print_scorecard(scorecard: dict[str, Any]) -> None:
     print("=" * 60)
 
 
-def main() -> int:
+def render_ci_summary(scorecard: dict[str, Any], *, threshold: float) -> str:
+    success_rate = float(scorecard.get("no_rescue_success_rate", 0.0) or 0.0)
+    status = (
+        "pass" if success_rate >= threshold and scorecard.get("status") != "no_data" else "fail"
+    )
+    return " ".join(
+        [
+            f"status={status}",
+            f"scorecard_status={scorecard.get('status', 'unknown')}",
+            f"success_rate={success_rate:.3f}",
+            f"threshold={threshold:.3f}",
+            f"total_ticks={int(scorecard.get('total_ticks', 0) or 0)}",
+            f"unique_issues_attempted={int(scorecard.get('unique_issues_attempted', 0) or 0)}",
+            f"unique_issues_succeeded={int(scorecard.get('unique_issues_succeeded', 0) or 0)}",
+            f"unique_issues_failed={int(scorecard.get('unique_issues_failed', 0) or 0)}",
+        ]
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="B0 Benchmark Scorecard")
     parser.add_argument(
         "--metrics",
@@ -162,14 +182,34 @@ def main() -> int:
         help="Path to boss_metrics.jsonl",
     )
     parser.add_argument("--window", type=int, default=None, help="Last N ticks only")
-    parser.add_argument("--json", action="store_true", help="JSON output")
-    args = parser.parse_args()
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="JSON output")
+    output_group.add_argument(
+        "--ci",
+        action="store_true",
+        help="CI output: one-line summary and threshold-based exit status",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Minimum no-rescue success rate required in --ci mode (default: 0.5)",
+    )
+    args = parser.parse_args(argv)
 
     rows = load_metrics(args.metrics, args.window)
     scorecard = compute_scorecard(rows)
 
     if args.json:
         print(json.dumps(scorecard, indent=2))
+    elif args.ci:
+        print(render_ci_summary(scorecard, threshold=args.threshold))
+        return (
+            0
+            if scorecard.get("status") != "no_data"
+            and scorecard.get("no_rescue_success_rate", 0.0) >= args.threshold
+            else 1
+        )
     else:
         print_scorecard(scorecard)
 

--- a/tests/scripts/test_measure_b0_scorecard.py
+++ b/tests/scripts/test_measure_b0_scorecard.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import measure_b0_scorecard as mod  # noqa: E402
+
+
+def _write_metrics(path: Path, rows: list[dict[str, object]]) -> Path:
+    path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_main_ci_passes_at_threshold(tmp_path: Path, capsys) -> None:
+    metrics_path = _write_metrics(
+        tmp_path / "boss_metrics.jsonl",
+        [
+            {"issue_number": 1001, "terminal_class": "deliverable_pr_created"},
+            {"issue_number": 1002, "terminal_class": "rescue_worker_crash"},
+        ],
+    )
+
+    exit_code = mod.main(["--metrics", str(metrics_path), "--ci", "--threshold", "0.5"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert (
+        captured.out.strip()
+        == "status=pass scorecard_status=active success_rate=0.500 threshold=0.500 "
+        "total_ticks=2 unique_issues_attempted=2 unique_issues_succeeded=1 unique_issues_failed=1"
+    )
+
+
+def test_main_ci_fails_below_threshold(tmp_path: Path, capsys) -> None:
+    metrics_path = _write_metrics(
+        tmp_path / "boss_metrics.jsonl",
+        [
+            {"issue_number": 1001, "terminal_class": "deliverable_pr_created"},
+            {"issue_number": 1002, "terminal_class": "rescue_worker_crash"},
+        ],
+    )
+
+    exit_code = mod.main(["--metrics", str(metrics_path), "--ci", "--threshold", "0.75"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert (
+        captured.out.strip()
+        == "status=fail scorecard_status=active success_rate=0.500 threshold=0.750 "
+        "total_ticks=2 unique_issues_attempted=2 unique_issues_succeeded=1 unique_issues_failed=1"
+    )
+
+
+def test_main_json_mode_keeps_json_output(tmp_path: Path, capsys) -> None:
+    metrics_path = _write_metrics(
+        tmp_path / "boss_metrics.jsonl",
+        [
+            {"issue_number": 1001, "terminal_class": "deliverable_pr_created"},
+        ],
+    )
+
+    exit_code = mod.main(["--metrics", str(metrics_path), "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["status"] == "active"
+    assert payload["no_rescue_success_rate"] == 1.0
+    assert payload["unique_issues_attempted"] == 1


### PR DESCRIPTION
## Summary
- add a CI output mode for the B0 scorecard with threshold-based exit status
- keep the existing human-readable and JSON output modes intact via mutually exclusive CLI modes
- cover the new CLI behavior with focused script tests

## Validation
- python3 -m pytest tests/scripts/test_measure_b0_scorecard.py -q
- python3 -m ruff check scripts/measure_b0_scorecard.py tests/scripts/test_measure_b0_scorecard.py
- python3 scripts/measure_b0_scorecard.py --ci --threshold 0.5
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Note: in this worktree the last command exits 1 with `status=fail` because no local boss metrics file is present; that is the intended fail-closed CI behavior.

Closes #5424