### PR TITLE
fix(ci): simplify codex auth path resolution

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -95,22 +95,7 @@ jobs:
         shell: bash
         run: |
           RUNNER_USER="${ARAGORA_USER_ID:-${USER:-$(id -un)}}"
-          RUNNER_HOME="$(
-            python3 - "$RUNNER_USER" <<'PY'
-            import pwd
-            import sys
-            from pathlib import Path
-
-            user = str(sys.argv[1] or "").strip()
-            if user:
-                try:
-                    print(pwd.getpwnam(user).pw_dir)
-                    raise SystemExit(0)
-                except KeyError:
-                    pass
-            print(Path.home())
-            PY
-          )"
+          RUNNER_HOME="$(python3 -c 'import os, pathlib, pwd, sys; user = sys.argv[1].strip() if len(sys.argv) > 1 else ""; print(pwd.getpwnam(user).pw_dir if user and user in {entry.pw_name for entry in pwd.getpwall()} else pathlib.Path.home())' "$RUNNER_USER")"
           echo "HOME=$RUNNER_HOME" >> "$GITHUB_ENV"
           echo "CODEX_HOME=$RUNNER_HOME/.codex" >> "$GITHUB_ENV"
           echo "ARAGORA_RUNNER_REGISTRY_PATH=$RUNNER_HOME/.aragora/swarm_runners.json" >> "$GITHUB_ENV"

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -84,7 +84,9 @@ def test_resolves_codex_auth_paths_before_runner_refresh() -> None:
 
     run = str(_workflow_step("Resolve Codex runner auth paths").get("run", ""))
     assert 'RUNNER_USER="${ARAGORA_USER_ID:-${USER:-$(id -un)}}"' in run
+    assert 'RUNNER_HOME="$(python3 -c' in run
     assert "pwd.getpwnam" in run
+    assert "pwd.getpwall" in run
     assert 'echo "HOME=$RUNNER_HOME" >> "$GITHUB_ENV"' in run
     assert 'echo "CODEX_HOME=$RUNNER_HOME/.codex" >> "$GITHUB_ENV"' in run
     assert (


### PR DESCRIPTION
## Summary
- replace the fragile heredoc-in-command-substitution with a single Python expression for runner-home resolution
- keep exporting HOME, CODEX_HOME, and the Aragora runner registry path before the Codex probe and recurrence steps
- preserve the focused workflow test around the auth-path contract

## Validation
- `python3 -m pytest tests/scripts/test_benchmark_truth_publication_workflow.py -q`
- `python3 -m ruff check tests/scripts/test_benchmark_truth_publication_workflow.py`
- `bash scripts/automation_pr_preflight.sh origin/main codex/benchmark-publication-codex-auth-home-shellfix`

Follow-up to PR #5715 after workflow run 24434792992 failed in `Resolve Codex runner auth paths` on `main`.
