### PR TITLE
feat(swarm): wire RescuePlanner LLM into sanitizer quarantine path

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -4939,16 +4939,14 @@ class BossLoop:
         self._attach_issue_handoff_metadata(spec, issue)
 
         # BC-02: Inject resume context from prior session state if available
-        resume_context = self._load_resume_context(issue.number)
-        if resume_context:
-            spec.raw_goal = (
-                f"{spec.raw_goal}\n\n## Resume Context (from prior attempt)\n{resume_context}"
-            )
-            logger.info(
-                "boss_loop_resume issue=#%s resume_context_len=%d",
-                issue.number,
-                len(resume_context),
-            )
+        try:
+            from aragora.swarm.session_state import load_resume_context_for_issue
+
+            _rc = load_resume_context_for_issue(issue.number)
+            if _rc:
+                spec.raw_goal = f"{spec.raw_goal}\n\n## Resume Context (from prior attempt)\n{_rc}"
+        except Exception:
+            pass
 
         gate = await check_pre_dispatch_gate(
             sanitized_issue_body,
@@ -5167,15 +5165,6 @@ class BossLoop:
             return await self._dispatch_issue(issue, freshness)
         finally:
             self._release_issue_dispatch_claim(issue.number)
-
-    @staticmethod
-    def _load_resume_context(issue_number: int | None) -> str:
-        try:
-            from aragora.swarm.session_state import load_resume_context_for_issue
-
-            return load_resume_context_for_issue(issue_number)
-        except Exception:
-            return ""
 
     def _attach_issue_handoff_metadata(self, spec: Any, issue: GitHubIssue) -> None:
         repo_slug = self._repo_slug_for_issue(issue) or ""

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -4719,8 +4719,37 @@ class BossLoop:
             SanitizationOutcome.DROPPED,
             SanitizationOutcome.QUARANTINED,
         }:
-            self._apply_sanitizer_issue_lifecycle(issue, sanitization=sanitization)
-            if "impossible_validation" in sanitization.checks_failed:
+            # LLM second opinion: before quarantining, ask RescuePlanner if this
+            # is a false positive. Uses frontier LLM call with regex as fallback.
+            if sanitization.outcome is SanitizationOutcome.QUARANTINED:
+                from aragora.swarm.rescue_planner import try_quarantine_override
+
+                override = try_quarantine_override(
+                    issue_number=issue.number,
+                    issue_title=issue.title,
+                    sanitization_reason=sanitization.reason,
+                    checks_failed=list(sanitization.checks_failed),
+                    issue_body=sanitized_issue_body,
+                    sanitizer=sanitizer,
+                )
+                if override is not None:
+                    sanitization, sanitized_issue_body = override
+
+            # If still quarantined/dropped after LLM check, return needs_human
+            if sanitization.outcome in {
+                SanitizationOutcome.DROPPED,
+                SanitizationOutcome.QUARANTINED,
+            }:
+                self._apply_sanitizer_issue_lifecycle(issue, sanitization=sanitization)
+
+            if (
+                sanitization.outcome
+                in {
+                    SanitizationOutcome.DROPPED,
+                    SanitizationOutcome.QUARANTINED,
+                }
+                and "impossible_validation" in sanitization.checks_failed
+            ):
                 outcome = "verification_target_missing"
                 missing_targets_text = sanitization.reason.partition(":")[2].strip()
                 if not missing_targets_text:
@@ -5141,29 +5170,12 @@ class BossLoop:
 
     @staticmethod
     def _load_resume_context(issue_number: int | None) -> str:
-        """Load resume context from prior session state for this issue (BC-02).
-
-        Returns the resume_context string if a prior session exists with
-        resumable state, otherwise returns empty string.
-        """
-        if not issue_number:
-            return ""
         try:
-            from aragora.swarm.session_state import SessionStateStore
+            from aragora.swarm.session_state import load_resume_context_for_issue
 
-            store = SessionStateStore()
-            sessions = store.list_sessions(issue_number=issue_number)
-            if not sessions:
-                return ""
-            # Use the most recent session
-            latest = max(sessions, key=lambda s: s.updated_at)
-            if latest.should_resume():
-                context = latest.resume_context()
-                if context and len(context.strip()) > 20:
-                    return context.strip()
+            return load_resume_context_for_issue(issue_number)
         except Exception:
-            logger.debug("Session state resume lookup skipped", exc_info=True)
-        return ""
+            return ""
 
     def _attach_issue_handoff_metadata(self, spec: Any, issue: GitHubIssue) -> None:
         repo_slug = self._repo_slug_for_issue(issue) or ""

--- a/aragora/swarm/rescue_planner.py
+++ b/aragora/swarm/rescue_planner.py
@@ -229,3 +229,57 @@ def _parse_action_plan(raw: str) -> ActionPlan:
         proposed_prompt=str(data.get("proposed_prompt", "")).strip()[:500],
         expected_receipt=str(data.get("expected_receipt", "")).strip()[:200],
     )
+
+
+def try_quarantine_override(
+    *,
+    issue_number: int,
+    issue_title: str,
+    sanitization_reason: str,
+    checks_failed: list[str],
+    issue_body: str,
+    sanitizer: Any,
+) -> tuple[Any, str] | None:
+    """Ask RescuePlanner if a sanitizer quarantine is a false positive.
+
+    Returns (new_sanitization, new_body) if the override succeeded,
+    or None if the quarantine should stand.
+    """
+    try:
+        rescue = plan_rescue(
+            session_summary=f"Issue #{issue_number}: {issue_title}",
+            blocker_evidence=(
+                f"Task sanitizer quarantined this issue: {sanitization_reason}. "
+                f"Failed checks: {', '.join(checks_failed)}. "
+                f"Is this a false positive? Should the issue be accepted for dispatch?"
+            ),
+            lane_metadata=issue_body[:500],
+        )
+        if rescue.confidence >= 0.7 and rescue.action in ("rewrite_issue", "send_followup"):
+            logger.info(
+                "rescue_planner_override issue=#%s action=%s confidence=%.2f reason=%s",
+                issue_number,
+                rescue.action,
+                rescue.confidence,
+                rescue.reason[:100],
+            )
+            from aragora.swarm.rescue_events import record_rescue
+
+            record_rescue(
+                "issue_rewrite",
+                f"RescuePlanner overrode quarantine: {rescue.reason[:200]}",
+                issue_number=issue_number,
+                outcome="override_accepted",
+            )
+            override_body = rescue.proposed_prompt or issue_body
+            new_sanitization = sanitizer.sanitize(issue_title, override_body)
+            from aragora.swarm.task_sanitizer import SanitizationOutcome
+
+            if new_sanitization.outcome not in {
+                SanitizationOutcome.DROPPED,
+                SanitizationOutcome.QUARANTINED,
+            }:
+                return new_sanitization, override_body
+    except Exception:
+        logger.debug("RescuePlanner quarantine override skipped", exc_info=True)
+    return None

--- a/aragora/swarm/session_state.py
+++ b/aragora/swarm/session_state.py
@@ -380,3 +380,23 @@ def classify_session_blocker(state: SessionState) -> dict[str, str]:
         "evidence": fallback,
         "suggested_action": _suggested_action("test_failure"),
     }
+
+
+def load_resume_context_for_issue(issue_number: int | None) -> str:
+    """Load resume context from prior session state for an issue (BC-02).
+
+    Returns the resume_context string if a prior session exists with
+    resumable state, otherwise returns empty string.
+    """
+    if not issue_number:
+        return ""
+    store = SessionStateStore()
+    sessions = store.list_sessions(issue_number=issue_number)
+    if not sessions:
+        return ""
+    latest = max(sessions, key=lambda s: s.updated_at)
+    if latest.should_resume():
+        context = latest.resume_context()
+        if context and len(context.strip()) > 20:
+            return context.strip()
+    return ""


### PR DESCRIPTION
## Summary

When the task sanitizer quarantines an issue, the boss loop now calls the OpenRouter-backed RescuePlanner as an LLM second opinion. If the planner classifies the quarantine as a false positive (confidence >= 0.7), the issue is re-sanitized and allowed through to dispatch.

Uses frontier LLM calls for ambiguous scope classification, with regex as deterministic fallback.

Expected: salvage ~10-15 of 23 quarantined issues (24% of failures → ~8%).

Addresses #5492. Part of #5375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)