### PR TITLE
feat(benchmarks): persist rescue productization issue links

### DIFF
--- a/scripts/rescue_to_fixtures.py
+++ b/scripts/rescue_to_fixtures.py
@@ -48,6 +48,49 @@ def _slugify_fragment(value: str) -> str:
     return slug.strip("-") or "repeated-rescue-class"
 
 
+def _normalize_issue_target(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if candidate.startswith("#"):
+        return candidate
+    match = re.search(r"/issues/(\d+)(?:[/?#].*)?$", candidate)
+    if match:
+        return f"#{match.group(1)}"
+    return candidate
+
+
+def upsert_productization_entry(
+    path: Path,
+    *,
+    class_name: str,
+    target_kind: str,
+    target: str,
+    title: str,
+    notes: str = "",
+) -> Path:
+    existing_entries = load_productization_map(path)
+    existing_entries[class_name] = {
+        "target_kind": target_kind.strip(),
+        "target": target.strip(),
+        "title": title.strip(),
+        "notes": notes.strip(),
+    }
+    payload = {
+        "schema_version": 1,
+        "entries": [
+            {
+                "class": rescue_class,
+                **entry,
+            }
+            for rescue_class, entry in sorted(existing_entries.items())
+        ],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
 def build_issue_drafts(report: dict[str, Any]) -> list[dict[str, Any]]:
     repeated_rows = list(report.get("repeated_classes") or [])
     drafts: list[dict[str, Any]] = []
@@ -150,6 +193,7 @@ def create_substrate_issues(
     *,
     repo: str = "synaptent/aragora",
     dry_run: bool = False,
+    productization_map_path: Path = DEFAULT_PRODUCTIZATION_MAP_PATH,
 ) -> list[str]:
     created: list[str] = []
     for draft in issue_drafts:
@@ -178,7 +222,20 @@ def create_substrate_issues(
                 check=False,
             )
             if result.returncode == 0:
-                created.append(result.stdout.strip())
+                issue_url = result.stdout.strip()
+                issue_target = _normalize_issue_target(issue_url)
+                notes = "Auto-linked by scripts/rescue_to_fixtures.py after bounded substrate issue creation."
+                upsert_productization_entry(
+                    productization_map_path,
+                    class_name=str(draft.get("class") or "").strip(),
+                    target_kind="issue",
+                    target=issue_target or issue_url,
+                    title=str(draft.get("title") or "").strip(),
+                    notes=notes,
+                )
+                created.append(
+                    f"{issue_url} [recorded in {productization_map_path.as_posix()} as {issue_target or issue_url}]"
+                )
             else:
                 created.append(f"FAILED: {result.stderr.strip()[:100]}")
         except (subprocess.TimeoutExpired, OSError) as exc:
@@ -239,6 +296,7 @@ def main(argv: list[str] | None = None) -> int:
             issue_drafts,
             repo=str(args.repo),
             dry_run=bool(args.dry_run),
+            productization_map_path=args.productization_map,
         )
         for item in results:
             print(f"  {item}")

--- a/tests/scripts/test_rescue_to_fixtures.py
+++ b/tests/scripts/test_rescue_to_fixtures.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from subprocess import CompletedProcess
 from pathlib import Path
 
 from aragora.swarm.rescue_events import RescueEvent, RescueEventLedger
@@ -173,3 +174,59 @@ def test_create_substrate_issues_dry_run_uses_issue_drafts_only(tmp_path: Path) 
 
     assert len(results) == 1
     assert results[0].startswith("DRY-RUN: would create '[TW-03] Productize repeated rescue class:")
+
+
+def test_create_substrate_issues_records_issue_link_in_productization_map(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    ledger = _ledger_with_events(
+        tmp_path,
+        [
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5512,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5515,
+            ),
+        ],
+    )
+    productization_map_path = tmp_path / "rescue_productization.json"
+    report = mod.load_rescue_productization_report(
+        ledger_path=ledger.path,
+        threshold=2,
+        productization_map_path=productization_map_path,
+    )
+    drafts = mod.build_issue_drafts(report)
+
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *args, **kwargs: CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="https://github.com/synaptent/aragora/issues/6001\n",
+            stderr="",
+        ),
+    )
+
+    results = mod.create_substrate_issues(
+        drafts,
+        repo="synaptent/aragora",
+        dry_run=False,
+        productization_map_path=productization_map_path,
+    )
+    refreshed = mod.load_rescue_productization_report(
+        ledger_path=ledger.path,
+        threshold=2,
+        productization_map_path=productization_map_path,
+    )
+
+    assert len(results) == 1
+    assert "#6001" in results[0]
+    assert refreshed["repeated_classes"][0]["productization_status"] == "linked_issue"
+    assert refreshed["repeated_classes"][0]["productization_target"] == "#6001"


### PR DESCRIPTION
## Summary
- persist created rescue-productization issue links back into `docs/benchmarks/rescue_productization.json`
- normalize created GitHub issue references to stable `#<number>` targets for the harvest loop
- add focused regression coverage proving the next harvest pass shows a created issue as `linked_issue`

## Validation
- python3 scripts/rescue_to_fixtures.py --help
- python3 -m pytest tests/scripts/test_rescue_to_fixtures.py tests/scripts/test_harvest_rescue_classes.py -q
- python3 -m ruff check scripts/rescue_to_fixtures.py tests/scripts/test_rescue_to_fixtures.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5330
