### PR TITLE
fix(ci): allow benchmark recurrence to create metrics window

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -58,21 +58,10 @@ jobs:
         run: |
           command -v gh >/dev/null
           METRICS_PATH=".aragora/overnight/boss_metrics.jsonl"
+          mkdir -p "$(dirname "$METRICS_PATH")"
           if [[ ! -f "$METRICS_PATH" ]]; then
-            for candidate in \
-              "$HOME/.aragora/overnight/boss_metrics.jsonl" \
-              ".aragora/boss_metrics.jsonl" \
-              "$HOME/.aragora/boss_metrics.jsonl"
-            do
-              if [[ -f "$candidate" ]]; then
-                mkdir -p "$(dirname "$METRICS_PATH")"
-                cp "$candidate" "$METRICS_PATH"
-                echo "::notice::Seeded repo-local benchmark metrics from $candidate"
-                break
-              fi
-            done
+            echo "::notice::No repo-local benchmark metrics snapshot found; recurrence will generate a fresh window"
           fi
-          test -f "$METRICS_PATH"
 
       - name: Refresh recurring benchmark corpus metrics
         env:

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -22,11 +22,9 @@ def _benchmark_truth_publication_run() -> str:
     raise AssertionError("Verify runtime prerequisites step not found")
 
 
-def test_runtime_prereq_recovers_repo_local_metrics_from_runner_paths() -> None:
+def test_runtime_prereq_creates_metrics_dir_and_allows_fresh_recurrence() -> None:
     run = _benchmark_truth_publication_run()
     assert 'METRICS_PATH=".aragora/overnight/boss_metrics.jsonl"' in run
-    assert '"$HOME/.aragora/overnight/boss_metrics.jsonl"' in run
-    assert '".aragora/boss_metrics.jsonl"' in run
-    assert '"$HOME/.aragora/boss_metrics.jsonl"' in run
-    assert 'cp "$candidate" "$METRICS_PATH"' in run
-    assert 'test -f "$METRICS_PATH"' in run
+    assert 'mkdir -p "$(dirname "$METRICS_PATH")"' in run
+    assert "recurrence will generate a fresh window" in run
+    assert 'test -f "$METRICS_PATH"' not in run


### PR DESCRIPTION
## Summary
- stop the benchmark publication workflow from requiring a preexisting repo-local metrics file before recurrence starts
- keep the prerequisite step limited to Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` availability and metrics-directory setup
- update the workflow regression test to reflect that recurrence, not the prerequisite step, owns fresh metrics-window creation

## Validation
- python3 -m pytest tests/scripts/test_run_benchmark_corpus_recurrence.py tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_check_branch_mutation_policy.py -q
- python3 -m ruff check tests/scripts/test_benchmark_truth_publication_workflow.py
- python3 scripts/check_branch_mutation_policy.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5705