### PR TITLE
feat(autonomy): enforce proof-first benchmark and queue loop

### DIFF
--- a/.github/workflows/auto-pr-publisher.yml
+++ b/.github/workflows/auto-pr-publisher.yml
@@ -6,6 +6,7 @@ on:
       - "codex/**"
       - "factory/**"
       - "aragora/boss-harvest/**"
+      - "benchmark-truth-publication/**"
   # Schedule disabled — push trigger is sufficient; cron caused 714 PR flood (2026-04-09)
   # schedule:
   #   - cron: "*/15 * * * *"
@@ -84,7 +85,8 @@ jobs:
               return (
                 ref.startsWith("codex/") ||
                 ref.startsWith("factory/") ||
-                ref.startsWith("aragora/boss-harvest/")
+                ref.startsWith("aragora/boss-harvest/") ||
+                ref.startsWith("benchmark-truth-publication/")
               );
             }
 

--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -2,13 +2,13 @@ name: Benchmark Truth Publication
 
 on:
   schedule:
-    - cron: "20 13 * * 1"
+    - cron: "20 13 * * *"
   workflow_dispatch:
 
 permissions:
   contents: write
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: benchmark-truth-publication
@@ -325,10 +325,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           cat docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Commit and open PR for refreshed trust-loop surfaces
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Commit and publish refreshed trust-loop surfaces branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -348,25 +345,12 @@ jobs:
 
           branch="benchmark-truth-publication/${GITHUB_RUN_ID}"
           title="docs(status): refresh recurring trust-loop surfaces"
-          body_file="$RUNNER_TEMP/benchmark-truth-publication-pr.md"
-
-          cat > "$body_file" <<EOF
-          ## Summary
-
-          Automated refresh of recurring trust-loop benchmark and rescue status surfaces.
-
-          - updates benchmark truth artifacts and scorecards
-          - updates rescue productization outputs
-          - refreshes the rendered status pages
-
-          Source workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
-          EOF
 
           git checkout -b "$branch"
-          git commit -m "${title} [skip ci]"
+          git commit -m "${title}"
           git push origin "$branch"
-          gh pr create \
-            --base main \
-            --head "$branch" \
-            --title "$title" \
-            --body-file "$body_file"
+          {
+            echo "Published automation branch: \`$branch\`"
+            echo ""
+            echo "Auto PR Publisher will open the draft PR if repository policy allows it."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-admission-controller.yml
+++ b/.github/workflows/pr-admission-controller.yml
@@ -40,7 +40,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/checkout-integrity
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git sparse-checkout disable || true
+            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
+            git reset --hard FETCH_HEAD
+            git clean -ffd || true
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::Standard recovery failed; attempting archive restore"
+            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+            git archive "${GITHUB_SHA:-HEAD}" | tar -x || git archive HEAD | tar -x
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
+            echo "PWD=$(pwd)"
+            ls -la
+            exit 1
+          fi
 
       - name: Prepare writable tool cache
         shell: bash

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -32,6 +32,7 @@ from aragora.swarm.boss_loop_outcome import (
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
 from aragora.swarm.dispatch_contract_gate import dispatch_contract_gate
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.proof_first_queue import filter_noncanonical_boss_ready_issues
 from aragora.swarm.roadmap_priority import load_roadmap_priority_policy
 from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
 from aragora.swarm.mission import GateType, GateVerdict
@@ -2041,6 +2042,17 @@ class BossLoop:
                 close=closed,
             )
 
+    def _filter_noncanonical_boss_ready_issues(
+        self,
+        issues: list[GitHubIssue],
+    ) -> list[GitHubIssue]:
+        return filter_noncanonical_boss_ready_issues(
+            issues,
+            repo_root=Path.cwd(),
+            repo_slug_for_issue=self._repo_slug_for_issue,
+            comment_and_update_issue=self._comment_and_update_issue,
+        )
+
     @staticmethod
     def _reuse_existing_published_branch_deliverable(
         worker_result: dict[str, Any],
@@ -3569,6 +3581,8 @@ class BossLoop:
                 elapsed_seconds=time.monotonic() - iter_start,
                 error="issue_feed_error",
             )
+
+        issues = self._filter_noncanonical_boss_ready_issues(issues)
 
         # Step 1b: Log strategic refill candidates when queue is low
         if len(issues) < self.config.auto_refill_threshold:

--- a/aragora/swarm/proof_first_queue.py
+++ b/aragora/swarm/proof_first_queue.py
@@ -1,0 +1,238 @@
+"""Proof-first queue governance for canonical boss-ready work."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
+
+from aragora.swarm.roadmap_priority import (
+    RoadmapPriority,
+    RoadmapPriorityPolicy,
+    extract_roadmap_codes,
+    load_roadmap_priority_policy,
+)
+
+if TYPE_CHECKING:
+    from aragora.swarm.boss_feed import GitHubIssue
+
+_BENCHMARK_TERMS = (
+    "benchmark",
+    "corpus",
+    "scorecard",
+    "truth artifact",
+    "truth surface",
+    "truth metrics",
+    "freshness",
+    "stale",
+    "linkage",
+    "tw-01",
+    "tw-02",
+)
+_RESCUE_TERMS = (
+    "rescue",
+    "productization",
+    "repeated rescue class",
+    "tw-03",
+)
+_DOCS_TERMS = (
+    "docs",
+    "status",
+    "roadmap",
+    "positioning",
+    "commercial",
+    "external claims",
+)
+_PROOF_TERMS = (
+    "proof",
+    "truth",
+    "benchmark",
+    "rescue",
+    "measured",
+    "corpus",
+)
+_DRIFT_TERMS = (
+    "drift",
+    "reconcile",
+    "align",
+    "narrower",
+    "outrun",
+    "current gate",
+)
+
+
+@dataclass(frozen=True)
+class ProofFirstQueueDecision:
+    allowed: bool
+    lane: str
+    reason: str
+    matched_terms: tuple[str, ...] = ()
+    roadmap_codes: tuple[str, ...] = ()
+    blocked_codes: tuple[str, ...] = ()
+
+
+def _normalize_text(*parts: str) -> str:
+    return " ".join(str(part or "").strip().lower() for part in parts if str(part or "").strip())
+
+
+def _matched_terms(text: str, terms: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(term for term in terms if term in text)
+
+
+def _load_policy(
+    *,
+    repo_root: Path | str | None,
+    roadmap_policy: RoadmapPriorityPolicy | None,
+) -> RoadmapPriorityPolicy | None:
+    if roadmap_policy is not None:
+        return roadmap_policy
+    if repo_root is None:
+        return None
+    return load_roadmap_priority_policy(Path(repo_root))
+
+
+def classify_proof_first_queue_issue(
+    title: str,
+    body: str = "",
+    *,
+    labels: list[str] | tuple[str, ...] | set[str] = (),
+    repo_root: Path | str | None = None,
+    roadmap_policy: RoadmapPriorityPolicy | None = None,
+) -> ProofFirstQueueDecision:
+    """Return whether an issue belongs in the canonical proof-first queue."""
+
+    normalized_text = _normalize_text(title, body, " ".join(str(label) for label in labels))
+    policy = _load_policy(repo_root=repo_root, roadmap_policy=roadmap_policy)
+    roadmap_codes = extract_roadmap_codes(f"{title}\n{body}")
+
+    if policy is not None:
+        priority = policy.priority_for_text(title, body)
+        if priority.priority is RoadmapPriority.DO_NOW:
+            return ProofFirstQueueDecision(
+                allowed=True,
+                lane="roadmap_do_now",
+                reason="references a current do-now roadmap lane",
+                matched_terms=(),
+                roadmap_codes=priority.codes,
+                blocked_codes=(),
+            )
+        if priority.priority.blocks_boss_ready:
+            return ProofFirstQueueDecision(
+                allowed=False,
+                lane="blocked_roadmap_lane",
+                reason="references delayed or avoided roadmap work",
+                matched_terms=(),
+                roadmap_codes=priority.codes,
+                blocked_codes=priority.blocked_codes,
+            )
+
+    benchmark_matches = _matched_terms(normalized_text, _BENCHMARK_TERMS)
+    if "[tw-02]" in normalized_text or (
+        "benchmark" in benchmark_matches
+        and any(
+            term in benchmark_matches
+            for term in ("corpus", "scorecard", "truth artifact", "freshness", "stale")
+        )
+    ):
+        return ProofFirstQueueDecision(
+            allowed=True,
+            lane="benchmark_regression",
+            reason="matches benchmark/truth publication follow-up signals",
+            matched_terms=benchmark_matches,
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
+
+    rescue_matches = _matched_terms(normalized_text, _RESCUE_TERMS)
+    if "[tw-03]" in normalized_text or (
+        "rescue" in rescue_matches
+        and any(
+            term in rescue_matches for term in ("productization", "repeated rescue class", "tw-03")
+        )
+    ):
+        return ProofFirstQueueDecision(
+            allowed=True,
+            lane="rescue_productization",
+            reason="matches repeated rescue-class productization signals",
+            matched_terms=rescue_matches,
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
+
+    docs_matches = _matched_terms(normalized_text, _DOCS_TERMS)
+    proof_matches = _matched_terms(normalized_text, _PROOF_TERMS)
+    drift_matches = _matched_terms(normalized_text, _DRIFT_TERMS)
+    if docs_matches and proof_matches and drift_matches:
+        return ProofFirstQueueDecision(
+            allowed=True,
+            lane="docs_proof_drift",
+            reason="matches docs/proof drift reconciliation signals",
+            matched_terms=docs_matches + proof_matches + drift_matches,
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
+
+    return ProofFirstQueueDecision(
+        allowed=False,
+        lane="non_canonical",
+        reason="does not match proof-first benchmark, rescue, or docs-proof lanes",
+        matched_terms=benchmark_matches
+        + rescue_matches
+        + docs_matches
+        + proof_matches
+        + drift_matches,
+        roadmap_codes=roadmap_codes,
+        blocked_codes=(),
+    )
+
+
+def filter_noncanonical_boss_ready_issues(
+    issues: list["GitHubIssue"],
+    *,
+    repo_root: Path | str,
+    repo_slug_for_issue: Callable[["GitHubIssue"], str | None],
+    comment_and_update_issue: Callable[..., Any],
+) -> list["GitHubIssue"]:
+    """Remove boss-ready from non-canonical issues and exclude them from dispatch."""
+
+    kept: list[GitHubIssue] = []
+    for issue in issues:
+        if "boss-ready" not in issue.labels:
+            kept.append(issue)
+            continue
+
+        decision = classify_proof_first_queue_issue(
+            issue.title,
+            issue.body or "",
+            labels=issue.labels,
+            repo_root=repo_root,
+        )
+        if decision.allowed:
+            kept.append(issue)
+            continue
+
+        detail = ", ".join(
+            decision.blocked_codes or decision.roadmap_codes or decision.matched_terms
+        )
+        if not detail:
+            detail = decision.lane
+        comment = (
+            "Boss removed `boss-ready` because this issue is outside the canonical "
+            f"proof-first queue for the current tranche ({detail})."
+        )
+        issue.labels = [value for value in issue.labels if value != "boss-ready"]
+        if repo := repo_slug_for_issue(issue):
+            comment_and_update_issue(
+                issue.number,
+                repo,
+                comment,
+                remove_labels=("boss-ready",),
+            )
+    return kept
+
+
+__all__ = [
+    "ProofFirstQueueDecision",
+    "classify_proof_first_queue_issue",
+    "filter_noncanonical_boss_ready_issues",
+]

--- a/aragora/swarm/roadmap_priority.py
+++ b/aragora/swarm/roadmap_priority.py
@@ -77,7 +77,7 @@ def load_roadmap_priority_policy(repo_root: Path | str) -> RoadmapPriorityPolicy
     if not path.exists():
         return None
     text = path.read_text(encoding="utf-8")
-    buckets = {
+    buckets: dict[str, set[str]] = {
         _SECTION_DO_NOW: set(),
         _SECTION_DELAY: set(),
         _SECTION_AVOID: set(),
@@ -87,7 +87,7 @@ def load_roadmap_priority_policy(repo_root: Path | str) -> RoadmapPriorityPolicy
         line = raw_line.strip()
         if not line:
             continue
-        if line.startswith("### "):
+        if line.startswith("#"):
             current_section = _SECTION_NAMES.get(line, "")
             continue
         if not current_section or not line.startswith("- "):

--- a/scripts/check_branch_mutation_policy.py
+++ b/scripts/check_branch_mutation_policy.py
@@ -141,11 +141,21 @@ def find_mutating_workflow_violations(workflows: dict[str, str]) -> list[Violati
                         ),
                     )
                 )
-            if "gh pr create" not in text:
+            if re.search(r"git push\s+origin\s+(?:HEAD:)?main\b", text):
                 violations.append(
                     Violation(
                         path=f".github/workflows/{name}",
-                        message="must open a pull request instead of pushing directly to main",
+                        message="must not push directly to main",
+                    )
+                )
+            if "gh pr create" in text:
+                violations.append(
+                    Violation(
+                        path=f".github/workflows/{name}",
+                        message=(
+                            "must delegate pull request creation to Auto PR Publisher "
+                            "instead of invoking gh pr create"
+                        ),
                     )
                 )
     return violations

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -29,10 +29,8 @@ sys.path.insert(0, str(REPO_ROOT))
 from aragora.swarm.decomposition_bridge import DecompositionBridge  # noqa: E402
 from aragora.swarm.issue_scanner import BossIssueCandidate, scan_all  # noqa: E402
 from aragora.swarm.issue_upgrader import upgrade_issue_heuristic  # noqa: E402
-from aragora.swarm.roadmap_priority import (  # noqa: E402
-    RoadmapPriority,
-    load_roadmap_priority_policy,
-)
+from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue  # noqa: E402
+from aragora.swarm.roadmap_priority import load_roadmap_priority_policy  # noqa: E402
 
 _GENERIC_PARENT_PHRASES: tuple[str, ...] = (
     "read the module and identify all public functions",
@@ -512,12 +510,19 @@ def main() -> None:
             continue
 
         body = format_boss_ready_body(candidate)
-        if args.label == "boss-ready" and priority_policy is not None:
-            priority = priority_policy.priority_for_text(candidate.title, body)
-            if priority.priority is not RoadmapPriority.DO_NOW:
+        if args.label == "boss-ready":
+            decision = classify_proof_first_queue_issue(
+                candidate.title,
+                body,
+                repo_root=repo_root,
+                roadmap_policy=priority_policy,
+            )
+            if not decision.allowed:
                 skipped_priority += 1
                 if args.verbose:
-                    detail = ", ".join(priority.blocked_codes) or priority.priority.value
+                    detail = (
+                        ", ".join(decision.blocked_codes or decision.roadmap_codes) or decision.lane
+                    )
                     print(f"  SKIP (canonical priority): {candidate.title} [{detail}]")
                 continue
         ok, reason = validate_body(body)

--- a/scripts/reconcile_proof_first_queue.py
+++ b/scripts/reconcile_proof_first_queue.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Reconcile the live boss-ready queue against proof-first canonical lanes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue  # noqa: E402
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_QUEUE_LABEL = "boss-ready"
+DEFAULT_DOCS_ISSUE_TITLE = "[CS-01..03] Reconcile docs/status surfaces to current proof"
+
+
+def list_open_queue_issues(*, repo: str, label: str) -> list[dict[str, Any]]:
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            label,
+            "--json",
+            "number,title,body,labels,url",
+            "--limit",
+            "200",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh issue list failed")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        raise RuntimeError("gh issue list returned a non-list payload")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def remove_queue_label(*, repo: str, issue_number: int, label: str) -> None:
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "edit",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--remove-label",
+            label,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh issue edit failed")
+
+
+def load_status_reconciliation_report(*, repo_root: Path) -> dict[str, Any]:
+    result = subprocess.run(
+        ["python3", "scripts/reconcile_status_docs.py", "--json"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            result.stderr.strip() or result.stdout.strip() or "status reconciliation failed"
+        )
+    payload = json.loads(result.stdout or "{}")
+    if not isinstance(payload, dict):
+        raise RuntimeError("status reconciliation returned a non-object payload")
+    return payload
+
+
+def docs_proof_drift_detected(report: dict[str, Any]) -> bool:
+    summary = dict(report.get("summary") or {})
+    return int(summary.get("critical", 0) or 0) > 0 or int(summary.get("warning", 0) or 0) > 0
+
+
+def build_docs_proof_drift_issue(report: dict[str, Any]) -> dict[str, Any] | None:
+    if not docs_proof_drift_detected(report):
+        return None
+    findings = [
+        dict(item)
+        for item in list(report.get("findings") or [])
+        if isinstance(item, dict)
+        and str(item.get("severity") or "").strip().lower() in {"critical", "warning"}
+    ]
+    lines = [
+        "## Goal",
+        "Reconcile roadmap/status/positioning surfaces so external claims stay narrower than current measured proof.",
+        "",
+        "## Why now",
+        "The recurring docs reconciliation check found proof drift that should become exactly one bounded `CS-01..03` follow-up issue.",
+        "",
+        "## Findings",
+    ]
+    for finding in findings:
+        lines.append(
+            f"- `{str(finding.get('severity') or '').strip()}` "
+            f"`{str(finding.get('source') or '').strip()}`: "
+            f"{str(finding.get('message') or '').strip()}"
+        )
+    lines.extend(
+        [
+            "",
+            "## Acceptance",
+            "- Update the affected docs/status surfaces so claims stay narrower than the current proof surfaces.",
+            "- Keep `docs/status/NEXT_STEPS_CANONICAL.md`, `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md` mutually consistent.",
+            "- Re-run `python3 scripts/reconcile_status_docs.py --json` until warning and critical findings are cleared.",
+        ]
+    )
+    return {
+        "title": DEFAULT_DOCS_ISSUE_TITLE,
+        "body": "\n".join(lines),
+        "labels": ["boss-ready", "autonomous"],
+    }
+
+
+def find_existing_open_issue_by_title(*, repo: str, title: str) -> dict[str, Any] | None:
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--search",
+            title,
+            "--json",
+            "number,title,url",
+            "--limit",
+            "100",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh issue list failed")
+    payload = json.loads(result.stdout or "[]")
+    if not isinstance(payload, list):
+        return None
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("title") or "").strip() == title:
+            return item
+    return None
+
+
+def create_issue(*, repo: str, title: str, body: str, labels: list[str]) -> dict[str, Any]:
+    cmd = ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body]
+    for label in labels:
+        cmd.extend(["--label", label])
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh issue create failed")
+    url = str(result.stdout or "").strip().splitlines()[-1].strip()
+    return {"title": title, "url": url}
+
+
+def reconcile_proof_first_queue(
+    *,
+    repo: str,
+    repo_root: Path,
+    apply: bool = False,
+    queue_label: str = DEFAULT_QUEUE_LABEL,
+) -> dict[str, Any]:
+    issues = list_open_queue_issues(repo=repo, label=queue_label)
+    kept: list[dict[str, Any]] = []
+    removed: list[dict[str, Any]] = []
+
+    for issue in issues:
+        labels = [
+            str(item.get("name") or "").strip()
+            for item in list(issue.get("labels") or [])
+            if isinstance(item, dict)
+        ]
+        decision = classify_proof_first_queue_issue(
+            str(issue.get("title") or "").strip(),
+            str(issue.get("body") or "").strip(),
+            labels=labels,
+            repo_root=repo_root,
+        )
+        record = {
+            "number": int(issue.get("number", 0) or 0),
+            "title": str(issue.get("title") or "").strip(),
+            "url": str(issue.get("url") or "").strip(),
+            "lane": decision.lane,
+            "reason": decision.reason,
+        }
+        if decision.allowed:
+            kept.append(record)
+            continue
+        if apply and record["number"] > 0:
+            remove_queue_label(repo=repo, issue_number=record["number"], label=queue_label)
+            record["action"] = "removed_label"
+        else:
+            record["action"] = "would_remove_label"
+        removed.append(record)
+
+    docs_report = load_status_reconciliation_report(repo_root=repo_root)
+    docs_issue_payload = build_docs_proof_drift_issue(docs_report)
+    docs_issue_action: dict[str, Any] | None = None
+    if docs_issue_payload is not None:
+        existing = find_existing_open_issue_by_title(repo=repo, title=docs_issue_payload["title"])
+        if existing is not None:
+            docs_issue_action = {
+                "action": "existing_issue",
+                "title": docs_issue_payload["title"],
+                "number": int(existing.get("number", 0) or 0),
+                "url": str(existing.get("url") or "").strip(),
+            }
+        elif apply:
+            created = create_issue(
+                repo=repo,
+                title=str(docs_issue_payload["title"]),
+                body=str(docs_issue_payload["body"]),
+                labels=list(docs_issue_payload["labels"]),
+            )
+            docs_issue_action = {
+                "action": "created_issue",
+                "title": docs_issue_payload["title"],
+                "url": str(created.get("url") or "").strip(),
+            }
+        else:
+            docs_issue_action = {
+                "action": "would_create_issue",
+                "title": docs_issue_payload["title"],
+            }
+
+    return {
+        "repo": repo,
+        "queue_label": queue_label,
+        "kept": kept,
+        "removed": removed,
+        "docs_issue": docs_issue_action,
+        "docs_report_summary": dict(docs_report.get("summary") or {}),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reconcile proof-first boss-ready queue.")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    parser.add_argument("--queue-label", default=DEFAULT_QUEUE_LABEL)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = reconcile_proof_first_queue(
+        repo=args.repo,
+        repo_root=Path(args.repo_root).resolve(),
+        apply=args.apply,
+        queue_label=args.queue_label,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"kept={len(report['kept'])} removed={len(report['removed'])} "
+            f"docs_issue={report.get('docs_issue', {}).get('action') if report.get('docs_issue') else 'none'}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Run a bounded proof-first unattended shift."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.nomic.checkpoints import load_latest_checkpoint  # noqa: E402
+from aragora.nomic.shift_controller import ShiftConfig, ShiftController, ShiftState  # noqa: E402
+from scripts.reconcile_proof_first_queue import reconcile_proof_first_queue  # noqa: E402
+from scripts.watch_boss_lane import collect_snapshot  # noqa: E402
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_SHIFT_DIRNAME = "proof_first_shift"
+DEFAULT_AUTOMATION_BACKLOG_LIMIT = 12
+DEFAULT_REFRESH_MINUTES = 120
+DEFAULT_MAX_HOURS = 12.0
+DEFAULT_INTERVAL_SECONDS = 120
+DEFAULT_BOSS_LABEL = "com.aragora.swarm-boss-loop"
+DEFAULT_MERGE_LABEL = "com.aragora.swarm-merge-arbiter"
+AUTOMATION_BRANCH_PREFIXES = (
+    "codex/",
+    "factory/",
+    "aragora/boss-harvest/",
+    "benchmark-truth-publication/",
+)
+
+
+@dataclass
+class ProofFirstRuntimeState:
+    boss_restart_count: int = 0
+    merge_restart_count: int = 0
+    auth_failure_count: int = 0
+    publication_failure_count: int = 0
+    last_benchmark_run_id: int | None = None
+    last_triggered_benchmark_run_id: int | None = None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _assessment_id() -> str:
+    return f"proof-first-{_utc_now().strftime('%Y%m%dT%H%M%SZ')}"
+
+
+def _runtime_state_path(repo_root: Path) -> Path:
+    return repo_root / ".aragora" / DEFAULT_SHIFT_DIRNAME / "runtime_state.json"
+
+
+def load_runtime_state(path: Path) -> ProofFirstRuntimeState:
+    if not path.exists():
+        return ProofFirstRuntimeState()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return ProofFirstRuntimeState()
+    return ProofFirstRuntimeState(
+        boss_restart_count=int(payload.get("boss_restart_count", 0) or 0),
+        merge_restart_count=int(payload.get("merge_restart_count", 0) or 0),
+        auth_failure_count=int(payload.get("auth_failure_count", 0) or 0),
+        publication_failure_count=int(payload.get("publication_failure_count", 0) or 0),
+        last_benchmark_run_id=(
+            int(payload["last_benchmark_run_id"]) if payload.get("last_benchmark_run_id") else None
+        ),
+        last_triggered_benchmark_run_id=(
+            int(payload["last_triggered_benchmark_run_id"])
+            if payload.get("last_triggered_benchmark_run_id")
+            else None
+        ),
+    )
+
+
+def save_runtime_state(path: Path, state: ProofFirstRuntimeState) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(state), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _run_json(args: list[str], *, cwd: Path, timeout: int = 30) -> Any:
+    proc = _run(args, cwd=cwd, timeout=timeout)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            proc.stderr.strip() or proc.stdout.strip() or f"command failed: {' '.join(args)}"
+        )
+    return json.loads(proc.stdout or "{}")
+
+
+def restore_shift_controller(
+    controller: ShiftController,
+    *,
+    checkpoint_dir: Path,
+) -> ShiftState | None:
+    payload = load_latest_checkpoint(str(checkpoint_dir))
+    if not isinstance(payload, dict):
+        return None
+    shift_payload = payload.get("shift_state")
+    if not isinstance(shift_payload, dict):
+        return None
+    state = ShiftState.from_dict(shift_payload)
+    controller._state = state  # noqa: SLF001
+    return state
+
+
+def collect_boss_lane_snapshot(*, repo_root: Path, repo: str) -> dict[str, Any]:
+    args = argparse.Namespace(
+        repo_root=str(repo_root),
+        repo=repo,
+        watch_session=[],
+        watch_pr=[],
+        pr_search_issue=0,
+        queue_limit=12,
+        stale_minutes=30,
+    )
+    return collect_snapshot(args)
+
+
+def list_open_prs(*, repo_root: Path, repo: str) -> list[dict[str, Any]]:
+    payload = _run_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,headRefName,isDraft,url",
+        ],
+        cwd=repo_root,
+        timeout=45,
+    )
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list returned a non-list payload")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def count_automation_backlog(prs: list[dict[str, Any]]) -> int:
+    return sum(
+        1 for pr in prs if str(pr.get("headRefName") or "").startswith(AUTOMATION_BRANCH_PREFIXES)
+    )
+
+
+def has_open_benchmark_publication_pr(prs: list[dict[str, Any]]) -> bool:
+    return any(
+        str(pr.get("headRefName") or "").startswith("benchmark-truth-publication/") for pr in prs
+    )
+
+
+def latest_benchmark_run(*, repo_root: Path, repo: str) -> dict[str, Any] | None:
+    payload = _run_json(
+        [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--workflow",
+            "Benchmark Truth Publication",
+            "--limit",
+            "1",
+            "--json",
+            "databaseId,createdAt,status,conclusion",
+        ],
+        cwd=repo_root,
+        timeout=45,
+    )
+    if not isinstance(payload, list) or not payload:
+        return None
+    run = payload[0]
+    return run if isinstance(run, dict) else None
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
+
+
+def should_trigger_benchmark_rerun(
+    *,
+    benchmark_mode: str,
+    latest_run: dict[str, Any] | None,
+    has_open_publication_pr: bool,
+    automation_backlog: int,
+    automation_backlog_limit: int,
+    last_triggered_run_id: int | None,
+    max_age_hours: float = 24.0,
+) -> tuple[bool, str]:
+    if benchmark_mode != "hybrid":
+        return False, "benchmark_mode_disabled"
+    if has_open_publication_pr:
+        return False, "benchmark_pr_open"
+    if automation_backlog >= automation_backlog_limit:
+        return False, "automation_backlog_full"
+    if latest_run is None:
+        if int(last_triggered_run_id or 0) == -1:
+            return False, "awaiting_first_run_visibility"
+        return True, "no_prior_run"
+
+    run_id = int(latest_run.get("databaseId", 0) or 0)
+    created_at = _parse_timestamp(str(latest_run.get("createdAt") or ""))
+    if created_at is not None:
+        age_hours = (_utc_now() - created_at).total_seconds() / 3600.0
+        if age_hours >= max_age_hours:
+            if run_id and run_id == int(last_triggered_run_id or 0):
+                return False, "awaiting_new_benchmark_run"
+            return True, "stale_publication_window"
+
+    conclusion = str(latest_run.get("conclusion") or "").strip().lower()
+    if conclusion == "failure" and run_id != int(last_triggered_run_id or 0):
+        return True, "retry_after_failed_run"
+    return False, "fresh_enough"
+
+
+def classify_benchmark_failure_log(text: str) -> str:
+    lowered = str(text or "").lower()
+    if any(
+        token in lowered
+        for token in (
+            "authentication",
+            "auth required",
+            "codex login",
+            "not logged in",
+            "api token",
+        )
+    ):
+        return "auth_failure"
+    if any(
+        token in lowered
+        for token in (
+            "resource not accessible by integration",
+            "not permitted to create pull requests",
+            "pr_creation_forbidden",
+            "pull request creation is not allowed",
+        )
+    ):
+        return "publication_failure"
+    return "other_failure"
+
+
+def fetch_benchmark_failure_log(*, repo_root: Path, run_id: int) -> str:
+    proc = _run(
+        ["gh", "run", "view", str(run_id), "--log-failed"],
+        cwd=repo_root,
+        timeout=60,
+    )
+    return proc.stdout or proc.stderr or ""
+
+
+def process_running(pattern: str) -> bool:
+    proc = subprocess.run(
+        ["pgrep", "-f", pattern],
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    return proc.returncode == 0 and bool(proc.stdout.strip())
+
+
+def should_restart_service(
+    *,
+    is_running: bool,
+    pending_count: int,
+    restart_count: int,
+    restart_limit: int = 1,
+) -> bool:
+    return (not is_running) and pending_count > 0 and restart_count < restart_limit
+
+
+def kickstart_launchd(label: str) -> None:
+    uid = os.getuid()
+    proc = subprocess.run(
+        ["launchctl", "kickstart", f"gui/{uid}/{label}"],
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            proc.stderr.strip() or proc.stdout.strip() or f"launchctl kickstart failed for {label}"
+        )
+
+
+def run_merge_arbiter_apply(
+    *,
+    repo_root: Path,
+    repo: str,
+    limit: int,
+) -> dict[str, Any]:
+    payload = _run_json(
+        [
+            "python3",
+            "scripts/merge_codex_automation_prs.py",
+            "--root",
+            str(repo_root),
+            "--repo",
+            repo,
+            "--limit",
+            str(limit),
+            "--apply",
+            "--json",
+        ],
+        cwd=repo_root,
+        timeout=120,
+    )
+    if not isinstance(payload, dict):
+        raise RuntimeError("merge arbiter helper returned a non-object payload")
+    return payload
+
+
+def trigger_benchmark_workflow(*, repo_root: Path, repo: str) -> None:
+    proc = _run(
+        ["gh", "workflow", "run", "Benchmark Truth Publication", "--repo", repo],
+        cwd=repo_root,
+        timeout=45,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh workflow run failed")
+
+
+def run_shift_cycle(
+    *,
+    repo_root: Path,
+    repo: str,
+    benchmark_mode: str,
+    automation_backlog_limit: int,
+    runtime_state: ProofFirstRuntimeState,
+) -> dict[str, Any]:
+    queue_report = reconcile_proof_first_queue(repo=repo, repo_root=repo_root, apply=True)
+    snapshot = collect_boss_lane_snapshot(repo_root=repo_root, repo=repo)
+    prs = list_open_prs(repo_root=repo_root, repo=repo)
+    automation_backlog = count_automation_backlog(prs)
+    open_pr_count = len(prs)
+    canonical_queue_count = len(queue_report["kept"])
+
+    boss_running = process_running(r"aragora\.cli\.main swarm boss-loop")
+    merge_running = process_running(r"aragora\.cli\.main swarm merge-arbiter")
+
+    actions: list[str] = []
+    if should_restart_service(
+        is_running=boss_running,
+        pending_count=canonical_queue_count,
+        restart_count=runtime_state.boss_restart_count,
+    ):
+        kickstart_launchd(DEFAULT_BOSS_LABEL)
+        runtime_state.boss_restart_count += 1
+        actions.append("restart_boss_loop")
+
+    if should_restart_service(
+        is_running=merge_running,
+        pending_count=open_pr_count,
+        restart_count=runtime_state.merge_restart_count,
+    ):
+        kickstart_launchd(DEFAULT_MERGE_LABEL)
+        runtime_state.merge_restart_count += 1
+        actions.append("restart_merge_arbiter")
+
+    merge_report = run_merge_arbiter_apply(
+        repo_root=repo_root,
+        repo=repo,
+        limit=automation_backlog_limit,
+    )
+    merged_numbers = list(merge_report.get("merged") or [])
+    if merged_numbers:
+        actions.append(f"merged_prs:{','.join(str(number) for number in merged_numbers)}")
+
+    latest_run = latest_benchmark_run(repo_root=repo_root, repo=repo)
+    if latest_run is not None:
+        run_id = int(latest_run.get("databaseId", 0) or 0)
+        conclusion = str(latest_run.get("conclusion") or "").strip().lower()
+        if run_id and run_id != int(runtime_state.last_benchmark_run_id or 0):
+            runtime_state.last_benchmark_run_id = run_id
+            if conclusion == "failure":
+                failure_log = fetch_benchmark_failure_log(repo_root=repo_root, run_id=run_id)
+                failure_class = classify_benchmark_failure_log(failure_log)
+                if failure_class == "auth_failure":
+                    runtime_state.auth_failure_count += 1
+                elif failure_class == "publication_failure":
+                    runtime_state.publication_failure_count += 1
+
+    should_trigger, trigger_reason = should_trigger_benchmark_rerun(
+        benchmark_mode=benchmark_mode,
+        latest_run=latest_run,
+        has_open_publication_pr=has_open_benchmark_publication_pr(prs),
+        automation_backlog=automation_backlog,
+        automation_backlog_limit=automation_backlog_limit,
+        last_triggered_run_id=runtime_state.last_triggered_benchmark_run_id,
+    )
+    if should_trigger:
+        trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
+        actions.append(f"trigger_benchmark:{trigger_reason}")
+        if latest_run is not None:
+            runtime_state.last_triggered_benchmark_run_id = int(
+                latest_run.get("databaseId", 0) or 0
+            )
+        else:
+            runtime_state.last_triggered_benchmark_run_id = -1
+
+    stop_reason = ""
+    if runtime_state.auth_failure_count >= 2:
+        stop_reason = "RepeatedAuthFailure: benchmark publication failed auth twice"
+    elif runtime_state.publication_failure_count >= 2:
+        stop_reason = "RepeatedPublicationFailure: benchmark publication failed PR handoff twice"
+
+    return {
+        "queue_report": queue_report,
+        "snapshot": snapshot,
+        "open_pr_count": open_pr_count,
+        "automation_backlog": automation_backlog,
+        "latest_benchmark_run": latest_run,
+        "actions": actions,
+        "stop_reason": stop_reason,
+    }
+
+
+def build_cycle_objective(report: dict[str, Any]) -> str:
+    queue_kept = len(report["queue_report"]["kept"])
+    queue_removed = len(report["queue_report"]["removed"])
+    actions = ",".join(report.get("actions") or []) or "steady_state"
+    return (
+        "proof-first shift tick: "
+        f"queue_kept={queue_kept} queue_removed={queue_removed} "
+        f"open_prs={int(report.get('open_pr_count', 0) or 0)} "
+        f"automation_backlog={int(report.get('automation_backlog', 0) or 0)} "
+        f"actions={actions}"
+    )
+
+
+async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
+    repo_root = Path(args.repo_root).resolve()
+    checkpoint_dir = repo_root / ".aragora" / DEFAULT_SHIFT_DIRNAME / "checkpoints"
+    runtime_state_path = _runtime_state_path(repo_root)
+    runtime_state = load_runtime_state(runtime_state_path)
+
+    controller = ShiftController(
+        ShiftConfig(
+            max_duration_hours=float(args.max_hours),
+            refresh_interval_minutes=float(args.refresh_minutes),
+            budget_limit_usd=9999.0,
+            max_cycles=10000,
+            require_fresh_assessment=False,
+            repo_path=str(repo_root),
+            checkpoint_dir=str(checkpoint_dir),
+        )
+    )
+    restored = restore_shift_controller(controller, checkpoint_dir=checkpoint_dir)
+    if restored is None:
+        await controller.start_shift(assessment_id=_assessment_id())
+    elif restored.status == "paused_for_refresh":
+        await controller.resume_after_refresh(_assessment_id())
+    elif restored.status != "running":
+        await controller.start_shift(assessment_id=_assessment_id())
+
+    cycle_reports: list[dict[str, Any]] = []
+    while True:
+        should_stop, reason = controller.check_should_stop()
+        if should_stop:
+            if reason.startswith("RefreshDue"):
+                await controller.pause_for_refresh(reason)
+                await controller.resume_after_refresh(_assessment_id())
+            else:
+                controller.complete_shift(reason)
+                break
+
+        report = run_shift_cycle(
+            repo_root=repo_root,
+            repo=args.repo,
+            benchmark_mode=args.benchmark_mode,
+            automation_backlog_limit=int(args.automation_backlog_limit),
+            runtime_state=runtime_state,
+        )
+        cycle_reports.append(report)
+        save_runtime_state(runtime_state_path, runtime_state)
+
+        objective = build_cycle_objective(report)
+        await controller.run_cycle(objective)
+        if report["stop_reason"]:
+            controller.complete_shift(str(report["stop_reason"]))
+            break
+        if args.once:
+            controller.complete_shift("completed")
+            break
+        await asyncio.sleep(float(args.interval_seconds))
+
+    summary = {
+        "shift": controller.get_progress_summary(),
+        "runtime_state": asdict(runtime_state),
+        "cycles": cycle_reports,
+    }
+    save_runtime_state(runtime_state_path, runtime_state)
+    return summary
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run a bounded proof-first unattended shift.")
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--max-hours", type=float, default=DEFAULT_MAX_HOURS)
+    parser.add_argument("--refresh-minutes", type=float, default=DEFAULT_REFRESH_MINUTES)
+    parser.add_argument("--benchmark-mode", default="hybrid", choices=["hybrid", "disabled"])
+    parser.add_argument("--queue-source", default="canonical", choices=["canonical"])
+    parser.add_argument(
+        "--automation-backlog-limit",
+        type=int,
+        default=DEFAULT_AUTOMATION_BACKLOG_LIMIT,
+    )
+    parser.add_argument("--interval-seconds", type=float, default=DEFAULT_INTERVAL_SECONDS)
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    summary = asyncio.run(_run_shift(args))
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        shift = summary["shift"]
+        print(
+            f"shift_id={shift.get('shift_id')} status={shift.get('status')} "
+            f"cycles={shift.get('cycles_completed')} stop_reason={shift.get('stop_reason')}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_auto_pr_publisher_workflow.py
+++ b/tests/scripts/test_auto_pr_publisher_workflow.py
@@ -18,6 +18,33 @@ def _auto_pr_publisher_steps() -> list[dict[str, object]]:
     return [step for step in steps if isinstance(step, dict)]
 
 
+def _auto_pr_publisher_workflow() -> dict[str, object]:
+    workflow_path = (
+        Path(__file__).resolve().parents[2] / ".github" / "workflows" / "auto-pr-publisher.yml"
+    )
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    if not isinstance(workflow, dict):
+        raise AssertionError("auto-pr-publisher workflow not found")
+    return workflow
+
+
+def _workflow_on(workflow: dict[str, object]) -> dict[str, object]:
+    on = workflow.get("on", workflow.get(True))
+    if not isinstance(on, dict):
+        raise AssertionError("auto-pr-publisher triggers not found")
+    return on
+
+
+def test_auto_pr_publisher_triggers_for_benchmark_publication_branches() -> None:
+    workflow = _auto_pr_publisher_workflow()
+    on = _workflow_on(workflow)
+    push = on.get("push")
+    assert isinstance(push, dict)
+    branches = push.get("branches")
+    assert isinstance(branches, list)
+    assert "benchmark-truth-publication/**" in branches
+
+
 def test_auto_pr_publisher_runs_publish_guard_before_pr_creation() -> None:
     steps = _auto_pr_publisher_steps()
     names = [str(step.get("name", "")) for step in steps]
@@ -59,3 +86,12 @@ def test_auto_pr_publisher_stops_when_automation_backlog_hits_cap() -> None:
     assert "const backlogLimit = 12;" in script
     assert "if (automationBacklog >= backlogLimit)" in script
     assert 'core.setOutput("status", "backlog_full")' in script
+
+
+def test_auto_pr_publisher_treats_benchmark_publication_branches_as_automation() -> None:
+    steps = _auto_pr_publisher_steps()
+    publish_step = next(
+        step for step in steps if step.get("name") == "Publish draft PR for automation branch"
+    )
+    script = str((publish_step.get("with") or {}).get("script", ""))
+    assert 'ref.startsWith("benchmark-truth-publication/")' in script

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -39,6 +39,13 @@ def _benchmark_truth_publication_steps() -> list[dict[str, object]]:
     return [step for step in steps if isinstance(step, dict)]
 
 
+def _workflow_on(workflow: dict[str, object]) -> dict[str, object]:
+    on = workflow.get("on", workflow.get(True))
+    if not isinstance(on, dict):
+        raise AssertionError("workflow triggers not found")
+    return on
+
+
 def _workflow_step(name: str) -> dict[str, object]:
     for step in _benchmark_truth_publication_steps():
         if str(step.get("name", "")) == name:
@@ -141,25 +148,34 @@ def test_refreshes_execution_verified_codex_runner_before_recurrence() -> None:
     assert "No execution-verified Codex runner selected after refresh." in run
 
 
-def test_publishes_refresh_via_pr_branch_instead_of_direct_main_push() -> None:
+def test_runs_daily_and_manual_dispatch() -> None:
+    workflow = _benchmark_truth_publication_workflow()
+    on = _workflow_on(workflow)
+    assert on.get("workflow_dispatch") is None or on.get("workflow_dispatch") == {}
+    schedule = on.get("schedule")
+    assert isinstance(schedule, list)
+    assert schedule == [{"cron": "20 13 * * *"}]
+
+
+def test_publishes_refresh_via_branch_only_and_delegates_pr_creation() -> None:
     workflow = _benchmark_truth_publication_workflow()
     permissions = workflow.get("permissions")
     assert permissions == {
         "contents": "write",
         "issues": "write",
-        "pull-requests": "write",
+        "pull-requests": "read",
     }
 
     publish_run = str(_workflow_step("Publish tracked trust-loop surfaces").get("run", ""))
-    run = str(_workflow_step("Commit and open PR for refreshed trust-loop surfaces").get("run", ""))
+    run = str(
+        _workflow_step("Commit and publish refreshed trust-loop surfaces branch").get("run", "")
+    )
     assert "--freshness-map docs/benchmarks/benchmark_corpus_freshness.json \\" in publish_run
     assert "--ensure-issues \\" in publish_run
     assert 'branch="benchmark-truth-publication/${GITHUB_RUN_ID}"' in run
     assert 'git checkout -b "$branch"' in run
     assert 'git push origin "$branch"' in run
-    assert "docs/benchmarks/benchmark_corpus_freshness.json \\" in run
-    assert "gh pr create \\" in run
-    assert "--base main \\" in run
-    assert '--head "$branch" \\' in run
-    assert '--body-file "$body_file"' in run
+    assert 'git commit -m "${title}"' in run
+    assert "[skip ci]" not in run
+    assert "gh pr create" not in run
     assert "git push origin HEAD:main" not in run

--- a/tests/scripts/test_check_branch_mutation_policy.py
+++ b/tests/scripts/test_check_branch_mutation_policy.py
@@ -46,6 +46,7 @@ def test_find_mutating_workflow_violations_requires_safe_benchmark_truth_publica
             "jobs:\n  x:\n    steps:\n      - run: |\n"
             '          branch="unsafe/tmp"\n'
             '          git push origin "$branch"\n'
+            '          gh pr create --base main --head "$branch"\n'
         ),
     }
     violations = find_mutating_workflow_violations(workflows)
@@ -58,8 +59,7 @@ def test_find_mutating_workflow_violations_requires_safe_benchmark_truth_publica
         for v in violations
     )
     assert any(
-        "must open a pull request instead of pushing directly to main" in v.message
-        for v in violations
+        "must delegate pull request creation to Auto PR Publisher" in v.message for v in violations
     )
 
 

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -93,6 +93,8 @@ def test_main_dry_run_fetches_and_filters_like_real_mode(
             "--dry-run",
             "--max-issues",
             "5",
+            "--label",
+            "lane:test",
         ],
     )
 
@@ -145,7 +147,7 @@ def test_main_create_mode_trims_to_max_and_writes_fingerprint(
             "--max-issues",
             "1",
             "--label",
-            "boss-ready",
+            "lane:test",
         ],
     )
 
@@ -157,7 +159,7 @@ def test_main_create_mode_trims_to_max_and_writes_fingerprint(
     repo, title, body, label = created[0]
     assert repo == "org/repo"
     assert title == first.title
-    assert label == "boss-ready"
+    assert label == "lane:test"
     assert f"<!-- fingerprint:{first.fingerprint} -->" in body
 
 
@@ -278,6 +280,70 @@ def test_main_non_boss_ready_label_allows_unknown_priority(monkeypatch, capsys) 
     out = capsys.readouterr().out
     assert "Done: 1 created, 0 failed" in out
     assert created[0][3] == "lane:test"
+
+
+def test_main_boss_ready_allows_tw02_benchmark_follow_up_without_do_now_code(
+    monkeypatch,
+    capsys,
+) -> None:
+    candidate = BossIssueCandidate(
+        category="test_coverage",
+        title="[TW-02] Restock stale issues in tw-01-bounded-execution-v1 rev-1",
+        description=(
+            "Refresh benchmark corpus freshness by updating docs/benchmarks/corpus.json "
+            "after stale closed issues were detected."
+        ),
+        file_scope=["docs/benchmarks/corpus.json"],
+        new_files=[],
+        validation_command="python3 scripts/measure_b0_scorecard.py --json",
+        acceptance_criteria=[
+            "Recurring benchmark truth publication reports fresh corpus membership."
+        ],
+    )
+    created: list[tuple[str, str, str, str]] = []
+
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: [candidate],
+    )
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+    monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(
+        mod,
+        "load_roadmap_priority_policy",
+        lambda repo_root: RoadmapPriorityPolicy(
+            do_now=frozenset({"CS-01", "CS-02", "CS-03"}),
+            delay=frozenset({"BC-07"}),
+            avoid=frozenset({"CS-04"}),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "create_github_issue",
+        lambda repo, title, body, label: (created.append((repo, title, body, label)) or True),
+    )
+    monkeypatch.setattr(mod.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--repo",
+            "org/repo",
+            "--max-issues",
+            "1",
+            "--label",
+            "boss-ready",
+        ],
+    )
+
+    mod.main()
+
+    out = capsys.readouterr().out
+    assert "Done: 1 created, 0 failed" in out
+    assert created[0][1] == candidate.title
 
 
 def test_fetch_existing_boss_issues_includes_fingerprinted_open_issues_without_label_filter(

--- a/tests/scripts/test_pr_admission_controller_workflow.py
+++ b/tests/scripts/test_pr_admission_controller_workflow.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def _pr_admission_controller_workflow() -> dict[str, object]:
+    workflow_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "pr-admission-controller.yml"
+    )
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    if not isinstance(workflow, dict):
+        raise AssertionError("pr-admission-controller workflow not found")
+    return workflow
+
+
+def _pr_admission_controller_steps() -> list[dict[str, object]]:
+    workflow = _pr_admission_controller_workflow()
+    jobs = workflow.get("jobs", {})
+    enforce_job = jobs.get("enforce-admission", {})
+    steps = enforce_job.get("steps", [])
+    if not isinstance(steps, list):
+        raise AssertionError("enforce-admission steps not found")
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def test_pr_admission_controller_inlines_checkout_integrity_after_checkout() -> None:
+    steps = _pr_admission_controller_steps()
+    names = [str(step.get("name", "")) for step in steps]
+    checkout_index = names.index("Checkout")
+    integrity_index = names.index("Verify checkout integrity")
+    assert checkout_index < integrity_index
+
+    integrity_step = steps[integrity_index]
+    assert integrity_step.get("uses") is None
+
+    run = str(integrity_step.get("run", ""))
+    assert "git sparse-checkout disable || true" in run
+    assert 'git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"' in run
+    assert 'git archive "${GITHUB_SHA:-HEAD}" | tar -x || git archive HEAD | tar -x' in run
+    assert "Repository checkout is incomplete (pyproject.toml missing)" in run

--- a/tests/scripts/test_reconcile_proof_first_queue.py
+++ b/tests/scripts/test_reconcile_proof_first_queue.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import reconcile_proof_first_queue as mod
+
+
+def test_reconcile_proof_first_queue_dry_run_removes_noncanonical_and_plans_docs_issue(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "list_open_queue_issues",
+        lambda **kwargs: [
+            {
+                "number": 1,
+                "title": "Replace silent exception swallowing in postgres_store.py",
+                "body": "Generic cleanup only.",
+                "labels": [{"name": "boss-ready"}],
+                "url": "https://github.com/org/repo/issues/1",
+            },
+            {
+                "number": 2,
+                "title": "[TW-02] Restock stale issues in tw-01-bounded-execution-v1 rev-1",
+                "body": "Refresh benchmark corpus freshness after stale closed issues were detected.",
+                "labels": [{"name": "boss-ready"}],
+                "url": "https://github.com/org/repo/issues/2",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "load_status_reconciliation_report",
+        lambda **kwargs: {
+            "summary": {"critical": 0, "warning": 1, "info": 0},
+            "findings": [
+                {
+                    "severity": "warning",
+                    "source": "status/NEXT_STEPS_CANONICAL.md",
+                    "message": "Docs claims outrun measured proof.",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(mod, "find_existing_open_issue_by_title", lambda **kwargs: None)
+
+    report = mod.reconcile_proof_first_queue(
+        repo="org/repo",
+        repo_root=Path("/tmp/repo"),
+        apply=False,
+    )
+
+    assert [item["number"] for item in report["kept"]] == [2]
+    assert [item["number"] for item in report["removed"]] == [1]
+    assert report["removed"][0]["action"] == "would_remove_label"
+    assert report["docs_issue"] == {
+        "action": "would_create_issue",
+        "title": mod.DEFAULT_DOCS_ISSUE_TITLE,
+    }
+
+
+def test_reconcile_proof_first_queue_apply_removes_label_and_reuses_existing_docs_issue(
+    monkeypatch,
+) -> None:
+    removed: list[int] = []
+    monkeypatch.setattr(
+        mod,
+        "list_open_queue_issues",
+        lambda **kwargs: [
+            {
+                "number": 5,
+                "title": "Replace silent exception swallowing in postgres_store.py",
+                "body": "Generic cleanup only.",
+                "labels": [{"name": "boss-ready"}],
+                "url": "https://github.com/org/repo/issues/5",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "remove_queue_label",
+        lambda **kwargs: removed.append(int(kwargs["issue_number"])),
+    )
+    monkeypatch.setattr(
+        mod,
+        "load_status_reconciliation_report",
+        lambda **kwargs: {
+            "summary": {"critical": 1, "warning": 0, "info": 0},
+            "findings": [
+                {
+                    "severity": "critical",
+                    "source": "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+                    "message": "Drift",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "find_existing_open_issue_by_title",
+        lambda **kwargs: {
+            "number": 42,
+            "title": mod.DEFAULT_DOCS_ISSUE_TITLE,
+            "url": "https://github.com/org/repo/issues/42",
+        },
+    )
+
+    report = mod.reconcile_proof_first_queue(
+        repo="org/repo",
+        repo_root=Path("/tmp/repo"),
+        apply=True,
+    )
+
+    assert removed == [5]
+    assert report["docs_issue"] == {
+        "action": "existing_issue",
+        "title": mod.DEFAULT_DOCS_ISSUE_TITLE,
+        "number": 42,
+        "url": "https://github.com/org/repo/issues/42",
+    }

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from scripts import run_proof_first_shift as mod
+
+
+def test_should_trigger_benchmark_rerun_when_latest_run_is_stale() -> None:
+    trigger, reason = mod.should_trigger_benchmark_rerun(
+        benchmark_mode="hybrid",
+        latest_run={
+            "databaseId": 123,
+            "createdAt": "2026-04-14T00:00:00Z",
+            "status": "completed",
+            "conclusion": "success",
+        },
+        has_open_publication_pr=False,
+        automation_backlog=0,
+        automation_backlog_limit=12,
+        last_triggered_run_id=None,
+        max_age_hours=1.0,
+    )
+
+    assert trigger is True
+    assert reason == "stale_publication_window"
+
+
+def test_should_trigger_benchmark_rerun_respects_backlog_cap() -> None:
+    trigger, reason = mod.should_trigger_benchmark_rerun(
+        benchmark_mode="hybrid",
+        latest_run=None,
+        has_open_publication_pr=False,
+        automation_backlog=12,
+        automation_backlog_limit=12,
+        last_triggered_run_id=None,
+    )
+
+    assert trigger is False
+    assert reason == "automation_backlog_full"
+
+
+def test_should_restart_service_requires_pending_work_and_budget() -> None:
+    assert (
+        mod.should_restart_service(
+            is_running=False, pending_count=3, restart_count=0, restart_limit=1
+        )
+        is True
+    )
+    assert (
+        mod.should_restart_service(
+            is_running=False, pending_count=3, restart_count=1, restart_limit=1
+        )
+        is False
+    )
+    assert mod.should_restart_service(is_running=True, pending_count=3, restart_count=0) is False
+
+
+def test_classify_benchmark_failure_log_detects_auth_and_publication_failures() -> None:
+    assert (
+        mod.classify_benchmark_failure_log("codex login required before benchmark publish")
+        == "auth_failure"
+    )
+    assert (
+        mod.classify_benchmark_failure_log(
+            "resource not accessible by integration during pr creation"
+        )
+        == "publication_failure"
+    )
+    assert mod.classify_benchmark_failure_log("unknown shell failure") == "other_failure"

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3083,48 +3083,84 @@ class TestBossLoopCLI:
         parsed = json.loads(out)
         assert parsed["stop_reason"] == "no_suitable_issue"
 
-    def test_boss_loop_label_filter_passes_with_all_labels(self, capsys):
-        """Issues carrying ALL required labels pass the filter."""
-        from aragora.cli.commands.swarm import cmd_swarm
 
-        fixture_issues = [
-            _make_issue(
-                1,
-                "Full match",
-                labels=["P0", "queue-eligible", "enhancement"],
-                body=(
-                    "Fix the thing\n\n"
-                    "Acceptance Criteria:\n"
-                    "- pytest -q tests/swarm/test_boss_loop.py\n"
-                ),
+def test_boss_loop_label_filter_passes_with_all_labels(self, capsys):
+    """Issues carrying ALL required labels pass the filter."""
+    from aragora.cli.commands.swarm import cmd_swarm
+
+    fixture_issues = [
+        _make_issue(
+            1,
+            "Full match",
+            labels=["P0", "queue-eligible", "enhancement"],
+            body=(
+                "Fix the thing\n\nAcceptance Criteria:\n- pytest -q tests/swarm/test_boss_loop.py\n"
             ),
-        ]
-        feed = MagicMock(spec=GitHubIssueFeed)
-        feed.fetch.return_value = fixture_issues
+        ),
+    ]
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = fixture_issues
 
-        args = self._swarm_args(
-            json=True,
-            max_ticks=1,
-            labels=["P0", "queue-eligible"],
-            no_dispatch=True,
-        )
+    args = self._swarm_args(
+        json=True,
+        max_ticks=1,
+        labels=["P0", "queue-eligible"],
+        no_dispatch=True,
+    )
 
-        with (
-            patch(
-                "aragora.swarm.boss_loop.check_runner_freshness",
-                return_value=_fresh_result(fresh=True),
-            ),
-            patch(
-                "aragora.swarm.boss_loop.GitHubIssueFeed",
-                return_value=feed,
-            ),
-        ):
-            cmd_swarm(args)
+    with (
+        patch(
+            "aragora.swarm.boss_loop.check_runner_freshness",
+            return_value=_fresh_result(fresh=True),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.GitHubIssueFeed",
+            return_value=feed,
+        ),
+    ):
+        cmd_swarm(args)
 
-        out = capsys.readouterr().out
-        parsed = json.loads(out)
-        # The issue was selected (didn't stop with no_suitable_issue)
-        assert parsed["stop_reason"] != "no_suitable_issue"
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    # The issue was selected (didn't stop with no_suitable_issue)
+    assert parsed["stop_reason"] != "no_suitable_issue"
+
+
+def test_filter_noncanonical_boss_ready_issues_strips_label_and_excludes_issue() -> None:
+    generic = _make_issue(
+        901,
+        "Replace silent exception swallowing in postgres_store.py",
+        body="Generic cleanup only.",
+        labels=["boss-ready"],
+    )
+    canonical = _make_issue(
+        902,
+        "[TW-02] Restock stale issues in tw-01-bounded-execution-v1 rev-1",
+        body="Refresh benchmark corpus freshness after stale closed issues were detected.",
+        labels=["boss-ready"],
+    )
+    loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
+    commands: list[list[str]] = []
+    comments: list[str] = []
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        commands.append(list(cmd))
+        if cmd[:3] == ["gh", "issue", "comment"]:
+            comments.append(cmd[cmd.index("--body") + 1])
+        return result
+
+    with patch("aragora.swarm.boss_loop.subprocess.run", side_effect=_run):
+        kept = loop._filter_noncanonical_boss_ready_issues([generic, canonical])
+
+    assert kept == [canonical]
+    assert "boss-ready" not in generic.labels
+    assert comments
+    assert "outside the canonical proof-first queue" in comments[-1]
+    assert any(cmd[:3] == ["gh", "issue", "edit"] for cmd in commands)
 
 
 @pytest.mark.asyncio

--- a/tests/swarm/test_proof_first_queue.py
+++ b/tests/swarm/test_proof_first_queue.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue
+from aragora.swarm.roadmap_priority import RoadmapPriorityPolicy
+
+
+def test_classify_proof_first_queue_issue_allows_do_now_roadmap_lane() -> None:
+    decision = classify_proof_first_queue_issue(
+        "[CS-01..03] Reconcile docs/status surfaces to current proof",
+        "Keep roadmap, status, and positioning docs narrower than measured proof.",
+        roadmap_policy=RoadmapPriorityPolicy(
+            do_now=frozenset({"CS-01", "CS-02", "CS-03"}),
+            delay=frozenset({"BC-07"}),
+            avoid=frozenset({"CS-04"}),
+        ),
+    )
+
+    assert decision.allowed is True
+    assert decision.lane == "roadmap_do_now"
+
+
+def test_classify_proof_first_queue_issue_allows_tw02_benchmark_follow_up() -> None:
+    decision = classify_proof_first_queue_issue(
+        "[TW-02] Restock stale issues in tw-01-bounded-execution-v1 rev-1",
+        "Refresh benchmark corpus freshness after stale closed issues were detected in the truth artifact.",
+    )
+
+    assert decision.allowed is True
+    assert decision.lane == "benchmark_regression"
+
+
+def test_classify_proof_first_queue_issue_allows_tw03_rescue_follow_up() -> None:
+    decision = classify_proof_first_queue_issue(
+        "[TW-03] Productize repeated rescue class: blocked-auth-failure",
+        "Repeated rescue class productization follow-up for rescue ledger drift.",
+    )
+
+    assert decision.allowed is True
+    assert decision.lane == "rescue_productization"
+
+
+def test_classify_proof_first_queue_issue_blocks_generic_cleanup() -> None:
+    decision = classify_proof_first_queue_issue(
+        "Replace silent exception swallowing in postgres_store.py",
+        "Tighten exception hygiene in a single module.",
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "non_canonical"

--- a/tests/swarm/test_roadmap_priority.py
+++ b/tests/swarm/test_roadmap_priority.py
@@ -52,3 +52,25 @@ def test_load_priority_policy_parses_canonical_sections(tmp_path: Path) -> None:
     assert blocked.blocked_codes == ("BC-07",)
     avoid = policy.priority_for_text("Refs: (`UDW-08`)")
     assert avoid.priority == RoadmapPriority.AVOID
+
+
+def test_load_priority_policy_resets_section_on_higher_level_heading(tmp_path: Path) -> None:
+    docs = tmp_path / "docs" / "status"
+    docs.mkdir(parents=True)
+    (docs / "NEXT_STEPS_CANONICAL.md").write_text(
+        "\n".join(
+            [
+                "### Avoid in this tranche",
+                "- `CS-04..12`",
+                "",
+                "## Live Boss-Ready Queue",
+                "- `TW-01`, `TW-02`, and `TW-03` publish through recurring status surfaces.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    policy = load_roadmap_priority_policy(tmp_path)
+
+    assert policy is not None
+    assert "TW-02" not in policy.avoid


### PR DESCRIPTION
## Summary
- switch benchmark truth publication to branch-only publish and let Auto PR Publisher own draft PR creation
- add proof-first queue governance, including canonical benchmark/rescue/docs classification, queue reconciliation, and boss-loop stripping of non-canonical `boss-ready`
- add `scripts/run_proof_first_shift.py` as the bounded unattended shift entrypoint with checkpointed runtime state and restart/rerun policy helpers

## Validation
- `python3 -m pytest tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_auto_pr_publisher_workflow.py tests/scripts/test_check_branch_mutation_policy.py tests/scripts/test_pr_admission_controller_workflow.py tests/swarm/test_roadmap_priority.py tests/swarm/test_proof_first_queue.py tests/scripts/test_reconcile_proof_first_queue.py tests/scripts/test_generate_boss_issues.py tests/scripts/test_run_proof_first_shift.py -q`
- `python3 -m ruff check aragora/swarm/roadmap_priority.py aragora/swarm/proof_first_queue.py scripts/reconcile_proof_first_queue.py scripts/run_proof_first_shift.py scripts/generate_boss_issues.py aragora/swarm/boss_loop.py tests/swarm/test_roadmap_priority.py tests/swarm/test_proof_first_queue.py tests/scripts/test_reconcile_proof_first_queue.py tests/scripts/test_run_proof_first_shift.py tests/scripts/test_generate_boss_issues.py tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_auto_pr_publisher_workflow.py tests/scripts/test_check_branch_mutation_policy.py tests/scripts/test_pr_admission_controller_workflow.py`
- `python3 scripts/check_branch_mutation_policy.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
- Applied `python3 scripts/reconcile_proof_first_queue.py --repo synaptent/aragora --repo-root . --apply --json`, which removed `boss-ready` from 13 non-canonical live issues and left the queue empty until a canonical proof-surface follow-up exists.
