### PR TITLE
fix(benchmarks): fail closed on incomplete corpus coverage

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -55,7 +55,8 @@ jobs:
           python3 scripts/measure_b0_scorecard.py \
             --publish \
             --publish-dir docs/status/generated/benchmark_scorecards \
-            --truth-publish-dir docs/status/generated/benchmark_truth_artifacts
+            --truth-publish-dir docs/status/generated/benchmark_truth_artifacts \
+            --fail-incomplete
 
           python3 scripts/render_benchmark_truth_status.py \
             --output docs/status/B0_BENCHMARK_TRUTH_STATUS.md

--- a/.github/workflows/benchmark-truth.yml
+++ b/.github/workflows/benchmark-truth.yml
@@ -70,6 +70,7 @@ jobs:
             --repo synaptent/aragora \
             --metrics-file "$METRICS_FILE" \
             --corpus docs/benchmarks/corpus.json \
+            --fail-incomplete \
             --json > truth-artifact.json
           echo "## Truth Artifact Summary" >> "$GITHUB_STEP_SUMMARY"
           python3 -c "

--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -358,6 +358,19 @@ def main(argv: list[str] | None = None) -> int:
         publish_dir = args.publish_dir.resolve()
     elif args.publish:
         publish_dir = DEFAULT_PUBLISH_DIR
+    if args.json or (args.output is None and publish_dir is None):
+        print(json.dumps(artifact, indent=2, sort_keys=True))
+    is_complete = artifact.get("run_status") == "complete"
+    if args.fail_incomplete and not is_complete:
+        missing_issue_numbers = list(
+            (artifact.get("coverage") or {}).get("missing_issue_numbers") or []
+        )
+        missing_suffix = ", ".join(str(item) for item in missing_issue_numbers) or "unknown"
+        print(
+            f"incomplete corpus coverage: missing issue numbers {missing_suffix}",
+            file=sys.stderr,
+        )
+        return 2
     if args.output is not None:
         output_path = write_artifact(args.output.resolve(), artifact)
         print(str(output_path))
@@ -371,18 +384,6 @@ def main(argv: list[str] | None = None) -> int:
             print(str(published_path), file=sys.stderr)
         else:
             print(str(published_path))
-    if args.json or (args.output is None and publish_dir is None):
-        print(json.dumps(artifact, indent=2, sort_keys=True))
-    if args.fail_incomplete and artifact.get("run_status") != "complete":
-        missing_issue_numbers = list(
-            (artifact.get("coverage") or {}).get("missing_issue_numbers") or []
-        )
-        missing_suffix = ", ".join(str(item) for item in missing_issue_numbers) or "unknown"
-        print(
-            f"incomplete corpus coverage: missing issue numbers {missing_suffix}",
-            file=sys.stderr,
-        )
-        return 2
     return 0
 
 

--- a/scripts/measure_b0_scorecard.py
+++ b/scripts/measure_b0_scorecard.py
@@ -625,9 +625,11 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
 
+    incomplete_corpus = (scorecard.get("coverage") or {}).get("is_complete") is False
+
     published_scorecard: dict[str, Any] | None = None
     published_path: Path | None = None
-    if publish_dir is not None:
+    if publish_dir is not None and not (args.fail_incomplete and incomplete_corpus):
         if truth_artifact_path is None:
             if corpus_path is None:
                 raise SystemExit("publish mode requires --truth-artifact PATH or --corpus PATH")
@@ -682,7 +684,7 @@ def main(argv: list[str] | None = None) -> int:
     elif published_path is None:
         print_scorecard(scorecard)
 
-    if args.fail_incomplete and (scorecard.get("coverage") or {}).get("is_complete") is False:
+    if args.fail_incomplete and incomplete_corpus:
         missing_issue_numbers = list(
             (scorecard.get("coverage") or {}).get("missing_issue_numbers") or []
         )

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -271,6 +271,71 @@ def test_main_fail_incomplete_returns_nonzero_and_emits_artifact(
     assert "incomplete corpus coverage" in captured.err
 
 
+def test_main_fail_incomplete_does_not_publish_artifacts(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text("", encoding="utf-8")
+    corpus_path = tmp_path / "corpus.json"
+    corpus_path.write_text(
+        json.dumps(
+            {
+                "corpus_id": "tw-01-bounded-execution-v1",
+                "revision": 1,
+                "recorded_on": "2026-04-14",
+                "success_contract": "mergeable_pr_or_merged_pr",
+                "issues": [
+                    {"issue_id": 1064, "title": "Issue A"},
+                    {"issue_id": 873, "title": "Issue B"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    fake_client = FakeGitHubTruthClient(
+        issues={
+            1064: {"title": "Issue A", "comments": []},
+            873: {"title": "Issue B", "comments": []},
+        },
+        prs={
+            1064: {
+                "number": 6002,
+                "title": "mergeable fix",
+                "url": "https://github.com/synaptent/aragora/pull/6002",
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": None,
+                "isDraft": False,
+            }
+        },
+    )
+
+    monkeypatch.setattr(mod, "GitHubTruthClient", lambda: fake_client)
+
+    publish_dir = tmp_path / "published"
+    exit_code = mod.main(
+        [
+            "--repo",
+            "synaptent/aragora",
+            "--metrics-file",
+            str(metrics_path),
+            "--corpus",
+            str(corpus_path),
+            "--publish-dir",
+            str(publish_dir),
+            "--fail-incomplete",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "incomplete corpus coverage" in captured.err
+    assert not publish_dir.exists()
+
+
 def test_write_artifact_emits_diffable_json(tmp_path: Path) -> None:
     payload = {
         "generated_at": "2026-04-13T20:00:00Z",

--- a/tests/scripts/test_measure_b0_scorecard.py
+++ b/tests/scripts/test_measure_b0_scorecard.py
@@ -476,3 +476,45 @@ def test_main_ci_fail_incomplete_fails_for_missing_corpus_issue(tmp_path: Path, 
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "coverage_status=incomplete" in captured.out
+
+
+def test_main_publish_fail_incomplete_does_not_write_scorecard_or_truth_artifact(
+    tmp_path: Path, capsys
+) -> None:
+    metrics_path = _write_metrics(
+        tmp_path / "boss_metrics.jsonl",
+        [{"issue_number": 1001, "terminal_class": "deliverable_pr_created"}],
+    )
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 1,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [
+                {"issue_id": 1001, "title": "Issue A"},
+                {"issue_id": 1002, "title": "Issue B"},
+            ],
+        },
+    )
+
+    exit_code = mod.main(
+        [
+            "--metrics",
+            str(metrics_path),
+            "--corpus",
+            str(corpus_path),
+            "--publish-dir",
+            str(tmp_path / "published"),
+            "--truth-publish-dir",
+            str(tmp_path / "truth-published"),
+            "--fail-incomplete",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "incomplete corpus coverage" in captured.err
+    assert not (tmp_path / "published").exists()
+    assert not (tmp_path / "truth-published").exists()


### PR DESCRIPTION
## Summary
- stop benchmark publish paths from writing repo-tracked artifacts when corpus coverage is incomplete and --fail-incomplete is set
- make the recurring benchmark publication workflows use fail-closed incomplete-coverage validation
- add focused regression tests for the no-publish-on-incomplete behavior

## Validation
- pytest tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_measure_b0_scorecard.py tests/scripts/test_check_branch_mutation_policy.py -q
- ruff check scripts/build_benchmark_truth_artifact.py scripts/measure_b0_scorecard.py tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_measure_b0_scorecard.py
- python3 - <<'PY'
from pathlib import Path
import yaml
for rel in [Path('.github/workflows/benchmark-truth-publication.yml'), Path('.github/workflows/benchmark-truth.yml')]:
    with rel.open('r', encoding='utf-8') as f:
        yaml.safe_load(f)
    print(rel)
PY
- bash scripts/automation_pr_preflight.sh origin/main HEAD