### PR TITLE
fix(ci): install gh for benchmark publication

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -58,6 +58,29 @@ jobs:
         run: |
           python -m pip install -e ".[dev]" --quiet 2>/dev/null || python -m pip install -e . --quiet
 
+      - name: Install GitHub CLI
+        shell: bash
+        run: |
+          arch="$(uname -m)"
+          case "$arch" in
+            x86_64|amd64) gh_arch="amd64" ;;
+            aarch64|arm64) gh_arch="arm64" ;;
+            *)
+              echo "::error::Unsupported architecture for gh install: $arch"
+              exit 1
+              ;;
+          esac
+          gh_version="$(
+            curl -fsSL https://api.github.com/repos/cli/cli/releases/latest |
+              python3 -c 'import json, sys; print(json.load(sys.stdin)["tag_name"].lstrip("v"))'
+          )"
+          gh_root="$RUNNER_TEMP/gh-cli"
+          archive="gh_${gh_version}_linux_${gh_arch}.tar.gz"
+          mkdir -p "$gh_root"
+          curl -fsSL "https://github.com/cli/cli/releases/download/v${gh_version}/${archive}" |
+            tar -xz -C "$gh_root"
+          echo "$gh_root/gh_${gh_version}_linux_${gh_arch}/bin" >> "$GITHUB_PATH"
+
       - name: Verify runtime prerequisites
         shell: bash
         run: |

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -54,3 +54,15 @@ def test_installs_dependencies_before_recurrence() -> None:
     assert install_index < recurrence_index
     install_run = str(steps[install_index].get("run", ""))
     assert 'python -m pip install -e ".[dev]" --quiet' in install_run
+
+
+def test_installs_github_cli_before_runtime_prerequisites() -> None:
+    steps = _benchmark_truth_publication_steps()
+    names = [str(step.get("name", "")) for step in steps]
+    gh_index = names.index("Install GitHub CLI")
+    prereq_index = names.index("Verify runtime prerequisites")
+    assert gh_index < prereq_index
+    gh_run = str(steps[gh_index].get("run", ""))
+    assert "https://api.github.com/repos/cli/cli/releases/latest" in gh_run
+    assert "https://github.com/cli/cli/releases/download/" in gh_run
+    assert 'echo "$gh_root/gh_${gh_version}_linux_${gh_arch}/bin" >> "$GITHUB_PATH"' in gh_run


### PR DESCRIPTION
## Summary
- bootstrap GitHub CLI inside the benchmark publication workflow instead of assuming the self-hosted runner image already has it
- keep the runtime prerequisite check honest by verifying Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` after provisioning it
- extend the workflow regression test so GitHub CLI bootstrap stays ordered ahead of recurrence and publication steps

## Validation
- python3 -m pytest tests/scripts/test_run_benchmark_corpus_recurrence.py tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_check_branch_mutation_policy.py -q
- python3 -m ruff check tests/scripts/test_benchmark_truth_publication_workflow.py
- python3 scripts/check_branch_mutation_policy.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Closes #5709