### PR TITLE
fix(ci): move toolchain PATH before setup-python in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -48,15 +48,10 @@ jobs:
             exit 1
           fi
 
-      - name: Setup Python
-        uses: ./.github/actions/setup-python-safe
-        with:
-          python-version: "3.11"
-
       - name: Ensure local toolchain on PATH
         shell: bash
         run: |
-          # Self-hosted Mac runners have tools via Homebrew and pyenv
+          # Must run BEFORE setup-python so its fallback finds pyenv python3.11
           for dir in /opt/homebrew/bin "$HOME/.pyenv/shims"; do
             if [[ -d "$dir" ]]; then
               echo "$dir" >> "$GITHUB_PATH"
@@ -66,6 +61,11 @@ jobs:
           python3 --version
           node --version || true
           npm --version || true
+
+      - name: Setup Python
+        uses: ./.github/actions/setup-python-safe
+        with:
+          python-version: "3.11"
 
       - name: Install dependencies
         shell: bash


### PR DESCRIPTION
## Summary

Reorder workflow steps so Homebrew and pyenv are on GITHUB_PATH **before** setup-python-safe runs. The setup-python-safe fallback searches for `python3.11` on PATH, but previously pyenv shims were added in a later step, so the fallback found system Python 3.9.6 instead.

## Test plan

- [x] Workflow YAML validates
- [x] Previous run confirmed Mac runner picked up the job and reached the publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)