### PR TITLE
feat(autonomy): harden proof-first operator surfaces

### DIFF
--- a/aragora/swarm/shift_ledger.py
+++ b/aragora/swarm/shift_ledger.py
@@ -18,6 +18,14 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 DEFAULT_LEDGER_PATH = ".aragora/proof_first_shift/shift_ledger.jsonl"
+GREEN_SHIFT_REQUIRED_HOURS = 12.0
+FAILURE_THRESHOLDS = {
+    "auth_failure": 2,
+    "publication_failure": 2,
+    "runtime_failure": 1,
+    "service_failure": 1,
+}
+HEALTHY_STOP_PREFIXES = ("completed", "TimeLimit:")
 
 
 @dataclass
@@ -152,20 +160,24 @@ class ShiftLedger:
         self,
         *,
         queue_size: int,
+        queue_removed: int = 0,
         open_prs: int,
         boss_running: bool,
         merge_running: bool,
         benchmark_fresh: bool,
         actions: list[str] | None = None,
+        stop_reason: str = "",
     ) -> LedgerEntry:
         return self.append(
             "cycle_tick",
             queue_size=queue_size,
+            queue_removed=queue_removed,
             open_prs=open_prs,
             boss_running=boss_running,
             merge_running=merge_running,
             benchmark_fresh=benchmark_fresh,
             actions=actions or [],
+            stop_reason=stop_reason,
         )
 
     def record_service_restart(
@@ -196,12 +208,119 @@ class ShiftLedger:
 
     # -- Status summary --
 
+    def _parse_timestamp(self, value: str) -> datetime | None:
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+        except ValueError:
+            return None
+
+    def _latest_shift_entries(self, entries: list[LedgerEntry]) -> list[LedgerEntry]:
+        for index in range(len(entries) - 1, -1, -1):
+            if entries[index].entry_type == "shift_start":
+                return entries[index:]
+        return []
+
+    def _build_failure_policy_summary(
+        self, entries: list[LedgerEntry]
+    ) -> dict[str, dict[str, Any]]:
+        counts = {
+            "auth_failure": sum(1 for e in entries if e.entry_type == "auth_failure"),
+            "publication_failure": sum(1 for e in entries if e.entry_type == "publication_failure"),
+            "runtime_failure": sum(1 for e in entries if e.entry_type == "runtime_failure"),
+            "service_failure": sum(1 for e in entries if e.entry_type == "service_failure"),
+        }
+        status: dict[str, dict[str, Any]] = {}
+        for failure_type, count in counts.items():
+            stop_after = FAILURE_THRESHOLDS[failure_type]
+            status[failure_type] = {
+                "count": count,
+                "stop_after": stop_after,
+                "remaining_self_heal_attempts": max(0, stop_after - count - 1),
+                "will_stop": count >= stop_after,
+            }
+        return status
+
+    def _build_green_shift_summary(self, entries: list[LedgerEntry]) -> dict[str, Any]:
+        if not entries:
+            return {
+                "required_hours": GREEN_SHIFT_REQUIRED_HOURS,
+                "observed_hours": 0.0,
+                "window_complete": False,
+                "benchmark_fresh": False,
+                "queue_disciplined": False,
+                "boss_service_healthy": False,
+                "merge_service_healthy": False,
+                "no_repeated_failures": False,
+                "healthy_stop_reason": False,
+                "is_green": False,
+                "last_stop_reason": "",
+            }
+
+        ticks = [e for e in entries if e.entry_type == "cycle_tick"]
+        stops = [e for e in entries if e.entry_type == "shift_stop"]
+        last_tick = ticks[-1] if ticks else None
+        last_stop = stops[-1] if stops else None
+        start_time = self._parse_timestamp(entries[0].timestamp)
+        end_time = self._parse_timestamp((last_stop or entries[-1]).timestamp)
+        observed_hours = 0.0
+        if start_time is not None and end_time is not None:
+            observed_hours = max(0.0, (end_time - start_time).total_seconds() / 3600.0)
+
+        failure_policy = self._build_failure_policy_summary(entries)
+        last_stop_reason = ""
+        if last_stop is not None:
+            last_stop_reason = str(last_stop.payload.get("reason", ""))
+        elif last_tick is not None:
+            last_stop_reason = str(last_tick.payload.get("stop_reason", ""))
+
+        current_queue_size = last_tick.payload.get("queue_size") if last_tick else None
+        current_open_prs = last_tick.payload.get("open_prs") if last_tick else None
+        boss_running = bool(last_tick.payload.get("boss_running")) if last_tick else False
+        merge_running = bool(last_tick.payload.get("merge_running")) if last_tick else False
+        benchmark_fresh = bool(last_tick.payload.get("benchmark_fresh")) if last_tick else False
+        queue_removed = sum(int(e.payload.get("queue_removed", 0) or 0) for e in ticks)
+        boss_service_healthy = boss_running or current_queue_size in (0, None)
+        merge_service_healthy = merge_running or current_open_prs in (0, None)
+        healthy_stop_reason = last_stop_reason == "" or any(
+            last_stop_reason.startswith(p) for p in HEALTHY_STOP_PREFIXES
+        )
+        no_repeated_failures = all(not status["will_stop"] for status in failure_policy.values())
+        queue_disciplined = queue_removed == 0
+        window_complete = observed_hours >= GREEN_SHIFT_REQUIRED_HOURS
+
+        return {
+            "required_hours": GREEN_SHIFT_REQUIRED_HOURS,
+            "observed_hours": round(observed_hours, 2),
+            "window_complete": window_complete,
+            "benchmark_fresh": benchmark_fresh,
+            "queue_disciplined": queue_disciplined,
+            "queue_removed": queue_removed,
+            "boss_service_healthy": boss_service_healthy,
+            "merge_service_healthy": merge_service_healthy,
+            "no_repeated_failures": no_repeated_failures,
+            "healthy_stop_reason": healthy_stop_reason,
+            "last_stop_reason": last_stop_reason,
+            "is_green": all(
+                (
+                    window_complete,
+                    benchmark_fresh,
+                    queue_disciplined,
+                    boss_service_healthy,
+                    merge_service_healthy,
+                    no_repeated_failures,
+                    healthy_stop_reason,
+                )
+            ),
+        }
+
     def get_status_summary(self, *, max_age_hours: float = 24.0) -> dict[str, Any]:
         """Build a status summary from recent ledger entries.
 
         This is the single truthful view that replaces shell sampling.
         """
+        all_entries = self.read_all()
         recent = self.read_recent(max_age_hours=max_age_hours)
+        latest_shift_entries = self._latest_shift_entries(all_entries)
 
         shifts = [e for e in recent if e.entry_type == "shift_start"]
         stops = [e for e in recent if e.entry_type == "shift_stop"]
@@ -211,10 +330,14 @@ class ShiftLedger:
         restarts = [e for e in recent if e.entry_type == "service_restart"]
         auth_failures = [e for e in recent if e.entry_type == "auth_failure"]
         pub_failures = [e for e in recent if e.entry_type == "publication_failure"]
+        runtime_failures = [e for e in recent if e.entry_type == "runtime_failure"]
+        service_failures = [e for e in recent if e.entry_type == "service_failure"]
 
         last_tick = ticks[-1] if ticks else None
         last_stop = stops[-1] if stops else None
         last_benchmark = benchmarks[-1] if benchmarks else None
+        failure_policy = self._build_failure_policy_summary(latest_shift_entries)
+        green_shift = self._build_green_shift_summary(latest_shift_entries)
 
         return {
             "period_hours": max_age_hours,
@@ -230,11 +353,17 @@ class ShiftLedger:
             "restart_failures": sum(1 for e in restarts if not e.payload.get("success")),
             "auth_failures": len(auth_failures),
             "publication_failures": len(pub_failures),
+            "runtime_failures": len(runtime_failures),
+            "service_failures": len(service_failures),
             "benchmark_runs": len(benchmarks),
             "last_benchmark_conclusion": (
                 last_benchmark.payload.get("conclusion", "") if last_benchmark else ""
             ),
             "current_queue_size": (last_tick.payload.get("queue_size", 0) if last_tick else None),
+            "current_queue_removed": (
+                last_tick.payload.get("queue_removed", 0) if last_tick else None
+            ),
+            "current_open_prs": (last_tick.payload.get("open_prs", 0) if last_tick else None),
             "current_boss_running": (last_tick.payload.get("boss_running") if last_tick else None),
             "current_merge_running": (
                 last_tick.payload.get("merge_running") if last_tick else None
@@ -242,4 +371,6 @@ class ShiftLedger:
             "current_benchmark_fresh": (
                 last_tick.payload.get("benchmark_fresh") if last_tick else None
             ),
+            "failure_policy": failure_policy,
+            "green_shift": green_shift,
         }

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -35,6 +35,32 @@ DEFAULT_BOSS_LABEL = "com.aragora.swarm-boss-loop"
 DEFAULT_MERGE_LABEL = "com.aragora.swarm-merge-arbiter"
 DEFAULT_BOSS_PROCESS_PATTERN = r"aragora\.cli\.main swarm boss-loop|run_boss_cycle\.sh"
 DEFAULT_MERGE_PROCESS_PATTERN = r"aragora\.cli\.main swarm merge-arbiter"
+AUTH_FAILURE_STOP_AFTER = 2
+PUBLICATION_FAILURE_STOP_AFTER = 2
+RUNTIME_FAILURE_STOP_AFTER = 1
+SERVICE_FAILURE_STOP_AFTER = 1
+FAILURE_POLICIES: dict[str, dict[str, Any]] = {
+    "auth_failure": {
+        "stop_after": AUTH_FAILURE_STOP_AFTER,
+        "self_heal": "retry_benchmark_once",
+        "description": "Allow one benchmark auth failure, then fail closed on the next one.",
+    },
+    "publication_failure": {
+        "stop_after": PUBLICATION_FAILURE_STOP_AFTER,
+        "self_heal": "retry_benchmark_once",
+        "description": "Allow one benchmark publication handoff failure, then fail closed.",
+    },
+    "runtime_failure": {
+        "stop_after": RUNTIME_FAILURE_STOP_AFTER,
+        "self_heal": "none",
+        "description": "Stop immediately when the shift runtime loses truthful control surfaces.",
+    },
+    "service_failure": {
+        "stop_after": SERVICE_FAILURE_STOP_AFTER,
+        "self_heal": "restart_service_once",
+        "description": "Attempt one service restart when work is pending, then fail closed.",
+    },
+}
 AUTOMATION_BRANCH_PREFIXES = (
     "codex/",
     "factory/",
@@ -49,6 +75,7 @@ class ProofFirstRuntimeState:
     merge_restart_count: int = 0
     auth_failure_count: int = 0
     publication_failure_count: int = 0
+    runtime_failure_count: int = 0
     last_benchmark_run_id: int | None = None
     last_triggered_benchmark_run_id: int | None = None
 
@@ -76,6 +103,7 @@ def load_runtime_state(path: Path) -> ProofFirstRuntimeState:
         merge_restart_count=int(payload.get("merge_restart_count", 0) or 0),
         auth_failure_count=int(payload.get("auth_failure_count", 0) or 0),
         publication_failure_count=int(payload.get("publication_failure_count", 0) or 0),
+        runtime_failure_count=int(payload.get("runtime_failure_count", 0) or 0),
         last_benchmark_run_id=(
             int(payload["last_benchmark_run_id"]) if payload.get("last_benchmark_run_id") else None
         ),
@@ -281,6 +309,32 @@ def github_unavailable_stop_reason(queue_report: dict[str, Any]) -> str:
     return "GitHubUnavailable: proof-first queue reconciliation could not reach GitHub"
 
 
+def build_failure_policy_status(
+    runtime_state: ProofFirstRuntimeState,
+    *,
+    service_failure_count: int = 0,
+) -> dict[str, dict[str, Any]]:
+    counts = {
+        "auth_failure": int(runtime_state.auth_failure_count or 0),
+        "publication_failure": int(runtime_state.publication_failure_count or 0),
+        "runtime_failure": int(runtime_state.runtime_failure_count or 0),
+        "service_failure": int(service_failure_count or 0),
+    }
+    status: dict[str, dict[str, Any]] = {}
+    for failure_type, policy in FAILURE_POLICIES.items():
+        stop_after = int(policy["stop_after"])
+        count = counts[failure_type]
+        status[failure_type] = {
+            "count": count,
+            "stop_after": stop_after,
+            "remaining_self_heal_attempts": max(0, stop_after - count - 1),
+            "self_heal": str(policy["self_heal"]),
+            "description": str(policy["description"]),
+            "will_stop": count >= stop_after,
+        }
+    return status
+
+
 def fetch_benchmark_failure_log(*, repo_root: Path, run_id: int) -> str:
     proc = _run(
         ["gh", "run", "view", str(run_id), "--log-failed"],
@@ -398,7 +452,23 @@ def run_shift_cycle(
 ) -> dict[str, Any]:
     queue_report = reconcile_proof_first_queue(repo=repo, repo_root=repo_root, apply=True)
     github_status = dict(queue_report.get("github_status") or {})
+    queue_removed_count = len(queue_report.get("removed") or [])
     if github_status.get("available") is False:
+        runtime_state.runtime_failure_count += 1
+        stop_reason = github_unavailable_stop_reason(queue_report)
+        failure_policy = build_failure_policy_status(runtime_state)
+        if ledger:
+            ledger.record_failure(failure_type="runtime_failure", detail=stop_reason)
+            ledger.record_cycle_tick(
+                queue_size=len(queue_report.get("kept") or []),
+                queue_removed=queue_removed_count,
+                open_prs=0,
+                boss_running=False,
+                merge_running=False,
+                benchmark_fresh=False,
+                actions=[],
+                stop_reason=stop_reason,
+            )
         return {
             "queue_report": queue_report,
             "snapshot": {},
@@ -406,7 +476,8 @@ def run_shift_cycle(
             "automation_backlog": 0,
             "latest_benchmark_run": None,
             "actions": [],
-            "stop_reason": github_unavailable_stop_reason(queue_report),
+            "stop_reason": stop_reason,
+            "failure_policy": failure_policy,
         }
     snapshot = collect_boss_lane_snapshot(repo_root=repo_root, repo=repo)
     prs = list_open_prs(repo_root=repo_root, repo=repo)
@@ -424,6 +495,7 @@ def run_shift_cycle(
 
     actions: list[str] = []
     service_failures: list[str] = []
+    runtime_failures: list[str] = []
     if should_restart_service(
         is_running=boss_running,
         pending_count=canonical_queue_count,
@@ -440,11 +512,11 @@ def run_shift_cycle(
                 ledger.record_service_restart(service="boss_loop", success=True)
         else:
             actions.append("restart_boss_loop_failed")
-            service_failures.append(
-                f"BossRestartFailed: {detail or 'boss loop restart did not produce a running process'}"
-            )
+            stop_reason = f"BossRestartFailed: {detail or 'boss loop restart did not produce a running process'}"
+            service_failures.append(stop_reason)
             if ledger:
                 ledger.record_service_restart(service="boss_loop", success=False, detail=detail)
+                ledger.record_failure(failure_type="service_failure", detail=stop_reason)
 
     if should_restart_service(
         is_running=merge_running,
@@ -462,11 +534,11 @@ def run_shift_cycle(
                 ledger.record_service_restart(service="merge_arbiter", success=True)
         else:
             actions.append("restart_merge_arbiter_failed")
-            service_failures.append(
-                f"MergeArbiterRestartFailed: {detail or 'merge arbiter restart did not produce a running process'}"
-            )
+            stop_reason = f"MergeArbiterRestartFailed: {detail or 'merge arbiter restart did not produce a running process'}"
+            service_failures.append(stop_reason)
             if ledger:
                 ledger.record_service_restart(service="merge_arbiter", success=False, detail=detail)
+                ledger.record_failure(failure_type="service_failure", detail=stop_reason)
 
     merge_report = run_merge_arbiter_apply(
         repo_root=repo_root,
@@ -505,9 +577,21 @@ def run_shift_cycle(
                         ledger.record_failure(
                             failure_type="publication_failure", detail=failure_log[:500]
                         )
+                else:
+                    runtime_state.runtime_failure_count += 1
+                    runtime_failures.append(
+                        "RuntimeFailure: benchmark publication failed with an unclassified runtime error"
+                    )
+                    if ledger:
+                        ledger.record_failure(
+                            failure_type="runtime_failure",
+                            detail=failure_log[:500]
+                            or "benchmark publication failed with an unclassified runtime error",
+                        )
             elif conclusion == "success":
                 runtime_state.auth_failure_count = 0
                 runtime_state.publication_failure_count = 0
+                runtime_state.runtime_failure_count = 0
 
     should_trigger, trigger_reason = should_trigger_benchmark_rerun(
         benchmark_mode=benchmark_mode,
@@ -518,22 +602,40 @@ def run_shift_cycle(
         last_triggered_run_id=runtime_state.last_triggered_benchmark_run_id,
     )
     if should_trigger:
-        trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
-        actions.append(f"trigger_benchmark:{trigger_reason}")
-        if latest_run is not None:
-            runtime_state.last_triggered_benchmark_run_id = int(
-                latest_run.get("databaseId", 0) or 0
-            )
+        try:
+            trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
+        except RuntimeError as exc:
+            runtime_state.runtime_failure_count += 1
+            detail = str(exc).strip() or "benchmark workflow trigger failed"
+            runtime_failures.append(f"RuntimeFailure: {detail}")
+            actions.append(f"trigger_benchmark_failed:{trigger_reason}")
+            if ledger:
+                ledger.record_failure(failure_type="runtime_failure", detail=detail)
         else:
-            runtime_state.last_triggered_benchmark_run_id = -1
+            actions.append(f"trigger_benchmark:{trigger_reason}")
+            if latest_run is not None:
+                runtime_state.last_triggered_benchmark_run_id = int(
+                    latest_run.get("databaseId", 0) or 0
+                )
+            else:
+                runtime_state.last_triggered_benchmark_run_id = -1
 
     stop_reason = ""
-    if runtime_state.auth_failure_count >= 2:
-        stop_reason = "RepeatedAuthFailure: benchmark publication failed auth twice"
-    elif runtime_state.publication_failure_count >= 2:
-        stop_reason = "RepeatedPublicationFailure: benchmark publication failed PR handoff twice"
+    if runtime_failures:
+        stop_reason = runtime_failures[0]
     elif service_failures:
         stop_reason = service_failures[0]
+    elif runtime_state.auth_failure_count >= AUTH_FAILURE_STOP_AFTER:
+        stop_reason = "RepeatedAuthFailure: benchmark publication failed auth twice"
+    elif runtime_state.publication_failure_count >= PUBLICATION_FAILURE_STOP_AFTER:
+        stop_reason = "RepeatedPublicationFailure: benchmark publication failed PR handoff twice"
+    elif runtime_state.runtime_failure_count >= RUNTIME_FAILURE_STOP_AFTER:
+        stop_reason = "RuntimeFailure: proof-first shift lost a required runtime control surface"
+
+    failure_policy = build_failure_policy_status(
+        runtime_state,
+        service_failure_count=len(service_failures),
+    )
 
     # Record cycle tick in ledger
     benchmark_fresh = False
@@ -543,11 +645,13 @@ def run_shift_cycle(
     if ledger:
         ledger.record_cycle_tick(
             queue_size=canonical_queue_count,
+            queue_removed=queue_removed_count,
             open_prs=open_pr_count,
             boss_running=boss_running,
             merge_running=merge_running,
             benchmark_fresh=benchmark_fresh,
             actions=actions,
+            stop_reason=stop_reason,
         )
 
     return {
@@ -558,6 +662,7 @@ def run_shift_cycle(
         "latest_benchmark_run": latest_run,
         "actions": actions,
         "stop_reason": stop_reason,
+        "failure_policy": failure_policy,
     }
 
 

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+from aragora.swarm.shift_ledger import ShiftLedger
 from scripts import run_proof_first_shift as mod
 
 
@@ -16,6 +17,8 @@ def _run_shift_cycle(
     failure_log: str = "",
     benchmark_mode: str = "disabled",
     restart_service_side_effect: list[tuple[bool, str]] | None = None,
+    trigger_benchmark_side_effect: Exception | None = None,
+    ledger: ShiftLedger | None = None,
 ) -> dict[str, object]:
     restart_patch = (
         patch(
@@ -47,7 +50,10 @@ def _run_shift_cycle(
         patch(
             "scripts.run_proof_first_shift.fetch_benchmark_failure_log", return_value=failure_log
         ),
-        patch("scripts.run_proof_first_shift.trigger_benchmark_workflow"),
+        patch(
+            "scripts.run_proof_first_shift.trigger_benchmark_workflow",
+            side_effect=trigger_benchmark_side_effect,
+        ),
     ):
         return mod.run_shift_cycle(
             repo_root=Path(".").resolve(),
@@ -55,6 +61,7 @@ def _run_shift_cycle(
             benchmark_mode=benchmark_mode,
             automation_backlog_limit=12,
             runtime_state=runtime_state,
+            ledger=ledger,
         )
 
 
@@ -164,6 +171,7 @@ def test_run_shift_cycle_clears_failure_budget_after_successful_benchmark_run() 
     state = mod.ProofFirstRuntimeState(
         auth_failure_count=1,
         publication_failure_count=1,
+        runtime_failure_count=1,
         last_benchmark_run_id=100,
     )
 
@@ -180,6 +188,7 @@ def test_run_shift_cycle_clears_failure_budget_after_successful_benchmark_run() 
 
     assert state.auth_failure_count == 0
     assert state.publication_failure_count == 0
+    assert state.runtime_failure_count == 0
 
     report = _run_shift_cycle(
         state,
@@ -195,7 +204,9 @@ def test_run_shift_cycle_clears_failure_budget_after_successful_benchmark_run() 
 
     assert state.auth_failure_count == 1
     assert state.publication_failure_count == 0
+    assert state.runtime_failure_count == 0
     assert report["stop_reason"] == ""
+    assert report["failure_policy"]["auth_failure"]["will_stop"] is False
 
 
 def test_run_shift_cycle_reports_restart_failure_instead_of_crashing() -> None:
@@ -210,10 +221,12 @@ def test_run_shift_cycle_reports_restart_failure_instead_of_crashing() -> None:
     assert state.boss_restart_count == 1
     assert report["actions"] == ["restart_boss_loop_failed"]
     assert report["stop_reason"] == "BossRestartFailed: launchctl kickstart timed out for boss loop"
+    assert report["failure_policy"]["service_failure"]["will_stop"] is True
 
 
-def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable() -> None:
+def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable(tmp_path: Path) -> None:
     state = mod.ProofFirstRuntimeState()
+    ledger = ShiftLedger(path=tmp_path / "test_shift_ledger.jsonl")
 
     with (
         patch(
@@ -243,6 +256,7 @@ def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable() -> None:
             benchmark_mode="hybrid",
             automation_backlog_limit=12,
             runtime_state=state,
+            ledger=ledger,
         )
 
     assert report["snapshot"] == {}
@@ -251,3 +265,71 @@ def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable() -> None:
     assert report["latest_benchmark_run"] is None
     assert report["actions"] == []
     assert report["stop_reason"] == "GitHubUnavailable: error connecting to api.github.com"
+    assert report["failure_policy"]["runtime_failure"]["will_stop"] is True
+    assert state.runtime_failure_count == 1
+    assert ledger.get_status_summary()["runtime_failures"] == 1
+
+
+def test_run_shift_cycle_fails_closed_after_second_auth_failure() -> None:
+    state = mod.ProofFirstRuntimeState(auth_failure_count=1, last_benchmark_run_id=100)
+
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[True, True],
+        latest_run={
+            "databaseId": 101,
+            "createdAt": "2026-04-15T13:00:00Z",
+            "status": "completed",
+            "conclusion": "failure",
+        },
+        failure_log="codex login required before benchmark publish",
+    )
+
+    assert state.auth_failure_count == 2
+    assert report["stop_reason"] == "RepeatedAuthFailure: benchmark publication failed auth twice"
+    assert report["failure_policy"]["auth_failure"]["will_stop"] is True
+
+
+def test_run_shift_cycle_fails_closed_after_second_publication_failure() -> None:
+    state = mod.ProofFirstRuntimeState(publication_failure_count=1, last_benchmark_run_id=200)
+
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[True, True],
+        latest_run={
+            "databaseId": 201,
+            "createdAt": "2026-04-15T13:00:00Z",
+            "status": "completed",
+            "conclusion": "failure",
+        },
+        failure_log="resource not accessible by integration during pr creation",
+    )
+
+    assert state.publication_failure_count == 2
+    assert (
+        report["stop_reason"]
+        == "RepeatedPublicationFailure: benchmark publication failed PR handoff twice"
+    )
+    assert report["failure_policy"]["publication_failure"]["will_stop"] is True
+
+
+def test_run_shift_cycle_fails_closed_when_benchmark_trigger_runtime_fails() -> None:
+    state = mod.ProofFirstRuntimeState()
+
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[True, True],
+        benchmark_mode="hybrid",
+        latest_run={
+            "databaseId": 123,
+            "createdAt": "2026-04-14T00:00:00Z",
+            "status": "completed",
+            "conclusion": "success",
+        },
+        trigger_benchmark_side_effect=RuntimeError("gh workflow run failed"),
+    )
+
+    assert state.runtime_failure_count == 1
+    assert report["actions"] == ["trigger_benchmark_failed:stale_publication_window"]
+    assert report["stop_reason"] == "RuntimeFailure: gh workflow run failed"
+    assert report["failure_policy"]["runtime_failure"]["will_stop"] is True

--- a/tests/swarm/test_shift_ledger.py
+++ b/tests/swarm/test_shift_ledger.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import time
 from pathlib import Path
 
 import pytest
@@ -77,6 +76,7 @@ class TestShiftLedger:
         )
         ledger.record_cycle_tick(
             queue_size=5,
+            queue_removed=0,
             open_prs=2,
             boss_running=True,
             merge_running=True,
@@ -120,6 +120,7 @@ class TestStatusSummary:
         )
         ledger.record_cycle_tick(
             queue_size=3,
+            queue_removed=0,
             open_prs=1,
             boss_running=True,
             merge_running=True,
@@ -146,12 +147,17 @@ class TestStatusSummary:
         assert summary["benchmark_runs"] == 1
         assert summary["last_benchmark_conclusion"] == "success"
         assert summary["current_queue_size"] == 3
+        assert summary["current_queue_removed"] == 0
+        assert summary["current_open_prs"] == 1
         assert summary["current_boss_running"] is True
         assert summary["current_benchmark_fresh"] is True
+        assert summary["failure_policy"]["auth_failure"]["count"] == 1
+        assert summary["green_shift"]["is_green"] is False
 
     def test_multiple_ticks_uses_latest(self, ledger: ShiftLedger) -> None:
         ledger.record_cycle_tick(
             queue_size=10,
+            queue_removed=1,
             open_prs=5,
             boss_running=False,
             merge_running=True,
@@ -159,6 +165,7 @@ class TestStatusSummary:
         )
         ledger.record_cycle_tick(
             queue_size=3,
+            queue_removed=0,
             open_prs=1,
             boss_running=True,
             merge_running=True,
@@ -167,3 +174,113 @@ class TestStatusSummary:
         summary = ledger.get_status_summary()
         assert summary["current_queue_size"] == 3
         assert summary["current_boss_running"] is True
+
+    def test_green_shift_summary_marks_healthy_12_hour_shift_green(
+        self, ledger: ShiftLedger
+    ) -> None:
+        entries = [
+            LedgerEntry(
+                entry_type="shift_start",
+                timestamp="2026-04-15T00:00:00Z",
+                payload={
+                    "shift_id": "s1",
+                    "max_hours": 12,
+                    "benchmark_mode": "hybrid",
+                    "queue_size": 0,
+                },
+            ),
+            LedgerEntry(
+                entry_type="cycle_tick",
+                timestamp="2026-04-15T12:00:00Z",
+                payload={
+                    "queue_size": 0,
+                    "queue_removed": 0,
+                    "open_prs": 0,
+                    "boss_running": False,
+                    "merge_running": False,
+                    "benchmark_fresh": True,
+                    "actions": [],
+                    "stop_reason": "",
+                },
+            ),
+            LedgerEntry(
+                entry_type="shift_stop",
+                timestamp="2026-04-15T12:00:00Z",
+                payload={
+                    "shift_id": "s1",
+                    "reason": "TimeLimit: 12.00h >= max 12.00h",
+                    "cycles": 60,
+                    "duration_seconds": 43200,
+                },
+            ),
+        ]
+        ledger.path.write_text(
+            "\n".join(json.dumps(entry.to_dict(), sort_keys=True) for entry in entries) + "\n",
+            encoding="utf-8",
+        )
+
+        summary = ledger.get_status_summary(max_age_hours=48.0)
+
+        assert summary["green_shift"]["window_complete"] is True
+        assert summary["green_shift"]["benchmark_fresh"] is True
+        assert summary["green_shift"]["queue_disciplined"] is True
+        assert summary["green_shift"]["boss_service_healthy"] is True
+        assert summary["green_shift"]["merge_service_healthy"] is True
+        assert summary["green_shift"]["healthy_stop_reason"] is True
+        assert summary["green_shift"]["is_green"] is True
+
+    def test_green_shift_summary_marks_failure_class_as_not_green(
+        self, ledger: ShiftLedger
+    ) -> None:
+        entries = [
+            LedgerEntry(
+                entry_type="shift_start",
+                timestamp="2026-04-15T00:00:00Z",
+                payload={
+                    "shift_id": "s2",
+                    "max_hours": 12,
+                    "benchmark_mode": "hybrid",
+                    "queue_size": 1,
+                },
+            ),
+            LedgerEntry(
+                entry_type="runtime_failure",
+                timestamp="2026-04-15T06:00:00Z",
+                payload={"detail": "GitHubUnavailable: api outage"},
+            ),
+            LedgerEntry(
+                entry_type="cycle_tick",
+                timestamp="2026-04-15T06:00:00Z",
+                payload={
+                    "queue_size": 1,
+                    "queue_removed": 0,
+                    "open_prs": 0,
+                    "boss_running": False,
+                    "merge_running": True,
+                    "benchmark_fresh": False,
+                    "actions": [],
+                    "stop_reason": "GitHubUnavailable: api outage",
+                },
+            ),
+            LedgerEntry(
+                entry_type="shift_stop",
+                timestamp="2026-04-15T06:00:00Z",
+                payload={
+                    "shift_id": "s2",
+                    "reason": "GitHubUnavailable: api outage",
+                    "cycles": 3,
+                    "duration_seconds": 21600,
+                },
+            ),
+        ]
+        ledger.path.write_text(
+            "\n".join(json.dumps(entry.to_dict(), sort_keys=True) for entry in entries) + "\n",
+            encoding="utf-8",
+        )
+
+        summary = ledger.get_status_summary(max_age_hours=48.0)
+
+        assert summary["failure_policy"]["runtime_failure"]["will_stop"] is True
+        assert summary["green_shift"]["window_complete"] is False
+        assert summary["green_shift"]["healthy_stop_reason"] is False
+        assert summary["green_shift"]["is_green"] is False


### PR DESCRIPTION
## Summary
- encode explicit failure-class policy in the proof-first shift operator for auth, publication, runtime, and service restart failures
- record service/runtime failures durably and expose machine-readable failure policy state in shift output
- add green 12-hour shift assessment to the shift ledger summary for operator status surfaces

## Validation
- python3 -m pytest tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py -q
- python3 -m ruff check scripts/run_proof_first_shift.py aragora/swarm/shift_ledger.py tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py
- python3 -m ruff format --check scripts/run_proof_first_shift.py aragora/swarm/shift_ledger.py tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py
- python3 scripts/run_proof_first_shift.py --once --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD