### PR TITLE
feat(swarm): use contract receipts for dispatch admission

### DIFF
--- a/aragora/swarm/dispatch_contract_gate.py
+++ b/aragora/swarm/dispatch_contract_gate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -11,11 +12,10 @@ from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.env_utils import git_safe_env
 from aragora.swarm.preflight import (
     PreflightReceipt,
-    run_remote_publish_validation_receipt,
-    run_scratch_validation_receipt,
+    run_contract_preflight_receipt,
 )
 from aragora.swarm.terminal_truth import TerminalClass, classify_preflight_failure
-from aragora.swarm.worker_contract import build_worker_contract
+from aragora.swarm.worker_contract import WorkerContract, build_worker_contract
 from aragora.swarm.worker_process import LaunchConfig
 
 
@@ -216,6 +216,30 @@ def _required_preflight_receipts(loop: Any) -> list[str]:
     return required
 
 
+def _persist_preview_contract(
+    *,
+    repo_root: Path,
+    issue_number: int,
+    contract: WorkerContract,
+) -> Path:
+    checksum = contract.checksum()
+    contract_dir = repo_root / ".aragora" / "dispatch_contracts"
+    contract_dir.mkdir(parents=True, exist_ok=True)
+    contract_path = contract_dir / f"issue-{issue_number}-{checksum[:12]}.json"
+    contract_path.write_text(
+        json.dumps(
+            {
+                "worker_contract": contract.to_dict(),
+                "worker_contract_checksum": checksum,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return contract_path
+
+
 def _preflight_receipt_summary(receipt: PreflightReceipt) -> dict[str, Any]:
     terminal_class = receipt.failure_terminal_class
     return {
@@ -305,22 +329,28 @@ def _run_dispatch_preflight_receipts(
     *,
     repo_root: Path,
     envelope: CredentialEnvelope,
-    preview_env: Mapping[str, str],
+    target_agent: str,
+    contract_path: Path,
 ) -> list[PreflightReceipt]:
     receipts = [
-        run_scratch_validation_receipt(
+        run_contract_preflight_receipt(
             repo_root=repo_root,
+            agent=target_agent,
+            base_ref=str(loop.config.target_branch or "main"),
+            skip_publication=True,
+            contract_path=contract_path,
             envelope=envelope,
-            env=preview_env,
         )
     ]
     if bool(loop.config.auto_publish_deliverables):
         receipts.append(
-            run_remote_publish_validation_receipt(
+            run_contract_preflight_receipt(
                 repo_root=repo_root,
-                envelope=envelope,
+                agent=target_agent,
                 base_ref=str(loop.config.target_branch or "main"),
-                env=preview_env,
+                skip_publication=False,
+                contract_path=contract_path,
+                envelope=envelope,
             )
         )
     return receipts
@@ -359,6 +389,7 @@ def dispatch_contract_gate(
         allow_codex_full_auto=loop.config.allow_codex_full_auto,
     )
     contract_valid = True
+    preview_contract: WorkerContract | None = None
     for work_order in _preview_work_orders(spec):
         try:
             contract = build_worker_contract(
@@ -372,6 +403,8 @@ def dispatch_contract_gate(
             if not contract.admission_check():
                 contract_valid = False
                 break
+            if preview_contract is None:
+                preview_contract = contract
         except ValueError:
             contract_valid = False
             break
@@ -379,11 +412,19 @@ def dispatch_contract_gate(
     if contract_valid and not missing_slices:
         required_receipts = _required_preflight_receipts(loop)
         try:
+            if preview_contract is None:
+                raise RuntimeError("dispatch preview contract missing")
+            contract_path = _persist_preview_contract(
+                repo_root=Path.cwd(),
+                issue_number=issue.number,
+                contract=preview_contract,
+            )
             receipt_payloads = _run_dispatch_preflight_receipts(
                 loop,
                 repo_root=Path.cwd(),
                 envelope=envelope,
-                preview_env=preview_env,
+                target_agent=target_agent,
+                contract_path=contract_path,
             )
         except Exception as exc:  # noqa: BLE001 - fail closed on receipt routing issues
             detail = str(exc or "").strip() or "preflight receipt generation failed"

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3514,9 +3514,13 @@ async def test_dispatch_issue_contract_gate_allows_complete_cli_dispatch() -> No
             ),
         ),
         patch(
-            "aragora.swarm.dispatch_contract_gate.run_scratch_validation_receipt",
+            "aragora.swarm.dispatch_contract_gate._persist_preview_contract",
+            return_value=Path("/tmp/issue-2464-contract.json"),
+        ),
+        patch(
+            "aragora.swarm.dispatch_contract_gate.run_contract_preflight_receipt",
             return_value=_preflight_receipt(),
-        ) as scratch_receipt,
+        ) as contract_receipt,
         patch(
             "aragora.swarm.boss_loop.dispatch_bounded_spec",
             new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
@@ -3525,7 +3529,8 @@ async def test_dispatch_issue_contract_gate_allows_complete_cli_dispatch() -> No
         result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
 
     assert result["status"] == "completed"
-    scratch_receipt.assert_called_once()
+    contract_receipt.assert_called_once()
+    assert contract_receipt.call_args.kwargs["skip_publication"] is True
     dispatch_mock.assert_awaited_once()
 
 
@@ -3616,9 +3621,13 @@ async def test_dispatch_issue_contract_gate_blocks_failed_scratch_preflight_rece
             ),
         ),
         patch(
-            "aragora.swarm.dispatch_contract_gate.run_scratch_validation_receipt",
+            "aragora.swarm.dispatch_contract_gate._persist_preview_contract",
+            return_value=Path("/tmp/issue-2467-contract.json"),
+        ),
+        patch(
+            "aragora.swarm.dispatch_contract_gate.run_contract_preflight_receipt",
             return_value=failed_receipt,
-        ) as scratch_receipt,
+        ) as contract_receipt,
         patch(
             "aragora.swarm.boss_loop.dispatch_bounded_spec",
             new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
@@ -3633,7 +3642,7 @@ async def test_dispatch_issue_contract_gate_blocks_failed_scratch_preflight_rece
     assert result["dispatch_contract"]["preflight_receipts"][0]["failure_terminal_class"] == (
         "blocked_not_dispatch_bounded"
     )
-    scratch_receipt.assert_called_once()
+    contract_receipt.assert_called_once()
     dispatch_mock.assert_not_awaited()
 
 
@@ -3725,13 +3734,13 @@ async def test_dispatch_issue_contract_gate_blocks_failed_remote_publish_receipt
             ),
         ),
         patch(
-            "aragora.swarm.dispatch_contract_gate.run_scratch_validation_receipt",
-            return_value=_preflight_receipt(),
-        ) as scratch_receipt,
+            "aragora.swarm.dispatch_contract_gate._persist_preview_contract",
+            return_value=Path("/tmp/issue-2468-contract.json"),
+        ),
         patch(
-            "aragora.swarm.dispatch_contract_gate.run_remote_publish_validation_receipt",
-            return_value=remote_failure,
-        ) as remote_receipt,
+            "aragora.swarm.dispatch_contract_gate.run_contract_preflight_receipt",
+            side_effect=[_preflight_receipt(), remote_failure],
+        ) as contract_receipt,
         patch(
             "aragora.swarm.boss_loop.dispatch_bounded_spec",
             new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
@@ -3746,8 +3755,11 @@ async def test_dispatch_issue_contract_gate_blocks_failed_remote_publish_receipt
     assert result["dispatch_contract"]["preflight_receipts"][1]["failure_terminal_class"] == (
         "blocked_auth_failure"
     )
-    scratch_receipt.assert_called_once()
-    remote_receipt.assert_called_once()
+    assert contract_receipt.call_count == 2
+    assert [call.kwargs["skip_publication"] for call in contract_receipt.call_args_list] == [
+        True,
+        False,
+    ]
     dispatch_mock.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary
- route live dispatch admission through `run_contract_preflight_receipt()` instead of the environment-only receipt shortcut
- persist the preview worker contract under `.aragora/dispatch_contracts` so dispatch preflight and operator truth use the same contract-backed evidence path
- update boss-loop tests to assert the contract-backed receipt path for scratch and remote publish checks

## Validation
- pytest tests/swarm/test_boss_loop.py tests/swarm/test_preflight.py -q -k 'contract_gate or contract_preflight_receipt'
- ruff check aragora/swarm/dispatch_contract_gate.py tests/swarm/test_boss_loop.py
- python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/swarm/dispatch_contract_gate.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Roadmap
- RS-07: make receipt-backed contract preflight the default admission truth on the live dispatch path
