### PR TITLE
feat(swarm): persist repair lifecycle in session state

### DIFF
--- a/aragora/swarm/session_state.py
+++ b/aragora/swarm/session_state.py
@@ -81,6 +81,12 @@ def _coerce_path_list(value: Any) -> list[str]:
     return [str(item).strip() for item in value if str(item).strip()]
 
 
+def _coerce_dict(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return dict(value)
+
+
 @dataclass(slots=True)
 class SessionState:
     """Durable local session metadata for future retry/repair orchestration."""
@@ -175,6 +181,11 @@ class SessionState:
         changed_files: list[str] | tuple[str, ...] | set[str] | None,
         test_output: str | None,
         worker_outcome: str | None,
+        *,
+        failure_reason: str | None = None,
+        failing_verification: Mapping[str, Any] | None = None,
+        stdout_tail: str | None = None,
+        stderr_tail: str | None = None,
     ) -> dict[str, Any]:
         attempt = {
             "at": _utcnow().isoformat(),
@@ -182,6 +193,10 @@ class SessionState:
             "changed_files": _coerce_path_list(changed_files),
             "test_output": _optional_text(test_output),
             "worker_outcome": _optional_text(worker_outcome),
+            "failure_reason": _optional_text(failure_reason),
+            "failing_verification": _coerce_dict(failing_verification),
+            "stdout_tail": _optional_text(stdout_tail),
+            "stderr_tail": _optional_text(stderr_tail),
         }
         self.attempts.append(attempt)
         self.retry_count = max(self.retry_count, len(self.attempts))
@@ -224,16 +239,59 @@ class SessionState:
                 worker_outcome = _optional_text(attempt.get("worker_outcome"))
                 if worker_outcome:
                     summary.append(worker_outcome)
+                failure_reason = _optional_text(attempt.get("failure_reason"))
+                if failure_reason:
+                    summary.append(f"reason={failure_reason}")
                 changed = _coerce_path_list(attempt.get("changed_files"))
                 if changed:
                     summary.append(f"changed={', '.join(changed[:5])}")
                 lines.append(f"- Attempt {index}: {', '.join(summary) if summary else 'recorded'}")
+                failing = _coerce_dict(attempt.get("failing_verification"))
+                if failing:
+                    command = _optional_text(failing.get("command"))
+                    if command:
+                        lines.append(
+                            f"  Failing verification: {command} (exit {failing.get('exit_code')})"
+                        )
+                    stderr_tail = _optional_text(failing.get("stderr_tail"))
+                    if stderr_tail:
+                        lines.append(f"  Verification stderr: {stderr_tail[-240:]}")
                 test_output = _optional_text(attempt.get("test_output"))
                 if test_output:
-                    lines.append(f"  Test output: {test_output[-240:]}")
+                    lines.append(f"  Evidence: {test_output[-240:]}")
+                stderr_tail = _optional_text(attempt.get("stderr_tail"))
+                if stderr_tail:
+                    lines.append(f"  stderr: {stderr_tail[-240:]}")
+                stdout_tail = _optional_text(attempt.get("stdout_tail"))
+                if stdout_tail:
+                    lines.append(f"  stdout: {stdout_tail[-240:]}")
 
         if self.repair_journal:
             lines.append(f"Repair journal entries available: {len(self.repair_journal)}")
+            for entry in self.repair_journal[-2:]:
+                at = _optional_text(entry.get("at"))
+                worker_outcome = _optional_text(entry.get("worker_outcome"))
+                failure_reason = _optional_text(entry.get("failure_reason"))
+                header_parts = [part for part in [worker_outcome, failure_reason] if part]
+                header = f"- Repair {at}: " if at else "- Repair: "
+                header += ", ".join(header_parts) if header_parts else "recorded"
+                lines.append(header)
+                failing = _coerce_dict(entry.get("failing_verification"))
+                if failing:
+                    command = _optional_text(failing.get("command"))
+                    if command:
+                        lines.append(
+                            f"  Failing verification: {command} (exit {failing.get('exit_code')})"
+                        )
+                    stderr_tail = _optional_text(failing.get("stderr_tail"))
+                    if stderr_tail:
+                        lines.append(f"  Verification stderr: {stderr_tail[-240:]}")
+                blocker = _optional_text(entry.get("blocker_evidence"))
+                if blocker:
+                    lines.append(f"  Blocker evidence: {blocker[-240:]}")
+                changed = _coerce_path_list(entry.get("changed_paths"))
+                if changed:
+                    lines.append(f"  Changed: {', '.join(changed[:5])}")
 
         return "\n".join(lines).strip()
 
@@ -243,6 +301,15 @@ class SessionState:
 
     def clear_blocker(self) -> None:
         self.blocker_evidence = None
+        self.touch()
+
+    def sync_repair_journal(self, entries: Any, *, max_entries: int = 3) -> None:
+        if not isinstance(entries, list):
+            return
+        normalized = [dict(entry) for entry in entries if isinstance(entry, Mapping)]
+        if not normalized:
+            return
+        self.repair_journal = normalized[-max_entries:]
         self.touch()
 
 

--- a/aragora/swarm/supervisor_workers.py
+++ b/aragora/swarm/supervisor_workers.py
@@ -34,6 +34,144 @@ _strict_bool = _supervisor._strict_bool
 CHAIN_WAVE_SUMMARY_METADATA_KEY = "chain_wave_summary"
 
 
+def _coerce_int(value: Any) -> int | None:
+    if value in {None, ""}:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _latest_repair_entry(metadata: dict[str, Any]) -> dict[str, Any]:
+    raw_entries = metadata.get("repair_journal")
+    if not isinstance(raw_entries, list):
+        return {}
+    for entry in reversed(raw_entries):
+        if isinstance(entry, dict):
+            return dict(entry)
+    return {}
+
+
+def _session_phase_from_work_order(
+    work_order: dict[str, Any],
+    *,
+    requested_phase: str | None,
+    requested_status: str | None,
+    metadata: dict[str, Any],
+) -> str:
+    phase = str(requested_phase or "").strip().lower()
+    if phase == "fallback":
+        return "repair"
+    if phase and phase != "terminal":
+        return phase
+
+    has_pr = bool(str(work_order.get("pr_url", "") or work_order.get("adopted_pr", "")).strip())
+    review_status = str(
+        work_order.get("review_status", "") or metadata.get("review_status", "")
+    ).strip()
+    has_verification = bool(work_order.get("verification_results") or work_order.get("tests_run"))
+    has_repair_journal = bool(metadata.get("repair_journal"))
+    has_blocker = bool(
+        str(work_order.get("blocker_evidence", "") or metadata.get("blocker_evidence", "")).strip()
+    )
+    status = str(requested_status or work_order.get("status", "")).strip().lower()
+
+    if has_pr or review_status in {
+        "pending",
+        "pending_heterogeneous_review",
+        "changes_requested",
+        "approved",
+    }:
+        return "publish"
+    if status in {"retrying", "failed", "needs_human"} or has_blocker or has_repair_journal:
+        return "repair"
+    if has_verification:
+        return "verify"
+    return phase or "dispatch"
+
+
+def _record_attempt_from_work_order(
+    session: Any,
+    work_order: dict[str, Any],
+    *,
+    metadata: dict[str, Any],
+    exit_code: int | None,
+    worker_outcome: str | None,
+    changed_files: list[str] | None,
+    test_output: str | None,
+) -> None:
+    latest_repair = _latest_repair_entry(metadata)
+    effective_exit_code = exit_code
+    if effective_exit_code is None:
+        effective_exit_code = _coerce_int(latest_repair.get("exit_code"))
+    if effective_exit_code is None:
+        effective_exit_code = _coerce_int(work_order.get("exit_code"))
+
+    effective_worker_outcome = (
+        worker_outcome
+        or str(
+            latest_repair.get("worker_outcome", "") or work_order.get("worker_outcome", "")
+        ).strip()
+    )
+    effective_changed_files = changed_files or list(
+        latest_repair.get("changed_paths", []) or work_order.get("changed_paths", []) or []
+    )
+    failure_reason = (
+        str(
+            latest_repair.get("failure_reason", "")
+            or work_order.get("failure_reason", "")
+            or metadata.get("last_failure_reason", "")
+        ).strip()
+        or None
+    )
+    failing_verification = latest_repair.get("failing_verification")
+    stdout_tail = (
+        str(latest_repair.get("stdout_tail", "") or work_order.get("stdout_tail", "")).strip()
+        or None
+    )
+    stderr_tail = (
+        str(latest_repair.get("stderr_tail", "") or work_order.get("stderr_tail", "")).strip()
+        or None
+    )
+    effective_test_output = (
+        str(test_output or "").strip()
+        or str(
+            latest_repair.get("blocker_evidence", "")
+            or work_order.get("blocker_evidence", "")
+            or metadata.get("blocker_evidence", "")
+        ).strip()
+        or None
+    )
+
+    if not any(
+        [
+            effective_exit_code is not None,
+            effective_worker_outcome,
+            effective_changed_files,
+            effective_test_output,
+            failure_reason,
+            isinstance(failing_verification, dict),
+            stdout_tail,
+            stderr_tail,
+        ]
+    ):
+        return
+
+    session.record_attempt(
+        exit_code=effective_exit_code,
+        changed_files=effective_changed_files,
+        test_output=effective_test_output,
+        worker_outcome=effective_worker_outcome,
+        failure_reason=failure_reason,
+        failing_verification=failing_verification
+        if isinstance(failing_verification, dict)
+        else None,
+        stdout_tail=stdout_tail,
+        stderr_tail=stderr_tail,
+    )
+
+
 def _record_session_state(
     work_order: dict[str, Any],
     *,
@@ -115,10 +253,15 @@ def _record_session_state(
             "review_status": str(work_order.get("review_status", "")).strip() or None,
         }
         session.metadata.update({key: value for key, value in selected_metadata.items() if value})
+        session.sync_repair_journal(metadata.get("repair_journal"))
         if status:
             session.status = status
-        if phase:
-            session.phase = phase
+        session.phase = _session_phase_from_work_order(
+            work_order,
+            requested_phase=phase,
+            requested_status=status,
+            metadata=metadata,
+        )
         effective_blocker_evidence = (
             blocker_evidence
             or str(
@@ -127,13 +270,15 @@ def _record_session_state(
         )
         if effective_blocker_evidence:
             session.set_blocker(effective_blocker_evidence)
-        if exit_code is not None or worker_outcome:
-            session.record_attempt(
-                exit_code=exit_code,
-                changed_files=changed_files or [],
-                test_output=(test_output or "")[-800:],
-                worker_outcome=worker_outcome,
-            )
+        _record_attempt_from_work_order(
+            session,
+            work_order,
+            metadata=metadata,
+            exit_code=exit_code,
+            worker_outcome=worker_outcome,
+            changed_files=changed_files or [],
+            test_output=(test_output or "")[-800:],
+        )
 
         store = SessionStateStore()
         store.save(session)

--- a/tests/swarm/test_session_state.py
+++ b/tests/swarm/test_session_state.py
@@ -209,6 +209,34 @@ def test_resume_context_summarizes_prior_attempts() -> None:
     assert "AssertionError: blocker evidence missing" in text
 
 
+def test_resume_context_includes_repair_journal_details() -> None:
+    state = SessionState(
+        session_id="resume-journal-details",
+        phase="repair",
+        repair_journal=[
+            {
+                "at": "2026-04-13T11:00:00+00:00",
+                "worker_outcome": "merge_gate_failed",
+                "failure_reason": "merge_gate_failed",
+                "changed_paths": ["aragora/swarm/supervisor_workers.py"],
+                "blocker_evidence": "Quality Gates failed on lint-run",
+                "failing_verification": {
+                    "command": "python -m pytest tests/swarm/test_supervisor.py -q",
+                    "exit_code": 1,
+                    "stderr_tail": "AssertionError: boom",
+                },
+            }
+        ],
+    )
+
+    text = state.resume_context()
+
+    assert "Repair journal entries available: 1" in text
+    assert "merge_gate_failed" in text
+    assert "python -m pytest tests/swarm/test_supervisor.py -q" in text
+    assert "Quality Gates failed on lint-run" in text
+
+
 def test_blocker_evidence_roundtrips_through_serialization() -> None:
     state = SessionState(
         session_id="blocker-roundtrip", blocker_evidence="pytest timed out on lane"
@@ -299,6 +327,62 @@ def test_record_session_state_syncs_branch_pr_and_blocker_metadata(
     assert restored is not None
     assert restored.pr_url == "https://github.com/synaptent/aragora/pull/12345"
     assert restored.branch_name == "claude/bc01-lifecycle"
+
+
+def test_record_session_state_persists_terminal_attempt_and_publish_phase(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    work_order = {
+        "work_order_id": "wo-publish",
+        "issue_number": 5515,
+        "target_agent": "codex",
+        "branch": "codex/bc01-publish-phase",
+        "worktree_path": "/tmp/codex-bc01-publish-phase",
+        "status": "completed",
+        "worker_outcome": "completed",
+        "exit_code": 0,
+        "changed_paths": ["aragora/swarm/session_state.py"],
+        "stdout_tail": "worker output",
+        "stderr_tail": "",
+        "pr_url": "https://github.com/synaptent/aragora/pull/5515",
+        "review_status": "pending_heterogeneous_review",
+        "metadata": {
+            "supervisor_run_id": "run-publish",
+            "repair_journal": [
+                {
+                    "at": "2026-04-13T12:00:00+00:00",
+                    "worker_outcome": "completed",
+                    "failure_reason": "merge_gate_failed",
+                    "changed_paths": ["aragora/swarm/session_state.py"],
+                    "blocker_evidence": "Previous merge gate failure",
+                    "failing_verification": {
+                        "command": "python -m pytest tests/swarm/test_session_state.py -q",
+                        "exit_code": 1,
+                        "stderr_tail": "AssertionError: before retry",
+                    },
+                }
+            ],
+        },
+    }
+
+    _record_session_state(work_order, status="completed", phase="terminal")
+
+    session_data = work_order["metadata"]["session_state"]
+    assert session_data["phase"] == "publish"
+    assert session_data["repair_journal"][0]["failure_reason"] == "merge_gate_failed"
+    assert session_data["attempts"][-1]["worker_outcome"] == "completed"
+    assert session_data["attempts"][-1]["changed_files"] == ["aragora/swarm/session_state.py"]
+    assert session_data["attempts"][-1]["failing_verification"]["command"] == (
+        "python -m pytest tests/swarm/test_session_state.py -q"
+    )
+
+    store = SessionStateStore()
+    restored = store.load("swarm-wo-publish")
+    assert restored is not None
+    assert restored.phase == "publish"
+    assert restored.repair_journal[0]["blocker_evidence"] == "Previous merge gate failure"
+    assert restored.attempts[-1]["stdout_tail"] == "worker output"
 
 
 def test_classify_session_blocker_import_error() -> None:


### PR DESCRIPTION
## Summary
- sync persisted repair-journal entries into the durable session state store
- record terminal attempt evidence and infer verify/repair/publish lifecycle phase from live work-order state
- enrich resume context so retries survive restart with blocker and verification details

## Validation
- pytest tests/swarm/test_session_state.py -q
- ruff check aragora/swarm/session_state.py aragora/swarm/supervisor_workers.py tests/swarm/test_session_state.py
- python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/swarm/session_state.py aragora/swarm/supervisor_workers.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Refs #805