### PR TITLE
feat(benchmarks): unify rescue productization flow

### DIFF
--- a/scripts/rescue_to_fixtures.py
+++ b/scripts/rescue_to_fixtures.py
@@ -1,161 +1,160 @@
 #!/usr/bin/env python3
-"""TW-03: Convert repeated rescue classes into boss-ready substrate tickets.
-
-Reads the RescueEvent ledger AND boss_metrics.jsonl to identify repeated
-failure patterns, then creates GitHub issues that fix the root cause.
-
-Usage:
-  python3 scripts/rescue_to_fixtures.py                    # report only
-  python3 scripts/rescue_to_fixtures.py --create-issues    # create GitHub issues
-  python3 scripts/rescue_to_fixtures.py --json             # machine-readable
-"""
+"""TW-03: Convert repeated rescue classes into linked fixture or issue work."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
-from collections import Counter
+import sys
 from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_METRICS_PATH = REPO_ROOT / ".aragora" / "overnight" / "boss_metrics.jsonl"
-THRESHOLD = 3  # minimum occurrences to be considered "repeated"
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.rescue_events import DEFAULT_RESCUE_LEDGER_PATH, RescueEventLedger
+from scripts.harvest_rescue_classes import (
+    DEFAULT_PRODUCTIZATION_MAP_PATH,
+    load_productization_map,
+    summarize_rescue_classes,
+)
 
 
-def load_failure_patterns(
-    metrics_path: Path = DEFAULT_METRICS_PATH,
-    window: int = 200,
-) -> list[dict[str, Any]]:
-    """Identify repeated failure patterns from boss metrics."""
-    if not metrics_path.exists():
-        return []
+def load_rescue_productization_report(
+    *,
+    ledger_path: Path = DEFAULT_RESCUE_LEDGER_PATH,
+    threshold: int = 2,
+    recent_limit: int = 500,
+    example_limit: int = 5,
+    one_off_limit: int = 20,
+    productization_map_path: Path = DEFAULT_PRODUCTIZATION_MAP_PATH,
+) -> dict[str, Any]:
+    ledger = RescueEventLedger(path=ledger_path)
+    productization_map = load_productization_map(productization_map_path)
+    return summarize_rescue_classes(
+        ledger,
+        threshold=threshold,
+        recent_limit=recent_limit,
+        example_limit=example_limit,
+        one_off_limit=one_off_limit,
+        productization_map=productization_map,
+    )
 
-    rows: list[dict[str, Any]] = []
-    for line in metrics_path.read_text(encoding="utf-8", errors="replace").splitlines():
-        try:
-            rows.append(json.loads(line))
-        except json.JSONDecodeError:
+
+def _slugify_fragment(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
+    return slug.strip("-") or "repeated-rescue-class"
+
+
+def build_issue_drafts(report: dict[str, Any]) -> list[dict[str, Any]]:
+    repeated_rows = list(report.get("repeated_classes") or [])
+    drafts: list[dict[str, Any]] = []
+    for row in repeated_rows:
+        if str(row.get("productization_status") or "").strip() != "unlinked":
             continue
-
-    rows = rows[-window:]
-
-    # Group failures by terminal class + failure pattern
-    pattern_counter: Counter[str] = Counter()
-    pattern_examples: dict[str, list[dict[str, Any]]] = {}
-
-    for row in rows:
-        tc = str(row.get("terminal_class", "")).strip()
-        if not tc or tc.startswith("success") or tc.startswith("deliverable"):
-            continue
-
-        # Build a pattern key from terminal class + sanitizer outcome
-        sanitizer = str(row.get("sanitizer_outcome", "")).strip()
-        pattern_key = f"{tc}"
-        if sanitizer and sanitizer != "accepted":
-            pattern_key = f"{tc}:{sanitizer}"
-
-        pattern_counter[pattern_key] += 1
-        examples = pattern_examples.setdefault(pattern_key, [])
-        if len(examples) < 5:
-            examples.append(
-                {
-                    "issue_number": row.get("issue_number"),
-                    "issue_title": str(row.get("issue_title", ""))[:80],
-                    "elapsed_seconds": row.get("elapsed_seconds"),
-                }
-            )
-
-    # Filter to repeated patterns
-    repeated = []
-    for pattern, count in pattern_counter.most_common():
-        if count < THRESHOLD:
-            continue
-        repeated.append(
+        rescue_class = str(row.get("class") or "").strip()
+        count = int(row.get("count", 0) or 0)
+        issue_numbers = [
+            int(item)
+            for item in list(row.get("issue_numbers") or [])
+            if isinstance(item, int) and item > 0
+        ]
+        title = (
+            f"[TW-03] Productize repeated rescue class: "
+            f"{_slugify_fragment(rescue_class)} ({count}x)"
+        )
+        examples_text = (
+            "\n".join(f"- #{issue_number}" for issue_number in issue_numbers) or "- none"
+        )
+        body = (
+            "## Goal\n"
+            f"Productize the repeated rescue class `{rescue_class}` so it stops requiring ad hoc human intervention.\n\n"
+            "## Why now\n"
+            f"This rescue class appeared {count} times in the recent rescue ledger and is still unlinked.\n\n"
+            "## Evidence\n"
+            f"- Rescue class: `{rescue_class}`\n"
+            f"- Count: {count}\n"
+            f"- Event type: `{str(row.get('event_type') or '').strip()}`\n"
+            f"- Reason excerpt: `{str(row.get('reason_excerpt') or '').strip()}`\n\n"
+            "### Example issue numbers\n"
+            f"{examples_text}\n\n"
+            "## Acceptance\n"
+            "- Either add a benchmark fixture path to `docs/benchmarks/rescue_productization.json`\n"
+            "- Or link the bounded substrate/control-plane issue that resolves this class\n"
+            "- Keep the harvest/report loop truthful so this class shows up as linked on the next pass\n"
+        )
+        drafts.append(
             {
-                "pattern": pattern,
+                "class": rescue_class,
                 "count": count,
-                "percentage": round(count / len(rows) * 100, 1) if rows else 0,
-                "examples": pattern_examples.get(pattern, []),
-                "suggested_fix": _suggest_fix(pattern),
+                "issue_numbers": issue_numbers,
+                "title": title,
+                "body": body,
             }
         )
-
-    return repeated
-
-
-def _suggest_fix(pattern: str) -> str:
-    """Generate a human-readable fix suggestion for a failure pattern."""
-    fixes = {
-        "blocked_not_dispatch_bounded": "Improve issue upgrader to add missing file scope and acceptance criteria",
-        "blocked_sanitation_failed": "Tighten sanitizer false positive rules or add RescuePlanner LLM override",
-        "blocked_sanitation_failed:quarantined": "Fix sanitizer contradictory_scope false positive pattern",
-        "blocked_sanitation_failed:dropped": "Improve issue body generation to include validation contracts",
-        "blocked_validation_target_missing": "Update issue generator to check validation target existence",
-        "rescue_no_deliverable": "Wire Conductor retry recommendations into boss loop retry path",
-        "rescue_timeout": "Increase worker timeout or decompose into smaller tasks",
-        "rescue_worker_crash": "Add worker crash recovery with session state resume",
-        "rescue_verification_failed": "Improve worker prompt to include verification commands",
-    }
-    for key, fix in fixes.items():
-        if pattern.startswith(key):
-            return fix
-    return "Investigate and create a substrate fix for this failure pattern"
+    return drafts
 
 
-def render_report(patterns: list[dict[str, Any]]) -> str:
-    """Render a human-readable report of repeated failure patterns."""
-    if not patterns:
-        return "No repeated failure patterns found above threshold."
+def render_report(report: dict[str, Any], *, issue_drafts: list[dict[str, Any]]) -> str:
+    summary = dict(report.get("summary") or {})
+    repeated_rows = list(report.get("repeated_classes") or [])
+    if not repeated_rows:
+        return "No repeated rescue classes found."
+
+    linked_rows = [
+        row
+        for row in repeated_rows
+        if str(row.get("productization_status") or "").strip() != "unlinked"
+    ]
+    unlinked_rows = [
+        row
+        for row in repeated_rows
+        if str(row.get("productization_status") or "").strip() == "unlinked"
+    ]
 
     lines = [
         "=" * 60,
-        "  TW-03: REPEATED RESCUE CLASS REPORT",
+        "  TW-03: RESCUE PRODUCTIZATION REPORT",
         "=" * 60,
+        f"  repeated classes:        {int(summary.get('repeated_class_count', 0) or 0)}",
+        f"  linked repeated classes: {len(linked_rows)}",
+        f"  issue drafts queued:     {len(issue_drafts)}",
         "",
     ]
-    for p in patterns:
-        lines.append(f"  {p['count']}x ({p['percentage']}%) — {p['pattern']}")
-        lines.append(f"     Fix: {p['suggested_fix']}")
-        for ex in p["examples"][:3]:
-            lines.append(f"     e.g. #{ex['issue_number']} {ex['issue_title']}")
+    if linked_rows:
+        lines.append("  Already linked:")
+        for row in linked_rows:
+            lines.append(
+                "    - "
+                f"{row['class']} -> "
+                f"{str(row.get('productization_target_kind') or '').strip()}:"
+                f"{str(row.get('productization_target') or '').strip()}"
+            )
+        lines.append("")
+    if unlinked_rows:
+        lines.append("  Still unlinked:")
+        for row in unlinked_rows:
+            issue_numbers = (
+                ", ".join(f"#{num}" for num in list(row.get("issue_numbers") or [])) or "-"
+            )
+            lines.append(f"    - {row['class']} ({row['count']}x) [{issue_numbers}]")
         lines.append("")
     lines.append("=" * 60)
     return "\n".join(lines)
 
 
 def create_substrate_issues(
-    patterns: list[dict[str, Any]],
+    issue_drafts: list[dict[str, Any]],
+    *,
     repo: str = "synaptent/aragora",
     dry_run: bool = False,
 ) -> list[str]:
-    """Create boss-ready GitHub issues for each repeated failure pattern."""
     created: list[str] = []
-
-    for p in patterns:
-        title = f"[TW-03] Fix repeated failure: {p['pattern']} ({p['count']}x)"
-        examples_text = "\n".join(
-            f"- #{ex['issue_number']} {ex['issue_title']}" for ex in p["examples"][:5]
-        )
-        body = f"""## Goal
-Fix the repeated failure pattern `{p["pattern"]}` which accounts for {p["percentage"]}% of recent boss loop failures.
-
-## Suggested Fix
-{p["suggested_fix"]}
-
-## Evidence
-This pattern appeared {p["count"]} times in the last 200 boss loop ticks.
-
-### Example issues
-{examples_text}
-
-## Validation
-python3 scripts/measure_b0_scorecard.py
-# Success rate should improve after fix
-"""
+    for draft in issue_drafts:
         if dry_run:
-            created.append(f"DRY-RUN: would create '{title}'")
+            created.append(f"DRY-RUN: would create '{draft['title']}'")
             continue
 
         try:
@@ -167,11 +166,11 @@ python3 scripts/measure_b0_scorecard.py
                     "--repo",
                     repo,
                     "--title",
-                    title,
+                    str(draft["title"]),
                     "--label",
                     "boss-ready",
                     "--body",
-                    body,
+                    str(draft["body"]),
                 ],
                 capture_output=True,
                 text=True,
@@ -179,38 +178,70 @@ python3 scripts/measure_b0_scorecard.py
                 check=False,
             )
             if result.returncode == 0:
-                url = result.stdout.strip()
-                created.append(url)
+                created.append(result.stdout.strip())
             else:
                 created.append(f"FAILED: {result.stderr.strip()[:100]}")
         except (subprocess.TimeoutExpired, OSError) as exc:
             created.append(f"ERROR: {exc}")
-
     return created
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="TW-03: Rescue to fixture conversion")
-    parser.add_argument("--metrics", type=Path, default=DEFAULT_METRICS_PATH)
-    parser.add_argument("--window", type=int, default=200)
-    parser.add_argument("--threshold", type=int, default=THRESHOLD)
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="TW-03: Convert repeated rescue classes into fixture or issue work."
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=DEFAULT_RESCUE_LEDGER_PATH,
+        help="Path to the RescueEvent JSONL ledger.",
+    )
+    parser.add_argument(
+        "--productization-map",
+        type=Path,
+        default=DEFAULT_PRODUCTIZATION_MAP_PATH,
+        help="Path to the tracked rescue-productization map.",
+    )
+    parser.add_argument("--threshold", type=int, default=2)
+    parser.add_argument("--recent-limit", type=int, default=500)
+    parser.add_argument("--example-limit", type=int, default=5)
+    parser.add_argument("--one-off-limit", type=int, default=20)
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--create-issues", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--repo", default="synaptent/aragora")
-    args = parser.parse_args()
+    return parser
 
-    patterns = load_failure_patterns(args.metrics, args.window)
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = load_rescue_productization_report(
+        ledger_path=args.path,
+        threshold=max(1, args.threshold),
+        recent_limit=max(1, args.recent_limit),
+        example_limit=max(1, args.example_limit),
+        one_off_limit=max(0, args.one_off_limit),
+        productization_map_path=args.productization_map,
+    )
+    issue_drafts = build_issue_drafts(report)
 
     if args.json:
-        print(json.dumps(patterns, indent=2))
+        payload = {
+            **report,
+            "issue_drafts": issue_drafts,
+        }
+        print(json.dumps(payload, indent=2))
     else:
-        print(render_report(patterns))
+        print(render_report(report, issue_drafts=issue_drafts))
 
     if args.create_issues or args.dry_run:
-        results = create_substrate_issues(patterns, repo=args.repo, dry_run=args.dry_run)
-        for r in results:
-            print(f"  {r}")
+        results = create_substrate_issues(
+            issue_drafts,
+            repo=str(args.repo),
+            dry_run=bool(args.dry_run),
+        )
+        for item in results:
+            print(f"  {item}")
 
     return 0
 

--- a/tests/scripts/test_rescue_to_fixtures.py
+++ b/tests/scripts/test_rescue_to_fixtures.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from aragora.swarm.rescue_events import RescueEvent, RescueEventLedger
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import rescue_to_fixtures as mod  # noqa: E402
+
+
+def _ledger_with_events(tmp_path: Path, events: list[RescueEvent]) -> RescueEventLedger:
+    ledger = RescueEventLedger(path=tmp_path / "rescue_events.jsonl")
+    for event in events:
+        ledger.record(event)
+    return ledger
+
+
+def _write_productization_map(path: Path, entries: list[dict[str, object]]) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "entries": entries,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_build_issue_drafts_only_for_unlinked_repeated_classes(tmp_path: Path) -> None:
+    ledger = _ledger_with_events(
+        tmp_path,
+        [
+            RescueEvent(
+                event_type="session_restart",
+                reason="runner freshness gate blocked launch",
+                issue_number=5514,
+            ),
+            RescueEvent(
+                event_type="session_restart",
+                reason="runner freshness gate blocked launch",
+                issue_number=5514,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5512,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5515,
+            ),
+        ],
+    )
+    productization_map_path = _write_productization_map(
+        tmp_path / "rescue_productization.json",
+        [
+            {
+                "class": "session_restart:runner freshness gate blocked launch",
+                "target_kind": "issue",
+                "target": "#5514",
+                "title": "use contract receipts for dispatch admission",
+            }
+        ],
+    )
+
+    report = mod.load_rescue_productization_report(
+        ledger_path=ledger.path,
+        threshold=2,
+        productization_map_path=productization_map_path,
+    )
+    drafts = mod.build_issue_drafts(report)
+
+    assert len(drafts) == 1
+    assert drafts[0]["class"] == "followup_prompt:needs explicit next step from founder"
+    assert drafts[0]["issue_numbers"] == [5512, 5515]
+    assert "Productize the repeated rescue class" in drafts[0]["body"]
+
+
+def test_main_json_reports_linked_classes_and_issue_drafts(tmp_path: Path, capsys) -> None:
+    ledger = _ledger_with_events(
+        tmp_path,
+        [
+            RescueEvent(
+                event_type="session_restart",
+                reason="runner freshness gate blocked launch",
+                issue_number=5514,
+            ),
+            RescueEvent(
+                event_type="session_restart",
+                reason="runner freshness gate blocked launch",
+                issue_number=5514,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5512,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5515,
+            ),
+        ],
+    )
+    productization_map_path = _write_productization_map(
+        tmp_path / "rescue_productization.json",
+        [
+            {
+                "class": "session_restart:runner freshness gate blocked launch",
+                "target_kind": "fixture",
+                "target": "docs/benchmarks/corpus.json",
+                "title": "benchmark corpus",
+            }
+        ],
+    )
+
+    exit_code = mod.main(
+        [
+            "--path",
+            str(ledger.path),
+            "--productization-map",
+            str(productization_map_path),
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["summary"]["linked_fixture_count"] == 1
+    assert payload["summary"]["unlinked_repeated_class_count"] == 1
+    assert len(payload["issue_drafts"]) == 1
+    assert (
+        payload["issue_drafts"][0]["class"]
+        == "followup_prompt:needs explicit next step from founder"
+    )
+
+
+def test_create_substrate_issues_dry_run_uses_issue_drafts_only(tmp_path: Path) -> None:
+    ledger = _ledger_with_events(
+        tmp_path,
+        [
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5512,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5515,
+            ),
+        ],
+    )
+
+    report = mod.load_rescue_productization_report(
+        ledger_path=ledger.path,
+        threshold=2,
+        productization_map_path=tmp_path / "missing.json",
+    )
+    drafts = mod.build_issue_drafts(report)
+    results = mod.create_substrate_issues(drafts, dry_run=True)
+
+    assert len(results) == 1
+    assert results[0].startswith("DRY-RUN: would create '[TW-03] Productize repeated rescue class:")


### PR DESCRIPTION
## Summary
- rebuild `scripts/rescue_to_fixtures.py` on top of the existing rescue harvest and tracked productization map
- draft substrate issues only for repeated rescue classes that are still unlinked
- add focused coverage for the rescue conversion flow

## Validation
- pytest tests/scripts/test_harvest_rescue_classes.py tests/scripts/test_rescue_to_fixtures.py -q
- ruff check scripts/rescue_to_fixtures.py tests/scripts/test_rescue_to_fixtures.py tests/scripts/test_harvest_rescue_classes.py
- python3 scripts/rescue_to_fixtures.py --help
- python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes scripts/rescue_to_fixtures.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Refs #5330