### PR TITLE
fix(swarm): allow preflight admission inside boss event loops

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import hashlib
@@ -21,6 +20,7 @@ from aragora.swarm.mission import GateEvaluation, GateType, GateVerdict, Mission
 from aragora.swarm.terminal_truth import TerminalClass, classify_preflight_failure
 from aragora.swarm.worker_contract import WorkerContract, checksum_contract_payload
 from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher, WorkerProcess
+from aragora.utils.async_utils import run_async
 
 _PREFLIGHT_RECEIPT_SCHEMA_VERSION = 1
 _PREFLIGHT_TTL_SECONDS = {
@@ -1659,14 +1659,15 @@ def run_preflight(
         )
         worktree_created = True
 
-        worker = asyncio.run(
+        worker = run_async(
             _run_worker(
                 repo_root=resolved_repo_root,
                 worktree_path=worktree_path,
                 branch=branch,
                 agent=normalized_agent,
                 contract=expected_contract,
-            )
+            ),
+            timeout=900.0,
         )
         dispatch_gate = _validate_worker_contract(worker)
         if expected_contract is not None:

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
@@ -122,6 +123,46 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
         result.worker["worker_contract"]
     )
     assert cleanup_commands[0] == ["git", "worktree", "remove", "--force", str(expected_worktree)]
+    assert cleanup_commands[1] == ["git", "branch", "-D", branch]
+
+
+@pytest.mark.asyncio
+async def test_run_preflight_succeeds_inside_running_event_loop(
+    monkeypatch, tmp_path: Path
+) -> None:
+    branch = "preflight/20260414-async-loop"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    commands: list[list[str]] = []
+    cleanup_commands: list[list[str]] = []
+
+    async def fake_run_worker(**_: object) -> WorkerProcess:
+        await asyncio.sleep(0)
+        return _worker(branch=branch)
+
+    def fake_run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
+        commands.append(list(cmd))
+
+    def fake_subprocess_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        cleanup_commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod, "_branch_name", lambda: branch)
+    monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
+    monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+
+    result = mod.run_preflight(
+        repo_root=repo_root,
+        agent="codex",
+        base_ref="main",
+        skip_publication=True,
+    )
+
+    assert result.passed is True
+    assert result.worker["branch"] == branch
+    assert commands[0][:4] == ["git", "worktree", "add", "-b"]
+    assert cleanup_commands[0][:4] == ["git", "worktree", "remove", "--force"]
     assert cleanup_commands[1] == ["git", "branch", "-D", branch]
 
 


### PR DESCRIPTION
## Summary
- switch preflight worker execution from raw `asyncio.run()` to Aragora's `run_async()` bridge
- keep the sync preflight API intact while allowing it to be called from inside the boss loop's active event loop
- add a regression test covering `run_preflight()` invoked from an async test context

## Why
Boss dispatch against issue #5680 was failing before any work started because preflight receipt admission hit:
- `contract_preflight: asyncio.run() cannot be called from a running event loop`

This patch removes that nested-loop failure so receipt admission can run inside boss-loop dispatch.

## Validation
- `python3 -m ruff check aragora/swarm/preflight.py tests/swarm/test_preflight.py`
- `python3 -m pytest tests/swarm/test_preflight.py tests/swarm/test_dispatch_contract_gate.py -q`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
