### PR TITLE
feat(benchmarks): add stable recurring benchmark pointers

### DIFF
--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -156,6 +156,16 @@ def _slugify(value: str) -> str:
     return slug.strip("-") or "benchmark-corpus"
 
 
+def _corpus_publish_dir(*, publish_dir: Path, corpus: dict[str, Any]) -> Path:
+    corpus_id = _slugify(str(corpus.get("corpus_id") or "benchmark-corpus"))
+    return publish_dir / corpus_id
+
+
+def _revision_publish_dir(*, publish_dir: Path, corpus: dict[str, Any]) -> Path:
+    revision = int(corpus.get("revision", 0) or 0)
+    return _corpus_publish_dir(publish_dir=publish_dir, corpus=corpus) / f"rev-{revision}"
+
+
 def resolve_published_artifact_path(
     *,
     publish_dir: Path,
@@ -168,10 +178,24 @@ def resolve_published_artifact_path(
     timestamp = _coerce_utc_datetime(
         generated_at if isinstance(generated_at, str) else None
     ).strftime("%Y%m%dT%H%M%SZ")
-    corpus_id = _slugify(str(corpus.get("corpus_id") or "benchmark-corpus"))
-    revision = int(corpus.get("revision", 0) or 0)
     filename = f"truth-{timestamp}.json"
-    return publish_dir / corpus_id / f"rev-{revision}" / filename
+    return _revision_publish_dir(publish_dir=publish_dir, corpus=corpus) / filename
+
+
+def resolve_latest_artifact_paths(
+    *,
+    publish_dir: Path,
+    artifact: dict[str, Any],
+) -> dict[str, Path]:
+    corpus = artifact.get("corpus")
+    if not isinstance(corpus, dict):
+        corpus = {}
+    return {
+        "corpus_latest": _corpus_publish_dir(publish_dir=publish_dir, corpus=corpus)
+        / "latest.json",
+        "revision_latest": _revision_publish_dir(publish_dir=publish_dir, corpus=corpus)
+        / "latest.json",
+    }
 
 
 def build_benchmark_truth_artifact(
@@ -263,6 +287,23 @@ def write_artifact(path: Path, artifact: dict[str, Any]) -> Path:
     return path
 
 
+def publish_artifact_bundle(
+    *,
+    publish_dir: Path,
+    artifact: dict[str, Any],
+) -> dict[str, Path]:
+    timestamped_path = write_artifact(
+        resolve_published_artifact_path(publish_dir=publish_dir, artifact=artifact),
+        artifact,
+    )
+    latest_paths = resolve_latest_artifact_paths(publish_dir=publish_dir, artifact=artifact)
+    return {
+        "timestamped": timestamped_path,
+        "corpus_latest": write_artifact(latest_paths["corpus_latest"], artifact),
+        "revision_latest": write_artifact(latest_paths["revision_latest"], artifact),
+    }
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", default="synaptent/aragora", help="GitHub repo owner/name")
@@ -288,7 +329,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--publish",
         action="store_true",
-        help="Write a timestamped artifact under the repo-stable publish path",
+        help="Write a timestamped artifact plus stable latest.json pointers under the repo-stable publish path",
     )
     parser.add_argument(
         "--publish-dir",
@@ -321,13 +362,11 @@ def main(argv: list[str] | None = None) -> int:
         output_path = write_artifact(args.output.resolve(), artifact)
         print(str(output_path))
     if publish_dir is not None:
-        published_path = write_artifact(
-            resolve_published_artifact_path(
-                publish_dir=publish_dir,
-                artifact=artifact,
-            ),
-            artifact,
+        published_paths = publish_artifact_bundle(
+            publish_dir=publish_dir,
+            artifact=artifact,
         )
+        published_path = published_paths["timestamped"]
         if args.json:
             print(str(published_path), file=sys.stderr)
         else:

--- a/scripts/measure_b0_scorecard.py
+++ b/scripts/measure_b0_scorecard.py
@@ -34,8 +34,7 @@ from build_benchmark_truth_artifact import (
     DEFAULT_PUBLISH_DIR as DEFAULT_TRUTH_ARTIFACT_PUBLISH_DIR,
     build_benchmark_truth_artifact,
     load_corpus as load_benchmark_corpus,
-    resolve_published_artifact_path as resolve_truth_artifact_path,
-    write_artifact as write_truth_artifact,
+    publish_artifact_bundle as publish_truth_artifact_bundle,
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -91,6 +90,16 @@ def _repo_stable_path(path: Path) -> str:
 def _slugify(value: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
     return slug.strip("-") or "benchmark-corpus"
+
+
+def _corpus_publish_dir(*, publish_dir: Path, corpus: dict[str, Any]) -> Path:
+    corpus_id = _slugify(str(corpus.get("corpus_id") or "benchmark-corpus"))
+    return publish_dir / corpus_id
+
+
+def _revision_publish_dir(*, publish_dir: Path, corpus: dict[str, Any]) -> Path:
+    revision = int(corpus.get("revision", 0) or 0)
+    return _corpus_publish_dir(publish_dir=publish_dir, corpus=corpus) / f"rev-{revision}"
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -182,14 +191,11 @@ def auto_publish_truth_artifact(
         metrics_file=metrics_path,
         corpus_path=corpus_path,
     )
-    published_path = write_truth_artifact(
-        resolve_truth_artifact_path(
-            publish_dir=truth_publish_dir,
-            artifact=artifact,
-        ),
-        artifact,
+    published_path = publish_truth_artifact_bundle(
+        publish_dir=truth_publish_dir,
+        artifact=artifact,
     )
-    return published_path, artifact
+    return published_path["timestamped"], artifact
 
 
 def _metric_value(payload: dict[str, Any], *path: str) -> float | None:
@@ -220,9 +226,24 @@ def resolve_published_scorecard_path(
     timestamp = _coerce_utc_datetime(str(published_scorecard.get("generated_at") or None)).strftime(
         "%Y%m%dT%H%M%SZ"
     )
-    corpus_id = _slugify(str(corpus.get("corpus_id") or "benchmark-corpus"))
-    revision = int(corpus.get("revision", 0) or 0)
-    return publish_dir / corpus_id / f"rev-{revision}" / f"scorecard-{timestamp}.json"
+    return (
+        _revision_publish_dir(publish_dir=publish_dir, corpus=corpus)
+        / f"scorecard-{timestamp}.json"
+    )
+
+
+def resolve_latest_scorecard_paths(
+    *,
+    publish_dir: Path,
+    published_scorecard: dict[str, Any],
+) -> dict[str, Path]:
+    corpus = dict(published_scorecard.get("corpus") or {})
+    return {
+        "corpus_latest": _corpus_publish_dir(publish_dir=publish_dir, corpus=corpus)
+        / "latest.json",
+        "revision_latest": _revision_publish_dir(publish_dir=publish_dir, corpus=corpus)
+        / "latest.json",
+    }
 
 
 def resolve_available_published_scorecard_path(
@@ -338,6 +359,29 @@ def write_artifact(path: Path, payload: dict[str, Any]) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
+
+
+def publish_scorecard_bundle(
+    *,
+    publish_dir: Path,
+    published_scorecard: dict[str, Any],
+) -> dict[str, Path]:
+    timestamped_path = write_artifact(
+        resolve_available_published_scorecard_path(
+            publish_dir=publish_dir,
+            published_scorecard=published_scorecard,
+        ),
+        published_scorecard,
+    )
+    latest_paths = resolve_latest_scorecard_paths(
+        publish_dir=publish_dir,
+        published_scorecard=published_scorecard,
+    )
+    return {
+        "timestamped": timestamped_path,
+        "corpus_latest": write_artifact(latest_paths["corpus_latest"], published_scorecard),
+        "revision_latest": write_artifact(latest_paths["revision_latest"], published_scorecard),
+    }
 
 
 def load_metrics(path: Path, window: int | None = None) -> list[dict[str, Any]]:
@@ -504,7 +548,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--publish",
         action="store_true",
-        help="Write a timestamped scorecard artifact under the repo-stable publish path",
+        help="Write a timestamped scorecard artifact plus stable latest.json pointers under the repo-stable publish path",
     )
     parser.add_argument(
         "--publish-dir",
@@ -613,13 +657,11 @@ def main(argv: list[str] | None = None) -> int:
             truth_artifact_path=truth_artifact_path,
             publish_dir=publish_dir,
         )
-        published_path = write_artifact(
-            resolve_available_published_scorecard_path(
-                publish_dir=publish_dir,
-                published_scorecard=published_scorecard,
-            ),
-            published_scorecard,
+        published_paths = publish_scorecard_bundle(
+            publish_dir=publish_dir,
+            published_scorecard=published_scorecard,
         )
+        published_path = published_paths["timestamped"]
         if args.json or args.ci:
             print(str(published_path), file=sys.stderr)
         else:

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -348,6 +348,24 @@ def test_resolve_published_artifact_path_uses_corpus_revision_and_timestamp() ->
     )
 
 
+def test_resolve_latest_artifact_paths_use_corpus_and_revision_roots() -> None:
+    paths = mod.resolve_latest_artifact_paths(
+        publish_dir=Path("/tmp/published"),
+        artifact={
+            "generated_at": "2026-04-14T02:03:04Z",
+            "corpus": {
+                "corpus_id": "TW-01 Bounded Execution v1",
+                "revision": 7,
+            },
+        },
+    )
+
+    assert paths == {
+        "corpus_latest": Path("/tmp/published/tw-01-bounded-execution-v1/latest.json"),
+        "revision_latest": Path("/tmp/published/tw-01-bounded-execution-v1/rev-7/latest.json"),
+    }
+
+
 def test_main_publish_dir_writes_timestamped_artifact_and_prints_path(
     tmp_path: Path,
     monkeypatch,
@@ -404,6 +422,22 @@ def test_main_publish_dir_writes_timestamped_artifact_and_prints_path(
     )
     parsed = json.loads(written_path.read_text(encoding="utf-8"))
     assert parsed["generated_at"] == "2026-04-14T05:06:07Z"
+    assert (
+        json.loads(
+            (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
+                encoding="utf-8"
+            )
+        )["generated_at"]
+        == "2026-04-14T05:06:07Z"
+    )
+    assert (
+        json.loads(
+            (
+                tmp_path / "published" / "tw-01-bounded-execution-v1" / "rev-8" / "latest.json"
+            ).read_text(encoding="utf-8")
+        )["generated_at"]
+        == "2026-04-14T05:06:07Z"
+    )
     assert captured.err == ""
 
 
@@ -456,6 +490,14 @@ def test_main_publish_dir_with_json_keeps_stdout_json_and_reports_path_on_stderr
     payload = json.loads(captured.out)
     assert exit_code == 0
     assert payload["generated_at"] == "2026-04-14T08:09:10Z"
+    assert (
+        json.loads(
+            (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
+                encoding="utf-8"
+            )
+        )["generated_at"]
+        == "2026-04-14T08:09:10Z"
+    )
     assert captured.err.strip() == str(
         tmp_path
         / "published"

--- a/tests/scripts/test_measure_b0_scorecard.py
+++ b/tests/scripts/test_measure_b0_scorecard.py
@@ -181,6 +181,21 @@ def test_resolve_available_published_scorecard_path_avoids_same_second_collision
     assert reserved_path.name == "scorecard-20260414T151617Z-2.json"
 
 
+def test_resolve_latest_scorecard_paths_use_corpus_and_revision_roots() -> None:
+    paths = mod.resolve_latest_scorecard_paths(
+        publish_dir=Path("/tmp/published"),
+        published_scorecard={
+            "generated_at": "2026-04-14T15:16:17Z",
+            "corpus": {"corpus_id": "tw-01-bounded-execution-v1", "revision": 3},
+        },
+    )
+
+    assert paths == {
+        "corpus_latest": Path("/tmp/published/tw-01-bounded-execution-v1/latest.json"),
+        "revision_latest": Path("/tmp/published/tw-01-bounded-execution-v1/rev-3/latest.json"),
+    }
+
+
 def test_main_publish_dir_writes_timestamped_artifact_and_prints_path(
     tmp_path: Path, capsys
 ) -> None:
@@ -228,6 +243,19 @@ def test_main_publish_dir_writes_timestamped_artifact_and_prints_path(
     payload = json.loads(written_path.read_text(encoding="utf-8"))
     assert payload["truth_artifact_path"] == str(truth_artifact_path)
     assert payload["proxy_metrics"]["no_rescue_success_rate"] == 1.0
+    assert (
+        json.loads(
+            (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
+                encoding="utf-8"
+            )
+        )["proxy_metrics"]["no_rescue_success_rate"]
+        == 1.0
+    )
+    assert json.loads(
+        (tmp_path / "published" / "tw-01-bounded-execution-v1" / "rev-4" / "latest.json").read_text(
+            encoding="utf-8"
+        )
+    )["truth_artifact_path"] == str(truth_artifact_path)
     assert captured.err == ""
 
 
@@ -278,6 +306,14 @@ def test_main_publish_dir_with_json_keeps_stdout_json_and_reports_path_on_stderr
     assert exit_code == 0
     assert payload["corpus"]["revision"] == 5
     assert payload["proxy_metrics"]["unique_issues_attempted"] == 1
+    assert (
+        json.loads(
+            (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
+                encoding="utf-8"
+            )
+        )["corpus"]["revision"]
+        == 5
+    )
     assert reported_path.parent == tmp_path / "published" / "tw-01-bounded-execution-v1" / "rev-5"
 
 
@@ -360,6 +396,12 @@ def test_main_publish_mode_uses_default_corpus_to_build_truth_artifact(
         }
         truth_artifact_path.parent.mkdir(parents=True, exist_ok=True)
         truth_artifact_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        (tmp_path / "truth-artifacts" / "tw-01-bounded-execution-v1").mkdir(
+            parents=True, exist_ok=True
+        )
+        (tmp_path / "truth-artifacts" / "tw-01-bounded-execution-v1" / "latest.json").write_text(
+            json.dumps(payload, indent=2), encoding="utf-8"
+        )
         return truth_artifact_path, payload
 
     monkeypatch.setattr(mod, "DEFAULT_CORPUS_PATH", corpus_path)
@@ -383,6 +425,19 @@ def test_main_publish_mode_uses_default_corpus_to_build_truth_artifact(
     assert payload["corpus"]["revision"] == 3
     assert payload["proxy_metrics"]["unique_issues_attempted"] == 1
     assert payload["truth_artifact_path"] == str(truth_artifact_path)
+    assert json.loads(
+        (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
+            encoding="utf-8"
+        )
+    )["truth_artifact_path"] == str(truth_artifact_path)
+    assert (
+        json.loads(
+            (tmp_path / "truth-artifacts" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
+                encoding="utf-8"
+            )
+        )["generated_at"]
+        == "2026-04-14T15:00:00Z"
+    )
     assert reported_path.parent == tmp_path / "published" / "tw-01-bounded-execution-v1" / "rev-3"
 
 


### PR DESCRIPTION
## Summary
- publish stable `latest.json` status surfaces alongside timestamped benchmark truth artifacts
- publish stable `latest.json` status surfaces alongside timestamped benchmark scorecards
- extend focused script tests for the recurring publish surfaces and auto-publish path

## Validation
- pytest tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_measure_b0_scorecard.py -q
- ruff check scripts/build_benchmark_truth_artifact.py scripts/measure_b0_scorecard.py tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_measure_b0_scorecard.py
- python3 scripts/build_benchmark_truth_artifact.py --help
- python3 scripts/measure_b0_scorecard.py --help
- python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes scripts/build_benchmark_truth_artifact.py scripts/measure_b0_scorecard.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Refs #5540