### PR TITLE
feat(autonomy): harden proof-first operator truth loop

### DIFF
--- a/aragora/cli/commands/swarm_status.py
+++ b/aragora/cli/commands/swarm_status.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH, ShiftLedger
 from aragora.swarm.terminal_truth import TerminalClass, classify_from_metrics
 
 DEFAULT_METRICS_PATH = Path(".aragora") / "overnight" / "boss_metrics.jsonl"
@@ -146,6 +147,47 @@ def _boss_ready_queue_depth(repo_root: Path, *, boss_repo: str | None = None) ->
     return len(payload) if isinstance(payload, list) else None
 
 
+def _load_ledger_operator_status(
+    repo_root: Path,
+    *,
+    max_age_hours: float = 24.0,
+) -> dict[str, Any] | None:
+    ledger_path = repo_root / Path(DEFAULT_LEDGER_PATH)
+    if not ledger_path.exists():
+        return None
+
+    summary = ShiftLedger(path=ledger_path).get_status_summary(max_age_hours=max_age_hours)
+    if int(summary.get("total_entries", 0) or 0) <= 0:
+        return None
+
+    return {
+        "available": True,
+        "source": "ledger",
+        "ledger_path": str(ledger_path),
+        "summary": {
+            "queue_depth": summary.get("current_queue_size", "unknown"),
+            "benchmark_fresh": summary.get("current_benchmark_fresh"),
+            "boss_running": summary.get("current_boss_running"),
+            "merge_running": summary.get("current_merge_running"),
+            "last_stop_reason": summary.get("last_stop_reason", ""),
+            "restart_successes": summary.get("restart_successes", 0),
+            "restart_failures": summary.get("restart_failures", 0),
+            "service_restarts": summary.get("service_restarts", 0),
+            "prs_merged": summary.get("prs_merged", 0),
+            "pr_numbers_merged": summary.get("pr_numbers_merged", []),
+            "auth_failures": summary.get("auth_failures", 0),
+            "publication_failures": summary.get("publication_failures", 0),
+            "benchmark_runs": summary.get("benchmark_runs", 0),
+            "last_benchmark_conclusion": summary.get("last_benchmark_conclusion", ""),
+            "cycle_ticks": summary.get("cycle_ticks", 0),
+            "shifts_started": summary.get("shifts_started", 0),
+            "shifts_stopped": summary.get("shifts_stopped", 0),
+        },
+        "last_iterations": [],
+        "per_issue_success": [],
+    }
+
+
 def load_operator_status(
     repo_root: Path,
     *,
@@ -153,6 +195,10 @@ def load_operator_status(
     boss_repo: str | None = None,
     metrics_path: Path | None = None,
 ) -> dict[str, Any]:
+    ledger_payload = _load_ledger_operator_status(repo_root)
+    if ledger_payload is not None:
+        return ledger_payload
+
     metrics_file = metrics_path or (repo_root / DEFAULT_METRICS_PATH)
     rows = _load_metrics_rows(metrics_file)
     queue_depth = _boss_ready_queue_depth(repo_root, boss_repo=boss_repo)
@@ -222,6 +268,7 @@ def load_operator_status(
 
     return {
         "available": metrics_file.exists(),
+        "source": "metrics",
         "metrics_path": str(metrics_file),
         "summary": {
             "unique_issues_attempted": len(attempted_issues),
@@ -237,6 +284,52 @@ def load_operator_status(
 
 
 def render_operator_status(payload: dict[str, Any]) -> str:
+    if payload.get("source") == "ledger":
+        summary = payload.get("summary", {}) if isinstance(payload.get("summary"), dict) else {}
+        queue_depth = summary.get("queue_depth", "unknown")
+        benchmark_fresh = summary.get("benchmark_fresh")
+        benchmark_state = (
+            "fresh"
+            if benchmark_fresh is True
+            else "stale"
+            if benchmark_fresh is False
+            else "unknown"
+        )
+        boss_running = summary.get("boss_running")
+        merge_running = summary.get("merge_running")
+        boss_state = (
+            "running" if boss_running is True else "stopped" if boss_running is False else "unknown"
+        )
+        merge_state = (
+            "running"
+            if merge_running is True
+            else "stopped"
+            if merge_running is False
+            else "unknown"
+        )
+        lines = [
+            "operator queue_depth={queue_depth} benchmark={benchmark} boss={boss} merge={merge} "
+            "prs_merged={prs_merged} restarts={restart_successes}/{restart_failures} "
+            "auth_failures={auth_failures} publication_failures={publication_failures}".format(
+                queue_depth=queue_depth,
+                benchmark=benchmark_state,
+                boss=boss_state,
+                merge=merge_state,
+                prs_merged=summary.get("prs_merged", 0),
+                restart_successes=summary.get("restart_successes", 0),
+                restart_failures=summary.get("restart_failures", 0),
+                auth_failures=summary.get("auth_failures", 0),
+                publication_failures=summary.get("publication_failures", 0),
+            )
+        ]
+        last_stop_reason = _optional_text(summary.get("last_stop_reason"))
+        if last_stop_reason:
+            lines.append(f"last stop: {last_stop_reason}")
+        last_benchmark_conclusion = _optional_text(summary.get("last_benchmark_conclusion"))
+        if last_benchmark_conclusion:
+            lines.append(f"last benchmark conclusion: {last_benchmark_conclusion}")
+        return "\n".join(lines)
+
     summary = payload.get("summary", {}) if isinstance(payload.get("summary"), dict) else {}
     lines = [
         "operator attempted={attempted} completed={completed} sanitizer_rejection_rate={rate:.1%} "

--- a/aragora/server/fastapi/routes/swarm_status.py
+++ b/aragora/server/fastapi/routes/swarm_status.py
@@ -13,6 +13,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH, ShiftLedger
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_METRICS_PATH = Path(".aragora/overnight/boss_metrics.jsonl")
@@ -57,15 +59,48 @@ def _tail_jsonl(path: Path, max_lines: int) -> list[dict[str, Any]]:
 def swarm_status_summary(
     *,
     metrics_path: Path | None = None,
+    ledger_path: Path | None = None,
     window: int = DEFAULT_WINDOW,
 ) -> dict[str, Any]:
-    """Build a swarm status summary from boss metrics JSONL."""
+    """Build a swarm status summary from shift ledger or boss metrics JSONL."""
+    ledger_file = ledger_path or Path(DEFAULT_LEDGER_PATH)
+    if ledger_file.exists():
+        ledger_summary = ShiftLedger(path=ledger_file).get_status_summary()
+    else:
+        ledger_summary = {}
+    if int(ledger_summary.get("total_entries", 0) or 0) > 0:
+        return {
+            "status": "active",
+            "source": "ledger",
+            "ledger_path": str(ledger_file),
+            "period_hours": ledger_summary.get("period_hours", 24.0),
+            "total_entries": ledger_summary.get("total_entries", 0),
+            "shifts_started": ledger_summary.get("shifts_started", 0),
+            "shifts_stopped": ledger_summary.get("shifts_stopped", 0),
+            "cycle_ticks": ledger_summary.get("cycle_ticks", 0),
+            "queue_depth": ledger_summary.get("current_queue_size"),
+            "benchmark_fresh": ledger_summary.get("current_benchmark_fresh"),
+            "boss_running": ledger_summary.get("current_boss_running"),
+            "merge_running": ledger_summary.get("current_merge_running"),
+            "last_stop_reason": ledger_summary.get("last_stop_reason", ""),
+            "service_restarts": ledger_summary.get("service_restarts", 0),
+            "restart_successes": ledger_summary.get("restart_successes", 0),
+            "restart_failures": ledger_summary.get("restart_failures", 0),
+            "prs_merged": ledger_summary.get("prs_merged", 0),
+            "pr_numbers_merged": ledger_summary.get("pr_numbers_merged", []),
+            "auth_failures": ledger_summary.get("auth_failures", 0),
+            "publication_failures": ledger_summary.get("publication_failures", 0),
+            "benchmark_runs": ledger_summary.get("benchmark_runs", 0),
+            "last_benchmark_conclusion": ledger_summary.get("last_benchmark_conclusion", ""),
+        }
+
     path = metrics_path or DEFAULT_METRICS_PATH
     rows = _tail_jsonl(path, window)
 
     if not rows:
         return {
             "status": "no_data",
+            "source": "metrics",
             "metrics_path": str(path),
             "window": window,
             "total_ticks": 0,
@@ -126,6 +161,7 @@ def swarm_status_summary(
 
     return {
         "status": "active",
+        "source": "metrics",
         "metrics_path": str(path),
         "window": window,
         "total_ticks": len(rows),

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -1,6 +1,6 @@
 # Active Execution Issues
 
-Last updated: 2026-04-14
+Last updated: 2026-04-15
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -36,14 +36,14 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
-Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is keeping the recurring truth/productization surfaces boring and keeping claims narrower than proof, not reopening already-landed guard work.
+Status note: the latest published B0 surface on `main` is 80.0% truth success and 80.0% no-rescue truth success as of 2026-04-15. The remaining near-term gate is cutting the proof-first operator lane over to ledger-backed truth and fail-closed self-heal while keeping claims narrower than proof, not reopening already-landed guard work.
 
 ## Current 30-Day Execution Set
 
 Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
-- Do now: `CS-01..03`
-- Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Do now: `RS-12`, `BC-07`, `RS-11`, `BC-12`, with `CS-01..03` enforced as a standing proof-claim guard
+- Delay: `BC-08..09`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
 - Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
@@ -73,7 +73,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 ### Milestone 1.4 — Ledger & Self-Heal `[90d]`
 
-- [ ] **RS-10** Mirror probes, queue state, contracts, and receipts into `AutonomyLedger`
+- [x] **RS-10** Mirror probes, queue state, contracts, and receipts into `AutonomyLedger` _(Done 2026-04-15 via [#5857](https://github.com/synaptent/aragora/pull/5857))_
 - [ ] **RS-11** Add quarantine and fallback rules for auth drift, rate limits, permission mismatch, and publication failures
 - [ ] **RS-12** Cut `studio-health`, reporter, and status surfaces to ledger-backed truth
 

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-04-14
+Last updated: 2026-04-15
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -10,7 +10,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to keep `TW-01/TW-02/TW-03` recurring and boring on current `main`, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
+The current gate is to keep `TW-01/TW-02/TW-03` recurring and boring on current `main`, operationalize ledger-backed operator truth and fail-closed self-heal in the proof-first loop, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
 
 What is already true:
 
@@ -19,7 +19,8 @@ What is already true:
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
 - terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
-- the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
+- the 30-day B0 target is still exceeded on the published tracked cohort at **80.0%** no-rescue truth success
+- `ShiftLedger` runtime truth is now on `main` via [#5857](https://github.com/synaptent/aragora/pull/5857)
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
 - launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
 - receipt-backed preflight is now the default operator and live dispatch admission truth on `main` via [#5514](https://github.com/synaptent/aragora/pull/5514)
@@ -59,7 +60,7 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
-Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are now repo-tracked status surfaces.
+Current status: the latest published B0 surface on `main` is **80.0%** truth success and **80.0%** no-rescue truth success as of 2026-04-15. The benchmark target is no longer the blocker; the near-term blocker is cutting the operator surfaces and shift policy over to ledger-backed proof-first truth.
 
 Primary truth metric:
 
@@ -115,18 +116,21 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
-| 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Epics #804 and #806 are closed; enforcement is now via proof-first queue governance and recurring publication surfaces. |
+| 1 | `RS-12`, `BC-07` | The proof-first loop still samples too much runtime state ad hoc. | `studio-health`, status surfaces, and operator views prefer `ShiftLedger` truth when present and degrade cleanly when absent. | Queue, benchmark freshness, stop reasons, restart history, and failure counts come from one truthful read path. | substrate | `RS-10` landed via [#5857](https://github.com/synaptent/aragora/pull/5857); the read-path cutover is the current do-now lane. |
+| 2 | `RS-11`, `BC-12` | Long unattended shifts still need explicit fail-closed policy and clear stop/go criteria. | One-shot recovery budgets are encoded per failure class, repeated failures stop truthfully, and green 12-hour shifts are machine-evaluable. | Three consecutive green shifts become the gate before widening autonomous scope. | substrate | Keep this bounded to auth, publication, GitHub, and service-restart failure classes. |
+| 3 | `CS-01..03` | The wedge still fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Treat this as a standing guard on every proof/status update, not queue fuel. |
 
 ## Do Now / Delay / Avoid
 
 ### Do now
 
-- `CS-01..03`
+- `RS-12` and the front half of `BC-07`
+- `RS-11` and `BC-12`
+- `CS-01..03` as a standing proof-claim guard on every status/doc change
 
 ### Delay
 
-- `BC-07..09` until the repair loop is truthful and resumable
-- `RS-10..12` until the operator-surface guard is real
+- `BC-08..09` until the ledger-backed read path and fail-closed shift policy are real
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
@@ -143,7 +147,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 ## Live Boss-Ready Queue
 
 - There is no dedicated open boss-ready trust-loop issue right now.
-- Keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
+- Keep `CS-01..03` enforced through the docs/status surfaces while `RS-12`, `BC-07`, `RS-11`, and `BC-12` productize the proof-first operator lane.
 - Let the recurring `TW-01/TW-02/TW-03` publication surfaces restock the queue only when they expose a fresh repeated rescue class or a concrete regression.
 
 `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)), `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)), and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) now publish through repo-tracked recurring status surfaces at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`. `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -10,7 +10,7 @@ import os
 import subprocess
 import sys
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import UTC
 from datetime import datetime
 from pathlib import Path
@@ -41,6 +41,26 @@ AUTOMATION_BRANCH_PREFIXES = (
     "aragora/boss-harvest/",
     "benchmark-truth-publication/",
 )
+RECOVERY_BUDGET_PER_FAILURE_CLASS = 1
+AUTH_DRIFT_FAILURE = "auth_drift"
+GITHUB_OUTAGE_FAILURE = "github_outage"
+PUBLICATION_FAILURE = "benchmark_publication_failure"
+BOSS_RESTART_FAILURE = "boss_restart_failure"
+MERGE_RESTART_FAILURE = "merge_restart_failure"
+RECOVERY_FAILURE_CLASSES = (
+    AUTH_DRIFT_FAILURE,
+    GITHUB_OUTAGE_FAILURE,
+    PUBLICATION_FAILURE,
+    BOSS_RESTART_FAILURE,
+    MERGE_RESTART_FAILURE,
+)
+RECOVERY_STOP_REASONS = {
+    AUTH_DRIFT_FAILURE: "RepeatedAuthFailure: benchmark publication auth drift persisted after one automatic recovery attempt",
+    GITHUB_OUTAGE_FAILURE: "RepeatedGitHubOutage: proof-first queue reconciliation could not reach GitHub after one automatic recovery attempt",
+    PUBLICATION_FAILURE: "RepeatedPublicationFailure: benchmark publication PR handoff persisted after one automatic recovery attempt",
+    BOSS_RESTART_FAILURE: "RepeatedBossRestartFailure: boss loop still required intervention after one automatic recovery attempt",
+    MERGE_RESTART_FAILURE: "RepeatedMergeArbiterRestartFailure: merge arbiter still required intervention after one automatic recovery attempt",
+}
 
 
 @dataclass
@@ -49,6 +69,8 @@ class ProofFirstRuntimeState:
     merge_restart_count: int = 0
     auth_failure_count: int = 0
     publication_failure_count: int = 0
+    github_outage_count: int = 0
+    recovery_attempt_counts: dict[str, int] = field(default_factory=dict)
     last_benchmark_run_id: int | None = None
     last_triggered_benchmark_run_id: int | None = None
 
@@ -65,6 +87,18 @@ def _runtime_state_path(repo_root: Path) -> Path:
     return repo_root / ".aragora" / DEFAULT_SHIFT_DIRNAME / "runtime_state.json"
 
 
+def _default_recovery_attempt_counts() -> dict[str, int]:
+    return dict.fromkeys(RECOVERY_FAILURE_CLASSES, 0)
+
+
+def _normalize_recovery_attempt_counts(payload: Any) -> dict[str, int]:
+    counts = _default_recovery_attempt_counts()
+    if isinstance(payload, dict):
+        for failure_class in RECOVERY_FAILURE_CLASSES:
+            counts[failure_class] = int(payload.get(failure_class, 0) or 0)
+    return counts
+
+
 def load_runtime_state(path: Path) -> ProofFirstRuntimeState:
     if not path.exists():
         return ProofFirstRuntimeState()
@@ -76,6 +110,10 @@ def load_runtime_state(path: Path) -> ProofFirstRuntimeState:
         merge_restart_count=int(payload.get("merge_restart_count", 0) or 0),
         auth_failure_count=int(payload.get("auth_failure_count", 0) or 0),
         publication_failure_count=int(payload.get("publication_failure_count", 0) or 0),
+        github_outage_count=int(payload.get("github_outage_count", 0) or 0),
+        recovery_attempt_counts=_normalize_recovery_attempt_counts(
+            payload.get("recovery_attempt_counts")
+        ),
         last_benchmark_run_id=(
             int(payload["last_benchmark_run_id"]) if payload.get("last_benchmark_run_id") else None
         ),
@@ -90,6 +128,63 @@ def load_runtime_state(path: Path) -> ProofFirstRuntimeState:
 def save_runtime_state(path: Path, state: ProofFirstRuntimeState) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(asdict(state), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def recovery_budget_remaining(runtime_state: ProofFirstRuntimeState, failure_class: str) -> int:
+    used = int(runtime_state.recovery_attempt_counts.get(failure_class, 0) or 0)
+    return max(0, RECOVERY_BUDGET_PER_FAILURE_CLASS - used)
+
+
+def consume_recovery_attempt(
+    runtime_state: ProofFirstRuntimeState,
+    *,
+    failure_class: str,
+) -> tuple[int, int]:
+    attempt_number = int(runtime_state.recovery_attempt_counts.get(failure_class, 0) or 0) + 1
+    runtime_state.recovery_attempt_counts[failure_class] = attempt_number
+    remaining_budget = max(0, RECOVERY_BUDGET_PER_FAILURE_CLASS - attempt_number)
+    return attempt_number, remaining_budget
+
+
+def record_recovery_attempt(
+    ledger: ShiftLedger | None,
+    runtime_state: ProofFirstRuntimeState,
+    *,
+    failure_class: str,
+    action: str,
+    success: bool,
+    detail: str = "",
+) -> None:
+    attempt_number, remaining_budget = consume_recovery_attempt(
+        runtime_state,
+        failure_class=failure_class,
+    )
+    if ledger:
+        ledger.append(
+            "recovery_attempt",
+            failure_class=failure_class,
+            action=action,
+            success=success,
+            detail=detail,
+            attempt_number=attempt_number,
+            budget_limit=RECOVERY_BUDGET_PER_FAILURE_CLASS,
+            remaining_budget=remaining_budget,
+        )
+
+
+def failure_budget_summary(
+    runtime_state: ProofFirstRuntimeState,
+) -> dict[str, dict[str, int | bool]]:
+    summary: dict[str, dict[str, int | bool]] = {}
+    for failure_class in RECOVERY_FAILURE_CLASSES:
+        attempts_used = int(runtime_state.recovery_attempt_counts.get(failure_class, 0) or 0)
+        summary[failure_class] = {
+            "budget": RECOVERY_BUDGET_PER_FAILURE_CLASS,
+            "attempts_used": attempts_used,
+            "remaining": max(0, RECOVERY_BUDGET_PER_FAILURE_CLASS - attempts_used),
+            "exhausted": attempts_used >= RECOVERY_BUDGET_PER_FAILURE_CLASS,
+        }
+    return summary
 
 
 def _run(
@@ -387,6 +482,65 @@ def trigger_benchmark_workflow(*, repo_root: Path, repo: str) -> None:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh workflow run failed")
 
 
+def benchmark_fresh_within_window(
+    latest_run: dict[str, Any] | None,
+    *,
+    max_age_hours: float,
+) -> bool:
+    if latest_run is None:
+        return False
+    conclusion = str(latest_run.get("conclusion") or "").strip().lower()
+    if conclusion != "success":
+        return False
+    created_at = _parse_timestamp(str(latest_run.get("createdAt") or ""))
+    if created_at is None:
+        return False
+    age_hours = (_utc_now() - created_at).total_seconds() / 3600.0
+    return age_hours < max_age_hours
+
+
+def evaluate_green_shift(
+    *,
+    queue_report: dict[str, Any],
+    queue_count: int,
+    open_pr_count: int,
+    boss_running: bool | None,
+    merge_running: bool | None,
+    latest_run: dict[str, Any] | None,
+    benchmark_drift_open: bool,
+    runtime_state: ProofFirstRuntimeState,
+    max_age_hours: float,
+    stop_reason: str,
+    repeated_failure_classes: list[str],
+) -> dict[str, Any]:
+    queue_canonical_or_empty = True
+    if dict(queue_report.get("github_status") or {}).get("available") is False:
+        queue_canonical_or_empty = False
+
+    boss_ok = bool(boss_running) or queue_count == 0
+    merge_ok = bool(merge_running) or open_pr_count == 0
+    criteria = {
+        "benchmark_fresh_within_window": benchmark_fresh_within_window(
+            latest_run,
+            max_age_hours=max_age_hours,
+        ),
+        "queue_canonical_or_empty": queue_canonical_or_empty,
+        "services_healthy_or_intentionally_idle": boss_ok and merge_ok,
+        "failure_budgets_respected": not repeated_failure_classes,
+        "no_open_benchmark_publication_drift": not benchmark_drift_open,
+    }
+    blocking_reasons = [name for name, passed in criteria.items() if not passed]
+    if stop_reason:
+        blocking_reasons.append("shift_stop_reason_present")
+    return {
+        "is_green": all(criteria.values()) and not stop_reason,
+        "criteria": criteria,
+        "blocking_reasons": blocking_reasons,
+        "repeated_failure_classes": repeated_failure_classes,
+        "recovery_budgets": failure_budget_summary(runtime_state),
+    }
+
+
 def run_shift_cycle(
     *,
     repo_root: Path,
@@ -395,18 +549,52 @@ def run_shift_cycle(
     automation_backlog_limit: int,
     runtime_state: ProofFirstRuntimeState,
     ledger: ShiftLedger | None = None,
+    max_hours: float = DEFAULT_MAX_HOURS,
 ) -> dict[str, Any]:
     queue_report = reconcile_proof_first_queue(repo=repo, repo_root=repo_root, apply=True)
     github_status = dict(queue_report.get("github_status") or {})
     if github_status.get("available") is False:
+        detail = github_unavailable_stop_reason(queue_report)
+        runtime_state.github_outage_count += 1
+        if ledger:
+            ledger.record_failure(failure_type=GITHUB_OUTAGE_FAILURE, detail=detail)
+        actions: list[str] = []
+        stop_reason = ""
+        repeated_failure_classes: list[str] = []
+        if recovery_budget_remaining(runtime_state, GITHUB_OUTAGE_FAILURE) > 0:
+            record_recovery_attempt(
+                ledger,
+                runtime_state,
+                failure_class=GITHUB_OUTAGE_FAILURE,
+                action="retry_queue_reconciliation_next_cycle",
+                success=False,
+                detail=detail,
+            )
+            actions.append("retry_github_outage_next_cycle")
+        else:
+            stop_reason = RECOVERY_STOP_REASONS[GITHUB_OUTAGE_FAILURE]
+            repeated_failure_classes.append(GITHUB_OUTAGE_FAILURE)
         return {
             "queue_report": queue_report,
             "snapshot": {},
             "open_pr_count": 0,
             "automation_backlog": 0,
             "latest_benchmark_run": None,
-            "actions": [],
-            "stop_reason": github_unavailable_stop_reason(queue_report),
+            "actions": actions,
+            "stop_reason": stop_reason,
+            "green_shift_evaluation": evaluate_green_shift(
+                queue_report=queue_report,
+                queue_count=0,
+                open_pr_count=0,
+                boss_running=None,
+                merge_running=None,
+                latest_run=None,
+                benchmark_drift_open=True,
+                runtime_state=runtime_state,
+                max_age_hours=max_hours,
+                stop_reason=stop_reason,
+                repeated_failure_classes=repeated_failure_classes,
+            ),
         }
     snapshot = collect_boss_lane_snapshot(repo_root=repo_root, repo=repo)
     prs = list_open_prs(repo_root=repo_root, repo=repo)
@@ -417,13 +605,9 @@ def run_shift_cycle(
     boss_running = process_running(DEFAULT_BOSS_PROCESS_PATTERN)
     merge_running = process_running(DEFAULT_MERGE_PROCESS_PATTERN)
 
-    if boss_running:
-        runtime_state.boss_restart_count = 0
-    if merge_running:
-        runtime_state.merge_restart_count = 0
-
     actions: list[str] = []
     service_failures: list[str] = []
+    repeated_failure_classes: list[str] = []
     if should_restart_service(
         is_running=boss_running,
         pending_count=canonical_queue_count,
@@ -434,7 +618,16 @@ def run_shift_cycle(
             process_pattern=DEFAULT_BOSS_PROCESS_PATTERN,
         )
         runtime_state.boss_restart_count += 1
+        record_recovery_attempt(
+            ledger,
+            runtime_state,
+            failure_class=BOSS_RESTART_FAILURE,
+            action="restart_boss_loop",
+            success=restarted,
+            detail=detail,
+        )
         if restarted:
+            boss_running = True
             actions.append("restart_boss_loop")
             if ledger:
                 ledger.record_service_restart(service="boss_loop", success=True)
@@ -445,6 +638,13 @@ def run_shift_cycle(
             )
             if ledger:
                 ledger.record_service_restart(service="boss_loop", success=False, detail=detail)
+                ledger.record_failure(
+                    failure_type=BOSS_RESTART_FAILURE,
+                    detail=detail or "boss loop restart did not produce a running process",
+                )
+    elif (not boss_running) and canonical_queue_count > 0 and runtime_state.boss_restart_count >= 1:
+        repeated_failure_classes.append(BOSS_RESTART_FAILURE)
+        service_failures.append(RECOVERY_STOP_REASONS[BOSS_RESTART_FAILURE])
 
     if should_restart_service(
         is_running=merge_running,
@@ -456,7 +656,16 @@ def run_shift_cycle(
             process_pattern=DEFAULT_MERGE_PROCESS_PATTERN,
         )
         runtime_state.merge_restart_count += 1
+        record_recovery_attempt(
+            ledger,
+            runtime_state,
+            failure_class=MERGE_RESTART_FAILURE,
+            action="restart_merge_arbiter",
+            success=restarted,
+            detail=detail,
+        )
         if restarted:
+            merge_running = True
             actions.append("restart_merge_arbiter")
             if ledger:
                 ledger.record_service_restart(service="merge_arbiter", success=True)
@@ -467,6 +676,13 @@ def run_shift_cycle(
             )
             if ledger:
                 ledger.record_service_restart(service="merge_arbiter", success=False, detail=detail)
+                ledger.record_failure(
+                    failure_type=MERGE_RESTART_FAILURE,
+                    detail=detail or "merge arbiter restart did not produce a running process",
+                )
+    elif (not merge_running) and open_pr_count > 0 and runtime_state.merge_restart_count >= 1:
+        repeated_failure_classes.append(MERGE_RESTART_FAILURE)
+        service_failures.append(RECOVERY_STOP_REASONS[MERGE_RESTART_FAILURE])
 
     merge_report = run_merge_arbiter_apply(
         repo_root=repo_root,
@@ -481,6 +697,8 @@ def run_shift_cycle(
                 ledger.record_pr_merged(pr_number=int(num))
 
     latest_run = latest_benchmark_run(repo_root=repo_root, repo=repo)
+    latest_failure_class = ""
+    latest_failure_detail = ""
     if latest_run is not None:
         run_id = int(latest_run.get("databaseId", 0) or 0)
         conclusion = str(latest_run.get("conclusion") or "").strip().lower()
@@ -497,10 +715,14 @@ def run_shift_cycle(
                 failure_class = classify_benchmark_failure_log(failure_log)
                 if failure_class == "auth_failure":
                     runtime_state.auth_failure_count += 1
+                    latest_failure_class = AUTH_DRIFT_FAILURE
+                    latest_failure_detail = failure_log[:500]
                     if ledger:
                         ledger.record_failure(failure_type="auth_failure", detail=failure_log[:500])
                 elif failure_class == "publication_failure":
                     runtime_state.publication_failure_count += 1
+                    latest_failure_class = PUBLICATION_FAILURE
+                    latest_failure_detail = failure_log[:500]
                     if ledger:
                         ledger.record_failure(
                             failure_type="publication_failure", detail=failure_log[:500]
@@ -516,30 +738,46 @@ def run_shift_cycle(
         automation_backlog=automation_backlog,
         automation_backlog_limit=automation_backlog_limit,
         last_triggered_run_id=runtime_state.last_triggered_benchmark_run_id,
+        max_age_hours=max_hours,
     )
-    if should_trigger:
-        trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
-        actions.append(f"trigger_benchmark:{trigger_reason}")
-        if latest_run is not None:
-            runtime_state.last_triggered_benchmark_run_id = int(
-                latest_run.get("databaseId", 0) or 0
-            )
-        else:
-            runtime_state.last_triggered_benchmark_run_id = -1
-
     stop_reason = ""
-    if runtime_state.auth_failure_count >= 2:
-        stop_reason = "RepeatedAuthFailure: benchmark publication failed auth twice"
-    elif runtime_state.publication_failure_count >= 2:
-        stop_reason = "RepeatedPublicationFailure: benchmark publication failed PR handoff twice"
-    elif service_failures:
+    if should_trigger:
+        if trigger_reason == "retry_after_failed_run" and latest_failure_class:
+            if recovery_budget_remaining(runtime_state, latest_failure_class) <= 0:
+                repeated_failure_classes.append(latest_failure_class)
+                stop_reason = RECOVERY_STOP_REASONS[latest_failure_class]
+            else:
+                trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
+                actions.append(f"trigger_benchmark:{trigger_reason}")
+                record_recovery_attempt(
+                    ledger,
+                    runtime_state,
+                    failure_class=latest_failure_class,
+                    action="trigger_benchmark_workflow",
+                    success=True,
+                    detail=latest_failure_detail or trigger_reason,
+                )
+                if latest_run is not None:
+                    runtime_state.last_triggered_benchmark_run_id = int(
+                        latest_run.get("databaseId", 0) or 0
+                    )
+                else:
+                    runtime_state.last_triggered_benchmark_run_id = -1
+        else:
+            trigger_benchmark_workflow(repo_root=repo_root, repo=repo)
+            actions.append(f"trigger_benchmark:{trigger_reason}")
+            if latest_run is not None:
+                runtime_state.last_triggered_benchmark_run_id = int(
+                    latest_run.get("databaseId", 0) or 0
+                )
+            else:
+                runtime_state.last_triggered_benchmark_run_id = -1
+
+    if not stop_reason and service_failures:
         stop_reason = service_failures[0]
 
     # Record cycle tick in ledger
-    benchmark_fresh = False
-    if latest_run is not None:
-        conclusion = str(latest_run.get("conclusion") or "").strip().lower()
-        benchmark_fresh = conclusion == "success"
+    benchmark_fresh = benchmark_fresh_within_window(latest_run, max_age_hours=max_hours)
     if ledger:
         ledger.record_cycle_tick(
             queue_size=canonical_queue_count,
@@ -550,6 +788,8 @@ def run_shift_cycle(
             actions=actions,
         )
 
+    benchmark_drift_open = has_open_benchmark_publication_pr(prs) or should_trigger
+
     return {
         "queue_report": queue_report,
         "snapshot": snapshot,
@@ -558,6 +798,19 @@ def run_shift_cycle(
         "latest_benchmark_run": latest_run,
         "actions": actions,
         "stop_reason": stop_reason,
+        "green_shift_evaluation": evaluate_green_shift(
+            queue_report=queue_report,
+            queue_count=canonical_queue_count,
+            open_pr_count=open_pr_count,
+            boss_running=boss_running,
+            merge_running=merge_running,
+            latest_run=latest_run,
+            benchmark_drift_open=benchmark_drift_open,
+            runtime_state=runtime_state,
+            max_age_hours=max_hours,
+            stop_reason=stop_reason,
+            repeated_failure_classes=repeated_failure_classes,
+        ),
     }
 
 
@@ -635,6 +888,7 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
             automation_backlog_limit=int(args.automation_backlog_limit),
             runtime_state=runtime_state,
             ledger=ledger,
+            max_hours=float(args.max_hours),
         )
         cycle_reports.append(report)
         cycle_count += 1
@@ -667,6 +921,24 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
         "runtime_state": asdict(runtime_state),
         "cycles": cycle_reports,
         "ledger_status": ledger.get_status_summary(max_age_hours=float(args.max_hours)),
+        "green_shift_evaluation": (
+            cycle_reports[-1]["green_shift_evaluation"]
+            if cycle_reports
+            else evaluate_green_shift(
+                queue_report={"kept": [], "removed": []},
+                queue_count=0,
+                open_pr_count=0,
+                boss_running=None,
+                merge_running=None,
+                latest_run=None,
+                benchmark_drift_open=True,
+                runtime_state=runtime_state,
+                max_age_hours=float(args.max_hours),
+                stop_reason=str(controller.get_progress_summary().get("stop_reason") or ""),
+                repeated_failure_classes=[],
+            )
+        ),
+        "recovery_budgets": failure_budget_summary(runtime_state),
     }
     save_runtime_state(runtime_state_path, runtime_state)
     return summary

--- a/scripts/studio-health.sh
+++ b/scripts/studio-health.sh
@@ -34,8 +34,43 @@ eval $SSH "
 
     echo ''
     echo '--- Worktrees ---'
-    find .worktrees -maxdepth 2 -type d 2>/dev/null | wc -l | tr -d ' '
+    git worktree list --porcelain 2>/dev/null | awk '/^worktree /{count++} END{print count+0}'
     echo 'worktrees'
+
+    echo ''
+    echo '--- Operator Truth ---'
+    python3 - <<'PY'
+from pathlib import Path
+
+from aragora.cli.commands.swarm_status import load_operator_status
+
+payload = load_operator_status(Path.cwd())
+summary = payload.get('summary', {}) if isinstance(payload.get('summary'), dict) else {}
+source = str(payload.get('source') or 'unknown')
+print(f'Source: {source}')
+
+if source == 'ledger':
+    benchmark_fresh = summary.get('benchmark_fresh')
+    benchmark_state = 'fresh' if benchmark_fresh is True else 'stale' if benchmark_fresh is False else 'unknown'
+    print(f\"Queue depth: {summary.get('queue_depth', 'unknown')}\")
+    print(f\"Benchmark: {benchmark_state}\")
+    print(f\"Boss loop: {summary.get('boss_running')}\")
+    print(f\"Merge arbiter: {summary.get('merge_running')}\")
+    print(f\"Last stop reason: {summary.get('last_stop_reason') or '-'}\")
+    print(
+        'Restarts: '
+        f\"{summary.get('restart_successes', 0)} success / {summary.get('restart_failures', 0)} failed\"
+    )
+    print(f\"Merged PRs: {summary.get('prs_merged', 0)}\")
+    print(f\"Auth failures: {summary.get('auth_failures', 0)}\")
+    print(f\"Publication failures: {summary.get('publication_failures', 0)}\")
+else:
+    print(f\"Queue depth: {summary.get('queue_depth', 'unknown')}\")
+    print(f\"Unique issues attempted: {summary.get('unique_issues_attempted', 0)}\")
+    print(f\"Unique issues completed: {summary.get('unique_issues_completed', 0)}\")
+    print(f\"Deferred publish count: {summary.get('deferred_publish_count', 0)}\")
+    print(f\"Sanitizer rejection count: {summary.get('sanitizer_rejection_count', 0)}\")
+PY
 
     echo ''
     echo '--- Open PRs ---'

--- a/scripts/tmux_send_prompt.sh
+++ b/scripts/tmux_send_prompt.sh
@@ -63,10 +63,11 @@ TARGET="${TMUX_SESSION}:${window_id}"
 
 # For multi-line prompts, use tmux paste buffer to avoid shell escaping issues
 if [[ "$(echo "${PROMPT}" | wc -l)" -gt 1 ]]; then
-    tmux set-buffer -b "aragora-prompt" "${PROMPT}"
-    tmux paste-buffer -b "aragora-prompt" -t "${TARGET}"
+    BUFFER_NAME="aragora-prompt-${NAME}-$$-$(date +%s%N)"
+    tmux set-buffer -b "${BUFFER_NAME}" "${PROMPT}"
+    tmux paste-buffer -b "${BUFFER_NAME}" -t "${TARGET}"
     tmux send-keys -t "${TARGET}" "" Enter
-    tmux delete-buffer -b "aragora-prompt" 2>/dev/null || true
+    tmux delete-buffer -b "${BUFFER_NAME}" 2>/dev/null || true
 else
     tmux send-keys -t "${TARGET}" "${PROMPT}" Enter
 fi

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -22,6 +22,37 @@ TMUX_SESSION="aragora"
 LOG_DIR="${HOME}/.aragora/tmux-sessions"
 mkdir -p "${LOG_DIR}"
 
+wait_for_agent_ready() {
+    local agent="$1"
+    local log_file="$2"
+    local timeout_seconds="$3"
+    local pattern=""
+    local elapsed=0
+
+    case "${agent}" in
+        codex)
+            pattern='OpenAI Codex|Use /skills to list available skills|Improve documentation in @filename'
+            ;;
+        claude)
+            pattern='Claude Code|ctrl\+g to edit in VS Code|don'"'"'t ask on'
+            ;;
+    esac
+
+    if [[ -z "${pattern}" ]]; then
+        return 1
+    fi
+
+    while (( elapsed < timeout_seconds )); do
+        if [[ -f "${log_file}" ]] && grep -Eq "${pattern}" "${log_file}"; then
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    return 1
+}
+
 # --- argument parsing ---
 NAME=""
 AGENT="codex"
@@ -144,7 +175,12 @@ echo "  Meta: ${META_FILE}"
 
 # If there's a prompt to send, wait for the session to initialize then send it
 if [[ -n "${PROMPT}" ]]; then
-    echo "Waiting 5s for session init before sending prompt..."
-    sleep 5
+    INIT_WAIT_SECONDS="${ARAGORA_TMUX_INIT_WAIT_SECONDS:-30}"
+    echo "Waiting up to ${INIT_WAIT_SECONDS}s for ${AGENT} readiness before sending prompt..."
+    if wait_for_agent_ready "${AGENT}" "${LOG_FILE}" "${INIT_WAIT_SECONDS}"; then
+        echo "Readiness markers detected for ${NAME}."
+    else
+        echo "Timed out waiting for readiness markers for ${NAME}; sending prompt anyway."
+    fi
     "${SCRIPT_DIR}/tmux_send_prompt.sh" --name "${NAME}" --prompt "${PROMPT}"
 fi

--- a/tests/cli/test_swarm_status_command.py
+++ b/tests/cli/test_swarm_status_command.py
@@ -12,6 +12,7 @@ from aragora.cli.commands.swarm_status import (
     load_operator_status,
     render_operator_status,
 )
+from aragora.swarm.shift_ledger import ShiftLedger
 
 
 def _write_metrics(metrics_path: Path, rows: list[dict[str, object]]) -> None:
@@ -110,6 +111,45 @@ def test_load_operator_status_reports_unknown_queue_depth_when_probe_unavailable
     assert payload["summary"]["queue_depth"] == "unknown"
 
 
+def test_load_operator_status_prefers_shift_ledger(tmp_path: Path) -> None:
+    ledger = ShiftLedger(path=tmp_path / ".aragora" / "proof_first_shift" / "shift_ledger.jsonl")
+    ledger.record_cycle_tick(
+        queue_size=4,
+        open_prs=1,
+        boss_running=True,
+        merge_running=False,
+        benchmark_fresh=True,
+        actions=["restart_boss_loop"],
+    )
+    ledger.record_service_restart(service="boss_loop", success=True)
+    ledger.record_service_restart(service="merge_arbiter", success=False, detail="timeout")
+    ledger.record_pr_merged(pr_number=5857, title="ledger-backed status")
+    ledger.record_failure(failure_type="auth_failure", detail="not logged in")
+    ledger.record_failure(failure_type="publication_failure", detail="gh unavailable")
+    ledger.record_shift_stop(
+        shift_id="shift-1",
+        reason="queue_empty",
+        cycles=4,
+        duration_seconds=120.0,
+    )
+
+    payload = load_operator_status(tmp_path)
+
+    assert payload["source"] == "ledger"
+    assert payload["summary"]["queue_depth"] == 4
+    assert payload["summary"]["benchmark_fresh"] is True
+    assert payload["summary"]["boss_running"] is True
+    assert payload["summary"]["merge_running"] is False
+    assert payload["summary"]["last_stop_reason"] == "queue_empty"
+    assert payload["summary"]["restart_successes"] == 1
+    assert payload["summary"]["restart_failures"] == 1
+    assert payload["summary"]["prs_merged"] == 1
+    assert payload["summary"]["auth_failures"] == 1
+    assert payload["summary"]["publication_failures"] == 1
+    assert payload["last_iterations"] == []
+    assert payload["per_issue_success"] == []
+
+
 def test_render_operator_status_includes_recent_iterations() -> None:
     text = render_operator_status(
         {
@@ -143,6 +183,33 @@ def test_render_operator_status_includes_recent_iterations() -> None:
     assert "recent iterations:" in text
     assert "#101 deliverable_pr_created" in text
     assert "per-issue success:" in text
+
+
+def test_render_operator_status_formats_shift_ledger_summary() -> None:
+    text = render_operator_status(
+        {
+            "source": "ledger",
+            "summary": {
+                "queue_depth": 2,
+                "benchmark_fresh": False,
+                "boss_running": True,
+                "merge_running": False,
+                "last_stop_reason": "BossRestartFailed",
+                "restart_successes": 1,
+                "restart_failures": 2,
+                "prs_merged": 3,
+                "auth_failures": 1,
+                "publication_failures": 0,
+                "last_benchmark_conclusion": "failure",
+            },
+        }
+    )
+
+    assert "operator queue_depth=2 benchmark=stale boss=running merge=stopped" in text
+    assert "restarts=1/2" in text
+    assert "auth_failures=1" in text
+    assert "last stop: BossRestartFailed" in text
+    assert "last benchmark conclusion: failure" in text
 
 
 def test_cmd_swarm_status_json_includes_operator_status(tmp_path: Path, capsys) -> None:
@@ -263,3 +330,78 @@ def test_cmd_swarm_status_text_includes_operator_metrics(tmp_path: Path, capsys)
     assert "runs=1 queued=0 leased=0 completed=1" in out
     assert "operator attempted=1 completed=1" in out
     assert "queue_depth=3" in out
+
+
+def test_cmd_swarm_status_text_prefers_shift_ledger(tmp_path: Path, capsys) -> None:
+    ledger = ShiftLedger(path=tmp_path / ".aragora" / "proof_first_shift" / "shift_ledger.jsonl")
+    ledger.record_cycle_tick(
+        queue_size=1,
+        open_prs=0,
+        boss_running=False,
+        merge_running=True,
+        benchmark_fresh=True,
+        actions=[],
+    )
+    ledger.record_service_restart(service="boss_loop", success=True)
+    ledger.record_pr_merged(pr_number=5845)
+    ledger.record_failure(failure_type="auth_failure", detail="expired token")
+    ledger.record_shift_stop(
+        shift_id="shift-2",
+        reason="benchmark_fresh",
+        cycles=3,
+        duration_seconds=90.0,
+    )
+
+    with (
+        patch("aragora.worktree.fleet.resolve_repo_root", return_value=tmp_path),
+        patch("aragora.worktree.fleet.build_fleet_rows", return_value=[]),
+        patch("aragora.worktree.fleet.FleetCoordinationStore") as store_cls,
+        patch(
+            "aragora.swarm.reporter.build_integrator_view",
+            return_value={
+                "summary": {
+                    "ready_lanes": 0,
+                    "review_lanes": 0,
+                    "blocked_lanes": 0,
+                    "stale_heartbeat_lanes": 0,
+                    "collision_lanes": 0,
+                    "missing_receipt_lanes": 0,
+                    "superseded_lanes": 0,
+                },
+                "next_actions": [],
+            },
+        ),
+        patch("aragora.swarm.SwarmSupervisor") as supervisor_cls,
+        patch(
+            "aragora.swarm.session_coordinator.read_directives",
+            return_value={
+                "summary": {
+                    "directive_count": 0,
+                    "session_count": 0,
+                    "claim_count": 0,
+                    "finding_count": 0,
+                },
+                "directives": [],
+                "claims": [],
+                "findings": [],
+            },
+        ),
+    ):
+        store_cls.return_value.list_claims.return_value = []
+        store_cls.return_value.list_merge_queue.return_value = []
+        supervisor_cls.return_value.status_summary.return_value = {
+            "runs": [],
+            "counts": {
+                "runs": 0,
+                "queued_work_orders": 0,
+                "leased_work_orders": 0,
+                "completed_work_orders": 0,
+            },
+            "coordination": {"counts": {"active_leases": 0}},
+        }
+        cmd_swarm(_swarm_status_args())
+
+    out = capsys.readouterr().out
+    assert "operator queue_depth=1 benchmark=fresh boss=stopped merge=running" in out
+    assert "prs_merged=1" in out
+    assert "last stop: benchmark_fresh" in out

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -137,17 +137,18 @@ def test_kickstart_launchd_returns_timeout_detail_instead_of_raising() -> None:
     assert detail == "launchctl timed out"
 
 
-def test_run_shift_cycle_restores_restart_budget_after_healthy_cycle() -> None:
+def test_run_shift_cycle_exhausts_restart_budget_within_shift_window() -> None:
     state = mod.ProofFirstRuntimeState(boss_restart_count=1, merge_restart_count=1)
 
-    _run_shift_cycle(
+    report = _run_shift_cycle(
         state,
         process_running_side_effect=[True, True],
         prs=[{"headRefName": "feature/test"}],
     )
 
-    assert state.boss_restart_count == 0
-    assert state.merge_restart_count == 0
+    assert report["actions"] == []
+    assert state.boss_restart_count == 1
+    assert state.merge_restart_count == 1
 
     report = _run_shift_cycle(
         state,
@@ -155,9 +156,40 @@ def test_run_shift_cycle_restores_restart_budget_after_healthy_cycle() -> None:
         prs=[{"headRefName": "feature/test"}],
     )
 
-    assert state.boss_restart_count == 1
-    assert state.merge_restart_count == 1
+    assert report["actions"] == []
+    assert report["stop_reason"] == mod.RECOVERY_STOP_REASONS[mod.BOSS_RESTART_FAILURE]
+    assert set(report["green_shift_evaluation"]["repeated_failure_classes"]) == {
+        mod.BOSS_RESTART_FAILURE,
+        mod.MERGE_RESTART_FAILURE,
+    }
+
+
+def test_run_shift_cycle_successful_restart_marks_services_healthy_for_green_shift() -> None:
+    state = mod.ProofFirstRuntimeState()
+
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[False, False],
+        prs=[{"headRefName": "feature/test"}],
+    )
+
     assert report["actions"] == ["restart_boss_loop", "restart_merge_arbiter"]
+    assert (
+        report["green_shift_evaluation"]["criteria"]["services_healthy_or_intentionally_idle"]
+        is True
+    )
+    assert (
+        report["green_shift_evaluation"]["recovery_budgets"][mod.BOSS_RESTART_FAILURE][
+            "attempts_used"
+        ]
+        == 1
+    )
+    assert (
+        report["green_shift_evaluation"]["recovery_budgets"][mod.MERGE_RESTART_FAILURE][
+            "attempts_used"
+        ]
+        == 1
+    )
 
 
 def test_run_shift_cycle_clears_failure_budget_after_successful_benchmark_run() -> None:
@@ -249,5 +281,55 @@ def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable() -> None:
     assert report["open_pr_count"] == 0
     assert report["automation_backlog"] == 0
     assert report["latest_benchmark_run"] is None
+    assert report["actions"] == ["retry_github_outage_next_cycle"]
+    assert report["stop_reason"] == ""
+    assert state.github_outage_count == 1
+    assert (
+        report["green_shift_evaluation"]["recovery_budgets"][mod.GITHUB_OUTAGE_FAILURE][
+            "attempts_used"
+        ]
+        == 1
+    )
+
+
+def test_run_shift_cycle_stops_after_repeated_github_outage() -> None:
+    state = mod.ProofFirstRuntimeState(
+        github_outage_count=1,
+        recovery_attempt_counts={mod.GITHUB_OUTAGE_FAILURE: 1},
+    )
+
+    with (
+        patch(
+            "scripts.run_proof_first_shift.reconcile_proof_first_queue",
+            return_value={
+                "kept": [],
+                "removed": [],
+                "github_status": {
+                    "available": False,
+                    "operation": "list_open_queue_issues",
+                    "error": "error connecting to api.github.com",
+                },
+            },
+        ),
+        patch(
+            "scripts.run_proof_first_shift.collect_boss_lane_snapshot",
+            side_effect=AssertionError("snapshot should not run when GitHub is unavailable"),
+        ),
+        patch(
+            "scripts.run_proof_first_shift.list_open_prs",
+            side_effect=AssertionError("pr listing should not run when GitHub is unavailable"),
+        ),
+    ):
+        report = mod.run_shift_cycle(
+            repo_root=Path(".").resolve(),
+            repo="synaptent/aragora",
+            benchmark_mode="hybrid",
+            automation_backlog_limit=12,
+            runtime_state=state,
+        )
+
     assert report["actions"] == []
-    assert report["stop_reason"] == "GitHubUnavailable: error connecting to api.github.com"
+    assert report["stop_reason"] == mod.RECOVERY_STOP_REASONS[mod.GITHUB_OUTAGE_FAILURE]
+    assert report["green_shift_evaluation"]["repeated_failure_classes"] == [
+        mod.GITHUB_OUTAGE_FAILURE
+    ]

--- a/tests/server/fastapi/routes/test_swarm_status.py
+++ b/tests/server/fastapi/routes/test_swarm_status.py
@@ -11,6 +11,7 @@ os.environ.setdefault("ARAGORA_USE_SECRETS_MANAGER", "0")
 
 from aragora.server.fastapi.routes import swarm_status
 from aragora.swarm.preflight import PreflightReceipt
+from aragora.swarm.shift_ledger import ShiftLedger
 
 
 def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
@@ -19,6 +20,7 @@ def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
 
 def test_swarm_status_summary_counts_deliverables_as_success(tmp_path: Path) -> None:
     metrics_path = tmp_path / "boss_metrics.jsonl"
+    missing_ledger_path = tmp_path / "missing-ledger.jsonl"
     _write_jsonl(
         metrics_path,
         [
@@ -39,7 +41,10 @@ def test_swarm_status_summary_counts_deliverables_as_success(tmp_path: Path) -> 
         ],
     )
 
-    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path)
+    summary = swarm_status.swarm_status_summary(
+        metrics_path=metrics_path,
+        ledger_path=missing_ledger_path,
+    )
 
     assert summary["status"] == "active"
     assert summary["total_ticks"] == 2
@@ -56,6 +61,7 @@ def test_swarm_status_summary_counts_deliverables_as_success(tmp_path: Path) -> 
 
 def test_swarm_status_summary_uses_issue_truth_for_success_rate(tmp_path: Path) -> None:
     metrics_path = tmp_path / "boss_metrics.jsonl"
+    missing_ledger_path = tmp_path / "missing-ledger.jsonl"
     _write_jsonl(
         metrics_path,
         [
@@ -76,7 +82,10 @@ def test_swarm_status_summary_uses_issue_truth_for_success_rate(tmp_path: Path) 
         ],
     )
 
-    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path)
+    summary = swarm_status.swarm_status_summary(
+        metrics_path=metrics_path,
+        ledger_path=missing_ledger_path,
+    )
 
     assert summary["unique_issues_attempted"] == 1
     assert summary["unique_issues_succeeded"] == 1
@@ -96,6 +105,7 @@ def test_swarm_status_summary_uses_issue_truth_for_success_rate(tmp_path: Path) 
 
 def test_swarm_status_summary_surfaces_compact_blocker_evidence(tmp_path: Path) -> None:
     metrics_path = tmp_path / "boss_metrics.jsonl"
+    missing_ledger_path = tmp_path / "missing-ledger.jsonl"
     _write_jsonl(
         metrics_path,
         [
@@ -113,7 +123,10 @@ def test_swarm_status_summary_surfaces_compact_blocker_evidence(tmp_path: Path) 
         ],
     )
 
-    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path)
+    summary = swarm_status.swarm_status_summary(
+        metrics_path=metrics_path,
+        ledger_path=missing_ledger_path,
+    )
 
     assert summary["recent_blockers"] == [
         {
@@ -125,6 +138,45 @@ def test_swarm_status_summary_surfaces_compact_blocker_evidence(tmp_path: Path) 
             "issue_title": "Repair auth preflight",
         }
     ]
+
+
+def test_swarm_status_summary_prefers_shift_ledger(tmp_path: Path) -> None:
+    ledger_path = tmp_path / ".aragora" / "proof_first_shift" / "shift_ledger.jsonl"
+    ledger = ShiftLedger(path=ledger_path)
+    ledger.record_cycle_tick(
+        queue_size=3,
+        open_prs=1,
+        boss_running=True,
+        merge_running=False,
+        benchmark_fresh=True,
+        actions=["restart_merge_arbiter"],
+    )
+    ledger.record_service_restart(service="boss_loop", success=True)
+    ledger.record_service_restart(service="merge_arbiter", success=False, detail="timeout")
+    ledger.record_pr_merged(pr_number=5857)
+    ledger.record_failure(failure_type="auth_failure", detail="token expired")
+    ledger.record_failure(failure_type="publication_failure", detail="gh pr failed")
+    ledger.record_shift_stop(
+        shift_id="shift-1",
+        reason="queue_empty",
+        cycles=5,
+        duration_seconds=120.0,
+    )
+
+    summary = swarm_status.swarm_status_summary(ledger_path=ledger_path)
+
+    assert summary["status"] == "active"
+    assert summary["source"] == "ledger"
+    assert summary["queue_depth"] == 3
+    assert summary["benchmark_fresh"] is True
+    assert summary["boss_running"] is True
+    assert summary["merge_running"] is False
+    assert summary["last_stop_reason"] == "queue_empty"
+    assert summary["restart_successes"] == 1
+    assert summary["restart_failures"] == 1
+    assert summary["prs_merged"] == 1
+    assert summary["auth_failures"] == 1
+    assert summary["publication_failures"] == 1
 
 
 def test_preflight_check_returns_receipt_dict() -> None:


### PR DESCRIPTION
## Summary
- prefer ShiftLedger-backed operator truth in CLI, FastAPI, and studio-health with metrics fallback
- add fail-closed proof-first shift recovery budgets and green-shift evaluation outputs
- reconcile canonical proof-first status docs and harden tmux lane prompt delivery

## Validation
- python3 -m pytest tests/cli/test_swarm_status_command.py tests/server/fastapi/routes/test_swarm_status.py tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py tests/scripts/test_reconcile_status_docs.py -q
- python3 -m ruff check aragora/cli/commands/swarm_status.py aragora/server/fastapi/routes/swarm_status.py scripts/run_proof_first_shift.py tests/cli/test_swarm_status_command.py tests/server/fastapi/routes/test_swarm_status.py tests/scripts/test_run_proof_first_shift.py tests/swarm/test_shift_ledger.py scripts/reconcile_status_docs.py tests/scripts/test_reconcile_status_docs.py
- bash -n scripts/studio-health.sh scripts/tmux_send_prompt.sh scripts/tmux_session_launcher.sh
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/run_proof_first_shift.py --once --benchmark-mode disabled --json