### PR TITLE
feat(benchmarks): add stable recurring truth status handles

### DIFF
--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -5,7 +5,7 @@ description: Active Execution Issues
 
 # Active Execution Issues
 
-Last updated: 2026-04-13
+Last updated: 2026-04-14
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -41,18 +41,18 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
-Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining gate is production guard proof, not inflating the benchmark story.
+Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is routine truth publication and rescue productization, not reopening already-landed guard work.
 
 ## Current 30-Day Execution Set
 
 Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
-- Do now: `RS-07`, `BC-01`, `BC-03`, `BC-02`, `TW-01`, `TW-02`, `TW-03`, `CS-01..03`
+- Do now: `TW-02`, `TW-03`, `CS-01..03`
 - Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Top 3 boss-ready next: `RS-07`, `BC-01`, `BC-03`
-- GitHub coverage for those top 3 remains epic-level only through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issues exist yet
+- Live boss-ready queue: `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)) and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)); `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14 and [#5516](https://github.com/synaptent/aragora/issues/5516) landed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535)
+- `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate
 
@@ -72,7 +72,7 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 ### Milestone 1.3 — Contract-Aware Preflight `[30-90d]`
 
-- [ ] **RS-07** Build `aragora swarm preflight run --contract ...` _(In progress as of 2026-04-13: the operator surface now has a contract-backed receipt path with persisted `PreflightReceipt` output and fail-closed admission verdicts; remaining follow-through is to make that receipt the default admission truth everywhere that consumes preflight.)_
+- [x] **RS-07** Build `aragora swarm preflight run --contract ...` _(Done 2026-04-14 via [#5514](https://github.com/synaptent/aragora/pull/5514))_
 - [x] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
 - [x] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
 
@@ -88,9 +88,9 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 ### Milestone 2.1 — Interactive Sessions & Repair Journal `[90d]`
 
-- [ ] **BC-01** Persist session state across `explore -> plan -> edit -> verify -> repair -> publish`
+- [x] **BC-01** Persist session state across `explore -> plan -> edit -> verify -> repair -> publish` _(Done 2026-04-14 via [#5503](https://github.com/synaptent/aragora/pull/5503))_
 - [x] **BC-02** Resume retries from prior session state instead of fresh prompts _(Done 2026-04-13 via [#5384](https://github.com/synaptent/aragora/pull/5384))_
-- [ ] **BC-03** Emit precise blocker evidence and repair transcripts for failed runs
+- [x] **BC-03** Emit precise blocker evidence and repair transcripts for failed runs _(Done 2026-04-14 via [#5512](https://github.com/synaptent/aragora/pull/5512))_
 
 ### Milestone 2.2 — Task Sanitizer & Admission Gate `[30-90d]`
 
@@ -116,9 +116,9 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 ### Milestone 3.1 — Autonomous Software Execution Benchmark `[30d]`
 
-- [ ] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Partial as of 2026-04-13: the frozen corpus manifest is checked in at `docs/benchmarks/corpus.json`; the remaining gap is recurring execution against that fixed revision.)_
-- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Partial as of 2026-04-13: diffable truth-artifact generation exists, including truth/no-rescue/failure-class/rescue-type reporting; the remaining gap is recurring publication and status linkage.)_
-- [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements
+- [x] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Done 2026-04-14 via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583))_
+- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Partial as of 2026-04-14: diffable truth-artifact and scorecard publication exist, with stable latest status handles at `.aragora/benchmark_truth_artifacts/latest.json` and `.aragora/benchmark_scorecards/latest.json`; the remaining gap is routine recurring runs on current `main`, tracked by [#5329](https://github.com/synaptent/aragora/issues/5329).)_
+- [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements _(Partial as of 2026-04-14: rescue-class productization reporting landed via [#5535](https://github.com/synaptent/aragora/pull/5535); the remaining gap is turning repeated classes into durable fixture-or-issue closure on the live loop, tracked by [#5330](https://github.com/synaptent/aragora/issues/5330).)_
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`
 

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -5,7 +5,7 @@ description: Next Steps (Canonical)
 
 # Next Steps (Canonical)
 
-Last updated: 2026-04-13
+Last updated: 2026-04-14
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
@@ -15,7 +15,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to finish `RS-07`, close the remaining truthful repair gaps in `BC-01/03`, and keep `TW-01/TW-02` publishing recurring truth artifacts before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to keep `TW-01` recurring and corpus-linked on current `main`, finish `TW-02` routine truth publication, finish `TW-03` rescue productization, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -27,17 +27,21 @@ What is already true:
 - the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
 - launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
+- receipt-backed preflight is now the default operator and live dispatch admission truth on `main` via [#5514](https://github.com/synaptent/aragora/pull/5514)
 - scratch and remote-publish preflight validation now run through the production preflight path and emit canonical terminal truth on `main`
 - task sanitizer outcomes and success-rate filtering are shaping safer boss-loop intake
 - original versus sanitized task text is already preserved for audit on `main`
+- session state now persists across the live supervisor lease/dispatch lifecycle on `main` via [#5503](https://github.com/synaptent/aragora/pull/5503)
 - retry dispatch now carries prior session resume context on `main` via [#5384](https://github.com/synaptent/aragora/pull/5384)
+- failed and `needs_human` lanes now persist normalized `blocker_evidence` on `main` via [#5512](https://github.com/synaptent/aragora/pull/5512)
 - the rescue loop can now record interventions, plan bounded recovery, and execute safe followups on `main` via [#5379](https://github.com/synaptent/aragora/pull/5379), [#5380](https://github.com/synaptent/aragora/pull/5380), and [#5383](https://github.com/synaptent/aragora/pull/5383)
+- recurring benchmark scorecards are now bound to the frozen corpus revision on `main` via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583)
+- repeated rescue-class reports now include fixture-or-issue productization status on `main` via [#5535](https://github.com/synaptent/aragora/pull/5535)
 
 What is still missing:
 
-- the last `RS-07` step is to make receipt-backed contract preflight the default operator admission truth everywhere, not just a substrate primitive — contract in, persisted receipt out, fail-closed on any mismatch ([#5327](https://github.com/synaptent/aragora/issues/5327))
-- broader repair truth on the live swarm loop still depends on full `BC-01` persistence and precise `BC-03` blocker evidence
-- recurring scheduled use of the frozen corpus and diffable truth artifact still needs to become routine status output ([#5329](https://github.com/synaptent/aragora/issues/5329))
+- recurring publication of the diffable truth artifact and scorecard still needs to stay routine and clearly linked from status surfaces ([#5540](https://github.com/synaptent/aragora/issues/5540), [#5329](https://github.com/synaptent/aragora/issues/5329))
+- repeated rescue classes still need the broader live-loop conversion from repeated patterns into benchmark fixtures or bounded issues beyond the landed productization report ([#5330](https://github.com/synaptent/aragora/issues/5330))
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
 - broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
@@ -58,7 +62,7 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
-Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; truthful guard completion is.
+Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are.
 
 Primary truth metric:
 
@@ -96,6 +100,7 @@ The recurring scorecard records the following per corpus run:
 Scorecard output rules:
 
 - Each run produces a timestamped scorecard artifact that is diffable against prior runs for week-over-week comparison.
+- The stable recurring status handles are `.aragora/benchmark_truth_artifacts/latest.json` and `.aragora/benchmark_scorecards/latest.json`; each published payload points back to timestamped corpus/revision history directories.
 - Human rescue is distinguished from autonomous completion at the issue level — a rescued issue is never counted as no-rescue success.
 - Proxy metrics (PR count, iteration count, token spend) are reported separately and never mixed with truth metrics.
 - The scorecard links back to the corpus revision it was run against.
@@ -106,7 +111,7 @@ Scorecard output rules:
 - The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
 - The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
 - The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
-- What remains is recurring scheduled use of that artifact path, not inventing a second benchmark definition.
+- `TW-01` is now landed on `main`, and recurring truth publication now exposes stable latest status handles at `.aragora/benchmark_truth_artifacts/latest.json` and `.aragora/benchmark_scorecards/latest.json`; what remains is routine `TW-02` publication and status linkage, not inventing a second benchmark definition.
 
 ## 30-Day Canonical Backlog
 
@@ -114,24 +119,14 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
-| 1 | `RS-07` | Preflight only deserves trust when it returns a receipt the supervisor can verify, not just a shell exit code. The gap is the admission path: contract in, receipt out, fail-closed on any mismatch. | `aragora swarm preflight run --contract ...` accepts a `WorkerContract`, runs production-equivalent git/auth/env checks, and returns a signed `PreflightReceipt` with pass/fail plus canonical terminal class on failure. Supervisor rejects admission when the receipt is absent or failed. | At least one guarded admission path is live through the operator surface with receipt-backed success and failure. Failures map to canonical terminal truth classes. | substrate | [#5327](https://github.com/synaptent/aragora/issues/5327); covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#805](https://github.com/synaptent/aragora/issues/805). |
-| 2 | `BC-01` | Session persistence is the prerequisite for truthful repair, retry, and operator control. | Session state survives `explore -> plan -> edit -> verify -> repair -> publish` and survives process restart. | Benchmark retry lanes show resumed state instead of cold restarts. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
-| 3 | `BC-03` | Founder time is wasted when a failed run does not say exactly what broke and what to try next. | Failed runs emit precise blocker evidence, canonical blocker class, and repair transcript or next-step evidence. | `100%` of failed bounded runs include receipt-backed blocker evidence mapped to canonical terminal truth. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
-| 4 | `BC-02` | Retry without state reuse just repeats prompt cost and rescue labor. | Retry resumes from prior state, contract, and repair evidence instead of re-prompting from scratch. | Retried runs emit resume-from-stage evidence and show lower repeated-rescue incidence on the same class. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
-| 5 | `TW-01` | The wedge only becomes real if the benchmark corpus keeps proving `prompt -> spec -> code -> verify -> PR` loops on bounded work. | A fixed benchmark corpus runs repeatedly on current `main` without ad hoc issue swapping. | Repeated benchmark runs report issue-level truth outcomes on the same bounded corpus. | trust | Covered by [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
-| 6 | `TW-02` | The project needs issue-level truth, not PR-count or iteration-count vanity metrics. | Weekly truth reporting uses `mergeable_pr OR merged_pr`, distinguishes proxy from truth, and stays linked from status docs. | Fresh `origin/main` truth reports publish issue-level truth success and no-rescue truth success. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
-| 7 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
-| 8 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+| 1 | `TW-02` | The project needs issue-level truth, not PR-count or iteration-count vanity metrics. | Weekly truth reporting uses `mergeable_pr OR merged_pr`, distinguishes proxy from truth, and stays linked from status docs. | Fresh `origin/main` truth reports publish issue-level truth success and no-rescue truth success. | trust | [#5540](https://github.com/synaptent/aragora/issues/5540), [#5329](https://github.com/synaptent/aragora/issues/5329) |
+| 2 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | [#5330](https://github.com/synaptent/aragora/issues/5330) |
+| 3 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
 
 ## Do Now / Delay / Avoid
 
 ### Do now
 
-- `RS-07`
-- `BC-01`
-- `BC-03`
-- `BC-02`
-- `TW-01`
 - `TW-02`
 - `TW-03`
 - `CS-01..03`
@@ -153,13 +148,13 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 - heavy DAG workbench work that is not backed by live runtime truth
 - generalized memory fabric work that is not directly improving the execution wedge
 
-## Top 3 Boss-Ready Next
+## Live Boss-Ready Queue
 
-1. `RS-07` ([#5327](https://github.com/synaptent/aragora/issues/5327)) because it closes the last missing guard on the live operator path and turns preflight into the admission truth the operator can actually trust.
-2. `BC-01` because retries and repair loops cannot become truthful until session state survives restarts.
-3. `BC-03` because founder leverage depends on precise blocker evidence before more retry logic is added.
+- `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)) because recurring truth publication is the remaining open proof surface on the frozen corpus.
+- `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) because repeated rescues only create leverage when the live loop turns them into fixtures or bounded issues.
+- There is no third dedicated boss-ready issue in this tranche right now; keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
 
-There is no dedicated open GitHub issue yet for those three codes. Existing issue coverage is still at the epic level through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806). Do not invent duplicate roadmap issues in this tranche unless the canonical docs stop being enough to drive bounded execution.
+The live queue for this tranche should now be driven by those trust-loop issues. `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, and [#5516](https://github.com/synaptent/aragora/issues/5516) completed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535). `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
 
 ## Reverse-Staged Rocket Bootstrap
 

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -112,7 +112,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 ### Milestone 3.1 — Autonomous Software Execution Benchmark `[30d]`
 
 - [x] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Done 2026-04-14 via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583))_
-- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Partial as of 2026-04-14: diffable truth-artifact generation exists, including truth/no-rescue/failure-class/rescue-type reporting; the remaining gap is recurring publication and status linkage, tracked by [#5540](https://github.com/synaptent/aragora/issues/5540).)_
+- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Partial as of 2026-04-14: diffable truth-artifact and scorecard publication exist, with stable latest status handles at `.aragora/benchmark_truth_artifacts/latest.json` and `.aragora/benchmark_scorecards/latest.json`; the remaining gap is routine recurring runs on current `main`, tracked by [#5329](https://github.com/synaptent/aragora/issues/5329).)_
 - [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements _(Partial as of 2026-04-14: rescue-class productization reporting landed via [#5535](https://github.com/synaptent/aragora/pull/5535); the remaining gap is turning repeated classes into durable fixture-or-issue closure on the live loop, tracked by [#5330](https://github.com/synaptent/aragora/issues/5330).)_
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -95,6 +95,7 @@ The recurring scorecard records the following per corpus run:
 Scorecard output rules:
 
 - Each run produces a timestamped scorecard artifact that is diffable against prior runs for week-over-week comparison.
+- The stable recurring status handles are `.aragora/benchmark_truth_artifacts/latest.json` and `.aragora/benchmark_scorecards/latest.json`; each published payload points back to timestamped corpus/revision history directories.
 - Human rescue is distinguished from autonomous completion at the issue level — a rescued issue is never counted as no-rescue success.
 - Proxy metrics (PR count, iteration count, token spend) are reported separately and never mixed with truth metrics.
 - The scorecard links back to the corpus revision it was run against.
@@ -105,7 +106,7 @@ Scorecard output rules:
 - The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
 - The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
 - The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
-- `TW-01` is now landed on `main`; what remains is routine `TW-02` publication and status linkage, not inventing a second benchmark definition.
+- `TW-01` is now landed on `main`, and recurring truth publication now exposes stable latest status handles at `.aragora/benchmark_truth_artifacts/latest.json` and `.aragora/benchmark_scorecards/latest.json`; what remains is routine `TW-02` publication and status linkage, not inventing a second benchmark definition.
 
 ## 30-Day Canonical Backlog
 

--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -191,6 +191,7 @@ def resolve_latest_artifact_paths(
     if not isinstance(corpus, dict):
         corpus = {}
     return {
+        "latest": publish_dir / "latest.json",
         "corpus_latest": _corpus_publish_dir(publish_dir=publish_dir, corpus=corpus)
         / "latest.json",
         "revision_latest": _revision_publish_dir(publish_dir=publish_dir, corpus=corpus)
@@ -299,6 +300,7 @@ def publish_artifact_bundle(
     latest_paths = resolve_latest_artifact_paths(publish_dir=publish_dir, artifact=artifact)
     return {
         "timestamped": timestamped_path,
+        "latest": write_artifact(latest_paths["latest"], artifact),
         "corpus_latest": write_artifact(latest_paths["corpus_latest"], artifact),
         "revision_latest": write_artifact(latest_paths["revision_latest"], artifact),
     }

--- a/scripts/measure_b0_scorecard.py
+++ b/scripts/measure_b0_scorecard.py
@@ -239,6 +239,7 @@ def resolve_latest_scorecard_paths(
 ) -> dict[str, Path]:
     corpus = dict(published_scorecard.get("corpus") or {})
     return {
+        "latest": publish_dir / "latest.json",
         "corpus_latest": _corpus_publish_dir(publish_dir=publish_dir, corpus=corpus)
         / "latest.json",
         "revision_latest": _revision_publish_dir(publish_dir=publish_dir, corpus=corpus)
@@ -379,6 +380,7 @@ def publish_scorecard_bundle(
     )
     return {
         "timestamped": timestamped_path,
+        "latest": write_artifact(latest_paths["latest"], published_scorecard),
         "corpus_latest": write_artifact(latest_paths["corpus_latest"], published_scorecard),
         "revision_latest": write_artifact(latest_paths["revision_latest"], published_scorecard),
     }

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -421,7 +421,12 @@ def test_main_publish_dir_writes_timestamped_artifact_and_prints_path(
         / "truth-20260414T050607Z.json"
     )
     parsed = json.loads(written_path.read_text(encoding="utf-8"))
+    latest_path = tmp_path / "published" / "latest.json"
     assert parsed["generated_at"] == "2026-04-14T05:06:07Z"
+    assert (
+        json.loads(latest_path.read_text(encoding="utf-8"))["generated_at"]
+        == "2026-04-14T05:06:07Z"
+    )
     assert (
         json.loads(
             (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
@@ -488,8 +493,13 @@ def test_main_publish_dir_with_json_keeps_stdout_json_and_reports_path_on_stderr
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
+    latest_path = tmp_path / "published" / "latest.json"
     assert exit_code == 0
     assert payload["generated_at"] == "2026-04-14T08:09:10Z"
+    assert (
+        json.loads(latest_path.read_text(encoding="utf-8"))["generated_at"]
+        == "2026-04-14T08:09:10Z"
+    )
     assert (
         json.loads(
             (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -361,6 +361,7 @@ def test_resolve_latest_artifact_paths_use_corpus_and_revision_roots() -> None:
     )
 
     assert paths == {
+        "latest": Path("/tmp/published/latest.json"),
         "corpus_latest": Path("/tmp/published/tw-01-bounded-execution-v1/latest.json"),
         "revision_latest": Path("/tmp/published/tw-01-bounded-execution-v1/rev-7/latest.json"),
     }

--- a/tests/scripts/test_measure_b0_scorecard.py
+++ b/tests/scripts/test_measure_b0_scorecard.py
@@ -191,6 +191,7 @@ def test_resolve_latest_scorecard_paths_use_corpus_and_revision_roots() -> None:
     )
 
     assert paths == {
+        "latest": Path("/tmp/published/latest.json"),
         "corpus_latest": Path("/tmp/published/tw-01-bounded-execution-v1/latest.json"),
         "revision_latest": Path("/tmp/published/tw-01-bounded-execution-v1/rev-3/latest.json"),
     }
@@ -314,10 +315,7 @@ def test_main_publish_dir_with_json_keeps_stdout_json_and_reports_path_on_stderr
     assert exit_code == 0
     assert payload["corpus"]["revision"] == 5
     assert payload["proxy_metrics"]["unique_issues_attempted"] == 1
-    assert (
-        json.loads(latest_path.read_text(encoding="utf-8"))["corpus"]["revision"]
-        == 5
-    )
+    assert json.loads(latest_path.read_text(encoding="utf-8"))["corpus"]["revision"] == 5
     assert (
         json.loads(
             (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
@@ -440,18 +438,18 @@ def test_main_publish_mode_uses_default_corpus_to_build_truth_artifact(
     assert payload["corpus"]["revision"] == 3
     assert payload["proxy_metrics"]["unique_issues_attempted"] == 1
     assert payload["truth_artifact_path"] == str(truth_artifact_path)
-    assert json.loads(
-        (tmp_path / "published" / "latest.json").read_text(encoding="utf-8")
-    )["truth_artifact_path"] == str(truth_artifact_path)
+    assert json.loads((tmp_path / "published" / "latest.json").read_text(encoding="utf-8"))[
+        "truth_artifact_path"
+    ] == str(truth_artifact_path)
     assert json.loads(
         (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
             encoding="utf-8"
         )
     )["truth_artifact_path"] == str(truth_artifact_path)
     assert (
-        json.loads(
-            (tmp_path / "truth-artifacts" / "latest.json").read_text(encoding="utf-8")
-        )["generated_at"]
+        json.loads((tmp_path / "truth-artifacts" / "latest.json").read_text(encoding="utf-8"))[
+            "generated_at"
+        ]
         == "2026-04-14T15:00:00Z"
     )
     assert (

--- a/tests/scripts/test_measure_b0_scorecard.py
+++ b/tests/scripts/test_measure_b0_scorecard.py
@@ -238,11 +238,18 @@ def test_main_publish_dir_writes_timestamped_artifact_and_prints_path(
 
     captured = capsys.readouterr()
     written_path = Path(captured.out.strip())
+    latest_path = tmp_path / "published" / "latest.json"
     assert exit_code == 0
     assert written_path.parent == tmp_path / "published" / "tw-01-bounded-execution-v1" / "rev-4"
     payload = json.loads(written_path.read_text(encoding="utf-8"))
     assert payload["truth_artifact_path"] == str(truth_artifact_path)
     assert payload["proxy_metrics"]["no_rescue_success_rate"] == 1.0
+    assert (
+        json.loads(latest_path.read_text(encoding="utf-8"))["proxy_metrics"][
+            "no_rescue_success_rate"
+        ]
+        == 1.0
+    )
     assert (
         json.loads(
             (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
@@ -303,9 +310,14 @@ def test_main_publish_dir_with_json_keeps_stdout_json_and_reports_path_on_stderr
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     reported_path = Path(captured.err.strip())
+    latest_path = tmp_path / "published" / "latest.json"
     assert exit_code == 0
     assert payload["corpus"]["revision"] == 5
     assert payload["proxy_metrics"]["unique_issues_attempted"] == 1
+    assert (
+        json.loads(latest_path.read_text(encoding="utf-8"))["corpus"]["revision"]
+        == 5
+    )
     assert (
         json.loads(
             (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
@@ -396,6 +408,9 @@ def test_main_publish_mode_uses_default_corpus_to_build_truth_artifact(
         }
         truth_artifact_path.parent.mkdir(parents=True, exist_ok=True)
         truth_artifact_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        (tmp_path / "truth-artifacts" / "latest.json").write_text(
+            json.dumps(payload, indent=2), encoding="utf-8"
+        )
         (tmp_path / "truth-artifacts" / "tw-01-bounded-execution-v1").mkdir(
             parents=True, exist_ok=True
         )
@@ -426,10 +441,19 @@ def test_main_publish_mode_uses_default_corpus_to_build_truth_artifact(
     assert payload["proxy_metrics"]["unique_issues_attempted"] == 1
     assert payload["truth_artifact_path"] == str(truth_artifact_path)
     assert json.loads(
+        (tmp_path / "published" / "latest.json").read_text(encoding="utf-8")
+    )["truth_artifact_path"] == str(truth_artifact_path)
+    assert json.loads(
         (tmp_path / "published" / "tw-01-bounded-execution-v1" / "latest.json").read_text(
             encoding="utf-8"
         )
     )["truth_artifact_path"] == str(truth_artifact_path)
+    assert (
+        json.loads(
+            (tmp_path / "truth-artifacts" / "latest.json").read_text(encoding="utf-8")
+        )["generated_at"]
+        == "2026-04-14T15:00:00Z"
+    )
     assert (
         json.loads(
             (tmp_path / "truth-artifacts" / "tw-01-bounded-execution-v1" / "latest.json").read_text(


### PR DESCRIPTION
## Summary
- add top-level `latest.json` publish pointers for recurring benchmark truth artifacts and scorecards while keeping corpus and revision latest pointers
- keep the canonical status docs aligned with the new recurring truth publication surfaces
- extend the focused benchmark publish tests for the new top-level latest handles

## Validation
- python3 scripts/build_benchmark_truth_artifact.py --help
- python3 scripts/measure_b0_scorecard.py --help
- python3 -m pytest tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_measure_b0_scorecard.py tests/scripts/test_docs_site_sync_links.py -q
- python3 -m ruff check scripts/build_benchmark_truth_artifact.py scripts/measure_b0_scorecard.py tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_measure_b0_scorecard.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5540
