### PR TITLE
docs: narrow commercial overview to the execution wedge

### DIFF
--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -5,7 +5,7 @@ description: Active Execution Issues
 
 # Active Execution Issues
 
-Last updated: 2026-04-12
+Last updated: 2026-04-13
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -41,27 +41,40 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
+Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining gate is production guard proof, not inflating the benchmark story.
+
+## Current 30-Day Execution Set
+
+Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
+
+- Do now: `RS-07`, `BC-01`, `BC-03`, `BC-02`, `TW-01`, `TW-02`, `TW-03`, `CS-01..03`
+- Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
+- Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
+- Top 3 boss-ready next: `RS-07`, `BC-01`, `BC-03`
+- GitHub coverage for those top 3 remains epic-level only through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issues exist yet
+
 ## Epic 1 — Reliability Substrate
 
 **Outcome:** make bounded unattended execution trustworthy on real multi-host backlogs.
 
 ### Milestone 1.1 — Failure Taxonomy & Benchmark Corpus `[30d]`
 
-- [x] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures
-- [x] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts
-- [x] **RS-03** Add a benchmark scoring lane and regression guardrails in CI
+- [x] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures _(Done 2026-04-10)_
+- [x] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts _(Done 2026-04-10)_
+- [x] **RS-03** Add a benchmark scoring lane and regression guardrails in CI _(Done 2026-04-11)_
 
 ### Milestone 1.2 — Worker Contracts & Credential Envelopes `[30-90d]`
 
-- [x] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules
-- [x] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth
-- [ ] **RS-06** Require launcher, supervisor, and tranche queue to dispatch only from complete contracts
+- [x] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules _(Done 2026-04-11)_
+- [x] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth _(Done 2026-04-12)_
+- [x] **RS-06** Require launcher, supervisor, and tranche queue to dispatch only from complete contracts _(Done 2026-04-13)_
 
 ### Milestone 1.3 — Contract-Aware Preflight `[30-90d]`
 
-- [ ] **RS-07** Build `aragora swarm preflight run --contract ...`
-- [ ] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path
-- [ ] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers
+- [ ] **RS-07** Build `aragora swarm preflight run --contract ...` _(In progress as of 2026-04-13: the operator surface now has a contract-backed receipt path with persisted `PreflightReceipt` output and fail-closed admission verdicts; remaining follow-through is to make that receipt the default admission truth everywhere that consumes preflight.)_
+- [x] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
+- [x] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
 
 ### Milestone 1.4 — Ledger & Self-Heal `[90d]`
 
@@ -76,14 +89,14 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 ### Milestone 2.1 — Interactive Sessions & Repair Journal `[90d]`
 
 - [ ] **BC-01** Persist session state across `explore -> plan -> edit -> verify -> repair -> publish`
-- [ ] **BC-02** Resume retries from prior session state instead of fresh prompts
+- [x] **BC-02** Resume retries from prior session state instead of fresh prompts _(Done 2026-04-13 via [#5384](https://github.com/synaptent/aragora/pull/5384))_
 - [ ] **BC-03** Emit precise blocker evidence and repair transcripts for failed runs
 
 ### Milestone 2.2 — Task Sanitizer & Admission Gate `[30-90d]`
 
-- [x] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined
-- [x] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch
-- [ ] **BC-06** Preserve original versus sanitized task text for audit
+- [x] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined _(Done 2026-04-12)_
+- [x] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch _(Done 2026-04-13)_
+- [x] **BC-06** Preserve original versus sanitized task text for audit _(Done 2026-04-13 via [#5113](https://github.com/synaptent/aragora/pull/5113), [#5190](https://github.com/synaptent/aragora/pull/5190), and [#5305](https://github.com/synaptent/aragora/pull/5305))_
 
 ### Milestone 2.3 — Truthful Lane / Integrator State `[90d]`
 
@@ -103,8 +116,8 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 
 ### Milestone 3.1 — Autonomous Software Execution Benchmark `[30d]`
 
-- [ ] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues
-- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate
+- [ ] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Partial as of 2026-04-13: the frozen corpus manifest is checked in at `docs/benchmarks/corpus.json`; the remaining gap is recurring execution against that fixed revision.)_
+- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Partial as of 2026-04-13: diffable truth-artifact generation exists, including truth/no-rescue/failure-class/rescue-type reporting; the remaining gap is recurring publication and status linkage.)_
 - [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -26,6 +26,23 @@ repo — editing files in the main directory causes concurrent overwrites.
 3. **Background cleanup** — A LaunchAgent runs every 5 minutes, reconciling worktrees with main
    (merge strategy) and cleaning up stale ones after 24h. Branches are auto-deleted after merge.
 
+### Worktree cleanup (IMPORTANT)
+
+**NEVER** use raw `find .worktrees -exec rm -rf` or similar ad-hoc deletion.
+This destroys active worktrees with uncommitted work. Always use the safe helpers:
+
+```bash
+# Safe cleanup (preferred) — respects TTL, checks merge status
+python3 scripts/codex_worktree_autopilot.py cleanup --base main --ttl-hours 24
+
+# Per-worktree safe removal — checks for blockers first
+python3 scripts/safe_worktree_cleanup.py inspect <worktree-path>
+python3 scripts/safe_worktree_cleanup.py remove <worktree-path>
+
+# Minimal safe option — only prunes already-deleted directories
+git worktree prune --expire=now
+```
+
 ### Manual worktree commands
 
 - `./scripts/codex_session.sh` — Legacy session bootstrap (creates worktree + metadata)
@@ -172,7 +189,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,000+ Python modules | 153,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 3,000+ Python modules | 154,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
 
 ## Architecture
 
@@ -420,7 +437,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-**Test Suite:** 153,000+ tests across 5,000+ test files
+**Test Suite:** 154,000+ tests across 5,000+ test files
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -341,7 +341,7 @@ aragora/
 └── cli/              # Command-line interface
 ```
 
-**Scale:** 3,000+ Python modules | 153,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
+**Scale:** 3,000+ Python modules | 154,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
 
 ---
 

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -5,7 +5,7 @@ description: Next Steps (Canonical)
 
 # Next Steps (Canonical)
 
-Last updated: 2026-04-12
+Last updated: 2026-04-13
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
@@ -15,7 +15,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is the transition from early `Teammate` behavior to reliable `Foreman` behavior across the current execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to finish `RS-07`, close the remaining truthful repair gaps in `BC-01/03`, and keep `TW-01/TW-02` publishing recurring truth artifacts before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -24,19 +24,30 @@ What is already true:
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
 - terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
+- the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
-- launcher-side contract admission and module-level contract-aware preflight are on `main`
+- launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
+- scratch and remote-publish preflight validation now run through the production preflight path and emit canonical terminal truth on `main`
 - task sanitizer outcomes and success-rate filtering are shaping safer boss-loop intake
+- original versus sanitized task text is already preserved for audit on `main`
+- retry dispatch now carries prior session resume context on `main` via [#5384](https://github.com/synaptent/aragora/pull/5384)
+- the rescue loop can now record interventions, plan bounded recovery, and execute safe followups on `main` via [#5379](https://github.com/synaptent/aragora/pull/5379), [#5380](https://github.com/synaptent/aragora/pull/5380), and [#5383](https://github.com/synaptent/aragora/pull/5383)
 
 What is still missing:
 
-- honest benchmarked proof of semi-autonomous success
-- contract-backed worker admission across launcher, supervisor, and tranche queue on the safest classes of work
-- top-level production-equivalent preflight on those classes
-- broader repair-loop coverage and persisted original-versus-sanitized task audit
+- the last `RS-07` step is to make receipt-backed contract preflight the default operator admission truth everywhere, not just a substrate primitive — contract in, persisted receipt out, fail-closed on any mismatch ([#5327](https://github.com/synaptent/aragora/issues/5327))
+- broader repair truth on the live swarm loop still depends on full `BC-01` persistence and precise `BC-03` blocker evidence
+- recurring scheduled use of the frozen corpus and diffable truth artifact still needs to become routine status output ([#5329](https://github.com/synaptent/aragora/issues/5329))
+- proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
+- broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”
+
+Queue rule for this tranche:
+
+- only roadmap codes in the **Do now** set may carry or be auto-created with `boss-ready`
+- delayed-track issues may stay open for planning truth, but restock and auto-decomposition should strip them from the live dispatch queue
 
 ## 30-Day Success Metric
 
@@ -47,13 +58,114 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
+Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; truthful guard completion is.
+
+Primary truth metric:
+
+- issue-level truth success remains `mergeable_pr OR merged_pr`
+- merged-only rate is a secondary truth metric, not the primary gate
+- PR-signal counts and iteration counts are proxies only
+
 If a task does not improve that metric, it is not first-tranche work.
+
+## TW-01/TW-02: Benchmark Corpus and No-Rescue Scorecard ([#5329](https://github.com/synaptent/aragora/issues/5329))
+
+`TW-01` (fixed benchmark corpus) and `TW-02` (no-rescue scorecard) are the measurement backbone for the execution wedge. Without them, progress claims are anecdotal.
+
+### Benchmark corpus requirements (TW-01)
+
+- The corpus is a fixed, versioned list of bounded issues checked into the repo (e.g. `docs/benchmarks/corpus.json`).
+- Issues in the corpus are not swapped ad hoc between runs; additions and removals are tracked as explicit corpus revisions.
+- Each corpus entry includes: issue identifier, expected execution class, and any known constraints.
+- The corpus runs against current `main` on a recurring basis (at minimum weekly) using the existing benchmark scoring lane.
+- Corpus membership criteria: issues must be bounded (clear scope, single-PR resolution, no external dependency chain).
+
+### No-rescue scorecard requirements (TW-02)
+
+The recurring scorecard records the following per corpus run:
+
+| Metric | Definition | Primary or proxy |
+|--------|-----------|-----------------|
+| Truth success rate | `mergeable_pr OR merged_pr` per issue | **primary** |
+| No-rescue success rate | Truth successes with zero human intervention | **primary** |
+| Verification pass rate | Fraction of runs where `verify` stage passes without repair | secondary |
+| Failure-class distribution | Count of failures per canonical terminal-truth class | secondary |
+| Merged-only rate | Fraction where the PR is actually merged (not just mergeable) | secondary |
+| Rescue count | Number of runs requiring human intervention, broken out by rescue type | secondary |
+
+Scorecard output rules:
+
+- Each run produces a timestamped scorecard artifact that is diffable against prior runs for week-over-week comparison.
+- Human rescue is distinguished from autonomous completion at the issue level — a rescued issue is never counted as no-rescue success.
+- Proxy metrics (PR count, iteration count, token spend) are reported separately and never mixed with truth metrics.
+- The scorecard links back to the corpus revision it was run against.
+
+### Current state
+
+- Terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are on `main`.
+- The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
+- The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
+- The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
+- What remains is recurring scheduled use of that artifact path, not inventing a second benchmark definition.
+
+## 30-Day Canonical Backlog
+
+This is the executable backlog for the next 30 days. Keep it to one bounded lane at a time for a founder budget of 5-10 hours per week.
+
+| Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
+|---|---|---|---|---|---|---|
+| 1 | `RS-07` | Preflight only deserves trust when it returns a receipt the supervisor can verify, not just a shell exit code. The gap is the admission path: contract in, receipt out, fail-closed on any mismatch. | `aragora swarm preflight run --contract ...` accepts a `WorkerContract`, runs production-equivalent git/auth/env checks, and returns a signed `PreflightReceipt` with pass/fail plus canonical terminal class on failure. Supervisor rejects admission when the receipt is absent or failed. | At least one guarded admission path is live through the operator surface with receipt-backed success and failure. Failures map to canonical terminal truth classes. | substrate | [#5327](https://github.com/synaptent/aragora/issues/5327); covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#805](https://github.com/synaptent/aragora/issues/805). |
+| 2 | `BC-01` | Session persistence is the prerequisite for truthful repair, retry, and operator control. | Session state survives `explore -> plan -> edit -> verify -> repair -> publish` and survives process restart. | Benchmark retry lanes show resumed state instead of cold restarts. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 3 | `BC-03` | Founder time is wasted when a failed run does not say exactly what broke and what to try next. | Failed runs emit precise blocker evidence, canonical blocker class, and repair transcript or next-step evidence. | `100%` of failed bounded runs include receipt-backed blocker evidence mapped to canonical terminal truth. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 4 | `BC-02` | Retry without state reuse just repeats prompt cost and rescue labor. | Retry resumes from prior state, contract, and repair evidence instead of re-prompting from scratch. | Retried runs emit resume-from-stage evidence and show lower repeated-rescue incidence on the same class. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
+| 5 | `TW-01` | The wedge only becomes real if the benchmark corpus keeps proving `prompt -> spec -> code -> verify -> PR` loops on bounded work. | A fixed benchmark corpus runs repeatedly on current `main` without ad hoc issue swapping. | Repeated benchmark runs report issue-level truth outcomes on the same bounded corpus. | trust | Covered by [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
+| 6 | `TW-02` | The project needs issue-level truth, not PR-count or iteration-count vanity metrics. | Weekly truth reporting uses `mergeable_pr OR merged_pr`, distinguishes proxy from truth, and stays linked from status docs. | Fresh `origin/main` truth reports publish issue-level truth success and no-rescue truth success. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
+| 7 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
+| 8 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+
+## Do Now / Delay / Avoid
+
+### Do now
+
+- `RS-07`
+- `BC-01`
+- `BC-03`
+- `BC-02`
+- `TW-01`
+- `TW-02`
+- `TW-03`
+- `CS-01..03`
+
+### Delay
+
+- `BC-07..09` until the repair loop is truthful and resumable
+- `RS-10..12` until the operator-surface guard is real
+- `TW-07..09` until the bounded execution wedge is boringly reliable
+- `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
+- `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
+
+### Avoid in this tranche
+
+- `UDW-07..12`
+- `MCF-04..12`
+- `CS-04..12`
+- broad provider-surface expansion
+- heavy DAG workbench work that is not backed by live runtime truth
+- generalized memory fabric work that is not directly improving the execution wedge
+
+## Top 3 Boss-Ready Next
+
+1. `RS-07` ([#5327](https://github.com/synaptent/aragora/issues/5327)) because it closes the last missing guard on the live operator path and turns preflight into the admission truth the operator can actually trust.
+2. `BC-01` because retries and repair loops cannot become truthful until session state survives restarts.
+3. `BC-03` because founder leverage depends on precise blocker evidence before more retry logic is added.
+
+There is no dedicated open GitHub issue yet for those three codes. Existing issue coverage is still at the epic level through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806). Do not invent duplicate roadmap issues in this tranche unless the canonical docs stop being enough to drive bounded execution.
 
 ## Reverse-Staged Rocket Bootstrap
 
 ### Booster 0 — Corpus
 
-Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This is the smallest booster and the only one that must clearly work in the first 30 days.
+Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This booster is already above target, so the remaining work is to keep it truthful while the guard layers catch up.
 
 ### Booster 1 — Assist
 

--- a/docs-site/docs/enterprise/commercial-overview.md
+++ b/docs-site/docs/enterprise/commercial-overview.md
@@ -5,132 +5,169 @@ description: Aragora Commercial Overview
 
 # Aragora Commercial Overview
 
-**Control plane for turning vague ideas into reviewed, auditable autonomous action.**
-**Last updated: April 9, 2026**
+**Internal positioning snapshot aligned to the current execution gate.**
+**Last updated: April 14, 2026**
 
 ## Executive Summary
 
-Aragora is building the Decision Integrity Platform and autonomous execution control plane.
+Aragora is currently a control plane for **bounded autonomous software execution**.
 
-We enter through a narrow wedge: reliable autonomous software execution for founders, technical leads, and small teams. Aragora takes a vague request, turns it into a reviewable spec, stress-tests the plan with heterogeneous agents, executes bounded work, verifies the result, and returns a receipt.
+The commercial wedge is deliberately narrow:
 
-Over time that wedge expands into a chief-of-staff layer and eventually an organization substrate for ideas, goals, actions, orchestration, and auditable memory.
+- take a bounded engineering task
+- run it through guarded autonomous execution
+- produce code, verification evidence, PR state, and operator-readable receipts
+- fail closed with explicit blocker evidence when autonomy should stop
 
-## Category
+That is the truthful sellable surface today. The current story is not "general AI for every decision" and not "omnichannel enterprise automation for everything." The near-term value is making unattended execution on bounded software work **measurable, inspectable, and auditable**.
 
-Aragora sits at the intersection of three categories:
+## What Is True On `main`
 
-1. **Decision Integrity Platform** — important decisions are debated, challenged, and receipted
-2. **Autonomous Execution Control Plane** — bounded work runs with contracts, verification, and human controls
-3. **SMB Operating System for Idea-to-Action** — small teams can translate messy intent into reliable autonomous work
+The claims below are the current proof base, not the long-term ambition.
 
-## Why This Wedge Wins Now
-
-The market shifted from “who can prompt best in chat” to “who can specify, coordinate, verify, and trust long-running agents.”
-
-Most teams do not need an abstract AGI narrative. They need:
-
-- help turning vague intent into a precise plan
-- autonomous execution that fails safely
-- receipts and evidence that make the work reviewable
-- optional intervention instead of all-or-nothing automation
-- memory that improves repeat work without becoming a security hole
-
-Software execution is the best first wedge because it is measurable, frequent, and easy to benchmark. That makes it the fastest path to trust.
-
-**Near-term proof bar:** benchmarked semi-autonomous software execution. The first claim to earn is that context-enriched workers can complete **50%+** of a fixed bounded issue corpus without human rescue and classify failures truthfully.
-
-## What the First Customer Actually Buys
-
-A customer buying Aragora today is buying a trust stack, not just a faster agent:
-
-- prompt-to-spec assistance
-- debate-validated plans
-- bounded autonomous execution
-- verification and repair loops
-- receipts, provenance, and dissent trails
-- optional human intervention at the level they choose
-- reusable memory and context for recurring work
-
-## Product Story by Stage
-
-| Stage | Buyer value | Product form |
+| Area | Current truth | Why it matters |
 |---|---|---|
-| **Tool** | Better one-shot outputs and review artifacts | Debate, review, prompt-to-spec, inbox triage |
-| **Teammate** | A bounded autonomous contributor | Scoped tasks with verification, receipts, and escalation |
-| **Foreman** | Coordination across many tasks and hosts | Backlog orchestration, operator controls, truthful status |
-| **Chief of Staff** | Goal translation, prioritization, and delegation | Planning, approvals, tradeoffs, portfolio reasoning |
-| **Organization Substrate** | Shared operating system for ideas to action | Unified DAG, memory fabric, auditable cross-functional workflows |
+| Guarded execution substrate | Boss, supervisor, tranche, contract, and preflight paths exist on the live swarm lane. | The system can decide when a run is admissible instead of blindly attempting work. |
+| Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
+| Truth artifacts | The repo has a diffable benchmark truth-artifact path and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth. |
+| Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
+| Operator truth | Preflight receipts, blocker evidence, and session-state work are materially underway and partially landed, but not yet fully closed across every live path. | This is the remaining gap between an impressive demo and a boring reliable product lane. |
 
-## Ideal Customers
+## Current Gate
 
-### 1. Founder / Technical Lead (2–50 people)
+The current commercial gate is the same as the current execution gate in [status/NEXT_STEPS_CANONICAL.md](../contributing/next-steps-canonical):
 
-Wants more output without hiring a large team, but cannot tolerate black-box automation. Values visibility, receipts, and control.
+- finish `RS-07` so receipt-backed preflight becomes the default admission truth
+- close the remaining truthful repair gaps in `BC-01` and `BC-03`
+- keep `TW-01`, `TW-02`, and `TW-03` publishing recurring corpus-linked truth
+- keep all external claims narrower than the measured proof
 
-### 2. Engineering-Led SMB (10–200 people)
+This means Aragora should currently be positioned as:
 
-Needs repeatable spec, review, implementation, and verification loops. Values trustworthy throughput over raw model demos.
+- a **guarded autonomous execution control plane** for bounded software tasks
+- a **truthful operator surface** that says what happened, what failed, and what to try next
+- a **measured benchmark system** for proving unattended execution on a fixed corpus
 
-### 3. Operations-Heavy SMB or Agency
+## What Aragora Can Be Sold For Now
 
-Wants the same control plane for inbox, support, policy, and internal operations once the software wedge is proven.
+### 1. Bounded engineering execution
 
-### 4. Regulated Teams (Later Motion)
+Aragora is strongest when the work is narrow, reviewable, and single-PR shaped:
 
-Care about audit trails, policy gates, air-gapped deployment, and compliance bundles. This becomes a stronger motion after the wedge is already repeatable.
+- focused bug fixes
+- bounded tests and validation work
+- safe code-generation loops with explicit verification
+- repair and retry on previously seen failure classes
 
-## Why Aragora Instead of Existing Alternatives?
+The operator value is not just "an AI wrote code." The value is:
 
-| Alternative | What it does well | Where Aragora differs |
-|---|---|---|
-| Chatbots | Fast answers | Aragora is about reviewed action, not conversation |
-| Coding agents | Rapid code generation | Aragora adds contracts, verification, receipts, and multi-host coordination |
-| Workflow tools | Deterministic automation | Aragora handles underspecified intent and reviewable agent work |
-| Governance/compliance tools | Policy and audit after the fact | Aragora makes receipts and dissent part of the execution path |
-| Cooperative agent frameworks | Task collaboration | Aragora's default stance is adversarial validation plus operator control |
+- the run is scoped
+- the run is checked before execution
+- the result is tied to receipts, verification, and PR truth
+- failure is explicit instead of silent
 
-## What We Can Claim Now vs. Later
+### 2. Benchmark-backed autonomy proof
 
-### Claims We Should Make Now
+Aragora can already support design-partner style proof loops where a team wants to know:
 
-- Aragora helps translate vague work into reviewable specs and bounded execution
-- Aragora can preserve receipts, provenance, and human control around agentic work
-- Aragora is proving benchmarked semi-autonomous software execution with a truthful operator control plane
+- what percentage of bounded tasks complete without rescue
+- which failure classes repeat
+- whether repairs are becoming more truthful over time
+- whether autonomous progress is improving on a fixed corpus rather than a changing sample
 
-### Claims We Should Earn Before Making Loudly
+This is commercially useful for internal platform teams and founder-led design partners because it turns autonomy from a vibe into an operating metric.
 
-- long unattended multi-host operation with low rescue overhead
-- chief-of-staff behavior across multiple projects and workflows
-- broad cross-functional operating-system coverage
-- deep vertical packaging for regulated industries
+### 3. Operator-facing trust surface
 
-## Commercial Motion
+The system is increasingly useful as an operator control plane for:
 
-1. Land with reliable autonomous software execution
-2. Expand to adjacent operator loops such as inbox, policy, and review flows
-3. Use GUI/control-plane and memory advantages as retention multipliers
-4. Package vertical and enterprise surfaces after repeatable wedge proof exists
+- admission truth
+- session and repair state
+- blocker evidence
+- benchmark scorecards
+- rescue-to-productization tracking
 
-## Packaging Logic
+That surface matters even before the system is fully autonomous, because it reduces the cost of supervising automation honestly.
 
-The commercial story should mirror the stage model:
+## Who This Is For Right Now
 
-- **Starter / Tool** — individual or small-team use for bounded review and execution loops
-- **Team / Teammate** — scoped autonomous contributors with receipts and approvals
-- **Ops / Foreman** — multi-host coordination, truthful operator views, and workflow reuse
-- **Enterprise / Substrate** — deployment controls, compliance, policy gates, and organization-wide workflows
+The current wedge is best suited to:
 
-The BYOK model remains strategically important: customers bring model keys, Aragora provides orchestration, trust, and leverage.
+- engineering leaders who want bounded unattended execution on narrow backlogs
+- founders or staff engineers running repeated benchmark-style issue queues
+- internal platform teams that need receipts, blocker evidence, and fail-closed automation
+- design partners willing to operate on a narrow, measurable execution class first
 
-## Durable Differentiators
+It is not yet best positioned as:
 
-- heterogeneous adversarial consensus rather than single-model trust
-- receipt-backed execution and decision provenance
-- unified DAG plus optional human interaction depth
-- permissioned memory and large-context handling
-- one substrate for execution, control, and self-improvement
+- a broad cross-functional decision platform
+- a universal enterprise copilot across every channel
+- a generalized memory or knowledge operating system
+- a finished regulator-ready compliance suite
 
-## Positioning Constraint
+## What Not To Claim Yet
 
-The company should market the broad vision, but sell the narrow proof. External positioning should always trail what the product can already do repeatably on real work.
+To stay truthful, external positioning should avoid these claims in the current tranche:
+
+- "enterprise-ready general decision platform"
+- "omnichannel AI operating system"
+- "fully autonomous software factory"
+- "broad multi-agent superiority across all workflows"
+- "compliance-complete platform for regulated industries"
+
+Those may be later-stage directions, but the current proof base is narrower. The commercial overview should stay narrower than the roadmap, not broader.
+
+## Longer-Term Direction
+
+The roadmap still supports a bigger business. The difference is sequencing.
+
+### Stage 1: Trusted bounded execution
+
+Prove that Aragora can repeatedly turn bounded tasks into:
+
+- guarded runs
+- truthful receipts
+- verification evidence
+- mergeable or merged PR outcomes
+
+### Stage 2: Adjacent operator loops
+
+Once the software-execution wedge is boringly reliable, extend the same substrate to:
+
+- inbox and operator action loops
+- prompt-to-spec handoff
+- thin truthful operator views backed by live receipts and state
+
+### Stage 3: Broader decision integrity platform
+
+Only after the wedge is proven and repeatable should Aragora broaden into the fuller long-horizon vision:
+
+- richer multi-agent decision workflows
+- broader channels and connectors
+- larger memory and context surfaces
+- wider organizational decision operations
+
+The long-term vision is still valid. The near-term positioning has to be earned by measured proof.
+
+## Commercial Positioning Guidance
+
+If a prospective customer asks what Aragora is today, the honest answer is:
+
+> Aragora is a control plane for guarded autonomous software execution on bounded work. It helps teams run narrow issue queues with receipts, verification evidence, blocker truth, and recurring benchmark measurement.
+
+If they ask what it can become, the honest answer is:
+
+> Aragora is being built toward a broader decision integrity platform, but the current go-to-market wedge is intentionally narrower: make bounded unattended execution reliable first, then expand from proved operator loops outward.
+
+## Proof Sources
+
+Use these documents as the canonical backing for commercial claims:
+
+- [status/NEXT_STEPS_CANONICAL.md](../contributing/next-steps-canonical)
+- [status/ACTIVE_EXECUTION_ISSUES.md](../contributing/active-execution-issues)
+- [plans/ARAGORA_EVOLUTION_ROADMAP.md](../contributing/aragora-evolution-roadmap)
+- [benchmarks/corpus.json](benchmarks/corpus.json)
+- `scripts/build_benchmark_truth_artifact.py`
+- `scripts/reconcile_b0_pr_truth.py`
+
+If a claim cannot be tied back to those sources or to current `main`, it should not be in first-tranche commercial positioning.

--- a/docs/COMMERCIAL_OVERVIEW.md
+++ b/docs/COMMERCIAL_OVERVIEW.md
@@ -1,131 +1,168 @@
 # Aragora Commercial Overview
 
-**Control plane for turning vague ideas into reviewed, auditable autonomous action.**
-**Last updated: April 9, 2026**
+**Internal positioning snapshot aligned to the current execution gate.**
+**Last updated: April 14, 2026**
 
 ## Executive Summary
 
-Aragora is building the Decision Integrity Platform and autonomous execution control plane.
+Aragora is currently a control plane for **bounded autonomous software execution**.
 
-We enter through a narrow wedge: reliable autonomous software execution for founders, technical leads, and small teams. Aragora takes a vague request, turns it into a reviewable spec, stress-tests the plan with heterogeneous agents, executes bounded work, verifies the result, and returns a receipt.
+The commercial wedge is deliberately narrow:
 
-Over time that wedge expands into a chief-of-staff layer and eventually an organization substrate for ideas, goals, actions, orchestration, and auditable memory.
+- take a bounded engineering task
+- run it through guarded autonomous execution
+- produce code, verification evidence, PR state, and operator-readable receipts
+- fail closed with explicit blocker evidence when autonomy should stop
 
-## Category
+That is the truthful sellable surface today. The current story is not "general AI for every decision" and not "omnichannel enterprise automation for everything." The near-term value is making unattended execution on bounded software work **measurable, inspectable, and auditable**.
 
-Aragora sits at the intersection of three categories:
+## What Is True On `main`
 
-1. **Decision Integrity Platform** — important decisions are debated, challenged, and receipted
-2. **Autonomous Execution Control Plane** — bounded work runs with contracts, verification, and human controls
-3. **SMB Operating System for Idea-to-Action** — small teams can translate messy intent into reliable autonomous work
+The claims below are the current proof base, not the long-term ambition.
 
-## Why This Wedge Wins Now
-
-The market shifted from “who can prompt best in chat” to “who can specify, coordinate, verify, and trust long-running agents.”
-
-Most teams do not need an abstract AGI narrative. They need:
-
-- help turning vague intent into a precise plan
-- autonomous execution that fails safely
-- receipts and evidence that make the work reviewable
-- optional intervention instead of all-or-nothing automation
-- memory that improves repeat work without becoming a security hole
-
-Software execution is the best first wedge because it is measurable, frequent, and easy to benchmark. That makes it the fastest path to trust.
-
-**Near-term proof bar:** benchmarked semi-autonomous software execution. The first claim to earn is that context-enriched workers can complete **50%+** of a fixed bounded issue corpus without human rescue and classify failures truthfully.
-
-## What the First Customer Actually Buys
-
-A customer buying Aragora today is buying a trust stack, not just a faster agent:
-
-- prompt-to-spec assistance
-- debate-validated plans
-- bounded autonomous execution
-- verification and repair loops
-- receipts, provenance, and dissent trails
-- optional human intervention at the level they choose
-- reusable memory and context for recurring work
-
-## Product Story by Stage
-
-| Stage | Buyer value | Product form |
+| Area | Current truth | Why it matters |
 |---|---|---|
-| **Tool** | Better one-shot outputs and review artifacts | Debate, review, prompt-to-spec, inbox triage |
-| **Teammate** | A bounded autonomous contributor | Scoped tasks with verification, receipts, and escalation |
-| **Foreman** | Coordination across many tasks and hosts | Backlog orchestration, operator controls, truthful status |
-| **Chief of Staff** | Goal translation, prioritization, and delegation | Planning, approvals, tradeoffs, portfolio reasoning |
-| **Organization Substrate** | Shared operating system for ideas to action | Unified DAG, memory fabric, auditable cross-functional workflows |
+| Guarded execution substrate | Boss, supervisor, tranche, contract, and preflight paths exist on the live swarm lane. | The system can decide when a run is admissible instead of blindly attempting work. |
+| Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
+| Truth artifacts | The repo has a diffable benchmark truth-artifact path and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth. |
+| Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
+| Operator truth | Preflight receipts, blocker evidence, and session-state work are materially underway and partially landed, but not yet fully closed across every live path. | This is the remaining gap between an impressive demo and a boring reliable product lane. |
 
-## Ideal Customers
+## Current Gate
 
-### 1. Founder / Technical Lead (2–50 people)
+The current commercial gate is the same as the current execution gate in [status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md):
 
-Wants more output without hiring a large team, but cannot tolerate black-box automation. Values visibility, receipts, and control.
+- finish `RS-07` so receipt-backed preflight becomes the default admission truth
+- close the remaining truthful repair gaps in `BC-01` and `BC-03`
+- keep `TW-01`, `TW-02`, and `TW-03` publishing recurring corpus-linked truth
+- keep all external claims narrower than the measured proof
 
-### 2. Engineering-Led SMB (10–200 people)
+This means Aragora should currently be positioned as:
 
-Needs repeatable spec, review, implementation, and verification loops. Values trustworthy throughput over raw model demos.
+- a **guarded autonomous execution control plane** for bounded software tasks
+- a **truthful operator surface** that says what happened, what failed, and what to try next
+- a **measured benchmark system** for proving unattended execution on a fixed corpus
 
-### 3. Operations-Heavy SMB or Agency
+## What Aragora Can Be Sold For Now
 
-Wants the same control plane for inbox, support, policy, and internal operations once the software wedge is proven.
+### 1. Bounded engineering execution
 
-### 4. Regulated Teams (Later Motion)
+Aragora is strongest when the work is narrow, reviewable, and single-PR shaped:
 
-Care about audit trails, policy gates, air-gapped deployment, and compliance bundles. This becomes a stronger motion after the wedge is already repeatable.
+- focused bug fixes
+- bounded tests and validation work
+- safe code-generation loops with explicit verification
+- repair and retry on previously seen failure classes
 
-## Why Aragora Instead of Existing Alternatives?
+The operator value is not just "an AI wrote code." The value is:
 
-| Alternative | What it does well | Where Aragora differs |
-|---|---|---|
-| Chatbots | Fast answers | Aragora is about reviewed action, not conversation |
-| Coding agents | Rapid code generation | Aragora adds contracts, verification, receipts, and multi-host coordination |
-| Workflow tools | Deterministic automation | Aragora handles underspecified intent and reviewable agent work |
-| Governance/compliance tools | Policy and audit after the fact | Aragora makes receipts and dissent part of the execution path |
-| Cooperative agent frameworks | Task collaboration | Aragora's default stance is adversarial validation plus operator control |
+- the run is scoped
+- the run is checked before execution
+- the result is tied to receipts, verification, and PR truth
+- failure is explicit instead of silent
 
-## What We Can Claim Now vs. Later
+### 2. Benchmark-backed autonomy proof
 
-### Claims We Should Make Now
+Aragora can already support design-partner style proof loops where a team wants to know:
 
-- Aragora helps translate vague work into reviewable specs and bounded execution
-- Aragora can preserve receipts, provenance, and human control around agentic work
-- Aragora is proving benchmarked semi-autonomous software execution with a truthful operator control plane
+- what percentage of bounded tasks complete without rescue
+- which failure classes repeat
+- whether repairs are becoming more truthful over time
+- whether autonomous progress is improving on a fixed corpus rather than a changing sample
 
-### Claims We Should Earn Before Making Loudly
+This is commercially useful for internal platform teams and founder-led design partners because it turns autonomy from a vibe into an operating metric.
 
-- long unattended multi-host operation with low rescue overhead
-- chief-of-staff behavior across multiple projects and workflows
-- broad cross-functional operating-system coverage
-- deep vertical packaging for regulated industries
+### 3. Operator-facing trust surface
 
-## Commercial Motion
+The system is increasingly useful as an operator control plane for:
 
-1. Land with reliable autonomous software execution
-2. Expand to adjacent operator loops such as inbox, policy, and review flows
-3. Use GUI/control-plane and memory advantages as retention multipliers
-4. Package vertical and enterprise surfaces after repeatable wedge proof exists
+- admission truth
+- session and repair state
+- blocker evidence
+- benchmark scorecards
+- rescue-to-productization tracking
 
-## Packaging Logic
+That surface matters even before the system is fully autonomous, because it reduces the cost of supervising automation honestly.
 
-The commercial story should mirror the stage model:
+## Who This Is For Right Now
 
-- **Starter / Tool** — individual or small-team use for bounded review and execution loops
-- **Team / Teammate** — scoped autonomous contributors with receipts and approvals
-- **Ops / Foreman** — multi-host coordination, truthful operator views, and workflow reuse
-- **Enterprise / Substrate** — deployment controls, compliance, policy gates, and organization-wide workflows
+The current wedge is best suited to:
 
-The BYOK model remains strategically important: customers bring model keys, Aragora provides orchestration, trust, and leverage.
+- engineering leaders who want bounded unattended execution on narrow backlogs
+- founders or staff engineers running repeated benchmark-style issue queues
+- internal platform teams that need receipts, blocker evidence, and fail-closed automation
+- design partners willing to operate on a narrow, measurable execution class first
 
-## Durable Differentiators
+It is not yet best positioned as:
 
-- heterogeneous adversarial consensus rather than single-model trust
-- receipt-backed execution and decision provenance
-- unified DAG plus optional human interaction depth
-- permissioned memory and large-context handling
-- one substrate for execution, control, and self-improvement
+- a broad cross-functional decision platform
+- a universal enterprise copilot across every channel
+- a generalized memory or knowledge operating system
+- a finished regulator-ready compliance suite
 
-## Positioning Constraint
+## What Not To Claim Yet
 
-The company should market the broad vision, but sell the narrow proof. External positioning should always trail what the product can already do repeatably on real work.
+To stay truthful, external positioning should avoid these claims in the current tranche:
+
+- "enterprise-ready general decision platform"
+- "omnichannel AI operating system"
+- "fully autonomous software factory"
+- "broad multi-agent superiority across all workflows"
+- "compliance-complete platform for regulated industries"
+
+Those may be later-stage directions, but the current proof base is narrower. The commercial overview should stay narrower than the roadmap, not broader.
+
+## Longer-Term Direction
+
+The roadmap still supports a bigger business. The difference is sequencing.
+
+### Stage 1: Trusted bounded execution
+
+Prove that Aragora can repeatedly turn bounded tasks into:
+
+- guarded runs
+- truthful receipts
+- verification evidence
+- mergeable or merged PR outcomes
+
+### Stage 2: Adjacent operator loops
+
+Once the software-execution wedge is boringly reliable, extend the same substrate to:
+
+- inbox and operator action loops
+- prompt-to-spec handoff
+- thin truthful operator views backed by live receipts and state
+
+### Stage 3: Broader decision integrity platform
+
+Only after the wedge is proven and repeatable should Aragora broaden into the fuller long-horizon vision:
+
+- richer multi-agent decision workflows
+- broader channels and connectors
+- larger memory and context surfaces
+- wider organizational decision operations
+
+The long-term vision is still valid. The near-term positioning has to be earned by measured proof.
+
+## Commercial Positioning Guidance
+
+If a prospective customer asks what Aragora is today, the honest answer is:
+
+> Aragora is a control plane for guarded autonomous software execution on bounded work. It helps teams run narrow issue queues with receipts, verification evidence, blocker truth, and recurring benchmark measurement.
+
+If they ask what it can become, the honest answer is:
+
+> Aragora is being built toward a broader decision integrity platform, but the current go-to-market wedge is intentionally narrower: make bounded unattended execution reliable first, then expand from proved operator loops outward.
+
+## Proof Sources
+
+Use these documents as the canonical backing for commercial claims:
+
+- [status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md)
+- [status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md)
+- [plans/ARAGORA_EVOLUTION_ROADMAP.md](plans/ARAGORA_EVOLUTION_ROADMAP.md)
+- [benchmarks/corpus.json](benchmarks/corpus.json)
+- `scripts/build_benchmark_truth_artifact.py`
+- `scripts/reconcile_b0_pr_truth.py`
+
+If a claim cannot be tied back to those sources or to current `main`, it should not be in first-tranche commercial positioning.

--- a/docs/status/COMMERCIAL_OVERVIEW.md
+++ b/docs/status/COMMERCIAL_OVERVIEW.md
@@ -1,309 +1,168 @@
-# Aragora -- The Decision Integrity Platform
+# Aragora -- Commercial Overview
 
-*Version 2.8.0 | Commercial Overview*
-*Status: Internal snapshot; metrics are directional unless sourced in docs/STATUS.md.*
+*Status: Internal positioning snapshot aligned to the current execution gate.*
+*Last updated: 2026-04-14.*
 
 ## Executive Summary
 
-Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types to adversarially vet decisions against your organization's knowledge, then delivering audit-ready decision receipts to any channel.
-
-**You don't just get an answer. You get a defensible decision trail.**
-
-Unlike chatbots, Aragora builds institutional memory with full audit trails. Vetted decisionmaking is the engine. The product is a defensible decision record.
-
----
-
-## Five Pillars
-
-Aragora is built on five architectural commitments that together produce something no single-model tool can offer.
-
-| Pillar | What It Means |
-|--------|---------------|
-| **1. SMB-Ready, Enterprise-Grade** | Useful to a 5-person startup on day one; scales to regulated enterprise without rearchitecting. Security and compliance built in, not bolted on. |
-| **2. Leading-Edge Memory and Context** | 4-tier Continuum Memory, Knowledge Mound (42 registered adapter specs), unified memory gateway, and RLM context management enable coherence across long multi-round sessions and large document sets. |
-| **3. Extensible and Modular** | Connectors, SDKs (Python 186 namespaces + TypeScript 185 namespaces), 3,000+ API operations, OpenClaw integration, workflow engine, marketplace. |
-| **4. Multi-Agent Robustness** | Heterogeneous agents (Claude, GPT, Gemini, Grok, Mistral, DeepSeek, Qwen, Kimi) produce outputs more robust, less biased, and higher quality than single models. |
-| **5. Self-Healing and Self-Extending** | Nomic Loop autonomous improvement, red-team stress-testing, multi-agent code editing with human approval gates. |
-
----
-
-## What Aragora Does
-
-| Capability | Description | Business Value |
-|------------|-------------|----------------|
-| **Omnivorous Input** | Ingest from documents, APIs, databases, web, voice | Single platform for all information sources |
-| **Multi-Channel Access** | Query via web, Slack, Telegram, WhatsApp, API | Meet users where they already work |
-| **Multi-Agent Consensus** | 43 heterogeneous agent types debate to conclusions | Diverse perspectives, defensible decisions |
-| **Bidirectional Dialogue** | Ask follow-ups, refine questions, drill into details | Interactive human-AI collaboration |
-| **Evidence Trails** | Cryptographic audit chains with provenance tracking | Compliance-ready documentation |
-| **Learn and Improve** | 4-tier memory with cross-session pattern learning | Continuously improving accuracy |
-
----
-
-## Core Value Proposition
-
-### For Engineering Leaders
-- **Reduce review bottlenecks**: AI agents provide first-pass critique 24/7
-- **Catch blind spots**: Different AI models notice different issues
-- **Accelerate decisions**: Get multi-perspective analysis in minutes, not days
-
-### For Compliance Officers
-- **Audit trails**: Every debate produces a cryptographic receipt
-- **Dissent tracking**: Know what was contested and why
-- **Provenance chains**: Trace every claim to its source
-
-### For Security Teams
-- **Adversarial testing**: Built-in red team mode attacks your specs
-- **Gauntlet mode**: Systematic stress-testing with risk heatmaps
-- **Pattern learning**: System remembers past vulnerabilities
-
----
-
-## Platform Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                         ARAGORA PLATFORM                                 │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                          │
-│  ┌──────────────────────────────────────────────────────────────────┐   │
-│  │                    AGENT LAYER (43 Agent Types)                   │   │
-│  │  Claude │ GPT │ Gemini │ Grok │ Mistral │ DeepSeek │ Qwen │ Kimi │   │
-│  │                     + Local Models (Ollama, LM Studio)            │   │
-│  └──────────────────────────────┬───────────────────────────────────┘   │
-│                                  ▼                                       │
-│  ┌──────────────────────────────────────────────────────────────────┐   │
-│  │                    DEBATE ENGINE                                  │   │
-│  │  • 9-round structured protocol (Propose → Critique → Synthesize)  │   │
-│  │  • Graph debates with branching │ Matrix debates for scenarios    │   │
-│  │  • Consensus detection │ Convergence analysis │ Forking support   │   │
-│  └──────────────────────────────┬───────────────────────────────────┘   │
-│                                  ▼                                       │
-│  ┌──────────────────────────────────────────────────────────────────┐   │
-│  │                    KNOWLEDGE LAYER                                │   │
-│  │  • Belief networks with Bayesian propagation                      │   │
-│  │  • Claims kernel with typed relationships                         │   │
-│  │  • Evidence provenance with hash chains                           │   │
-│  │  • Citation tracking and reliability scoring                      │   │
-│  └──────────────────────────────┬───────────────────────────────────┘   │
-│                                  ▼                                       │
-│  ┌──────────────────────────────────────────────────────────────────┐   │
-│  │                    MEMORY SYSTEM (4 tiers)                        │   │
-│  │  Fast → Medium → Slow → Glacial                                   │   │
-│  │  • Surprise-based learning │ Consolidation scoring                │   │
-│  │  • Cross-session pattern extraction                               │   │
-│  └──────────────────────────────┬───────────────────────────────────┘   │
-│                                  ▼                                       │
-│  ┌──────────────────────────────────────────────────────────────────┐   │
-│  │                    OUTPUT LAYER                                   │   │
-│  │  Decision Receipts │ Risk Heatmaps │ Dissent Trails │ Proofs     │   │
-│  └──────────────────────────────────────────────────────────────────┘   │
-│                                                                          │
-└─────────────────────────────────────────────────────────────────────────┘
-```
-
----
-
-## Commercial Readiness Assessment
-
-### Overall: Strong pre-GA foundation
-
-| Category | Score | Status | Notes |
-|----------|-------|--------|-------|
-| Error Handling & Resilience | 98% | Ready | Circuit breakers, retry policies, graceful degradation |
-| Security & Authentication | 98% | Ready | OIDC/SAML SSO, MFA, SCIM 2.0, AES-256-GCM encryption |
-| Scalability & Performance | 95% | Ready | Connection pooling, caching, rate limiting |
-| Observability & Monitoring | 95% | Ready | Prometheus, Grafana, OpenTelemetry |
-| Testing & QA | 98% | Ready | 208,000+ tests across 4,300+ files |
-| Documentation | 95% | Ready | API docs, runbooks, compliance guides |
-| Compliance & Governance | 98% | Ready | RBAC v2 with 420+ permissions, 7 roles, role hierarchy |
-| SDK & Integrations | 98% | Ready | 186 Python / 185 TypeScript namespaces |
-| **OVERALL** | **Pre-GA** | **Substantial foundation** | Enterprise-grade features integrated; launch truthfulness and remaining readiness work still open |
-
-### Deployment Readiness
-
-- Docker container with non-root user
-- Kubernetes manifests in `/deploy/kubernetes/`
-- Health checks and readiness probes
-- Prometheus metrics endpoint
-- Grafana dashboards included
-
----
-
-## Key Differentiators
-
-### 1. Heterogeneous Agent Orchestration
-Unlike single-model solutions, Aragora runs debates across 43 agent types/providers. Different models catch different issues—Claude excels at reasoning, GPT at breadth, Gemini at design, Grok at lateral thinking.
-
-### 2. Audit-Ready Output
-Every debate produces a **Decision Receipt** with:
-- Cryptographic hash chain
-- Evidence provenance
-- Dissent tracking
-- Timestamp verification
-
-### 3. Adversarial Testing Built-In
-**Gauntlet Mode** provides systematic stress-testing:
-- Security red-team attacks
-- Devil's advocate logic testing
-- Scaling critic analysis
-- Compliance verification (GDPR, HIPAA, SOC 2, AI Act)
-
-### 4. Learning Memory System
-The 4-tier **Continuum Memory** enables:
-- Pattern extraction from successful critiques
-- Cross-session learning
-- Institutional knowledge accumulation
-- Surprise-based prioritization
-
-### 5. Enterprise-Grade Security
-- OIDC/SAML SSO integration
-- MFA support (TOTP/HOTP)
-- AES-256-GCM encryption at rest
-- Multi-tenant isolation with quotas
-
----
-
-## Use Cases
-
-### Specification Review
-```bash
-aragora gauntlet spec.md --profile thorough --output receipt.html
-```
-Stress-test API specifications, architecture documents, and technical designs before implementation.
-
-### Compliance Audit
-```bash
-aragora gauntlet policy.yaml --input-type policy --persona gdpr
-```
-Automated compliance checking against GDPR, HIPAA, SOC 2, and AI Act requirements.
-
-### Code Review
-```bash
-git diff main | aragora review
-```
-AI red-team review of pull requests with unanimous consensus highlighting.
-
-### Decision Validation
-```python
-from aragora import Arena, Environment, DebateProtocol
-
-env = Environment(task="Should we adopt microservices?")
-protocol = DebateProtocol(rounds=5, consensus="majority")
-arena = Arena(env, agents, protocol)
-result = await arena.run()
-```
-Structured debate for strategic decisions with evidence-based recommendations.
-
----
-
-## Platform Statistics
-
-| Metric | Source |
-|--------|--------|
-| Codebase size & tests | See `docs/STATUS.md` |
-| Agent catalog | `AGENTS.md` |
-| Connector catalog | `docs/CONNECTORS.md` |
-| Memory tiers | 4 (see `docs/MEMORY_TIERS.md`) |
-
----
-
-## Deployment Options
-
-### Self-Hosted
-- Docker Compose for single-node deployment
-- Kubernetes for scale-out deployment
-- Supports SQLite (dev) or PostgreSQL (prod)
-
-### Cloud
-- AWS Lightsail (current production)
-- Any Kubernetes-compatible cloud (AWS EKS, GCP GKE, Azure AKS)
-- Cloudflare Tunnel for secure ingress
-
-### Hybrid
-- On-premises control plane
-- Cloud-based agent APIs
-- Air-gapped deployment support
-
----
-
-## Integration Points
-
-### Chat Platforms
-- Slack (bot + connector)
-- Discord (bot + connector)
-- Microsoft Teams (bot + connector)
-- Google Chat (connector)
-
-### Data Sources
-- GitHub, GitLab
-- SharePoint, Confluence, Notion
-- ArXiv, Wikipedia, news APIs
-- Healthcare systems (HL7/FHIR)
-- SEC filings, legal databases
-
-### Observability
-- Prometheus metrics export
-- Grafana dashboards included
-- OpenTelemetry tracing
-- SIEM integration
-
----
-
-## Enterprise Readiness
-
-| Capability | Resolution | Status |
-|------------|------------|--------|
-| Fine-grained RBAC | RBAC v2 with 7 roles, 420+ permissions | Complete |
-| Automated backups | BackupManager with incremental support | Complete |
-| Bot handler consolidation | BotHandlerMixin across 8 platforms | Complete |
-| Python SDK | 186 namespaces with typed clients | Complete |
-| TypeScript SDK | 185 namespaces with full IntelliSense | Complete |
-| OpenClaw integration | Portable agent governance | Complete |
-| Knowledge Mound Phase A2 | Contradiction detection, confidence decay, RBAC governance | Complete |
-| SLA documentation | Legally-binding service levels | In Progress |
-| Distributed rate limiting | Redis-backed cluster-aware limiting | In Progress |
-
----
-
-## Pricing
-
-| Tier | Price | Target | Key Features |
-|------|-------|--------|--------------|
-| **Free** | $0 forever | Individual developers | 10 debates/month, 3 agents, demo mode, Markdown receipts |
-| **Pro** | $49/seat/month | SMB teams (5-50) | Unlimited debates, 10 agents, cryptographic signing, all exports, CI/CD, channels, memory, workflows |
-| **Enterprise** | Custom | Regulated orgs (50+) | Everything in Pro + SSO/MFA/SCIM, RBAC (390+), multi-tenancy, encryption, compliance, self-hosted, custom SLA |
-
-### BYOK Model
-Customers bring their own LLM provider API keys. Aragora does not mark up LLM costs. Near-zero COGS on the platform side -- infrastructure costs ~$5/customer/month. This produces 85%+ gross margins without the typical AI infrastructure cost burden.
-
----
-
-## Getting Started
-
-### Quick Start (5 minutes)
-```bash
-git clone https://github.com/synaptent/aragora.git
-cd aragora
-pip install -e .
-export ANTHROPIC_API_KEY=your-key
-aragora ask "Design a rate limiter" --agents anthropic-api,openai-api
-```
-
-### Production Deployment
-See [PRODUCTION_READINESS.md](../deployment/PRODUCTION_READINESS.md) for the complete checklist.
-
-### API Integration
-See [SDK_GUIDE.md](../SDK_GUIDE.md) for the Python SDK reference.
-
----
-
-## Contact
-
-- **Domain**: [aragora.ai](https://aragora.ai)
-- **Documentation**: [docs/](.)
-- **API Reference**: [API_REFERENCE.md](../api/API_REFERENCE.md)
-
----
-
-*Document generated from comprehensive codebase exploration. Feature counts verified against actual module inventory. Last updated: February 25, 2026.*
+Aragora is currently a control plane for **bounded autonomous software execution**.
+
+The commercial wedge is deliberately narrow:
+
+- take a bounded engineering task
+- run it through guarded autonomous execution
+- produce code, verification evidence, PR state, and operator-readable receipts
+- fail closed with explicit blocker evidence when autonomy should stop
+
+That is the truthful sellable surface today. The current story is not "general AI for every decision" and not "omnichannel enterprise automation for everything." The near-term value is making unattended execution on bounded software work **measurable, inspectable, and auditable**.
+
+## What Is True On `main`
+
+The claims below are the current proof base, not the long-term ambition.
+
+| Area | Current truth | Why it matters |
+|---|---|---|
+| Guarded execution substrate | Boss, supervisor, tranche, contract, and preflight paths exist on the live swarm lane. | The system can decide when a run is admissible instead of blindly attempting work. |
+| Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
+| Truth artifacts | The repo has a diffable benchmark truth-artifact path and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth. |
+| Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
+| Operator truth | Preflight receipts, blocker evidence, and session-state work are materially underway and partially landed, but not yet fully closed across every live path. | This is the remaining gap between an impressive demo and a boring reliable product lane. |
+
+## Current Gate
+
+The current commercial gate is the same as the current execution gate in [NEXT_STEPS_CANONICAL.md](NEXT_STEPS_CANONICAL.md):
+
+- finish `RS-07` so receipt-backed preflight becomes the default admission truth
+- close the remaining truthful repair gaps in `BC-01` and `BC-03`
+- keep `TW-01`, `TW-02`, and `TW-03` publishing recurring corpus-linked truth
+- keep all external claims narrower than the measured proof
+
+This means Aragora should currently be positioned as:
+
+- a **guarded autonomous execution control plane** for bounded software tasks
+- a **truthful operator surface** that says what happened, what failed, and what to try next
+- a **measured benchmark system** for proving unattended execution on a fixed corpus
+
+## What Aragora Can Be Sold For Now
+
+### 1. Bounded engineering execution
+
+Aragora is strongest when the work is narrow, reviewable, and single-PR shaped:
+
+- focused bug fixes
+- bounded tests and validation work
+- safe code-generation loops with explicit verification
+- repair and retry on previously seen failure classes
+
+The operator value is not just "an AI wrote code." The value is:
+
+- the run is scoped
+- the run is checked before execution
+- the result is tied to receipts, verification, and PR truth
+- failure is explicit instead of silent
+
+### 2. Benchmark-backed autonomy proof
+
+Aragora can already support design-partner style proof loops where a team wants to know:
+
+- what percentage of bounded tasks complete without rescue
+- which failure classes repeat
+- whether repairs are becoming more truthful over time
+- whether autonomous progress is improving on a fixed corpus rather than a changing sample
+
+This is commercially useful for internal platform teams and founder-led design partners because it turns autonomy from a vibe into an operating metric.
+
+### 3. Operator-facing trust surface
+
+The system is increasingly useful as an operator control plane for:
+
+- admission truth
+- session and repair state
+- blocker evidence
+- benchmark scorecards
+- rescue-to-productization tracking
+
+That surface matters even before the system is fully autonomous, because it reduces the cost of supervising automation honestly.
+
+## Who This Is For Right Now
+
+The current wedge is best suited to:
+
+- engineering leaders who want bounded unattended execution on narrow backlogs
+- founders or staff engineers running repeated benchmark-style issue queues
+- internal platform teams that need receipts, blocker evidence, and fail-closed automation
+- design partners willing to operate on a narrow, measurable execution class first
+
+It is not yet best positioned as:
+
+- a broad cross-functional decision platform
+- a universal enterprise copilot across every channel
+- a generalized memory or knowledge operating system
+- a finished regulator-ready compliance suite
+
+## What Not To Claim Yet
+
+To stay truthful, external positioning should avoid these claims in the current tranche:
+
+- "enterprise-ready general decision platform"
+- "omnichannel AI operating system"
+- "fully autonomous software factory"
+- "broad multi-agent superiority across all workflows"
+- "compliance-complete platform for regulated industries"
+
+Those may be later-stage directions, but the current proof base is narrower. The commercial overview should stay narrower than the roadmap, not broader.
+
+## Longer-Term Direction
+
+The roadmap still supports a bigger business. The difference is sequencing.
+
+### Stage 1: Trusted bounded execution
+
+Prove that Aragora can repeatedly turn bounded tasks into:
+
+- guarded runs
+- truthful receipts
+- verification evidence
+- mergeable or merged PR outcomes
+
+### Stage 2: Adjacent operator loops
+
+Once the software-execution wedge is boringly reliable, extend the same substrate to:
+
+- inbox and operator action loops
+- prompt-to-spec handoff
+- thin truthful operator views backed by live receipts and state
+
+### Stage 3: Broader decision integrity platform
+
+Only after the wedge is proven and repeatable should Aragora broaden into the fuller long-horizon vision:
+
+- richer multi-agent decision workflows
+- broader channels and connectors
+- larger memory and context surfaces
+- wider organizational decision operations
+
+The long-term vision is still valid. The near-term positioning has to be earned by measured proof.
+
+## Commercial Positioning Guidance
+
+If a prospective customer asks what Aragora is today, the honest answer is:
+
+> Aragora is a control plane for guarded autonomous software execution on bounded work. It helps teams run narrow issue queues with receipts, verification evidence, blocker truth, and recurring benchmark measurement.
+
+If they ask what it can become, the honest answer is:
+
+> Aragora is being built toward a broader decision integrity platform, but the current go-to-market wedge is intentionally narrower: make bounded unattended execution reliable first, then expand from proved operator loops outward.
+
+## Proof Sources
+
+Use these documents as the canonical backing for commercial claims:
+
+- [NEXT_STEPS_CANONICAL.md](NEXT_STEPS_CANONICAL.md)
+- [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXECUTION_ISSUES.md)
+- [ARAGORA_EVOLUTION_ROADMAP.md](../plans/ARAGORA_EVOLUTION_ROADMAP.md)
+- [docs/benchmarks/corpus.json](../benchmarks/corpus.json)
+- `scripts/build_benchmark_truth_artifact.py`
+- `scripts/reconcile_b0_pr_truth.py`
+
+If a claim cannot be tied back to those sources or to current `main`, it should not be in first-tranche commercial positioning.


### PR DESCRIPTION
## Summary
- narrow the commercial overview to the currently measured bounded-execution wedge
- align the internal status copy and the published docs-site commercial overview with that posture
- sync generated docs-site mirrors that were stale relative to the canonical execution/status docs

## Validation
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- node docs-site/scripts/sync-docs.js

Closes #5542.
