### PR TITLE
fix(ci): upgrade pip/setuptools before install in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -70,6 +70,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
+          # Upgrade pip/setuptools first (Homebrew's may be too old for pyproject.toml)
+          python3 -m pip install --upgrade pip setuptools --quiet
           python3 -m pip install -e ".[dev]" --quiet 2>/dev/null || python3 -m pip install -e . --quiet
 
       - name: Install GitHub CLI


### PR DESCRIPTION
## Summary

Homebrew Python 3.11's bundled setuptools is too old for the `project.license` format in pyproject.toml. Add `pip install --upgrade pip setuptools` before the editable install.

## Test plan

- [x] Verified Python 3.11 is now found on PATH (previous run confirmed)
- [x] The only remaining failure was setuptools validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)