### PR TITLE
fix(swarm): make targeted boss issue misses truthful

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -634,10 +634,14 @@ class BossLoop:
         self._configured_parallel_dispatches = max(1, int(self.config.max_parallel_dispatches or 1))
         self._current_effective_parallel_dispatches: int | None = None
         self._max_effective_parallel_dispatches_observed: int | None = None
+        issue_numbers = [int(item) for item in (self.config.issue_numbers or []) if int(item) > 0]
+        if self.config.issue_number is not None and int(self.config.issue_number) > 0:
+            if int(self.config.issue_number) not in issue_numbers:
+                issue_numbers.append(int(self.config.issue_number))
         self._feed = issue_feed or GitHubIssueFeed(
             repo=self.config.repo,
             label_filter=self.config.label_filter,
-            issue_numbers=self.config.issue_numbers,
+            issue_numbers=issue_numbers or None,
             limit=self.config.issue_limit,
         )
         self._freshness_checker = freshness_checker or check_runner_freshness
@@ -1152,6 +1156,30 @@ class BossLoop:
                 ],
                 [
                     f"Add the required labels to issue #{issue_number} or adjust --require-label settings.",
+                    "Remove --boss-issue-number to return to feed-driven selection.",
+                ],
+            )
+
+        overlapping_scopes = sorted(
+            {
+                entry
+                for entry in infer_issue_scope_entries(issue)
+                if entry in self._blocked_issue_scopes()
+            }
+        )
+        if overlapping_scopes:
+            overlap_summary = ", ".join(overlapping_scopes[:3])
+            if len(overlapping_scopes) > 3:
+                overlap_summary = f"{overlap_summary}, +{len(overlapping_scopes) - 3} more"
+            return (
+                [
+                    (
+                        f"Target issue #{issue_number} overlaps files already owned by open PR or "
+                        f"in-flight work: {overlap_summary}."
+                    )
+                ],
+                [
+                    f"Merge, close, or retarget the overlapping work before redispatching issue #{issue_number}.",
                     "Remove --boss-issue-number to return to feed-driven selection.",
                 ],
             )

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1102,97 +1102,15 @@ class BossLoop:
         return candidates
 
     def _target_issue_miss_guidance(self, issue_number: int) -> tuple[list[str], list[str]]:
-        reasons = [
-            f"Target issue #{issue_number} was not found in the issue feed or is not eligible under current filters/retry state."
-        ]
-        next_actions = [
-            f"Verify issue #{issue_number} is still open, eligible, and has not exceeded retry limits.",
-            "Remove --boss-issue-number to return to feed-driven selection.",
-        ]
-        fetch_issue = getattr(self._feed, "_fetch_issue", None)
-        if not callable(fetch_issue):
-            return reasons, next_actions
-        try:
-            issue = fetch_issue(issue_number, allow_closed=True)
-        except TypeError:
-            try:
-                issue = fetch_issue(issue_number)
-            except Exception:
-                return reasons, next_actions
-        except Exception:
-            return reasons, next_actions
-        if not isinstance(issue, GitHubIssue):
-            return reasons, next_actions
+        from aragora.swarm.boss_loop_selection import target_issue_miss_guidance
 
-        state = str(issue.state or "").strip().lower()
-        if state and state != "open":
-            return (
-                [
-                    f"Target issue #{issue_number} is {state} and cannot be selected by the open-issue boss feed."
-                ],
-                [
-                    f"Reopen issue #{issue_number} if it should be eligible for Boss dispatch.",
-                    "Remove --boss-issue-number to return to feed-driven selection.",
-                ],
-            )
-
-        labels = {str(label).strip() for label in issue.labels if str(label).strip()}
-        skipped = sorted(labels & set(self.config.skip_labels or set()))
-        if skipped:
-            return (
-                [f"Target issue #{issue_number} is excluded by skip labels: {', '.join(skipped)}."],
-                [
-                    f"Remove skip labels from issue #{issue_number} or adjust --label-filter/skip-label settings.",
-                    "Remove --boss-issue-number to return to feed-driven selection.",
-                ],
-            )
-
-        required = set(self.config.require_labels or set())
-        missing_labels = sorted(required - labels)
-        if missing_labels:
-            return (
-                [
-                    f"Target issue #{issue_number} is missing required labels: {', '.join(missing_labels)}."
-                ],
-                [
-                    f"Add the required labels to issue #{issue_number} or adjust --require-label settings.",
-                    "Remove --boss-issue-number to return to feed-driven selection.",
-                ],
-            )
-
-        overlapping_scopes = sorted(
-            {
-                entry
-                for entry in infer_issue_scope_entries(issue)
-                if entry in self._blocked_issue_scopes()
-            }
+        return target_issue_miss_guidance(
+            issue_number=issue_number,
+            fetch_issue=getattr(self._feed, "_fetch_issue", None),
+            skip_labels=self.config.skip_labels,
+            require_labels=self.config.require_labels,
+            blocked_scopes=self._blocked_issue_scopes(),
         )
-        if overlapping_scopes:
-            overlap_summary = ", ".join(overlapping_scopes[:3])
-            if len(overlapping_scopes) > 3:
-                overlap_summary = f"{overlap_summary}, +{len(overlapping_scopes) - 3} more"
-            return (
-                [
-                    (
-                        f"Target issue #{issue_number} overlaps files already owned by open PR or "
-                        f"in-flight work: {overlap_summary}."
-                    )
-                ],
-                [
-                    f"Merge, close, or retarget the overlapping work before redispatching issue #{issue_number}.",
-                    "Remove --boss-issue-number to return to feed-driven selection.",
-                ],
-            )
-
-        if not issue.title:
-            return (
-                [f"Target issue #{issue_number} is missing a title and cannot be selected."],
-                [
-                    f"Add a non-empty title to issue #{issue_number}.",
-                    "Remove --boss-issue-number to return to feed-driven selection.",
-                ],
-            )
-        return reasons, next_actions
 
     @staticmethod
     def _skip_label_summary(report: IssueEligibilityReport) -> str | None:

--- a/aragora/swarm/boss_loop_selection.py
+++ b/aragora/swarm/boss_loop_selection.py
@@ -220,3 +220,106 @@ def select_issues_for_batch(
         if limit is not None and len(selected_issues) >= limit:
             break
     return selected_issues
+
+
+def target_issue_miss_guidance(
+    *,
+    issue_number: int,
+    fetch_issue: Any,
+    skip_labels: set[str] | None,
+    require_labels: set[str] | None,
+    blocked_scopes: set[str] | None,
+) -> tuple[list[str], list[str]]:
+    """Return truthful guidance for an explicitly targeted issue miss."""
+    from aragora.swarm.boss_loop import GitHubIssue, infer_issue_scope_entries
+
+    reasons = [
+        f"Target issue #{issue_number} was not found in the issue feed or is not eligible under current filters/retry state."
+    ]
+    next_actions = [
+        f"Verify issue #{issue_number} is still open, eligible, and has not exceeded retry limits.",
+        "Remove --boss-issue-number to return to feed-driven selection.",
+    ]
+    if not callable(fetch_issue):
+        return reasons, next_actions
+    try:
+        issue = fetch_issue(issue_number, allow_closed=True)
+    except TypeError:
+        try:
+            issue = fetch_issue(issue_number)
+        except Exception:
+            return reasons, next_actions
+    except Exception:
+        return reasons, next_actions
+    if not isinstance(issue, GitHubIssue):
+        return reasons, next_actions
+
+    state = str(issue.state or "").strip().lower()
+    if state and state != "open":
+        return (
+            [
+                f"Target issue #{issue_number} is {state} and cannot be selected by the open-issue boss feed."
+            ],
+            [
+                f"Reopen issue #{issue_number} if it should be eligible for Boss dispatch.",
+                "Remove --boss-issue-number to return to feed-driven selection.",
+            ],
+        )
+
+    labels = {str(label).strip() for label in issue.labels if str(label).strip()}
+    skipped = sorted(labels & set(skip_labels or set()))
+    if skipped:
+        return (
+            [f"Target issue #{issue_number} is excluded by skip labels: {', '.join(skipped)}."],
+            [
+                f"Remove skip labels from issue #{issue_number} or adjust --label-filter/skip-label settings.",
+                "Remove --boss-issue-number to return to feed-driven selection.",
+            ],
+        )
+
+    required = set(require_labels or set())
+    missing_labels = sorted(required - labels)
+    if missing_labels:
+        return (
+            [
+                f"Target issue #{issue_number} is missing required labels: {', '.join(missing_labels)}."
+            ],
+            [
+                f"Add the required labels to issue #{issue_number} or adjust --require-label settings.",
+                "Remove --boss-issue-number to return to feed-driven selection.",
+            ],
+        )
+
+    overlapping_scopes = sorted(
+        {
+            entry
+            for entry in infer_issue_scope_entries(issue)
+            if entry in set(blocked_scopes or set())
+        }
+    )
+    if overlapping_scopes:
+        overlap_summary = ", ".join(overlapping_scopes[:3])
+        if len(overlapping_scopes) > 3:
+            overlap_summary = f"{overlap_summary}, +{len(overlapping_scopes) - 3} more"
+        return (
+            [
+                (
+                    f"Target issue #{issue_number} overlaps files already owned by open PR or "
+                    f"in-flight work: {overlap_summary}."
+                )
+            ],
+            [
+                f"Merge, close, or retarget the overlapping work before redispatching issue #{issue_number}.",
+                "Remove --boss-issue-number to return to feed-driven selection.",
+            ],
+        )
+
+    if not issue.title:
+        return (
+            [f"Target issue #{issue_number} is missing a title and cannot be selected."],
+            [
+                f"Add a non-empty title to issue #{issue_number}.",
+                "Remove --boss-issue-number to return to feed-driven selection.",
+            ],
+        )
+    return reasons, next_actions

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1625,6 +1625,49 @@ class TestBossLoop:
         assert result.iterations_completed == 1
         assert result.issues_attempted[0]["number"] == 873
 
+    def test_specific_issue_number_seeds_explicit_feed_issue_numbers(self):
+        loop = BossLoop(config=_boss_config(max_iterations=1, issue_number=873))
+
+        assert isinstance(loop._feed, GitHubIssueFeed)
+        assert loop._feed.issue_numbers == [873]
+
+    def test_specific_issue_number_scope_conflict_reports_overlap_reason(self):
+        issue = _make_issue(
+            873,
+            "Publish recurring scorecard",
+            body=(
+                "Update `scripts/measure_b0_scorecard.py`.\n\n"
+                "Acceptance Criteria:\n"
+                "- python3 scripts/measure_b0_scorecard.py --help\n"
+            ),
+            labels=["boss-ready", "priority:critical", "autonomous"],
+        )
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [issue]
+        feed._fetch_issue.return_value = issue
+
+        loop = BossLoop(
+            config=_boss_config(
+                max_iterations=1,
+                issue_number=873,
+                label_filter="boss-ready",
+                require_labels={"boss-ready", "priority:critical", "autonomous"},
+            ),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._blocked_issue_scopes = lambda: {"scripts/measure_b0_scorecard.py"}
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+        assert (
+            "overlaps files already owned by open PR or in-flight work"
+            in result.needs_human_reasons[0]
+        )
+        assert "scripts/measure_b0_scorecard.py" in result.needs_human_reasons[0]
+        assert "Merge, close, or retarget" in result.next_actions[0]
+
     def test_specific_issue_number_missing_stops_truthfully(self):
         feed = MagicMock(spec=GitHubIssueFeed)
         feed.fetch.return_value = [_make_issue(909, "Meta benchmark issue")]


### PR DESCRIPTION
## Summary
- seed explicit issue numbers into the GitHub issue feed when  is used
- report overlapping open-PR or in-flight file scopes as the specific reason a targeted issue is ineligible
- add regressions for explicit issue-number feed seeding and targeted scope-conflict guidance

## Validation
- All checks passed!
- Compiling 'tests/swarm/test_boss_loop.py'...
- direct assertion: explicit issue-number feed seeding returns 
- direct assertion: target miss guidance reports the blocked scope instead of a generic miss

## Context
This came from the live boss-loop repro against : the queue was clean, but explicit targeting still returned a generic miss because the target was being filtered by open-PR scope conflicts.