### PR TITLE
fix(ci): publish benchmark truth surfaces via PR

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: write
   issues: read
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: benchmark-truth-publication
@@ -259,8 +259,9 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           cat docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Commit and push refreshed trust-loop surfaces
+      - name: Commit and open PR for refreshed trust-loop surfaces
         env:
+          GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
@@ -278,5 +279,27 @@ jobs:
             exit 0
           fi
 
-          git commit -m "docs(status): refresh recurring trust-loop surfaces [skip ci]"
-          git push origin HEAD:main
+          branch="benchmark-truth-publication/${GITHUB_RUN_ID}"
+          title="docs(status): refresh recurring trust-loop surfaces"
+          body_file="$RUNNER_TEMP/benchmark-truth-publication-pr.md"
+
+          cat > "$body_file" <<EOF
+          ## Summary
+
+          Automated refresh of recurring trust-loop benchmark and rescue status surfaces.
+
+          - updates benchmark truth artifacts and scorecards
+          - updates rescue productization outputs
+          - refreshes the rendered status pages
+
+          Source workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
+
+          git checkout -b "$branch"
+          git commit -m "${title} [skip ci]"
+          git push origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "$title" \
+            --body-file "$body_file"

--- a/scripts/check_branch_mutation_policy.py
+++ b/scripts/check_branch_mutation_policy.py
@@ -132,11 +132,20 @@ def find_mutating_workflow_violations(workflows: dict[str, str]) -> list[Violati
                         message="must not be triggered by pull_request/pull_request_target",
                     )
                 )
-            if "git push origin HEAD:main" not in text:
+            if not re.search(r'branch="benchmark-truth-publication/', text):
                 violations.append(
                     Violation(
                         path=f".github/workflows/{name}",
-                        message="must push only to main via HEAD:main",
+                        message=(
+                            "must push only to benchmark-truth-publication/* branch namespace"
+                        ),
+                    )
+                )
+            if "gh pr create" not in text:
+                violations.append(
+                    Violation(
+                        path=f".github/workflows/{name}",
+                        message="must open a pull request instead of pushing directly to main",
                     )
                 )
     return violations

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 
-def _benchmark_truth_publication_run() -> str:
+def _benchmark_truth_publication_workflow() -> dict[str, object]:
     workflow_path = (
         Path(__file__).resolve().parents[2]
         / ".github"
@@ -13,6 +13,13 @@ def _benchmark_truth_publication_run() -> str:
         / "benchmark-truth-publication.yml"
     )
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    if not isinstance(workflow, dict):
+        raise AssertionError("benchmark-truth-publication workflow not found")
+    return workflow
+
+
+def _benchmark_truth_publication_run() -> str:
+    workflow = _benchmark_truth_publication_workflow()
     jobs = workflow.get("jobs", {})
     publish_job = jobs.get("publish-benchmark-truth", {})
     steps = publish_job.get("steps", [])
@@ -23,13 +30,7 @@ def _benchmark_truth_publication_run() -> str:
 
 
 def _benchmark_truth_publication_steps() -> list[dict[str, object]]:
-    workflow_path = (
-        Path(__file__).resolve().parents[2]
-        / ".github"
-        / "workflows"
-        / "benchmark-truth-publication.yml"
-    )
-    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    workflow = _benchmark_truth_publication_workflow()
     jobs = workflow.get("jobs", {})
     publish_job = jobs.get("publish-benchmark-truth", {})
     steps = publish_job.get("steps", [])
@@ -60,7 +61,8 @@ def test_installs_dependencies_before_recurrence() -> None:
     recurrence_index = names.index("Refresh recurring benchmark corpus metrics")
     assert install_index < recurrence_index
     install_run = str(steps[install_index].get("run", ""))
-    assert 'python -m pip install -e ".[dev]" --quiet' in install_run
+    assert "python3 -m pip install --upgrade pip setuptools --quiet" in install_run
+    assert 'python3 -m pip install -e ".[dev]" --quiet' in install_run
 
 
 def test_installs_github_cli_before_runtime_prerequisites() -> None:
@@ -134,3 +136,23 @@ def test_refreshes_execution_verified_codex_runner_before_recurrence() -> None:
     assert "routing blocked_reason=" in run
     assert 'payload.get("routing_after") or {}' in run
     assert "No execution-verified Codex runner selected after refresh." in run
+
+
+def test_publishes_refresh_via_pr_branch_instead_of_direct_main_push() -> None:
+    workflow = _benchmark_truth_publication_workflow()
+    permissions = workflow.get("permissions")
+    assert permissions == {
+        "contents": "write",
+        "issues": "read",
+        "pull-requests": "write",
+    }
+
+    run = str(_workflow_step("Commit and open PR for refreshed trust-loop surfaces").get("run", ""))
+    assert 'branch="benchmark-truth-publication/${GITHUB_RUN_ID}"' in run
+    assert 'git checkout -b "$branch"' in run
+    assert 'git push origin "$branch"' in run
+    assert "gh pr create \\" in run
+    assert "--base main \\" in run
+    assert '--head "$branch" \\' in run
+    assert '--body-file "$body_file"' in run
+    assert "git push origin HEAD:main" not in run

--- a/tests/scripts/test_check_branch_mutation_policy.py
+++ b/tests/scripts/test_check_branch_mutation_policy.py
@@ -43,7 +43,9 @@ def test_find_mutating_workflow_violations_requires_safe_benchmark_truth_publica
     workflows = {
         "benchmark-truth-publication.yml": (
             "on:\n  pull_request:\n  workflow_dispatch:\n"
-            "jobs:\n  x:\n    steps:\n      - run: git push origin HEAD:feature\n"
+            "jobs:\n  x:\n    steps:\n      - run: |\n"
+            '          branch="unsafe/tmp"\n'
+            '          git push origin "$branch"\n'
         ),
     }
     violations = find_mutating_workflow_violations(workflows)
@@ -51,7 +53,14 @@ def test_find_mutating_workflow_violations_requires_safe_benchmark_truth_publica
     assert any(
         "must not be triggered by pull_request/pull_request_target" in v.message for v in violations
     )
-    assert any("must push only to main via HEAD:main" in v.message for v in violations)
+    assert any(
+        "must push only to benchmark-truth-publication/* branch namespace" in v.message
+        for v in violations
+    )
+    assert any(
+        "must open a pull request instead of pushing directly to main" in v.message
+        for v in violations
+    )
 
 
 def test_repo_branch_mutation_policy_passes_for_current_tree() -> None:


### PR DESCRIPTION
## Summary
- publish recurring benchmark truth surface updates through a branch+PR flow instead of pushing directly to protected main
- update the branch-mutation policy to require the benchmark publication branch namespace and PR creation
- lock the new workflow path with focused workflow/policy tests

## Validation
- python3 -m pytest tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_check_branch_mutation_policy.py -q
- python3 -m ruff check scripts/check_branch_mutation_policy.py tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_check_branch_mutation_policy.py
- python3 scripts/check_branch_mutation_policy.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD