### PR TITLE
feat(swarm): publish timestamped benchmark truth artifacts

### DIFF
--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -27,6 +28,7 @@ from scripts.reconcile_b0_pr_truth import (  # noqa: E402
 )
 
 DEFAULT_CORPUS_PATH = REPO_ROOT / "docs" / "benchmarks" / "corpus.json"
+DEFAULT_PUBLISH_DIR = REPO_ROOT / ".aragora" / "benchmark_truth_artifacts"
 
 
 def load_corpus(path: Path) -> dict[str, Any]:
@@ -106,6 +108,51 @@ def _missing_corpus_issue_numbers(aggregates: list[IssueMetricsAggregate]) -> li
     ]
 
 
+def _coerce_utc_datetime(value: str | None = None) -> dt.datetime:
+    if value:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    else:
+        parsed = dt.datetime.now(dt.UTC)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC).replace(microsecond=0)
+
+
+def normalize_generated_at(value: str | None = None) -> str:
+    return _coerce_utc_datetime(value).isoformat().replace("+00:00", "Z")
+
+
+def _repo_stable_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
+    return slug.strip("-") or "benchmark-corpus"
+
+
+def resolve_published_artifact_path(
+    *,
+    publish_dir: Path,
+    artifact: dict[str, Any],
+) -> Path:
+    corpus = artifact.get("corpus")
+    if not isinstance(corpus, dict):
+        corpus = {}
+    generated_at = artifact.get("generated_at")
+    timestamp = _coerce_utc_datetime(
+        generated_at if isinstance(generated_at, str) else None
+    ).strftime("%Y%m%dT%H%M%SZ")
+    corpus_id = _slugify(str(corpus.get("corpus_id") or "benchmark-corpus"))
+    revision = int(corpus.get("revision", 0) or 0)
+    filename = f"truth-{timestamp}.json"
+    return publish_dir / corpus_id / f"rev-{revision}" / filename
+
+
 def build_benchmark_truth_artifact(
     *,
     repo: str,
@@ -114,6 +161,7 @@ def build_benchmark_truth_artifact(
     client: GitHubTruthClient | None = None,
     generated_at: str | None = None,
 ) -> dict[str, Any]:
+    normalized_generated_at = normalize_generated_at(generated_at)
     rows = load_metrics_rows(metrics_file)
     corpus = load_corpus(corpus_path)
     aggregates = aggregate_corpus_issues(rows, corpus)
@@ -134,11 +182,11 @@ def build_benchmark_truth_artifact(
         corpus_issue_numbers={aggregate.issue_number for aggregate in aggregates},
     )
     return {
-        "generated_at": generated_at or dt.datetime.now(dt.UTC).isoformat(),
+        "generated_at": normalized_generated_at,
         "repo": repo,
-        "metrics_file": str(metrics_file),
+        "metrics_file": _repo_stable_path(metrics_file),
         "corpus": {
-            "path": str(corpus_path),
+            "path": _repo_stable_path(corpus_path),
             "corpus_id": str(corpus.get("corpus_id") or "").strip(),
             "revision": int(corpus.get("revision", 0) or 0),
             "recorded_on": str(corpus.get("recorded_on") or "").strip(),
@@ -212,6 +260,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Exit non-zero when the artifact does not cover every corpus issue",
     )
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        help="Write a timestamped artifact under the repo-stable publish path",
+    )
+    parser.add_argument(
+        "--publish-dir",
+        type=Path,
+        default=None,
+        help=f"Optional publish root override (default: {DEFAULT_PUBLISH_DIR})",
+    )
     return parser
 
 
@@ -228,10 +287,27 @@ def main(argv: list[str] | None = None) -> int:
         metrics_file=metrics_file,
         corpus_path=corpus_path,
     )
+    publish_dir: Path | None = None
+    if args.publish_dir is not None:
+        publish_dir = args.publish_dir.resolve()
+    elif args.publish:
+        publish_dir = DEFAULT_PUBLISH_DIR
     if args.output is not None:
         output_path = write_artifact(args.output.resolve(), artifact)
         print(str(output_path))
-    if args.json or args.output is None:
+    if publish_dir is not None:
+        published_path = write_artifact(
+            resolve_published_artifact_path(
+                publish_dir=publish_dir,
+                artifact=artifact,
+            ),
+            artifact,
+        )
+        if args.json:
+            print(str(published_path), file=sys.stderr)
+        else:
+            print(str(published_path))
+    if args.json or (args.output is None and publish_dir is None):
         print(json.dumps(artifact, indent=2, sort_keys=True))
     if args.fail_incomplete and artifact.get("run_status") != "complete":
         missing_issue_numbers = list(

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -277,3 +277,176 @@ def test_write_artifact_emits_diffable_json(tmp_path: Path) -> None:
     parsed = json.loads(output.read_text(encoding="utf-8"))
     assert parsed["corpus"]["revision"] == 1
     assert parsed["primary_metrics"]["truth_success_rate"] == 1.0
+
+
+def test_build_benchmark_truth_artifact_normalizes_generated_at_and_repo_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text("", encoding="utf-8")
+    repo_root = tmp_path / "repo"
+    corpus_path = repo_root / "docs" / "benchmarks" / "corpus.json"
+    corpus_path.parent.mkdir(parents=True)
+    corpus_path.write_text(
+        json.dumps(
+            {
+                "corpus_id": "tw-01-bounded-execution-v1",
+                "revision": 7,
+                "recorded_on": "2026-04-14",
+                "success_contract": "mergeable_pr_or_merged_pr",
+                "issues": [{"issue_id": 1064, "title": "Dependency bump"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "REPO_ROOT", repo_root)
+
+    artifact = mod.build_benchmark_truth_artifact(
+        repo="synaptent/aragora",
+        metrics_file=metrics_path,
+        corpus_path=corpus_path,
+        client=FakeGitHubTruthClient(
+            issues={1064: {"title": "Dependency bump", "comments": []}},
+            prs={},
+        ),
+        generated_at="2026-04-14T02:03:04+00:00",
+    )
+
+    assert artifact["generated_at"] == "2026-04-14T02:03:04Z"
+    assert artifact["corpus"]["path"] == "docs/benchmarks/corpus.json"
+    assert artifact["metrics_file"] == str(metrics_path)
+
+
+def test_resolve_published_artifact_path_uses_corpus_revision_and_timestamp() -> None:
+    path = mod.resolve_published_artifact_path(
+        publish_dir=Path("/tmp/published"),
+        artifact={
+            "generated_at": "2026-04-14T02:03:04Z",
+            "corpus": {
+                "corpus_id": "TW-01 Bounded Execution v1",
+                "revision": 7,
+            },
+        },
+    )
+
+    assert path == Path(
+        "/tmp/published/tw-01-bounded-execution-v1/rev-7/truth-20260414T020304Z.json"
+    )
+
+
+def test_main_publish_dir_writes_timestamped_artifact_and_prints_path(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text("", encoding="utf-8")
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 8,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Dependency bump"}],
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "build_benchmark_truth_artifact",
+        lambda **_: {
+            "generated_at": "2026-04-14T05:06:07Z",
+            "corpus": {
+                "corpus_id": "tw-01-bounded-execution-v1",
+                "revision": 8,
+                "issue_count": 1,
+            },
+            "primary_metrics": {"truth_success_rate": 1.0},
+        },
+    )
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            "synaptent/aragora",
+            "--metrics-file",
+            str(metrics_path),
+            "--corpus",
+            str(corpus_path),
+            "--publish-dir",
+            str(tmp_path / "published"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    written_path = Path(captured.out.strip())
+    assert exit_code == 0
+    assert written_path == Path(
+        tmp_path
+        / "published"
+        / "tw-01-bounded-execution-v1"
+        / "rev-8"
+        / "truth-20260414T050607Z.json"
+    )
+    parsed = json.loads(written_path.read_text(encoding="utf-8"))
+    assert parsed["generated_at"] == "2026-04-14T05:06:07Z"
+    assert captured.err == ""
+
+
+def test_main_publish_dir_with_json_keeps_stdout_json_and_reports_path_on_stderr(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text("", encoding="utf-8")
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 9,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Dependency bump"}],
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "build_benchmark_truth_artifact",
+        lambda **_: {
+            "generated_at": "2026-04-14T08:09:10Z",
+            "corpus": {
+                "corpus_id": "tw-01-bounded-execution-v1",
+                "revision": 9,
+                "issue_count": 1,
+            },
+            "primary_metrics": {"truth_success_rate": 1.0},
+        },
+    )
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            "synaptent/aragora",
+            "--metrics-file",
+            str(metrics_path),
+            "--corpus",
+            str(corpus_path),
+            "--publish-dir",
+            str(tmp_path / "published"),
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["generated_at"] == "2026-04-14T08:09:10Z"
+    assert captured.err.strip() == str(
+        tmp_path
+        / "published"
+        / "tw-01-bounded-execution-v1"
+        / "rev-9"
+        / "truth-20260414T080910Z.json"
+    )


### PR DESCRIPTION
Closes #5488

## Summary
- add a repo-stable publish mode for timestamped benchmark truth artifacts
- normalize generated timestamps and repo-owned paths for diffable outputs
- cover publish-path behavior and JSON/stdout compatibility in script tests