### PR TITLE
docs: reconcile CS queue truth

### DIFF
--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -51,7 +51,7 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 - Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
+- Live boss-ready queue: the current bounded `CS-01..03` claim-discipline issue is [#5541](https://github.com/synaptent/aragora/issues/5541); `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
 - `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -120,7 +120,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
-| 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+| 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Current bounded lane: [#5541](https://github.com/synaptent/aragora/issues/5541). |
 
 ## Do Now / Delay / Avoid
 
@@ -147,8 +147,8 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ## Live Boss-Ready Queue
 
-- There is no dedicated open boss-ready trust-loop issue right now.
-- Keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
+- The live `boss-ready` queue should contain only the current bounded `CS-01..03` claim-discipline issue: [#5541](https://github.com/synaptent/aragora/issues/5541).
+- Keep the rest of `CS-01..03` enforced through the docs/status surfaces unless another concrete bounded issue is needed.
 - Let the recurring `TW-01/TW-02/TW-03` publication surfaces restock the queue only when they expose a fresh repeated rescue class or a concrete regression.
 
 `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)), `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)), and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) now publish through repo-tracked recurring status surfaces at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`. `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.

--- a/docs-site/docs/enterprise/commercial-overview.md
+++ b/docs-site/docs/enterprise/commercial-overview.md
@@ -29,17 +29,16 @@ The claims below are the current proof base, not the long-term ambition.
 |---|---|---|
 | Guarded execution substrate | Boss, supervisor, tranche, contract, and preflight paths exist on the live swarm lane. | The system can decide when a run is admissible instead of blindly attempting work. |
 | Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
-| Truth artifacts | The repo has a diffable benchmark truth-artifact path and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth. |
+| Truth artifacts | The repo has a diffable benchmark truth-artifact path, frozen-corpus binding on recurring scorecards, and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth instead of drifting with ad hoc samples. |
 | Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
-| Operator truth | Preflight receipts, blocker evidence, and session-state work are materially underway and partially landed, but not yet fully closed across every live path. | This is the remaining gap between an impressive demo and a boring reliable product lane. |
+| Operator truth | Preflight receipts, blocker evidence, session-state work, recurring benchmark truth publication, and recurring rescue productization are on `main`. | This is the proof surface that turns an impressive demo into a boring reliable product lane. |
 
 ## Current Gate
 
 The current commercial gate is the same as the current execution gate in [status/NEXT_STEPS_CANONICAL.md](../contributing/next-steps-canonical):
 
-- finish `RS-07` so receipt-backed preflight becomes the default admission truth
-- close the remaining truthful repair gaps in `BC-01` and `BC-03`
-- keep `TW-01`, `TW-02`, and `TW-03` publishing recurring corpus-linked truth
+- keep `TW-01` landed so recurring scorecards stay tied to the frozen corpus on current `main`
+- keep `TW-03` recurring so repeated rescues keep becoming benchmark fixtures or bounded product work instead of invisible operator tax
 - keep all external claims narrower than the measured proof
 
 This means Aragora should currently be positioned as:
@@ -165,9 +164,13 @@ Use these documents as the canonical backing for commercial claims:
 
 - [status/NEXT_STEPS_CANONICAL.md](../contributing/next-steps-canonical)
 - [status/ACTIVE_EXECUTION_ISSUES.md](../contributing/active-execution-issues)
+- [status/B0_BENCHMARK_TRUTH_STATUS.md](status/B0_BENCHMARK_TRUTH_STATUS.md)
+- [status/TW03_RESCUE_PRODUCTIZATION_STATUS.md](status/TW03_RESCUE_PRODUCTIZATION_STATUS.md)
 - [plans/ARAGORA_EVOLUTION_ROADMAP.md](../contributing/aragora-evolution-roadmap)
 - [benchmarks/corpus.json](benchmarks/corpus.json)
+- [benchmarks/rescue_productization.json](benchmarks/rescue_productization.json)
 - `scripts/build_benchmark_truth_artifact.py`
+- `scripts/publish_rescue_productization_report.py`
 - `scripts/reconcile_b0_pr_truth.py`
 
 If a claim cannot be tied back to those sources or to current `main`, it should not be in first-tranche commercial positioning.

--- a/docs/COMMERCIAL_OVERVIEW.md
+++ b/docs/COMMERCIAL_OVERVIEW.md
@@ -26,14 +26,14 @@ The claims below are the current proof base, not the long-term ambition.
 | Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
 | Truth artifacts | The repo has a diffable benchmark truth-artifact path, frozen-corpus binding on recurring scorecards, and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth instead of drifting with ad hoc samples. |
 | Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
-| Operator truth | Preflight receipts, blocker evidence, and session-state work are on `main`; the remaining gap is keeping recurring truth publication and rescue productization boring on the live loop. | This is the remaining gap between an impressive demo and a boring reliable product lane. |
+| Operator truth | Preflight receipts, blocker evidence, session-state work, recurring benchmark truth publication, and recurring rescue productization are on `main`. | This is the proof surface that turns an impressive demo into a boring reliable product lane. |
 
 ## Current Gate
 
 The current commercial gate is the same as the current execution gate in [status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md):
 
 - keep `TW-01` landed so recurring scorecards stay tied to the frozen corpus on current `main`
-- finish `TW-03` so repeated rescues become benchmark fixtures or bounded product work instead of invisible operator tax
+- keep `TW-03` recurring so repeated rescues keep becoming benchmark fixtures or bounded product work instead of invisible operator tax
 - keep all external claims narrower than the measured proof
 
 This means Aragora should currently be positioned as:
@@ -160,9 +160,12 @@ Use these documents as the canonical backing for commercial claims:
 - [status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md)
 - [status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md)
 - [status/B0_BENCHMARK_TRUTH_STATUS.md](status/B0_BENCHMARK_TRUTH_STATUS.md)
+- [status/TW03_RESCUE_PRODUCTIZATION_STATUS.md](status/TW03_RESCUE_PRODUCTIZATION_STATUS.md)
 - [plans/ARAGORA_EVOLUTION_ROADMAP.md](plans/ARAGORA_EVOLUTION_ROADMAP.md)
 - [benchmarks/corpus.json](benchmarks/corpus.json)
+- [benchmarks/rescue_productization.json](benchmarks/rescue_productization.json)
 - `scripts/build_benchmark_truth_artifact.py`
+- `scripts/publish_rescue_productization_report.py`
 - `scripts/reconcile_b0_pr_truth.py`
 
 If a claim cannot be tied back to those sources or to current `main`, it should not be in first-tranche commercial positioning.

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -46,7 +46,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 - Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
+- Live boss-ready queue: the current bounded `CS-01..03` claim-discipline issue is [#5541](https://github.com/synaptent/aragora/issues/5541); `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
 - `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -115,7 +115,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
-| 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+| 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Current bounded lane: [#5541](https://github.com/synaptent/aragora/issues/5541). |
 
 ## Do Now / Delay / Avoid
 
@@ -142,8 +142,8 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ## Live Boss-Ready Queue
 
-- There is no dedicated open boss-ready trust-loop issue right now.
-- Keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
+- The live `boss-ready` queue should contain only the current bounded `CS-01..03` claim-discipline issue: [#5541](https://github.com/synaptent/aragora/issues/5541).
+- Keep the rest of `CS-01..03` enforced through the docs/status surfaces unless another concrete bounded issue is needed.
 - Let the recurring `TW-01/TW-02/TW-03` publication surfaces restock the queue only when they expose a fresh repeated rescue class or a concrete regression.
 
 `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)), `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)), and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) now publish through repo-tracked recurring status surfaces at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`. `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.


### PR DESCRIPTION
## Summary
- reconcile the top-level commercial overview to the current wedge-first proof posture on main
- update the canonical next-steps and active-execution docs so #5541 is the sole bounded CS-01..03 queue item
- sync the docs-site derived pages to match the updated source docs

## Validation
- python3 -m pytest tests/swarm/test_roadmap_priority.py tests/scripts/test_docs_site_sync_links.py -q
- node docs-site/scripts/sync-docs.js
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5541