### PR TITLE
ci(docs): trim docs-build python bootstrap

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -69,9 +69,13 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install Python dependencies
+      - name: Install minimal Python dependencies for docs checks
         run: |
-          bash scripts/ci_install_project.sh --extras dev
+          python -m pip install --disable-pip-version-check \
+            "httpx>=0.27,<1.0" \
+            "pydantic>=2.0,<3.0" \
+            "pydantic-settings>=2.0,<3.0" \
+            "PyYAML>=6.0,<7.0"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- replace the docs-build workflow's full `--extras dev` install with the small Python dependency set the docs checks actually import
- keep the docs job behavior unchanged for sync/build steps while removing the heaviest Python bootstrap path
- preserve the existing Node docs build path and workflow structure

## Why
Recent docs-build flakes were canceling or dying around the Python install path. This lane narrows that step from the entire dev environment to the packages the docs checks actually need: `httpx`, `pydantic`, `pydantic-settings`, and `PyYAML`.

## Validation
- `python3 - <<'PY'
from pathlib import Path
import yaml
with Path('.github/workflows/docs-build.yml').open('r', encoding='utf-8') as f:
    yaml.safe_load(f)
print('workflow-yaml-ok')
PY`
- `tmpvenv=$(mktemp -d /tmp/aragora-docs-ci-venv2-XXXXXX) && python3 -m venv "$tmpvenv" && . "$tmpvenv/bin/activate" && python -m pip install --disable-pip-version-check "httpx>=0.27,<1.0" "pydantic>=2.0,<3.0" "pydantic-settings>=2.0,<3.0" "PyYAML>=6.0,<7.0" && python scripts/doc_stats.py --write >/tmp/aragora-doc-stats.out && python scripts/check_capability_matrix_sync.py && python scripts/check_legacy_entrypoints.py && python scripts/generate_cli_reference.py --check && python scripts/capability_matrix_delta.py --base-ref origin/main --out /tmp/capability-matrix-summary.md`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
