### PR TITLE
fix(ci): prefer downloaded python in setup fallback

### DIFF
--- a/.github/actions/setup-python-safe/action.yml
+++ b/.github/actions/setup-python-safe/action.yml
@@ -45,24 +45,27 @@ runs:
         set -euo pipefail
         echo "::warning::actions/setup-python failed — falling back to system Python"
         PY_BIN=""
-        for cmd in python${{ inputs.python-version }} python3 python; do
-          if command -v "$cmd" &>/dev/null; then
-            echo "Found $cmd: $("$cmd" --version)"
-            PY_BIN="$(command -v "$cmd")"
-            break
-          fi
-        done
-
         # actions/setup-python may download and unpack a requested interpreter
-        # before failing to install into the hosted tool cache. Reuse that
-        # unpacked binary when available.
-        if [[ -z "${PY_BIN}" && -n "${RUNNER_TEMP:-}" ]]; then
+        # before failing to install into the hosted tool cache. Prefer that
+        # unpacked interpreter over the system Python so the requested version
+        # still wins on self-hosted runners with older defaults.
+        if [[ -n "${RUNNER_TEMP:-}" ]]; then
           DISCOVERED_PY="$(find "${RUNNER_TEMP}" -type f -name "python${{ inputs.python-version }}" -perm -u+x 2>/dev/null | head -n 1 || true)"
           if [[ -n "${DISCOVERED_PY}" ]]; then
             PY_BIN="${DISCOVERED_PY}"
             echo "Found unpacked interpreter in RUNNER_TEMP: ${PY_BIN}"
             "${PY_BIN}" --version || true
           fi
+        fi
+
+        if [[ -z "${PY_BIN}" ]]; then
+          for cmd in python${{ inputs.python-version }} python3 python; do
+            if command -v "$cmd" &>/dev/null; then
+              echo "Found $cmd: $("$cmd" --version)"
+              PY_BIN="$(command -v "$cmd")"
+              break
+            fi
+          done
         fi
 
         if [[ -z "${PY_BIN}" ]]; then

--- a/tests/scripts/test_setup_python_safe_action.py
+++ b/tests/scripts/test_setup_python_safe_action.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def _setup_python_safe_fallback_run() -> str:
+    action_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "actions"
+        / "setup-python-safe"
+        / "action.yml"
+    )
+    action = yaml.safe_load(action_path.read_text(encoding="utf-8"))
+    steps = action.get("runs", {}).get("steps", [])
+    if not isinstance(steps, list):
+        raise AssertionError("setup-python-safe steps not found")
+    for step in steps:
+        if str(step.get("name", "")) == "Fallback to system Python":
+            return str(step.get("run", ""))
+    raise AssertionError("Fallback to system Python step not found")
+
+
+def test_prefers_unpacked_requested_python_before_system_fallback() -> None:
+    run = _setup_python_safe_fallback_run()
+    unpacked_index = run.index('DISCOVERED_PY="$(find "${RUNNER_TEMP}"')
+    search_index = run.index("for cmd in python${{ inputs.python-version }} python3 python; do")
+    assert unpacked_index < search_index
+    assert "Found unpacked interpreter in RUNNER_TEMP" in run
+    assert "Found $cmd:" in run


### PR DESCRIPTION
## Summary
- make `setup-python-safe` reuse the downloaded requested interpreter from `RUNNER_TEMP` before falling back to system `python3`/`python`
- keep the existing shim behavior once a fallback interpreter is selected
- add a regression test that locks the fallback order in the composite action

## Validation
- `python3 -m pytest tests/scripts/test_setup_python_safe_action.py tests/scripts/test_benchmark_truth_publication_workflow.py -q`
- `python3 -m ruff check tests/scripts/test_setup_python_safe_action.py tests/scripts/test_benchmark_truth_publication_workflow.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`