### PR TITLE
[from CS-01/03] Reconcile top-level COMMERCIAL_OVERVIEW to current proof

### DIFF
--- a/docs-site/docs/contributing/b0-benchmark-truth-status.md
+++ b/docs-site/docs/contributing/b0-benchmark-truth-status.md
@@ -1,0 +1,55 @@
+---
+title: B0 Benchmark Truth Status
+description: B0 Benchmark Truth Status
+---
+
+# B0 Benchmark Truth Status
+
+Last updated: 2026-04-14T18:12:28Z
+
+This is the repo-tracked recurring `TW-02` publication surface for the fixed benchmark corpus.
+
+## Corpus
+
+- Corpus manifest: `docs/benchmarks/corpus.json`
+- Corpus id: `tw-01-bounded-execution-v1`
+- Revision: `1`
+- Recorded on: `2026-04-13`
+- Success contract: `mergeable_pr_or_merged_pr`
+- Coverage status: `incomplete`
+- Coverage: `1`/`5` issues attempted
+- Missing corpus issues: `1064`, `1641`, `1733`, `2712`
+
+## Published Paths
+
+- Latest truth artifact: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json`
+- Latest scorecard: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/latest.json`
+- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/latest.json`
+- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-1/latest.json`
+
+## Truth Metrics
+
+| Metric | Value |
+| --- | --- |
+| Truth success rate | 60.0% |
+| No-rescue truth success rate | 40.0% |
+| Merged-only rate | 60.0% |
+
+## Proxy Metrics
+
+| Metric | Value |
+| --- | --- |
+| No-rescue success rate | 0.0% |
+| Unique issues attempted | 1 |
+| Unique issues succeeded | 0 |
+| Unique issues failed | 1 |
+| Total ticks | 4 |
+
+## Failure Class Distribution
+
+- `blocked_sanitation_failed`: 1
+- `rescue_no_deliverable`: 3
+
+## Rescue Counts By Type
+
+- `rescue_no_deliverable`: 3

--- a/docs-site/docs/contributing/tw03-rescue-productization-status.md
+++ b/docs-site/docs/contributing/tw03-rescue-productization-status.md
@@ -1,0 +1,42 @@
+---
+title: TW-03 Rescue Productization Status
+description: TW-03 Rescue Productization Status
+---
+
+# TW-03 Rescue Productization Status
+
+Last updated: 2026-04-14T19:45:47Z
+
+This is the repo-tracked recurring `TW-03` publication surface for repeated rescue-class harvest and conversion.
+
+## Summary
+
+- Latest report: `docs/status/generated/rescue_productization/latest.json`
+- Rescue ledger path: `/Users/armand/.aragora/rescue_events.jsonl`
+- Productization map: `docs/benchmarks/rescue_productization.json`
+- Repeated rescue classes: `0`
+- Linked repeated classes: `0`
+- Unlinked repeated classes: `0`
+- One-off classes: `0`
+- Below-threshold classes: `0`
+- Issue drafts remaining: `0`
+
+## Repeated Rescue Classes
+
+- No repeated rescue classes found in the current ledger window.
+
+## Issue Linkage Actions
+
+- none
+
+## Remaining Issue Drafts
+
+- none
+
+## One-Off Rescue Classes
+
+- none
+
+## Below-Threshold Rescue Classes
+
+- none

--- a/docs-site/docs/enterprise/commercial-overview.md
+++ b/docs-site/docs/enterprise/commercial-overview.md
@@ -29,17 +29,16 @@ The claims below are the current proof base, not the long-term ambition.
 |---|---|---|
 | Guarded execution substrate | Boss, supervisor, tranche, contract, and preflight paths exist on the live swarm lane. | The system can decide when a run is admissible instead of blindly attempting work. |
 | Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
-| Truth artifacts | The repo has a diffable benchmark truth-artifact path and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth. |
+| Truth artifacts | The repo has a diffable benchmark truth-artifact path, frozen-corpus binding on recurring scorecards, and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth instead of drifting with ad hoc samples. |
 | Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
-| Operator truth | Preflight receipts, blocker evidence, and session-state work are materially underway and partially landed, but not yet fully closed across every live path. | This is the remaining gap between an impressive demo and a boring reliable product lane. |
+| Operator truth | Preflight receipts, blocker evidence, session-state work, recurring benchmark truth publication, and recurring rescue productization are on `main`. | This is the proof surface that turns an impressive demo into a boring reliable product lane. |
 
 ## Current Gate
 
 The current commercial gate is the same as the current execution gate in [status/NEXT_STEPS_CANONICAL.md](../contributing/next-steps-canonical):
 
-- finish `RS-07` so receipt-backed preflight becomes the default admission truth
-- close the remaining truthful repair gaps in `BC-01` and `BC-03`
-- keep `TW-01`, `TW-02`, and `TW-03` publishing recurring corpus-linked truth
+- keep `TW-01` landed so recurring scorecards stay tied to the frozen corpus on current `main`
+- keep `TW-03` recurring so repeated rescues keep becoming benchmark fixtures or bounded product work instead of invisible operator tax
 - keep all external claims narrower than the measured proof
 
 This means Aragora should currently be positioned as:
@@ -165,9 +164,13 @@ Use these documents as the canonical backing for commercial claims:
 
 - [status/NEXT_STEPS_CANONICAL.md](../contributing/next-steps-canonical)
 - [status/ACTIVE_EXECUTION_ISSUES.md](../contributing/active-execution-issues)
+- [status/B0_BENCHMARK_TRUTH_STATUS.md](../contributing/b0-benchmark-truth-status)
+- [status/TW03_RESCUE_PRODUCTIZATION_STATUS.md](../contributing/tw03-rescue-productization-status)
 - [plans/ARAGORA_EVOLUTION_ROADMAP.md](../contributing/aragora-evolution-roadmap)
-- [benchmarks/corpus.json](benchmarks/corpus.json)
+- `docs/benchmarks/corpus.json`
+- `docs/benchmarks/rescue_productization.json`
 - `scripts/build_benchmark_truth_artifact.py`
+- `scripts/publish_rescue_productization_report.py`
 - `scripts/reconcile_b0_pr_truth.py`
 
 If a claim cannot be tied back to those sources or to current `main`, it should not be in first-tranche commercial positioning.

--- a/docs-site/scripts/sync-docs.js
+++ b/docs-site/scripts/sync-docs.js
@@ -359,12 +359,15 @@ const DOC_MAP = {
   'status/FEATURE_DISCOVERY.md': 'contributing/feature-discovery.md',
   'FEATURE_GAP_LIST.md': 'contributing/feature-gap-list.md',
   'status/ACTIVE_EXECUTION_ISSUES.md': 'contributing/active-execution-issues.md',
+  'status/B0_BENCHMARK_TRUTH_STATUS.md': 'contributing/b0-benchmark-truth-status.md',
   'status/NEXT_STEPS_CANONICAL.md': 'contributing/next-steps-canonical.md',
   'status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md':
     'contributing/execution-next-6-weeks-2026-03-05.md',
   'status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md':
     'contributing/documentation-hygiene-and-gap-register.md',
   'status/PMF_SCORECARD.md': 'contributing/pmf-scorecard.md',
+  'status/TW03_RESCUE_PRODUCTIZATION_STATUS.md':
+    'contributing/tw03-rescue-productization-status.md',
   'CANONICAL_GOALS.md': 'contributing/canonical-goals.md',
   '../CLAUDE.md': 'contributing/claude.md',
   'EXTENDED_README.md': 'contributing/extended-readme.md',

--- a/docs/COMMERCIAL_OVERVIEW.md
+++ b/docs/COMMERCIAL_OVERVIEW.md
@@ -26,14 +26,14 @@ The claims below are the current proof base, not the long-term ambition.
 | Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
 | Truth artifacts | The repo has a diffable benchmark truth-artifact path, frozen-corpus binding on recurring scorecards, and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth instead of drifting with ad hoc samples. |
 | Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
-| Operator truth | Preflight receipts, blocker evidence, and session-state work are on `main`; the remaining gap is keeping recurring truth publication and rescue productization boring on the live loop. | This is the remaining gap between an impressive demo and a boring reliable product lane. |
+| Operator truth | Preflight receipts, blocker evidence, session-state work, recurring benchmark truth publication, and recurring rescue productization are on `main`. | This is the proof surface that turns an impressive demo into a boring reliable product lane. |
 
 ## Current Gate
 
 The current commercial gate is the same as the current execution gate in [status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md):
 
 - keep `TW-01` landed so recurring scorecards stay tied to the frozen corpus on current `main`
-- finish `TW-03` so repeated rescues become benchmark fixtures or bounded product work instead of invisible operator tax
+- keep `TW-03` recurring so repeated rescues keep becoming benchmark fixtures or bounded product work instead of invisible operator tax
 - keep all external claims narrower than the measured proof
 
 This means Aragora should currently be positioned as:
@@ -160,9 +160,12 @@ Use these documents as the canonical backing for commercial claims:
 - [status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md)
 - [status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md)
 - [status/B0_BENCHMARK_TRUTH_STATUS.md](status/B0_BENCHMARK_TRUTH_STATUS.md)
+- [status/TW03_RESCUE_PRODUCTIZATION_STATUS.md](status/TW03_RESCUE_PRODUCTIZATION_STATUS.md)
 - [plans/ARAGORA_EVOLUTION_ROADMAP.md](plans/ARAGORA_EVOLUTION_ROADMAP.md)
-- [benchmarks/corpus.json](benchmarks/corpus.json)
+- `docs/benchmarks/corpus.json`
+- `docs/benchmarks/rescue_productization.json`
 - `scripts/build_benchmark_truth_artifact.py`
+- `scripts/publish_rescue_productization_report.py`
 - `scripts/reconcile_b0_pr_truth.py`
 
 If a claim cannot be tied back to those sources or to current `main`, it should not be in first-tranche commercial positioning.

--- a/tests/scripts/test_docs_site_sync_links.py
+++ b/tests/scripts/test_docs_site_sync_links.py
@@ -66,10 +66,33 @@ def test_features_guide_points_to_current_state_docs_site_pages() -> None:
         assert link not in content
 
 
+def test_commercial_overview_rewrites_current_proof_status_links() -> None:
+    content = _read_docs_site("enterprise/commercial-overview.md")
+
+    expected_links = [
+        "[status/NEXT_STEPS_CANONICAL.md](../contributing/next-steps-canonical)",
+        "[status/ACTIVE_EXECUTION_ISSUES.md](../contributing/active-execution-issues)",
+        "[status/B0_BENCHMARK_TRUTH_STATUS.md](../contributing/b0-benchmark-truth-status)",
+        "[status/TW03_RESCUE_PRODUCTIZATION_STATUS.md](../contributing/tw03-rescue-productization-status)",
+    ]
+    for link in expected_links:
+        assert link in content
+
+    unresolved_source_links = [
+        "[status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md)",
+        "[status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md)",
+        "[status/B0_BENCHMARK_TRUTH_STATUS.md](status/B0_BENCHMARK_TRUTH_STATUS.md)",
+        "[status/TW03_RESCUE_PRODUCTIZATION_STATUS.md](status/TW03_RESCUE_PRODUCTIZATION_STATUS.md)",
+    ]
+    for link in unresolved_source_links:
+        assert link not in content
+
+
 def test_docs_site_sync_creates_linked_status_and_planning_pages() -> None:
     expected_pages = [
         DOCS_SITE_ROOT / "contributing" / "2026-03-26-pmf-14-day-execution-plan.md",
         DOCS_SITE_ROOT / "contributing" / "active-execution-issues.md",
+        DOCS_SITE_ROOT / "contributing" / "b0-benchmark-truth-status.md",
         DOCS_SITE_ROOT / "contributing" / "aragora-evolution-roadmap.md",
         DOCS_SITE_ROOT / "contributing" / "canonical-goals.md",
         DOCS_SITE_ROOT / "contributing" / "claude.md",
@@ -84,6 +107,7 @@ def test_docs_site_sync_creates_linked_status_and_planning_pages() -> None:
         DOCS_SITE_ROOT / "contributing" / "pmf-dogfood-execution-plan.md",
         DOCS_SITE_ROOT / "contributing" / "pmf-scorecard.md",
         DOCS_SITE_ROOT / "contributing" / "roadmap.md",
+        DOCS_SITE_ROOT / "contributing" / "tw03-rescue-productization-status.md",
         DOCS_SITE_ROOT / "guides" / "conductor-workflow.md",
         DOCS_SITE_ROOT / "guides" / "marketplace.md",
         DOCS_SITE_ROOT / "guides" / "swarm-dogfood-operator.md",


### PR DESCRIPTION
## Summary
- align the top-level commercial overview with the current `main` proof posture
- sync the docs-site commercial overview mirror and add docs-site routes for the recurring benchmark/rescue status pages
- cover the new docs-site link rewrites with a focused regression test

## Validation
- `node docs-site/scripts/sync-docs.js`
- `python3 -m pytest tests/scripts/test_docs_site_sync_links.py -q`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Closes #5541