### PR TITLE
fix(ci): route benchmark publication to mac-studio runner

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish-benchmark-truth:
-    runs-on: aragora
+    runs-on: mac-studio
     timeout-minutes: 20
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Route the Benchmark Truth Publication workflow to the `mac-studio` runner instead of the generic `aragora` label. The Mac Studio has:
- Codex CLI authenticated (`codex login status` → "Logged in using ChatGPT")
- Local metrics at `.aragora/overnight/boss_metrics.jsonl`
- All required tooling (Python, Node, gh)

Linux runners lack Codex auth, which is the current blocker (#5720).

## Test plan

- [x] Mac runner `mac-studio-m3ultra` has label `mac-studio` (verified via API)
- [x] `codex login status` passes locally
- [x] Workflow YAML is valid

Fixes #5720

🤖 Generated with [Claude Code](https://claude.com/claude-code)