### PR TITLE
fix(ci): seed benchmark publication metrics from runner state

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -57,7 +57,22 @@ jobs:
         shell: bash
         run: |
           command -v gh >/dev/null
-          test -f .aragora/overnight/boss_metrics.jsonl
+          METRICS_PATH=".aragora/overnight/boss_metrics.jsonl"
+          if [[ ! -f "$METRICS_PATH" ]]; then
+            for candidate in \
+              "$HOME/.aragora/overnight/boss_metrics.jsonl" \
+              ".aragora/boss_metrics.jsonl" \
+              "$HOME/.aragora/boss_metrics.jsonl"
+            do
+              if [[ -f "$candidate" ]]; then
+                mkdir -p "$(dirname "$METRICS_PATH")"
+                cp "$candidate" "$METRICS_PATH"
+                echo "::notice::Seeded repo-local benchmark metrics from $candidate"
+                break
+              fi
+            done
+          fi
+          test -f "$METRICS_PATH"
 
       - name: Refresh recurring benchmark corpus metrics
         env:

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def _benchmark_truth_publication_run() -> str:
+    workflow_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "benchmark-truth-publication.yml"
+    )
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    jobs = workflow.get("jobs", {})
+    publish_job = jobs.get("publish-benchmark-truth", {})
+    steps = publish_job.get("steps", [])
+    for step in steps:
+        if step.get("name") == "Verify runtime prerequisites":
+            return str(step.get("run", ""))
+    raise AssertionError("Verify runtime prerequisites step not found")
+
+
+def test_runtime_prereq_recovers_repo_local_metrics_from_runner_paths() -> None:
+    run = _benchmark_truth_publication_run()
+    assert 'METRICS_PATH=".aragora/overnight/boss_metrics.jsonl"' in run
+    assert '"$HOME/.aragora/overnight/boss_metrics.jsonl"' in run
+    assert '".aragora/boss_metrics.jsonl"' in run
+    assert '"$HOME/.aragora/boss_metrics.jsonl"' in run
+    assert 'cp "$candidate" "$METRICS_PATH"' in run
+    assert 'test -f "$METRICS_PATH"' in run


### PR DESCRIPTION
## Summary
- seed the repo-local benchmark metrics file from runner-local fallback paths before the publication workflow fails closed
- keep the runtime prerequisite guard strict by still requiring the repo-local overnight metrics path after recovery
- add a focused regression test that locks the benchmark publication workflow's metrics recovery contract into the tree

## Validation
- python3 -m pytest tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_check_branch_mutation_policy.py -q
- python3 -m ruff check tests/scripts/test_benchmark_truth_publication_workflow.py
- python3 scripts/check_branch_mutation_policy.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5703