### PR TITLE
fix(autonomy): fail closed on launchd restart hangs

### DIFF
--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -32,6 +32,8 @@ DEFAULT_MAX_HOURS = 12.0
 DEFAULT_INTERVAL_SECONDS = 120
 DEFAULT_BOSS_LABEL = "com.aragora.swarm-boss-loop"
 DEFAULT_MERGE_LABEL = "com.aragora.swarm-merge-arbiter"
+DEFAULT_BOSS_PROCESS_PATTERN = r"aragora\.cli\.main swarm boss-loop|run_boss_cycle\.sh"
+DEFAULT_MERGE_PROCESS_PATTERN = r"aragora\.cli\.main swarm merge-arbiter"
 AUTOMATION_BRANCH_PREFIXES = (
     "codex/",
     "factory/",
@@ -300,19 +302,43 @@ def should_restart_service(
     return (not is_running) and pending_count > 0 and restart_count < restart_limit
 
 
-def kickstart_launchd(label: str) -> None:
+def kickstart_launchd(label: str) -> tuple[bool, str]:
     uid = os.getuid()
-    proc = subprocess.run(
-        ["launchctl", "kickstart", f"gui/{uid}/{label}"],
-        text=True,
-        capture_output=True,
-        timeout=30,
-        check=False,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError(
-            proc.stderr.strip() or proc.stdout.strip() or f"launchctl kickstart failed for {label}"
+    try:
+        proc = subprocess.run(
+            ["launchctl", "kickstart", f"gui/{uid}/{label}"],
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=False,
         )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.strip() if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr.strip() if isinstance(exc.stderr, str) else ""
+        detail = stderr or stdout or f"launchctl kickstart timed out for {label}"
+        return False, detail
+    if proc.returncode != 0:
+        return (
+            False,
+            proc.stderr.strip() or proc.stdout.strip() or f"launchctl kickstart failed for {label}",
+        )
+    return True, ""
+
+
+def restart_service_via_launchd(
+    *,
+    label: str,
+    process_pattern: str,
+) -> tuple[bool, str]:
+    kicked, detail = kickstart_launchd(label)
+    if process_running(process_pattern):
+        return True, "" if kicked else detail
+    if kicked:
+        return (
+            False,
+            f"launchctl kickstart returned success for {label}, but process pattern {process_pattern!r} is still not running",
+        )
+    return False, detail
 
 
 def run_merge_arbiter_apply(
@@ -367,8 +393,8 @@ def run_shift_cycle(
     open_pr_count = len(prs)
     canonical_queue_count = len(queue_report["kept"])
 
-    boss_running = process_running(r"aragora\.cli\.main swarm boss-loop")
-    merge_running = process_running(r"aragora\.cli\.main swarm merge-arbiter")
+    boss_running = process_running(DEFAULT_BOSS_PROCESS_PATTERN)
+    merge_running = process_running(DEFAULT_MERGE_PROCESS_PATTERN)
 
     if boss_running:
         runtime_state.boss_restart_count = 0
@@ -376,23 +402,42 @@ def run_shift_cycle(
         runtime_state.merge_restart_count = 0
 
     actions: list[str] = []
+    service_failures: list[str] = []
     if should_restart_service(
         is_running=boss_running,
         pending_count=canonical_queue_count,
         restart_count=runtime_state.boss_restart_count,
     ):
-        kickstart_launchd(DEFAULT_BOSS_LABEL)
+        restarted, detail = restart_service_via_launchd(
+            label=DEFAULT_BOSS_LABEL,
+            process_pattern=DEFAULT_BOSS_PROCESS_PATTERN,
+        )
         runtime_state.boss_restart_count += 1
-        actions.append("restart_boss_loop")
+        if restarted:
+            actions.append("restart_boss_loop")
+        else:
+            actions.append("restart_boss_loop_failed")
+            service_failures.append(
+                f"BossRestartFailed: {detail or 'boss loop restart did not produce a running process'}"
+            )
 
     if should_restart_service(
         is_running=merge_running,
         pending_count=open_pr_count,
         restart_count=runtime_state.merge_restart_count,
     ):
-        kickstart_launchd(DEFAULT_MERGE_LABEL)
+        restarted, detail = restart_service_via_launchd(
+            label=DEFAULT_MERGE_LABEL,
+            process_pattern=DEFAULT_MERGE_PROCESS_PATTERN,
+        )
         runtime_state.merge_restart_count += 1
-        actions.append("restart_merge_arbiter")
+        if restarted:
+            actions.append("restart_merge_arbiter")
+        else:
+            actions.append("restart_merge_arbiter_failed")
+            service_failures.append(
+                f"MergeArbiterRestartFailed: {detail or 'merge arbiter restart did not produce a running process'}"
+            )
 
     merge_report = run_merge_arbiter_apply(
         repo_root=repo_root,
@@ -443,6 +488,8 @@ def run_shift_cycle(
         stop_reason = "RepeatedAuthFailure: benchmark publication failed auth twice"
     elif runtime_state.publication_failure_count >= 2:
         stop_reason = "RepeatedPublicationFailure: benchmark publication failed PR handoff twice"
+    elif service_failures:
+        stop_reason = service_failures[0]
 
     return {
         "queue_report": queue_report,

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,7 +15,19 @@ def _run_shift_cycle(
     latest_run: dict[str, object] | None = None,
     failure_log: str = "",
     benchmark_mode: str = "disabled",
+    restart_service_side_effect: list[tuple[bool, str]] | None = None,
 ) -> dict[str, object]:
+    restart_patch = (
+        patch(
+            "scripts.run_proof_first_shift.restart_service_via_launchd",
+            side_effect=restart_service_side_effect,
+        )
+        if restart_service_side_effect is not None
+        else patch(
+            "scripts.run_proof_first_shift.restart_service_via_launchd",
+            return_value=(True, ""),
+        )
+    )
     with (
         patch(
             "scripts.run_proof_first_shift.reconcile_proof_first_queue",
@@ -28,7 +41,7 @@ def _run_shift_cycle(
             "scripts.run_proof_first_shift.process_running",
             side_effect=process_running_side_effect,
         ),
-        patch("scripts.run_proof_first_shift.kickstart_launchd"),
+        restart_patch,
         patch("scripts.run_proof_first_shift.run_merge_arbiter_apply", return_value={"merged": []}),
         patch("scripts.run_proof_first_shift.latest_benchmark_run", return_value=latest_run),
         patch(
@@ -109,6 +122,21 @@ def test_classify_benchmark_failure_log_detects_auth_and_publication_failures() 
     assert mod.classify_benchmark_failure_log("unknown shell failure") == "other_failure"
 
 
+def test_kickstart_launchd_returns_timeout_detail_instead_of_raising() -> None:
+    with patch(
+        "scripts.run_proof_first_shift.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(
+            cmd=["launchctl", "kickstart", "gui/501/com.aragora.swarm-boss-loop"],
+            timeout=30,
+            stderr="launchctl timed out",
+        ),
+    ):
+        ok, detail = mod.kickstart_launchd("com.aragora.swarm-boss-loop")
+
+    assert ok is False
+    assert detail == "launchctl timed out"
+
+
 def test_run_shift_cycle_restores_restart_budget_after_healthy_cycle() -> None:
     state = mod.ProofFirstRuntimeState(boss_restart_count=1, merge_restart_count=1)
 
@@ -168,3 +196,17 @@ def test_run_shift_cycle_clears_failure_budget_after_successful_benchmark_run() 
     assert state.auth_failure_count == 1
     assert state.publication_failure_count == 0
     assert report["stop_reason"] == ""
+
+
+def test_run_shift_cycle_reports_restart_failure_instead_of_crashing() -> None:
+    state = mod.ProofFirstRuntimeState()
+
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[False, True],
+        restart_service_side_effect=[(False, "launchctl kickstart timed out for boss loop")],
+    )
+
+    assert state.boss_restart_count == 1
+    assert report["actions"] == ["restart_boss_loop_failed"]
+    assert report["stop_reason"] == "BossRestartFailed: launchctl kickstart timed out for boss loop"


### PR DESCRIPTION
## Summary
- make proof-first service restarts return status instead of throwing on launchctl hangs
- verify launchd restart attempts against the expected boss/merge process patterns
- add focused tests for timeout handling and fail-closed shift stop reasons

## Validation
- python3 -m pytest tests/scripts/test_run_proof_first_shift.py -q
- python3 -m ruff check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py
- python3 scripts/run_proof_first_shift.py --once --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD