### PR TITLE
fix(swarm): persist session state across supervisor lifecycle (#5502)

### DIFF
--- a/aragora/swarm/supervisor_workers.py
+++ b/aragora/swarm/supervisor_workers.py
@@ -56,7 +56,8 @@ def _record_session_state(
 
         metadata = work_order.get("metadata")
         if not isinstance(metadata, dict):
-            return
+            metadata = {}
+            work_order["metadata"] = metadata
         session_data = metadata.get("session_state")
         if not isinstance(session_data, dict):
             # Create a new session if one doesn't exist
@@ -67,18 +68,65 @@ def _record_session_state(
                 session_id=f"swarm-{wo_id[:12]}",
                 issue_number=work_order.get("issue_number"),
                 target_agent=str(work_order.get("target_agent", "")).strip() or None,
+                runner_type=str(work_order.get("target_agent", "")).strip() or None,
+                worktree_path=str(work_order.get("worktree_path", "")).strip() or None,
+                branch_name=str(work_order.get("branch", "")).strip() or None,
+                pr_url=(
+                    str(
+                        work_order.get("pr_url", "")
+                        or work_order.get("adopted_pr", "")
+                        or metadata.get("pr_url", "")
+                    ).strip()
+                    or None
+                ),
                 phase=phase or "dispatch",
                 status=status or "created",
             )
         else:
             session = SessionState.from_dict(session_data)
 
+        issue_number = work_order.get("issue_number")
+        if issue_number not in {None, ""}:
+            session.issue_number = issue_number
+        target_agent = str(work_order.get("target_agent", "")).strip()
+        if target_agent:
+            session.target_agent = target_agent
+            session.runner_type = target_agent
+        worktree_path = str(work_order.get("worktree_path", "")).strip()
+        if worktree_path:
+            session.worktree_path = worktree_path
+        branch_name = str(work_order.get("branch", "")).strip()
+        if branch_name:
+            session.branch_name = branch_name
+        pr_url = str(
+            work_order.get("pr_url", "")
+            or work_order.get("adopted_pr", "")
+            or metadata.get("pr_url", "")
+        ).strip()
+        if pr_url:
+            session.pr_url = pr_url
+        selected_metadata = {
+            "work_order_id": str(work_order.get("work_order_id", "")).strip() or None,
+            "supervisor_run_id": str(metadata.get("supervisor_run_id", "")).strip() or None,
+            "task_key": str(work_order.get("task_key", "") or metadata.get("task_key", "")).strip()
+            or None,
+            "lease_id": str(work_order.get("lease_id", "")).strip() or None,
+            "receipt_id": str(work_order.get("receipt_id", "")).strip() or None,
+            "review_status": str(work_order.get("review_status", "")).strip() or None,
+        }
+        session.metadata.update({key: value for key, value in selected_metadata.items() if value})
         if status:
             session.status = status
         if phase:
             session.phase = phase
-        if blocker_evidence:
-            session.set_blocker(blocker_evidence)
+        effective_blocker_evidence = (
+            blocker_evidence
+            or str(
+                work_order.get("blocker_evidence", "") or metadata.get("blocker_evidence", "")
+            ).strip()
+        )
+        if effective_blocker_evidence:
+            session.set_blocker(effective_blocker_evidence)
         if exit_code is not None or worker_outcome:
             session.record_attempt(
                 exit_code=exit_code,
@@ -845,6 +893,7 @@ async def dispatch_workers(self, run_id: str) -> list[WorkerProcess]:
                 }
                 item["prompt_chars"] = int(worker.prompt_chars or 0)
                 item["enriched_context_chars"] = int(worker.enriched_context_chars or 0)
+                _record_session_state(item, status="dispatched", phase="edit")
                 # Persist worker PID in lease metadata so reap_stale_leases
                 # can detect dead processes even if this supervisor dies.
                 lease_id = str(item.get("lease_id", "")).strip()
@@ -1388,6 +1437,7 @@ def _lease_work_order(
             "task_key": task_key,
         }
     )
+    _record_session_state(work_order, status="leased", phase="dispatch")
     return True
 
 

--- a/tests/swarm/test_session_state.py
+++ b/tests/swarm/test_session_state.py
@@ -9,6 +9,7 @@ from aragora.swarm.session_state import (
     SessionStateStore,
     classify_session_blocker,
 )
+from aragora.swarm.supervisor_workers import _record_session_state
 
 
 def _dt(text: str) -> datetime:
@@ -226,6 +227,78 @@ def test_set_blocker_and_clear_blocker() -> None:
 
     state.clear_blocker()
     assert state.blocker_evidence is None
+
+
+def test_record_session_state_creates_session_from_leased_work_order(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    work_order = {
+        "work_order_id": "wo-lease",
+        "issue_number": 5502,
+        "target_agent": "codex",
+        "branch": "codex/issue-5502-session-lifecycle",
+        "worktree_path": "/tmp/codex-session-lifecycle",
+        "metadata": {"supervisor_run_id": "run-lease"},
+    }
+
+    _record_session_state(work_order, status="leased", phase="dispatch")
+
+    session_data = work_order["metadata"]["session_state"]
+    assert session_data["status"] == "leased"
+    assert session_data["phase"] == "dispatch"
+    assert session_data["branch_name"] == "codex/issue-5502-session-lifecycle"
+    assert session_data["worktree_path"] == "/tmp/codex-session-lifecycle"
+    assert session_data["target_agent"] == "codex"
+    assert session_data["runner_type"] == "codex"
+    assert session_data["metadata"]["supervisor_run_id"] == "run-lease"
+
+
+def test_record_session_state_syncs_branch_pr_and_blocker_metadata(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    work_order = {
+        "work_order_id": "wo-dispatch",
+        "issue_number": 5502,
+        "target_agent": "claude",
+        "branch": "claude/bc01-lifecycle",
+        "worktree_path": "/tmp/claude-bc01-lifecycle",
+        "pr_url": "https://github.com/synaptent/aragora/pull/12345",
+        "receipt_id": "rcpt-123",
+        "review_status": "pending_heterogeneous_review",
+        "lease_id": "lease-123",
+        "metadata": {
+            "supervisor_run_id": "run-dispatch",
+            "session_state": {
+                "session_id": "resume-dispatch",
+                "phase": "dispatch",
+                "status": "created",
+            },
+        },
+    }
+
+    _record_session_state(
+        work_order,
+        status="dispatched",
+        phase="edit",
+        blocker_evidence="pytest timed out in tests/swarm/test_supervisor.py",
+    )
+
+    session_data = work_order["metadata"]["session_state"]
+    assert session_data["session_id"] == "resume-dispatch"
+    assert session_data["status"] == "dispatched"
+    assert session_data["phase"] == "edit"
+    assert session_data["branch_name"] == "claude/bc01-lifecycle"
+    assert session_data["pr_url"] == "https://github.com/synaptent/aragora/pull/12345"
+    assert session_data["blocker_evidence"] == "pytest timed out in tests/swarm/test_supervisor.py"
+    assert session_data["metadata"]["receipt_id"] == "rcpt-123"
+    assert session_data["metadata"]["review_status"] == "pending_heterogeneous_review"
+    store = SessionStateStore()
+    restored = store.load("resume-dispatch")
+    assert restored is not None
+    assert restored.pr_url == "https://github.com/synaptent/aragora/pull/12345"
+    assert restored.branch_name == "claude/bc01-lifecycle"
 
 
 def test_classify_session_blocker_import_error() -> None:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -6658,8 +6658,9 @@ def test_reset_worker_type_circuit_breaker_preserves_run_metadata(
 
 @pytest.mark.asyncio
 async def test_dispatch_workers_expires_worker_type_circuit_breaker(
-    repo: Path, store: DevCoordinationStore
+    repo: Path, store: DevCoordinationStore, monkeypatch
 ) -> None:
+    monkeypatch.setattr(Path, "home", lambda: repo / ".home")
     expired_at = datetime.now(UTC) - timedelta(minutes=10)
     run_record = store.create_supervisor_run(
         goal="expire worker breaker",
@@ -6721,6 +6722,12 @@ async def test_dispatch_workers_expires_worker_type_circuit_breaker(
     work_order = updated["work_orders"][0]
     assert work_order["status"] == "dispatched"
     assert work_order["target_agent"] == "claude"
+    session_state = work_order["metadata"]["session_state"]
+    assert session_state["status"] == "dispatched"
+    assert session_state["phase"] == "edit"
+    assert session_state["branch_name"] == "main"
+    assert session_state["worktree_path"] == str(repo)
+    assert session_state["target_agent"] == "claude"
 
     breaker = updated["metadata"][WORKER_TYPE_CIRCUIT_BREAKERS_KEY]["claude"]
     assert breaker["status"] == "closed"


### PR DESCRIPTION
## Summary
- persist session state when supervisor work orders become leased and when launched workers become dispatched
- sync branch, worktree, PR, lease, receipt, and review metadata into the durable session record
- add focused tests for helper-level persistence and the live dispatch transition

## Validation
- python3 -m pytest tests/swarm/test_session_state.py tests/swarm/test_supervisor.py -q -k "session_state or dispatch_workers_expires_worker_type_circuit_breaker"
- python3 -m ruff check aragora/swarm/supervisor_workers.py tests/swarm/test_session_state.py tests/swarm/test_supervisor.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5502