### PR TITLE
feat(autonomy): wire proof-first operator surfaces to ledger truth

### DIFF
--- a/aragora/cli/commands/swarm_status.py
+++ b/aragora/cli/commands/swarm_status.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH, ShiftLedger
 from aragora.swarm.terminal_truth import TerminalClass, classify_from_metrics
 
 DEFAULT_METRICS_PATH = Path(".aragora") / "overnight" / "boss_metrics.jsonl"
@@ -76,6 +77,17 @@ def _load_metrics_rows(metrics_path: Path) -> list[dict[str, Any]]:
             if isinstance(payload, dict):
                 rows.append(payload)
     return rows
+
+
+def _load_ledger_status(repo_root: Path) -> dict[str, Any] | None:
+    ledger_path = repo_root / Path(DEFAULT_LEDGER_PATH)
+    if not ledger_path.exists():
+        return None
+    try:
+        payload = ShiftLedger(path=ledger_path).get_status_summary()
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) and payload else None
 
 
 def _resolve_terminal_class(row: dict[str, Any]) -> str:
@@ -155,7 +167,12 @@ def load_operator_status(
 ) -> dict[str, Any]:
     metrics_file = metrics_path or (repo_root / DEFAULT_METRICS_PATH)
     rows = _load_metrics_rows(metrics_file)
-    queue_depth = _boss_ready_queue_depth(repo_root, boss_repo=boss_repo)
+    ledger_status = _load_ledger_status(repo_root)
+    queue_depth = _optional_int(
+        ledger_status.get("current_queue_size") if isinstance(ledger_status, dict) else None
+    )
+    if queue_depth is None:
+        queue_depth = _boss_ready_queue_depth(repo_root, boss_repo=boss_repo)
 
     attempted_issues = {
         issue_number
@@ -221,8 +238,9 @@ def load_operator_status(
         )
 
     return {
-        "available": metrics_file.exists(),
+        "available": metrics_file.exists() or bool(ledger_status),
         "metrics_path": str(metrics_file),
+        "ledger_status": ledger_status or {},
         "summary": {
             "unique_issues_attempted": len(attempted_issues),
             "unique_issues_completed": len(completed_issues),
@@ -248,6 +266,27 @@ def render_operator_status(payload: dict[str, Any]) -> str:
             queue_depth=summary.get("queue_depth", "unknown"),
         )
     ]
+    ledger_status = (
+        payload.get("ledger_status", {}) if isinstance(payload.get("ledger_status"), dict) else {}
+    )
+    if ledger_status:
+        green_shift = (
+            ledger_status.get("green_shift", {})
+            if isinstance(ledger_status.get("green_shift"), dict)
+            else {}
+        )
+        lines.append(
+            "proof-first queue={queue} boss={boss} merge={merge} benchmark_fresh={benchmark} "
+            "merged_prs={merged} last_stop={stop} green_shift={green}".format(
+                queue=ledger_status.get("current_queue_size", "unknown"),
+                boss=ledger_status.get("current_boss_running"),
+                merge=ledger_status.get("current_merge_running"),
+                benchmark=ledger_status.get("current_benchmark_fresh"),
+                merged=ledger_status.get("prs_merged", 0),
+                stop=ledger_status.get("last_stop_reason") or "-",
+                green=green_shift.get("is_green"),
+            )
+        )
 
     iterations = [item for item in payload.get("last_iterations", []) if isinstance(item, dict)]
     if iterations:

--- a/aragora/server/fastapi/routes/swarm_status.py
+++ b/aragora/server/fastapi/routes/swarm_status.py
@@ -13,6 +13,9 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH as DEFAULT_SHIFT_LEDGER_PATH
+from aragora.swarm.shift_ledger import ShiftLedger
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_METRICS_PATH = Path(".aragora/overnight/boss_metrics.jsonl")
@@ -54,16 +57,35 @@ def _tail_jsonl(path: Path, max_lines: int) -> list[dict[str, Any]]:
         return []
 
 
+def _load_ledger_status(
+    *,
+    repo_root: Path,
+    ledger_path: Path | None = None,
+) -> dict[str, Any] | None:
+    path = ledger_path or (repo_root / Path(DEFAULT_SHIFT_LEDGER_PATH))
+    if not path.exists():
+        return None
+    try:
+        payload = ShiftLedger(path=path).get_status_summary()
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) and payload else None
+
+
 def swarm_status_summary(
     *,
     metrics_path: Path | None = None,
+    repo_root: Path | None = None,
+    ledger_path: Path | None = None,
     window: int = DEFAULT_WINDOW,
 ) -> dict[str, Any]:
-    """Build a swarm status summary from boss metrics JSONL."""
+    """Build a swarm status summary, preferring proof-first ledger truth."""
     path = metrics_path or DEFAULT_METRICS_PATH
+    root = repo_root or Path.cwd()
     rows = _tail_jsonl(path, window)
+    ledger_status = _load_ledger_status(repo_root=root, ledger_path=ledger_path)
 
-    if not rows:
+    if not rows and not ledger_status:
         return {
             "status": "no_data",
             "metrics_path": str(path),
@@ -129,6 +151,30 @@ def swarm_status_summary(
         "metrics_path": str(path),
         "window": window,
         "total_ticks": len(rows),
+        "ledger_status": ledger_status or {},
+        "queue_depth": (
+            ledger_status.get("current_queue_size") if isinstance(ledger_status, dict) else None
+        ),
+        "boss_running": (
+            ledger_status.get("current_boss_running") if isinstance(ledger_status, dict) else None
+        ),
+        "merge_running": (
+            ledger_status.get("current_merge_running") if isinstance(ledger_status, dict) else None
+        ),
+        "benchmark_fresh": (
+            ledger_status.get("current_benchmark_fresh")
+            if isinstance(ledger_status, dict)
+            else None
+        ),
+        "last_stop_reason": (
+            ledger_status.get("last_stop_reason") if isinstance(ledger_status, dict) else ""
+        ),
+        "prs_merged_recent": (
+            ledger_status.get("prs_merged") if isinstance(ledger_status, dict) else 0
+        ),
+        "merged_pr_numbers": (
+            ledger_status.get("pr_numbers_merged") if isinstance(ledger_status, dict) else []
+        ),
         "unique_issues_attempted": len(issues_attempted),
         "unique_issues_succeeded": len(issues_succeeded),
         "success_rate": issue_success_rate,

--- a/aragora/swarm/shift_ledger.py
+++ b/aragora/swarm/shift_ledger.py
@@ -18,6 +18,14 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 DEFAULT_LEDGER_PATH = ".aragora/proof_first_shift/shift_ledger.jsonl"
+GREEN_SHIFT_REQUIRED_HOURS = 12.0
+FAILURE_THRESHOLDS = {
+    "auth_failure": 2,
+    "publication_failure": 2,
+    "runtime_failure": 1,
+    "service_failure": 1,
+}
+HEALTHY_STOP_PREFIXES = ("completed", "TimeLimit:")
 
 
 @dataclass
@@ -152,20 +160,24 @@ class ShiftLedger:
         self,
         *,
         queue_size: int,
+        queue_removed: int = 0,
         open_prs: int,
         boss_running: bool,
         merge_running: bool,
         benchmark_fresh: bool,
         actions: list[str] | None = None,
+        stop_reason: str = "",
     ) -> LedgerEntry:
         return self.append(
             "cycle_tick",
             queue_size=queue_size,
+            queue_removed=queue_removed,
             open_prs=open_prs,
             boss_running=boss_running,
             merge_running=merge_running,
             benchmark_fresh=benchmark_fresh,
             actions=actions or [],
+            stop_reason=stop_reason,
         )
 
     def record_service_restart(
@@ -196,12 +208,119 @@ class ShiftLedger:
 
     # -- Status summary --
 
+    def _parse_timestamp(self, value: str) -> datetime | None:
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+        except ValueError:
+            return None
+
+    def _latest_shift_entries(self, entries: list[LedgerEntry]) -> list[LedgerEntry]:
+        for index in range(len(entries) - 1, -1, -1):
+            if entries[index].entry_type == "shift_start":
+                return entries[index:]
+        return []
+
+    def _build_failure_policy_summary(
+        self, entries: list[LedgerEntry]
+    ) -> dict[str, dict[str, Any]]:
+        counts = {
+            "auth_failure": sum(1 for e in entries if e.entry_type == "auth_failure"),
+            "publication_failure": sum(1 for e in entries if e.entry_type == "publication_failure"),
+            "runtime_failure": sum(1 for e in entries if e.entry_type == "runtime_failure"),
+            "service_failure": sum(1 for e in entries if e.entry_type == "service_failure"),
+        }
+        status: dict[str, dict[str, Any]] = {}
+        for failure_type, count in counts.items():
+            stop_after = FAILURE_THRESHOLDS[failure_type]
+            status[failure_type] = {
+                "count": count,
+                "stop_after": stop_after,
+                "remaining_self_heal_attempts": max(0, stop_after - count - 1),
+                "will_stop": count >= stop_after,
+            }
+        return status
+
+    def _build_green_shift_summary(self, entries: list[LedgerEntry]) -> dict[str, Any]:
+        if not entries:
+            return {
+                "required_hours": GREEN_SHIFT_REQUIRED_HOURS,
+                "observed_hours": 0.0,
+                "window_complete": False,
+                "benchmark_fresh": False,
+                "queue_disciplined": False,
+                "boss_service_healthy": False,
+                "merge_service_healthy": False,
+                "no_repeated_failures": False,
+                "healthy_stop_reason": False,
+                "is_green": False,
+                "last_stop_reason": "",
+            }
+
+        ticks = [e for e in entries if e.entry_type == "cycle_tick"]
+        stops = [e for e in entries if e.entry_type == "shift_stop"]
+        last_tick = ticks[-1] if ticks else None
+        last_stop = stops[-1] if stops else None
+        start_time = self._parse_timestamp(entries[0].timestamp)
+        end_time = self._parse_timestamp((last_stop or entries[-1]).timestamp)
+        observed_hours = 0.0
+        if start_time is not None and end_time is not None:
+            observed_hours = max(0.0, (end_time - start_time).total_seconds() / 3600.0)
+
+        failure_policy = self._build_failure_policy_summary(entries)
+        last_stop_reason = ""
+        if last_stop is not None:
+            last_stop_reason = str(last_stop.payload.get("reason", ""))
+        elif last_tick is not None:
+            last_stop_reason = str(last_tick.payload.get("stop_reason", ""))
+
+        current_queue_size = last_tick.payload.get("queue_size") if last_tick else None
+        current_open_prs = last_tick.payload.get("open_prs") if last_tick else None
+        boss_running = bool(last_tick.payload.get("boss_running")) if last_tick else False
+        merge_running = bool(last_tick.payload.get("merge_running")) if last_tick else False
+        benchmark_fresh = bool(last_tick.payload.get("benchmark_fresh")) if last_tick else False
+        queue_removed = sum(int(e.payload.get("queue_removed", 0) or 0) for e in ticks)
+        boss_service_healthy = boss_running or current_queue_size in (0, None)
+        merge_service_healthy = merge_running or current_open_prs in (0, None)
+        healthy_stop_reason = last_stop_reason == "" or any(
+            last_stop_reason.startswith(p) for p in HEALTHY_STOP_PREFIXES
+        )
+        no_repeated_failures = all(not status["will_stop"] for status in failure_policy.values())
+        queue_disciplined = queue_removed == 0
+        window_complete = observed_hours >= GREEN_SHIFT_REQUIRED_HOURS
+
+        return {
+            "required_hours": GREEN_SHIFT_REQUIRED_HOURS,
+            "observed_hours": round(observed_hours, 2),
+            "window_complete": window_complete,
+            "benchmark_fresh": benchmark_fresh,
+            "queue_disciplined": queue_disciplined,
+            "queue_removed": queue_removed,
+            "boss_service_healthy": boss_service_healthy,
+            "merge_service_healthy": merge_service_healthy,
+            "no_repeated_failures": no_repeated_failures,
+            "healthy_stop_reason": healthy_stop_reason,
+            "last_stop_reason": last_stop_reason,
+            "is_green": all(
+                (
+                    window_complete,
+                    benchmark_fresh,
+                    queue_disciplined,
+                    boss_service_healthy,
+                    merge_service_healthy,
+                    no_repeated_failures,
+                    healthy_stop_reason,
+                )
+            ),
+        }
+
     def get_status_summary(self, *, max_age_hours: float = 24.0) -> dict[str, Any]:
         """Build a status summary from recent ledger entries.
 
         This is the single truthful view that replaces shell sampling.
         """
+        all_entries = self.read_all()
         recent = self.read_recent(max_age_hours=max_age_hours)
+        latest_shift_entries = self._latest_shift_entries(all_entries)
 
         shifts = [e for e in recent if e.entry_type == "shift_start"]
         stops = [e for e in recent if e.entry_type == "shift_stop"]
@@ -211,10 +330,14 @@ class ShiftLedger:
         restarts = [e for e in recent if e.entry_type == "service_restart"]
         auth_failures = [e for e in recent if e.entry_type == "auth_failure"]
         pub_failures = [e for e in recent if e.entry_type == "publication_failure"]
+        runtime_failures = [e for e in recent if e.entry_type == "runtime_failure"]
+        service_failures = [e for e in recent if e.entry_type == "service_failure"]
 
         last_tick = ticks[-1] if ticks else None
         last_stop = stops[-1] if stops else None
         last_benchmark = benchmarks[-1] if benchmarks else None
+        failure_policy = self._build_failure_policy_summary(latest_shift_entries)
+        green_shift = self._build_green_shift_summary(latest_shift_entries)
 
         return {
             "period_hours": max_age_hours,
@@ -230,11 +353,17 @@ class ShiftLedger:
             "restart_failures": sum(1 for e in restarts if not e.payload.get("success")),
             "auth_failures": len(auth_failures),
             "publication_failures": len(pub_failures),
+            "runtime_failures": len(runtime_failures),
+            "service_failures": len(service_failures),
             "benchmark_runs": len(benchmarks),
             "last_benchmark_conclusion": (
                 last_benchmark.payload.get("conclusion", "") if last_benchmark else ""
             ),
             "current_queue_size": (last_tick.payload.get("queue_size", 0) if last_tick else None),
+            "current_queue_removed": (
+                last_tick.payload.get("queue_removed", 0) if last_tick else None
+            ),
+            "current_open_prs": (last_tick.payload.get("open_prs", 0) if last_tick else None),
             "current_boss_running": (last_tick.payload.get("boss_running") if last_tick else None),
             "current_merge_running": (
                 last_tick.payload.get("merge_running") if last_tick else None
@@ -242,4 +371,6 @@ class ShiftLedger:
             "current_benchmark_fresh": (
                 last_tick.payload.get("benchmark_fresh") if last_tick else None
             ),
+            "failure_policy": failure_policy,
+            "green_shift": green_shift,
         }

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -1,6 +1,6 @@
 # Active Execution Issues
 
-Last updated: 2026-04-14
+Last updated: 2026-04-15
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -33,20 +33,20 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B0 — Corpus** | Prove `>=50%` no-rescue success on a fixed benchmark corpus | `RS-01..03`, `TW-02..03` |
 | **B1 — Assist** | Auto-draft safe work orders and validation plans | `BC-04..06`, `TW-07..09` |
 | **B2 — Guard** | Require contracts and production-like preflight before auto-run | `RS-04..09` |
-| **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
+| **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..12` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
-Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is keeping the recurring truth/productization surfaces boring and keeping claims narrower than proof, not reopening already-landed guard work.
+Status note: the latest published B0 surface is at 80.0% truth success and 80.0% no-rescue truth success as of 2026-04-15, while the latest published `TW-03` surface has 0 repeated rescue classes. The remaining near-term gate is keeping the recurring truth/productization surfaces boring, clearing stale corpus alerts through the normal publication loop, and keeping claims narrower than proof.
 
 ## Current 30-Day Execution Set
 
 Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 - Do now: `CS-01..03`
-- Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Delay: `BC-07..09`, `RS-11..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
+- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should keep the queue empty unless they expose a fresh bounded regression or repeated rescue class
 - `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate
@@ -73,7 +73,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 ### Milestone 1.4 — Ledger & Self-Heal `[90d]`
 
-- [ ] **RS-10** Mirror probes, queue state, contracts, and receipts into `AutonomyLedger`
+- [x] **RS-10** Mirror probes, queue state, contracts, and receipts into `AutonomyLedger` _(Done 2026-04-15 via [#5857](https://github.com/synaptent/aragora/pull/5857))_
 - [ ] **RS-11** Add quarantine and fallback rules for auth drift, rate limits, permission mismatch, and publication failures
 - [ ] **RS-12** Cut `studio-health`, reporter, and status surfaces to ledger-backed truth
 

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-04-14
+Last updated: 2026-04-15
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -19,7 +19,7 @@ What is already true:
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
 - terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
-- the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
+- the latest published B0 surface is **80.0%** truth success and **80.0%** no-rescue truth success on the tracked corpus, with one pending corpus-freshness alert to clear on the next publication
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
 - launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
 - receipt-backed preflight is now the default operator and live dispatch admission truth on `main` via [#5514](https://github.com/synaptent/aragora/pull/5514)
@@ -35,6 +35,7 @@ What is already true:
 - repeated rescue-class reports now include fixture-or-issue productization status on `main` via [#5535](https://github.com/synaptent/aragora/pull/5535)
 - repo-tracked recurring rescue productization now lands in `docs/status/generated/rescue_productization/`, with the stable status summary at `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`
 - the recurring `TW-03` harvest can now relink repeated rescue classes to tracked fixture/issue targets and auto-create bounded follow-on issues when a repeated class is still unlinked
+- proof-first runtime truth is now persisted in `ShiftLedger` on `main` via [#5857](https://github.com/synaptent/aragora/pull/5857)
 
 What is still missing:
 
@@ -59,7 +60,7 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
-Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are now repo-tracked status surfaces.
+Current status: the latest published B0 surface is at **80.0%** truth success and **80.0%** no-rescue truth success as of 2026-04-15, and the latest published `TW-03` surface shows zero repeated rescue classes. The benchmark target is no longer the blocker; recurring truth publication, stale-corpus cleanup through the normal publication loop, and proof-first operator discipline are the remaining near-term gates.
 
 Primary truth metric:
 
@@ -104,7 +105,7 @@ Scorecard output rules:
 ### Current state
 
 - Terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are on `main`.
-- The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
+- The latest published B0 surface is at **80.0%** truth success and **80.0%** no-rescue truth success as of 2026-04-15.
 - The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
 - The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
 - The stable recurring status surface is `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, backed by the latest JSON pointers under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`.
@@ -126,7 +127,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 ### Delay
 
 - `BC-07..09` until the repair loop is truthful and resumable
-- `RS-10..12` until the operator-surface guard is real
+- `RS-11..12` until the operator-surface guard is real
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
@@ -143,8 +144,8 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 ## Live Boss-Ready Queue
 
 - There is no dedicated open boss-ready trust-loop issue right now.
-- Keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
-- Let the recurring `TW-01/TW-02/TW-03` publication surfaces restock the queue only when they expose a fresh repeated rescue class or a concrete regression.
+- Keep the live queue empty unless the recurring `TW-01/TW-02/TW-03` publication surfaces expose a fresh repeated rescue class or a concrete regression.
+- Keep `CS-01..03` enforced through the docs/status surfaces while the live queue remains empty.
 
 `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)), `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)), and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) now publish through repo-tracked recurring status surfaces at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`. `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
 

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -35,6 +35,32 @@ DEFAULT_BOSS_LABEL = "com.aragora.swarm-boss-loop"
 DEFAULT_MERGE_LABEL = "com.aragora.swarm-merge-arbiter"
 DEFAULT_BOSS_PROCESS_PATTERN = r"aragora\.cli\.main swarm boss-loop|run_boss_cycle\.sh"
 DEFAULT_MERGE_PROCESS_PATTERN = r"aragora\.cli\.main swarm merge-arbiter"
+AUTH_FAILURE_STOP_AFTER = 2
+PUBLICATION_FAILURE_STOP_AFTER = 2
+RUNTIME_FAILURE_STOP_AFTER = 1
+SERVICE_FAILURE_STOP_AFTER = 1
+FAILURE_POLICIES: dict[str, dict[str, Any]] = {
+    "auth_failure": {
+        "stop_after": AUTH_FAILURE_STOP_AFTER,
+        "self_heal": "retry_benchmark_once",
+        "description": "Allow one benchmark auth failure, then fail closed on the next one.",
+    },
+    "publication_failure": {
+        "stop_after": PUBLICATION_FAILURE_STOP_AFTER,
+        "self_heal": "retry_benchmark_once",
+        "description": "Allow one benchmark publication handoff failure, then fail closed.",
+    },
+    "runtime_failure": {
+        "stop_after": RUNTIME_FAILURE_STOP_AFTER,
+        "self_heal": "none",
+        "description": "Stop immediately when the shift runtime loses truthful control surfaces.",
+    },
+    "service_failure": {
+        "stop_after": SERVICE_FAILURE_STOP_AFTER,
+        "self_heal": "restart_service_once",
+        "description": "Attempt one service restart when work is pending, then fail closed.",
+    },
+}
 AUTOMATION_BRANCH_PREFIXES = (
     "codex/",
     "factory/",
@@ -49,6 +75,7 @@ class ProofFirstRuntimeState:
     merge_restart_count: int = 0
     auth_failure_count: int = 0
     publication_failure_count: int = 0
+    runtime_failure_count: int = 0
     last_benchmark_run_id: int | None = None
     last_triggered_benchmark_run_id: int | None = None
 
@@ -76,6 +103,7 @@ def load_runtime_state(path: Path) -> ProofFirstRuntimeState:
         merge_restart_count=int(payload.get("merge_restart_count", 0) or 0),
         auth_failure_count=int(payload.get("auth_failure_count", 0) or 0),
         publication_failure_count=int(payload.get("publication_failure_count", 0) or 0),
+        runtime_failure_count=int(payload.get("runtime_failure_count", 0) or 0),
         last_benchmark_run_id=(
             int(payload["last_benchmark_run_id"]) if payload.get("last_benchmark_run_id") else None
         ),
@@ -281,6 +309,32 @@ def github_unavailable_stop_reason(queue_report: dict[str, Any]) -> str:
     return "GitHubUnavailable: proof-first queue reconciliation could not reach GitHub"
 
 
+def build_failure_policy_status(
+    runtime_state: ProofFirstRuntimeState,
+    *,
+    service_failure_count: int = 0,
+) -> dict[str, dict[str, Any]]:
+    counts = {
+        "auth_failure": int(runtime_state.auth_failure_count or 0),
+        "publication_failure": int(runtime_state.publication_failure_count or 0),
+        "runtime_failure": int(runtime_state.runtime_failure_count or 0),
+        "service_failure": int(service_failure_count or 0),
+    }
+    status: dict[str, dict[str, Any]] = {}
+    for failure_type, policy in FAILURE_POLICIES.items():
+        stop_after = int(policy["stop_after"])
+        count = counts[failure_type]
+        status[failure_type] = {
+            "count": count,
+            "stop_after": stop_after,
+            "remaining_self_heal_attempts": max(0, stop_after - count - 1),
+            "self_heal": str(policy["self_heal"]),
+            "description": str(policy["description"]),
+            "will_stop": count >= stop_after,
+        }
+    return status
+
+
 def fetch_benchmark_failure_log(*, repo_root: Path, run_id: int) -> str:
     proc = _run(
         ["gh", "run", "view", str(run_id), "--log-failed"],
@@ -398,7 +452,23 @@ def run_shift_cycle(
 ) -> dict[str, Any]:
     queue_report = reconcile_proof_first_queue(repo=repo, repo_root=repo_root, apply=True)
     github_status = dict(queue_report.get("github_status") or {})
+    queue_removed_count = len(queue_report.get("removed") or [])
     if github_status.get("available") is False:
+        runtime_state.runtime_failure_count += 1
+        stop_reason = github_unavailable_stop_reason(queue_report)
+        failure_policy = build_failure_policy_status(runtime_state)
+        if ledger:
+            ledger.record_failure(failure_type="runtime_failure", detail=stop_reason)
+            ledger.record_cycle_tick(
+                queue_size=len(queue_report.get("kept") or []),
+                queue_removed=queue_removed_count,
+                open_prs=0,
+                boss_running=False,
+                merge_running=False,
+                benchmark_fresh=False,
+                actions=[],
+                stop_reason=stop_reason,
+            )
         return {
             "queue_report": queue_report,
             "snapshot": {},
@@ -406,7 +476,8 @@ def run_shift_cycle(
             "automation_backlog": 0,
             "latest_benchmark_run": None,
             "actions": [],
-            "stop_reason": github_unavailable_stop_reason(queue_report),
+            "stop_reason": stop_reason,
+            "failure_policy": failure_policy,
         }
     snapshot = collect_boss_lane_snapshot(repo_root=repo_root, repo=repo)
     prs = list_open_prs(repo_root=repo_root, repo=repo)
@@ -424,6 +495,7 @@ def run_shift_cycle(
 
     actions: list[str] = []
     service_failures: list[str] = []
+    runtime_failures: list[str] = []
     if should_restart_service(
         is_running=boss_running,
         pending_count=canonical_queue_count,
@@ -440,11 +512,11 @@ def run_shift_cycle(
                 ledger.record_service_restart(service="boss_loop", success=True)
         else:
             actions.append("restart_boss_loop_failed")
-            service_failures.append(
-                f"BossRestartFailed: {detail or 'boss loop restart did not produce a running process'}"
-            )
+            stop_reason = f"BossRestartFailed: {detail or 'boss loop restart did not produce a running process'}"
+            service_failures.append(stop_reason)
             if ledger:
                 ledger.record_service_restart(service="boss_loop", success=False, detail=detail)
+                ledger.record_failure(failure_type="service_failure", detail=stop_reason)
 
     if should_restart_service(
         is_running=merge_running,
@@ -462,11 +534,11 @@ def run_shift_cycle(
                 ledger.record_service_restart(service="merge_arbiter", success=True)
         else:
             actions.append("restart_merge_arbiter_failed")
-            service_failures.append(
-                f"MergeArbiterRestartFailed: {detail or 'merge arbiter restart did not produce a running process'}"
-            )
+            stop_reason = f"MergeArbiterRestartFailed: {detail or 'merge arbiter restart did not produce a running process'}"
+            service_failures.append(stop_reason)
             if ledger:
                 ledger.record_service_restart(service="merge_arbiter", success=False, detail=detail)
+                ledger.record_failure(failure_type="service_failure", detail=stop_reason)
 
     merge_report = run_merge_arbiter_apply(
         repo_root=repo_root,
@@ -505,9 +577,21 @@ def run_shift_cycle(
                         ledger.record_failure(
                             failure_type="publication_failure", detail=failure_log[:500]
                         )
+                else:
+                    runtime_state.runtime_failure_count += 1
+                    runtime_failures.append(
+                        "RuntimeFailure: benchmark publication failed with an unclassified runtime error"
+                    )
+                    if ledger:
+                        ledger.record_failure(
+                            failure_type="runtime_failure",
+                            detail=failure_log[:500]
+                            or "benchmark publication failed with an unclassified runtime error",
+                        )
             elif conclusion == "success":
                 runtime_state.auth_failure_count = 0
                 runtime_state.publication_failure_count = 0
+                runtime_state.runtime_failure_count = 0
 
     should_trigger, trigger_reason = should_trigger_benchmark_rerun(
         benchmark_mode=benchmark_mode,
@@ -518,22 +602,40 @@ def run_shift_cycle(
         last_triggered_run_id=runtime_state.last_triggered_benchmark_run_id,
     )
     if should_trigger:
-        trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
-        actions.append(f"trigger_benchmark:{trigger_reason}")
-        if latest_run is not None:
-            runtime_state.last_triggered_benchmark_run_id = int(
-                latest_run.get("databaseId", 0) or 0
-            )
+        try:
+            trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
+        except RuntimeError as exc:
+            runtime_state.runtime_failure_count += 1
+            detail = str(exc).strip() or "benchmark workflow trigger failed"
+            runtime_failures.append(f"RuntimeFailure: {detail}")
+            actions.append(f"trigger_benchmark_failed:{trigger_reason}")
+            if ledger:
+                ledger.record_failure(failure_type="runtime_failure", detail=detail)
         else:
-            runtime_state.last_triggered_benchmark_run_id = -1
+            actions.append(f"trigger_benchmark:{trigger_reason}")
+            if latest_run is not None:
+                runtime_state.last_triggered_benchmark_run_id = int(
+                    latest_run.get("databaseId", 0) or 0
+                )
+            else:
+                runtime_state.last_triggered_benchmark_run_id = -1
 
     stop_reason = ""
-    if runtime_state.auth_failure_count >= 2:
-        stop_reason = "RepeatedAuthFailure: benchmark publication failed auth twice"
-    elif runtime_state.publication_failure_count >= 2:
-        stop_reason = "RepeatedPublicationFailure: benchmark publication failed PR handoff twice"
+    if runtime_failures:
+        stop_reason = runtime_failures[0]
     elif service_failures:
         stop_reason = service_failures[0]
+    elif runtime_state.auth_failure_count >= AUTH_FAILURE_STOP_AFTER:
+        stop_reason = "RepeatedAuthFailure: benchmark publication failed auth twice"
+    elif runtime_state.publication_failure_count >= PUBLICATION_FAILURE_STOP_AFTER:
+        stop_reason = "RepeatedPublicationFailure: benchmark publication failed PR handoff twice"
+    elif runtime_state.runtime_failure_count >= RUNTIME_FAILURE_STOP_AFTER:
+        stop_reason = "RuntimeFailure: proof-first shift lost a required runtime control surface"
+
+    failure_policy = build_failure_policy_status(
+        runtime_state,
+        service_failure_count=len(service_failures),
+    )
 
     # Record cycle tick in ledger
     benchmark_fresh = False
@@ -543,11 +645,13 @@ def run_shift_cycle(
     if ledger:
         ledger.record_cycle_tick(
             queue_size=canonical_queue_count,
+            queue_removed=queue_removed_count,
             open_prs=open_pr_count,
             boss_running=boss_running,
             merge_running=merge_running,
             benchmark_fresh=benchmark_fresh,
             actions=actions,
+            stop_reason=stop_reason,
         )
 
     return {
@@ -558,6 +662,7 @@ def run_shift_cycle(
         "latest_benchmark_run": latest_run,
         "actions": actions,
         "stop_reason": stop_reason,
+        "failure_policy": failure_policy,
     }
 
 

--- a/scripts/studio-health.sh
+++ b/scripts/studio-health.sh
@@ -22,6 +22,44 @@ eval $SSH "
     cd ~/Development/aragora 2>/dev/null || { echo 'REPO: NOT FOUND'; exit 1; }
     source .venv/bin/activate 2>/dev/null || { echo 'VENV: NOT FOUND'; exit 1; }
 
+    echo '--- Proof-First Ledger ---'
+    python3 - <<'PY'
+from pathlib import Path
+
+try:
+    from aragora.swarm.shift_ledger import ShiftLedger
+except Exception as exc:  # pragma: no cover - operator fallback
+    print(f'ledger: unavailable ({exc})')
+    raise SystemExit(0)
+
+repo_root = Path.cwd()
+ledger_path = repo_root / '.aragora' / 'proof_first_shift' / 'shift_ledger.jsonl'
+if not ledger_path.exists():
+    print('ledger: missing')
+    raise SystemExit(0)
+
+summary = ShiftLedger(path=ledger_path).get_status_summary()
+green = summary.get('green_shift') or {}
+print(
+    'queue={queue} boss={boss} merge={merge} benchmark_fresh={fresh} merged_prs={merged} last_stop={stop}'.format(
+        queue=summary.get('current_queue_size'),
+        boss=summary.get('current_boss_running'),
+        merge=summary.get('current_merge_running'),
+        fresh=summary.get('current_benchmark_fresh'),
+        merged=summary.get('prs_merged'),
+        stop=summary.get('last_stop_reason') or '-',
+    )
+)
+print(
+    'green_shift={green} observed_hours={hours} window_complete={window}'.format(
+        green=green.get('is_green'),
+        hours=green.get('observed_hours'),
+        window=green.get('window_complete'),
+    )
+)
+PY
+
+    echo ''
     echo '--- Processes ---'
     ARBITER=\$(pgrep -f 'swarm.*merge-arbiter' | head -1)
     BOSS=\$(pgrep -f 'swarm.*boss-loop' | head -1)

--- a/tests/cli/test_swarm_status_command.py
+++ b/tests/cli/test_swarm_status_command.py
@@ -12,6 +12,7 @@ from aragora.cli.commands.swarm_status import (
     load_operator_status,
     render_operator_status,
 )
+from aragora.swarm.shift_ledger import ShiftLedger
 
 
 def _write_metrics(metrics_path: Path, rows: list[dict[str, object]]) -> None:
@@ -110,6 +111,41 @@ def test_load_operator_status_reports_unknown_queue_depth_when_probe_unavailable
     assert payload["summary"]["queue_depth"] == "unknown"
 
 
+def test_load_operator_status_prefers_ledger_truth_for_queue_depth(tmp_path: Path) -> None:
+    metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    _write_metrics(metrics_path, [])
+    ledger = ShiftLedger(path=tmp_path / ".aragora" / "proof_first_shift" / "shift_ledger.jsonl")
+    ledger.record_shift_start(
+        shift_id="shift-1",
+        max_hours=12.0,
+        benchmark_mode="hybrid",
+        queue_size=0,
+    )
+    ledger.record_cycle_tick(
+        queue_size=2,
+        open_prs=1,
+        boss_running=False,
+        merge_running=True,
+        benchmark_fresh=True,
+        actions=["steady_state"],
+        stop_reason="completed",
+    )
+    ledger.record_pr_merged(pr_number=5857)
+    ledger.record_shift_stop(
+        shift_id="shift-1",
+        reason="completed",
+        cycles=1,
+        duration_seconds=30.0,
+    )
+
+    with patch("aragora.cli.commands.swarm_status._boss_ready_queue_depth", return_value=9):
+        payload = load_operator_status(tmp_path, metrics_path=metrics_path)
+
+    assert payload["summary"]["queue_depth"] == 2
+    assert payload["ledger_status"]["current_queue_size"] == 2
+    assert payload["ledger_status"]["prs_merged"] == 1
+
+
 def test_render_operator_status_includes_recent_iterations() -> None:
     text = render_operator_status(
         {
@@ -119,6 +155,15 @@ def test_render_operator_status_includes_recent_iterations() -> None:
                 "sanitizer_rejection_rate": 0.25,
                 "deferred_publish_count": 1,
                 "queue_depth": 4,
+            },
+            "ledger_status": {
+                "current_queue_size": 0,
+                "current_boss_running": False,
+                "current_merge_running": True,
+                "current_benchmark_fresh": True,
+                "prs_merged": 3,
+                "last_stop_reason": "completed",
+                "green_shift": {"is_green": False},
             },
             "last_iterations": [
                 {
@@ -140,6 +185,7 @@ def test_render_operator_status_includes_recent_iterations() -> None:
     )
 
     assert "operator attempted=2 completed=1" in text
+    assert "proof-first queue=0 boss=False merge=True benchmark_fresh=True" in text
     assert "recent iterations:" in text
     assert "#101 deliverable_pr_created" in text
     assert "per-issue success:" in text

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+from aragora.swarm.shift_ledger import ShiftLedger
 from scripts import run_proof_first_shift as mod
 
 
@@ -16,6 +17,8 @@ def _run_shift_cycle(
     failure_log: str = "",
     benchmark_mode: str = "disabled",
     restart_service_side_effect: list[tuple[bool, str]] | None = None,
+    trigger_benchmark_side_effect: Exception | None = None,
+    ledger: ShiftLedger | None = None,
 ) -> dict[str, object]:
     restart_patch = (
         patch(
@@ -47,7 +50,10 @@ def _run_shift_cycle(
         patch(
             "scripts.run_proof_first_shift.fetch_benchmark_failure_log", return_value=failure_log
         ),
-        patch("scripts.run_proof_first_shift.trigger_benchmark_workflow"),
+        patch(
+            "scripts.run_proof_first_shift.trigger_benchmark_workflow",
+            side_effect=trigger_benchmark_side_effect,
+        ),
     ):
         return mod.run_shift_cycle(
             repo_root=Path(".").resolve(),
@@ -55,6 +61,7 @@ def _run_shift_cycle(
             benchmark_mode=benchmark_mode,
             automation_backlog_limit=12,
             runtime_state=runtime_state,
+            ledger=ledger,
         )
 
 
@@ -164,6 +171,7 @@ def test_run_shift_cycle_clears_failure_budget_after_successful_benchmark_run() 
     state = mod.ProofFirstRuntimeState(
         auth_failure_count=1,
         publication_failure_count=1,
+        runtime_failure_count=1,
         last_benchmark_run_id=100,
     )
 
@@ -180,6 +188,7 @@ def test_run_shift_cycle_clears_failure_budget_after_successful_benchmark_run() 
 
     assert state.auth_failure_count == 0
     assert state.publication_failure_count == 0
+    assert state.runtime_failure_count == 0
 
     report = _run_shift_cycle(
         state,
@@ -195,7 +204,9 @@ def test_run_shift_cycle_clears_failure_budget_after_successful_benchmark_run() 
 
     assert state.auth_failure_count == 1
     assert state.publication_failure_count == 0
+    assert state.runtime_failure_count == 0
     assert report["stop_reason"] == ""
+    assert report["failure_policy"]["auth_failure"]["will_stop"] is False
 
 
 def test_run_shift_cycle_reports_restart_failure_instead_of_crashing() -> None:
@@ -210,10 +221,12 @@ def test_run_shift_cycle_reports_restart_failure_instead_of_crashing() -> None:
     assert state.boss_restart_count == 1
     assert report["actions"] == ["restart_boss_loop_failed"]
     assert report["stop_reason"] == "BossRestartFailed: launchctl kickstart timed out for boss loop"
+    assert report["failure_policy"]["service_failure"]["will_stop"] is True
 
 
-def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable() -> None:
+def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable(tmp_path: Path) -> None:
     state = mod.ProofFirstRuntimeState()
+    ledger = ShiftLedger(path=tmp_path / "test_shift_ledger.jsonl")
 
     with (
         patch(
@@ -243,6 +256,7 @@ def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable() -> None:
             benchmark_mode="hybrid",
             automation_backlog_limit=12,
             runtime_state=state,
+            ledger=ledger,
         )
 
     assert report["snapshot"] == {}
@@ -251,3 +265,71 @@ def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable() -> None:
     assert report["latest_benchmark_run"] is None
     assert report["actions"] == []
     assert report["stop_reason"] == "GitHubUnavailable: error connecting to api.github.com"
+    assert report["failure_policy"]["runtime_failure"]["will_stop"] is True
+    assert state.runtime_failure_count == 1
+    assert ledger.get_status_summary()["runtime_failures"] == 1
+
+
+def test_run_shift_cycle_fails_closed_after_second_auth_failure() -> None:
+    state = mod.ProofFirstRuntimeState(auth_failure_count=1, last_benchmark_run_id=100)
+
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[True, True],
+        latest_run={
+            "databaseId": 101,
+            "createdAt": "2026-04-15T13:00:00Z",
+            "status": "completed",
+            "conclusion": "failure",
+        },
+        failure_log="codex login required before benchmark publish",
+    )
+
+    assert state.auth_failure_count == 2
+    assert report["stop_reason"] == "RepeatedAuthFailure: benchmark publication failed auth twice"
+    assert report["failure_policy"]["auth_failure"]["will_stop"] is True
+
+
+def test_run_shift_cycle_fails_closed_after_second_publication_failure() -> None:
+    state = mod.ProofFirstRuntimeState(publication_failure_count=1, last_benchmark_run_id=200)
+
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[True, True],
+        latest_run={
+            "databaseId": 201,
+            "createdAt": "2026-04-15T13:00:00Z",
+            "status": "completed",
+            "conclusion": "failure",
+        },
+        failure_log="resource not accessible by integration during pr creation",
+    )
+
+    assert state.publication_failure_count == 2
+    assert (
+        report["stop_reason"]
+        == "RepeatedPublicationFailure: benchmark publication failed PR handoff twice"
+    )
+    assert report["failure_policy"]["publication_failure"]["will_stop"] is True
+
+
+def test_run_shift_cycle_fails_closed_when_benchmark_trigger_runtime_fails() -> None:
+    state = mod.ProofFirstRuntimeState()
+
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[True, True],
+        benchmark_mode="hybrid",
+        latest_run={
+            "databaseId": 123,
+            "createdAt": "2026-04-14T00:00:00Z",
+            "status": "completed",
+            "conclusion": "success",
+        },
+        trigger_benchmark_side_effect=RuntimeError("gh workflow run failed"),
+    )
+
+    assert state.runtime_failure_count == 1
+    assert report["actions"] == ["trigger_benchmark_failed:stale_publication_window"]
+    assert report["stop_reason"] == "RuntimeFailure: gh workflow run failed"
+    assert report["failure_policy"]["runtime_failure"]["will_stop"] is True

--- a/tests/server/fastapi/routes/test_swarm_status.py
+++ b/tests/server/fastapi/routes/test_swarm_status.py
@@ -11,6 +11,7 @@ os.environ.setdefault("ARAGORA_USE_SECRETS_MANAGER", "0")
 
 from aragora.server.fastapi.routes import swarm_status
 from aragora.swarm.preflight import PreflightReceipt
+from aragora.swarm.shift_ledger import ShiftLedger
 
 
 def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
@@ -125,6 +126,45 @@ def test_swarm_status_summary_surfaces_compact_blocker_evidence(tmp_path: Path) 
             "issue_title": "Repair auth preflight",
         }
     ]
+
+
+def test_swarm_status_summary_prefers_ledger_truth_when_present(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    _write_jsonl(metrics_path, [])
+    ledger = ShiftLedger(path=tmp_path / ".aragora" / "proof_first_shift" / "shift_ledger.jsonl")
+    ledger.record_shift_start(
+        shift_id="shift-1",
+        max_hours=12.0,
+        benchmark_mode="hybrid",
+        queue_size=0,
+    )
+    ledger.record_cycle_tick(
+        queue_size=0,
+        open_prs=0,
+        boss_running=False,
+        merge_running=True,
+        benchmark_fresh=True,
+        actions=["steady_state"],
+        stop_reason="completed",
+    )
+    ledger.record_pr_merged(pr_number=5857)
+    ledger.record_shift_stop(
+        shift_id="shift-1",
+        reason="completed",
+        cycles=1,
+        duration_seconds=45.0,
+    )
+
+    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path, repo_root=tmp_path)
+
+    assert summary["status"] == "active"
+    assert summary["ledger_status"]["current_benchmark_fresh"] is True
+    assert summary["queue_depth"] == 0
+    assert summary["boss_running"] is False
+    assert summary["merge_running"] is True
+    assert summary["last_stop_reason"] == "completed"
+    assert summary["prs_merged_recent"] == 1
+    assert summary["merged_pr_numbers"] == [5857]
 
 
 def test_preflight_check_returns_receipt_dict() -> None:

--- a/tests/swarm/test_shift_ledger.py
+++ b/tests/swarm/test_shift_ledger.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import time
 from pathlib import Path
 
 import pytest
@@ -77,6 +76,7 @@ class TestShiftLedger:
         )
         ledger.record_cycle_tick(
             queue_size=5,
+            queue_removed=0,
             open_prs=2,
             boss_running=True,
             merge_running=True,
@@ -120,6 +120,7 @@ class TestStatusSummary:
         )
         ledger.record_cycle_tick(
             queue_size=3,
+            queue_removed=0,
             open_prs=1,
             boss_running=True,
             merge_running=True,
@@ -146,12 +147,17 @@ class TestStatusSummary:
         assert summary["benchmark_runs"] == 1
         assert summary["last_benchmark_conclusion"] == "success"
         assert summary["current_queue_size"] == 3
+        assert summary["current_queue_removed"] == 0
+        assert summary["current_open_prs"] == 1
         assert summary["current_boss_running"] is True
         assert summary["current_benchmark_fresh"] is True
+        assert summary["failure_policy"]["auth_failure"]["count"] == 1
+        assert summary["green_shift"]["is_green"] is False
 
     def test_multiple_ticks_uses_latest(self, ledger: ShiftLedger) -> None:
         ledger.record_cycle_tick(
             queue_size=10,
+            queue_removed=1,
             open_prs=5,
             boss_running=False,
             merge_running=True,
@@ -159,6 +165,7 @@ class TestStatusSummary:
         )
         ledger.record_cycle_tick(
             queue_size=3,
+            queue_removed=0,
             open_prs=1,
             boss_running=True,
             merge_running=True,
@@ -167,3 +174,113 @@ class TestStatusSummary:
         summary = ledger.get_status_summary()
         assert summary["current_queue_size"] == 3
         assert summary["current_boss_running"] is True
+
+    def test_green_shift_summary_marks_healthy_12_hour_shift_green(
+        self, ledger: ShiftLedger
+    ) -> None:
+        entries = [
+            LedgerEntry(
+                entry_type="shift_start",
+                timestamp="2026-04-15T00:00:00Z",
+                payload={
+                    "shift_id": "s1",
+                    "max_hours": 12,
+                    "benchmark_mode": "hybrid",
+                    "queue_size": 0,
+                },
+            ),
+            LedgerEntry(
+                entry_type="cycle_tick",
+                timestamp="2026-04-15T12:00:00Z",
+                payload={
+                    "queue_size": 0,
+                    "queue_removed": 0,
+                    "open_prs": 0,
+                    "boss_running": False,
+                    "merge_running": False,
+                    "benchmark_fresh": True,
+                    "actions": [],
+                    "stop_reason": "",
+                },
+            ),
+            LedgerEntry(
+                entry_type="shift_stop",
+                timestamp="2026-04-15T12:00:00Z",
+                payload={
+                    "shift_id": "s1",
+                    "reason": "TimeLimit: 12.00h >= max 12.00h",
+                    "cycles": 60,
+                    "duration_seconds": 43200,
+                },
+            ),
+        ]
+        ledger.path.write_text(
+            "\n".join(json.dumps(entry.to_dict(), sort_keys=True) for entry in entries) + "\n",
+            encoding="utf-8",
+        )
+
+        summary = ledger.get_status_summary(max_age_hours=48.0)
+
+        assert summary["green_shift"]["window_complete"] is True
+        assert summary["green_shift"]["benchmark_fresh"] is True
+        assert summary["green_shift"]["queue_disciplined"] is True
+        assert summary["green_shift"]["boss_service_healthy"] is True
+        assert summary["green_shift"]["merge_service_healthy"] is True
+        assert summary["green_shift"]["healthy_stop_reason"] is True
+        assert summary["green_shift"]["is_green"] is True
+
+    def test_green_shift_summary_marks_failure_class_as_not_green(
+        self, ledger: ShiftLedger
+    ) -> None:
+        entries = [
+            LedgerEntry(
+                entry_type="shift_start",
+                timestamp="2026-04-15T00:00:00Z",
+                payload={
+                    "shift_id": "s2",
+                    "max_hours": 12,
+                    "benchmark_mode": "hybrid",
+                    "queue_size": 1,
+                },
+            ),
+            LedgerEntry(
+                entry_type="runtime_failure",
+                timestamp="2026-04-15T06:00:00Z",
+                payload={"detail": "GitHubUnavailable: api outage"},
+            ),
+            LedgerEntry(
+                entry_type="cycle_tick",
+                timestamp="2026-04-15T06:00:00Z",
+                payload={
+                    "queue_size": 1,
+                    "queue_removed": 0,
+                    "open_prs": 0,
+                    "boss_running": False,
+                    "merge_running": True,
+                    "benchmark_fresh": False,
+                    "actions": [],
+                    "stop_reason": "GitHubUnavailable: api outage",
+                },
+            ),
+            LedgerEntry(
+                entry_type="shift_stop",
+                timestamp="2026-04-15T06:00:00Z",
+                payload={
+                    "shift_id": "s2",
+                    "reason": "GitHubUnavailable: api outage",
+                    "cycles": 3,
+                    "duration_seconds": 21600,
+                },
+            ),
+        ]
+        ledger.path.write_text(
+            "\n".join(json.dumps(entry.to_dict(), sort_keys=True) for entry in entries) + "\n",
+            encoding="utf-8",
+        )
+
+        summary = ledger.get_status_summary(max_age_hours=48.0)
+
+        assert summary["failure_policy"]["runtime_failure"]["will_stop"] is True
+        assert summary["green_shift"]["window_complete"] is False
+        assert summary["green_shift"]["healthy_stop_reason"] is False
+        assert summary["green_shift"]["is_green"] is False


### PR DESCRIPTION
## Summary\n- prefer proof-first ShiftLedger truth in swarm status read surfaces and studio health\n- sync canonical proof-first docs to the latest published benchmark/rescue surfaces\n- keep metrics as secondary detail while the queue stays empty unless fresh proof restocks it\n\n## Validation\n- python3 -m pytest tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py tests/cli/test_swarm_status_command.py tests/server/fastapi/routes/test_swarm_status.py -q\n- python3 -m ruff check scripts/run_proof_first_shift.py aragora/swarm/shift_ledger.py aragora/cli/commands/swarm_status.py aragora/server/fastapi/routes/swarm_status.py tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py tests/cli/test_swarm_status_command.py tests/server/fastapi/routes/test_swarm_status.py\n- python3 -m ruff format --check scripts/run_proof_first_shift.py aragora/swarm/shift_ledger.py aragora/cli/commands/swarm_status.py aragora/server/fastapi/routes/swarm_status.py tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py tests/cli/test_swarm_status_command.py tests/server/fastapi/routes/test_swarm_status.py\n- bash -n scripts/studio-health.sh\n- python3 scripts/reconcile_status_docs.py --json\n- python3 scripts/run_proof_first_shift.py --once --json\n- bash scripts/automation_pr_preflight.sh origin/main HEAD