### PR TITLE
fix(ci): refresh codex runner before benchmark recurrence

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -91,6 +91,44 @@ jobs:
             echo "::notice::No repo-local benchmark metrics snapshot found; recurrence will generate a fresh window"
           fi
 
+      - name: Refresh execution-verified Codex runner
+        shell: bash
+        run: |
+          RUNNER_REPORT="$RUNNER_TEMP/codex-runner-maintain.json"
+          python3 -m aragora.cli.main swarm runner maintain \
+            --runner-type codex \
+            --probe-limit 1 \
+            --json > "$RUNNER_REPORT"
+          python3 - "$RUNNER_REPORT" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          summary = payload.get("summary") or {}
+          if int(summary.get("passed", 0) or 0) < 1:
+              raise SystemExit(
+                  "No Codex runner probe passed during benchmark publication setup."
+              )
+
+          routing = payload.get("routing_after") or {}
+          selected = [
+              item
+              for item in routing.get("selected_runners", [])
+              if isinstance(item, dict)
+          ]
+          verified = [
+              item
+              for item in selected
+              if str(item.get("runner_type", "")).strip() == "codex"
+              and str(item.get("probe_status", "")).strip() == "passed"
+          ]
+          if not verified:
+              raise SystemExit(
+                  "No execution-verified Codex runner selected after refresh."
+              )
+          PY
+
       - name: Refresh recurring benchmark corpus metrics
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -38,6 +38,13 @@ def _benchmark_truth_publication_steps() -> list[dict[str, object]]:
     return [step for step in steps if isinstance(step, dict)]
 
 
+def _workflow_step(name: str) -> dict[str, object]:
+    for step in _benchmark_truth_publication_steps():
+        if str(step.get("name", "")) == name:
+            return step
+    raise AssertionError(f"{name} step not found")
+
+
 def test_runtime_prereq_creates_metrics_dir_and_allows_fresh_recurrence() -> None:
     run = _benchmark_truth_publication_run()
     assert 'METRICS_PATH=".aragora/overnight/boss_metrics.jsonl"' in run
@@ -66,3 +73,19 @@ def test_installs_github_cli_before_runtime_prerequisites() -> None:
     assert "https://api.github.com/repos/cli/cli/releases/latest" in gh_run
     assert "https://github.com/cli/cli/releases/download/" in gh_run
     assert 'echo "$gh_root/gh_${gh_version}_linux_${gh_arch}/bin" >> "$GITHUB_PATH"' in gh_run
+
+
+def test_refreshes_execution_verified_codex_runner_before_recurrence() -> None:
+    steps = _benchmark_truth_publication_steps()
+    names = [str(step.get("name", "")) for step in steps]
+    refresh_index = names.index("Refresh execution-verified Codex runner")
+    recurrence_index = names.index("Refresh recurring benchmark corpus metrics")
+    assert refresh_index < recurrence_index
+
+    run = str(_workflow_step("Refresh execution-verified Codex runner").get("run", ""))
+    assert "python3 -m aragora.cli.main swarm runner maintain" in run
+    assert "--runner-type codex" in run
+    assert "--probe-limit 1" in run
+    assert 'RUNNER_REPORT="$RUNNER_TEMP/codex-runner-maintain.json"' in run
+    assert 'payload.get("routing_after") or {}' in run
+    assert "No execution-verified Codex runner selected after refresh." in run


### PR DESCRIPTION
## Summary
- refresh and verify a Codex runner before recurring benchmark corpus execution starts
- fail early in the workflow when no execution-verified Codex runner is selected
- lock the workflow ordering and command contract with a focused workflow test

## Validation
- `python3 -m pytest tests/scripts/test_benchmark_truth_publication_workflow.py -q`
- `python3 -m ruff check tests/scripts/test_benchmark_truth_publication_workflow.py`
- `python3 -m aragora.cli.main swarm runner maintain --runner-type codex --probe-limit 1 --json`
- `bash scripts/automation_pr_preflight.sh origin/main codex/benchmark-publication-refresh-codex-runner`

Fixes #5711.