### PR TITLE
feat(benchmarks): fingerprint recurring corpus artifacts

### DIFF
--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import re
 import sys
@@ -41,6 +42,26 @@ def load_corpus(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _corpus_issue_numbers(corpus: dict[str, Any]) -> list[int]:
+    issue_numbers: list[int] = []
+    for item in list(corpus.get("issues") or []):
+        if not isinstance(item, dict):
+            continue
+        issue_number = int(item.get("issue_id", 0) or 0)
+        if issue_number > 0:
+            issue_numbers.append(issue_number)
+    return sorted(issue_numbers)
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _corpus_membership_sha256(issue_numbers: list[int]) -> str:
+    normalized = json.dumps(issue_numbers, separators=(",", ":")).encode("utf-8")
+    return _sha256_bytes(normalized)
+
+
 def aggregate_corpus_issues(
     rows: list[dict[str, Any]],
     corpus: dict[str, Any],
@@ -61,10 +82,10 @@ def aggregate_corpus_issues(
 
     corpus_issue_numbers = set(by_issue)
     for row in rows:
-        issue_number = row.get("issue_number")
-        if not isinstance(issue_number, int) or issue_number not in corpus_issue_numbers:
+        row_issue_number: object = row.get("issue_number")
+        if not isinstance(row_issue_number, int) or row_issue_number not in corpus_issue_numbers:
             continue
-        aggregate = by_issue[issue_number]
+        aggregate = by_issue[row_issue_number]
         aggregate.row_count += 1
         terminal_class = resolve_terminal_class(row)
         publish_action = str(row.get("publish_action", "") or "").strip().lower()
@@ -164,6 +185,7 @@ def build_benchmark_truth_artifact(
     normalized_generated_at = normalize_generated_at(generated_at)
     rows = load_metrics_rows(metrics_file)
     corpus = load_corpus(corpus_path)
+    membership_issue_numbers = _corpus_issue_numbers(corpus)
     aggregates = aggregate_corpus_issues(rows, corpus)
     truth_client = client or GitHubTruthClient()
     records = [reconcile_issue_truth(repo, aggregate, truth_client) for aggregate in aggregates]
@@ -191,6 +213,9 @@ def build_benchmark_truth_artifact(
             "revision": int(corpus.get("revision", 0) or 0),
             "recorded_on": str(corpus.get("recorded_on") or "").strip(),
             "success_contract": str(corpus.get("success_contract") or "").strip(),
+            "manifest_sha256": _sha256_bytes(corpus_path.read_bytes()),
+            "membership_sha256": _corpus_membership_sha256(membership_issue_numbers),
+            "membership_issue_numbers": membership_issue_numbers,
             "issue_count": corpus_issue_count,
         },
         "run_status": "complete" if run_complete else "incomplete",

--- a/scripts/measure_b0_scorecard.py
+++ b/scripts/measure_b0_scorecard.py
@@ -166,20 +166,29 @@ def build_published_scorecard(
     if not corpus:
         raise ValueError(f"Truth artifact at {truth_artifact_path} is missing corpus metadata")
 
+    published_corpus: dict[str, Any] = {
+        "path": str(corpus.get("path") or "").strip() or None,
+        "corpus_id": str(corpus.get("corpus_id") or "").strip(),
+        "revision": int(corpus.get("revision", 0) or 0),
+        "recorded_on": str(corpus.get("recorded_on") or "").strip() or None,
+        "success_contract": str(corpus.get("success_contract") or "").strip() or None,
+        "manifest_sha256": str(corpus.get("manifest_sha256") or "").strip() or None,
+        "membership_sha256": str(corpus.get("membership_sha256") or "").strip() or None,
+        "membership_issue_numbers": [
+            int(item)
+            for item in list(corpus.get("membership_issue_numbers") or [])
+            if isinstance(item, int)
+        ],
+        "issue_count": int(corpus.get("issue_count", 0) or 0),
+    }
+
     published = {
         "generated_at": normalize_generated_at(generated_at),
         "metrics_file": _repo_stable_path(metrics_path),
         "truth_artifact_path": _repo_stable_path(truth_artifact_path),
         "truth_artifact_generated_at": str(truth_artifact.get("generated_at") or "").strip()
         or None,
-        "corpus": {
-            "path": str(corpus.get("path") or "").strip() or None,
-            "corpus_id": str(corpus.get("corpus_id") or "").strip(),
-            "revision": int(corpus.get("revision", 0) or 0),
-            "recorded_on": str(corpus.get("recorded_on") or "").strip() or None,
-            "success_contract": str(corpus.get("success_contract") or "").strip() or None,
-            "issue_count": int(corpus.get("issue_count", 0) or 0),
-        },
+        "corpus": published_corpus,
         "truth_metrics": dict(truth_artifact.get("primary_metrics") or {}),
         "coverage": dict(truth_artifact.get("coverage") or {}),
         "failure_class_distribution": dict(truth_artifact.get("failure_class_distribution") or {}),
@@ -189,8 +198,8 @@ def build_published_scorecard(
 
     previous_path = _previous_published_scorecard_path(
         publish_dir=publish_dir,
-        corpus_id=published["corpus"]["corpus_id"],
-        revision=int(published["corpus"]["revision"] or 0),
+        corpus_id=str(published_corpus["corpus_id"]),
+        revision=int(published_corpus["revision"] or 0),
     )
     if previous_path is not None:
         previous = _load_json(previous_path)

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -105,6 +106,12 @@ def test_build_benchmark_truth_artifact_links_corpus_revision_and_truth_metrics(
 
     assert artifact["corpus"]["corpus_id"] == "tw-01-bounded-execution-v1"
     assert artifact["corpus"]["revision"] == 3
+    assert (
+        artifact["corpus"]["manifest_sha256"]
+        == hashlib.sha256(corpus_path.read_bytes()).hexdigest()
+    )
+    assert artifact["corpus"]["membership_issue_numbers"] == [1064, 2712]
+    assert artifact["corpus"]["membership_sha256"] == hashlib.sha256(b"[1064,2712]").hexdigest()
     assert artifact["run_status"] == "complete"
     assert artifact["coverage"]["attempted_issue_count"] == 2
     assert artifact["coverage"]["missing_issue_numbers"] == []
@@ -179,6 +186,7 @@ def test_build_benchmark_truth_artifact_marks_partial_corpus_runs_incomplete(
     )
 
     assert artifact["run_status"] == "incomplete"
+    assert artifact["corpus"]["membership_issue_numbers"] == [873, 1064]
     assert artifact["coverage"]["attempted_issue_count"] == 1
     assert artifact["coverage"]["missing_issue_count"] == 1
     assert artifact["coverage"]["missing_issue_numbers"] == [873]
@@ -315,6 +323,11 @@ def test_build_benchmark_truth_artifact_normalizes_generated_at_and_repo_paths(
 
     assert artifact["generated_at"] == "2026-04-14T02:03:04Z"
     assert artifact["corpus"]["path"] == "docs/benchmarks/corpus.json"
+    assert (
+        artifact["corpus"]["manifest_sha256"]
+        == hashlib.sha256(corpus_path.read_bytes()).hexdigest()
+    )
+    assert artifact["corpus"]["membership_issue_numbers"] == [1064]
     assert artifact["metrics_file"] == str(metrics_path)
 
 

--- a/tests/scripts/test_measure_b0_scorecard.py
+++ b/tests/scripts/test_measure_b0_scorecard.py
@@ -102,6 +102,9 @@ def test_build_published_scorecard_links_truth_artifact_and_previous_delta(
                 "revision": 3,
                 "recorded_on": "2026-04-14",
                 "success_contract": "mergeable_pr_or_merged_pr",
+                "manifest_sha256": "abc123",
+                "membership_sha256": "def456",
+                "membership_issue_numbers": [1001, 1002],
                 "issue_count": 2,
             },
             "primary_metrics": {
@@ -142,6 +145,9 @@ def test_build_published_scorecard_links_truth_artifact_and_previous_delta(
 
     assert published["generated_at"] == "2026-04-14T15:16:17Z"
     assert published["corpus"]["corpus_id"] == "tw-01-bounded-execution-v1"
+    assert published["corpus"]["manifest_sha256"] == "abc123"
+    assert published["corpus"]["membership_sha256"] == "def456"
+    assert published["corpus"]["membership_issue_numbers"] == [1001, 1002]
     assert published["truth_metrics"]["truth_success_rate"] == 0.5
     assert published["proxy_metrics"]["no_rescue_success_rate"] == 0.5
     assert published["previous_artifact"]["path"].endswith(
@@ -192,6 +198,9 @@ def test_main_publish_dir_writes_timestamped_artifact_and_prints_path(
                 "revision": 4,
                 "recorded_on": "2026-04-14",
                 "success_contract": "mergeable_pr_or_merged_pr",
+                "manifest_sha256": "abc123",
+                "membership_sha256": "def456",
+                "membership_issue_numbers": [1001],
                 "issue_count": 1,
             },
             "primary_metrics": {"truth_success_rate": 1.0},
@@ -239,6 +248,9 @@ def test_main_publish_dir_with_json_keeps_stdout_json_and_reports_path_on_stderr
                 "revision": 5,
                 "recorded_on": "2026-04-14",
                 "success_contract": "mergeable_pr_or_merged_pr",
+                "manifest_sha256": "abc123",
+                "membership_sha256": "def456",
+                "membership_issue_numbers": [1001],
                 "issue_count": 1,
             },
             "primary_metrics": {"truth_success_rate": 1.0},


### PR DESCRIPTION
## Summary
- add exact corpus manifest and membership fingerprints to recurring truth artifacts
- carry the corpus fingerprint metadata through published scorecards
- extend focused script tests for diffable recurring corpus identity

## Validation
- pytest tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_measure_b0_scorecard.py -q
- ruff check scripts/build_benchmark_truth_artifact.py scripts/measure_b0_scorecard.py tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_measure_b0_scorecard.py
- python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes scripts/build_benchmark_truth_artifact.py scripts/measure_b0_scorecard.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5539