### PR TITLE
fix(benchmarks): restore recurring corpus input before publish

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -47,6 +47,14 @@ jobs:
           command -v gh >/dev/null
           test -f .aragora/overnight/boss_metrics.jsonl
 
+      - name: Refresh recurring benchmark corpus metrics
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/run_benchmark_corpus_recurrence.py \
+            --repo synaptent/aragora
+
       - name: Publish tracked trust-loop surfaces
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/run_benchmark_corpus_recurrence.py
+++ b/scripts/run_benchmark_corpus_recurrence.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Rotate benchmark metrics and run the open remainder of the fixed corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.boss_loop_outcome import append_iteration_metrics
+from build_benchmark_truth_artifact import DEFAULT_CORPUS_PATH, load_corpus
+from rotate_boss_metrics import DEFAULT_METRICS_PATH, rotate_metrics_file
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_OUTCOME_LEARNER_WINDOW = 500
+
+
+def corpus_issue_numbers(corpus: dict[str, Any]) -> list[int]:
+    numbers = [
+        int(item.get("issue_id", 0) or 0)
+        for item in list(corpus.get("issues") or [])
+        if isinstance(item, dict) and int(item.get("issue_id", 0) or 0) > 0
+    ]
+    return sorted(dict.fromkeys(numbers))
+
+
+def corpus_issue_titles(corpus: dict[str, Any]) -> dict[int, str]:
+    titles: dict[int, str] = {}
+    for item in list(corpus.get("issues") or []):
+        if not isinstance(item, dict):
+            continue
+        issue_number = int(item.get("issue_id", 0) or 0)
+        if issue_number <= 0:
+            continue
+        titles[issue_number] = str(item.get("title") or "").strip()
+    return titles
+
+
+def _run_json_object(
+    cmd: list[str],
+    *,
+    runner: Any = subprocess.run,
+) -> dict[str, Any]:
+    proc = runner(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "command failed")
+    payload = json.loads(proc.stdout or "{}")
+    if not isinstance(payload, dict):
+        raise RuntimeError("command did not return a JSON object")
+    return payload
+
+
+def filter_open_issue_numbers(
+    repo: str,
+    issue_numbers: list[int],
+    *,
+    runner: Any = subprocess.run,
+) -> list[int]:
+    open_numbers: list[int] = []
+    for issue_number in issue_numbers:
+        payload = _run_json_object(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue_number),
+                "--repo",
+                repo,
+                "--json",
+                "number,state",
+            ],
+            runner=runner,
+        )
+        if str(payload.get("state") or "").strip().upper() == "OPEN":
+            open_numbers.append(issue_number)
+    return open_numbers
+
+
+def append_closed_issue_rows(
+    *,
+    metrics_file: Path,
+    closed_issue_numbers: list[int],
+    issue_titles: dict[int, str],
+    dry_run: bool = False,
+) -> list[int]:
+    if dry_run:
+        return list(closed_issue_numbers)
+
+    appended: list[int] = []
+    for iteration, issue_number in enumerate(closed_issue_numbers, start=1):
+        title = issue_titles.get(issue_number, "")
+        append_iteration_metrics(
+            metrics_jsonl_path=str(metrics_file),
+            outcome_learner_window=DEFAULT_OUTCOME_LEARNER_WINDOW,
+            deferred_queue_depth=0,
+            iteration=iteration,
+            issue_number=issue_number,
+            worker_result={
+                "status": "completed",
+                "outcome": "issue_already_resolved",
+                "issue_title": title,
+                "receipt_metadata": {"issue_title": title},
+            },
+            elapsed_seconds=0.0,
+            files_changed=0,
+            tests_run=0,
+            tests_passed=0,
+        )
+        appended.append(issue_number)
+    return appended
+
+
+def build_boss_loop_command(
+    *,
+    repo: str,
+    issue_numbers: list[int],
+    max_ticks: int | None = None,
+    interval_seconds: float = 30.0,
+    max_consecutive_failures: int = 5,
+    autonomy: str = "fire_and_forget",
+    max_hours: float = 10.0,
+) -> list[str]:
+    if not issue_numbers:
+        raise ValueError("issue_numbers must not be empty")
+    effective_ticks = max_ticks if max_ticks is not None else max(len(issue_numbers) * 2, 1)
+    return [
+        sys.executable,
+        "-m",
+        "aragora.cli.main",
+        "swarm",
+        "boss-loop",
+        "--boss-repo",
+        repo,
+        "--boss-issue-list",
+        ",".join(str(item) for item in issue_numbers),
+        "--max-ticks",
+        str(effective_ticks),
+        "--interval",
+        str(interval_seconds),
+        "--max-consecutive-failures",
+        str(max(max_consecutive_failures, len(issue_numbers))),
+        "--autonomy",
+        autonomy,
+        "--max-hours",
+        str(max_hours),
+    ]
+
+
+def recorded_issue_numbers(metrics_file: Path) -> list[int]:
+    if not metrics_file.exists():
+        return []
+    recorded: set[int] = set()
+    for line in metrics_file.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        issue_number = payload.get("issue_number")
+        if isinstance(issue_number, int) and issue_number > 0:
+            recorded.add(issue_number)
+    return sorted(recorded)
+
+
+def run_recurrence(
+    *,
+    corpus_path: Path,
+    repo: str,
+    metrics_file: Path,
+    max_ticks: int | None = None,
+    interval_seconds: float = 30.0,
+    max_consecutive_failures: int = 5,
+    autonomy: str = "fire_and_forget",
+    max_hours: float = 10.0,
+    dry_run: bool = False,
+    runner: Any = subprocess.run,
+) -> dict[str, Any]:
+    corpus = load_corpus(corpus_path)
+    issue_numbers = corpus_issue_numbers(corpus)
+    issue_titles = corpus_issue_titles(corpus)
+    open_issue_numbers = filter_open_issue_numbers(repo, issue_numbers, runner=runner)
+    closed_issue_numbers = sorted(set(issue_numbers) - set(open_issue_numbers))
+    rotate_summary = rotate_metrics_file(metrics_file, dry_run=dry_run)
+    synthetic_resolved_issue_numbers = append_closed_issue_rows(
+        metrics_file=metrics_file,
+        closed_issue_numbers=closed_issue_numbers,
+        issue_titles=issue_titles,
+        dry_run=dry_run,
+    )
+    command = (
+        build_boss_loop_command(
+            repo=repo,
+            issue_numbers=open_issue_numbers,
+            max_ticks=max_ticks,
+            interval_seconds=interval_seconds,
+            max_consecutive_failures=max_consecutive_failures,
+            autonomy=autonomy,
+            max_hours=max_hours,
+        )
+        if open_issue_numbers
+        else None
+    )
+    boss_loop_exit_code: int | None = None
+    if command is not None and not dry_run:
+        proc = runner(command, check=False, cwd=str(REPO_ROOT))
+        boss_loop_exit_code = int(proc.returncode)
+
+    recorded_numbers = issue_numbers if dry_run else recorded_issue_numbers(metrics_file)
+    missing_issue_numbers = sorted(set(issue_numbers) - set(recorded_numbers))
+    if not dry_run and not boss_loop_exit_code and missing_issue_numbers:
+        raise RuntimeError(
+            "incomplete recurring benchmark corpus metrics: missing issue numbers "
+            + ", ".join(str(item) for item in missing_issue_numbers)
+        )
+
+    return {
+        "repo": repo,
+        "corpus_path": str(corpus_path),
+        "metrics_file": str(metrics_file),
+        "issue_numbers": issue_numbers,
+        "open_issue_numbers": open_issue_numbers,
+        "closed_issue_numbers": closed_issue_numbers,
+        "synthetic_resolved_issue_numbers": synthetic_resolved_issue_numbers,
+        "recorded_issue_numbers": recorded_numbers,
+        "missing_issue_numbers": missing_issue_numbers,
+        "rotated_metrics": rotate_summary,
+        "boss_loop_command": command,
+        "boss_loop_exit_code": boss_loop_exit_code,
+        "dry_run": dry_run,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=DEFAULT_CORPUS_PATH,
+        help=f"Benchmark corpus manifest (default: {DEFAULT_CORPUS_PATH})",
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--metrics-file",
+        type=Path,
+        default=DEFAULT_METRICS_PATH,
+        help=f"Metrics file rotated and fed into publish (default: {DEFAULT_METRICS_PATH})",
+    )
+    parser.add_argument("--max-ticks", type=int, default=None)
+    parser.add_argument("--interval-seconds", type=float, default=30.0)
+    parser.add_argument("--max-consecutive-failures", type=int, default=5)
+    parser.add_argument("--autonomy", default="fire_and_forget")
+    parser.add_argument("--max-hours", type=float, default=10.0)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    summary = run_recurrence(
+        corpus_path=args.corpus.resolve(),
+        repo=str(args.repo),
+        metrics_file=args.metrics_file.resolve(),
+        max_ticks=args.max_ticks,
+        interval_seconds=args.interval_seconds,
+        max_consecutive_failures=args.max_consecutive_failures,
+        autonomy=str(args.autonomy),
+        max_hours=float(args.max_hours),
+        dry_run=bool(args.dry_run),
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(
+            "Recurring benchmark corpus feed: "
+            f"{len(summary['open_issue_numbers'])} open issue(s), "
+            f"{len(summary['closed_issue_numbers'])} closed issue(s)."
+        )
+        if summary["boss_loop_command"] is None:
+            print(
+                "No open corpus issues remain; rotated metrics file and skipped boss-loop dispatch."
+            )
+        elif args.dry_run:
+            print("Would run:", " ".join(summary["boss_loop_command"]))
+        elif summary["boss_loop_exit_code"] is not None:
+            print(f"Boss loop exit code: {summary['boss_loop_exit_code']}")
+    return int(summary["boss_loop_exit_code"] or 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_run_benchmark_corpus_recurrence.py
+++ b/tests/scripts/test_run_benchmark_corpus_recurrence.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import run_benchmark_corpus_recurrence as mod  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _load_metrics(path: Path) -> list[dict[str, object]]:
+    return [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+def test_filter_open_issue_numbers_only_keeps_open_issues() -> None:
+    def runner(
+        cmd: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+        cwd: str | None = None,
+    ) -> SimpleNamespace:
+        del capture_output, text, check, cwd
+        issue_number = int(cmd[3])
+        state = "OPEN" if issue_number in {1001, 1003} else "CLOSED"
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"number": issue_number, "state": state}),
+            stderr="",
+        )
+
+    assert mod.filter_open_issue_numbers(
+        "synaptent/aragora",
+        [1001, 1002, 1003],
+        runner=runner,
+    ) == [1001, 1003]
+
+
+def test_build_boss_loop_command_uses_explicit_issue_list_contract() -> None:
+    command = mod.build_boss_loop_command(
+        repo="synaptent/aragora",
+        issue_numbers=[1064, 2712],
+    )
+
+    assert command[:4] == [sys.executable, "-m", "aragora.cli.main", "swarm"]
+    assert "--boss-issue-list" in command
+    assert command[command.index("--boss-issue-list") + 1] == "1064,2712"
+    assert command[command.index("--max-ticks") + 1] == "4"
+    assert command[command.index("--max-consecutive-failures") + 1] == "5"
+    assert command[command.index("--autonomy") + 1] == "fire_and_forget"
+
+
+def test_run_recurrence_rotates_metrics_appends_closed_rows_and_dispatches_open_issue(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 8,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [
+                {"issue_id": 1064, "title": "Closed issue"},
+                {"issue_id": 2712, "title": "Open issue"},
+            ],
+        },
+    )
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text('{"old": true}\n', encoding="utf-8")
+
+    def fake_append_iteration_metrics(
+        *,
+        metrics_jsonl_path: str | None,
+        outcome_learner_window: int,
+        deferred_queue_depth: int,
+        iteration: int,
+        issue_number: int | None,
+        worker_result: dict[str, object],
+        elapsed_seconds: float,
+        files_changed: int,
+        tests_run: int,
+        tests_passed: int,
+    ) -> None:
+        del outcome_learner_window, deferred_queue_depth, iteration, elapsed_seconds
+        del files_changed, tests_run, tests_passed
+        assert metrics_jsonl_path is not None
+        payload = {
+            "issue_number": issue_number,
+            "issue_title": worker_result.get("issue_title"),
+            "worker_status": worker_result.get("status"),
+            "worker_outcome": worker_result.get("outcome"),
+            "terminal_class": "issue_already_resolved",
+        }
+        with Path(metrics_jsonl_path).open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload) + "\n")
+
+    monkeypatch.setattr(mod, "append_iteration_metrics", fake_append_iteration_metrics)
+
+    def runner(
+        cmd: list[str],
+        *,
+        capture_output: bool = False,
+        text: bool = False,
+        check: bool = False,
+        cwd: str | None = None,
+    ) -> SimpleNamespace:
+        del capture_output, text, check, cwd
+        if cmd[:3] == ["gh", "issue", "view"]:
+            issue_number = int(cmd[3])
+            state = "OPEN" if issue_number == 2712 else "CLOSED"
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"number": issue_number, "state": state}),
+                stderr="",
+            )
+
+        assert cmd[:4] == [sys.executable, "-m", "aragora.cli.main", "swarm"]
+        with metrics_path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "issue_number": 2712,
+                        "issue_title": "Open issue",
+                        "worker_status": "completed",
+                        "worker_outcome": "pr_adopted",
+                        "publish_action": "pr_created",
+                        "terminal_class": "deliverable_pr_created",
+                    }
+                )
+                + "\n"
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    summary = mod.run_recurrence(
+        corpus_path=corpus_path,
+        repo="synaptent/aragora",
+        metrics_file=metrics_path,
+        runner=runner,
+    )
+
+    assert summary["open_issue_numbers"] == [2712]
+    assert summary["closed_issue_numbers"] == [1064]
+    assert summary["synthetic_resolved_issue_numbers"] == [1064]
+    assert summary["recorded_issue_numbers"] == [1064, 2712]
+    assert summary["missing_issue_numbers"] == []
+    assert summary["rotated_metrics"]["archived_existing_file"] is True
+    archived_path = Path(str(summary["rotated_metrics"]["archive_path"]))
+    assert archived_path.exists()
+
+    payloads = _load_metrics(metrics_path)
+    assert [payload["issue_number"] for payload in payloads] == [1064, 2712]
+    assert payloads[0]["terminal_class"] == "issue_already_resolved"
+    assert payloads[1]["terminal_class"] == "deliverable_pr_created"
+
+
+def test_run_recurrence_raises_when_open_issue_still_missing_from_metrics(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 8,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 2712, "title": "Open issue"}],
+        },
+    )
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text("", encoding="utf-8")
+
+    def fake_append_iteration_metrics(
+        *,
+        metrics_jsonl_path: str | None,
+        outcome_learner_window: int,
+        deferred_queue_depth: int,
+        iteration: int,
+        issue_number: int | None,
+        worker_result: dict[str, object],
+        elapsed_seconds: float,
+        files_changed: int,
+        tests_run: int,
+        tests_passed: int,
+    ) -> None:
+        del metrics_jsonl_path, outcome_learner_window, deferred_queue_depth, iteration
+        del issue_number, worker_result, elapsed_seconds, files_changed, tests_run, tests_passed
+
+    monkeypatch.setattr(mod, "append_iteration_metrics", fake_append_iteration_metrics)
+
+    def runner(
+        cmd: list[str],
+        *,
+        capture_output: bool = False,
+        text: bool = False,
+        check: bool = False,
+        cwd: str | None = None,
+    ) -> SimpleNamespace:
+        del capture_output, text, check, cwd
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"number": 2712, "state": "OPEN"}),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with pytest.raises(RuntimeError, match="missing issue numbers 2712"):
+        mod.run_recurrence(
+            corpus_path=corpus_path,
+            repo="synaptent/aragora",
+            metrics_file=metrics_path,
+            runner=runner,
+        )


### PR DESCRIPTION
## Summary
- run the frozen benchmark corpus before the recurring publish step
- write explicit `issue_already_resolved` metrics rows for closed corpus issues so coverage stays row-level and truthful
- fail fast if the refreshed metrics window is still missing any corpus issue

## Testing
- python3 -m pytest tests/scripts/test_run_benchmark_corpus_recurrence.py -q
- python3 -m ruff check scripts/run_benchmark_corpus_recurrence.py tests/scripts/test_run_benchmark_corpus_recurrence.py
- python3 scripts/run_benchmark_corpus_recurrence.py --help
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5675