### PR TITLE
feat(autonomy): wire proof-first operator surfaces to ledger truth

### DIFF
--- a/aragora/cli/commands/swarm_status.py
+++ b/aragora/cli/commands/swarm_status.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH, ShiftLedger
 from aragora.swarm.terminal_truth import TerminalClass, classify_from_metrics
 
 DEFAULT_METRICS_PATH = Path(".aragora") / "overnight" / "boss_metrics.jsonl"
@@ -76,6 +77,17 @@ def _load_metrics_rows(metrics_path: Path) -> list[dict[str, Any]]:
             if isinstance(payload, dict):
                 rows.append(payload)
     return rows
+
+
+def _load_ledger_status(repo_root: Path) -> dict[str, Any] | None:
+    ledger_path = repo_root / Path(DEFAULT_LEDGER_PATH)
+    if not ledger_path.exists():
+        return None
+    try:
+        payload = ShiftLedger(path=ledger_path).get_status_summary()
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) and payload else None
 
 
 def _resolve_terminal_class(row: dict[str, Any]) -> str:
@@ -155,7 +167,12 @@ def load_operator_status(
 ) -> dict[str, Any]:
     metrics_file = metrics_path or (repo_root / DEFAULT_METRICS_PATH)
     rows = _load_metrics_rows(metrics_file)
-    queue_depth = _boss_ready_queue_depth(repo_root, boss_repo=boss_repo)
+    ledger_status = _load_ledger_status(repo_root)
+    queue_depth = _optional_int(
+        ledger_status.get("current_queue_size") if isinstance(ledger_status, dict) else None
+    )
+    if queue_depth is None:
+        queue_depth = _boss_ready_queue_depth(repo_root, boss_repo=boss_repo)
 
     attempted_issues = {
         issue_number
@@ -221,8 +238,9 @@ def load_operator_status(
         )
 
     return {
-        "available": metrics_file.exists(),
+        "available": metrics_file.exists() or bool(ledger_status),
         "metrics_path": str(metrics_file),
+        "ledger_status": ledger_status or {},
         "summary": {
             "unique_issues_attempted": len(attempted_issues),
             "unique_issues_completed": len(completed_issues),
@@ -248,6 +266,27 @@ def render_operator_status(payload: dict[str, Any]) -> str:
             queue_depth=summary.get("queue_depth", "unknown"),
         )
     ]
+    ledger_status = (
+        payload.get("ledger_status", {}) if isinstance(payload.get("ledger_status"), dict) else {}
+    )
+    if ledger_status:
+        green_shift = (
+            ledger_status.get("green_shift", {})
+            if isinstance(ledger_status.get("green_shift"), dict)
+            else {}
+        )
+        lines.append(
+            "proof-first queue={queue} boss={boss} merge={merge} benchmark_fresh={benchmark} "
+            "merged_prs={merged} last_stop={stop} green_shift={green}".format(
+                queue=ledger_status.get("current_queue_size", "unknown"),
+                boss=ledger_status.get("current_boss_running"),
+                merge=ledger_status.get("current_merge_running"),
+                benchmark=ledger_status.get("current_benchmark_fresh"),
+                merged=ledger_status.get("prs_merged", 0),
+                stop=ledger_status.get("last_stop_reason") or "-",
+                green=green_shift.get("is_green"),
+            )
+        )
 
     iterations = [item for item in payload.get("last_iterations", []) if isinstance(item, dict)]
     if iterations:

--- a/aragora/server/fastapi/routes/swarm_status.py
+++ b/aragora/server/fastapi/routes/swarm_status.py
@@ -13,6 +13,9 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH as DEFAULT_SHIFT_LEDGER_PATH
+from aragora.swarm.shift_ledger import ShiftLedger
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_METRICS_PATH = Path(".aragora/overnight/boss_metrics.jsonl")
@@ -54,16 +57,35 @@ def _tail_jsonl(path: Path, max_lines: int) -> list[dict[str, Any]]:
         return []
 
 
+def _load_ledger_status(
+    *,
+    repo_root: Path,
+    ledger_path: Path | None = None,
+) -> dict[str, Any] | None:
+    path = ledger_path or (repo_root / Path(DEFAULT_SHIFT_LEDGER_PATH))
+    if not path.exists():
+        return None
+    try:
+        payload = ShiftLedger(path=path).get_status_summary()
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) and payload else None
+
+
 def swarm_status_summary(
     *,
     metrics_path: Path | None = None,
+    repo_root: Path | None = None,
+    ledger_path: Path | None = None,
     window: int = DEFAULT_WINDOW,
 ) -> dict[str, Any]:
-    """Build a swarm status summary from boss metrics JSONL."""
+    """Build a swarm status summary, preferring proof-first ledger truth."""
     path = metrics_path or DEFAULT_METRICS_PATH
+    root = repo_root or Path.cwd()
     rows = _tail_jsonl(path, window)
+    ledger_status = _load_ledger_status(repo_root=root, ledger_path=ledger_path)
 
-    if not rows:
+    if not rows and not ledger_status:
         return {
             "status": "no_data",
             "metrics_path": str(path),
@@ -129,6 +151,30 @@ def swarm_status_summary(
         "metrics_path": str(path),
         "window": window,
         "total_ticks": len(rows),
+        "ledger_status": ledger_status or {},
+        "queue_depth": (
+            ledger_status.get("current_queue_size") if isinstance(ledger_status, dict) else None
+        ),
+        "boss_running": (
+            ledger_status.get("current_boss_running") if isinstance(ledger_status, dict) else None
+        ),
+        "merge_running": (
+            ledger_status.get("current_merge_running") if isinstance(ledger_status, dict) else None
+        ),
+        "benchmark_fresh": (
+            ledger_status.get("current_benchmark_fresh")
+            if isinstance(ledger_status, dict)
+            else None
+        ),
+        "last_stop_reason": (
+            ledger_status.get("last_stop_reason") if isinstance(ledger_status, dict) else ""
+        ),
+        "prs_merged_recent": (
+            ledger_status.get("prs_merged") if isinstance(ledger_status, dict) else 0
+        ),
+        "merged_pr_numbers": (
+            ledger_status.get("pr_numbers_merged") if isinstance(ledger_status, dict) else []
+        ),
         "unique_issues_attempted": len(issues_attempted),
         "unique_issues_succeeded": len(issues_succeeded),
         "success_rate": issue_success_rate,

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -1,6 +1,6 @@
 # Active Execution Issues
 
-Last updated: 2026-04-14
+Last updated: 2026-04-15
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -33,20 +33,20 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B0 — Corpus** | Prove `>=50%` no-rescue success on a fixed benchmark corpus | `RS-01..03`, `TW-02..03` |
 | **B1 — Assist** | Auto-draft safe work orders and validation plans | `BC-04..06`, `TW-07..09` |
 | **B2 — Guard** | Require contracts and production-like preflight before auto-run | `RS-04..09` |
-| **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
+| **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..12` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
-Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is keeping the recurring truth/productization surfaces boring and keeping claims narrower than proof, not reopening already-landed guard work.
+Status note: the latest published B0 surface is at 80.0% truth success and 80.0% no-rescue truth success as of 2026-04-15, while the latest published `TW-03` surface has 0 repeated rescue classes. The remaining near-term gate is keeping the recurring truth/productization surfaces boring, clearing stale corpus alerts through the normal publication loop, and keeping claims narrower than proof.
 
 ## Current 30-Day Execution Set
 
 Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 - Do now: `CS-01..03`
-- Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Delay: `BC-07..09`, `RS-11..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
+- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should keep the queue empty unless they expose a fresh bounded regression or repeated rescue class
 - `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate
@@ -73,7 +73,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 ### Milestone 1.4 — Ledger & Self-Heal `[90d]`
 
-- [ ] **RS-10** Mirror probes, queue state, contracts, and receipts into `AutonomyLedger`
+- [x] **RS-10** Mirror probes, queue state, contracts, and receipts into `AutonomyLedger` _(Done 2026-04-15 via [#5857](https://github.com/synaptent/aragora/pull/5857))_
 - [ ] **RS-11** Add quarantine and fallback rules for auth drift, rate limits, permission mismatch, and publication failures
 - [ ] **RS-12** Cut `studio-health`, reporter, and status surfaces to ledger-backed truth
 

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-04-14
+Last updated: 2026-04-15
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -19,7 +19,7 @@ What is already true:
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
 - terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
-- the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
+- the latest published B0 surface is **80.0%** truth success and **80.0%** no-rescue truth success on the tracked corpus, with one pending corpus-freshness alert to clear on the next publication
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
 - launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
 - receipt-backed preflight is now the default operator and live dispatch admission truth on `main` via [#5514](https://github.com/synaptent/aragora/pull/5514)
@@ -35,6 +35,7 @@ What is already true:
 - repeated rescue-class reports now include fixture-or-issue productization status on `main` via [#5535](https://github.com/synaptent/aragora/pull/5535)
 - repo-tracked recurring rescue productization now lands in `docs/status/generated/rescue_productization/`, with the stable status summary at `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`
 - the recurring `TW-03` harvest can now relink repeated rescue classes to tracked fixture/issue targets and auto-create bounded follow-on issues when a repeated class is still unlinked
+- proof-first runtime truth is now persisted in `ShiftLedger` on `main` via [#5857](https://github.com/synaptent/aragora/pull/5857)
 
 What is still missing:
 
@@ -59,7 +60,7 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
-Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are now repo-tracked status surfaces.
+Current status: the latest published B0 surface is at **80.0%** truth success and **80.0%** no-rescue truth success as of 2026-04-15, and the latest published `TW-03` surface shows zero repeated rescue classes. The benchmark target is no longer the blocker; recurring truth publication, stale-corpus cleanup through the normal publication loop, and proof-first operator discipline are the remaining near-term gates.
 
 Primary truth metric:
 
@@ -104,7 +105,7 @@ Scorecard output rules:
 ### Current state
 
 - Terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are on `main`.
-- The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
+- The latest published B0 surface is at **80.0%** truth success and **80.0%** no-rescue truth success as of 2026-04-15.
 - The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
 - The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
 - The stable recurring status surface is `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, backed by the latest JSON pointers under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`.
@@ -126,7 +127,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 ### Delay
 
 - `BC-07..09` until the repair loop is truthful and resumable
-- `RS-10..12` until the operator-surface guard is real
+- `RS-11..12` until the operator-surface guard is real
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
@@ -143,8 +144,8 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 ## Live Boss-Ready Queue
 
 - There is no dedicated open boss-ready trust-loop issue right now.
-- Keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
-- Let the recurring `TW-01/TW-02/TW-03` publication surfaces restock the queue only when they expose a fresh repeated rescue class or a concrete regression.
+- Keep the live queue empty unless the recurring `TW-01/TW-02/TW-03` publication surfaces expose a fresh repeated rescue class or a concrete regression.
+- Keep `CS-01..03` enforced through the docs/status surfaces while the live queue remains empty.
 
 `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)), `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)), and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) now publish through repo-tracked recurring status surfaces at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`. `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
 

--- a/scripts/studio-health.sh
+++ b/scripts/studio-health.sh
@@ -22,6 +22,44 @@ eval $SSH "
     cd ~/Development/aragora 2>/dev/null || { echo 'REPO: NOT FOUND'; exit 1; }
     source .venv/bin/activate 2>/dev/null || { echo 'VENV: NOT FOUND'; exit 1; }
 
+    echo '--- Proof-First Ledger ---'
+    python3 - <<'PY'
+from pathlib import Path
+
+try:
+    from aragora.swarm.shift_ledger import ShiftLedger
+except Exception as exc:  # pragma: no cover - operator fallback
+    print(f'ledger: unavailable ({exc})')
+    raise SystemExit(0)
+
+repo_root = Path.cwd()
+ledger_path = repo_root / '.aragora' / 'proof_first_shift' / 'shift_ledger.jsonl'
+if not ledger_path.exists():
+    print('ledger: missing')
+    raise SystemExit(0)
+
+summary = ShiftLedger(path=ledger_path).get_status_summary()
+green = summary.get('green_shift') or {}
+print(
+    'queue={queue} boss={boss} merge={merge} benchmark_fresh={fresh} merged_prs={merged} last_stop={stop}'.format(
+        queue=summary.get('current_queue_size'),
+        boss=summary.get('current_boss_running'),
+        merge=summary.get('current_merge_running'),
+        fresh=summary.get('current_benchmark_fresh'),
+        merged=summary.get('prs_merged'),
+        stop=summary.get('last_stop_reason') or '-',
+    )
+)
+print(
+    'green_shift={green} observed_hours={hours} window_complete={window}'.format(
+        green=green.get('is_green'),
+        hours=green.get('observed_hours'),
+        window=green.get('window_complete'),
+    )
+)
+PY
+
+    echo ''
     echo '--- Processes ---'
     ARBITER=\$(pgrep -f 'swarm.*merge-arbiter' | head -1)
     BOSS=\$(pgrep -f 'swarm.*boss-loop' | head -1)

--- a/tests/cli/test_swarm_status_command.py
+++ b/tests/cli/test_swarm_status_command.py
@@ -12,6 +12,7 @@ from aragora.cli.commands.swarm_status import (
     load_operator_status,
     render_operator_status,
 )
+from aragora.swarm.shift_ledger import ShiftLedger
 
 
 def _write_metrics(metrics_path: Path, rows: list[dict[str, object]]) -> None:
@@ -110,6 +111,41 @@ def test_load_operator_status_reports_unknown_queue_depth_when_probe_unavailable
     assert payload["summary"]["queue_depth"] == "unknown"
 
 
+def test_load_operator_status_prefers_ledger_truth_for_queue_depth(tmp_path: Path) -> None:
+    metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    _write_metrics(metrics_path, [])
+    ledger = ShiftLedger(path=tmp_path / ".aragora" / "proof_first_shift" / "shift_ledger.jsonl")
+    ledger.record_shift_start(
+        shift_id="shift-1",
+        max_hours=12.0,
+        benchmark_mode="hybrid",
+        queue_size=0,
+    )
+    ledger.record_cycle_tick(
+        queue_size=2,
+        open_prs=1,
+        boss_running=False,
+        merge_running=True,
+        benchmark_fresh=True,
+        actions=["steady_state"],
+        stop_reason="completed",
+    )
+    ledger.record_pr_merged(pr_number=5857)
+    ledger.record_shift_stop(
+        shift_id="shift-1",
+        reason="completed",
+        cycles=1,
+        duration_seconds=30.0,
+    )
+
+    with patch("aragora.cli.commands.swarm_status._boss_ready_queue_depth", return_value=9):
+        payload = load_operator_status(tmp_path, metrics_path=metrics_path)
+
+    assert payload["summary"]["queue_depth"] == 2
+    assert payload["ledger_status"]["current_queue_size"] == 2
+    assert payload["ledger_status"]["prs_merged"] == 1
+
+
 def test_render_operator_status_includes_recent_iterations() -> None:
     text = render_operator_status(
         {
@@ -119,6 +155,15 @@ def test_render_operator_status_includes_recent_iterations() -> None:
                 "sanitizer_rejection_rate": 0.25,
                 "deferred_publish_count": 1,
                 "queue_depth": 4,
+            },
+            "ledger_status": {
+                "current_queue_size": 0,
+                "current_boss_running": False,
+                "current_merge_running": True,
+                "current_benchmark_fresh": True,
+                "prs_merged": 3,
+                "last_stop_reason": "completed",
+                "green_shift": {"is_green": False},
             },
             "last_iterations": [
                 {
@@ -140,6 +185,7 @@ def test_render_operator_status_includes_recent_iterations() -> None:
     )
 
     assert "operator attempted=2 completed=1" in text
+    assert "proof-first queue=0 boss=False merge=True benchmark_fresh=True" in text
     assert "recent iterations:" in text
     assert "#101 deliverable_pr_created" in text
     assert "per-issue success:" in text

--- a/tests/server/fastapi/routes/test_swarm_status.py
+++ b/tests/server/fastapi/routes/test_swarm_status.py
@@ -11,6 +11,7 @@ os.environ.setdefault("ARAGORA_USE_SECRETS_MANAGER", "0")
 
 from aragora.server.fastapi.routes import swarm_status
 from aragora.swarm.preflight import PreflightReceipt
+from aragora.swarm.shift_ledger import ShiftLedger
 
 
 def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
@@ -125,6 +126,45 @@ def test_swarm_status_summary_surfaces_compact_blocker_evidence(tmp_path: Path) 
             "issue_title": "Repair auth preflight",
         }
     ]
+
+
+def test_swarm_status_summary_prefers_ledger_truth_when_present(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    _write_jsonl(metrics_path, [])
+    ledger = ShiftLedger(path=tmp_path / ".aragora" / "proof_first_shift" / "shift_ledger.jsonl")
+    ledger.record_shift_start(
+        shift_id="shift-1",
+        max_hours=12.0,
+        benchmark_mode="hybrid",
+        queue_size=0,
+    )
+    ledger.record_cycle_tick(
+        queue_size=0,
+        open_prs=0,
+        boss_running=False,
+        merge_running=True,
+        benchmark_fresh=True,
+        actions=["steady_state"],
+        stop_reason="completed",
+    )
+    ledger.record_pr_merged(pr_number=5857)
+    ledger.record_shift_stop(
+        shift_id="shift-1",
+        reason="completed",
+        cycles=1,
+        duration_seconds=45.0,
+    )
+
+    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path, repo_root=tmp_path)
+
+    assert summary["status"] == "active"
+    assert summary["ledger_status"]["current_benchmark_fresh"] is True
+    assert summary["queue_depth"] == 0
+    assert summary["boss_running"] is False
+    assert summary["merge_running"] is True
+    assert summary["last_stop_reason"] == "completed"
+    assert summary["prs_merged_recent"] == 1
+    assert summary["merged_pr_numbers"] == [5857]
 
 
 def test_preflight_check_returns_receipt_dict() -> None:


### PR DESCRIPTION
## Summary
- prefer proof-first ShiftLedger truth in swarm status read surfaces and studio health
- sync canonical proof-first docs to the latest published benchmark/rescue surfaces
- keep metrics as secondary detail while the queue stays empty unless fresh proof restocks it

## Validation
- python3 -m pytest tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py tests/cli/test_swarm_status_command.py tests/server/fastapi/routes/test_swarm_status.py -q
- python3 -m ruff check scripts/run_proof_first_shift.py aragora/swarm/shift_ledger.py aragora/cli/commands/swarm_status.py aragora/server/fastapi/routes/swarm_status.py tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py tests/cli/test_swarm_status_command.py tests/server/fastapi/routes/test_swarm_status.py
- python3 -m ruff format --check scripts/run_proof_first_shift.py aragora/swarm/shift_ledger.py aragora/cli/commands/swarm_status.py aragora/server/fastapi/routes/swarm_status.py tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py tests/cli/test_swarm_status_command.py tests/server/fastapi/routes/test_swarm_status.py
- bash -n scripts/studio-health.sh
- python3 scripts/reconcile_status_docs.py --json
- python3 scripts/run_proof_first_shift.py --once --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD