### PR TITLE
feat(swarm): serialize dispatch followup wiring

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -4938,7 +4938,6 @@ class BossLoop:
 
         self._attach_issue_handoff_metadata(spec, issue)
 
-        # BC-02: Inject resume context from prior session state if available
         try:
             from aragora.swarm.session_state import load_resume_context_for_issue
 
@@ -4997,6 +4996,11 @@ class BossLoop:
                     }
                 )
 
+        from aragora.swarm import dispatch_followups as _dispatch_followups
+
+        spec = _dispatch_followups.maybe_upgrade_dispatch_spec(
+            issue=issue, spec=spec, sanitized_issue_body=sanitized_issue_body, repo_root=Path.cwd()
+        )
         if not spec.is_dispatch_bounded():
             return _with_sanitizer_metadata(
                 _blocked_pre_dispatch_result(
@@ -5154,6 +5158,9 @@ class BossLoop:
             error = str(result.get("error", "")).strip()
             if error:
                 logger.warning("Boss dispatch failed for issue #%d: %s", issue.number, error)
+        result = _dispatch_followups.annotate_result_with_conductor(
+            issue_number=issue.number, result=result, repo_root=Path.cwd()
+        )
         return result
 
     async def _dispatch_issue_under_claim(

--- a/aragora/swarm/dispatch_followups.py
+++ b/aragora/swarm/dispatch_followups.py
@@ -1,0 +1,96 @@
+"""Helpers for serialized boss-loop follow-up actions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from aragora.swarm.issue_scanner import infer_issue_category_from_title
+from aragora.swarm.issue_upgrader import upgrade_issue_heuristic
+from aragora.swarm.spec import SwarmSpec
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        ordered.append(text)
+    return ordered
+
+
+def maybe_upgrade_dispatch_spec(
+    *,
+    issue: Any,
+    spec: SwarmSpec,
+    sanitized_issue_body: str,
+    repo_root: Path,
+) -> SwarmSpec:
+    """Try upgrading an under-specified issue before blocking dispatch."""
+    if spec.is_dispatch_bounded():
+        return spec
+
+    category = infer_issue_category_from_title(getattr(issue, "title", None))
+    if category is None:
+        return spec
+
+    upgraded = upgrade_issue_heuristic(
+        str(getattr(issue, "title", "") or ""),
+        sanitized_issue_body,
+        repo_root=repo_root,
+        category=category,
+        acceptance_criteria=list(getattr(spec, "acceptance_criteria", []) or []),
+    )
+    if upgraded is None:
+        return spec
+
+    upgraded_spec = SwarmSpec.from_direct_goal(
+        f"[Issue #{issue.number}] {issue.title}\n\n{upgraded.upgraded_body}",
+        budget_limit_usd=spec.budget_limit_usd,
+        requires_approval=spec.requires_approval,
+        user_expertise=spec.user_expertise,
+        use_llm=False,
+    )
+    inferred_scope = SwarmSpec.infer_file_scope_hints(upgraded.upgraded_body)
+    spec.raw_goal = upgraded_spec.raw_goal
+    spec.refined_goal = upgraded_spec.refined_goal or spec.refined_goal
+    spec.constraints = _ordered_unique([*spec.constraints, *upgraded_spec.constraints])
+    spec.track_hints = _ordered_unique([*spec.track_hints, *upgraded_spec.track_hints])
+    spec.file_scope_hints = _ordered_unique(
+        [*spec.file_scope_hints, *upgraded_spec.file_scope_hints, *inferred_scope]
+    )
+    spec.estimated_complexity = upgraded_spec.estimated_complexity or spec.estimated_complexity
+    return spec
+
+
+def annotate_result_with_conductor(
+    *,
+    issue_number: int,
+    result: dict[str, Any],
+    repo_root: Path,
+) -> dict[str, Any]:
+    """Attach conductor follow-up hints to non-success dispatch results."""
+    if result.get("status") not in {"needs_human", "failed"}:
+        return result
+
+    try:
+        from aragora.swarm.conductor import Conductor
+
+        step = Conductor(repo_root=repo_root).evaluate_worker_output(issue_number, result)
+    except Exception:
+        return result
+
+    annotated = dict(result)
+    annotated.update(
+        {
+            "conductor_next_action": step.next_action,
+            "conductor_next_prompt": (step.next_prompt or "")[:500],
+            "conductor_terminal_class": step.terminal_class.value
+            if hasattr(step.terminal_class, "value")
+            else str(step.terminal_class),
+        }
+    )
+    return annotated

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3871,6 +3871,83 @@ async def test_dispatch_issue_preserves_pending_handoff_on_pre_run_failure() -> 
 
 
 @pytest.mark.asyncio
+async def test_dispatch_issue_uses_followup_upgrade_before_blocking_unbounded_spec() -> None:
+    issue = _make_issue(
+        1704,
+        "Narrow broad except in helper",
+        body="Narrow broad except usage in helper without additional scope.",
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1, require_validation_contract=False))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    def _upgrade(*, issue, spec, sanitized_issue_body, repo_root):
+        spec.file_scope_hints = ["aragora/swarm/helper.py"]
+        return spec
+
+    with (
+        patch(
+            "aragora.swarm.boss_loop.dispatch_contract_gate",
+            return_value=None,
+        ),
+        patch(
+            "aragora.swarm.dispatch_followups.maybe_upgrade_dispatch_spec",
+            side_effect=_upgrade,
+        ) as upgrade_mock,
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
+        ) as dispatch_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "completed"
+    upgrade_mock.assert_called_once()
+    dispatch_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_attaches_conductor_followup_to_failed_result() -> None:
+    issue = _make_issue(1705, "Dispatch failed")
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value={"status": "failed", "error": "boom"}),
+        ),
+        patch(
+            "aragora.swarm.dispatch_followups.annotate_result_with_conductor",
+            return_value={
+                "status": "failed",
+                "error": "boom",
+                "conductor_next_action": "retry_same",
+            },
+        ) as annotate_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["conductor_next_action"] == "retry_same"
+    annotate_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_issue_preserves_pending_handoff_on_failed_result_with_malformed_run_id() -> (
     None
 ):

--- a/tests/swarm/test_dispatch_followups.py
+++ b/tests/swarm/test_dispatch_followups.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from aragora.swarm.dispatch_followups import (
+    annotate_result_with_conductor,
+    maybe_upgrade_dispatch_spec,
+)
+from aragora.swarm.issue_upgrader import UpgradedIssue
+from aragora.swarm.spec import SwarmSpec
+
+
+def test_maybe_upgrade_dispatch_spec_uses_issue_category_for_unbounded_spec() -> None:
+    issue = SimpleNamespace(number=17, title="Narrow broad except in helper")
+    spec = SwarmSpec(
+        raw_goal="Fix the helper.",
+        refined_goal="Fix the helper.",
+        requires_approval=True,
+        user_expertise="developer",
+    )
+    upgraded = UpgradedIssue(
+        original_title=issue.title,
+        original_body="body",
+        upgraded_title=issue.title,
+        upgraded_body=(
+            "## Task\n\n"
+            "Narrow the broad exception handler in `aragora/swarm/helper.py`.\n\n"
+            "### File Scope\n"
+            "- `aragora/swarm/helper.py`\n"
+        ),
+        module_summary="Helper summary",
+        functions_found=["render_helper"],
+        loc=12,
+        imports=[],
+        complexity="simple",
+        upgrade_method="heuristic",
+    )
+
+    with patch(
+        "aragora.swarm.dispatch_followups.upgrade_issue_heuristic",
+        return_value=upgraded,
+    ) as upgrade_mock:
+        result = maybe_upgrade_dispatch_spec(
+            issue=issue,
+            spec=spec,
+            sanitized_issue_body="body",
+            repo_root=Path("/repo"),
+        )
+
+    assert result is spec
+    assert "aragora/swarm/helper.py" in result.file_scope_hints
+    upgrade_mock.assert_called_once_with(
+        issue.title,
+        "body",
+        repo_root=Path("/repo"),
+        category="broad_exception",
+        acceptance_criteria=[],
+    )
+
+
+def test_maybe_upgrade_dispatch_spec_leaves_bounded_spec_unchanged() -> None:
+    issue = SimpleNamespace(number=18, title="Add unit tests for helper")
+    spec = SwarmSpec(
+        raw_goal="Add tests for aragora/swarm/helper.py",
+        refined_goal="Add tests",
+        acceptance_criteria=["pytest tests/swarm/test_helper.py -q"],
+        file_scope_hints=["aragora/swarm/helper.py"],
+    )
+
+    with patch("aragora.swarm.dispatch_followups.upgrade_issue_heuristic") as upgrade_mock:
+        result = maybe_upgrade_dispatch_spec(
+            issue=issue,
+            spec=spec,
+            sanitized_issue_body="body",
+            repo_root=Path("/repo"),
+        )
+
+    assert result is spec
+    upgrade_mock.assert_not_called()
+
+
+def test_annotate_result_with_conductor_augments_non_success_result() -> None:
+    result = {"status": "needs_human", "reasons": ["boom"]}
+    step = SimpleNamespace(
+        next_action="retry_same",
+        next_prompt="retry prompt",
+        terminal_class=SimpleNamespace(value="worker_timeout"),
+    )
+
+    with patch("aragora.swarm.conductor.Conductor") as conductor_cls:
+        conductor_cls.return_value.evaluate_worker_output.return_value = step
+        annotated = annotate_result_with_conductor(
+            issue_number=22,
+            result=result,
+            repo_root=Path("/repo"),
+        )
+
+    assert annotated["conductor_next_action"] == "retry_same"
+    assert annotated["conductor_next_prompt"] == "retry prompt"
+    assert annotated["conductor_terminal_class"] == "worker_timeout"
+
+
+def test_annotate_result_with_conductor_ignores_completed_result() -> None:
+    result = {"status": "completed"}
+    assert (
+        annotate_result_with_conductor(
+            issue_number=23,
+            result=result,
+            repo_root=Path("/repo"),
+        )
+        is result
+    )


### PR DESCRIPTION
## Summary
- add a small helper module to keep the serialized follow-up wiring out of `boss_loop.py`
- upgrade under-specified dispatch specs before blocking by inferring the issue category from the title
- attach conductor follow-up hints to failed or needs-human dispatch results

## Validation
- pytest tests/swarm/test_dispatch_followups.py tests/swarm/test_boss_loop.py -q -k 'dispatch_followup or uses_followup_upgrade or attaches_conductor_followup'
- ruff check aragora/swarm/dispatch_followups.py aragora/swarm/boss_loop.py tests/swarm/test_dispatch_followups.py tests/swarm/test_boss_loop.py
- python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/swarm/dispatch_followups.py aragora/swarm/boss_loop.py
- python3 scripts/report_code_quality.py --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
- supersedes the closed parallel follow-up lanes #5500 and #5504 after #5499 merged
- keeps `aragora/swarm/boss_loop.py` under the 5400 LOC ratchet
