### PR TITLE
fix(exceptions): replace silent swallowing in 9 modules + add 21 tests

### DIFF
--- a/aragora/connectors/crm/pipedrive.py
+++ b/aragora/connectors/crm/pipedrive.py
@@ -732,7 +732,10 @@ class PipedriveClient:
                             try:
                                 delay = float(retry_after)
                             except (ValueError, TypeError):
-                                pass
+                                logger.debug(
+                                    "Pipedrive: unparseable Retry-After header value: %r, using default delay",
+                                    retry_after,
+                                )
                         logger.warning(
                             "Pipedrive %s %s returned %d, retrying in %.1fs (attempt %d/%d)",
                             method,

--- a/aragora/connectors/ecommerce/shipstation.py
+++ b/aragora/connectors/ecommerce/shipstation.py
@@ -657,7 +657,7 @@ def _parse_datetime(value: str | None) -> datetime | None:
     try:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except (ValueError, AttributeError):
-        pass
+        logger.debug("shipstation: datetime not ISO format, trying fallback strptime: %r", value)
     try:
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
     except (ValueError, AttributeError):

--- a/aragora/pipeline/canvas_workflow_sync.py
+++ b/aragora/pipeline/canvas_workflow_sync.py
@@ -58,8 +58,8 @@ def sync_canvas_to_workflow(graph: Any) -> dict[str, Any]:
         from aragora.canvas.stages import PipelineStage
 
         pipeline_stage_orchestration = PipelineStage.ORCHESTRATION
-    except ImportError:
-        pass
+    except ImportError as exc:
+        logger.debug("aragora.canvas.stages unavailable, stage filtering degraded: %s", exc)
 
     # Get orchestration nodes
     orch_nodes: dict[str, Any] = {}

--- a/aragora/pipeline/dag_model.py
+++ b/aragora/pipeline/dag_model.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass, field
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from aragora.canvas.stages import PipelineStage, StageEdgeType
 
@@ -58,7 +61,7 @@ def _coerce_edge_type(value: StageEdgeType | str | None) -> StageEdgeType:
         try:
             return StageEdgeType(str(value))
         except ValueError:
-            pass
+            logger.debug("Unknown StageEdgeType %r, defaulting to RELATES_TO", value)
     return StageEdgeType.RELATES_TO
 
 

--- a/aragora/pipeline/dag_operations.py
+++ b/aragora/pipeline/dag_operations.py
@@ -645,7 +645,7 @@ class DAGOperationsCoordinator:
                 if task is None:
                     break
                 status_val = getattr(task, "status", None)
-                status_str = status_val.value if hasattr(status_val, "value") else str(status_val)
+                status_str = status_val.value if hasattr(status_val, "value") else str(status_val)  # type: ignore[union-attr]
                 if status_str in ("completed", "failed", "cancelled"):
                     node.metadata["execution_status"] = status_str
                     node.metadata["task_result"] = getattr(task, "result", None)

--- a/aragora/pipeline/dag_operations.py
+++ b/aragora/pipeline/dag_operations.py
@@ -87,8 +87,8 @@ class DAGOperationsCoordinator:
                 for agent_name in agents:
                     try:
                         debate_agents.append(create_agent(agent_name))  # type: ignore[arg-type]
-                    except (RuntimeError, ImportError, ValueError):
-                        pass
+                    except (RuntimeError, ImportError, ValueError) as exc:
+                        logger.debug("Skipping agent %r: %s", agent_name, exc)
 
             if not debate_agents:
                 return DAGOperationResult(
@@ -309,8 +309,8 @@ class DAGOperationsCoordinator:
                 for name in ("claude", "gpt", "gemini", "mistral", "grok"):
                     try:
                         available_agents.append(create_agent(name))  # type: ignore[arg-type]
-                    except (RuntimeError, ImportError, ValueError):
-                        pass
+                    except (RuntimeError, ImportError, ValueError) as exc:
+                        logger.debug("Skipping agent %r: %s", name, exc)
             except ImportError:
                 return DAGOperationResult(
                     success=False,

--- a/aragora/pipeline/decision_integrity.py
+++ b/aragora/pipeline/decision_integrity.py
@@ -321,8 +321,8 @@ def _build_cost_summary_for_receipt(
         summary = dct.get_debate_cost(debate_id)
         if summary and summary.total_calls > 0:
             return summary.to_dict()
-    except (ImportError, RuntimeError, ValueError, TypeError, AttributeError):
-        pass
+    except (ImportError, RuntimeError, ValueError, TypeError, AttributeError) as exc:
+        logger.debug("DebateCostTracker unavailable, falling back to DebateResult fields: %s", exc)
 
     # Fallback: build minimal summary from DebateResult fields
     if debate_result.total_cost_usd > 0 or debate_result.per_agent_cost:

--- a/aragora/pipeline/decision_integrity.py
+++ b/aragora/pipeline/decision_integrity.py
@@ -140,7 +140,7 @@ async def capture_context_snapshot(
     enforce_tenant = False
 
     try:
-        from aragora.memory.access import (
+        from aragora.memory.access import (  # type: ignore[no-redef]
             build_access_envelope,
             emit_denial_telemetry,
             filter_entries,

--- a/aragora/pipeline/idea_to_execution.py
+++ b/aragora/pipeline/idea_to_execution.py
@@ -667,7 +667,7 @@ class IdeaToExecutionPipeline:
             description = getattr(goal, "description", str(goal))
             rationale = getattr(goal, "rationale", "")
             track = getattr(goal, "track", None)
-            track_str = track.value if hasattr(track, "value") else str(track or "core")
+            track_str = track.value if hasattr(track, "value") else str(track or "core")  # type: ignore[union-attr]
 
             parts = [f"[{impact}]"]
             if track_str:

--- a/aragora/pipeline/idea_to_execution.py
+++ b/aragora/pipeline/idea_to_execution.py
@@ -1397,7 +1397,7 @@ class IdeaToExecutionPipeline:
 
             provenance_chain = ReasoningProvenanceChain()
         except ImportError:
-            pass
+            logger.debug("ReasoningProvenanceChain not available; skipping provenance tracking")
 
         # MetaLearner self-tuning: adjust debate rounds based on past performance
         if cfg.enable_meta_tuning:
@@ -1533,8 +1533,8 @@ class IdeaToExecutionPipeline:
                             try:
                                 introspection_data = tracker.get_all_summaries()
                                 cfg._introspection_data = introspection_data
-                            except (AttributeError, TypeError):
-                                pass
+                            except (AttributeError, TypeError) as exc:
+                                logger.debug("Introspection data unavailable: %s", exc)
                 elif sr.status == "failed":
                     result.stage_status[PipelineStage.IDEAS.value] = "failed"
 
@@ -1547,8 +1547,8 @@ class IdeaToExecutionPipeline:
                             source_type=SourceType.SYNTHESIS,
                             source_id=getattr(link, "id", "pipeline"),
                         )
-                except (AttributeError, TypeError, ValueError):
-                    pass
+                except (AttributeError, TypeError, ValueError) as exc:
+                    logger.debug("Provenance record failed (ideation): %s", exc)
 
             # Stage 1.5: Principles extraction (opt-in)
             if cfg.enable_principles and "principles" in cfg.stages_to_run:
@@ -1618,8 +1618,8 @@ class IdeaToExecutionPipeline:
                             source_type=SourceType.SYNTHESIS,
                             source_id=getattr(link, "id", "pipeline"),
                         )
-                except (AttributeError, TypeError, ValueError):
-                    pass
+                except (AttributeError, TypeError, ValueError) as exc:
+                    logger.debug("Provenance record failed (goals): %s", exc)
 
             # Stage 3: Workflow generation
             if "workflow" in cfg.stages_to_run:
@@ -1733,8 +1733,8 @@ class IdeaToExecutionPipeline:
                         if result.receipt is None:
                             result.receipt = {}
                         result.receipt["provenance_chain_valid"] = chain_valid
-                    except (AttributeError, TypeError, ValueError):
-                        pass
+                    except (AttributeError, TypeError, ValueError) as exc:
+                        logger.debug("Provenance chain verification failed: %s", exc)
 
             # Feed pipeline metrics back to MetaLearner
             if cfg.enable_meta_tuning:
@@ -2485,8 +2485,10 @@ class IdeaToExecutionPipeline:
                             await ws_mgr.fail_bead(
                                 task["id"], error=task_result.get("error", "failed")
                             )
-                    except (AttributeError, KeyError, TypeError, RuntimeError):
-                        pass
+                    except (AttributeError, KeyError, TypeError, RuntimeError) as exc:
+                        logger.debug(
+                            "Bead lifecycle update failed for task %r: %s", task.get("id"), exc
+                        )
 
                 self._emit(
                     cfg,
@@ -2524,8 +2526,8 @@ class IdeaToExecutionPipeline:
                     merge_result = {"completed": completed, "failed": total - completed}
                     await ws_mgr.complete_convoy(convoy_id, merge_result)
                     logger.info("convoy_completed convoy_id=%s tasks=%d", convoy_id, completed)
-                except (AttributeError, KeyError, TypeError, RuntimeError):
-                    pass
+                except (AttributeError, KeyError, TypeError, RuntimeError) as exc:
+                    logger.debug("Convoy lifecycle finalization failed: %s", exc)
 
             orch_result: dict[str, Any] = {
                 "status": "executed",
@@ -2691,8 +2693,8 @@ class IdeaToExecutionPipeline:
                 top_agents = [name for name, _ in ranked[:3]]
                 if top_agents:
                     instruction += f"\n\nPreferred agents: {', '.join(top_agents)}"
-            except (AttributeError, TypeError, ValueError):
-                pass
+            except (AttributeError, TypeError, ValueError) as exc:
+                logger.debug("Could not rank preferred agents from introspection data: %s", exc)
 
         # Backend 1: HardenedOrchestrator (worktree isolation + gauntlet)
         if cfg.use_hardened_orchestrator:

--- a/aragora/pipeline/km_bridge.py
+++ b/aragora/pipeline/km_bridge.py
@@ -228,8 +228,8 @@ class PipelineKMBridge:
                                     "confidence": meta.get("confidence", 0.0),
                                 }
                             )
-                except (AttributeError, TypeError, RuntimeError, ValueError):
-                    pass
+                except (AttributeError, TypeError, RuntimeError, ValueError) as exc:
+                    logger.debug("KM search for receipt precedents failed: %s", exc)
 
             return results[:limit]
         except (ImportError, RuntimeError, AttributeError) as exc:
@@ -281,8 +281,8 @@ class PipelineKMBridge:
                                     "lessons_learned": meta.get("lessons_learned", ""),
                                 }
                             )
-                except (AttributeError, TypeError, RuntimeError, ValueError):
-                    pass
+                except (AttributeError, TypeError, RuntimeError, ValueError) as exc:
+                    logger.debug("KM search for outcome precedents failed: %s", exc)
 
             # Supplement from adapter's local cache
             if len(results) < limit:
@@ -375,8 +375,8 @@ class PipelineKMBridge:
                                     "consensus_reached": meta.get("consensus_reached", False),
                                 }
                             )
-                except (AttributeError, TypeError, RuntimeError, ValueError):
-                    pass
+                except (AttributeError, TypeError, RuntimeError, ValueError) as exc:
+                    logger.debug("KM search for debate precedents failed: %s", exc)
 
             return results[:limit]
         except (ImportError, RuntimeError, AttributeError) as exc:
@@ -602,8 +602,10 @@ class PipelineKMBridge:
             if callable(store_method):
                 store_method(result_dict)
                 return True
-        except (ImportError, AttributeError, RuntimeError, TypeError, ValueError):
-            pass
+        except (ImportError, AttributeError, RuntimeError, TypeError, ValueError) as exc:
+            logger.debug(
+                "DecisionPlanAdapter store unavailable, falling back to direct KM: %s", exc
+            )
 
         # Fallback: store directly in KM as a knowledge item
         try:

--- a/aragora/pipeline/km_bridge.py
+++ b/aragora/pipeline/km_bridge.py
@@ -57,7 +57,7 @@ class PipelineKMBridge:
         results: dict[str, list[dict[str, Any]]] = {}
         for goal in goal_graph.goals:
             try:
-                matches = self._km.search(
+                matches = self._km.search(  # type: ignore[union-attr]
                     query=goal.title,
                     limit=3,
                     min_similarity=0.5,
@@ -88,7 +88,7 @@ class PipelineKMBridge:
         results: dict[str, list[dict[str, Any]]] = {}
         for node_id, node in actions_canvas.nodes.items():
             try:
-                matches = self._km.search(
+                matches = self._km.search(  # type: ignore[union-attr]
                     query=node.label,
                     limit=3,
                     min_similarity=0.5,
@@ -611,7 +611,7 @@ class PipelineKMBridge:
         try:
             objective = result_dict.get("objective", "pipeline result")
             cycle_id = result_dict.get("cycle_id", "unknown")
-            self._km.add(
+            self._km.add(  # type: ignore[union-attr]
                 content=(f"Pipeline cycle {cycle_id}: {objective}"),
                 metadata={
                     "item_type": "pipeline_result",

--- a/aragora/pipeline/receipt_gate.py
+++ b/aragora/pipeline/receipt_gate.py
@@ -399,8 +399,8 @@ def _build_receipt(plan: Any) -> DecisionReceipt:
         if trust_score is not None:
             try:
                 receipt.consensus_proof.trust_score = float(trust_score)
-            except (TypeError, ValueError):
-                pass
+            except (TypeError, ValueError) as exc:
+                logger.debug("Could not coerce trust_score %r to float: %s", trust_score, exc)
         tainted_proposals = _list_of_strings(consensus.get("tainted_proposals"))
         if tainted_proposals:
             receipt.consensus_proof.tainted_proposals = tainted_proposals

--- a/tests/swarm/test_env_utils.py
+++ b/tests/swarm/test_env_utils.py
@@ -1,0 +1,85 @@
+"""Tests for aragora.swarm.env_utils.git_safe_env edge cases."""
+
+from aragora.swarm.env_utils import git_safe_env
+
+_ALL_TOKEN_KEYS = (
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_ENTERPRISE_TOKEN",
+    "GITHUB_ENTERPRISE_TOKEN",
+)
+
+
+def test_default_env_strips_all_token_keys(monkeypatch):
+    """git_safe_env() with no args strips all four token keys from os.environ."""
+    for key in _ALL_TOKEN_KEYS:
+        monkeypatch.setenv(key, "secret-value")
+
+    result = git_safe_env()
+
+    for key in _ALL_TOKEN_KEYS:
+        assert key not in result
+
+
+def test_custom_base_env_with_all_tokens_stripped():
+    """Explicit dict containing all four token keys is fully stripped."""
+    base = dict.fromkeys(_ALL_TOKEN_KEYS, "tok")
+    result = git_safe_env(base)
+
+    for key in _ALL_TOKEN_KEYS:
+        assert key not in result
+
+
+def test_preserves_non_token_vars():
+    """Non-token variables PATH, HOME, MY_VAR are preserved in result."""
+    base = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": "/home/user",
+        "MY_VAR": "hello",
+        "GH_TOKEN": "secret",
+    }
+    result = git_safe_env(base)
+
+    assert result["PATH"] == "/usr/bin:/bin"
+    assert result["HOME"] == "/home/user"
+    assert result["MY_VAR"] == "hello"
+
+
+def test_no_mutation_of_input():
+    """The original base_env dict is not modified by git_safe_env."""
+    base = {"GH_TOKEN": "secret", "KEEP_ME": "value"}
+    original_copy = dict(base)
+
+    git_safe_env(base)
+
+    assert base == original_copy
+
+
+def test_empty_env_falls_back_to_os_environ(monkeypatch):
+    """An empty dict is falsy, so git_safe_env falls back to os.environ.
+
+    The implementation uses ``base_env or os.environ``, meaning an empty
+    mapping triggers the same default-env path as no argument.  The result
+    therefore contains os.environ minus any token keys.
+    """
+    monkeypatch.setenv("GH_TOKEN", "secret")
+    monkeypatch.setenv("MY_SENTINEL", "present")
+
+    result = git_safe_env({})
+
+    # Token keys must be absent even when falling back to os.environ
+    assert "GH_TOKEN" not in result
+    # Non-token env vars from os.environ must be present
+    assert result.get("MY_SENTINEL") == "present"
+
+
+def test_partial_tokens_only_strips_present_key():
+    """Only GH_TOKEN is stripped; other token keys are not added to the result."""
+    base = {"GH_TOKEN": "secret", "MY_VAR": "keep"}
+    result = git_safe_env(base)
+
+    assert "GH_TOKEN" not in result
+    assert result["MY_VAR"] == "keep"
+    # Other token keys were never in base, so they must not appear in result either
+    for key in ("GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"):
+        assert key not in result

--- a/tests/swarm/test_worker_process.py
+++ b/tests/swarm/test_worker_process.py
@@ -1,0 +1,126 @@
+"""Tests for aragora.swarm.worker_process module."""
+
+import pytest
+
+from aragora.swarm.worker_process import (
+    LaunchConfig,
+    WorkerProcess,
+    is_ignored_changed_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_ignored_changed_path — session artifact names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        ".codex_session_meta.json",
+        ".codex_session.log",
+        ".codex_session_active",
+        ".swarm_worker_stdout.log",
+        ".swarm_worker_stderr.log",
+    ],
+)
+def test_session_artifact_names_are_ignored(artifact):
+    """Each session artifact filename returns True."""
+    assert is_ignored_changed_path(artifact) is True
+
+
+# ---------------------------------------------------------------------------
+# is_ignored_changed_path — node_modules paths
+# ---------------------------------------------------------------------------
+
+
+def test_node_modules_top_level_is_ignored():
+    """node_modules/react/index.js is treated as runtime noise."""
+    assert is_ignored_changed_path("node_modules/react/index.js") is True
+
+
+def test_node_modules_nested_is_ignored():
+    """Nested node_modules inside a subdirectory is treated as runtime noise."""
+    assert is_ignored_changed_path("frontend/node_modules/lodash/index.js") is True
+
+
+# ---------------------------------------------------------------------------
+# is_ignored_changed_path — normal source files
+# ---------------------------------------------------------------------------
+
+
+def test_normal_source_file_is_not_ignored():
+    """A regular source file returns False."""
+    assert is_ignored_changed_path("aragora/swarm/boss_loop.py") is False
+
+
+def test_empty_string_returns_false():
+    """An empty string is not treated as ignored."""
+    assert is_ignored_changed_path("") is False
+
+
+def test_leading_dot_slash_normal_file_returns_false():
+    """./aragora/swarm/boss_loop.py is stripped correctly and returns False."""
+    assert is_ignored_changed_path("./aragora/swarm/boss_loop.py") is False
+
+
+def test_leading_dot_slash_session_artifact_returns_true():
+    """./.codex_session.log is recognised as a session artifact after stripping."""
+    assert is_ignored_changed_path("./.codex_session.log") is True
+
+
+# ---------------------------------------------------------------------------
+# WorkerProcess dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_worker_process_is_running_true_when_pid_set_and_no_exit_code():
+    """is_running returns True when exit_code is None and pid is set."""
+    wp = WorkerProcess(
+        work_order_id="wo-1",
+        agent="claude",
+        worktree_path="/tmp/wt",
+        branch="work/test",
+        pid=12345,
+    )
+    assert wp.is_running is True
+
+
+def test_worker_process_is_running_false_after_exit():
+    """is_running returns False once exit_code is set."""
+    wp = WorkerProcess(
+        work_order_id="wo-2",
+        agent="codex",
+        worktree_path="/tmp/wt",
+        branch="work/test",
+        pid=9999,
+        exit_code=0,
+    )
+    assert wp.is_running is False
+
+
+def test_worker_process_is_running_false_without_pid():
+    """is_running returns False when pid has not been set yet."""
+    wp = WorkerProcess(
+        work_order_id="wo-3",
+        agent="claude",
+        worktree_path="/tmp/wt",
+        branch="work/test",
+    )
+    assert wp.is_running is False
+
+
+# ---------------------------------------------------------------------------
+# LaunchConfig defaults
+# ---------------------------------------------------------------------------
+
+
+def test_launch_config_default_construction():
+    """LaunchConfig() constructs without error and has expected defaults."""
+    cfg = LaunchConfig()
+    assert cfg.claude_path == "claude"
+    assert cfg.codex_path == "codex"
+    assert cfg.timeout_seconds == 2400.0
+    assert cfg.auto_commit is True
+    assert cfg.allow_claude_dangerously_skip_permissions is False
+    assert cfg.allow_codex_full_auto is False


### PR DESCRIPTION
## Summary

- Replace `except ...: pass` in 9 pipeline/connector modules with proper logging
- Add 21 tests in 2 new test files for env_utils and worker_process

## Test plan

- [x] `pytest tests/swarm/test_env_utils.py tests/swarm/test_worker_process.py -v` — 21/21 pass
- [x] `ruff check` — clean on all 11 files

Closes #5644, #5645, #5646, #5647, #5648, #5649, #5650, #5651, #5652, #5664, #5665

🤖 Generated with [Claude Code](https://claude.com/claude-code)