### PR TITLE
fix(swarm): align preflight contract receipt admission

### DIFF
--- a/aragora/swarm/dispatch_contract_gate.py
+++ b/aragora/swarm/dispatch_contract_gate.py
@@ -17,6 +17,7 @@ from aragora.swarm.preflight import (
 from aragora.swarm.terminal_truth import TerminalClass, classify_preflight_failure
 from aragora.swarm.worker_contract import WorkerContract, build_worker_contract
 from aragora.swarm.worker_process import LaunchConfig
+from aragora.swarm.worker_launcher import build_worker_runtime_env
 
 
 def _target_agent(
@@ -128,6 +129,18 @@ def _preview_work_orders(spec: Any) -> list[dict[str, Any]]:
                 str(path).strip()
                 for path in getattr(spec, "file_scope_hints", [])
                 if str(path).strip()
+            ],
+            "mission_id": str(getattr(spec, "mission_id", "") or "").strip(),
+            "stage_id": str(getattr(spec, "stage_id", "") or "").strip(),
+            "assertion_ids": [
+                str(entry).strip()
+                for entry in getattr(spec, "assertion_ids", [])
+                if str(entry).strip()
+            ],
+            "evidence_expectations": [
+                str(entry).strip()
+                for entry in getattr(spec, "evidence_expectations", [])
+                if str(entry).strip()
             ],
             "expected_tests": [],
             "mission_context_policies": dict(getattr(spec, "mission_context_policies", {}) or {}),
@@ -375,6 +388,15 @@ def dispatch_contract_gate(
     missing_slices = _missing_slices(loop, envelope=envelope, target_agent=target_agent)
     required_receipts: list[str] = []
     preflight_receipts: list[dict[str, Any]] = []
+    preview_contract_env = build_worker_runtime_env(
+        agent=target_agent,
+        worker_env_overrides=worker_env,
+        claude_profile=(
+            str((selected_runner or {}).get("profile", "")).strip() or None
+            if target_agent == "claude"
+            else None
+        ),
+    )
     launch_config = LaunchConfig(
         base_branch=loop.config.target_branch,
         execution_mode=loop.config.execution_mode,
@@ -396,7 +418,7 @@ def dispatch_contract_gate(
                 agent=target_agent,
                 config=launch_config,
                 worktree_path=str(Path.cwd()),
-                env=preview_env,
+                env=preview_contract_env,
                 work_order=work_order,
             )
             contract.validate()

--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -1412,13 +1412,11 @@ def _work_order(agent: str, *, contract: WorkerContract | None = None) -> dict[s
         "receipt",
     ]
     if contract is not None:
-        mission_id = str(contract.mission_id or "").strip() or mission_id
-        stage_id = str(contract.stage_id or "").strip() or stage_id
+        mission_id = str(contract.mission_id or "").strip()
+        stage_id = str(contract.stage_id or "").strip()
         assertion_ids = [
             str(item).strip() for item in list(contract.assertion_ids or []) if str(item).strip()
         ]
-        if not assertion_ids:
-            assertion_ids = ["RS-PREFLIGHT-ASSERT-1"]
         evidence_expectations = [
             str(item).strip()
             for item in list(contract.evidence_expectations or [])

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -18,7 +18,7 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import Any
+from typing import Any, Mapping
 
 from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.security.capability_gate import (
@@ -71,6 +71,42 @@ def _strip_github_tokens(env: dict[str, str]) -> None:
         "GITHUB_ENTERPRISE_TOKEN",
     ):
         env.pop(key, None)
+
+
+def build_worker_runtime_env(
+    *,
+    agent: str,
+    worker_env_overrides: Mapping[str, str] | None = None,
+    claude_profile: str | None = None,
+    base_env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build the worker runtime environment used for contract emission.
+
+    The dispatch preview path uses the same helper so contract checksums match
+    the environment the launcher will actually hand to the worker process.
+    """
+
+    overrides = {
+        str(key).strip(): str(value)
+        for key, value in dict(worker_env_overrides or {}).items()
+        if str(key).strip()
+    }
+    normalized_agent = str(agent or "").strip().lower()
+    if normalized_agent == "claude":
+        effective_profile = str(claude_profile or "").strip()
+        if effective_profile and "ARAGORA_CLAUDE_PROFILE" not in overrides:
+            overrides["ARAGORA_CLAUDE_PROFILE"] = effective_profile
+
+    worker_env = dict(base_env or os.environ)
+    _strip_github_tokens(worker_env)
+    if normalized_agent == "codex":
+        codex_home = Path.home() / ".codex"
+        if (codex_home / "auth.json").exists():
+            worker_env["CODEX_HOME"] = str(codex_home)
+    if overrides:
+        worker_env.update(overrides)
+    _strip_github_tokens(worker_env)
+    return worker_env
 
 
 class WorkerLauncher:
@@ -142,29 +178,11 @@ class WorkerLauncher:
             worktree_path,
         )
         raw_worker_env = metadata.get("worker_env", {}) if isinstance(metadata, dict) else {}
-        worker_env_overrides = {
-            str(key).strip(): str(value)
-            for key, value in dict(raw_worker_env or {}).items()
-            if str(key).strip()
-        }
-        if agent == "claude":
-            effective_profile = profile_override or self.config.claude_profile
-            if effective_profile and "ARAGORA_CLAUDE_PROFILE" not in worker_env_overrides:
-                worker_env_overrides["ARAGORA_CLAUDE_PROFILE"] = effective_profile
-
-        # Codex CLI multi-agent mode creates isolated config dirs that lack
-        # auth credentials.  Pin CODEX_HOME to the user's main config so
-        # workers can authenticate.  Claude Code doesn't use this var.
-        worker_env = dict(os.environ)
-        _strip_github_tokens(worker_env)
-        if agent == "codex":
-            codex_home = Path.home() / ".codex"
-            if (codex_home / "auth.json").exists():
-                worker_env["CODEX_HOME"] = str(codex_home)
-        if worker_env_overrides:
-            worker_env.update(worker_env_overrides)
-        # Allow task-scoped overrides, but keep GitHub auth out of worker envs.
-        _strip_github_tokens(worker_env)
+        worker_env = build_worker_runtime_env(
+            agent=agent,
+            worker_env_overrides=raw_worker_env,
+            claude_profile=profile_override or self.config.claude_profile,
+        )
 
         contract = build_worker_contract(
             agent=agent,

--- a/tests/swarm/test_dispatch_contract_gate.py
+++ b/tests/swarm/test_dispatch_contract_gate.py
@@ -291,6 +291,131 @@ class TestDispatchContractGate:
 
         assert result is None
 
+    def test_preview_contract_uses_worker_runtime_env(self, tmp_path) -> None:
+        """Preview contract checksum must use the launcher's runtime env normalization."""
+        loop = _make_loop()
+        issue = _make_issue(11)
+        spec = MagicMock()
+        spec.work_orders = None
+        spec.file_scope_hints = ["aragora/swarm/preflight.py"]
+        spec.mission_context_policies = {}
+        runtime_env = {"CODEX_HOME": "/tmp/codex-home", "CODEX_COMMAND": "codex"}
+
+        def fake_build_worker_contract(**kwargs):
+            assert kwargs["env"] == runtime_env
+            return _make_valid_contract_mock()
+
+        with (
+            patch(
+                "aragora.swarm.dispatch_contract_gate.build_worker_runtime_env",
+                return_value=runtime_env,
+            ) as mock_runtime_env,
+            patch(
+                "aragora.swarm.dispatch_contract_gate.build_worker_contract",
+                side_effect=fake_build_worker_contract,
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate._persist_preview_contract",
+                return_value=tmp_path / "contract.json",
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate.run_contract_preflight_receipt",
+                return_value=_make_passing_receipt(),
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate.CredentialEnvelope.from_environment"
+            ) as mock_env,
+        ):
+            mock_env.return_value.missing_slices.return_value = []
+            mock_env.return_value.preflight_cache_payload.return_value = {}
+
+            result = dispatch_contract_gate(
+                loop,
+                issue,
+                spec,
+                selected_runner={"runner_type": "codex", "profile": "default"},
+                requested_target_agent="codex",
+                worker_env={"CODEX_COMMAND": "codex"},
+                claimed_runner_id=None,
+            )
+
+        assert result is None
+        mock_runtime_env.assert_called_once()
+
+    def test_preview_contract_fallback_preserves_spec_mission_lineage(self, tmp_path) -> None:
+        """Specs without explicit work_orders must still carry mission lineage into the preview contract."""
+        loop = _make_loop()
+        issue = _make_issue(12)
+        spec = MagicMock()
+        spec.work_orders = None
+        spec.file_scope_hints = ["github/workflows/benchmark-truth-publication.yml"]
+        spec.mission_id = "mission-tw02"
+        spec.stage_id = "stage-benchmark-publication"
+        spec.assertion_ids = ["TW-02-ASSERT-1"]
+        spec.evidence_expectations = ["worker_contract", "worker_contract_checksum"]
+        spec.mission_context_policies = {
+            "worker": {
+                "role": "worker",
+                "allowed_artifact_classes": ["file_scope"],
+                "max_source_count": 4,
+                "max_chars": 12000,
+                "freshness_ttl_seconds": 3600,
+                "transcript_allowance": "none",
+                "required_sources": ["github/workflows/benchmark-truth-publication.yml"],
+                "forbidden_sources": ["raw_worker_transcript"],
+            }
+        }
+        captured: dict[str, object] = {}
+
+        def fake_build_worker_contract(**kwargs):
+            captured["work_order"] = kwargs["work_order"]
+            return _make_valid_contract_mock()
+
+        with (
+            patch(
+                "aragora.swarm.dispatch_contract_gate.build_worker_runtime_env",
+                return_value={"CODEX_HOME": "/tmp/codex-home"},
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate.build_worker_contract",
+                side_effect=fake_build_worker_contract,
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate._persist_preview_contract",
+                return_value=tmp_path / "contract.json",
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate.run_contract_preflight_receipt",
+                return_value=_make_passing_receipt(),
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate.CredentialEnvelope.from_environment"
+            ) as mock_env,
+        ):
+            mock_env.return_value.missing_slices.return_value = []
+            mock_env.return_value.preflight_cache_payload.return_value = {}
+
+            result = dispatch_contract_gate(
+                loop,
+                issue,
+                spec,
+                selected_runner={"runner_type": "codex"},
+                requested_target_agent="codex",
+                worker_env=None,
+                claimed_runner_id=None,
+            )
+
+        assert result is None
+        assert captured["work_order"] == {
+            "file_scope": ["github/workflows/benchmark-truth-publication.yml"],
+            "mission_id": "mission-tw02",
+            "stage_id": "stage-benchmark-publication",
+            "assertion_ids": ["TW-02-ASSERT-1"],
+            "evidence_expectations": ["worker_contract", "worker_contract_checksum"],
+            "expected_tests": [],
+            "mission_context_policies": spec.mission_context_policies,
+        }
+
     def test_missing_slices_returns_blocked_outcome(self, tmp_path) -> None:
         """Missing credential slices block dispatch before preflight."""
         loop = _make_loop()

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -12,8 +12,13 @@ from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.mission import GateType, GateVerdict
 from aragora.swarm import preflight as mod
 from aragora.swarm.terminal_truth import TerminalClass
-from aragora.swarm.worker_contract import checksum_contract_payload
-from aragora.swarm.worker_process import WorkerProcess
+from aragora.swarm.worker_contract import (
+    WorkerContract,
+    build_worker_contract,
+    checksum_contract_payload,
+)
+from aragora.swarm.worker_launcher import build_worker_runtime_env
+from aragora.swarm.worker_process import LaunchConfig, WorkerProcess
 
 
 def _worker(*, branch: str, checksum: str | None = None) -> WorkerProcess:
@@ -448,6 +453,29 @@ def test_run_preflight_rejects_emitted_contract_drift(monkeypatch, tmp_path: Pat
         )
 
     assert cleanup_commands[0][:4] == ["git", "worktree", "remove", "--force"]
+
+
+def test_contract_preflight_work_order_roundtrips_empty_lineage(tmp_path: Path) -> None:
+    contract_payload = _worker(branch="preflight/20260414-empty-lineage").worker_contract
+    contract_payload["mission_id"] = ""
+    contract_payload["stage_id"] = ""
+    contract_payload["assertion_ids"] = []
+    contract = WorkerContract.from_dict(contract_payload)
+
+    round_tripped = build_worker_contract(
+        agent="codex",
+        config=LaunchConfig(
+            allow_claude_dangerously_skip_permissions=True,
+            allow_codex_full_auto=True,
+        ),
+        worktree_path=str(tmp_path),
+        env=build_worker_runtime_env(agent="codex"),
+        work_order=mod._work_order("codex", contract=contract),
+    )
+
+    assert round_tripped.mission_id == ""
+    assert round_tripped.stage_id == ""
+    assert round_tripped.assertion_ids == []
 
 
 def test_run_contract_preflight_receipt_persists_and_returns_receipt(


### PR DESCRIPTION
## Summary
- normalize preview contracts with the same worker runtime env the launcher uses
- preserve mission lineage in fallback preview work orders and stop preflight from inventing lineage defaults when checking an expected contract
- add regressions for the preview-contract env path and the empty-lineage preflight case

## Validation
- python3 -m pytest tests/swarm/test_dispatch_contract_gate.py tests/swarm/test_preflight.py -q
- python3 -m ruff check aragora/swarm/preflight.py aragora/swarm/dispatch_contract_gate.py aragora/swarm/worker_launcher.py tests/swarm/test_dispatch_contract_gate.py tests/swarm/test_preflight.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 -m aragora.cli.main swarm boss-loop --boss-repo synaptent/aragora --label autonomous --label boss-ready --boss-issue-number 5680 --max-ticks 1 --autonomy full-auto --worker-model codex --review-model codex --no-wait --json

## Outcome
Before this patch, #5680 failed preflight receipt admission because the worker contract drifted from the expected contract. After this patch, the same direct retry moved past contract admission and failed later on a different blocker: the preflight worker did not produce a commit.
