### PR TITLE
fix(tmux): harden launcher readiness and prompt transport

### DIFF
--- a/scripts/tmux_send_prompt.sh
+++ b/scripts/tmux_send_prompt.sh
@@ -63,10 +63,11 @@ TARGET="${TMUX_SESSION}:${window_id}"
 
 # For multi-line prompts, use tmux paste buffer to avoid shell escaping issues
 if [[ "$(echo "${PROMPT}" | wc -l)" -gt 1 ]]; then
-    tmux set-buffer -b "aragora-prompt" "${PROMPT}"
-    tmux paste-buffer -b "aragora-prompt" -t "${TARGET}"
+    BUFFER_NAME="aragora-prompt-${NAME}-$$-$(date +%s%N)"
+    tmux set-buffer -b "${BUFFER_NAME}" "${PROMPT}"
+    tmux paste-buffer -b "${BUFFER_NAME}" -t "${TARGET}"
     tmux send-keys -t "${TARGET}" "" Enter
-    tmux delete-buffer -b "aragora-prompt" 2>/dev/null || true
+    tmux delete-buffer -b "${BUFFER_NAME}" 2>/dev/null || true
 else
     tmux send-keys -t "${TARGET}" "${PROMPT}" Enter
 fi

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -22,6 +22,37 @@ TMUX_SESSION="aragora"
 LOG_DIR="${HOME}/.aragora/tmux-sessions"
 mkdir -p "${LOG_DIR}"
 
+wait_for_agent_ready() {
+    local agent="$1"
+    local log_file="$2"
+    local timeout_seconds="$3"
+    local pattern=""
+    local elapsed=0
+
+    case "${agent}" in
+        codex)
+            pattern='OpenAI Codex|Use /skills to list available skills|Improve documentation in @filename'
+            ;;
+        claude)
+            pattern='Claude Code|ctrl\+g to edit in VS Code|don'"'"'t ask on'
+            ;;
+    esac
+
+    if [[ -z "${pattern}" ]]; then
+        return 1
+    fi
+
+    while (( elapsed < timeout_seconds )); do
+        if [[ -f "${log_file}" ]] && grep -Eq "${pattern}" "${log_file}"; then
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    return 1
+}
+
 # --- argument parsing ---
 NAME=""
 AGENT="codex"
@@ -144,7 +175,12 @@ echo "  Meta: ${META_FILE}"
 
 # If there's a prompt to send, wait for the session to initialize then send it
 if [[ -n "${PROMPT}" ]]; then
-    echo "Waiting 5s for session init before sending prompt..."
-    sleep 5
+    INIT_WAIT_SECONDS="${ARAGORA_TMUX_INIT_WAIT_SECONDS:-30}"
+    echo "Waiting up to ${INIT_WAIT_SECONDS}s for ${AGENT} readiness before sending prompt..."
+    if wait_for_agent_ready "${AGENT}" "${LOG_FILE}" "${INIT_WAIT_SECONDS}"; then
+        echo "Readiness markers detected for ${NAME}."
+    else
+        echo "Timed out waiting for readiness markers for ${NAME}; sending prompt anyway."
+    fi
     "${SCRIPT_DIR}/tmux_send_prompt.sh" --name "${NAME}" --prompt "${PROMPT}"
 fi

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_fake_tmux(tmp_path: Path, *, window_name: str = "testpane") -> Path:
+    fake_tmux = tmp_path / "tmux"
+    fake_tmux.write_text(
+        f"""#!/usr/bin/env python3
+import json
+import os
+import sys
+
+log_path = os.environ["FAKE_TMUX_LOG"]
+with open(log_path, "a", encoding="utf-8") as handle:
+    handle.write(json.dumps(sys.argv[1:]) + "\\n")
+
+cmd = sys.argv[1:]
+if cmd[:3] == ["has-session", "-t", "aragora"]:
+    raise SystemExit(0)
+if cmd[:3] == ["list-windows", "-t", "aragora"]:
+    print("0 {window_name}")
+    raise SystemExit(0)
+if cmd[:2] in (["new-session", "-d"], ["new-window", "-t"], ["pipe-pane", "-t"]):
+    raise SystemExit(0)
+if cmd[:2] in (["send-keys", "-t"], ["set-buffer", "-b"], ["paste-buffer", "-b"], ["delete-buffer", "-b"]):
+    raise SystemExit(0)
+
+print(f"unexpected tmux command: {{cmd}}", file=sys.stderr)
+raise SystemExit(1)
+""",
+        encoding="utf-8",
+    )
+    fake_tmux.chmod(fake_tmux.stat().st_mode | stat.S_IEXEC)
+    return fake_tmux
+
+
+def _fake_tmux_env(tmp_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["FAKE_TMUX_LOG"] = str(tmp_path / "tmux-calls.jsonl")
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    env["HOME"] = str(tmp_path / "home")
+    return env
+
+
+def _load_tmux_calls(env: dict[str, str]) -> list[list[str]]:
+    log_path = Path(env["FAKE_TMUX_LOG"])
+    return [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_tmux_send_prompt_uses_unique_buffer_for_multiline_prompt(tmp_path: Path) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("line one\nline two\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_send_prompt.sh"),
+            "--name",
+            "testpane",
+            "--prompt-file",
+            str(prompt_file),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Prompt sent to 'testpane'" in result.stdout
+    calls = _load_tmux_calls(env)
+    set_buffer_call = next(call for call in calls if call[:2] == ["set-buffer", "-b"])
+    paste_buffer_call = next(call for call in calls if call[:2] == ["paste-buffer", "-b"])
+    delete_buffer_call = next(call for call in calls if call[:2] == ["delete-buffer", "-b"])
+
+    buffer_name = set_buffer_call[2]
+    assert buffer_name == paste_buffer_call[2] == delete_buffer_call[2]
+    assert buffer_name.startswith("aragora-prompt-testpane-")
+    assert buffer_name != "aragora-prompt"
+
+
+def test_tmux_session_launcher_waits_for_readiness_marker_before_prompt_send(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+
+    log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
+    log_dir.mkdir(parents=True)
+    (log_dir / "testpane.log").write_text("boot\nOpenAI Codex\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "testpane",
+            "--agent",
+            "codex",
+            "--prompt",
+            "hello from launcher",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Readiness markers detected for testpane." in result.stdout
+    calls = _load_tmux_calls(env)
+    assert any(call[:2] == ["new-window", "-t"] for call in calls)
+    assert any("hello from launcher" in call for call in calls if call[:2] == ["send-keys", "-t"])


### PR DESCRIPTION
## Summary
- use a unique tmux paste buffer per prompt send so concurrent multiline prompt injection does not clobber sibling lanes
- replace the fixed 5-second launcher sleep with readiness-marker waiting plus timeout fallback before first prompt injection
- add focused script tests that exercise the real shell wrappers through a fake tmux binary

## Validation
- python3 -m pytest tests/scripts/test_tmux_transport_scripts.py -q
- python3 -m ruff check tests/scripts/test_tmux_transport_scripts.py
- bash -n scripts/tmux_send_prompt.sh scripts/tmux_session_launcher.sh
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Context
This is the tmux-only extraction from #5862 after #5861 landed, so it does not overlap the proof-first operator surfaces or shift-policy work.