### PR TITLE
fix(ci): install deps before benchmark recurrence

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install -e ".[dev]" --quiet 2>/dev/null || python -m pip install -e . --quiet
+
       - name: Verify runtime prerequisites
         shell: bash
         run: |

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -22,9 +22,35 @@ def _benchmark_truth_publication_run() -> str:
     raise AssertionError("Verify runtime prerequisites step not found")
 
 
+def _benchmark_truth_publication_steps() -> list[dict[str, object]]:
+    workflow_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "benchmark-truth-publication.yml"
+    )
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    jobs = workflow.get("jobs", {})
+    publish_job = jobs.get("publish-benchmark-truth", {})
+    steps = publish_job.get("steps", [])
+    if not isinstance(steps, list):
+        raise AssertionError("publish-benchmark-truth steps not found")
+    return [step for step in steps if isinstance(step, dict)]
+
+
 def test_runtime_prereq_creates_metrics_dir_and_allows_fresh_recurrence() -> None:
     run = _benchmark_truth_publication_run()
     assert 'METRICS_PATH=".aragora/overnight/boss_metrics.jsonl"' in run
     assert 'mkdir -p "$(dirname "$METRICS_PATH")"' in run
     assert "recurrence will generate a fresh window" in run
     assert 'test -f "$METRICS_PATH"' not in run
+
+
+def test_installs_dependencies_before_recurrence() -> None:
+    steps = _benchmark_truth_publication_steps()
+    names = [str(step.get("name", "")) for step in steps]
+    install_index = names.index("Install dependencies")
+    recurrence_index = names.index("Refresh recurring benchmark corpus metrics")
+    assert install_index < recurrence_index
+    install_run = str(steps[install_index].get("run", ""))
+    assert 'python -m pip install -e ".[dev]" --quiet' in install_run


### PR DESCRIPTION
## Summary
- install repo Python dependencies in the benchmark publication workflow before the recurrence script runs on the self-hosted runner
- keep the workflow regression test aligned with the required install-before-recurrence ordering
- preserve the benchmark lane's fail-closed behavior while removing the new import/setup blocker

## Validation
- python3 -m pytest tests/scripts/test_run_benchmark_corpus_recurrence.py tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_check_branch_mutation_policy.py -q
- python3 -m ruff check tests/scripts/test_benchmark_truth_publication_workflow.py
- python3 scripts/check_branch_mutation_policy.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5707