### PR TITLE
docs(status): reconcile proof-first docs and tmux runbook

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -32,6 +32,7 @@ Operational runbooks for responding to Aragora alerts and incidents.
 | Redis Failover | [redis-failover.md](./redis-failover.md) | Redis HA and recovery procedures |
 | Multi-Region | [RUNBOOK_MULTI_REGION_SETUP.md](./RUNBOOK_MULTI_REGION_SETUP.md) | Multi-region deployment and failover |
 | Fleet Coordination | [RUNBOOK_FLEET_COORDINATION.md](./RUNBOOK_FLEET_COORDINATION.md) | Multi-agent worktree ownership and merge queue policy |
+| Proof-First tmux Operator | [RUNBOOK_PROOF_FIRST_TMUX_OPERATOR.md](./RUNBOOK_PROOF_FIRST_TMUX_OPERATOR.md) | Conductor-led tmux coordination for benchmark/docs/monitor lanes without replacing the unattended proof-first shift |
 
 ## Incident Severity Levels
 

--- a/docs/runbooks/RUNBOOK_PROOF_FIRST_TMUX_OPERATOR.md
+++ b/docs/runbooks/RUNBOOK_PROOF_FIRST_TMUX_OPERATOR.md
@@ -1,0 +1,145 @@
+# Proof-First tmux Operator Runbook
+
+## Purpose
+
+Use tmux as the coordination layer for parallel proof-first work without turning tmux into the unattended execution substrate.
+
+The unattended substrate remains:
+
+- `python3 scripts/run_proof_first_shift.py`
+
+tmux is for:
+
+- conductor-led parallel implementation and review lanes
+- bounded benchmark/docs/monitor tracks
+- fast harvesting of lane output without restocking generic queue work
+
+## When To Use This Runbook
+
+Use this runbook when all of the following are true:
+
+- the live `boss-ready` queue is empty or intentionally constrained by proof-first policy
+- the next project move is driven by benchmark truth, docs reconciliation, or operator-surface hardening
+- you need multiple bounded lanes with disjoint ownership
+
+Do not use this runbook to:
+
+- repopulate generic cleanup issues
+- run multiple independent conductors
+- replace `run_proof_first_shift.py` for unattended operation
+
+## Core Rules
+
+1. One conductor only.
+2. One proof-first objective at a time.
+3. One managed worktree per write lane.
+4. Disjoint file ownership across lanes.
+5. Keep the root checkout for live services and operator verification, not feature editing.
+6. Keep the live queue empty unless fresh proof surfaces expose one bounded regression.
+
+## Standard Lane Set
+
+Use at most four lanes for the current proof-first tranche:
+
+- `codex-conductor`
+  Orchestrates prompts, harvests output, sequences merges, and keeps queue discipline.
+- `benchmark-proof`
+  Owns benchmark/publication reconciliation only.
+- `docs-proof`
+  Owns canonical proof-first docs only.
+- `monitor-proof`
+  Read-only lane for PR checks, workflow runs, and queue drift.
+
+Recommended ownership:
+
+- `benchmark-proof`
+  `scripts/reconcile_b0_pr_truth.py`
+  `scripts/build_benchmark_truth_artifact.py`
+  `scripts/render_benchmark_truth_status.py`
+  focused tests under `tests/scripts/`
+- `docs-proof`
+  `docs/status/NEXT_STEPS_CANONICAL.md`
+  `docs/status/ACTIVE_EXECUTION_ISSUES.md`
+  `scripts/reconcile_status_docs.py` and focused tests only if needed
+- `monitor-proof`
+  read-only; no code changes
+
+## Setup
+
+Start from a managed worktree, not the dirty root checkout.
+
+```bash
+python3 scripts/codex_worktree_autopilot.py ensure --agent codex --base main --reconcile --print-path
+```
+
+Create prompt files under `~/.aragora/tmux-prompts/` so prompts are reusable and auditable.
+
+## Launch
+
+Launch named sessions with the repo-native wrapper:
+
+```bash
+scripts/tmux_session_launcher.sh --name benchmark-proof --agent claude --prompt-file ~/.aragora/tmux-prompts/proof-first/benchmark.md
+scripts/tmux_session_launcher.sh --name docs-proof --agent claude --prompt-file ~/.aragora/tmux-prompts/proof-first/docs.md
+scripts/tmux_session_launcher.sh --name monitor-proof --agent claude --prompt-file ~/.aragora/tmux-prompts/proof-first/monitor.md
+```
+
+Useful commands:
+
+```bash
+scripts/tmux_session_launcher.sh --list
+scripts/tmux_send_prompt.sh --name benchmark-proof --prompt-file ~/.aragora/tmux-prompts/proof-first/benchmark-followup.md
+scripts/tmux_harvest.sh --name benchmark-proof --lines 120
+tmux attach -t aragora
+```
+
+For richer session discovery, use:
+
+```bash
+python3 scripts/swarm_session_mux.py list
+python3 scripts/swarm_session_mux.py status --name benchmark-proof
+python3 scripts/swarm_session_mux.py tail --name benchmark-proof --lines 120
+```
+
+## Conductor Loop
+
+Run this loop until the bounded objective is complete:
+
+1. Establish truth first.
+   Check benchmark surface, open PRs, and live queue state before assigning work.
+2. Launch only the lanes needed for the current objective.
+3. Assign explicit file ownership in each prompt.
+4. Harvest every 10-15 minutes or when a lane reports completion.
+5. Merge only green, bounded PRs.
+6. Re-run benchmark publication only after the benchmark lane lands.
+7. Keep the queue empty unless the refreshed proof surfaces expose one new bounded issue.
+
+## Relationship To Proof-First Shift
+
+`run_proof_first_shift.py` remains the only supported unattended operator path.
+
+Use tmux around that path for:
+
+- pre-merge implementation tracks
+- read-only monitoring during a soak
+- post-run review and evidence harvesting
+
+Do not use tmux to approximate the unattended shift by hand with ad hoc shell babysitting.
+
+## Stop Conditions
+
+Stop and regroup if any of the following occurs:
+
+- two write lanes start touching the same file set
+- benchmark truth is stale and no lane is actively fixing or refreshing it
+- the queue is repopulated with non-canonical work
+- a lane starts broadening scope beyond the bounded proof-first objective
+
+## Success Criteria For This Tranche
+
+For the current roadmap tranche, tmux-assisted work is successful when:
+
+- benchmark truth publication is complete and fresh
+- canonical docs match current merged proof
+- the queue remains canonical and usually empty
+- the next unattended run can be evaluated against explicit `BC-12` green-shift criteria

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -36,7 +36,7 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..12` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
-Status note: the latest published B0 surface is at 80.0% truth success and 80.0% no-rescue truth success as of 2026-04-15, while the latest published `TW-03` surface has 0 repeated rescue classes. The remaining near-term gate is keeping the recurring truth/productization surfaces boring, clearing stale corpus alerts through the normal publication loop, and keeping claims narrower than proof.
+Status note: use `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md` as the live recurring proof surfaces instead of hardcoded percentages here. When the B0 surface is stale, incomplete, or otherwise untrustworthy, restoring benchmark publication completeness becomes the immediate gate again.
 
 ## Current 30-Day Execution Set
 
@@ -74,8 +74,8 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 ### Milestone 1.4 — Ledger & Self-Heal `[90d]`
 
 - [x] **RS-10** Mirror probes, queue state, contracts, and receipts into `AutonomyLedger` _(Done 2026-04-15 via [#5857](https://github.com/synaptent/aragora/pull/5857))_
-- [ ] **RS-11** Add quarantine and fallback rules for auth drift, rate limits, permission mismatch, and publication failures
-- [ ] **RS-12** Cut `studio-health`, reporter, and status surfaces to ledger-backed truth
+- [ ] **RS-11** Add quarantine and fallback rules for auth drift, rate limits, permission mismatch, and publication failures _(Partial 2026-04-15: one-shot recovery budgets and fail-closed handling landed for auth drift, GitHub outage, publication failure, and boss/merge restart failures via [#5867](https://github.com/synaptent/aragora/pull/5867); rate-limit and permission-mismatch coverage still need explicit policy.)_
+- [ ] **RS-12** Cut `studio-health`, reporter, and status surfaces to ledger-backed truth _(Partial 2026-04-15: `swarm status`, FastAPI swarm-status routes, and `studio-health.sh` now prefer ledger-backed truth via [#5861](https://github.com/synaptent/aragora/pull/5861) and [#5868](https://github.com/synaptent/aragora/pull/5868); reporter and remaining status surfaces are still incomplete.)_
 
 ## Epic 2 — Bounded Autonomy Control Plane
 
@@ -103,7 +103,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 - [ ] **BC-10** Run repeated multi-host soak tests on the bounded backlog
 - [ ] **BC-11** Route Nomic-generated work through the same substrate as operator work
-- [ ] **BC-12** Define explicit stop/go criteria for unattended 12-hour runs
+- [ ] **BC-12** Define explicit stop/go criteria for unattended 12-hour runs _(Partial 2026-04-15: proof-first shifts now emit machine-readable `green_shift_evaluation` via [#5867](https://github.com/synaptent/aragora/pull/5867), but the 12-hour unattended gate is not yet proven by repeated green runs.)_
 
 ## Epic 3 — Trust-Wedge Product Loops
 

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -10,7 +10,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to keep `TW-01/TW-02/TW-03` recurring and boring on current `main`, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
+The immediate gate is keeping recurring benchmark truth publication complete, fresh, and trustworthy on current `main`, then keeping `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
 
 What is already true:
 
@@ -19,7 +19,7 @@ What is already true:
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
 - terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
-- the latest published B0 surface is **80.0%** truth success and **80.0%** no-rescue truth success on the tracked corpus, with one pending corpus-freshness alert to clear on the next publication
+- the recurring B0 benchmark truth surface is repo-tracked at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`; operator decisions should read the live published surface there instead of hardcoding percentages in this document
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
 - launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
 - receipt-backed preflight is now the default operator and live dispatch admission truth on `main` via [#5514](https://github.com/synaptent/aragora/pull/5514)
@@ -36,10 +36,13 @@ What is already true:
 - repo-tracked recurring rescue productization now lands in `docs/status/generated/rescue_productization/`, with the stable status summary at `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`
 - the recurring `TW-03` harvest can now relink repeated rescue classes to tracked fixture/issue targets and auto-create bounded follow-on issues when a repeated class is still unlinked
 - proof-first runtime truth is now persisted in `ShiftLedger` on `main` via [#5857](https://github.com/synaptent/aragora/pull/5857)
+- proof-first shifts now fail closed after repeated recovery failures for the implemented failure classes via [#5867](https://github.com/synaptent/aragora/pull/5867)
+- `swarm status`, FastAPI swarm-status routes, and `studio-health.sh` now prefer ledger-backed operator truth on `main` via [#5861](https://github.com/synaptent/aragora/pull/5861) and [#5868](https://github.com/synaptent/aragora/pull/5868)
 
 What is still missing:
 
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
+- proof that recurring benchmark publication stays complete and fresh on `main` without operator babysitting
 - broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
 - ongoing discipline so external claims stay narrower than the recurring proof surfaces
@@ -60,7 +63,7 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
-Current status: the latest published B0 surface is at **80.0%** truth success and **80.0%** no-rescue truth success as of 2026-04-15, and the latest published `TW-03` surface shows zero repeated rescue classes. The benchmark target is no longer the blocker; recurring truth publication, stale-corpus cleanup through the normal publication loop, and proof-first operator discipline are the remaining near-term gates.
+Current status: `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md` are the live recurring proof surfaces. When benchmark publication drifts, lags, or lands incomplete corpus coverage, restoring that publication becomes the immediate gate again before any scope widening.
 
 Primary truth metric:
 
@@ -105,7 +108,7 @@ Scorecard output rules:
 ### Current state
 
 - Terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are on `main`.
-- The latest published B0 surface is at **80.0%** truth success and **80.0%** no-rescue truth success as of 2026-04-15.
+- The latest recurring benchmark status must be read from `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, not copied into this document as a hardcoded percentage.
 - The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
 - The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
 - The stable recurring status surface is `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, backed by the latest JSON pointers under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`.
@@ -126,8 +129,8 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ### Delay
 
-- `BC-07..09` until the repair loop is truthful and resumable
-- `RS-11..12` until the operator-surface guard is real
+- `BC-07..09` until the repair loop is truthful, resumable, and consolidated into one operator model
+- `RS-11..12` until recovery-budget coverage extends to the remaining failure classes and the remaining status/reporter surfaces are ledger-backed
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
@@ -153,7 +156,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ### Booster 0 — Corpus
 
-Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This booster is already above target, so the remaining work is to keep it truthful while the guard layers catch up.
+Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This booster only counts as above target while the recurring B0 surface stays complete and fresh on current `main`; if publication drifts, restoring that surface takes priority over scope widening.
 
 ### Booster 1 — Assist
 


### PR DESCRIPTION
This updates the canonical proof-first docs to stop hardcoding stale benchmark percentages, records the partial RS-11/RS-12 and BC-12 progress now landed on main, and adds a runbook for tmux-based proof-first coordination lanes.\n\nSequence note: this follows the refreshed benchmark truth publication that restored complete B0 coverage on main.