### PR TITLE
fix(ci): use Python 3.11 and ensure pyenv PATH for mac-studio runner

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -51,12 +51,22 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "3.12"
+          python-version: "3.11"
+
+      - name: Ensure pyenv Python on PATH
+        shell: bash
+        run: |
+          # Self-hosted Mac runners use pyenv; ensure shims are on PATH
+          if [[ -d "$HOME/.pyenv/shims" ]]; then
+            export PATH="$HOME/.pyenv/shims:$PATH"
+            echo "$HOME/.pyenv/shims" >> "$GITHUB_PATH"
+          fi
+          python3 --version
 
       - name: Install dependencies
         shell: bash
         run: |
-          python -m pip install -e ".[dev]" --quiet 2>/dev/null || python -m pip install -e . --quiet
+          python3 -m pip install -e ".[dev]" --quiet 2>/dev/null || python3 -m pip install -e . --quiet
 
       - name: Install GitHub CLI
         shell: bash


### PR DESCRIPTION
## Summary

- Target Python 3.11 (available via pyenv on Mac Studio) instead of 3.12
- Add pyenv shims to PATH so the runner finds the right Python
- Use `python3` consistently instead of bare `python`

Follows #5722 which routed the workflow to the Mac Studio runner.

## Test plan

- [x] `python3 --version` → Python 3.11.11 on this Mac
- [x] Workflow YAML validates
- [x] All downstream steps already use `python3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)