### PR TITLE
feat(benchmarks): publish recurring truth surfaces

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -1,0 +1,84 @@
+name: Benchmark Truth Publication
+
+on:
+  schedule:
+    - cron: "20 13 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: benchmark-truth-publication
+  cancel-in-progress: false
+
+jobs:
+  publish-benchmark-truth:
+    runs-on: aragora
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
+            echo "PWD=$(pwd)"
+            ls -la
+            exit 1
+          fi
+
+      - name: Setup Python
+        uses: ./.github/actions/setup-python-safe
+        with:
+          python-version: "3.12"
+
+      - name: Verify runtime prerequisites
+        shell: bash
+        run: |
+          command -v gh >/dev/null
+          test -f .aragora/overnight/boss_metrics.jsonl
+
+      - name: Publish tracked benchmark truth surfaces
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/measure_b0_scorecard.py \
+            --publish \
+            --publish-dir docs/status/generated/benchmark_scorecards \
+            --truth-publish-dir docs/status/generated/benchmark_truth_artifacts
+
+          python3 scripts/render_benchmark_truth_status.py \
+            --output docs/status/B0_BENCHMARK_TRUTH_STATUS.md
+
+      - name: Publish workflow summary
+        run: |
+          cat docs/status/B0_BENCHMARK_TRUTH_STATUS.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit and push refreshed truth surfaces
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            docs/status/B0_BENCHMARK_TRUTH_STATUS.md \
+            docs/status/generated/benchmark_scorecards \
+            docs/status/generated/benchmark_truth_artifacts
+
+          if git diff --cached --quiet; then
+            echo "No benchmark truth surface changes to commit."
+            exit 0
+          fi
+
+          git commit -m "docs(status): refresh benchmark truth surfaces [skip ci]"
+          git push origin HEAD:main

--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -5,7 +5,7 @@ description: Active Execution Issues
 
 # Active Execution Issues
 
-Last updated: 2026-04-13
+Last updated: 2026-04-14
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -41,18 +41,18 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
-Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining gate is production guard proof, not inflating the benchmark story.
+Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is routine truth publication and rescue productization, not reopening already-landed guard work.
 
 ## Current 30-Day Execution Set
 
 Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
-- Do now: `RS-07`, `BC-01`, `BC-03`, `BC-02`, `TW-01`, `TW-02`, `TW-03`, `CS-01..03`
+- Do now: `TW-03`, `CS-01..03`
 - Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Top 3 boss-ready next: `RS-07`, `BC-01`, `BC-03`
-- GitHub coverage for those top 3 remains epic-level only through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issues exist yet
+- Live boss-ready queue: `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)); `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, `TW-02` now publishes through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, and [#5516](https://github.com/synaptent/aragora/issues/5516) landed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535)
+- `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate
 
@@ -72,7 +72,7 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 ### Milestone 1.3 — Contract-Aware Preflight `[30-90d]`
 
-- [ ] **RS-07** Build `aragora swarm preflight run --contract ...` _(In progress as of 2026-04-13: the operator surface now has a contract-backed receipt path with persisted `PreflightReceipt` output and fail-closed admission verdicts; remaining follow-through is to make that receipt the default admission truth everywhere that consumes preflight.)_
+- [x] **RS-07** Build `aragora swarm preflight run --contract ...` _(Done 2026-04-14 via [#5514](https://github.com/synaptent/aragora/pull/5514))_
 - [x] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
 - [x] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers _(Done 2026-04-13 via [#5261](https://github.com/synaptent/aragora/pull/5261))_
 
@@ -88,9 +88,9 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 ### Milestone 2.1 — Interactive Sessions & Repair Journal `[90d]`
 
-- [ ] **BC-01** Persist session state across `explore -> plan -> edit -> verify -> repair -> publish`
+- [x] **BC-01** Persist session state across `explore -> plan -> edit -> verify -> repair -> publish` _(Done 2026-04-14 via [#5503](https://github.com/synaptent/aragora/pull/5503))_
 - [x] **BC-02** Resume retries from prior session state instead of fresh prompts _(Done 2026-04-13 via [#5384](https://github.com/synaptent/aragora/pull/5384))_
-- [ ] **BC-03** Emit precise blocker evidence and repair transcripts for failed runs
+- [x] **BC-03** Emit precise blocker evidence and repair transcripts for failed runs _(Done 2026-04-14 via [#5512](https://github.com/synaptent/aragora/pull/5512))_
 
 ### Milestone 2.2 — Task Sanitizer & Admission Gate `[30-90d]`
 
@@ -116,9 +116,9 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 ### Milestone 3.1 — Autonomous Software Execution Benchmark `[30d]`
 
-- [ ] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Partial as of 2026-04-13: the frozen corpus manifest is checked in at `docs/benchmarks/corpus.json`; the remaining gap is recurring execution against that fixed revision.)_
-- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Partial as of 2026-04-13: diffable truth-artifact generation exists, including truth/no-rescue/failure-class/rescue-type reporting; the remaining gap is recurring publication and status linkage.)_
-- [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements
+- [x] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Done 2026-04-14 via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583))_
+- [x] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Done 2026-04-14: recurring publication now writes repo-tracked outputs under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`, with the stable status summary at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`.)_
+- [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements _(Partial as of 2026-04-14: rescue-class productization reporting landed via [#5535](https://github.com/synaptent/aragora/pull/5535); the remaining gap is turning repeated classes into durable fixture-or-issue closure on the live loop, tracked by [#5330](https://github.com/synaptent/aragora/issues/5330).)_
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`
 

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -5,7 +5,7 @@ description: Next Steps (Canonical)
 
 # Next Steps (Canonical)
 
-Last updated: 2026-04-13
+Last updated: 2026-04-14
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
@@ -15,7 +15,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to finish `RS-07`, close the remaining truthful repair gaps in `BC-01/03`, and keep `TW-01/TW-02` publishing recurring truth artifacts before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to keep `TW-01/TW-02` recurring and boring on current `main`, finish `TW-03` rescue productization, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -27,17 +27,21 @@ What is already true:
 - the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
 - launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
+- receipt-backed preflight is now the default operator and live dispatch admission truth on `main` via [#5514](https://github.com/synaptent/aragora/pull/5514)
 - scratch and remote-publish preflight validation now run through the production preflight path and emit canonical terminal truth on `main`
 - task sanitizer outcomes and success-rate filtering are shaping safer boss-loop intake
 - original versus sanitized task text is already preserved for audit on `main`
+- session state now persists across the live supervisor lease/dispatch lifecycle on `main` via [#5503](https://github.com/synaptent/aragora/pull/5503)
 - retry dispatch now carries prior session resume context on `main` via [#5384](https://github.com/synaptent/aragora/pull/5384)
+- failed and `needs_human` lanes now persist normalized `blocker_evidence` on `main` via [#5512](https://github.com/synaptent/aragora/pull/5512)
 - the rescue loop can now record interventions, plan bounded recovery, and execute safe followups on `main` via [#5379](https://github.com/synaptent/aragora/pull/5379), [#5380](https://github.com/synaptent/aragora/pull/5380), and [#5383](https://github.com/synaptent/aragora/pull/5383)
+- recurring benchmark scorecards are now bound to the frozen corpus revision on `main` via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583)
+- repo-tracked recurring truth publication now lands in `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`, with the stable status summary at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`
+- repeated rescue-class reports now include fixture-or-issue productization status on `main` via [#5535](https://github.com/synaptent/aragora/pull/5535)
 
 What is still missing:
 
-- the last `RS-07` step is to make receipt-backed contract preflight the default operator admission truth everywhere, not just a substrate primitive — contract in, persisted receipt out, fail-closed on any mismatch ([#5327](https://github.com/synaptent/aragora/issues/5327))
-- broader repair truth on the live swarm loop still depends on full `BC-01` persistence and precise `BC-03` blocker evidence
-- recurring scheduled use of the frozen corpus and diffable truth artifact still needs to become routine status output ([#5329](https://github.com/synaptent/aragora/issues/5329))
+- repeated rescue classes still need the broader live-loop conversion from repeated patterns into benchmark fixtures or bounded issues beyond the landed productization report ([#5330](https://github.com/synaptent/aragora/issues/5330))
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
 - broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
@@ -58,7 +62,7 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
-Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; truthful guard completion is.
+Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are.
 
 Primary truth metric:
 
@@ -106,7 +110,7 @@ Scorecard output rules:
 - The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
 - The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
 - The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
-- What remains is recurring scheduled use of that artifact path, not inventing a second benchmark definition.
+- The stable recurring status surface is `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, backed by the latest JSON pointers under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`.
 
 ## 30-Day Canonical Backlog
 
@@ -114,25 +118,13 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
-| 1 | `RS-07` | Preflight only deserves trust when it returns a receipt the supervisor can verify, not just a shell exit code. The gap is the admission path: contract in, receipt out, fail-closed on any mismatch. | `aragora swarm preflight run --contract ...` accepts a `WorkerContract`, runs production-equivalent git/auth/env checks, and returns a signed `PreflightReceipt` with pass/fail plus canonical terminal class on failure. Supervisor rejects admission when the receipt is absent or failed. | At least one guarded admission path is live through the operator surface with receipt-backed success and failure. Failures map to canonical terminal truth classes. | substrate | [#5327](https://github.com/synaptent/aragora/issues/5327); covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#805](https://github.com/synaptent/aragora/issues/805). |
-| 2 | `BC-01` | Session persistence is the prerequisite for truthful repair, retry, and operator control. | Session state survives `explore -> plan -> edit -> verify -> repair -> publish` and survives process restart. | Benchmark retry lanes show resumed state instead of cold restarts. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
-| 3 | `BC-03` | Founder time is wasted when a failed run does not say exactly what broke and what to try next. | Failed runs emit precise blocker evidence, canonical blocker class, and repair transcript or next-step evidence. | `100%` of failed bounded runs include receipt-backed blocker evidence mapped to canonical terminal truth. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
-| 4 | `BC-02` | Retry without state reuse just repeats prompt cost and rescue labor. | Retry resumes from prior state, contract, and repair evidence instead of re-prompting from scratch. | Retried runs emit resume-from-stage evidence and show lower repeated-rescue incidence on the same class. | control plane | Covered by [#805](https://github.com/synaptent/aragora/issues/805); no dedicated lane issue exists yet. |
-| 5 | `TW-01` | The wedge only becomes real if the benchmark corpus keeps proving `prompt -> spec -> code -> verify -> PR` loops on bounded work. | A fixed benchmark corpus runs repeatedly on current `main` without ad hoc issue swapping. | Repeated benchmark runs report issue-level truth outcomes on the same bounded corpus. | trust | Covered by [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
-| 6 | `TW-02` | The project needs issue-level truth, not PR-count or iteration-count vanity metrics. | Weekly truth reporting uses `mergeable_pr OR merged_pr`, distinguishes proxy from truth, and stays linked from status docs. | Fresh `origin/main` truth reports publish issue-level truth success and no-rescue truth success. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
-| 7 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804) and [#806](https://github.com/synaptent/aragora/issues/806); no dedicated lane issue exists yet. |
-| 8 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+| 1 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | [#5330](https://github.com/synaptent/aragora/issues/5330) |
+| 2 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
 
 ## Do Now / Delay / Avoid
 
 ### Do now
 
-- `RS-07`
-- `BC-01`
-- `BC-03`
-- `BC-02`
-- `TW-01`
-- `TW-02`
 - `TW-03`
 - `CS-01..03`
 
@@ -153,13 +145,12 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 - heavy DAG workbench work that is not backed by live runtime truth
 - generalized memory fabric work that is not directly improving the execution wedge
 
-## Top 3 Boss-Ready Next
+## Live Boss-Ready Queue
 
-1. `RS-07` ([#5327](https://github.com/synaptent/aragora/issues/5327)) because it closes the last missing guard on the live operator path and turns preflight into the admission truth the operator can actually trust.
-2. `BC-01` because retries and repair loops cannot become truthful until session state survives restarts.
-3. `BC-03` because founder leverage depends on precise blocker evidence before more retry logic is added.
+- `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) because repeated rescues only create leverage when the live loop turns them into fixtures or bounded issues.
+- There is no second dedicated boss-ready issue in this tranche right now; keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
 
-There is no dedicated open GitHub issue yet for those three codes. Existing issue coverage is still at the epic level through [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806). Do not invent duplicate roadmap issues in this tranche unless the canonical docs stop being enough to drive bounded execution.
+The live queue for this tranche should now be driven by `TW-03`. `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, `TW-02` is now published through the repo-tracked recurring truth surface at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, and [#5516](https://github.com/synaptent/aragora/issues/5516) completed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535). `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
 
 ## Reverse-Staged Rocket Bootstrap
 

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -42,11 +42,11 @@ Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort
 
 Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
-- Do now: `TW-02`, `TW-03`, `CS-01..03`
+- Do now: `TW-03`, `CS-01..03`
 - Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Live boss-ready queue: `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)) and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)); `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14 and [#5516](https://github.com/synaptent/aragora/issues/5516) landed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535)
+- Live boss-ready queue: `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)); `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, `TW-02` now publishes through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, and [#5516](https://github.com/synaptent/aragora/issues/5516) landed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535)
 - `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate
@@ -112,7 +112,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 ### Milestone 3.1 — Autonomous Software Execution Benchmark `[30d]`
 
 - [x] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Done 2026-04-14 via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583))_
-- [ ] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Partial as of 2026-04-14: diffable truth-artifact generation exists, including truth/no-rescue/failure-class/rescue-type reporting; the remaining gap is recurring publication and status linkage, tracked by [#5540](https://github.com/synaptent/aragora/issues/5540).)_
+- [x] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Done 2026-04-14: recurring publication now writes repo-tracked outputs under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`, with the stable status summary at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`.)_
 - [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements _(Partial as of 2026-04-14: rescue-class productization reporting landed via [#5535](https://github.com/synaptent/aragora/pull/5535); the remaining gap is turning repeated classes into durable fixture-or-issue closure on the live loop, tracked by [#5330](https://github.com/synaptent/aragora/issues/5330).)_
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`

--- a/docs/status/B0_BENCHMARK_TRUTH_STATUS.md
+++ b/docs/status/B0_BENCHMARK_TRUTH_STATUS.md
@@ -1,0 +1,50 @@
+# B0 Benchmark Truth Status
+
+Last updated: 2026-04-14T18:12:28Z
+
+This is the repo-tracked recurring `TW-02` publication surface for the fixed benchmark corpus.
+
+## Corpus
+
+- Corpus manifest: `docs/benchmarks/corpus.json`
+- Corpus id: `tw-01-bounded-execution-v1`
+- Revision: `1`
+- Recorded on: `2026-04-13`
+- Success contract: `mergeable_pr_or_merged_pr`
+- Coverage status: `incomplete`
+- Coverage: `1`/`5` issues attempted
+- Missing corpus issues: `1064`, `1641`, `1733`, `2712`
+
+## Published Paths
+
+- Latest truth artifact: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json`
+- Latest scorecard: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/latest.json`
+- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/latest.json`
+- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-1/latest.json`
+
+## Truth Metrics
+
+| Metric | Value |
+| --- | --- |
+| Truth success rate | 60.0% |
+| No-rescue truth success rate | 40.0% |
+| Merged-only rate | 60.0% |
+
+## Proxy Metrics
+
+| Metric | Value |
+| --- | --- |
+| No-rescue success rate | 0.0% |
+| Unique issues attempted | 1 |
+| Unique issues succeeded | 0 |
+| Unique issues failed | 1 |
+| Total ticks | 4 |
+
+## Failure Class Distribution
+
+- `blocked_sanitation_failed`: 1
+- `rescue_no_deliverable`: 3
+
+## Rescue Counts By Type
+
+- `rescue_no_deliverable`: 3

--- a/docs/status/COMMERCIAL_OVERVIEW.md
+++ b/docs/status/COMMERCIAL_OVERVIEW.md
@@ -33,7 +33,6 @@ The claims below are the current proof base, not the long-term ambition.
 The current commercial gate is the same as the current execution gate in [NEXT_STEPS_CANONICAL.md](NEXT_STEPS_CANONICAL.md):
 
 - keep `TW-01` landed so recurring scorecards stay tied to the frozen corpus on current `main`
-- finish `TW-02` so recurring truth artifacts and scorecards are routinely published and linked from status surfaces
 - finish `TW-03` so repeated rescues become benchmark fixtures or bounded product work instead of invisible operator tax
 - keep all external claims narrower than the measured proof
 
@@ -160,6 +159,7 @@ Use these documents as the canonical backing for commercial claims:
 
 - [NEXT_STEPS_CANONICAL.md](NEXT_STEPS_CANONICAL.md)
 - [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXECUTION_ISSUES.md)
+- [B0_BENCHMARK_TRUTH_STATUS.md](B0_BENCHMARK_TRUTH_STATUS.md)
 - [ARAGORA_EVOLUTION_ROADMAP.md](../plans/ARAGORA_EVOLUTION_ROADMAP.md)
 - [docs/benchmarks/corpus.json](../benchmarks/corpus.json)
 - `scripts/build_benchmark_truth_artifact.py`

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -10,7 +10,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to keep `TW-01` recurring and corpus-linked on current `main`, finish `TW-02` routine truth publication, finish `TW-03` rescue productization, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to keep `TW-01/TW-02` recurring and boring on current `main`, finish `TW-03` rescue productization, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -31,11 +31,11 @@ What is already true:
 - failed and `needs_human` lanes now persist normalized `blocker_evidence` on `main` via [#5512](https://github.com/synaptent/aragora/pull/5512)
 - the rescue loop can now record interventions, plan bounded recovery, and execute safe followups on `main` via [#5379](https://github.com/synaptent/aragora/pull/5379), [#5380](https://github.com/synaptent/aragora/pull/5380), and [#5383](https://github.com/synaptent/aragora/pull/5383)
 - recurring benchmark scorecards are now bound to the frozen corpus revision on `main` via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583)
+- repo-tracked recurring truth publication now lands in `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`, with the stable status summary at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`
 - repeated rescue-class reports now include fixture-or-issue productization status on `main` via [#5535](https://github.com/synaptent/aragora/pull/5535)
 
 What is still missing:
 
-- recurring publication of the diffable truth artifact and scorecard still needs to stay routine and clearly linked from status surfaces ([#5540](https://github.com/synaptent/aragora/issues/5540), [#5329](https://github.com/synaptent/aragora/issues/5329))
 - repeated rescue classes still need the broader live-loop conversion from repeated patterns into benchmark fixtures or bounded issues beyond the landed productization report ([#5330](https://github.com/synaptent/aragora/issues/5330))
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
 - broader repair-loop coverage on top of the existing audit trail
@@ -105,7 +105,7 @@ Scorecard output rules:
 - The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
 - The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
 - The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
-- `TW-01` is now landed on `main`; what remains is routine `TW-02` publication and status linkage, not inventing a second benchmark definition.
+- The stable recurring status surface is `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, backed by the latest JSON pointers under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`.
 
 ## 30-Day Canonical Backlog
 
@@ -113,15 +113,13 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
-| 1 | `TW-02` | The project needs issue-level truth, not PR-count or iteration-count vanity metrics. | Weekly truth reporting uses `mergeable_pr OR merged_pr`, distinguishes proxy from truth, and stays linked from status docs. | Fresh `origin/main` truth reports publish issue-level truth success and no-rescue truth success. | trust | [#5540](https://github.com/synaptent/aragora/issues/5540), [#5329](https://github.com/synaptent/aragora/issues/5329) |
-| 2 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | [#5330](https://github.com/synaptent/aragora/issues/5330) |
-| 3 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+| 1 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | [#5330](https://github.com/synaptent/aragora/issues/5330) |
+| 2 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
 
 ## Do Now / Delay / Avoid
 
 ### Do now
 
-- `TW-02`
 - `TW-03`
 - `CS-01..03`
 
@@ -144,11 +142,10 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ## Live Boss-Ready Queue
 
-- `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)) because recurring truth publication is the remaining open proof surface on the frozen corpus.
 - `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) because repeated rescues only create leverage when the live loop turns them into fixtures or bounded issues.
-- There is no third dedicated boss-ready issue in this tranche right now; keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
+- There is no second dedicated boss-ready issue in this tranche right now; keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
 
-The live queue for this tranche should now be driven by those trust-loop issues. `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, and [#5516](https://github.com/synaptent/aragora/issues/5516) completed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535). `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
+The live queue for this tranche should now be driven by `TW-03`. `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, `TW-02` is now published through the repo-tracked recurring truth surface at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, and [#5516](https://github.com/synaptent/aragora/issues/5516) completed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535). `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
 
 ## Reverse-Staged Rocket Bootstrap
 

--- a/docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/latest.json
+++ b/docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/latest.json
@@ -1,0 +1,87 @@
+{
+  "corpus": {
+    "corpus_id": "tw-01-bounded-execution-v1",
+    "issue_count": 5,
+    "manifest_sha256": "01f5f941cb437675344d2e5c6292d3b31df3ea8041e623e32eb9f3f89b971804",
+    "membership_issue_numbers": [
+      873,
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "membership_sha256": "04b6651df7d6f8b78c9c33709ea1379da8babec4417f01372a63374fa5c6103a",
+    "path": "docs/benchmarks/corpus.json",
+    "recorded_on": "2026-04-13",
+    "revision": 1,
+    "success_contract": "mergeable_pr_or_merged_pr"
+  },
+  "coverage": {
+    "attempted_issue_count": 1,
+    "is_complete": false,
+    "missing_issue_count": 4,
+    "missing_issue_numbers": [
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "status": "incomplete"
+  },
+  "failure_class_distribution": {
+    "blocked_sanitation_failed": 1,
+    "rescue_no_deliverable": 3
+  },
+  "generated_at": "2026-04-14T18:12:28Z",
+  "metrics_file": ".aragora/overnight/boss_metrics.jsonl",
+  "proxy_metrics": {
+    "corpus": {
+      "corpus_id": "tw-01-bounded-execution-v1",
+      "issue_count": 5,
+      "path": "docs/benchmarks/corpus.json",
+      "recorded_on": "2026-04-13",
+      "revision": 1,
+      "success_contract": "mergeable_pr_or_merged_pr"
+    },
+    "coverage": {
+      "attempted_issue_count": 1,
+      "is_complete": false,
+      "missing_issue_count": 4,
+      "missing_issue_numbers": [
+        1064,
+        1641,
+        1733,
+        2712
+      ],
+      "status": "incomplete"
+    },
+    "failure_classes": {
+      "blocked_sanitation_failed": 1,
+      "rescue_no_deliverable": 3
+    },
+    "mean_elapsed_seconds": 33.8,
+    "median_elapsed_seconds": 32.5,
+    "no_rescue_success_rate": 0.0,
+    "status": "active",
+    "success_classes": {},
+    "terminal_class_distribution": {
+      "blocked_sanitation_failed": 1,
+      "rescue_no_deliverable": 3
+    },
+    "tick_success_rate": 0.0,
+    "total_ticks": 4,
+    "unique_issues_attempted": 1,
+    "unique_issues_failed": 1,
+    "unique_issues_succeeded": 0
+  },
+  "rescue_counts_by_type": {
+    "rescue_no_deliverable": 3
+  },
+  "truth_artifact_generated_at": "2026-04-14T18:12:12Z",
+  "truth_artifact_path": "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/truth-20260414T181212Z.json",
+  "truth_metrics": {
+    "merged_only_rate": 0.6,
+    "no_rescue_truth_success_rate": 0.4,
+    "truth_success_rate": 0.6
+  }
+}

--- a/docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-1/latest.json
+++ b/docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-1/latest.json
@@ -1,0 +1,87 @@
+{
+  "corpus": {
+    "corpus_id": "tw-01-bounded-execution-v1",
+    "issue_count": 5,
+    "manifest_sha256": "01f5f941cb437675344d2e5c6292d3b31df3ea8041e623e32eb9f3f89b971804",
+    "membership_issue_numbers": [
+      873,
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "membership_sha256": "04b6651df7d6f8b78c9c33709ea1379da8babec4417f01372a63374fa5c6103a",
+    "path": "docs/benchmarks/corpus.json",
+    "recorded_on": "2026-04-13",
+    "revision": 1,
+    "success_contract": "mergeable_pr_or_merged_pr"
+  },
+  "coverage": {
+    "attempted_issue_count": 1,
+    "is_complete": false,
+    "missing_issue_count": 4,
+    "missing_issue_numbers": [
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "status": "incomplete"
+  },
+  "failure_class_distribution": {
+    "blocked_sanitation_failed": 1,
+    "rescue_no_deliverable": 3
+  },
+  "generated_at": "2026-04-14T18:12:28Z",
+  "metrics_file": ".aragora/overnight/boss_metrics.jsonl",
+  "proxy_metrics": {
+    "corpus": {
+      "corpus_id": "tw-01-bounded-execution-v1",
+      "issue_count": 5,
+      "path": "docs/benchmarks/corpus.json",
+      "recorded_on": "2026-04-13",
+      "revision": 1,
+      "success_contract": "mergeable_pr_or_merged_pr"
+    },
+    "coverage": {
+      "attempted_issue_count": 1,
+      "is_complete": false,
+      "missing_issue_count": 4,
+      "missing_issue_numbers": [
+        1064,
+        1641,
+        1733,
+        2712
+      ],
+      "status": "incomplete"
+    },
+    "failure_classes": {
+      "blocked_sanitation_failed": 1,
+      "rescue_no_deliverable": 3
+    },
+    "mean_elapsed_seconds": 33.8,
+    "median_elapsed_seconds": 32.5,
+    "no_rescue_success_rate": 0.0,
+    "status": "active",
+    "success_classes": {},
+    "terminal_class_distribution": {
+      "blocked_sanitation_failed": 1,
+      "rescue_no_deliverable": 3
+    },
+    "tick_success_rate": 0.0,
+    "total_ticks": 4,
+    "unique_issues_attempted": 1,
+    "unique_issues_failed": 1,
+    "unique_issues_succeeded": 0
+  },
+  "rescue_counts_by_type": {
+    "rescue_no_deliverable": 3
+  },
+  "truth_artifact_generated_at": "2026-04-14T18:12:12Z",
+  "truth_artifact_path": "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/truth-20260414T181212Z.json",
+  "truth_metrics": {
+    "merged_only_rate": 0.6,
+    "no_rescue_truth_success_rate": 0.4,
+    "truth_success_rate": 0.6
+  }
+}

--- a/docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-1/scorecard-20260414T181228Z.json
+++ b/docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-1/scorecard-20260414T181228Z.json
@@ -1,0 +1,87 @@
+{
+  "corpus": {
+    "corpus_id": "tw-01-bounded-execution-v1",
+    "issue_count": 5,
+    "manifest_sha256": "01f5f941cb437675344d2e5c6292d3b31df3ea8041e623e32eb9f3f89b971804",
+    "membership_issue_numbers": [
+      873,
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "membership_sha256": "04b6651df7d6f8b78c9c33709ea1379da8babec4417f01372a63374fa5c6103a",
+    "path": "docs/benchmarks/corpus.json",
+    "recorded_on": "2026-04-13",
+    "revision": 1,
+    "success_contract": "mergeable_pr_or_merged_pr"
+  },
+  "coverage": {
+    "attempted_issue_count": 1,
+    "is_complete": false,
+    "missing_issue_count": 4,
+    "missing_issue_numbers": [
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "status": "incomplete"
+  },
+  "failure_class_distribution": {
+    "blocked_sanitation_failed": 1,
+    "rescue_no_deliverable": 3
+  },
+  "generated_at": "2026-04-14T18:12:28Z",
+  "metrics_file": ".aragora/overnight/boss_metrics.jsonl",
+  "proxy_metrics": {
+    "corpus": {
+      "corpus_id": "tw-01-bounded-execution-v1",
+      "issue_count": 5,
+      "path": "docs/benchmarks/corpus.json",
+      "recorded_on": "2026-04-13",
+      "revision": 1,
+      "success_contract": "mergeable_pr_or_merged_pr"
+    },
+    "coverage": {
+      "attempted_issue_count": 1,
+      "is_complete": false,
+      "missing_issue_count": 4,
+      "missing_issue_numbers": [
+        1064,
+        1641,
+        1733,
+        2712
+      ],
+      "status": "incomplete"
+    },
+    "failure_classes": {
+      "blocked_sanitation_failed": 1,
+      "rescue_no_deliverable": 3
+    },
+    "mean_elapsed_seconds": 33.8,
+    "median_elapsed_seconds": 32.5,
+    "no_rescue_success_rate": 0.0,
+    "status": "active",
+    "success_classes": {},
+    "terminal_class_distribution": {
+      "blocked_sanitation_failed": 1,
+      "rescue_no_deliverable": 3
+    },
+    "tick_success_rate": 0.0,
+    "total_ticks": 4,
+    "unique_issues_attempted": 1,
+    "unique_issues_failed": 1,
+    "unique_issues_succeeded": 0
+  },
+  "rescue_counts_by_type": {
+    "rescue_no_deliverable": 3
+  },
+  "truth_artifact_generated_at": "2026-04-14T18:12:12Z",
+  "truth_artifact_path": "docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/truth-20260414T181212Z.json",
+  "truth_metrics": {
+    "merged_only_rate": 0.6,
+    "no_rescue_truth_success_rate": 0.4,
+    "truth_success_rate": 0.6
+  }
+}

--- a/docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json
+++ b/docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json
@@ -1,0 +1,240 @@
+{
+  "corpus": {
+    "corpus_id": "tw-01-bounded-execution-v1",
+    "issue_count": 5,
+    "manifest_sha256": "01f5f941cb437675344d2e5c6292d3b31df3ea8041e623e32eb9f3f89b971804",
+    "membership_issue_numbers": [
+      873,
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "membership_sha256": "04b6651df7d6f8b78c9c33709ea1379da8babec4417f01372a63374fa5c6103a",
+    "path": "docs/benchmarks/corpus.json",
+    "recorded_on": "2026-04-13",
+    "revision": 1,
+    "success_contract": "mergeable_pr_or_merged_pr"
+  },
+  "coverage": {
+    "attempted_issue_count": 1,
+    "is_complete": false,
+    "missing_issue_count": 4,
+    "missing_issue_numbers": [
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "status": "incomplete"
+  },
+  "failure_class_distribution": {
+    "blocked_sanitation_failed": 1,
+    "rescue_no_deliverable": 3
+  },
+  "generated_at": "2026-04-14T18:12:12Z",
+  "issues": [
+    {
+      "had_rescue": true,
+      "issue_number": 873,
+      "issue_title": "Bump @eslint/eslintrc from 3.2.0 to 3.3.0 in /aragora/live",
+      "linked_prs": [
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T17:12:37Z",
+          "number": 880,
+          "state": "MERGED",
+          "title": "fix(swarm): enforce file-scope constraints in Boss-loop worker execution",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/880"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T17:56:06Z",
+          "number": 881,
+          "state": "MERGED",
+          "title": "fix(swarm): stop on terminal worker state",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/881"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T18:53:09Z",
+          "number": 882,
+          "state": "MERGED",
+          "title": "fix(swarm): prevent autonomous workers from committing session artifacts",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/882"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T23:53:16Z",
+          "number": 885,
+          "state": "MERGED",
+          "title": "fix(swarm): backfill file_scope from spec hints on work orders",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/885"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T00:25:34Z",
+          "number": 886,
+          "state": "MERGED",
+          "title": "fix(swarm): escalate waiting_conflict deadlock to needs_human",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/886"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T02:32:13Z",
+          "number": 887,
+          "state": "MERGED",
+          "title": "fix(swarm): override wrong decomposer scopes with spec hints",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/887"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T03:40:12Z",
+          "number": 890,
+          "state": "MERGED",
+          "title": "fix(decomposer): LLM-first subtask extraction with OpenRouter fallback",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/890"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T04:52:34Z",
+          "number": 893,
+          "state": "MERGED",
+          "title": "fix(boss-loop): fail closed when no concrete deliverable exists",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/893"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T06:20:41Z",
+          "number": 900,
+          "state": "MERGED",
+          "title": "fix(swarm): route no-progress timeout through result collection (#899)",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/900"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-19T14:54:15Z",
+          "number": 1059,
+          "state": "MERGED",
+          "title": "feat(swarm): allow boss-loop to target one issue",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/1059"
+        }
+      ],
+      "no_rescue_truth_success": false,
+      "proxy_pr_signal": false,
+      "truth_state": "merged_pr",
+      "truth_success": true
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 1064,
+      "issue_title": "Boss-loop execution: bump @supabase/supabase-js from 2.99.1 to 2.99.3 in /aragora/live",
+      "linked_prs": [
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-19T17:21:15Z",
+          "number": 1066,
+          "state": "MERGED",
+          "title": "fix(live): bump @supabase/supabase-js from 2.99.1 to 2.99.3",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/1066"
+        }
+      ],
+      "no_rescue_truth_success": true,
+      "proxy_pr_signal": false,
+      "truth_state": "merged_pr",
+      "truth_success": true
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 1641,
+      "issue_title": "Wire prompt refiner env",
+      "linked_prs": [
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-30T18:37:50Z",
+          "number": 1714,
+          "state": "MERGED",
+          "title": "feat(swarm): pass prompt-refiner hints via worker env",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/1714"
+        }
+      ],
+      "no_rescue_truth_success": true,
+      "proxy_pr_signal": false,
+      "truth_state": "merged_pr",
+      "truth_success": true
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 1733,
+      "issue_title": "Tighten supervisor merge gate",
+      "linked_prs": [],
+      "no_rescue_truth_success": false,
+      "proxy_pr_signal": false,
+      "truth_state": "no_linked_pr",
+      "truth_success": false
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 2712,
+      "issue_title": "Fail closed on string booleans in QualityPipelineConfig.from_dict",
+      "linked_prs": [],
+      "no_rescue_truth_success": false,
+      "proxy_pr_signal": false,
+      "truth_state": "no_linked_pr",
+      "truth_success": false
+    }
+  ],
+  "metrics_file": ".aragora/overnight/boss_metrics.jsonl",
+  "primary_metrics": {
+    "merged_only_rate": 0.6,
+    "no_rescue_truth_success_rate": 0.4,
+    "truth_success_rate": 0.6
+  },
+  "proxy_metrics": {
+    "attempted_issue_count": 1,
+    "note": "Proxy metrics are secondary. Truth metrics remain mergeable_pr OR merged_pr.",
+    "proxy_pr_signal_issue_count": 0,
+    "proxy_pr_signal_issue_rate": 0.0
+  },
+  "repo": "synaptent/aragora",
+  "rescue_counts_by_type": {
+    "rescue_no_deliverable": 3
+  },
+  "run_status": "incomplete"
+}

--- a/docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/latest.json
+++ b/docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/latest.json
@@ -1,0 +1,240 @@
+{
+  "corpus": {
+    "corpus_id": "tw-01-bounded-execution-v1",
+    "issue_count": 5,
+    "manifest_sha256": "01f5f941cb437675344d2e5c6292d3b31df3ea8041e623e32eb9f3f89b971804",
+    "membership_issue_numbers": [
+      873,
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "membership_sha256": "04b6651df7d6f8b78c9c33709ea1379da8babec4417f01372a63374fa5c6103a",
+    "path": "docs/benchmarks/corpus.json",
+    "recorded_on": "2026-04-13",
+    "revision": 1,
+    "success_contract": "mergeable_pr_or_merged_pr"
+  },
+  "coverage": {
+    "attempted_issue_count": 1,
+    "is_complete": false,
+    "missing_issue_count": 4,
+    "missing_issue_numbers": [
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "status": "incomplete"
+  },
+  "failure_class_distribution": {
+    "blocked_sanitation_failed": 1,
+    "rescue_no_deliverable": 3
+  },
+  "generated_at": "2026-04-14T18:12:12Z",
+  "issues": [
+    {
+      "had_rescue": true,
+      "issue_number": 873,
+      "issue_title": "Bump @eslint/eslintrc from 3.2.0 to 3.3.0 in /aragora/live",
+      "linked_prs": [
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T17:12:37Z",
+          "number": 880,
+          "state": "MERGED",
+          "title": "fix(swarm): enforce file-scope constraints in Boss-loop worker execution",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/880"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T17:56:06Z",
+          "number": 881,
+          "state": "MERGED",
+          "title": "fix(swarm): stop on terminal worker state",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/881"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T18:53:09Z",
+          "number": 882,
+          "state": "MERGED",
+          "title": "fix(swarm): prevent autonomous workers from committing session artifacts",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/882"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T23:53:16Z",
+          "number": 885,
+          "state": "MERGED",
+          "title": "fix(swarm): backfill file_scope from spec hints on work orders",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/885"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T00:25:34Z",
+          "number": 886,
+          "state": "MERGED",
+          "title": "fix(swarm): escalate waiting_conflict deadlock to needs_human",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/886"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T02:32:13Z",
+          "number": 887,
+          "state": "MERGED",
+          "title": "fix(swarm): override wrong decomposer scopes with spec hints",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/887"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T03:40:12Z",
+          "number": 890,
+          "state": "MERGED",
+          "title": "fix(decomposer): LLM-first subtask extraction with OpenRouter fallback",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/890"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T04:52:34Z",
+          "number": 893,
+          "state": "MERGED",
+          "title": "fix(boss-loop): fail closed when no concrete deliverable exists",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/893"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T06:20:41Z",
+          "number": 900,
+          "state": "MERGED",
+          "title": "fix(swarm): route no-progress timeout through result collection (#899)",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/900"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-19T14:54:15Z",
+          "number": 1059,
+          "state": "MERGED",
+          "title": "feat(swarm): allow boss-loop to target one issue",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/1059"
+        }
+      ],
+      "no_rescue_truth_success": false,
+      "proxy_pr_signal": false,
+      "truth_state": "merged_pr",
+      "truth_success": true
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 1064,
+      "issue_title": "Boss-loop execution: bump @supabase/supabase-js from 2.99.1 to 2.99.3 in /aragora/live",
+      "linked_prs": [
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-19T17:21:15Z",
+          "number": 1066,
+          "state": "MERGED",
+          "title": "fix(live): bump @supabase/supabase-js from 2.99.1 to 2.99.3",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/1066"
+        }
+      ],
+      "no_rescue_truth_success": true,
+      "proxy_pr_signal": false,
+      "truth_state": "merged_pr",
+      "truth_success": true
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 1641,
+      "issue_title": "Wire prompt refiner env",
+      "linked_prs": [
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-30T18:37:50Z",
+          "number": 1714,
+          "state": "MERGED",
+          "title": "feat(swarm): pass prompt-refiner hints via worker env",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/1714"
+        }
+      ],
+      "no_rescue_truth_success": true,
+      "proxy_pr_signal": false,
+      "truth_state": "merged_pr",
+      "truth_success": true
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 1733,
+      "issue_title": "Tighten supervisor merge gate",
+      "linked_prs": [],
+      "no_rescue_truth_success": false,
+      "proxy_pr_signal": false,
+      "truth_state": "no_linked_pr",
+      "truth_success": false
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 2712,
+      "issue_title": "Fail closed on string booleans in QualityPipelineConfig.from_dict",
+      "linked_prs": [],
+      "no_rescue_truth_success": false,
+      "proxy_pr_signal": false,
+      "truth_state": "no_linked_pr",
+      "truth_success": false
+    }
+  ],
+  "metrics_file": ".aragora/overnight/boss_metrics.jsonl",
+  "primary_metrics": {
+    "merged_only_rate": 0.6,
+    "no_rescue_truth_success_rate": 0.4,
+    "truth_success_rate": 0.6
+  },
+  "proxy_metrics": {
+    "attempted_issue_count": 1,
+    "note": "Proxy metrics are secondary. Truth metrics remain mergeable_pr OR merged_pr.",
+    "proxy_pr_signal_issue_count": 0,
+    "proxy_pr_signal_issue_rate": 0.0
+  },
+  "repo": "synaptent/aragora",
+  "rescue_counts_by_type": {
+    "rescue_no_deliverable": 3
+  },
+  "run_status": "incomplete"
+}

--- a/docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/truth-20260414T181212Z.json
+++ b/docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/truth-20260414T181212Z.json
@@ -1,0 +1,240 @@
+{
+  "corpus": {
+    "corpus_id": "tw-01-bounded-execution-v1",
+    "issue_count": 5,
+    "manifest_sha256": "01f5f941cb437675344d2e5c6292d3b31df3ea8041e623e32eb9f3f89b971804",
+    "membership_issue_numbers": [
+      873,
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "membership_sha256": "04b6651df7d6f8b78c9c33709ea1379da8babec4417f01372a63374fa5c6103a",
+    "path": "docs/benchmarks/corpus.json",
+    "recorded_on": "2026-04-13",
+    "revision": 1,
+    "success_contract": "mergeable_pr_or_merged_pr"
+  },
+  "coverage": {
+    "attempted_issue_count": 1,
+    "is_complete": false,
+    "missing_issue_count": 4,
+    "missing_issue_numbers": [
+      1064,
+      1641,
+      1733,
+      2712
+    ],
+    "status": "incomplete"
+  },
+  "failure_class_distribution": {
+    "blocked_sanitation_failed": 1,
+    "rescue_no_deliverable": 3
+  },
+  "generated_at": "2026-04-14T18:12:12Z",
+  "issues": [
+    {
+      "had_rescue": true,
+      "issue_number": 873,
+      "issue_title": "Bump @eslint/eslintrc from 3.2.0 to 3.3.0 in /aragora/live",
+      "linked_prs": [
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T17:12:37Z",
+          "number": 880,
+          "state": "MERGED",
+          "title": "fix(swarm): enforce file-scope constraints in Boss-loop worker execution",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/880"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T17:56:06Z",
+          "number": 881,
+          "state": "MERGED",
+          "title": "fix(swarm): stop on terminal worker state",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/881"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T18:53:09Z",
+          "number": 882,
+          "state": "MERGED",
+          "title": "fix(swarm): prevent autonomous workers from committing session artifacts",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/882"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-09T23:53:16Z",
+          "number": 885,
+          "state": "MERGED",
+          "title": "fix(swarm): backfill file_scope from spec hints on work orders",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/885"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T00:25:34Z",
+          "number": 886,
+          "state": "MERGED",
+          "title": "fix(swarm): escalate waiting_conflict deadlock to needs_human",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/886"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T02:32:13Z",
+          "number": 887,
+          "state": "MERGED",
+          "title": "fix(swarm): override wrong decomposer scopes with spec hints",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/887"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T03:40:12Z",
+          "number": 890,
+          "state": "MERGED",
+          "title": "fix(decomposer): LLM-first subtask extraction with OpenRouter fallback",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/890"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T04:52:34Z",
+          "number": 893,
+          "state": "MERGED",
+          "title": "fix(boss-loop): fail closed when no concrete deliverable exists",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/893"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-10T06:20:41Z",
+          "number": 900,
+          "state": "MERGED",
+          "title": "fix(swarm): route no-progress timeout through result collection (#899)",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/900"
+        },
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-19T14:54:15Z",
+          "number": 1059,
+          "state": "MERGED",
+          "title": "feat(swarm): allow boss-loop to target one issue",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/1059"
+        }
+      ],
+      "no_rescue_truth_success": false,
+      "proxy_pr_signal": false,
+      "truth_state": "merged_pr",
+      "truth_success": true
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 1064,
+      "issue_title": "Boss-loop execution: bump @supabase/supabase-js from 2.99.1 to 2.99.3 in /aragora/live",
+      "linked_prs": [
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-19T17:21:15Z",
+          "number": 1066,
+          "state": "MERGED",
+          "title": "fix(live): bump @supabase/supabase-js from 2.99.1 to 2.99.3",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/1066"
+        }
+      ],
+      "no_rescue_truth_success": true,
+      "proxy_pr_signal": false,
+      "truth_state": "merged_pr",
+      "truth_success": true
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 1641,
+      "issue_title": "Wire prompt refiner env",
+      "linked_prs": [
+        {
+          "is_draft": false,
+          "merge_state_status": "UNKNOWN",
+          "mergeable": "UNKNOWN",
+          "merged_at": "2026-03-30T18:37:50Z",
+          "number": 1714,
+          "state": "MERGED",
+          "title": "feat(swarm): pass prompt-refiner hints via worker env",
+          "truth_state": "merged_pr",
+          "url": "https://github.com/synaptent/aragora/pull/1714"
+        }
+      ],
+      "no_rescue_truth_success": true,
+      "proxy_pr_signal": false,
+      "truth_state": "merged_pr",
+      "truth_success": true
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 1733,
+      "issue_title": "Tighten supervisor merge gate",
+      "linked_prs": [],
+      "no_rescue_truth_success": false,
+      "proxy_pr_signal": false,
+      "truth_state": "no_linked_pr",
+      "truth_success": false
+    },
+    {
+      "had_rescue": false,
+      "issue_number": 2712,
+      "issue_title": "Fail closed on string booleans in QualityPipelineConfig.from_dict",
+      "linked_prs": [],
+      "no_rescue_truth_success": false,
+      "proxy_pr_signal": false,
+      "truth_state": "no_linked_pr",
+      "truth_success": false
+    }
+  ],
+  "metrics_file": ".aragora/overnight/boss_metrics.jsonl",
+  "primary_metrics": {
+    "merged_only_rate": 0.6,
+    "no_rescue_truth_success_rate": 0.4,
+    "truth_success_rate": 0.6
+  },
+  "proxy_metrics": {
+    "attempted_issue_count": 1,
+    "note": "Proxy metrics are secondary. Truth metrics remain mergeable_pr OR merged_pr.",
+    "proxy_pr_signal_issue_count": 0,
+    "proxy_pr_signal_issue_rate": 0.0
+  },
+  "repo": "synaptent/aragora",
+  "rescue_counts_by_type": {
+    "rescue_no_deliverable": 3
+  },
+  "run_status": "incomplete"
+}

--- a/scripts/check_branch_mutation_policy.py
+++ b/scripts/check_branch_mutation_policy.py
@@ -41,6 +41,7 @@ REQUIRED_MATCH_COUNTS: dict[str, int] = {
 }
 
 WORKFLOW_MUTATION_ALLOWLIST = {
+    "benchmark-truth-publication.yml",
     "openapi.yml",
     "release-notes.yml",
     "testfixer-auto.yml",
@@ -120,6 +121,22 @@ def find_mutating_workflow_violations(workflows: dict[str, str]) -> list[Violati
                     Violation(
                         path=f".github/workflows/{name}",
                         message="must push only to testfixer/* branch namespace",
+                    )
+                )
+
+        if name == "benchmark-truth-publication.yml":
+            if re.search(r"^\s*pull_request(_target)?\s*:", text, flags=re.MULTILINE):
+                violations.append(
+                    Violation(
+                        path=f".github/workflows/{name}",
+                        message="must not be triggered by pull_request/pull_request_target",
+                    )
+                )
+            if "git push origin HEAD:main" not in text:
+                violations.append(
+                    Violation(
+                        path=f".github/workflows/{name}",
+                        message="must push only to main via HEAD:main",
                     )
                 )
     return violations

--- a/scripts/render_benchmark_truth_status.py
+++ b/scripts/render_benchmark_truth_status.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Render a repo-tracked B0 benchmark truth status summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CORPUS_PATH = REPO_ROOT / "docs" / "benchmarks" / "corpus.json"
+DEFAULT_TRUTH_ROOT = REPO_ROOT / "docs" / "status" / "generated" / "benchmark_truth_artifacts"
+DEFAULT_SCORECARD_ROOT = REPO_ROOT / "docs" / "status" / "generated" / "benchmark_scorecards"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "status" / "B0_BENCHMARK_TRUTH_STATUS.md"
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
+    return slug.strip("-") or "benchmark-corpus"
+
+
+def _repo_stable_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON payload at {path} must be an object")
+    return payload
+
+
+def load_corpus(path: Path) -> dict[str, Any]:
+    payload = _load_json(path)
+    issues = payload.get("issues")
+    if not isinstance(issues, list) or not issues:
+        raise ValueError(f"Corpus at {path} must contain a non-empty 'issues' list")
+    return payload
+
+
+def resolve_latest_paths(
+    *,
+    corpus_path: Path,
+    truth_root: Path,
+    scorecard_root: Path,
+) -> dict[str, Path]:
+    corpus = load_corpus(corpus_path)
+    corpus_id = str(corpus.get("corpus_id") or "").strip()
+    revision = int(corpus.get("revision", 0) or 0)
+    slug = _slugify(corpus_id)
+    return {
+        "truth_corpus_latest": truth_root / slug / "latest.json",
+        "truth_revision_latest": truth_root / slug / f"rev-{revision}" / "latest.json",
+        "scorecard_corpus_latest": scorecard_root / slug / "latest.json",
+        "scorecard_revision_latest": scorecard_root / slug / f"rev-{revision}" / "latest.json",
+    }
+
+
+def _format_percent(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.1%}"
+    return "n/a"
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    if value is None or value == "":
+        return "n/a"
+    return str(value)
+
+
+def _render_mapping(mapping: dict[str, Any]) -> list[str]:
+    if not mapping:
+        return ["- none"]
+    return [f"- `{key}`: {_format_value(value)}" for key, value in mapping.items()]
+
+
+def render_status_markdown(
+    *,
+    corpus_path: Path,
+    truth_path: Path,
+    scorecard_path: Path,
+    truth_payload: dict[str, Any],
+    scorecard_payload: dict[str, Any],
+    latest_paths: dict[str, Path],
+) -> str:
+    corpus = dict(scorecard_payload.get("corpus") or truth_payload.get("corpus") or {})
+    coverage = dict(scorecard_payload.get("coverage") or truth_payload.get("coverage") or {})
+    truth_metrics = dict(
+        scorecard_payload.get("truth_metrics") or truth_payload.get("primary_metrics") or {}
+    )
+    proxy_metrics = dict(scorecard_payload.get("proxy_metrics") or {})
+    previous_artifact = dict(scorecard_payload.get("previous_artifact") or {})
+    deltas = dict(scorecard_payload.get("deltas") or {})
+    failure_distribution = dict(scorecard_payload.get("failure_class_distribution") or {})
+    rescue_counts = dict(scorecard_payload.get("rescue_counts_by_type") or {})
+    generated_at = (
+        str(scorecard_payload.get("generated_at") or "").strip()
+        or str(truth_payload.get("generated_at") or "").strip()
+        or "unknown"
+    )
+
+    lines = [
+        "# B0 Benchmark Truth Status",
+        "",
+        f"Last updated: {generated_at}",
+        "",
+        "This is the repo-tracked recurring `TW-02` publication surface for the fixed benchmark corpus.",
+        "",
+        "## Corpus",
+        "",
+        f"- Corpus manifest: `{_repo_stable_path(corpus_path)}`",
+        f"- Corpus id: `{_format_value(corpus.get('corpus_id'))}`",
+        f"- Revision: `{_format_value(corpus.get('revision'))}`",
+        f"- Recorded on: `{_format_value(corpus.get('recorded_on'))}`",
+        f"- Success contract: `{_format_value(corpus.get('success_contract'))}`",
+        f"- Coverage status: `{_format_value(coverage.get('status'))}`",
+        (
+            f"- Coverage: `{_format_value(coverage.get('attempted_issue_count'))}`/"
+            f"`{_format_value(corpus.get('issue_count'))}` issues attempted"
+        ),
+    ]
+    missing_issue_numbers = list(coverage.get("missing_issue_numbers") or [])
+    if missing_issue_numbers:
+        lines.append(
+            "- Missing corpus issues: " + ", ".join(f"`{item}`" for item in missing_issue_numbers)
+        )
+    lines.extend(
+        [
+            "",
+            "## Published Paths",
+            "",
+            f"- Latest truth artifact: `{_repo_stable_path(truth_path)}`",
+            f"- Latest scorecard: `{_repo_stable_path(scorecard_path)}`",
+            f"- Revision-scoped truth pointer: `{_repo_stable_path(latest_paths['truth_revision_latest'])}`",
+            f"- Revision-scoped scorecard pointer: `{_repo_stable_path(latest_paths['scorecard_revision_latest'])}`",
+            "",
+            "## Truth Metrics",
+            "",
+            "| Metric | Value |",
+            "| --- | --- |",
+            f"| Truth success rate | {_format_percent(truth_metrics.get('truth_success_rate'))} |",
+            f"| No-rescue truth success rate | {_format_percent(truth_metrics.get('no_rescue_truth_success_rate'))} |",
+            f"| Merged-only rate | {_format_percent(truth_metrics.get('merged_only_rate'))} |",
+            "",
+            "## Proxy Metrics",
+            "",
+            "| Metric | Value |",
+            "| --- | --- |",
+            f"| No-rescue success rate | {_format_percent(proxy_metrics.get('no_rescue_success_rate'))} |",
+            f"| Unique issues attempted | {_format_value(proxy_metrics.get('unique_issues_attempted'))} |",
+            f"| Unique issues succeeded | {_format_value(proxy_metrics.get('unique_issues_succeeded'))} |",
+            f"| Unique issues failed | {_format_value(proxy_metrics.get('unique_issues_failed'))} |",
+            f"| Total ticks | {_format_value(proxy_metrics.get('total_ticks'))} |",
+            "",
+            "## Failure Class Distribution",
+            "",
+            *_render_mapping(failure_distribution),
+            "",
+            "## Rescue Counts By Type",
+            "",
+            *_render_mapping(rescue_counts),
+        ]
+    )
+    if previous_artifact:
+        lines.extend(
+            [
+                "",
+                "## Previous Published Artifact",
+                "",
+                f"- Previous artifact path: `{_format_value(previous_artifact.get('path'))}`",
+                f"- Previous generated_at: `{_format_value(previous_artifact.get('generated_at'))}`",
+            ]
+        )
+    if deltas:
+        lines.extend(
+            [
+                "",
+                "## Deltas",
+                "",
+                *_render_mapping(deltas),
+            ]
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_output(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=DEFAULT_CORPUS_PATH,
+        help=f"Benchmark corpus manifest (default: {DEFAULT_CORPUS_PATH})",
+    )
+    parser.add_argument(
+        "--truth-root",
+        type=Path,
+        default=DEFAULT_TRUTH_ROOT,
+        help=f"Tracked truth-artifact root (default: {DEFAULT_TRUTH_ROOT})",
+    )
+    parser.add_argument(
+        "--scorecard-root",
+        type=Path,
+        default=DEFAULT_SCORECARD_ROOT,
+        help=f"Tracked scorecard root (default: {DEFAULT_SCORECARD_ROOT})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Markdown status output path (default: {DEFAULT_OUTPUT})",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    corpus_path = args.corpus.resolve()
+    truth_root = args.truth_root.resolve()
+    scorecard_root = args.scorecard_root.resolve()
+    output_path = args.output.resolve()
+    if not corpus_path.exists():
+        raise SystemExit(f"corpus file not found: {corpus_path}")
+
+    latest_paths = resolve_latest_paths(
+        corpus_path=corpus_path,
+        truth_root=truth_root,
+        scorecard_root=scorecard_root,
+    )
+    truth_path = latest_paths["truth_corpus_latest"]
+    scorecard_path = latest_paths["scorecard_corpus_latest"]
+    if not truth_path.exists():
+        raise SystemExit(f"truth artifact not found: {truth_path}")
+    if not scorecard_path.exists():
+        raise SystemExit(f"scorecard not found: {scorecard_path}")
+
+    content = render_status_markdown(
+        corpus_path=corpus_path,
+        truth_path=truth_path,
+        scorecard_path=scorecard_path,
+        truth_payload=_load_json(truth_path),
+        scorecard_payload=_load_json(scorecard_path),
+        latest_paths=latest_paths,
+    )
+    written = write_output(output_path, content)
+    print(str(written))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_branch_mutation_policy.py
+++ b/tests/scripts/test_check_branch_mutation_policy.py
@@ -39,6 +39,21 @@ def test_find_mutating_workflow_violations_requires_testfixer_prefix() -> None:
     assert "testfixer/*" in violations[0].message
 
 
+def test_find_mutating_workflow_violations_requires_safe_benchmark_truth_publication() -> None:
+    workflows = {
+        "benchmark-truth-publication.yml": (
+            "on:\n  pull_request:\n  workflow_dispatch:\n"
+            "jobs:\n  x:\n    steps:\n      - run: git push origin HEAD:feature\n"
+        ),
+    }
+    violations = find_mutating_workflow_violations(workflows)
+    assert violations
+    assert any(
+        "must not be triggered by pull_request/pull_request_target" in v.message for v in violations
+    )
+    assert any("must push only to main via HEAD:main" in v.message for v in violations)
+
+
 def test_repo_branch_mutation_policy_passes_for_current_tree() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     violations = check_repo(repo_root)

--- a/tests/scripts/test_render_benchmark_truth_status.py
+++ b/tests/scripts/test_render_benchmark_truth_status.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import render_benchmark_truth_status as mod  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_render_status_markdown_includes_metrics_and_paths(tmp_path: Path) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 1,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    latest_paths = mod.resolve_latest_paths(
+        corpus_path=corpus_path,
+        truth_root=tmp_path / "truth",
+        scorecard_root=tmp_path / "scorecards",
+    )
+    markdown = mod.render_status_markdown(
+        corpus_path=corpus_path,
+        truth_path=latest_paths["truth_corpus_latest"],
+        scorecard_path=latest_paths["scorecard_corpus_latest"],
+        latest_paths=latest_paths,
+        truth_payload={
+            "generated_at": "2026-04-14T19:00:00Z",
+            "corpus": {
+                "corpus_id": "tw-01-bounded-execution-v1",
+                "revision": 1,
+                "recorded_on": "2026-04-14",
+                "success_contract": "mergeable_pr_or_merged_pr",
+                "issue_count": 1,
+            },
+        },
+        scorecard_payload={
+            "generated_at": "2026-04-14T19:05:00Z",
+            "corpus": {
+                "corpus_id": "tw-01-bounded-execution-v1",
+                "revision": 1,
+                "recorded_on": "2026-04-14",
+                "success_contract": "mergeable_pr_or_merged_pr",
+                "issue_count": 1,
+            },
+            "coverage": {
+                "status": "complete",
+                "attempted_issue_count": 1,
+                "missing_issue_numbers": [],
+            },
+            "truth_metrics": {
+                "truth_success_rate": 1.0,
+                "no_rescue_truth_success_rate": 1.0,
+                "merged_only_rate": 0.0,
+            },
+            "proxy_metrics": {
+                "no_rescue_success_rate": 1.0,
+                "unique_issues_attempted": 1,
+                "unique_issues_succeeded": 1,
+                "unique_issues_failed": 0,
+                "total_ticks": 1,
+            },
+            "failure_class_distribution": {},
+            "rescue_counts_by_type": {},
+            "previous_artifact": {
+                "path": "docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-1/scorecard-20260407T190500Z.json",
+                "generated_at": "2026-04-07T19:05:00Z",
+            },
+            "deltas": {
+                "truth_success_rate": 0.25,
+                "proxy_no_rescue_success_rate": 0.5,
+            },
+        },
+    )
+
+    assert "B0 Benchmark Truth Status" in markdown
+    assert f"`{latest_paths['truth_corpus_latest']}`" in markdown
+    assert f"`{latest_paths['scorecard_corpus_latest']}`" in markdown
+    assert "| Truth success rate | 100.0% |" in markdown
+    assert "## Proxy Metrics" in markdown
+    assert "## Deltas" in markdown
+    assert "`truth_success_rate`: 0.2500" in markdown
+
+
+def test_main_writes_markdown_from_latest_paths(tmp_path: Path, capsys) -> None:
+    corpus_path = _write_json(
+        tmp_path / "docs" / "benchmarks" / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 2,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    truth_root = tmp_path / "docs" / "status" / "generated" / "benchmark_truth_artifacts"
+    scorecard_root = tmp_path / "docs" / "status" / "generated" / "benchmark_scorecards"
+    _write_json(
+        truth_root / "tw-01-bounded-execution-v1" / "latest.json",
+        {
+            "generated_at": "2026-04-14T20:00:00Z",
+            "corpus": {
+                "corpus_id": "tw-01-bounded-execution-v1",
+                "revision": 2,
+                "recorded_on": "2026-04-14",
+                "success_contract": "mergeable_pr_or_merged_pr",
+                "issue_count": 1,
+            },
+        },
+    )
+    _write_json(
+        scorecard_root / "tw-01-bounded-execution-v1" / "latest.json",
+        {
+            "generated_at": "2026-04-14T20:05:00Z",
+            "corpus": {
+                "corpus_id": "tw-01-bounded-execution-v1",
+                "revision": 2,
+                "recorded_on": "2026-04-14",
+                "success_contract": "mergeable_pr_or_merged_pr",
+                "issue_count": 1,
+            },
+            "coverage": {
+                "status": "incomplete",
+                "attempted_issue_count": 0,
+                "missing_issue_numbers": [1064],
+            },
+            "truth_metrics": {
+                "truth_success_rate": 0.0,
+                "no_rescue_truth_success_rate": 0.0,
+                "merged_only_rate": 0.0,
+            },
+            "proxy_metrics": {
+                "no_rescue_success_rate": 0.0,
+                "unique_issues_attempted": 0,
+                "unique_issues_succeeded": 0,
+                "unique_issues_failed": 0,
+                "total_ticks": 0,
+            },
+            "failure_class_distribution": {"blocked_auth_failure": 1},
+            "rescue_counts_by_type": {},
+        },
+    )
+    output_path = tmp_path / "docs" / "status" / "B0_BENCHMARK_TRUTH_STATUS.md"
+
+    exit_code = mod.main(
+        [
+            "--corpus",
+            str(corpus_path),
+            "--truth-root",
+            str(truth_root),
+            "--scorecard-root",
+            str(scorecard_root),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == str(output_path)
+    content = output_path.read_text(encoding="utf-8")
+    assert "Coverage status: `incomplete`" in content
+    assert "Missing corpus issues: `1064`" in content
+    assert "`blocked_auth_failure`: 1" in content


### PR DESCRIPTION
## Summary
- add a weekly benchmark truth publication workflow that writes repo-tracked scorecard and truth artifacts on `main`
- render a stable markdown status surface at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and align the canonical status/docs-site queue around `TW-02` being complete
- seed the first tracked benchmark truth + scorecard outputs under `docs/status/generated/...`

## Validation
- python3 -m ruff check scripts/render_benchmark_truth_status.py tests/scripts/test_render_benchmark_truth_status.py
- python3 -m pytest tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_measure_b0_scorecard.py tests/scripts/test_render_benchmark_truth_status.py -q
- python3 -m pytest tests/scripts/test_render_benchmark_truth_status.py tests/scripts/test_docs_site_sync_links.py -q
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5540
