### PR TITLE
fix: fail closed on repeated boss-loop rescue streaks

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -4497,6 +4497,48 @@ class BossLoop:
 
             if self.config.auto_continue_on_needs_human:
                 self._consecutive_failures += 1
+                threshold_reason = (
+                    "Repeated rescue outcomes without a typed deliverable reached "
+                    f"threshold ({self.config.max_consecutive_failures})."
+                )
+                if self._consecutive_failures >= self.config.max_consecutive_failures:
+                    logger.warning(
+                        "boss_loop_stop issue=#%s "
+                        "(needs_human, no typed deliverable, consecutive failure threshold reached)",
+                        issue_dict.get("number", "?"),
+                    )
+                    self._append_iteration_metrics(
+                        iteration=iteration,
+                        issue_number=issue_number,
+                        worker_result=worker_result,
+                        elapsed_seconds=elapsed_seconds,
+                    )
+                    return BossIterationStatus(
+                        iteration=iteration,
+                        run_id=self.run_id,
+                        timestamp=timestamp,
+                        runner_freshness=runner_freshness,
+                        selected_issue=issue_dict,
+                        worker_status="needs_human",
+                        stop_reason=BossStopReason.CONSECUTIVE_FAILURES.value,
+                        needs_human_reasons=list(
+                            dict.fromkeys(
+                                [
+                                    *worker_result.get(
+                                        "reasons",
+                                        ["Worker requires human input."],
+                                    ),
+                                    threshold_reason,
+                                ]
+                            )
+                        ),
+                        next_actions=[
+                            threshold_reason,
+                            "Investigate the rescue streak before resuming the boss loop.",
+                        ],
+                        elapsed_seconds=elapsed_seconds,
+                        worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
+                    )
                 if has_untyped_deliverable:
                     logger.warning(
                         "boss_loop_skip issue=#%s "
@@ -5309,6 +5351,12 @@ class BossLoop:
                 "Create issues with concrete scope, or adjust --label-filter.",
             ]
         if self._stop_reason == BossStopReason.CONSECUTIVE_FAILURES.value:
+            for status in reversed(self._iteration_statuses):
+                if (
+                    status.stop_reason == BossStopReason.CONSECUTIVE_FAILURES.value
+                    and status.next_actions
+                ):
+                    return list(status.next_actions)
             return [
                 f"{self._consecutive_failures} consecutive failures.",
                 "Investigate the last failures before resuming.",

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1780,6 +1780,11 @@ class TestBossLoop:
             issue_feed=feed,
             freshness_checker=lambda **kw: _fresh_result(fresh=True),
         )
+        loop._blocked_issue_scopes = lambda: set()
+        loop._filter_issues_with_active_claims = lambda issues: issues
+        loop._has_open_pr_for_issue = lambda issue_number: None
+        loop._claim_issue_dispatch = lambda issue_number: (True, None)
+        loop._release_issue_dispatch_claim = lambda issue_number: None
         loop._dispatch_issue = _needs_human_dispatch
 
         result = asyncio.run(loop.run())
@@ -1814,6 +1819,50 @@ class TestBossLoop:
             "Skipping to next issue (auto-continue mode)."
         ]
         assert "Approval required for merge." in result.iteration_statuses[0]["needs_human_reasons"]
+
+    def test_auto_continue_needs_human_no_typed_deliverable_stops_at_threshold(self):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        call_count = 0
+
+        def _fetch():
+            nonlocal call_count
+            call_count += 1
+            return [_make_issue(call_count, f"Needs human review {call_count}")]
+
+        feed.fetch.side_effect = _fetch
+
+        config = _boss_config(
+            auto_continue_on_needs_human=True,
+            max_consecutive_failures=2,
+            max_iterations=10,
+        )
+
+        async def _needs_human_dispatch(issue, freshness):
+            return {
+                "status": "needs_human",
+                "reasons": ["Worker produced no typed deliverable."],
+            }
+
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._dispatch_issue = _needs_human_dispatch
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.CONSECUTIVE_FAILURES.value
+        assert result.iterations_completed == 2
+        assert len(result.issues_failed) == 2
+        assert result.next_actions == [
+            "Repeated rescue outcomes without a typed deliverable reached threshold (2).",
+            "Investigate the rescue streak before resuming the boss loop.",
+        ]
+        assert any(
+            "without a typed deliverable reached threshold (2)" in reason
+            for reason in result.needs_human_reasons
+        )
 
     def test_retry_rotation_switches_target_agent_after_needs_human(self):
         feed = MagicMock(spec=GitHubIssueFeed)


### PR DESCRIPTION
## Summary
- stop the boss loop with `consecutive_failures` when auto-continued `needs_human` runs keep ending without a typed deliverable
- preserve the specific stop guidance for consecutive-failure exits instead of collapsing back to the generic fallback text
- add a regression test for the new no-typed-deliverable rescue-streak stop path

## Validation
- `python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py`
- `python3 -m py_compile aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py`
- `git diff --check`

## Notes
- Focused `pytest` on `tests/swarm/test_boss_loop.py` is currently blocked locally because importing `aragora.swarm.boss_loop` hangs before the target test body executes in this environment. CI should be used to confirm the runtime path.

Closes #5674.
