### PR TITLE
fix(benchmarks): fail closed on missing corpus truth

### DIFF
--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -21,6 +21,7 @@ from scripts.reconcile_b0_pr_truth import (  # noqa: E402
     DEFAULT_METRICS_PATH,
     GitHubTruthClient,
     IssueMetricsAggregate,
+    IssueTruthRecord,
     reconcile_issue_truth,
     report_to_json as _unused_report_to_json,
     resolve_metrics_path,
@@ -212,7 +213,22 @@ def build_benchmark_truth_artifact(
     membership_issue_numbers = _corpus_issue_numbers(corpus)
     aggregates = aggregate_corpus_issues(rows, corpus)
     truth_client = client or GitHubTruthClient()
-    records = [reconcile_issue_truth(repo, aggregate, truth_client) for aggregate in aggregates]
+    records: list[IssueTruthRecord] = []
+    for aggregate in aggregates:
+        if aggregate.row_count <= 0:
+            records.append(
+                IssueTruthRecord(
+                    issue_number=aggregate.issue_number,
+                    issue_title=aggregate.title,
+                    proxy_pr_signal=False,
+                    had_rescue=False,
+                    truth_state="not_attempted",
+                    truth_success=False,
+                    no_rescue_truth_success=False,
+                )
+            )
+            continue
+        records.append(reconcile_issue_truth(repo, aggregate, truth_client))
     corpus_issue_count = len(aggregates)
     attempted_issue_count = sum(1 for aggregate in aggregates if aggregate.row_count > 0)
     truth_success_issue_count = sum(1 for record in records if record.truth_success)

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -192,6 +192,76 @@ def test_build_benchmark_truth_artifact_marks_partial_corpus_runs_incomplete(
     assert artifact["coverage"]["missing_issue_numbers"] == [873]
     assert artifact["coverage"]["is_complete"] is False
     assert artifact["primary_metrics"]["truth_success_rate"] == 0.5
+    assert [issue["truth_state"] for issue in artifact["issues"]] == ["not_attempted", "merged_pr"]
+
+
+def test_build_benchmark_truth_artifact_does_not_count_historical_truth_for_unattempted_issues(
+    tmp_path: Path,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        json.dumps(
+            {
+                "issue_number": 1064,
+                "issue_title": "Dependency bump",
+                "terminal_class": "rescue_worker_crash",
+                "worker_outcome": "crash",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 4,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [
+                {"issue_id": 1064, "title": "Dependency bump"},
+                {"issue_id": 873, "title": "ESLint bump"},
+            ],
+        },
+    )
+    client = FakeGitHubTruthClient(
+        issues={
+            1064: {"title": "Dependency bump", "comments": []},
+            873: {
+                "title": "ESLint bump",
+                "comments": [{"body": "PR: https://github.com/synaptent/aragora/pull/6001"}],
+            },
+        },
+        prs={
+            6001: {
+                "number": 6001,
+                "title": "merged fix",
+                "url": "https://github.com/synaptent/aragora/pull/6001",
+                "state": "MERGED",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": "2026-04-13T12:00:00Z",
+                "isDraft": False,
+            }
+        },
+    )
+
+    artifact = mod.build_benchmark_truth_artifact(
+        repo="synaptent/aragora",
+        metrics_file=metrics_path,
+        corpus_path=corpus_path,
+        client=client,
+        generated_at="2026-04-14T01:00:00Z",
+    )
+
+    assert artifact["run_status"] == "incomplete"
+    assert artifact["coverage"]["missing_issue_numbers"] == [873]
+    assert artifact["primary_metrics"]["truth_success_rate"] == 0.0
+    assert artifact["primary_metrics"]["no_rescue_truth_success_rate"] == 0.0
+    assert [issue["truth_state"] for issue in artifact["issues"]] == [
+        "not_attempted",
+        "no_linked_pr",
+    ]
 
 
 def test_main_fail_incomplete_returns_nonzero_and_emits_artifact(


### PR DESCRIPTION
## Summary
- stop benchmark truth artifacts from reconciling GitHub success for corpus issues with no current metrics rows
- mark unattempted corpus entries as `not_attempted` so incomplete runs fail closed instead of inflating success
- cover the partial-coverage overclaim case in the benchmark artifact tests

## Validation
- python3 -m pytest tests/scripts/test_build_benchmark_truth_artifact.py -q
- python3 -m pytest tests/scripts/test_measure_b0_scorecard.py -q
- python3 -m pytest tests/scripts/test_run_benchmark_corpus_recurrence.py -q
- ruff check scripts/build_benchmark_truth_artifact.py tests/scripts/test_build_benchmark_truth_artifact.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD