### PR TITLE
fix(ops): surface operator truth in studio health

### DIFF
--- a/scripts/studio-health.sh
+++ b/scripts/studio-health.sh
@@ -72,8 +72,43 @@ PY
 
     echo ''
     echo '--- Worktrees ---'
-    find .worktrees -maxdepth 2 -type d 2>/dev/null | wc -l | tr -d ' '
+    git worktree list --porcelain 2>/dev/null | awk '/^worktree /{count++} END{print count+0}'
     echo 'worktrees'
+
+    echo ''
+    echo '--- Operator Truth ---'
+    python3 - <<'PY'
+from pathlib import Path
+
+from aragora.cli.commands.swarm_status import load_operator_status
+
+payload = load_operator_status(Path.cwd())
+summary = payload.get('summary', {}) if isinstance(payload.get('summary'), dict) else {}
+source = str(payload.get('source') or 'unknown')
+print(f'Source: {source}')
+
+if source == 'ledger':
+    benchmark_fresh = summary.get('benchmark_fresh')
+    benchmark_state = 'fresh' if benchmark_fresh is True else 'stale' if benchmark_fresh is False else 'unknown'
+    print(f\"Queue depth: {summary.get('queue_depth', 'unknown')}\")
+    print(f\"Benchmark: {benchmark_state}\")
+    print(f\"Boss loop: {summary.get('boss_running')}\")
+    print(f\"Merge arbiter: {summary.get('merge_running')}\")
+    print(f\"Last stop reason: {summary.get('last_stop_reason') or '-'}\")
+    print(
+        'Restarts: '
+        f\"{summary.get('restart_successes', 0)} success / {summary.get('restart_failures', 0)} failed\"
+    )
+    print(f\"Merged PRs: {summary.get('prs_merged', 0)}\")
+    print(f\"Auth failures: {summary.get('auth_failures', 0)}\")
+    print(f\"Publication failures: {summary.get('publication_failures', 0)}\")
+else:
+    print(f\"Queue depth: {summary.get('queue_depth', 'unknown')}\")
+    print(f\"Unique issues attempted: {summary.get('unique_issues_attempted', 0)}\")
+    print(f\"Unique issues completed: {summary.get('unique_issues_completed', 0)}\")
+    print(f\"Deferred publish count: {summary.get('deferred_publish_count', 0)}\")
+    print(f\"Sanitizer rejection count: {summary.get('sanitizer_rejection_count', 0)}\")
+PY
 
     echo ''
     echo '--- Open PRs ---'

--- a/tests/scripts/test_studio_health.py
+++ b/tests/scripts/test_studio_health.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_studio_health_uses_operator_status_and_git_worktree_count() -> None:
+    script = (REPO_ROOT / "scripts" / "studio-health.sh").read_text(encoding="utf-8")
+
+    assert "git worktree list --porcelain" in script
+    assert "from aragora.cli.commands.swarm_status import load_operator_status" in script
+    assert "echo '--- Operator Truth ---'" in script
+    assert "find .worktrees -maxdepth 2 -type d" not in script


### PR DESCRIPTION
## Summary
- switch `studio-health.sh` from raw `.worktrees` directory counting to real `git worktree list --porcelain` counting
- show ledger-backed operator truth through `load_operator_status`, including benchmark freshness, queue depth, restart results, and failure counts
- add a focused regression test that locks the script contents to the new operator-truth path

## Validation
- python3 -m pytest tests/scripts/test_studio_health.py -q
- python3 -m ruff check tests/scripts/test_studio_health.py
- bash -n scripts/studio-health.sh
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Context
This is the final small follow-up extracted from closed #5862 after the tmux transport moved to #5863 and the proof-first shift policy moved to #5867.
