### PR TITLE
fix(scripts): fail closed on unknown boss-ready refill priority

### DIFF
--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -29,7 +29,10 @@ sys.path.insert(0, str(REPO_ROOT))
 from aragora.swarm.decomposition_bridge import DecompositionBridge  # noqa: E402
 from aragora.swarm.issue_scanner import BossIssueCandidate, scan_all  # noqa: E402
 from aragora.swarm.issue_upgrader import upgrade_issue_heuristic  # noqa: E402
-from aragora.swarm.roadmap_priority import load_roadmap_priority_policy  # noqa: E402
+from aragora.swarm.roadmap_priority import (  # noqa: E402
+    RoadmapPriority,
+    load_roadmap_priority_policy,
+)
 
 _GENERIC_PARENT_PHRASES: tuple[str, ...] = (
     "read the module and identify all public functions",
@@ -506,13 +509,11 @@ def main() -> None:
         body = format_boss_ready_body(candidate)
         if args.label == "boss-ready" and priority_policy is not None:
             priority = priority_policy.priority_for_text(candidate.title, body)
-            if priority.priority.blocks_boss_ready:
+            if priority.priority is not RoadmapPriority.DO_NOW:
                 skipped_priority += 1
                 if args.verbose:
-                    print(
-                        "  SKIP (canonical priority): "
-                        f"{candidate.title} [{', '.join(priority.blocked_codes)}]"
-                    )
+                    detail = ", ".join(priority.blocked_codes) or priority.priority.value
+                    print(f"  SKIP (canonical priority): {candidate.title} [{detail}]")
                 continue
         ok, reason = validate_body(body)
         if not ok:

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from aragora.swarm.issue_scanner import BossIssueCandidate
+from aragora.swarm.roadmap_priority import RoadmapPriorityPolicy
 from scripts import generate_boss_issues as mod
 
 
@@ -81,6 +82,7 @@ def test_main_dry_run_fetches_and_filters_like_real_mode(
         "create_github_issue",
         lambda repo, title, body, label: (create_calls.append((repo, title, body, label)) or True),
     )
+    monkeypatch.setattr(mod, "load_roadmap_priority_policy", lambda repo_root: None)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -103,7 +105,10 @@ def test_main_dry_run_fetches_and_filters_like_real_mode(
     assert fetch_pr_calls == ["org/repo"]
     assert "DRY RUN — would create 1 issues" in out
     assert eligible.title in out
-    assert "Skipped: 1 duplicates, 1 PR conflicts, 0 validation failures" in out
+    assert (
+        "Skipped: 1 duplicates, 1 PR conflicts, 0 canonical priority blocks, "
+        "0 validation failures" in out
+    )
     assert not create_calls
 
 
@@ -123,6 +128,7 @@ def test_main_create_mode_trims_to_max_and_writes_fingerprint(
     monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
     monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
     monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(mod, "load_roadmap_priority_policy", lambda repo_root: None)
     monkeypatch.setattr(
         mod,
         "create_github_issue",
@@ -169,6 +175,7 @@ def test_main_passes_explicit_min_success_rate(monkeypatch, capsys) -> None:
     monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
     monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
     monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(mod, "load_roadmap_priority_policy", lambda repo_root: None)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -185,6 +192,92 @@ def test_main_passes_explicit_min_success_rate(monkeypatch, capsys) -> None:
     _ = capsys.readouterr()
     assert scan_calls
     assert scan_calls[0][2] == 0.5
+
+
+def test_main_boss_ready_requires_explicit_do_now_priority(monkeypatch, capsys) -> None:
+    unknown = _candidate("eligible_module", file_scope=["aragora/eligible_module.py"])
+
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: [unknown],
+    )
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+    monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(
+        mod,
+        "load_roadmap_priority_policy",
+        lambda repo_root: RoadmapPriorityPolicy(
+            do_now=frozenset({"TW-01"}),
+            delay=frozenset({"BC-07"}),
+            avoid=frozenset({"CS-04"}),
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--dry-run",
+            "--label",
+            "boss-ready",
+        ],
+    )
+
+    mod.main()
+
+    out = capsys.readouterr().out
+    assert "DRY RUN — would create 0 issues" in out
+    assert "1 canonical priority blocks" in out
+
+
+def test_main_non_boss_ready_label_allows_unknown_priority(monkeypatch, capsys) -> None:
+    unknown = _candidate("eligible_module", file_scope=["aragora/eligible_module.py"])
+    created: list[tuple[str, str, str, str]] = []
+
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: [unknown],
+    )
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+    monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(
+        mod,
+        "load_roadmap_priority_policy",
+        lambda repo_root: RoadmapPriorityPolicy(
+            do_now=frozenset({"TW-01"}),
+            delay=frozenset({"BC-07"}),
+            avoid=frozenset({"CS-04"}),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "create_github_issue",
+        lambda repo, title, body, label: (created.append((repo, title, body, label)) or True),
+    )
+    monkeypatch.setattr(mod.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--repo",
+            "org/repo",
+            "--max-issues",
+            "1",
+            "--label",
+            "lane:test",
+        ],
+    )
+
+    mod.main()
+
+    out = capsys.readouterr().out
+    assert "Done: 1 created, 0 failed" in out
+    assert created[0][3] == "lane:test"
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_run_boss_cycle.py
+++ b/tests/scripts/test_run_boss_cycle.py
@@ -43,6 +43,10 @@ def _read_calls(log_path: Path) -> list[list[str]]:
     return [line.split("\t") for line in log_path.read_text(encoding="utf-8").splitlines() if line]
 
 
+def _runtime_calls(log_path: Path) -> list[list[str]]:
+    return [call for call in _read_calls(log_path) if call[:2] != ["-c", "import pydantic"]]
+
+
 def test_run_boss_cycle_runs_post_loop_refill_after_success(tmp_path: Path) -> None:
     _fake_python3, log_path = _write_fake_python3(tmp_path)
     env = os.environ.copy()
@@ -73,7 +77,7 @@ def test_run_boss_cycle_runs_post_loop_refill_after_success(tmp_path: Path) -> N
     )
 
     assert result.returncode == 0
-    calls = _read_calls(log_path)
+    calls = _runtime_calls(log_path)
     assert len(calls) == 2
     assert calls[0][:5] == ["-u", "-m", "aragora.cli.main", "swarm", "boss-loop"]
     assert "--boss-repo" in calls[0]
@@ -116,7 +120,7 @@ def test_run_boss_cycle_skips_post_loop_refill_after_failure(tmp_path: Path) -> 
     )
 
     assert result.returncode == 9
-    calls = _read_calls(log_path)
+    calls = _runtime_calls(log_path)
     assert len(calls) == 1
     assert calls[0][:5] == ["-u", "-m", "aragora.cli.main", "swarm", "boss-loop"]
     assert "Skipping post-loop issue refill because boss loop exited non-zero." in result.stderr


### PR DESCRIPTION
## Summary
- make boss-ready generation require explicit `Do now` roadmap priority instead of allowing unknown scanner issues through
- keep non-boss-ready labels unaffected so preview and side-lane generation still work
- update the boss-cycle test surface to ignore the python resolver probe and keep asserting refill behavior

## Validation
- python3 -m pytest tests/scripts/test_generate_boss_issues.py tests/scripts/test_run_boss_cycle.py -q
- python3 -m ruff check scripts/generate_boss_issues.py tests/scripts/test_generate_boss_issues.py tests/scripts/test_run_boss_cycle.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5597.
