### PR TITLE
feat(swarm): report rescue productization status

### DIFF
--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -5,7 +5,7 @@ description: Active Execution Issues
 
 # Active Execution Issues
 
-Last updated: 2026-04-12
+Last updated: 2026-04-13
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -41,27 +41,40 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
+Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining gate is production guard proof, not inflating the benchmark story.
+
+## Current 30-Day Execution Set
+
+Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
+
+- Do now: `RS-07`, `BC-01`, `BC-03`, `BC-02`, `TW-01`, `TW-02`, `TW-03`, `CS-01..03`
+- Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
+- Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
+- Top 3 boss-ready next: `RS-07`, `BC-01`, `BC-03`
+- GitHub coverage for those top 3 remains epic-level only through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issues exist yet
+
 ## Epic 1 — Reliability Substrate
 
 **Outcome:** make bounded unattended execution trustworthy on real multi-host backlogs.
 
 ### Milestone 1.1 — Failure Taxonomy & Benchmark Corpus `[30d]`
 
-- [x] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures
-- [x] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts
-- [x] **RS-03** Add a benchmark scoring lane and regression guardrails in CI
+- [x] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures _(Done 2026-04-10)_
+- [x] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts _(Done 2026-04-10)_
+- [x] **RS-03** Add a benchmark scoring lane and regression guardrails in CI _(Done 2026-04-11)_
 
 ### Milestone 1.2 — Worker Contracts & Credential Envelopes `[30-90d]`
 
-- [x] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules
-- [x] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth
-- [ ] **RS-06** Require launcher, supervisor, and tranche queue to dispatch only from complete contracts
+- [x] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules _(Done 2026-04-11)_
+- [x] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth _(Done 2026-04-12)_
+- [x] **RS-06** Require launcher, supervisor, and tranche queue to dispatch only from complete contracts _(Done 2026-04-13)_
 
 ### Milestone 1.3 — Contract-Aware Preflight `[30-90d]`
 
-- [ ] **RS-07** Build `aragora swarm preflight run --contract ...`
-- [ ] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path
-- [ ] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers
+- [ ] **RS-07** Build `aragora swarm preflight run --contract ...` _(In progress as of 2026-04-13: the operator surface now has a contract-backed receipt path with persisted `PreflightReceipt` output and fail-closed admission verdicts; remaining follow-through is to make that receipt the default admission truth everywhere that consumes preflight.)_
+- [x] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
+- [x] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
 
 ### Milestone 1.4 — Ledger & Self-Heal `[90d]`
 
@@ -76,14 +89,14 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 ### Milestone 2.1 — Interactive Sessions & Repair Journal `[90d]`
 
 - [ ] **BC-01** Persist session state across `explore -> plan -> edit -> verify -> repair -> publish`
-- [ ] **BC-02** Resume retries from prior session state instead of fresh prompts
+- [x] **BC-02** Resume retries from prior session state instead of fresh prompts _(Done 2026-04-13 via [#5384](https://github.com/synaptent/aragora/pull/5384))_
 - [ ] **BC-03** Emit precise blocker evidence and repair transcripts for failed runs
 
 ### Milestone 2.2 — Task Sanitizer & Admission Gate `[30-90d]`
 
-- [x] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined
-- [x] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch
-- [ ] **BC-06** Preserve original versus sanitized task text for audit
+- [x] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined _(Done 2026-04-12)_
+- [x] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch _(Done 2026-04-13)_
+- [x] **BC-06** Preserve original versus sanitized task text for audit _(Done 2026-04-13 via [#5113](https://github.com/synaptent/aragora/pull/5113), [#5190](https://github.com/synaptent/aragora/pull/5190), and [#5305](https://github.com/synaptent/aragora/pull/5305))_
 
 ### Milestone 2.3 — Truthful Lane / Integrator State `[90d]`
 
@@ -103,8 +116,8 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 
 ### Milestone 3.1 — Autonomous Software Execution Benchmark `[30d]`
 
-- [ ] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues
-- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate
+- [ ] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Partial as of 2026-04-13: the frozen corpus manifest is checked in at `docs/benchmarks/corpus.json`; the remaining gap is recurring execution against that fixed revision.)_
+- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Partial as of 2026-04-13: diffable truth-artifact generation exists, including truth/no-rescue/failure-class/rescue-type reporting; the remaining gap is recurring publication and status linkage.)_
 - [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -26,6 +26,23 @@ repo — editing files in the main directory causes concurrent overwrites.
 3. **Background cleanup** — A LaunchAgent runs every 5 minutes, reconciling worktrees with main
    (merge strategy) and cleaning up stale ones after 24h. Branches are auto-deleted after merge.
 
+### Worktree cleanup (IMPORTANT)
+
+**NEVER** use raw `find .worktrees -exec rm -rf` or similar ad-hoc deletion.
+This destroys active worktrees with uncommitted work. Always use the safe helpers:
+
+```bash
+# Safe cleanup (preferred) — respects TTL, checks merge status
+python3 scripts/codex_worktree_autopilot.py cleanup --base main --ttl-hours 24
+
+# Per-worktree safe removal — checks for blockers first
+python3 scripts/safe_worktree_cleanup.py inspect <worktree-path>
+python3 scripts/safe_worktree_cleanup.py remove <worktree-path>
+
+# Minimal safe option — only prunes already-deleted directories
+git worktree prune --expire=now
+```
+
 ### Manual worktree commands
 
 - `./scripts/codex_session.sh` — Legacy session bootstrap (creates worktree + metadata)
@@ -172,7 +189,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,000+ Python modules | 153,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 3,000+ Python modules | 154,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
 
 ## Architecture
 
@@ -420,7 +437,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-**Test Suite:** 153,000+ tests across 5,000+ test files
+**Test Suite:** 154,000+ tests across 5,000+ test files
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -341,7 +341,7 @@ aragora/
 └── cli/              # Command-line interface
 ```
 
-**Scale:** 3,000+ Python modules | 153,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
+**Scale:** 3,000+ Python modules | 154,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
 
 ---
 

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -5,7 +5,7 @@ description: Next Steps (Canonical)
 
 # Next Steps (Canonical)
 
-Last updated: 2026-04-12
+Last updated: 2026-04-13
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
@@ -15,7 +15,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is the transition from early `Teammate` behavior to reliable `Foreman` behavior across the current execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to finish `RS-07`, close the remaining truthful repair gaps in `BC-01/03`, and keep `TW-01/TW-02` publishing recurring truth artifacts before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -24,19 +24,30 @@ What is already true:
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
 - terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
+- the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
-- launcher-side contract admission and module-level contract-aware preflight are on `main`
+- launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
+- scratch and remote-publish preflight validation now run through the production preflight path and emit canonical terminal truth on `main`
 - task sanitizer outcomes and success-rate filtering are shaping safer boss-loop intake
+- original versus sanitized task text is already preserved for audit on `main`
+- retry dispatch now carries prior session resume context on `main` via [#5384](https://github.com/synaptent/aragora/pull/5384)
+- the rescue loop can now record interventions, plan bounded recovery, and execute safe followups on `main` via [#5379](https://github.com/synaptent/aragora/pull/5379), [#5380](https://github.com/synaptent/aragora/pull/5380), and [#5383](https://github.com/synaptent/aragora/pull/5383)
 
 What is still missing:
 
-- honest benchmarked proof of semi-autonomous success
-- contract-backed worker admission across launcher, supervisor, and tranche queue on the safest classes of work
-- top-level production-equivalent preflight on those classes
-- broader repair-loop coverage and persisted original-versus-sanitized task audit
+- the last `RS-07` step is to make receipt-backed contract preflight the default operator admission truth everywhere, not just a substrate primitive — contract in, persisted receipt out, fail-closed on any mismatch ([#5327](https://github.com/synaptent/aragora/issues/5327))
+- broader repair truth on the live swarm loop still depends on full `BC-01` persistence and precise `BC-03` blocker evidence
+- recurring scheduled use of the frozen corpus and diffable truth artifact still needs to become routine status output ([#5329](https://github.com/synaptent/aragora/issues/5329))
+- proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
+- broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”
+
+Queue rule for this tranche:
+
+- only roadmap codes in the **Do now** set may carry or be auto-created with `boss-ready`
+- delayed-track issues may stay open for planning truth, but restock and auto-decomposition should strip them from the live dispatch queue
 
 ## 30-Day Success Metric
 
@@ -47,13 +58,114 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
+Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; truthful guard completion is.
+
+Primary truth metric:
+
+- issue-level truth success remains `mergeable_pr OR merged_pr`
+- merged-only rate is a secondary truth metric, not the primary gate
+- PR-signal counts and iteration counts are proxies only
+
 If a task does not improve that metric, it is not first-tranche work.
+
+## TW-01/TW-02: Benchmark Corpus and No-Rescue Scorecard ([#5329](https://github.com/synaptent/aragora/issues/5329))
+
+`TW-01` (fixed benchmark corpus) and `TW-02` (no-rescue scorecard) are the measurement backbone for the execution wedge. Without them, progress claims are anecdotal.
+
+### Benchmark corpus requirements (TW-01)
+
+- The corpus is a fixed, versioned list of bounded issues checked into the repo (e.g. `docs/benchmarks/corpus.json`).
+- Issues in the corpus are not swapped ad hoc between runs; additions and removals are tracked as explicit corpus revisions.
+- Each corpus entry includes: issue identifier, expected execution class, and any known constraints.
+- The corpus runs against current `main` on a recurring basis (at minimum weekly) using the existing benchmark scoring lane.
+- Corpus membership criteria: issues must be bounded (clear scope, single-PR resolution, no external dependency chain).
+
+### No-rescue scorecard requirements (TW-02)
+
+The recurring scorecard records the following per corpus run:
+
+| Metric | Definition | Primary or proxy |
+|--------|-----------|-----------------|
+| Truth success rate | `mergeable_pr OR merged_pr` per issue | **primary** |
+| No-rescue success rate | Truth successes with zero human intervention | **primary** |
+| Verification pass rate | Fraction of runs where `verify` stage passes without repair | secondary |
+| Failure-class distribution | Count of failures per canonical terminal-truth class | secondary |
+| Merged-only rate | Fraction where the PR is actually merged (not just mergeable) | secondary |
+| Rescue count | Number of runs requiring human intervention, broken out by rescue type | secondary |
+
+Scorecard output rules:
+
+- Each run produces a timestamped scorecard artifact that is diffable against prior runs for week-over-week comparison.
+- Human rescue is distinguished from autonomous completion at the issue level — a rescued issue is never counted as no-rescue success.
+- Proxy metrics (PR count, iteration count, token spend) are reported separately and never mixed with truth metrics.
+- The scorecard links back to the corpus revision it was run against.
+
+### Current state
+
+- Terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are on `main`.
+- The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
+- The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
+- The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
+- What remains is recurring scheduled use of that artifact path, not inventing a second benchmark definition.
+
+## 30-Day Canonical Backlog
+
+This is the executable backlog for the next 30 days. Keep it to one bounded lane at a time for a founder budget of 5-10 hours per week.
+
+| Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
+|---|---|---|---|---|---|---|
+| 1 | `RS-07` | Preflight only deserves trust when it returns a receipt the supervisor can verify, not just a shell exit code. The gap is the admission path: contract in, receipt out, fail-closed on any mismatch. | `aragora swarm preflight run --contract ...` accepts a `WorkerContract`, runs production-equivalent git/auth/env checks, and returns a signed `PreflightReceipt` with pass/fail plus canonical terminal class on failure. Supervisor rejects admission when the receipt is absent or failed. | At least one guarded admission path is live through the operator surface with receipt-backed success and failure. Failures map to canonical terminal truth classes. | substrate | [#5327](https://github.com/synaptent/aragora/issues/5327); covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#805](https://github.com/synaptent/aragora/issues/805). |
+| 2 | `BC-01` | Session persistence is the prerequisite for truthful repair, retry, and operator control. | Session state survives `explore -> plan -> edit -> verify -> repair -> publish` and survives process restart. | Benchmark retry lanes show resumed state instead of cold restarts. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 3 | `BC-03` | Founder time is wasted when a failed run does not say exactly what broke and what to try next. | Failed runs emit precise blocker evidence, canonical blocker class, and repair transcript or next-step evidence. | `100%` of failed bounded runs include receipt-backed blocker evidence mapped to canonical terminal truth. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 4 | `BC-02` | Retry without state reuse just repeats prompt cost and rescue labor. | Retry resumes from prior state, contract, and repair evidence instead of re-prompting from scratch. | Retried runs emit resume-from-stage evidence and show lower repeated-rescue incidence on the same class. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 5 | `TW-01` | The wedge only becomes real if the benchmark corpus keeps proving `prompt -> spec -> code -> verify -> PR` loops on bounded work. | A fixed benchmark corpus runs repeatedly on current `main` without ad hoc issue swapping. | Repeated benchmark runs report issue-level truth outcomes on the same bounded corpus. | trust | Covered by [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
+| 6 | `TW-02` | The project needs issue-level truth, not PR-count or iteration-count vanity metrics. | Weekly truth reporting uses `mergeable_pr OR merged_pr`, distinguishes proxy from truth, and stays linked from status docs. | Fresh `origin/main` truth reports publish issue-level truth success and no-rescue truth success. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
+| 7 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
+| 8 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+
+## Do Now / Delay / Avoid
+
+### Do now
+
+- `RS-07`
+- `BC-01`
+- `BC-03`
+- `BC-02`
+- `TW-01`
+- `TW-02`
+- `TW-03`
+- `CS-01..03`
+
+### Delay
+
+- `BC-07..09` until the repair loop is truthful and resumable
+- `RS-10..12` until the operator-surface guard is real
+- `TW-07..09` until the bounded execution wedge is boringly reliable
+- `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
+- `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
+
+### Avoid in this tranche
+
+- `UDW-07..12`
+- `MCF-04..12`
+- `CS-04..12`
+- broad provider-surface expansion
+- heavy DAG workbench work that is not backed by live runtime truth
+- generalized memory fabric work that is not directly improving the execution wedge
+
+## Top 3 Boss-Ready Next
+
+1. `RS-07` ([#5327](https://github.com/synaptent/aragora/issues/5327)) because it closes the last missing guard on the live operator path and turns preflight into the admission truth the operator can actually trust.
+2. `BC-01` because retries and repair loops cannot become truthful until session state survives restarts.
+3. `BC-03` because founder leverage depends on precise blocker evidence before more retry logic is added.
+
+There is no dedicated open GitHub issue yet for those three codes. Existing issue coverage is still at the epic level through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806). Do not invent duplicate roadmap issues in this tranche unless the canonical docs stop being enough to drive bounded execution.
 
 ## Reverse-Staged Rocket Bootstrap
 
 ### Booster 0 — Corpus
 
-Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This is the smallest booster and the only one that must clearly work in the first 30 days.
+Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This booster is already above target, so the remaining work is to keep it truthful while the guard layers catch up.
 
 ### Booster 1 — Assist
 

--- a/docs/benchmarks/rescue_productization.json
+++ b/docs/benchmarks/rescue_productization.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "entries": []
+}

--- a/scripts/harvest_rescue_classes.py
+++ b/scripts/harvest_rescue_classes.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +15,75 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from aragora.swarm.rescue_events import DEFAULT_RESCUE_LEDGER_PATH, RescueEventLedger
 
+DEFAULT_PRODUCTIZATION_MAP_PATH = REPO_ROOT / "docs" / "benchmarks" / "rescue_productization.json"
+
+
+def load_productization_map(path: Path) -> dict[str, dict[str, str]]:
+    """Load rescue-class linkage metadata from a tracked JSON file."""
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Productization map at {path} must be a JSON object")
+    raw_entries = payload.get("entries", [])
+    if not isinstance(raw_entries, list):
+        raise ValueError(f"Productization map at {path} must contain an 'entries' list")
+
+    entries: dict[str, dict[str, str]] = {}
+    for raw_entry in raw_entries:
+        if not isinstance(raw_entry, dict):
+            continue
+        class_name = str(raw_entry.get("class", "") or "").strip()
+        if not class_name:
+            continue
+        entries[class_name] = {
+            "target_kind": str(raw_entry.get("target_kind", "") or "").strip(),
+            "target": str(raw_entry.get("target", "") or "").strip(),
+            "title": str(raw_entry.get("title", "") or "").strip(),
+            "notes": str(raw_entry.get("notes", "") or "").strip(),
+        }
+    return entries
+
+
+def _rescue_class_key(event: Any) -> str:
+    return f"{event.event_type}:{event.reason[:60]}"
+
+
+def _productization_fields(
+    class_name: str,
+    *,
+    productization_map: dict[str, dict[str, str]] | None = None,
+) -> dict[str, str]:
+    entry = dict((productization_map or {}).get(class_name, {}) or {})
+    target_kind = str(entry.get("target_kind", "") or "").strip()
+    target = str(entry.get("target", "") or "").strip()
+    if target_kind == "fixture" and target:
+        status = "linked_fixture"
+    elif target_kind == "issue" and target:
+        status = "linked_issue"
+    elif target:
+        status = "linked_other"
+    else:
+        status = "unlinked"
+    return {
+        "productization_status": status,
+        "productization_target_kind": target_kind,
+        "productization_target": target,
+        "productization_title": str(entry.get("title", "") or "").strip(),
+        "productization_notes": str(entry.get("notes", "") or "").strip(),
+    }
+
+
+def _class_counts(
+    ledger: RescueEventLedger,
+    *,
+    recent_limit: int,
+) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for event in ledger.recent(limit=recent_limit):
+        counts[_rescue_class_key(event)] += 1
+    return counts
+
 
 def harvest_repeated_rescue_classes(
     ledger: RescueEventLedger,
@@ -22,6 +91,7 @@ def harvest_repeated_rescue_classes(
     threshold: int = 2,
     recent_limit: int = 500,
     example_limit: int = 5,
+    productization_map: dict[str, dict[str, str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Return repeated rescue classes plus example issue numbers."""
     repeated = ledger.repeated_classes(threshold=threshold)
@@ -32,7 +102,7 @@ def harvest_repeated_rescue_classes(
     for event in ledger.recent(limit=recent_limit):
         if event.issue_number is None:
             continue
-        key = f"{event.event_type}:{event.reason[:60]}"
+        key = _rescue_class_key(event)
         bucket = issue_numbers_by_class[key]
         if event.issue_number not in bucket:
             bucket.append(event.issue_number)
@@ -49,9 +119,87 @@ def harvest_repeated_rescue_classes(
                 "reason_excerpt": reason_excerpt,
                 "count": count,
                 "issue_numbers": issue_numbers_by_class.get(class_name, [])[:example_limit],
+                **_productization_fields(
+                    class_name,
+                    productization_map=productization_map,
+                ),
             }
         )
     return rows
+
+
+def summarize_rescue_classes(
+    ledger: RescueEventLedger,
+    *,
+    threshold: int = 2,
+    recent_limit: int = 500,
+    example_limit: int = 5,
+    one_off_limit: int = 20,
+    productization_map: dict[str, dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Summarize repeated rescue patterns versus one-off or below-threshold noise."""
+    counts = _class_counts(ledger, recent_limit=recent_limit)
+    repeated_rows = harvest_repeated_rescue_classes(
+        ledger,
+        threshold=threshold,
+        recent_limit=recent_limit,
+        example_limit=example_limit,
+        productization_map=productization_map,
+    )
+    repeated_class_names = {str(row.get("class", "")).strip() for row in repeated_rows}
+
+    one_off_rows: list[dict[str, Any]] = []
+    below_threshold_rows: list[dict[str, Any]] = []
+    for class_name, count in counts.most_common():
+        if class_name in repeated_class_names:
+            continue
+        event_type, _, reason_excerpt = class_name.partition(":")
+        row = {
+            "class": class_name,
+            "event_type": event_type,
+            "reason_excerpt": reason_excerpt,
+            "count": count,
+            **_productization_fields(
+                class_name,
+                productization_map=productization_map,
+            ),
+        }
+        if count <= 1:
+            one_off_rows.append(row)
+        else:
+            below_threshold_rows.append(row)
+
+    linked_fixture_count = sum(
+        1 for row in repeated_rows if row.get("productization_status") == "linked_fixture"
+    )
+    linked_issue_count = sum(
+        1 for row in repeated_rows if row.get("productization_status") == "linked_issue"
+    )
+    linked_other_count = sum(
+        1 for row in repeated_rows if row.get("productization_status") == "linked_other"
+    )
+
+    return {
+        "summary": {
+            "threshold": threshold,
+            "recent_limit": recent_limit,
+            "total_unique_classes": len(counts),
+            "repeated_class_count": len(repeated_rows),
+            "one_off_class_count": sum(1 for count in counts.values() if count <= 1),
+            "below_threshold_class_count": sum(
+                1 for count in counts.values() if 1 < count < threshold
+            ),
+            "linked_fixture_count": linked_fixture_count,
+            "linked_issue_count": linked_issue_count,
+            "linked_other_count": linked_other_count,
+            "unlinked_repeated_class_count": sum(
+                1 for row in repeated_rows if row.get("productization_status") == "unlinked"
+            ),
+        },
+        "repeated_classes": repeated_rows,
+        "one_off_classes": one_off_rows[: max(0, one_off_limit)],
+        "below_threshold_classes": below_threshold_rows[: max(0, one_off_limit)],
+    }
 
 
 def _format_issue_numbers(issue_numbers: list[int]) -> str:
@@ -64,11 +212,13 @@ def render_table(rows: list[dict[str, Any]]) -> str:
     if not rows:
         return "No repeated rescue classes found."
 
-    headers = ("class", "count", "issue_numbers")
+    headers = ("class", "count", "productization", "target", "issue_numbers")
     table_rows = [
         (
             str(row.get("class", "")).strip(),
             str(int(row.get("count", 0) or 0)),
+            str(row.get("productization_status", "")).strip() or "unlinked",
+            str(row.get("productization_target", "")).strip() or "-",
             _format_issue_numbers(list(row.get("issue_numbers", []) or [])),
         )
         for row in rows
@@ -78,7 +228,7 @@ def render_table(rows: list[dict[str, Any]]) -> str:
         for index in range(len(headers))
     ]
 
-    def _render_row(values: tuple[str, str, str]) -> str:
+    def _render_row(values: tuple[str, str, str, str, str]) -> str:
         return " | ".join(value.ljust(widths[index]) for index, value in enumerate(values))
 
     separator = "-+-".join("-" * width for width in widths)
@@ -120,19 +270,52 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit machine-readable JSON instead of a table.",
     )
+    parser.add_argument(
+        "--report-json",
+        action="store_true",
+        help="Emit a richer JSON report with repeated, one-off, and below-threshold classes.",
+    )
+    parser.add_argument(
+        "--productization-map",
+        type=Path,
+        default=DEFAULT_PRODUCTIZATION_MAP_PATH,
+        help="Path to the tracked rescue-productization map.",
+    )
+    parser.add_argument(
+        "--one-off-limit",
+        type=int,
+        default=20,
+        help="Maximum number of one-off or below-threshold classes to emit in report JSON.",
+    )
     return parser
 
 
-def main() -> int:
-    args = build_parser().parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
     ledger = RescueEventLedger(path=args.path)
+    productization_map = load_productization_map(args.productization_map)
     rows = harvest_repeated_rescue_classes(
         ledger,
         threshold=max(1, args.threshold),
         recent_limit=max(1, args.recent_limit),
         example_limit=max(1, args.example_limit),
+        productization_map=productization_map,
     )
-    if args.json:
+    if args.report_json:
+        print(
+            json.dumps(
+                summarize_rescue_classes(
+                    ledger,
+                    threshold=max(1, args.threshold),
+                    recent_limit=max(1, args.recent_limit),
+                    example_limit=max(1, args.example_limit),
+                    one_off_limit=max(0, args.one_off_limit),
+                    productization_map=productization_map,
+                ),
+                indent=2,
+            )
+        )
+    elif args.json:
         print(json.dumps(rows, indent=2))
     else:
         print(render_table(rows))

--- a/tests/scripts/test_harvest_rescue_classes.py
+++ b/tests/scripts/test_harvest_rescue_classes.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from aragora.swarm.rescue_events import RescueEvent, RescueEventLedger
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import harvest_rescue_classes as mod  # noqa: E402
+
+
+def _ledger_with_events(tmp_path: Path, events: list[RescueEvent]) -> RescueEventLedger:
+    ledger = RescueEventLedger(path=tmp_path / "rescue_events.jsonl")
+    for event in events:
+        ledger.record(event)
+    return ledger
+
+
+def _write_productization_map(path: Path, entries: list[dict[str, object]]) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "entries": entries,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_harvest_repeated_rescue_classes_includes_productization_fields(tmp_path: Path) -> None:
+    ledger = _ledger_with_events(
+        tmp_path,
+        [
+            RescueEvent(
+                event_type="session_restart",
+                reason="runner freshness gate blocked launch",
+                issue_number=5514,
+            ),
+            RescueEvent(
+                event_type="session_restart",
+                reason="runner freshness gate blocked launch",
+                issue_number=5514,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5512,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5515,
+            ),
+        ],
+    )
+    productization_map = mod.load_productization_map(
+        _write_productization_map(
+            tmp_path / "rescue_productization.json",
+            [
+                {
+                    "class": "session_restart:runner freshness gate blocked launch",
+                    "target_kind": "issue",
+                    "target": "#5514",
+                    "title": "use contract receipts for dispatch admission",
+                }
+            ],
+        )
+    )
+
+    rows = mod.harvest_repeated_rescue_classes(
+        ledger,
+        threshold=2,
+        recent_limit=20,
+        example_limit=5,
+        productization_map=productization_map,
+    )
+
+    by_class = {row["class"]: row for row in rows}
+    assert (
+        by_class["session_restart:runner freshness gate blocked launch"]["productization_status"]
+        == "linked_issue"
+    )
+    assert (
+        by_class["session_restart:runner freshness gate blocked launch"]["productization_target"]
+        == "#5514"
+    )
+    assert (
+        by_class["followup_prompt:needs explicit next step from founder"]["productization_status"]
+        == "unlinked"
+    )
+
+
+def test_summarize_rescue_classes_separates_repeated_from_one_off_noise(tmp_path: Path) -> None:
+    ledger = _ledger_with_events(
+        tmp_path,
+        [
+            RescueEvent(event_type="manual_merge", reason="required review gate"),
+            RescueEvent(event_type="manual_merge", reason="required review gate"),
+            RescueEvent(event_type="issue_rewrite", reason="scope contradicted itself"),
+            RescueEvent(event_type="permission_approval", reason="grant shell access"),
+            RescueEvent(event_type="permission_approval", reason="grant shell access"),
+            RescueEvent(event_type="permission_approval", reason="grant shell access"),
+        ],
+    )
+
+    report = mod.summarize_rescue_classes(
+        ledger,
+        threshold=2,
+        recent_limit=20,
+        example_limit=5,
+        one_off_limit=10,
+        productization_map={},
+    )
+
+    assert report["summary"]["repeated_class_count"] == 2
+    assert report["summary"]["one_off_class_count"] == 1
+    assert report["summary"]["below_threshold_class_count"] == 0
+    assert {row["class"] for row in report["repeated_classes"]} == {
+        "permission_approval:grant shell access",
+        "manual_merge:required review gate",
+    }
+    assert report["one_off_classes"] == [
+        {
+            "class": "issue_rewrite:scope contradicted itself",
+            "count": 1,
+            "event_type": "issue_rewrite",
+            "productization_notes": "",
+            "productization_status": "unlinked",
+            "productization_target": "",
+            "productization_target_kind": "",
+            "productization_title": "",
+            "reason_excerpt": "scope contradicted itself",
+        }
+    ]
+
+
+def test_main_report_json_emits_summary_and_linkage(tmp_path: Path, capsys) -> None:
+    ledger = _ledger_with_events(
+        tmp_path,
+        [
+            RescueEvent(
+                event_type="session_restart",
+                reason="runner freshness gate blocked launch",
+                issue_number=5514,
+            ),
+            RescueEvent(
+                event_type="session_restart",
+                reason="runner freshness gate blocked launch",
+                issue_number=5514,
+            ),
+            RescueEvent(event_type="issue_rewrite", reason="single occurrence"),
+        ],
+    )
+    productization_path = _write_productization_map(
+        tmp_path / "rescue_productization.json",
+        [
+            {
+                "class": "session_restart:runner freshness gate blocked launch",
+                "target_kind": "fixture",
+                "target": "docs/benchmarks/corpus.json",
+                "title": "benchmark corpus",
+            }
+        ],
+    )
+
+    exit_code = mod.main(
+        [
+            "--path",
+            str(ledger.path),
+            "--productization-map",
+            str(productization_path),
+            "--report-json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["summary"]["linked_fixture_count"] == 1
+    assert payload["summary"]["one_off_class_count"] == 1
+    assert payload["repeated_classes"][0]["productization_status"] == "linked_fixture"
+    assert payload["repeated_classes"][0]["productization_target"] == "docs/benchmarks/corpus.json"
+
+
+def test_load_productization_map_returns_empty_for_missing_file(tmp_path: Path) -> None:
+    loaded = mod.load_productization_map(tmp_path / "missing.json")
+
+    assert loaded == {}


### PR DESCRIPTION
Closes #5516

## Summary
- extend rescue-class harvesting with fixture-or-issue linkage metadata from a tracked productization map
- add report JSON output that separates repeated rescue classes from one-off or below-threshold noise
- cover linkage, summary, and CLI behavior with focused script tests

## Roadmap
- TW-03: make repeated rescue classes visible as productized fixture-or-issue work instead of raw counts only