### PR TITLE
feat(benchmarks): publish recurring rescue productization

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -47,7 +47,7 @@ jobs:
           command -v gh >/dev/null
           test -f .aragora/overnight/boss_metrics.jsonl
 
-      - name: Publish tracked benchmark truth surfaces
+      - name: Publish tracked trust-loop surfaces
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -60,25 +60,40 @@ jobs:
           python3 scripts/render_benchmark_truth_status.py \
             --output docs/status/B0_BENCHMARK_TRUTH_STATUS.md
 
+          python3 scripts/publish_rescue_productization_report.py \
+            --publish-dir docs/status/generated/rescue_productization \
+            --productization-map docs/benchmarks/rescue_productization.json \
+            --ensure-issues \
+            --repo synaptent/aragora
+
+          python3 scripts/render_rescue_productization_status.py \
+            --report-root docs/status/generated/rescue_productization \
+            --output docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md
+
       - name: Publish workflow summary
         run: |
           cat docs/status/B0_BENCHMARK_TRUTH_STATUS.md >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Commit and push refreshed truth surfaces
+      - name: Commit and push refreshed trust-loop surfaces
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add \
+            docs/benchmarks/rescue_productization.json \
             docs/status/B0_BENCHMARK_TRUTH_STATUS.md \
+            docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md \
             docs/status/generated/benchmark_scorecards \
-            docs/status/generated/benchmark_truth_artifacts
+            docs/status/generated/benchmark_truth_artifacts \
+            docs/status/generated/rescue_productization
 
           if git diff --cached --quiet; then
-            echo "No benchmark truth surface changes to commit."
+            echo "No recurring trust-loop surface changes to commit."
             exit 0
           fi
 
-          git commit -m "docs(status): refresh benchmark truth surfaces [skip ci]"
+          git commit -m "docs(status): refresh recurring trust-loop surfaces [skip ci]"
           git push origin HEAD:main

--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -41,17 +41,17 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
-Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is routine truth publication and rescue productization, not reopening already-landed guard work.
+Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is keeping the recurring truth/productization surfaces boring and keeping claims narrower than proof, not reopening already-landed guard work.
 
 ## Current 30-Day Execution Set
 
 Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
-- Do now: `TW-03`, `CS-01..03`
+- Do now: `CS-01..03`
 - Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Live boss-ready queue: `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)); `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, `TW-02` now publishes through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, and [#5516](https://github.com/synaptent/aragora/issues/5516) landed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535)
+- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
 - `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate
@@ -118,7 +118,7 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 - [x] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Done 2026-04-14 via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583))_
 - [x] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Done 2026-04-14: recurring publication now writes repo-tracked outputs under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`, with the stable status summary at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`.)_
-- [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements _(Partial as of 2026-04-14: rescue-class productization reporting landed via [#5535](https://github.com/synaptent/aragora/pull/5535); the remaining gap is turning repeated classes into durable fixture-or-issue closure on the live loop, tracked by [#5330](https://github.com/synaptent/aragora/issues/5330).)_
+- [x] **TW-03** Convert human rescues into benchmark fixtures and product requirements _(Done 2026-04-14: recurring publication now writes repo-tracked outputs under `docs/status/generated/rescue_productization/`, the stable status summary lives at `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring harvest can relink or auto-create bounded follow-on issues through `docs/benchmarks/rescue_productization.json`.)_
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`
 

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -15,7 +15,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to keep `TW-01/TW-02` recurring and boring on current `main`, finish `TW-03` rescue productization, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to keep `TW-01/TW-02/TW-03` recurring and boring on current `main`, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -38,13 +38,15 @@ What is already true:
 - recurring benchmark scorecards are now bound to the frozen corpus revision on `main` via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583)
 - repo-tracked recurring truth publication now lands in `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`, with the stable status summary at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`
 - repeated rescue-class reports now include fixture-or-issue productization status on `main` via [#5535](https://github.com/synaptent/aragora/pull/5535)
+- repo-tracked recurring rescue productization now lands in `docs/status/generated/rescue_productization/`, with the stable status summary at `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`
+- the recurring `TW-03` harvest can now relink repeated rescue classes to tracked fixture/issue targets and auto-create bounded follow-on issues when a repeated class is still unlinked
 
 What is still missing:
 
-- repeated rescue classes still need the broader live-loop conversion from repeated patterns into benchmark fixtures or bounded issues beyond the landed productization report ([#5330](https://github.com/synaptent/aragora/issues/5330))
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
 - broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
+- ongoing discipline so external claims stay narrower than the recurring proof surfaces
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”
 
@@ -62,7 +64,7 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
-Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are.
+Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are now repo-tracked status surfaces.
 
 Primary truth metric:
 
@@ -118,14 +120,12 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
-| 1 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | [#5330](https://github.com/synaptent/aragora/issues/5330) |
-| 2 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+| 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
 
 ## Do Now / Delay / Avoid
 
 ### Do now
 
-- `TW-03`
 - `CS-01..03`
 
 ### Delay
@@ -147,10 +147,11 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ## Live Boss-Ready Queue
 
-- `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) because repeated rescues only create leverage when the live loop turns them into fixtures or bounded issues.
-- There is no second dedicated boss-ready issue in this tranche right now; keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
+- There is no dedicated open boss-ready trust-loop issue right now.
+- Keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
+- Let the recurring `TW-01/TW-02/TW-03` publication surfaces restock the queue only when they expose a fresh repeated rescue class or a concrete regression.
 
-The live queue for this tranche should now be driven by `TW-03`. `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, `TW-02` is now published through the repo-tracked recurring truth surface at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, and [#5516](https://github.com/synaptent/aragora/issues/5516) completed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535). `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
+`TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)), `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)), and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) now publish through repo-tracked recurring status surfaces at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`. `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
 
 ## Reverse-Staged Rocket Bootstrap
 

--- a/docs/benchmarks/rescue_productization.json
+++ b/docs/benchmarks/rescue_productization.json
@@ -1,4 +1,12 @@
 {
   "schema_version": 1,
-  "entries": []
+  "entries": [
+    {
+      "class": "session_restart:runner freshness gate blocked launch",
+      "notes": "Receipt-backed dispatch admission landed on main via #5514 and closed RS-07/#5327.",
+      "target": "#5327",
+      "target_kind": "issue",
+      "title": "RS-07 Add a receipt-backed contract preflight path for safe admission"
+    }
+  ]
 }

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -36,17 +36,17 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
-Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is routine truth publication and rescue productization, not reopening already-landed guard work.
+Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is keeping the recurring truth/productization surfaces boring and keeping claims narrower than proof, not reopening already-landed guard work.
 
 ## Current 30-Day Execution Set
 
 Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
-- Do now: `TW-02`, `TW-03`, `CS-01..03`
+- Do now: `CS-01..03`
 - Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Live boss-ready queue: intentionally empty while active trust-loop PRs own the current bounded scopes. `TW-02` is in flight on [#5601](https://github.com/synaptent/aragora/pull/5601), `TW-03` is in flight on [#5602](https://github.com/synaptent/aragora/pull/5602), `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, and [#5516](https://github.com/synaptent/aragora/issues/5516) landed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535)
+- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
 - `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate
@@ -113,7 +113,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 - [x] **TW-01** Prove `prompt -> spec -> code -> verify -> PR` loops on a fixed benchmark corpus of bounded repos/issues _(Done 2026-04-14 via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583))_
 - [x] **TW-02** Measure rescue rate, verification pass rate, wall-clock throughput, and no-rescue completion rate _(Done 2026-04-14: recurring publication now writes repo-tracked outputs under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`, with the stable status summary at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`.)_
-- [ ] **TW-03** Convert human rescues into benchmark fixtures and product requirements _(Partial as of 2026-04-14: rescue-class productization reporting landed via [#5535](https://github.com/synaptent/aragora/pull/5535); the remaining gap is turning repeated classes into durable fixture-or-issue closure on the live loop, tracked by [#5330](https://github.com/synaptent/aragora/issues/5330).)_
+- [x] **TW-03** Convert human rescues into benchmark fixtures and product requirements _(Done 2026-04-14: recurring publication now writes repo-tracked outputs under `docs/status/generated/rescue_productization/`, the stable status summary lives at `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring harvest can relink or auto-create bounded follow-on issues through `docs/benchmarks/rescue_productization.json`.)_
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`
 

--- a/docs/status/COMMERCIAL_OVERVIEW.md
+++ b/docs/status/COMMERCIAL_OVERVIEW.md
@@ -26,14 +26,14 @@ The claims below are the current proof base, not the long-term ambition.
 | Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
 | Truth artifacts | The repo has a diffable benchmark truth-artifact path, frozen-corpus binding on recurring scorecards, and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth instead of drifting with ad hoc samples. |
 | Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
-| Operator truth | Preflight receipts, blocker evidence, and session-state work are on `main`; the remaining gap is keeping recurring truth publication and rescue productization boring on the live loop. | This is the remaining gap between an impressive demo and a boring reliable product lane. |
+| Operator truth | Preflight receipts, blocker evidence, session-state work, recurring benchmark truth publication, and recurring rescue productization are on `main`. | This is the proof surface that turns an impressive demo into a boring reliable product lane. |
 
 ## Current Gate
 
 The current commercial gate is the same as the current execution gate in [NEXT_STEPS_CANONICAL.md](NEXT_STEPS_CANONICAL.md):
 
 - keep `TW-01` landed so recurring scorecards stay tied to the frozen corpus on current `main`
-- finish `TW-03` so repeated rescues become benchmark fixtures or bounded product work instead of invisible operator tax
+- keep `TW-03` recurring so repeated rescues keep becoming benchmark fixtures or bounded product work instead of invisible operator tax
 - keep all external claims narrower than the measured proof
 
 This means Aragora should currently be positioned as:
@@ -160,9 +160,12 @@ Use these documents as the canonical backing for commercial claims:
 - [NEXT_STEPS_CANONICAL.md](NEXT_STEPS_CANONICAL.md)
 - [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXECUTION_ISSUES.md)
 - [B0_BENCHMARK_TRUTH_STATUS.md](B0_BENCHMARK_TRUTH_STATUS.md)
+- [TW03_RESCUE_PRODUCTIZATION_STATUS.md](TW03_RESCUE_PRODUCTIZATION_STATUS.md)
 - [ARAGORA_EVOLUTION_ROADMAP.md](../plans/ARAGORA_EVOLUTION_ROADMAP.md)
 - [docs/benchmarks/corpus.json](../benchmarks/corpus.json)
+- [docs/benchmarks/rescue_productization.json](../benchmarks/rescue_productization.json)
 - `scripts/build_benchmark_truth_artifact.py`
+- `scripts/publish_rescue_productization_report.py`
 - `scripts/reconcile_b0_pr_truth.py`
 
 If a claim cannot be tied back to those sources or to current `main`, it should not be in first-tranche commercial positioning.

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -10,7 +10,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to keep `TW-01/TW-02` recurring and boring on current `main`, finish `TW-03` rescue productization, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to keep `TW-01/TW-02/TW-03` recurring and boring on current `main`, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -33,13 +33,15 @@ What is already true:
 - recurring benchmark scorecards are now bound to the frozen corpus revision on `main` via [#5582](https://github.com/synaptent/aragora/pull/5582) and [#5583](https://github.com/synaptent/aragora/pull/5583)
 - repo-tracked recurring truth publication now lands in `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`, with the stable status summary at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`
 - repeated rescue-class reports now include fixture-or-issue productization status on `main` via [#5535](https://github.com/synaptent/aragora/pull/5535)
+- repo-tracked recurring rescue productization now lands in `docs/status/generated/rescue_productization/`, with the stable status summary at `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`
+- the recurring `TW-03` harvest can now relink repeated rescue classes to tracked fixture/issue targets and auto-create bounded follow-on issues when a repeated class is still unlinked
 
 What is still missing:
 
-- repeated rescue classes still need the broader live-loop conversion from repeated patterns into benchmark fixtures or bounded issues beyond the landed productization report ([#5330](https://github.com/synaptent/aragora/issues/5330))
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
 - broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
+- ongoing discipline so external claims stay narrower than the recurring proof surfaces
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”
 
@@ -57,7 +59,7 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
-Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are.
+Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are now repo-tracked status surfaces.
 
 Primary truth metric:
 
@@ -113,16 +115,12 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
-| 1 | `TW-02` | The project still needs routine issue-level truth publication linked cleanly from status surfaces, not one-off benchmark artifacts. | Weekly truth reporting uses `mergeable_pr OR merged_pr`, distinguishes proxy from truth, and stays linked from status docs. | Fresh `origin/main` truth reports publish issue-level truth success and no-rescue truth success. | trust | [#5540](https://github.com/synaptent/aragora/issues/5540), [#5601](https://github.com/synaptent/aragora/pull/5601) |
-| 2 | `TW-03` | Human rescues only create leverage when they become fixtures or product work. | Every repeated rescue class becomes a benchmark fixture or bounded substrate issue within one weekly cycle. | Repeated rescue classes trend down, and every repeated class has a linked fixture or bounded issue. | trust | [#5330](https://github.com/synaptent/aragora/issues/5330), [#5602](https://github.com/synaptent/aragora/pull/5602) |
-| 3 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+| 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
 
 ## Do Now / Delay / Avoid
 
 ### Do now
 
-- `TW-02`
-- `TW-03`
 - `CS-01..03`
 
 ### Delay
@@ -144,11 +142,11 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ## Live Boss-Ready Queue
 
-- The live `boss-ready` queue should stay empty while active trust-loop PRs already own the current bounded scopes.
-- `TW-02` remains the top open trust item, but its current bounded implementation is already in flight on [#5601](https://github.com/synaptent/aragora/pull/5601).
-- `TW-03` remains the second open trust item, but its current bounded implementation is already in flight on [#5602](https://github.com/synaptent/aragora/pull/5602).
+- There is no dedicated open boss-ready trust-loop issue right now.
+- Keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
+- Let the recurring `TW-01/TW-02/TW-03` publication surfaces restock the queue only when they expose a fresh repeated rescue class or a concrete regression.
 
-The live merge lane for this tranche is now carried by those trust-loop PRs. `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)) completed on 2026-04-14, and [#5516](https://github.com/synaptent/aragora/issues/5516) completed under `TW-03` via [#5535](https://github.com/synaptent/aragora/pull/5535). `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
+`TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)), `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)), and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) now publish through repo-tracked recurring status surfaces at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`. `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
 
 ## Reverse-Staged Rocket Bootstrap
 

--- a/docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md
+++ b/docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md
@@ -1,0 +1,37 @@
+# TW-03 Rescue Productization Status
+
+Last updated: 2026-04-14T19:45:47Z
+
+This is the repo-tracked recurring `TW-03` publication surface for repeated rescue-class harvest and conversion.
+
+## Summary
+
+- Latest report: `docs/status/generated/rescue_productization/latest.json`
+- Rescue ledger path: `/Users/armand/.aragora/rescue_events.jsonl`
+- Productization map: `docs/benchmarks/rescue_productization.json`
+- Repeated rescue classes: `0`
+- Linked repeated classes: `0`
+- Unlinked repeated classes: `0`
+- One-off classes: `0`
+- Below-threshold classes: `0`
+- Issue drafts remaining: `0`
+
+## Repeated Rescue Classes
+
+- No repeated rescue classes found in the current ledger window.
+
+## Issue Linkage Actions
+
+- none
+
+## Remaining Issue Drafts
+
+- none
+
+## One-Off Rescue Classes
+
+- none
+
+## Below-Threshold Rescue Classes
+
+- none

--- a/docs/status/generated/rescue_productization/latest.json
+++ b/docs/status/generated/rescue_productization/latest.json
@@ -1,0 +1,24 @@
+{
+  "below_threshold_classes": [],
+  "generated_at": "2026-04-14T19:45:47Z",
+  "initial_issue_drafts": [],
+  "issue_drafts": [],
+  "issue_linkage_results": [],
+  "ledger_path": "/Users/armand/.aragora/rescue_events.jsonl",
+  "one_off_classes": [],
+  "productization_map_path": "docs/benchmarks/rescue_productization.json",
+  "repeated_classes": [],
+  "repo": "synaptent/aragora",
+  "summary": {
+    "below_threshold_class_count": 0,
+    "linked_fixture_count": 0,
+    "linked_issue_count": 0,
+    "linked_other_count": 0,
+    "one_off_class_count": 0,
+    "recent_limit": 500,
+    "repeated_class_count": 0,
+    "threshold": 2,
+    "total_unique_classes": 0,
+    "unlinked_repeated_class_count": 0
+  }
+}

--- a/docs/status/generated/rescue_productization/rescue-productization-20260414T194547Z.json
+++ b/docs/status/generated/rescue_productization/rescue-productization-20260414T194547Z.json
@@ -1,0 +1,24 @@
+{
+  "below_threshold_classes": [],
+  "generated_at": "2026-04-14T19:45:47Z",
+  "initial_issue_drafts": [],
+  "issue_drafts": [],
+  "issue_linkage_results": [],
+  "ledger_path": "/Users/armand/.aragora/rescue_events.jsonl",
+  "one_off_classes": [],
+  "productization_map_path": "docs/benchmarks/rescue_productization.json",
+  "repeated_classes": [],
+  "repo": "synaptent/aragora",
+  "summary": {
+    "below_threshold_class_count": 0,
+    "linked_fixture_count": 0,
+    "linked_issue_count": 0,
+    "linked_other_count": 0,
+    "one_off_class_count": 0,
+    "recent_limit": 500,
+    "repeated_class_count": 0,
+    "threshold": 2,
+    "total_unique_classes": 0,
+    "unlinked_repeated_class_count": 0
+  }
+}

--- a/scripts/publish_rescue_productization_report.py
+++ b/scripts/publish_rescue_productization_report.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Publish recurring TW-03 rescue productization artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.harvest_rescue_classes import DEFAULT_PRODUCTIZATION_MAP_PATH  # noqa: E402
+from scripts.rescue_to_fixtures import (  # noqa: E402
+    build_issue_drafts,
+    build_issue_title,
+    load_rescue_productization_report,
+)
+
+DEFAULT_RESCUE_LEDGER_PATH = Path.home() / ".aragora" / "rescue_events.jsonl"
+DEFAULT_PUBLISH_DIR = REPO_ROOT / ".aragora" / "rescue_productization"
+
+
+def _coerce_utc_datetime(value: str | None = None) -> dt.datetime:
+    if value:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    else:
+        parsed = dt.datetime.now(dt.UTC)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC).replace(microsecond=0)
+
+
+def normalize_generated_at(value: str | None = None) -> str:
+    return _coerce_utc_datetime(value).isoformat().replace("+00:00", "Z")
+
+
+def _repo_stable_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def resolve_published_report_path(
+    *,
+    publish_dir: Path,
+    generated_at: str,
+) -> Path:
+    timestamp = _coerce_utc_datetime(generated_at).strftime("%Y%m%dT%H%M%SZ")
+    return publish_dir / f"rescue-productization-{timestamp}.json"
+
+
+def resolve_latest_report_path(*, publish_dir: Path) -> Path:
+    return publish_dir / "latest.json"
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def load_productization_map_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"schema_version": 1, "entries": []}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Productization map at {path} must be a JSON object")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError(f"Productization map at {path} must contain an 'entries' list")
+    return {
+        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "entries": entries,
+    }
+
+
+def write_productization_map_payload(path: Path, payload: dict[str, Any]) -> Path:
+    entries = [
+        entry
+        for entry in list(payload.get("entries") or [])
+        if isinstance(entry, dict) and str(entry.get("class") or "").strip()
+    ]
+    entries.sort(key=lambda entry: str(entry.get("class") or "").strip())
+    normalized = {
+        "schema_version": int(payload.get("schema_version", 1) or 1),
+        "entries": entries,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(normalized, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _issue_ref(number: int) -> str:
+    return f"#{number}"
+
+
+def find_existing_issue_by_title(*, repo: str, title: str) -> dict[str, Any] | None:
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--search",
+            title,
+            "--json",
+            "number,title,url,state",
+            "--limit",
+            "100",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh issue list failed")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        return None
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("title") or "").strip() != title:
+            continue
+        number = int(item.get("number", 0) or 0)
+        if number <= 0:
+            continue
+        return {
+            "number": number,
+            "title": str(item.get("title") or "").strip(),
+            "url": str(item.get("url") or "").strip(),
+            "state": str(item.get("state") or "").strip().lower(),
+        }
+    return None
+
+
+def create_issue_for_draft(*, repo: str, draft: dict[str, Any]) -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            str(draft.get("title") or "").strip(),
+            "--body",
+            str(draft.get("body") or "").strip(),
+            "--label",
+            "boss-ready",
+            "--label",
+            "autonomous",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh issue create failed")
+    url = str(result.stdout or "").strip().splitlines()[-1].strip()
+    match = re.search(r"/issues/(\d+)$", url)
+    if not match:
+        raise RuntimeError(f"could not parse issue URL from gh output: {url}")
+    return {
+        "number": int(match.group(1)),
+        "title": str(draft.get("title") or "").strip(),
+        "url": url,
+        "state": "open",
+    }
+
+
+def _upsert_issue_entry(
+    *,
+    entries_by_class: dict[str, dict[str, Any]],
+    class_name: str,
+    issue: dict[str, Any],
+) -> None:
+    existing = dict(entries_by_class.get(class_name, {}) or {})
+    notes = str(existing.get("notes") or "").strip()
+    entries_by_class[class_name] = {
+        "class": class_name,
+        "target_kind": "issue",
+        "target": _issue_ref(int(issue["number"])),
+        "title": str(issue.get("title") or "").strip(),
+        "notes": notes or "Auto-linked by recurring TW-03 harvest.",
+    }
+
+
+def ensure_issue_linkage(
+    *,
+    issue_drafts: list[dict[str, Any]],
+    productization_map_path: Path,
+    repo: str,
+    dry_run: bool = False,
+) -> list[dict[str, Any]]:
+    payload = load_productization_map_payload(productization_map_path)
+    entries_by_class = {
+        str(entry.get("class") or "").strip(): dict(entry)
+        for entry in list(payload.get("entries") or [])
+        if isinstance(entry, dict) and str(entry.get("class") or "").strip()
+    }
+    results: list[dict[str, Any]] = []
+    changed = False
+
+    for draft in issue_drafts:
+        class_name = str(draft.get("class") or "").strip()
+        title = str(draft.get("title") or "").strip() or build_issue_title(class_name)
+        if not class_name or not title:
+            continue
+        try:
+            existing = find_existing_issue_by_title(repo=repo, title=title)
+            if existing:
+                _upsert_issue_entry(
+                    entries_by_class=entries_by_class, class_name=class_name, issue=existing
+                )
+                results.append(
+                    {
+                        "class": class_name,
+                        "action": "linked_existing_issue",
+                        "target_kind": "issue",
+                        "target": _issue_ref(existing["number"]),
+                        "url": existing["url"],
+                    }
+                )
+                changed = True
+                continue
+            if dry_run:
+                results.append(
+                    {
+                        "class": class_name,
+                        "action": "dry_run_issue_create",
+                        "target_kind": "issue",
+                        "target": title,
+                    }
+                )
+                continue
+            created = create_issue_for_draft(repo=repo, draft=draft)
+            _upsert_issue_entry(
+                entries_by_class=entries_by_class, class_name=class_name, issue=created
+            )
+            results.append(
+                {
+                    "class": class_name,
+                    "action": "created_issue",
+                    "target_kind": "issue",
+                    "target": _issue_ref(created["number"]),
+                    "url": created["url"],
+                }
+            )
+            changed = True
+        except (RuntimeError, subprocess.TimeoutExpired, OSError, json.JSONDecodeError) as exc:
+            results.append(
+                {
+                    "class": class_name,
+                    "action": "error",
+                    "error": str(exc),
+                }
+            )
+
+    if changed and not dry_run:
+        write_productization_map_payload(
+            productization_map_path,
+            {
+                "schema_version": int(payload.get("schema_version", 1) or 1),
+                "entries": list(entries_by_class.values()),
+            },
+        )
+    return results
+
+
+def build_published_report(
+    *,
+    ledger_path: Path,
+    productization_map_path: Path,
+    repo: str,
+    generated_at: str | None = None,
+    threshold: int = 2,
+    recent_limit: int = 500,
+    example_limit: int = 5,
+    one_off_limit: int = 20,
+    ensure_issues: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    normalized_generated_at = normalize_generated_at(generated_at)
+    initial_report = load_rescue_productization_report(
+        ledger_path=ledger_path,
+        threshold=threshold,
+        recent_limit=recent_limit,
+        example_limit=example_limit,
+        one_off_limit=one_off_limit,
+        productization_map_path=productization_map_path,
+    )
+    initial_issue_drafts = build_issue_drafts(initial_report)
+
+    issue_linkage_results: list[dict[str, Any]] = []
+    if ensure_issues and initial_issue_drafts:
+        issue_linkage_results = ensure_issue_linkage(
+            issue_drafts=initial_issue_drafts,
+            productization_map_path=productization_map_path,
+            repo=repo,
+            dry_run=dry_run,
+        )
+
+    final_report = load_rescue_productization_report(
+        ledger_path=ledger_path,
+        threshold=threshold,
+        recent_limit=recent_limit,
+        example_limit=example_limit,
+        one_off_limit=one_off_limit,
+        productization_map_path=productization_map_path,
+    )
+    final_issue_drafts = build_issue_drafts(final_report)
+    return {
+        "generated_at": normalized_generated_at,
+        "repo": repo,
+        "ledger_path": _repo_stable_path(ledger_path),
+        "productization_map_path": _repo_stable_path(productization_map_path),
+        "summary": final_report.get("summary") or {},
+        "repeated_classes": final_report.get("repeated_classes") or [],
+        "one_off_classes": final_report.get("one_off_classes") or [],
+        "below_threshold_classes": final_report.get("below_threshold_classes") or [],
+        "initial_issue_drafts": initial_issue_drafts,
+        "issue_linkage_results": issue_linkage_results,
+        "issue_drafts": final_issue_drafts,
+    }
+
+
+def publish_report_bundle(
+    *,
+    publish_dir: Path,
+    payload: dict[str, Any],
+) -> dict[str, Path]:
+    timestamped_path = write_json(
+        resolve_published_report_path(
+            publish_dir=publish_dir,
+            generated_at=str(payload.get("generated_at") or ""),
+        ),
+        payload,
+    )
+    return {
+        "timestamped": timestamped_path,
+        "latest": write_json(resolve_latest_report_path(publish_dir=publish_dir), payload),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=DEFAULT_RESCUE_LEDGER_PATH,
+        help=f"Path to the RescueEvent ledger (default: {DEFAULT_RESCUE_LEDGER_PATH})",
+    )
+    parser.add_argument(
+        "--productization-map",
+        type=Path,
+        default=DEFAULT_PRODUCTIZATION_MAP_PATH,
+        help=f"Tracked rescue-productization map (default: {DEFAULT_PRODUCTIZATION_MAP_PATH})",
+    )
+    parser.add_argument(
+        "--publish-dir",
+        type=Path,
+        default=DEFAULT_PUBLISH_DIR,
+        help=f"Directory for latest/timestamped report JSON (default: {DEFAULT_PUBLISH_DIR})",
+    )
+    parser.add_argument("--repo", default="synaptent/aragora")
+    parser.add_argument("--threshold", type=int, default=2)
+    parser.add_argument("--recent-limit", type=int, default=500)
+    parser.add_argument("--example-limit", type=int, default=5)
+    parser.add_argument("--one-off-limit", type=int, default=20)
+    parser.add_argument(
+        "--ensure-issues",
+        action="store_true",
+        help="Create or relink bounded follow-on issues for unlinked repeated rescue classes.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = build_published_report(
+        ledger_path=args.path,
+        productization_map_path=args.productization_map,
+        repo=str(args.repo),
+        threshold=max(1, args.threshold),
+        recent_limit=max(1, args.recent_limit),
+        example_limit=max(1, args.example_limit),
+        one_off_limit=max(0, args.one_off_limit),
+        ensure_issues=bool(args.ensure_issues),
+        dry_run=bool(args.dry_run),
+    )
+    published = publish_report_bundle(
+        publish_dir=args.publish_dir.resolve(),
+        payload=payload,
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(str(published["timestamped"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_rescue_productization_status.py
+++ b/scripts/render_rescue_productization_status.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Render a repo-tracked TW-03 rescue productization status summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REPORT_ROOT = REPO_ROOT / "docs" / "status" / "generated" / "rescue_productization"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "status" / "TW03_RESCUE_PRODUCTIZATION_STATUS.md"
+
+
+def _repo_stable_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON payload at {path} must be an object")
+    return payload
+
+
+def _format_value(value: Any) -> str:
+    if value is None or value == "":
+        return "n/a"
+    return str(value)
+
+
+def _issue_numbers_cell(value: Any) -> str:
+    if not isinstance(value, list) or not value:
+        return "-"
+    return ", ".join(f"#{int(item)}" for item in value if isinstance(item, int))
+
+
+def _render_repeated_classes(rows: list[dict[str, Any]]) -> list[str]:
+    if not rows:
+        return ["- No repeated rescue classes found in the current ledger window."]
+
+    lines = [
+        "| Rescue class | Count | Productization | Target | Example issues |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            "| "
+            f"`{str(row.get('class') or '').strip()}` | "
+            f"{int(row.get('count', 0) or 0)} | "
+            f"`{str(row.get('productization_status') or 'unlinked').strip() or 'unlinked'}` | "
+            f"`{str(row.get('productization_target') or '-').strip() or '-'}` | "
+            f"{_issue_numbers_cell(row.get('issue_numbers'))} |"
+        )
+    return lines
+
+
+def _render_linkage_actions(rows: list[dict[str, Any]]) -> list[str]:
+    if not rows:
+        return ["- none"]
+    lines: list[str] = []
+    for row in rows:
+        target = str(row.get("target") or "").strip()
+        url = str(row.get("url") or "").strip()
+        error = str(row.get("error") or "").strip()
+        action = str(row.get("action") or "").strip()
+        class_name = str(row.get("class") or "").strip()
+        if url:
+            lines.append(f"- `{action}` `{class_name}` -> `{target}` ([link]({url}))")
+        elif error:
+            lines.append(f"- `{action}` `{class_name}`: `{error}`")
+        else:
+            lines.append(f"- `{action}` `{class_name}` -> `{target or 'n/a'}`")
+    return lines
+
+
+def _render_issue_drafts(rows: list[dict[str, Any]]) -> list[str]:
+    if not rows:
+        return ["- none"]
+    return [
+        f"- `{str(row.get('class') or '').strip()}` -> `{str(row.get('title') or '').strip()}`"
+        for row in rows
+    ]
+
+
+def render_status_markdown(*, report_path: Path, payload: dict[str, Any]) -> str:
+    summary = dict(payload.get("summary") or {})
+    repeated_classes = list(payload.get("repeated_classes") or [])
+    one_off_classes = list(payload.get("one_off_classes") or [])
+    below_threshold_classes = list(payload.get("below_threshold_classes") or [])
+    issue_linkage_results = list(payload.get("issue_linkage_results") or [])
+    issue_drafts = list(payload.get("issue_drafts") or [])
+    generated_at = str(payload.get("generated_at") or "").strip() or "unknown"
+
+    lines = [
+        "# TW-03 Rescue Productization Status",
+        "",
+        f"Last updated: {generated_at}",
+        "",
+        "This is the repo-tracked recurring `TW-03` publication surface for repeated rescue-class harvest and conversion.",
+        "",
+        "## Summary",
+        "",
+        f"- Latest report: `{_repo_stable_path(report_path)}`",
+        f"- Rescue ledger path: `{_format_value(payload.get('ledger_path'))}`",
+        f"- Productization map: `{_format_value(payload.get('productization_map_path'))}`",
+        f"- Repeated rescue classes: `{_format_value(summary.get('repeated_class_count'))}`",
+        f"- Linked repeated classes: `{_format_value(summary.get('linked_fixture_count', 0) + summary.get('linked_issue_count', 0) + summary.get('linked_other_count', 0))}`",
+        f"- Unlinked repeated classes: `{_format_value(summary.get('unlinked_repeated_class_count'))}`",
+        f"- One-off classes: `{_format_value(summary.get('one_off_class_count'))}`",
+        f"- Below-threshold classes: `{_format_value(summary.get('below_threshold_class_count'))}`",
+        f"- Issue drafts remaining: `{len(issue_drafts)}`",
+        "",
+        "## Repeated Rescue Classes",
+        "",
+        *_render_repeated_classes(repeated_classes),
+        "",
+        "## Issue Linkage Actions",
+        "",
+        *_render_linkage_actions(issue_linkage_results),
+        "",
+        "## Remaining Issue Drafts",
+        "",
+        *_render_issue_drafts(issue_drafts),
+        "",
+        "## One-Off Rescue Classes",
+        "",
+    ]
+    if one_off_classes:
+        lines.extend(
+            f"- `{str(row.get('class') or '').strip()}` ({int(row.get('count', 0) or 0)}x)"
+            for row in one_off_classes
+        )
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Below-Threshold Rescue Classes", ""])
+    if below_threshold_classes:
+        lines.extend(
+            f"- `{str(row.get('class') or '').strip()}` ({int(row.get('count', 0) or 0)}x)"
+            for row in below_threshold_classes
+        )
+    else:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_output(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report-root",
+        type=Path,
+        default=DEFAULT_REPORT_ROOT,
+        help=f"Tracked rescue-productization report root (default: {DEFAULT_REPORT_ROOT})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Markdown status output path (default: {DEFAULT_OUTPUT})",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report_root = args.report_root.resolve()
+    output_path = args.output.resolve()
+    report_path = report_root / "latest.json"
+    if not report_path.exists():
+        raise SystemExit(f"rescue productization report not found: {report_path}")
+
+    content = render_status_markdown(report_path=report_path, payload=_load_json(report_path))
+    written = write_output(output_path, content)
+    print(str(written))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rescue_to_fixtures.py
+++ b/scripts/rescue_to_fixtures.py
@@ -48,6 +48,10 @@ def _slugify_fragment(value: str) -> str:
     return slug.strip("-") or "repeated-rescue-class"
 
 
+def build_issue_title(rescue_class: str) -> str:
+    return f"[TW-03] Productize repeated rescue class: {_slugify_fragment(rescue_class)}"
+
+
 def _normalize_issue_target(value: str) -> str:
     candidate = value.strip()
     if not candidate:
@@ -104,10 +108,7 @@ def build_issue_drafts(report: dict[str, Any]) -> list[dict[str, Any]]:
             for item in list(row.get("issue_numbers") or [])
             if isinstance(item, int) and item > 0
         ]
-        title = (
-            f"[TW-03] Productize repeated rescue class: "
-            f"{_slugify_fragment(rescue_class)} ({count}x)"
-        )
+        title = build_issue_title(rescue_class)
         examples_text = (
             "\n".join(f"- #{issue_number}" for issue_number in issue_numbers) or "- none"
         )

--- a/tests/scripts/test_publish_rescue_productization_report.py
+++ b/tests/scripts/test_publish_rescue_productization_report.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from aragora.swarm.rescue_events import RescueEvent, RescueEventLedger
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import publish_rescue_productization_report as mod  # noqa: E402
+
+
+def _ledger_with_events(tmp_path: Path, events: list[RescueEvent]) -> RescueEventLedger:
+    ledger = RescueEventLedger(path=tmp_path / "rescue_events.jsonl")
+    for event in events:
+        ledger.record(event)
+    return ledger
+
+
+def test_build_published_report_links_existing_issue_and_updates_map(
+    tmp_path: Path, monkeypatch
+) -> None:
+    ledger = _ledger_with_events(
+        tmp_path,
+        [
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5512,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5515,
+            ),
+        ],
+    )
+    productization_map_path = tmp_path / "rescue_productization.json"
+    mod.write_productization_map_payload(
+        productization_map_path,
+        {
+            "schema_version": 1,
+            "entries": [],
+        },
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "find_existing_issue_by_title",
+        lambda **_: {
+            "number": 6001,
+            "title": "[TW-03] Productize repeated rescue class: followup-prompt-needs-explicit-next-step-from-founder",
+            "url": "https://github.com/synaptent/aragora/issues/6001",
+            "state": "open",
+        },
+    )
+
+    payload = mod.build_published_report(
+        ledger_path=ledger.path,
+        productization_map_path=productization_map_path,
+        repo="synaptent/aragora",
+        generated_at="2026-04-14T18:35:00Z",
+        ensure_issues=True,
+    )
+
+    assert payload["summary"]["linked_issue_count"] == 1
+    assert payload["issue_drafts"] == []
+    assert payload["issue_linkage_results"] == [
+        {
+            "action": "linked_existing_issue",
+            "class": "followup_prompt:needs explicit next step from founder",
+            "target": "#6001",
+            "target_kind": "issue",
+            "url": "https://github.com/synaptent/aragora/issues/6001",
+        }
+    ]
+    written_map = json.loads(productization_map_path.read_text(encoding="utf-8"))
+    assert written_map["entries"] == [
+        {
+            "class": "followup_prompt:needs explicit next step from founder",
+            "notes": "Auto-linked by recurring TW-03 harvest.",
+            "target": "#6001",
+            "target_kind": "issue",
+            "title": "[TW-03] Productize repeated rescue class: followup-prompt-needs-explicit-next-step-from-founder",
+        }
+    ]
+
+
+def test_publish_report_bundle_writes_timestamped_and_latest(tmp_path: Path) -> None:
+    payload = {
+        "generated_at": "2026-04-14T18:36:07Z",
+        "summary": {"repeated_class_count": 0},
+    }
+
+    written = mod.publish_report_bundle(
+        publish_dir=tmp_path / "published",
+        payload=payload,
+    )
+
+    assert written["timestamped"] == (
+        tmp_path / "published" / "rescue-productization-20260414T183607Z.json"
+    )
+    assert written["latest"] == tmp_path / "published" / "latest.json"
+    assert json.loads(written["latest"].read_text(encoding="utf-8"))["generated_at"] == (
+        "2026-04-14T18:36:07Z"
+    )

--- a/tests/scripts/test_render_rescue_productization_status.py
+++ b/tests/scripts/test_render_rescue_productization_status.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import render_rescue_productization_status as mod  # noqa: E402
+
+
+def test_render_status_markdown_includes_repeated_classes_and_actions(tmp_path: Path) -> None:
+    report_path = tmp_path / "latest.json"
+    payload = {
+        "generated_at": "2026-04-14T18:40:00Z",
+        "ledger_path": "/Users/test/.aragora/rescue_events.jsonl",
+        "productization_map_path": "docs/benchmarks/rescue_productization.json",
+        "summary": {
+            "repeated_class_count": 2,
+            "linked_fixture_count": 0,
+            "linked_issue_count": 1,
+            "linked_other_count": 0,
+            "unlinked_repeated_class_count": 1,
+            "one_off_class_count": 1,
+            "below_threshold_class_count": 0,
+        },
+        "repeated_classes": [
+            {
+                "class": "followup_prompt:needs explicit next step from founder",
+                "count": 2,
+                "productization_status": "linked_issue",
+                "productization_target": "#6001",
+                "issue_numbers": [5512, 5515],
+            },
+            {
+                "class": "manual_merge:required review gate",
+                "count": 2,
+                "productization_status": "unlinked",
+                "productization_target": "",
+                "issue_numbers": [5617],
+            },
+        ],
+        "issue_linkage_results": [
+            {
+                "class": "followup_prompt:needs explicit next step from founder",
+                "action": "linked_existing_issue",
+                "target": "#6001",
+                "url": "https://github.com/synaptent/aragora/issues/6001",
+            }
+        ],
+        "issue_drafts": [
+            {
+                "class": "manual_merge:required review gate",
+                "title": "[TW-03] Productize repeated rescue class: manual-merge-required-review-gate",
+            }
+        ],
+        "one_off_classes": [
+            {"class": "issue_rewrite:scope contradicted itself", "count": 1},
+        ],
+        "below_threshold_classes": [],
+    }
+
+    markdown = mod.render_status_markdown(report_path=report_path, payload=payload)
+
+    assert "# TW-03 Rescue Productization Status" in markdown
+    assert "`followup_prompt:needs explicit next step from founder`" in markdown
+    assert "`manual_merge:required review gate`" in markdown
+    assert "[link](https://github.com/synaptent/aragora/issues/6001)" in markdown
+    assert "Issue drafts remaining: `1`" in markdown
+    assert "issue_rewrite:scope contradicted itself" in markdown
+
+
+def test_main_writes_output_from_latest_report(tmp_path: Path) -> None:
+    report_root = tmp_path / "generated" / "rescue_productization"
+    report_root.mkdir(parents=True)
+    latest_path = report_root / "latest.json"
+    latest_path.write_text(
+        """{
+  "generated_at": "2026-04-14T18:42:00Z",
+  "ledger_path": "/Users/test/.aragora/rescue_events.jsonl",
+  "productization_map_path": "docs/benchmarks/rescue_productization.json",
+  "summary": {
+    "repeated_class_count": 0,
+    "linked_fixture_count": 0,
+    "linked_issue_count": 0,
+    "linked_other_count": 0,
+    "unlinked_repeated_class_count": 0,
+    "one_off_class_count": 0,
+    "below_threshold_class_count": 0
+  },
+  "repeated_classes": [],
+  "issue_linkage_results": [],
+  "issue_drafts": [],
+  "one_off_classes": [],
+  "below_threshold_classes": []
+}
+""",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "TW03_RESCUE_PRODUCTIZATION_STATUS.md"
+
+    exit_code = mod.main(
+        [
+            "--report-root",
+            str(report_root),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    rendered = output_path.read_text(encoding="utf-8")
+    assert "No repeated rescue classes found in the current ledger window." in rendered
+    assert "Last updated: 2026-04-14T18:42:00Z" in rendered


### PR DESCRIPTION
## Summary
- add a recurring TW-03 rescue-productization publish path with stable JSON artifacts, a repo-tracked markdown status surface, and weekly workflow refresh on `main`
- allow the recurring harvest to relink or create bounded follow-on issues and sync the tracked `docs/benchmarks/rescue_productization.json` map
- reconcile the canonical status/docs-site surfaces so the live trust-loop queue empties after TW-03 and only restocks from recurring proof

## Validation
- python3 -m ruff check scripts/rescue_to_fixtures.py scripts/publish_rescue_productization_report.py scripts/render_rescue_productization_status.py tests/scripts/test_harvest_rescue_classes.py tests/scripts/test_rescue_to_fixtures.py tests/scripts/test_publish_rescue_productization_report.py tests/scripts/test_render_rescue_productization_status.py
- python3 -m pytest tests/scripts/test_harvest_rescue_classes.py tests/scripts/test_rescue_to_fixtures.py tests/scripts/test_publish_rescue_productization_report.py tests/scripts/test_render_rescue_productization_status.py tests/scripts/test_docs_site_sync_links.py -q
- python3 scripts/check_branch_mutation_policy.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5330
