### PR TITLE
fix(ci): surface codex probe failures in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -96,6 +96,7 @@ jobs:
         run: |
           RUNNER_USER="${ARAGORA_USER_ID:-${USER:-$(id -un)}}"
           RUNNER_HOME="$(python3 -c 'import os, pathlib, pwd, sys; user = sys.argv[1].strip() if len(sys.argv) > 1 else ""; print(pwd.getpwnam(user).pw_dir if user and user in {entry.pw_name for entry in pwd.getpwall()} else pathlib.Path.home())' "$RUNNER_USER")"
+          mkdir -p "$RUNNER_HOME/.codex" "$RUNNER_HOME/.aragora"
           echo "HOME=$RUNNER_HOME" >> "$GITHUB_ENV"
           echo "CODEX_HOME=$RUNNER_HOME/.codex" >> "$GITHUB_ENV"
           echo "ARAGORA_RUNNER_REGISTRY_PATH=$RUNNER_HOME/.aragora/swarm_runners.json" >> "$GITHUB_ENV"
@@ -115,12 +116,59 @@ jobs:
 
           payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
           summary = payload.get("summary") or {}
-          if int(summary.get("passed", 0) or 0) < 1:
-              raise SystemExit(
-                  "No Codex runner probe passed during benchmark publication setup."
-              )
-
+          runners = [item for item in payload.get("runners", []) if isinstance(item, dict)]
           routing = payload.get("routing_after") or {}
+
+          def _snapshot(item):
+              return {
+                  "runner_id": item.get("runner_id"),
+                  "runner_type": item.get("runner_type"),
+                  "auth_mode": item.get("auth_mode"),
+                  "status_summary": item.get("status_summary"),
+                  "probe_status": item.get("probe_status"),
+                  "probe_detail": item.get("probe_detail"),
+                  "next_action": item.get("next_action"),
+              }
+
+          diagnostic = {
+              "summary": summary,
+              "routing_after": {
+                  "blocked_reason": routing.get("blocked_reason"),
+                  "selected_runner_ids": routing.get("selected_runner_ids"),
+                  "next_action": routing.get("next_action"),
+              },
+              "runners": [_snapshot(item) for item in runners],
+              "discovered_runners": [
+                  _snapshot(item)
+                  for item in payload.get("discovered_runners", [])
+                  if isinstance(item, dict)
+              ],
+          }
+
+          failed_runner = next(
+              (
+                  item
+                  for item in runners
+                  if str(item.get("probe_status", "")).strip() == "failed"
+              ),
+              None,
+          )
+          failure_parts = ["No Codex runner probe passed during benchmark publication setup."]
+          if failed_runner:
+              probe_detail = str(failed_runner.get("probe_detail") or "").strip()
+              next_action = str(failed_runner.get("next_action") or "").strip()
+              if probe_detail:
+                  failure_parts.append(probe_detail)
+              if next_action and next_action not in failure_parts:
+                  failure_parts.append(next_action)
+          blocked_reason = str(routing.get("blocked_reason") or "").strip()
+          if blocked_reason:
+              failure_parts.append(f"routing blocked_reason={blocked_reason}")
+
+          if int(summary.get("passed", 0) or 0) < 1:
+              print(json.dumps(diagnostic, indent=2))
+              raise SystemExit(" ".join(part for part in failure_parts if part))
+
           selected = [
               item
               for item in routing.get("selected_runners", [])
@@ -133,6 +181,7 @@ jobs:
               and str(item.get("probe_status", "")).strip() == "passed"
           ]
           if not verified:
+              print(json.dumps(diagnostic, indent=2))
               raise SystemExit(
                   "No execution-verified Codex runner selected after refresh."
               )

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -87,6 +87,7 @@ def test_resolves_codex_auth_paths_before_runner_refresh() -> None:
     assert 'RUNNER_HOME="$(python3 -c' in run
     assert "pwd.getpwnam" in run
     assert "pwd.getpwall" in run
+    assert 'mkdir -p "$RUNNER_HOME/.codex" "$RUNNER_HOME/.aragora"' in run
     assert 'echo "HOME=$RUNNER_HOME" >> "$GITHUB_ENV"' in run
     assert 'echo "CODEX_HOME=$RUNNER_HOME/.codex" >> "$GITHUB_ENV"' in run
     assert (
@@ -107,5 +108,8 @@ def test_refreshes_execution_verified_codex_runner_before_recurrence() -> None:
     assert "--runner-type codex" in run
     assert "--probe-limit 1" in run
     assert 'RUNNER_REPORT="$RUNNER_TEMP/codex-runner-maintain.json"' in run
+    assert "failed_runner = next(" in run
+    assert "print(json.dumps(diagnostic, indent=2))" in run
+    assert "routing blocked_reason=" in run
     assert 'payload.get("routing_after") or {}' in run
     assert "No execution-verified Codex runner selected after refresh." in run


### PR DESCRIPTION
## Summary
- create the resolved Codex state directories before runner refresh so the workflow does not fail on a missing `CODEX_HOME` path alone
- print the structured runner-maintain diagnostic payload before failing the benchmark workflow
- fail with the real probe detail / next action instead of only `passed=0`

## Validation
- `python3 -m pytest tests/scripts/test_benchmark_truth_publication_workflow.py -q`
- `python3 -m ruff check tests/scripts/test_benchmark_truth_publication_workflow.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`