### PR TITLE
fix(swarm): persist blocker evidence on failed lanes

### DIFF
--- a/aragora/swarm/supervisor_probes.py
+++ b/aragora/swarm/supervisor_probes.py
@@ -22,6 +22,7 @@ _path_in_scope = _supervisor._path_in_scope
 
 _REPAIR_JOURNAL_MAX_ENTRIES = 3
 _REPAIR_JOURNAL_TAIL_CHARS = 800
+_BLOCKER_EVIDENCE_MAX_CHARS = 240
 _BEST_EFFORT_STORE_EXCEPTIONS = (
     AttributeError,
     KeyError,
@@ -48,6 +49,13 @@ def _tail_text(text: str, *, max_chars: int = _REPAIR_JOURNAL_TAIL_CHARS) -> str
     return text[-max_chars:]
 
 
+def _compact_blocker_evidence(text: Any, *, max_chars: int = _BLOCKER_EVIDENCE_MAX_CHARS) -> str:
+    compact = " ".join(str(text or "").split())
+    if len(compact) <= max_chars:
+        return compact
+    return compact[: max_chars - 3].rstrip() + "..."
+
+
 def _summarize_verification_failure(verification_results: list[dict[str, Any]]) -> dict[str, Any]:
     for entry in verification_results:
         if not isinstance(entry, dict):
@@ -61,6 +69,86 @@ def _summarize_verification_failure(verification_results: list[dict[str, Any]]) 
                 "stderr_tail": _tail_text(str(entry.get("stderr", ""))),
             }
     return {}
+
+
+def _verification_blocker_evidence(summary: dict[str, Any]) -> str:
+    if not summary:
+        return ""
+    evidence = _compact_blocker_evidence(
+        str(summary.get("stderr_tail") or summary.get("stdout_tail") or "")
+    )
+    if not evidence:
+        return ""
+    command = str(summary.get("command", "")).strip()
+    exit_code = summary.get("exit_code")
+    if command and exit_code not in (None, ""):
+        return _compact_blocker_evidence(f"{command} (exit {exit_code}): {evidence}")
+    if command:
+        return _compact_blocker_evidence(f"{command}: {evidence}")
+    return evidence
+
+
+def _derive_blocker_evidence(
+    item: dict[str, Any],
+    *,
+    result: WorkerProcess | None = None,
+    merge_gate: dict[str, Any] | None = None,
+    reason: str | None = None,
+) -> str:
+    metadata = dict(item.get("metadata") or {})
+    existing = _compact_blocker_evidence(
+        item.get("blocker_evidence") or metadata.get("blocker_evidence")
+    )
+    if existing:
+        return existing
+
+    failing = _summarize_verification_failure(item.get("verification_results", []) or [])
+    verification_evidence = _verification_blocker_evidence(failing)
+    if verification_evidence:
+        return verification_evidence
+
+    if isinstance(merge_gate, dict):
+        blocked_reasons = [
+            _compact_blocker_evidence(reason_text)
+            for reason_text in merge_gate.get("blocked_reasons", [])
+            if _compact_blocker_evidence(reason_text)
+        ]
+        if blocked_reasons:
+            return blocked_reasons[0]
+
+    for candidate in (
+        item.get("stderr_tail"),
+        result.stderr if result is not None else "",
+        item.get("stdout_tail"),
+        result.stdout if result is not None else "",
+        item.get("dispatch_error"),
+        item.get("resource_error"),
+        reason,
+        item.get("failure_reason"),
+    ):
+        compact = _compact_blocker_evidence(candidate)
+        if compact:
+            return compact
+
+    return "needs_human"
+
+
+def _persist_blocker_evidence(item: dict[str, Any], evidence: str | None) -> None:
+    compact = _compact_blocker_evidence(evidence)
+    if not compact:
+        return
+    metadata = dict(item.get("metadata") or {})
+    metadata["blocker_evidence"] = compact
+    item["metadata"] = metadata
+    item["blocker_evidence"] = compact
+
+
+def _clear_blocker_evidence(item: dict[str, Any]) -> None:
+    item.pop("blocker_evidence", None)
+    metadata = dict(item.get("metadata") or {})
+    if "blocker_evidence" in metadata:
+        metadata.pop("blocker_evidence", None)
+        item["metadata"] = metadata
 
 
 def _append_repair_journal(
@@ -78,6 +166,7 @@ def _append_repair_journal(
 
     verification_results = item.get("verification_results", []) or []
     failing = _summarize_verification_failure(verification_results)
+    blocker_evidence = _derive_blocker_evidence(item, result=result, reason=reason)
     entry = {
         "at": datetime.now(UTC).isoformat(),
         "agent": str(item.get("target_agent", result.agent)).strip() or result.agent,
@@ -88,12 +177,14 @@ def _append_repair_journal(
         "commit_shas": list(result.commit_shas or [])[:5],
         "tests_run": list(item.get("tests_run", []) or [])[:3],
         "failing_verification": failing or None,
+        "blocker_evidence": blocker_evidence or None,
         "stdout_tail": _tail_text(result.stdout or ""),
         "stderr_tail": _tail_text(result.stderr or ""),
     }
     entries.append(entry)
     metadata["repair_journal"] = entries[-_REPAIR_JOURNAL_MAX_ENTRIES:]
     item["metadata"] = metadata
+    _persist_blocker_evidence(item, blocker_evidence)
     try:
         self.store.record_worker_repair_journal(
             task_id=str(item.get("work_order_id", "")).strip(),
@@ -331,6 +422,7 @@ def _finalize_completed_work_order_result(
             for key in ("resource_error", "conflicts", "scope_violation"):
                 item.pop(key, None)
             item.pop("blockers", None)
+            _persist_blocker_evidence(item, _derive_blocker_evidence(item, merge_gate=merge_gate))
             self._mark_needs_human(
                 item,
                 self._merge_gate_failure_reason(merge_gate),
@@ -434,6 +526,7 @@ def _finalize_completed_work_order_result(
     self._register_pr_if_present(item, result)
     item["status"] = "completed"
     item["review_status"] = "pending_heterogeneous_review"
+    _clear_blocker_evidence(item)
     for key in (
         "dispatch_error",
         "resource_error",
@@ -657,6 +750,7 @@ def _apply_worker_result(
         # receipt for the current salvaged deliverable.
         item["status"] = "completed"
         item["review_status"] = "pending_heterogeneous_review"
+        _clear_blocker_evidence(item)
         for key in (
             "dispatch_error",
             "resource_error",

--- a/aragora/swarm/supervisor_workers.py
+++ b/aragora/swarm/supervisor_workers.py
@@ -142,6 +142,21 @@ def _record_session_state(
         logger.debug("Session state update skipped", exc_info=True)
 
 
+def _persist_terminal_blocker_evidence(item: dict[str, Any]) -> str | None:
+    try:
+        from aragora.swarm.supervisor_probes import (
+            _derive_blocker_evidence,
+            _persist_blocker_evidence,
+        )
+
+        evidence = _derive_blocker_evidence(item)
+        _persist_blocker_evidence(item, evidence)
+        return evidence or None
+    except Exception:
+        logger.debug("Blocker evidence persistence skipped", exc_info=True)
+        return None
+
+
 def _enrich_chain_wave_summary(
     metadata: dict[str, Any],
     work_orders: list[dict[str, Any]],
@@ -330,6 +345,7 @@ def refresh_run(self, run_id: str) -> SupervisorRun:
                         str(exc),
                         failure_reason="work_order_leasing_failed",
                     )
+                    _persist_terminal_blocker_evidence(item)
                     continue
 
     derived_status = self._derive_status(work_orders)
@@ -1359,6 +1375,7 @@ def _lease_work_order(
             "Work order has no declared file scope; declare scope before dispatch.",
             failure_reason="scope_violation",
         )
+        _persist_terminal_blocker_evidence(work_order)
         return False
     session = self.lifecycle.ensure_managed_worktree(
         managed_dir=managed_dir,
@@ -1378,6 +1395,7 @@ def _lease_work_order(
             "Declared file scope resolved to no valid in-repo paths; declare scope before dispatch.",
             failure_reason="scope_violation",
         )
+        _persist_terminal_blocker_evidence(work_order)
         return False
     dependency_base = self._dependency_base_reference(work_order, work_orders)
     if dependency_base is not None:
@@ -1442,19 +1460,23 @@ def _lease_work_order(
 
 
 def _release_terminal_lease(self, item: dict[str, Any]) -> None:
-    lease_id = str(item.get("lease_id", "")).strip()
-    if not lease_id:
-        return
-
     # BC-01: Record terminal session state
     wo_status = str(item.get("status", "")).strip().lower()
     terminal_status = "completed" if wo_status in {"completed", "merged"} else "failed"
+    blocker_evidence = None
+    if terminal_status == "failed" or wo_status == "needs_human":
+        blocker_evidence = _persist_terminal_blocker_evidence(item)
     _record_session_state(
         item,
         status=terminal_status,
         phase="terminal",
         worker_outcome=str(item.get("worker_outcome", "")).strip() or None,
+        blocker_evidence=blocker_evidence,
     )
+
+    lease_id = str(item.get("lease_id", "")).strip()
+    if not lease_id:
+        return
 
     try:
         self.store.release_lease(lease_id, status=LeaseStatus.RELEASED)
@@ -1684,6 +1706,7 @@ def _requeue_with_fallback(
         "failure_reason",
         "blocking_question",
         "blocker",
+        "blocker_evidence",
         "resource_error",
         "worker_outcome",
         "confidence",
@@ -1704,6 +1727,10 @@ def _requeue_with_fallback(
         "scope_violation",
     ):
         item.pop(key, None)
+    metadata = dict(item.get("metadata") or {})
+    if "blocker_evidence" in metadata:
+        metadata.pop("blocker_evidence", None)
+        item["metadata"] = metadata
     return True
 
 
@@ -1999,6 +2026,7 @@ def _mark_worker_type_blocked(
         f"worker dispatch blocked: {detail}",
         failure_reason="worker_type_blocked",
     )
+    _persist_terminal_blocker_evidence(item)
     self._release_terminal_lease(item)
     item.pop("lease_id", None)
     item.pop("owner_session_id", None)
@@ -2039,6 +2067,7 @@ def _mark_dispatch_failed(item: dict[str, Any], reason: str) -> None:
         "failure_reason",
         "blocking_question",
         "blocker",
+        "blocker_evidence",
         "last_observed_at",
         "last_progress_at",
         "first_output_at",
@@ -2048,6 +2077,10 @@ def _mark_dispatch_failed(item: dict[str, Any], reason: str) -> None:
     ):
         item.pop(key, None)
     item.pop("blockers", None)
+    metadata = dict(item.get("metadata") or {})
+    if "blocker_evidence" in metadata:
+        metadata.pop("blocker_evidence", None)
+        item["metadata"] = metadata
 
 
 def _clear_stale_prelaunch_deliverable_state(item: dict[str, Any]) -> None:
@@ -2058,6 +2091,7 @@ def _clear_stale_prelaunch_deliverable_state(item: dict[str, Any]) -> None:
         "failure_reason",
         "blocking_question",
         "blocker",
+        "blocker_evidence",
         "conflicts",
         "receipt_id",
         "confidence",
@@ -2081,6 +2115,10 @@ def _clear_stale_prelaunch_deliverable_state(item: dict[str, Any]) -> None:
     ):
         item.pop(key, None)
     item.pop("blockers", None)
+    metadata = dict(item.get("metadata") or {})
+    if "blocker_evidence" in metadata:
+        metadata.pop("blocker_evidence", None)
+        item["metadata"] = metadata
 
 
 def _clear_stale_runtime_deliverable_state(item: dict[str, Any]) -> None:
@@ -2105,9 +2143,14 @@ def _clear_stale_runtime_deliverable_state(item: dict[str, Any]) -> None:
         "resource_error",
         "conflicts",
         "blockers",
+        "blocker_evidence",
         "scope_violation",
     ):
         item.pop(key, None)
+    metadata = dict(item.get("metadata") or {})
+    if "blocker_evidence" in metadata:
+        metadata.pop("blocker_evidence", None)
+        item["metadata"] = metadata
 
 
 def _release_orphaned_conflict_leases(self, conflicts: list[dict[str, Any]]) -> int:

--- a/tests/swarm/test_reporter.py
+++ b/tests/swarm/test_reporter.py
@@ -2466,6 +2466,49 @@ Result: timed out after 30s
         assert needs_human["blocker_evidence"] == "pytest timed out in tests/swarm/test_reporter.py"
         assert needs_human["next_action"] == "Fix verification failure before rerunning the lane."
 
+    def test_build_boss_payload_prefers_persisted_top_level_blocker_evidence(self) -> None:
+        payload = build_boss_payload(
+            run={
+                "run_id": "run-1b",
+                "status": "needs_human",
+                "goal": "Repair failing lane",
+                "target_branch": "main",
+                "work_orders": [
+                    {
+                        "work_order_id": "wo-1b",
+                        "title": "Repair failing lane",
+                        "status": "needs_human",
+                        "failure_reason": "worker_no_progress_timeout",
+                        "blocker_evidence": "stalled warning",
+                        "metadata": {
+                            "repair_journal": [
+                                {
+                                    "failure_reason": "worker_no_progress_timeout",
+                                    "exit_code": -1,
+                                    "stderr_tail": "older stderr tail",
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+            integrator_view={
+                "lanes": [
+                    {
+                        "work_order_id": "wo-1b",
+                        "title": "Repair failing lane",
+                        "status": "needs_human",
+                        "blockers": ["worker_no_progress_timeout"],
+                        "failure_classes": ["worker_no_progress_timeout"],
+                    }
+                ]
+            },
+        )
+
+        lane = payload["lanes"][0]
+        assert lane["blocker_evidence"] == "stalled warning"
+        assert payload["needs_human"][0]["blocker_evidence"] == "stalled warning"
+
     def test_render_boss_text_includes_needs_human_blocker_evidence(self) -> None:
         payload = build_boss_payload(
             run={

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -4559,6 +4559,14 @@ async def test_collect_results_blocks_merge_gate_without_verification_plan(
     assert wo["failure_reason"] == "missing_verification_plan"
     assert "verification command" in wo["blocking_question"]
     assert "missing verification plan" in wo["dispatch_error"]
+    assert (
+        wo["blocker_evidence"]
+        == "merge gate blocked: missing verification plan or verification command"
+    )
+    assert (
+        wo["metadata"]["blocker_evidence"]
+        == "merge gate blocked: missing verification plan or verification command"
+    )
 
 
 @pytest.mark.asyncio
@@ -7442,6 +7450,11 @@ async def test_collect_finished_results_marks_no_progress_timeout_needs_human(
     assert "stalled lane" in work_order["blocking_question"]
     assert work_order["worker_outcome"] == "timeout_no_progress"
     assert work_order["blockers"] == [work_order["dispatch_error"]]
+    assert work_order["blocker_evidence"] in {"stalled warning", work_order["dispatch_error"]}
+    assert work_order["metadata"]["blocker_evidence"] in {
+        "stalled warning",
+        work_order["dispatch_error"],
+    }
     for key in (
         "receipt_id",
         "confidence",


### PR DESCRIPTION
Closes #5501

Supersedes #5509.

## Summary
- persist a normalized blocker_evidence field on failed and needs_human supervisor lanes
- thread blocker evidence into terminal session-state updates while clearing stale evidence on retry or completion
- cover persisted blocker evidence in supervisor and reporter tests