### PR TITLE
feat(swarm): add RS-10 shift ledger for proof-first runtime truth

### DIFF
--- a/aragora/swarm/shift_ledger.py
+++ b/aragora/swarm/shift_ledger.py
@@ -1,0 +1,245 @@
+"""Persistent shift ledger for proof-first runtime truth (RS-10).
+
+Accumulates structured entries across shifts so operator status
+can be answered from the ledger rather than shell sampling.
+Each entry is one JSONL line with a type, timestamp, and payload.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LEDGER_PATH = ".aragora/proof_first_shift/shift_ledger.jsonl"
+
+
+@dataclass
+class LedgerEntry:
+    """One ledger row."""
+
+    entry_type: str
+    timestamp: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LedgerEntry:
+        return cls(
+            entry_type=str(data.get("entry_type", "unknown")),
+            timestamp=str(data.get("timestamp", "")),
+            payload=dict(data.get("payload") or {}),
+        )
+
+
+class ShiftLedger:
+    """Append-only JSONL ledger for shift runtime truth.
+
+    Entry types:
+        shift_start     — new shift began
+        shift_stop      — shift ended (with reason)
+        cycle_tick      — periodic tick with queue/process/benchmark state
+        service_restart — boss loop or merge arbiter restarted
+        service_failure — restart attempt failed
+        benchmark_run   — benchmark publication run observed
+        queue_change    — boss-ready queue restocked or pruned
+        pr_merged       — automation PR merged
+        auth_failure    — Codex/GitHub auth failure detected
+        publication_failure — benchmark PR publication failure
+    """
+
+    def __init__(self, path: Path | None = None):
+        self._path = path or Path(DEFAULT_LEDGER_PATH)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _now_iso(self) -> str:
+        return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def append(self, entry_type: str, **payload: Any) -> LedgerEntry:
+        """Append a typed entry to the ledger."""
+        entry = LedgerEntry(
+            entry_type=entry_type,
+            timestamp=self._now_iso(),
+            payload=payload,
+        )
+        try:
+            with self._path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry.to_dict(), sort_keys=True) + "\n")
+        except OSError as exc:
+            logger.warning("shift_ledger_write_failed: %s", exc)
+        return entry
+
+    def read_all(self) -> list[LedgerEntry]:
+        """Read all entries from the ledger."""
+        if not self._path.exists():
+            return []
+        entries: list[LedgerEntry] = []
+        for line in self._path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(LedgerEntry.from_dict(json.loads(line)))
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.debug("shift_ledger_parse_skip: %s", exc)
+        return entries
+
+    def read_recent(self, *, max_age_hours: float = 24.0) -> list[LedgerEntry]:
+        """Read entries from the last N hours."""
+        cutoff = time.time() - (max_age_hours * 3600)
+        entries = self.read_all()
+        recent: list[LedgerEntry] = []
+        for entry in entries:
+            try:
+                ts = datetime.fromisoformat(entry.timestamp.replace("Z", "+00:00")).timestamp()
+                if ts >= cutoff:
+                    recent.append(entry)
+            except (ValueError, AttributeError):
+                recent.append(entry)  # keep unparseable entries
+        return recent
+
+    def read_by_type(self, entry_type: str) -> list[LedgerEntry]:
+        """Read all entries of a specific type."""
+        return [e for e in self.read_all() if e.entry_type == entry_type]
+
+    # -- Convenience recording methods --
+
+    def record_shift_start(
+        self,
+        *,
+        shift_id: str,
+        max_hours: float,
+        benchmark_mode: str,
+        queue_size: int,
+    ) -> LedgerEntry:
+        return self.append(
+            "shift_start",
+            shift_id=shift_id,
+            max_hours=max_hours,
+            benchmark_mode=benchmark_mode,
+            queue_size=queue_size,
+        )
+
+    def record_shift_stop(
+        self,
+        *,
+        shift_id: str,
+        reason: str,
+        cycles: int,
+        duration_seconds: float,
+    ) -> LedgerEntry:
+        return self.append(
+            "shift_stop",
+            shift_id=shift_id,
+            reason=reason,
+            cycles=cycles,
+            duration_seconds=duration_seconds,
+        )
+
+    def record_cycle_tick(
+        self,
+        *,
+        queue_size: int,
+        open_prs: int,
+        boss_running: bool,
+        merge_running: bool,
+        benchmark_fresh: bool,
+        actions: list[str] | None = None,
+    ) -> LedgerEntry:
+        return self.append(
+            "cycle_tick",
+            queue_size=queue_size,
+            open_prs=open_prs,
+            boss_running=boss_running,
+            merge_running=merge_running,
+            benchmark_fresh=benchmark_fresh,
+            actions=actions or [],
+        )
+
+    def record_service_restart(
+        self, *, service: str, success: bool, detail: str = ""
+    ) -> LedgerEntry:
+        return self.append(
+            "service_restart",
+            service=service,
+            success=success,
+            detail=detail,
+        )
+
+    def record_pr_merged(self, *, pr_number: int, title: str = "") -> LedgerEntry:
+        return self.append("pr_merged", pr_number=pr_number, title=title)
+
+    def record_benchmark_run(
+        self, *, run_id: int, conclusion: str, created_at: str = ""
+    ) -> LedgerEntry:
+        return self.append(
+            "benchmark_run",
+            run_id=run_id,
+            conclusion=conclusion,
+            created_at=created_at,
+        )
+
+    def record_failure(self, *, failure_type: str, detail: str = "") -> LedgerEntry:
+        return self.append(failure_type, detail=detail)
+
+    # -- Status summary --
+
+    def get_status_summary(self, *, max_age_hours: float = 24.0) -> dict[str, Any]:
+        """Build a status summary from recent ledger entries.
+
+        This is the single truthful view that replaces shell sampling.
+        """
+        recent = self.read_recent(max_age_hours=max_age_hours)
+
+        shifts = [e for e in recent if e.entry_type == "shift_start"]
+        stops = [e for e in recent if e.entry_type == "shift_stop"]
+        ticks = [e for e in recent if e.entry_type == "cycle_tick"]
+        merges = [e for e in recent if e.entry_type == "pr_merged"]
+        benchmarks = [e for e in recent if e.entry_type == "benchmark_run"]
+        restarts = [e for e in recent if e.entry_type == "service_restart"]
+        auth_failures = [e for e in recent if e.entry_type == "auth_failure"]
+        pub_failures = [e for e in recent if e.entry_type == "publication_failure"]
+
+        last_tick = ticks[-1] if ticks else None
+        last_stop = stops[-1] if stops else None
+        last_benchmark = benchmarks[-1] if benchmarks else None
+
+        return {
+            "period_hours": max_age_hours,
+            "total_entries": len(recent),
+            "shifts_started": len(shifts),
+            "shifts_stopped": len(stops),
+            "last_stop_reason": last_stop.payload.get("reason", "") if last_stop else "",
+            "cycle_ticks": len(ticks),
+            "prs_merged": len(merges),
+            "pr_numbers_merged": [e.payload.get("pr_number") for e in merges],
+            "service_restarts": len(restarts),
+            "restart_successes": sum(1 for e in restarts if e.payload.get("success")),
+            "restart_failures": sum(1 for e in restarts if not e.payload.get("success")),
+            "auth_failures": len(auth_failures),
+            "publication_failures": len(pub_failures),
+            "benchmark_runs": len(benchmarks),
+            "last_benchmark_conclusion": (
+                last_benchmark.payload.get("conclusion", "") if last_benchmark else ""
+            ),
+            "current_queue_size": (last_tick.payload.get("queue_size", 0) if last_tick else None),
+            "current_boss_running": (last_tick.payload.get("boss_running") if last_tick else None),
+            "current_merge_running": (
+                last_tick.payload.get("merge_running") if last_tick else None
+            ),
+            "current_benchmark_fresh": (
+                last_tick.payload.get("benchmark_fresh") if last_tick else None
+            ),
+        }

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from aragora.nomic.checkpoints import load_latest_checkpoint  # noqa: E402
 from aragora.nomic.shift_controller import ShiftConfig, ShiftController, ShiftState  # noqa: E402
+from aragora.swarm.shift_ledger import ShiftLedger  # noqa: E402
 from scripts.reconcile_proof_first_queue import reconcile_proof_first_queue  # noqa: E402
 from scripts.watch_boss_lane import collect_snapshot  # noqa: E402
 
@@ -385,6 +386,7 @@ def run_shift_cycle(
     benchmark_mode: str,
     automation_backlog_limit: int,
     runtime_state: ProofFirstRuntimeState,
+    ledger: ShiftLedger | None = None,
 ) -> dict[str, Any]:
     queue_report = reconcile_proof_first_queue(repo=repo, repo_root=repo_root, apply=True)
     snapshot = collect_boss_lane_snapshot(repo_root=repo_root, repo=repo)
@@ -415,11 +417,15 @@ def run_shift_cycle(
         runtime_state.boss_restart_count += 1
         if restarted:
             actions.append("restart_boss_loop")
+            if ledger:
+                ledger.record_service_restart(service="boss_loop", success=True)
         else:
             actions.append("restart_boss_loop_failed")
             service_failures.append(
                 f"BossRestartFailed: {detail or 'boss loop restart did not produce a running process'}"
             )
+            if ledger:
+                ledger.record_service_restart(service="boss_loop", success=False, detail=detail)
 
     if should_restart_service(
         is_running=merge_running,
@@ -433,11 +439,15 @@ def run_shift_cycle(
         runtime_state.merge_restart_count += 1
         if restarted:
             actions.append("restart_merge_arbiter")
+            if ledger:
+                ledger.record_service_restart(service="merge_arbiter", success=True)
         else:
             actions.append("restart_merge_arbiter_failed")
             service_failures.append(
                 f"MergeArbiterRestartFailed: {detail or 'merge arbiter restart did not produce a running process'}"
             )
+            if ledger:
+                ledger.record_service_restart(service="merge_arbiter", success=False, detail=detail)
 
     merge_report = run_merge_arbiter_apply(
         repo_root=repo_root,
@@ -447,6 +457,9 @@ def run_shift_cycle(
     merged_numbers = list(merge_report.get("merged") or [])
     if merged_numbers:
         actions.append(f"merged_prs:{','.join(str(number) for number in merged_numbers)}")
+        if ledger:
+            for num in merged_numbers:
+                ledger.record_pr_merged(pr_number=int(num))
 
     latest_run = latest_benchmark_run(repo_root=repo_root, repo=repo)
     if latest_run is not None:
@@ -454,13 +467,25 @@ def run_shift_cycle(
         conclusion = str(latest_run.get("conclusion") or "").strip().lower()
         if run_id and run_id != int(runtime_state.last_benchmark_run_id or 0):
             runtime_state.last_benchmark_run_id = run_id
+            if ledger:
+                ledger.record_benchmark_run(
+                    run_id=run_id,
+                    conclusion=conclusion,
+                    created_at=str(latest_run.get("createdAt", "")),
+                )
             if conclusion == "failure":
                 failure_log = fetch_benchmark_failure_log(repo_root=repo_root, run_id=run_id)
                 failure_class = classify_benchmark_failure_log(failure_log)
                 if failure_class == "auth_failure":
                     runtime_state.auth_failure_count += 1
+                    if ledger:
+                        ledger.record_failure(failure_type="auth_failure", detail=failure_log[:500])
                 elif failure_class == "publication_failure":
                     runtime_state.publication_failure_count += 1
+                    if ledger:
+                        ledger.record_failure(
+                            failure_type="publication_failure", detail=failure_log[:500]
+                        )
             elif conclusion == "success":
                 runtime_state.auth_failure_count = 0
                 runtime_state.publication_failure_count = 0
@@ -491,6 +516,21 @@ def run_shift_cycle(
     elif service_failures:
         stop_reason = service_failures[0]
 
+    # Record cycle tick in ledger
+    benchmark_fresh = False
+    if latest_run is not None:
+        conclusion = str(latest_run.get("conclusion") or "").strip().lower()
+        benchmark_fresh = conclusion == "success"
+    if ledger:
+        ledger.record_cycle_tick(
+            queue_size=canonical_queue_count,
+            open_prs=open_pr_count,
+            boss_running=boss_running,
+            merge_running=merge_running,
+            benchmark_fresh=benchmark_fresh,
+            actions=actions,
+        )
+
     return {
         "queue_report": queue_report,
         "snapshot": snapshot,
@@ -520,6 +560,9 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
     checkpoint_dir = repo_root / ".aragora" / DEFAULT_SHIFT_DIRNAME / "checkpoints"
     runtime_state_path = _runtime_state_path(repo_root)
     runtime_state = load_runtime_state(runtime_state_path)
+    ledger = ShiftLedger(path=repo_root / ".aragora" / DEFAULT_SHIFT_DIRNAME / "shift_ledger.jsonl")
+    shift_id = _assessment_id()
+    shift_start_time = time.monotonic()
 
     controller = ShiftController(
         ShiftConfig(
@@ -534,13 +577,22 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
     )
     restored = restore_shift_controller(controller, checkpoint_dir=checkpoint_dir)
     if restored is None:
-        await controller.start_shift(assessment_id=_assessment_id())
+        await controller.start_shift(assessment_id=shift_id)
     elif restored.status == "paused_for_refresh":
-        await controller.resume_after_refresh(_assessment_id())
+        await controller.resume_after_refresh(shift_id)
     elif restored.status != "running":
-        await controller.start_shift(assessment_id=_assessment_id())
+        await controller.start_shift(assessment_id=shift_id)
+
+    # Record shift start in ledger
+    ledger.record_shift_start(
+        shift_id=shift_id,
+        max_hours=float(args.max_hours),
+        benchmark_mode=args.benchmark_mode,
+        queue_size=0,  # will be updated on first tick
+    )
 
     cycle_reports: list[dict[str, Any]] = []
+    cycle_count = 0
     while True:
         should_stop, reason = controller.check_should_stop()
         if should_stop:
@@ -549,6 +601,12 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
                 await controller.resume_after_refresh(_assessment_id())
             else:
                 controller.complete_shift(reason)
+                ledger.record_shift_stop(
+                    shift_id=shift_id,
+                    reason=reason,
+                    cycles=cycle_count,
+                    duration_seconds=time.monotonic() - shift_start_time,
+                )
                 break
 
         report = run_shift_cycle(
@@ -557,17 +615,31 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
             benchmark_mode=args.benchmark_mode,
             automation_backlog_limit=int(args.automation_backlog_limit),
             runtime_state=runtime_state,
+            ledger=ledger,
         )
         cycle_reports.append(report)
+        cycle_count += 1
         save_runtime_state(runtime_state_path, runtime_state)
 
         objective = build_cycle_objective(report)
         await controller.run_cycle(objective)
         if report["stop_reason"]:
             controller.complete_shift(str(report["stop_reason"]))
+            ledger.record_shift_stop(
+                shift_id=shift_id,
+                reason=str(report["stop_reason"]),
+                cycles=cycle_count,
+                duration_seconds=time.monotonic() - shift_start_time,
+            )
             break
         if args.once:
             controller.complete_shift("completed")
+            ledger.record_shift_stop(
+                shift_id=shift_id,
+                reason="completed",
+                cycles=cycle_count,
+                duration_seconds=time.monotonic() - shift_start_time,
+            )
             break
         await asyncio.sleep(float(args.interval_seconds))
 
@@ -575,6 +647,7 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
         "shift": controller.get_progress_summary(),
         "runtime_state": asdict(runtime_state),
         "cycles": cycle_reports,
+        "ledger_status": ledger.get_status_summary(max_age_hours=float(args.max_hours)),
     }
     save_runtime_state(runtime_state_path, runtime_state)
     return summary

--- a/tests/swarm/test_shift_ledger.py
+++ b/tests/swarm/test_shift_ledger.py
@@ -1,0 +1,169 @@
+"""Tests for the shift ledger (RS-10 runtime truth)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm.shift_ledger import LedgerEntry, ShiftLedger
+
+
+@pytest.fixture()
+def ledger(tmp_path: Path) -> ShiftLedger:
+    return ShiftLedger(path=tmp_path / "test_ledger.jsonl")
+
+
+class TestLedgerEntry:
+    def test_roundtrip(self) -> None:
+        entry = LedgerEntry(
+            entry_type="shift_start",
+            timestamp="2026-04-15T12:00:00Z",
+            payload={"shift_id": "s1", "max_hours": 12},
+        )
+        d = entry.to_dict()
+        restored = LedgerEntry.from_dict(d)
+        assert restored.entry_type == "shift_start"
+        assert restored.payload["shift_id"] == "s1"
+        assert restored.timestamp == "2026-04-15T12:00:00Z"
+
+    def test_from_dict_defaults(self) -> None:
+        entry = LedgerEntry.from_dict({})
+        assert entry.entry_type == "unknown"
+        assert entry.payload == {}
+
+
+class TestShiftLedger:
+    def test_append_and_read_all(self, ledger: ShiftLedger) -> None:
+        ledger.append("shift_start", shift_id="s1")
+        ledger.append("cycle_tick", queue_size=5)
+        entries = ledger.read_all()
+        assert len(entries) == 2
+        assert entries[0].entry_type == "shift_start"
+        assert entries[1].entry_type == "cycle_tick"
+        assert entries[1].payload["queue_size"] == 5
+
+    def test_read_empty_ledger(self, ledger: ShiftLedger) -> None:
+        assert ledger.read_all() == []
+
+    def test_read_by_type(self, ledger: ShiftLedger) -> None:
+        ledger.append("cycle_tick", queue_size=3)
+        ledger.append("pr_merged", pr_number=123)
+        ledger.append("cycle_tick", queue_size=2)
+        ticks = ledger.read_by_type("cycle_tick")
+        assert len(ticks) == 2
+        merges = ledger.read_by_type("pr_merged")
+        assert len(merges) == 1
+
+    def test_jsonl_format(self, ledger: ShiftLedger) -> None:
+        ledger.append("shift_start", shift_id="s1")
+        lines = ledger.path.read_text().splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["entry_type"] == "shift_start"
+        assert "timestamp" in parsed
+
+    def test_malformed_lines_skipped(self, ledger: ShiftLedger) -> None:
+        ledger.path.write_text("not json\n{}\n")
+        entries = ledger.read_all()
+        assert len(entries) == 1
+        assert entries[0].entry_type == "unknown"
+
+    def test_record_shift_lifecycle(self, ledger: ShiftLedger) -> None:
+        ledger.record_shift_start(
+            shift_id="s1", max_hours=12, benchmark_mode="hybrid", queue_size=5
+        )
+        ledger.record_cycle_tick(
+            queue_size=5,
+            open_prs=2,
+            boss_running=True,
+            merge_running=True,
+            benchmark_fresh=True,
+        )
+        ledger.record_pr_merged(pr_number=100, title="fix something")
+        ledger.record_service_restart(service="boss_loop", success=True)
+        ledger.record_benchmark_run(run_id=999, conclusion="success")
+        ledger.record_shift_stop(shift_id="s1", reason="completed", cycles=5, duration_seconds=3600)
+
+        entries = ledger.read_all()
+        assert len(entries) == 6
+        types = [e.entry_type for e in entries]
+        assert types == [
+            "shift_start",
+            "cycle_tick",
+            "pr_merged",
+            "service_restart",
+            "benchmark_run",
+            "shift_stop",
+        ]
+
+    def test_record_failure(self, ledger: ShiftLedger) -> None:
+        ledger.record_failure(failure_type="auth_failure", detail="401 Unauthorized")
+        entries = ledger.read_all()
+        assert len(entries) == 1
+        assert entries[0].entry_type == "auth_failure"
+        assert entries[0].payload["detail"] == "401 Unauthorized"
+
+
+class TestStatusSummary:
+    def test_empty_summary(self, ledger: ShiftLedger) -> None:
+        summary = ledger.get_status_summary()
+        assert summary["total_entries"] == 0
+        assert summary["prs_merged"] == 0
+        assert summary["current_queue_size"] is None
+
+    def test_populated_summary(self, ledger: ShiftLedger) -> None:
+        ledger.record_shift_start(
+            shift_id="s1", max_hours=12, benchmark_mode="hybrid", queue_size=5
+        )
+        ledger.record_cycle_tick(
+            queue_size=3,
+            open_prs=1,
+            boss_running=True,
+            merge_running=True,
+            benchmark_fresh=True,
+        )
+        ledger.record_pr_merged(pr_number=100)
+        ledger.record_pr_merged(pr_number=101)
+        ledger.record_service_restart(service="boss_loop", success=True)
+        ledger.record_service_restart(service="boss_loop", success=False, detail="timeout")
+        ledger.record_benchmark_run(run_id=999, conclusion="success")
+        ledger.record_failure(failure_type="auth_failure", detail="401")
+        ledger.record_shift_stop(shift_id="s1", reason="completed", cycles=1, duration_seconds=3600)
+
+        summary = ledger.get_status_summary()
+        assert summary["shifts_started"] == 1
+        assert summary["shifts_stopped"] == 1
+        assert summary["last_stop_reason"] == "completed"
+        assert summary["prs_merged"] == 2
+        assert summary["pr_numbers_merged"] == [100, 101]
+        assert summary["service_restarts"] == 2
+        assert summary["restart_successes"] == 1
+        assert summary["restart_failures"] == 1
+        assert summary["auth_failures"] == 1
+        assert summary["benchmark_runs"] == 1
+        assert summary["last_benchmark_conclusion"] == "success"
+        assert summary["current_queue_size"] == 3
+        assert summary["current_boss_running"] is True
+        assert summary["current_benchmark_fresh"] is True
+
+    def test_multiple_ticks_uses_latest(self, ledger: ShiftLedger) -> None:
+        ledger.record_cycle_tick(
+            queue_size=10,
+            open_prs=5,
+            boss_running=False,
+            merge_running=True,
+            benchmark_fresh=False,
+        )
+        ledger.record_cycle_tick(
+            queue_size=3,
+            open_prs=1,
+            boss_running=True,
+            merge_running=True,
+            benchmark_fresh=True,
+        )
+        summary = ledger.get_status_summary()
+        assert summary["current_queue_size"] == 3
+        assert summary["current_boss_running"] is True


### PR DESCRIPTION
## Summary
- Implements RS-10: persistent JSONL shift ledger replacing shell sampling
- New module: `aragora/swarm/shift_ledger.py` (ShiftLedger class)
- Entry types: shift_start, shift_stop, cycle_tick, service_restart, pr_merged, benchmark_run, auth_failure, publication_failure
- `get_status_summary()` provides single truthful operator view
- Wired into `run_proof_first_shift.py` — every tick, restart, merge, and failure is recorded
- 12 new tests + 8 existing tests pass (20 total)

This is Stage 1 of the proof-first plan: centralizing runtime truth so operator status stops depending on shell sampling.

## Test plan
- [x] `pytest tests/swarm/test_shift_ledger.py` — 12 passed
- [x] `pytest tests/scripts/test_run_proof_first_shift.py` — 8 passed
- [x] Syntax verification on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)