### PR TITLE
fix(status): reconcile proof-first execution docs

### DIFF
--- a/scripts/reconcile_status_docs.py
+++ b/scripts/reconcile_status_docs.py
@@ -573,11 +573,32 @@ def _closed_current_execution_epic_findings() -> list[dict]:
     if not closed_epics:
         return findings
 
+    completed_context_markers = (
+        "completed",
+        "closed",
+        "foundation",
+        "foundational",
+        "historical",
+        "already completed",
+    )
     for path, label in CURRENT_EXECUTION_EPIC_DOCS:
         if not path.exists():
             continue
         content = path.read_text(encoding="utf-8", errors="replace")
-        referenced = [epic for epic in closed_epics if f"/issues/{int(epic['number'])}" in content]
+        referenced: list[dict] = []
+        lines = content.splitlines()
+        for epic in closed_epics:
+            issue_token = f"/issues/{int(epic['number'])}"
+            epic_lines = [line for line in lines if issue_token in line]
+            if not epic_lines:
+                continue
+            if any(
+                marker in line.lower()
+                for line in epic_lines
+                for marker in completed_context_markers
+            ):
+                continue
+            referenced.append(epic)
         if not referenced:
             continue
         refs = ", ".join(

--- a/tests/scripts/test_reconcile_status_docs.py
+++ b/tests/scripts/test_reconcile_status_docs.py
@@ -123,3 +123,73 @@ def test_check_execution_issue_tracking_ignores_open_current_epics(
     findings = mod._check_execution_issue_tracking()
 
     assert all(item["severity"] != "critical" for item in findings)
+
+
+def test_check_execution_issue_tracking_allows_completed_context_links(
+    monkeypatch, tmp_path: Path
+) -> None:
+    docs_status = tmp_path / "docs" / "status"
+    docs_status.mkdir(parents=True)
+
+    active = docs_status / "ACTIVE_EXECUTION_ISSUES.md"
+    active.write_text(
+        "\n".join(
+            [
+                "# Active Execution Issues",
+                "- Execution epics (closed): "
+                "[#804](https://github.com/synaptent/aragora/issues/804), "
+                "[#805](https://github.com/synaptent/aragora/issues/805), "
+                "[#806](https://github.com/synaptent/aragora/issues/806)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    next_steps = docs_status / "NEXT_STEPS_CANONICAL.md"
+    next_steps.write_text(
+        "\n".join(
+            [
+                "# Next Steps",
+                "[ACTIVE_EXECUTION_ISSUES](ACTIVE_EXECUTION_ISSUES.md)",
+                "The execution epics "
+                "[#804](https://github.com/synaptent/aragora/issues/804), "
+                "[#805](https://github.com/synaptent/aragora/issues/805), "
+                "[#806](https://github.com/synaptent/aragora/issues/806) are now closed on main.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(mod, "ACTIVE_EXECUTION_ISSUES", active)
+    monkeypatch.setattr(mod, "NEXT_STEPS_CANONICAL", next_steps)
+    monkeypatch.setattr(
+        mod,
+        "EXECUTION_TRACKING_DOCS",
+        [(next_steps, "status/NEXT_STEPS_CANONICAL.md")],
+    )
+    monkeypatch.setattr(mod, "REQUIRED_EXECUTION_ISSUES", [804, 805, 806])
+    monkeypatch.setattr(
+        mod,
+        "CURRENT_EXECUTION_EPIC_DOCS",
+        [
+            (next_steps, "status/NEXT_STEPS_CANONICAL.md"),
+            (active, "status/ACTIVE_EXECUTION_ISSUES.md"),
+        ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "_load_github_issue_metadata",
+        lambda issue_number, repo=mod.DEFAULT_GITHUB_REPO: {
+            "number": issue_number,
+            "state": "CLOSED",
+            "state_reason": "COMPLETED",
+            "title": f"Issue {issue_number}",
+            "url": f"https://github.com/synaptent/aragora/issues/{issue_number}",
+        },
+    )
+
+    findings = mod._check_execution_issue_tracking()
+
+    assert all(item["severity"] != "critical" for item in findings)


### PR DESCRIPTION
## Summary
- update the canonical proof-first status docs to treat #804/#805/#806 as completed foundation work
- point the live trust-loop lane at #5844 and its bounded follow-up issues
- allow the status reconciler to accept completed-context epic links while still flagging active closed-epic references

## Validation
- python3 scripts/reconcile_status_docs.py --json
- python3 -m pytest tests/scripts/test_reconcile_status_docs.py -q
- python3 -m ruff check scripts/reconcile_status_docs.py tests/scripts/test_reconcile_status_docs.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD