### PR TITLE
fix(swarm): run preflight workers in owned worktrees

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -1389,15 +1389,6 @@ def _worktree_path(repo_root: Path, branch: str) -> Path:
 
 
 def _preflight_filename(contract: WorkerContract | None = None) -> str:
-    if contract is not None:
-        policy = dict(contract.mission_context_policy or {})
-        required_sources = [
-            str(item).strip()
-            for item in list(policy.get("required_sources", []) or [])
-            if str(item).strip()
-        ]
-        if required_sources:
-            return required_sources[0]
     return "scratch/preflight_worker_check.txt"
 
 
@@ -1412,6 +1403,12 @@ def _work_order(agent: str, *, contract: WorkerContract | None = None) -> dict[s
         "receipt",
     ]
     if contract is not None:
+        policy = dict(contract.mission_context_policy or {})
+        required_sources = [
+            str(item).strip()
+            for item in list(policy.get("required_sources", []) or [])
+            if str(item).strip()
+        ]
         mission_id = str(contract.mission_id or "").strip()
         stage_id = str(contract.stage_id or "").strip()
         assertion_ids = [
@@ -1422,6 +1419,18 @@ def _work_order(agent: str, *, contract: WorkerContract | None = None) -> dict[s
             for item in list(contract.evidence_expectations or [])
             if str(item).strip()
         ] or evidence_expectations
+    description = (
+        f"Create a file named `{filename}` with a single line "
+        "timestamp. Commit it with message `chore: preflight worker check`. "
+        "Do not modify any other files."
+    )
+    if contract is not None and required_sources:
+        quoted_sources = ", ".join(f"`{item}`" for item in required_sources)
+        description = (
+            f"Read the required source files {quoted_sources} to confirm access, then "
+            + description
+        )
+
     return {
         "work_order_id": f"preflight-{int(time.time())}",
         "target_agent": agent,
@@ -1437,11 +1446,7 @@ def _work_order(agent: str, *, contract: WorkerContract | None = None) -> dict[s
         "title": "Contract-aware preflight worker check"
         if contract is not None
         else "Preflight worker check",
-        "description": (
-            f"Create a file named `{filename}` with a single line "
-            "timestamp. Commit it with message `chore: preflight worker check`. "
-            "Do not modify any other files."
-        ),
+        "description": description,
         "file_scope": [filename],
         "expected_tests": [],
         "metadata": {"admin_approved": True},
@@ -1459,6 +1464,11 @@ async def _run_worker(
     config = LaunchConfig(
         allow_claude_dangerously_skip_permissions=True,
         allow_codex_full_auto=True,
+        # Preflight already provisions and owns the disposable worktree.
+        # Wrapping the worker in codex_session.sh tries to create another
+        # managed worktree on top of it and fails before any commit happens.
+        use_managed_session_script=False,
+        require_explicit_approval=False,
     )
     launcher = WorkerLauncher(config=config)
     work_order = _work_order(agent, contract=contract)

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -478,6 +478,56 @@ def test_contract_preflight_work_order_roundtrips_empty_lineage(tmp_path: Path) 
     assert round_tripped.assertion_ids == []
 
 
+def test_contract_preflight_uses_scratch_output_not_required_source() -> None:
+    contract_payload = _worker(branch="preflight/20260415-required-source").worker_contract
+    contract_payload["mission_context_policy"]["required_sources"] = [
+        "github/workflows/benchmark-truth-publication.yml",
+        "workflow/action",
+    ]
+    contract = WorkerContract.from_dict(contract_payload)
+
+    work_order = mod._work_order("codex", contract=contract)
+
+    assert work_order["file_scope"] == ["scratch/preflight_worker_check.txt"]
+    assert "Read the required source files" in str(work_order["description"])
+    assert "`github/workflows/benchmark-truth-publication.yml`" in str(work_order["description"])
+    assert "Create a file named `scratch/preflight_worker_check.txt`" in str(
+        work_order["description"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_worker_disables_managed_session_wrapper(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeLauncher:
+        def __init__(self, config: LaunchConfig) -> None:
+            captured["config"] = config
+
+        async def launch_and_wait(
+            self, work_order: dict[str, object], **kwargs: object
+        ) -> WorkerProcess:
+            captured["work_order"] = work_order
+            captured["kwargs"] = kwargs
+            return _worker(branch=str(kwargs["branch"]))
+
+    monkeypatch.setattr(mod, "WorkerLauncher", FakeLauncher)
+
+    result = await mod._run_worker(
+        repo_root=tmp_path,
+        worktree_path=tmp_path / "worktree",
+        branch="preflight/20260415-direct-launch",
+        agent="codex",
+        contract=None,
+    )
+
+    config = captured["config"]
+    assert isinstance(config, LaunchConfig)
+    assert config.use_managed_session_script is False
+    assert config.require_explicit_approval is False
+    assert isinstance(result, WorkerProcess)
+
+
 def test_run_contract_preflight_receipt_persists_and_returns_receipt(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- keep contract-aware preflight scratch output separate from required source inputs
- launch preflight workers directly inside the owned disposable worktree instead of re-entering the managed session wrapper
- add regression coverage for scratch output selection and direct worker launch config

## Validation
- python3 -m ruff check aragora/swarm/preflight.py tests/swarm/test_preflight.py
- python3 -m pytest tests/swarm/test_preflight.py tests/swarm/test_dispatch_contract_gate.py -q
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Unblocks #5680