### PR TITLE
fix(openapi): count decorator-backed handler routes

### DIFF
--- a/scripts/validate_openapi_routes.py
+++ b/scripts/validate_openapi_routes.py
@@ -110,6 +110,18 @@ def get_handler_routes() -> set[str]:
                 if isinstance(method_routes, (list, tuple)):
                     routes.update(method_routes)
 
+        # Collect decorator-backed OpenAPI metadata for handlers that rely on
+        # @api_endpoint instead of legacy ROUTES constants.
+        for attr_name in dir(handler_class):
+            try:
+                attr = getattr(handler_class, attr_name)
+            except Exception:  # noqa: BLE001 - defensive: discovery should stay best-effort
+                continue
+            endpoint = getattr(attr, "_openapi", None)
+            path = getattr(endpoint, "path", None)
+            if isinstance(path, str) and path:
+                routes.add(path)
+
     return routes
 
 

--- a/tests/scripts/test_validate_openapi_routes.py
+++ b/tests/scripts/test_validate_openapi_routes.py
@@ -105,6 +105,54 @@ def test_get_handler_routes_resolves_deferred_imports(monkeypatch):
     assert "/api/v1/test/get" in routes
 
 
+def test_get_handler_routes_includes_api_endpoint_metadata(monkeypatch):
+    endpoint = types.SimpleNamespace(path="/api/v1/coordination/fleet/status")
+
+    class DummyHandler:
+        def handle(self):
+            return None
+
+    setattr(DummyHandler.handle, "_openapi", endpoint)
+
+    fake_registry = types.SimpleNamespace(HANDLER_REGISTRY=[("_dummy", DummyHandler)])
+    monkeypatch.setitem(sys.modules, "aragora.server.handler_registry", fake_registry)
+
+    routes = validate_openapi_routes.get_handler_routes()
+
+    assert "/api/v1/coordination/fleet/status" in routes
+
+
+def test_validate_coverage_treats_decorator_routes_as_implemented(monkeypatch, tmp_path: Path):
+    endpoint = types.SimpleNamespace(path="/api/v1/coordination/swarm/integrator")
+
+    class DummyHandler:
+        def handle(self):
+            return None
+
+    setattr(DummyHandler.handle, "_openapi", endpoint)
+
+    fake_registry = types.SimpleNamespace(HANDLER_REGISTRY=[("_dummy", DummyHandler)])
+    monkeypatch.setitem(sys.modules, "aragora.server.handler_registry", fake_registry)
+    monkeypatch.setattr(
+        validate_openapi_routes,
+        "get_openapi_routes",
+        lambda _spec: {"/api/v1/coordination/swarm/integrator"},
+    )
+
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text('{"missing_in_spec": [], "orphaned_in_spec": []}\n', encoding="utf-8")
+
+    results = validate_openapi_routes.validate_coverage(
+        "ignored.json",
+        fail_on_missing=False,
+        output_json=True,
+        baseline_path=str(baseline),
+        include_internal=True,
+    )
+
+    assert "/api/v1/coordination/swarm/integrator" not in results["orphaned_in_spec"]
+
+
 def test_get_openapi_routes_includes_sibling_generated_snapshot(tmp_path: Path):
     spec = tmp_path / "openapi.json"
     generated = tmp_path / "openapi_generated.json"


### PR DESCRIPTION
## Summary
- teach `validate_openapi_routes.py` to count handler routes declared via `@api_endpoint` metadata
- add focused regression coverage for decorator-backed handler discovery and coverage validation
- remove the false coordination fleet/swarm orphan findings from validator output

## Validation
- python3 -m pytest tests/scripts/test_validate_openapi_routes.py -q
- python3 -m pytest tests/handlers/control_plane/test_coordination.py -q
- python3 scripts/validate_openapi_routes.py --spec docs/api/openapi.json --json
- python3 -m ruff check scripts/validate_openapi_routes.py tests/scripts/test_validate_openapi_routes.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD