### PR TITLE
fix(ci): reuse codex auth home in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -91,6 +91,30 @@ jobs:
             echo "::notice::No repo-local benchmark metrics snapshot found; recurrence will generate a fresh window"
           fi
 
+      - name: Resolve Codex runner auth paths
+        shell: bash
+        run: |
+          RUNNER_USER="${ARAGORA_USER_ID:-${USER:-$(id -un)}}"
+          RUNNER_HOME="$(
+            python3 - "$RUNNER_USER" <<'PY'
+            import pwd
+            import sys
+            from pathlib import Path
+
+            user = str(sys.argv[1] or "").strip()
+            if user:
+                try:
+                    print(pwd.getpwnam(user).pw_dir)
+                    raise SystemExit(0)
+                except KeyError:
+                    pass
+            print(Path.home())
+            PY
+          )"
+          echo "HOME=$RUNNER_HOME" >> "$GITHUB_ENV"
+          echo "CODEX_HOME=$RUNNER_HOME/.codex" >> "$GITHUB_ENV"
+          echo "ARAGORA_RUNNER_REGISTRY_PATH=$RUNNER_HOME/.aragora/swarm_runners.json" >> "$GITHUB_ENV"
+
       - name: Refresh execution-verified Codex runner
         shell: bash
         run: |

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -75,6 +75,24 @@ def test_installs_github_cli_before_runtime_prerequisites() -> None:
     assert 'echo "$gh_root/gh_${gh_version}_linux_${gh_arch}/bin" >> "$GITHUB_PATH"' in gh_run
 
 
+def test_resolves_codex_auth_paths_before_runner_refresh() -> None:
+    steps = _benchmark_truth_publication_steps()
+    names = [str(step.get("name", "")) for step in steps]
+    resolve_index = names.index("Resolve Codex runner auth paths")
+    refresh_index = names.index("Refresh execution-verified Codex runner")
+    assert resolve_index < refresh_index
+
+    run = str(_workflow_step("Resolve Codex runner auth paths").get("run", ""))
+    assert 'RUNNER_USER="${ARAGORA_USER_ID:-${USER:-$(id -un)}}"' in run
+    assert "pwd.getpwnam" in run
+    assert 'echo "HOME=$RUNNER_HOME" >> "$GITHUB_ENV"' in run
+    assert 'echo "CODEX_HOME=$RUNNER_HOME/.codex" >> "$GITHUB_ENV"' in run
+    assert (
+        'echo "ARAGORA_RUNNER_REGISTRY_PATH=$RUNNER_HOME/.aragora/swarm_runners.json" >> "$GITHUB_ENV"'
+        in run
+    )
+
+
 def test_refreshes_execution_verified_codex_runner_before_recurrence() -> None:
     steps = _benchmark_truth_publication_steps()
     names = [str(step.get("name", "")) for step in steps]


### PR DESCRIPTION
## Summary
- resolve the actual self-hosted runner home before Codex probe/recurrence
- export HOME, CODEX_HOME, and the Aragora runner registry path for later workflow steps
- lock the workflow contract with a focused workflow test

## Validation
- `python3 -m pytest tests/scripts/test_benchmark_truth_publication_workflow.py -q`
- `python3 -m ruff check tests/scripts/test_benchmark_truth_publication_workflow.py`
- `bash scripts/automation_pr_preflight.sh origin/main codex/benchmark-publication-codex-auth-home`

Fixes #5713.