### PR TITLE
fix(ci): add Homebrew and pyenv to PATH for mac-studio runner

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -53,15 +53,19 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Ensure pyenv Python on PATH
+      - name: Ensure local toolchain on PATH
         shell: bash
         run: |
-          # Self-hosted Mac runners use pyenv; ensure shims are on PATH
-          if [[ -d "$HOME/.pyenv/shims" ]]; then
-            export PATH="$HOME/.pyenv/shims:$PATH"
-            echo "$HOME/.pyenv/shims" >> "$GITHUB_PATH"
-          fi
+          # Self-hosted Mac runners have tools via Homebrew and pyenv
+          for dir in /opt/homebrew/bin "$HOME/.pyenv/shims"; do
+            if [[ -d "$dir" ]]; then
+              echo "$dir" >> "$GITHUB_PATH"
+              export PATH="$dir:$PATH"
+            fi
+          done
           python3 --version
+          node --version || true
+          npm --version || true
 
       - name: Install dependencies
         shell: bash


### PR DESCRIPTION
## Summary

The Mac Studio runner has all required tools (npm, node, codex, python3.11) installed via Homebrew and pyenv, but GitHub Actions PATH doesn't include `/opt/homebrew/bin` or `~/.pyenv/shims` by default, causing `npm: command not found` and falling back to system Python 3.9.6.

This adds both directories to `GITHUB_PATH` early in the workflow.

## Test plan

- [x] `which npm node codex python3` all resolve on this Mac
- [x] Workflow YAML validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)