### PR TITLE
fix(tmux): harden session readiness and mux status

### DIFF
--- a/aragora/swarm/session_mux.py
+++ b/aragora/swarm/session_mux.py
@@ -493,7 +493,12 @@ def send_prompt(
     if not _tmux_session_exists(record.tmux_session):
         raise RuntimeError(f"tmux session is not running: {name}")
 
-    prompt_text = text if text is not None else file_path.read_text(encoding="utf-8")
+    if text is not None:
+        prompt_text = text
+    else:
+        if file_path is None:
+            raise ValueError("Provide either text or file_path")
+        prompt_text = file_path.read_text(encoding="utf-8")
     prompt_id = uuid.uuid4().hex[:8]
     prompt_at = _utc_now()
     append_prompt_marker(Path(record.log_path), prompt_id=prompt_id, at=prompt_at)

--- a/aragora/swarm/session_mux.py
+++ b/aragora/swarm/session_mux.py
@@ -11,6 +11,22 @@ import uuid
 
 _REGISTRY_SCHEMA_VERSION = 1
 _PROMPT_MARKER_PREFIX = "=== ARAGORA_SESSION_MUX_PROMPT "
+_CODEX_READY_MARKERS = (
+    "openai codex",
+    "use /skills to list available skills",
+    "find and fix a bug in @filename",
+    "explain this codebase",
+    "use /rename to rename your threads",
+)
+_CLAUDE_READY_MARKERS = (
+    "claude code",
+    "don't ask on",
+    "ctrl+g to edit in vs code",
+)
+_PROMPT_ACCEPTED_MARKERS = (
+    "[pasted content",
+    "[pasted text",
+)
 
 
 def resolve_repo_root(path_hint: Path | None = None) -> Path:
@@ -66,6 +82,32 @@ def _tail_text(text: str, line_count: int) -> str:
         return text
     lines = text.splitlines()
     return "\n".join(lines[-line_count:])
+
+
+def _agent_ready_markers(agent_name: str) -> tuple[str, ...]:
+    lowered = agent_name.lower()
+    if "claude" in lowered:
+        return _CLAUDE_READY_MARKERS
+    return _CODEX_READY_MARKERS
+
+
+def _readiness_state_from_log(*, agent_name: str, log_text: str) -> dict[str, Any]:
+    lowered = log_text.lower()
+    ready = any(marker in lowered for marker in _agent_ready_markers(agent_name))
+    prompt_accepted = any(marker in lowered for marker in _PROMPT_ACCEPTED_MARKERS)
+    if prompt_accepted:
+        phase = "prompt_accepted"
+    elif ready:
+        phase = "ready"
+    elif log_text.strip():
+        phase = "booting"
+    else:
+        phase = "no_output"
+    return {
+        "ready": ready,
+        "prompt_accepted": prompt_accepted,
+        "phase": phase,
+    }
 
 
 def prompt_marker(prompt_id: str, *, at: datetime | None = None) -> str:
@@ -353,6 +395,10 @@ def session_status(repo_root: Path, *, name: str) -> dict[str, Any]:
     payload = record.to_dict()
     payload["running"] = running
     payload["tmux_target"] = record.tmux_target
+    log_text = (
+        Path(record.log_path).read_text(encoding="utf-8") if Path(record.log_path).exists() else ""
+    )
+    payload["readiness"] = _readiness_state_from_log(agent_name=record.name, log_text=log_text)
     return payload
 
 
@@ -365,6 +411,15 @@ def list_sessions(repo_root: Path) -> list[dict[str, Any]]:
         status = refreshed.to_dict()
         status["running"] = _tmux_session_exists(refreshed.tmux_session)
         status["tmux_target"] = refreshed.tmux_target
+        log_text = (
+            Path(refreshed.log_path).read_text(encoding="utf-8")
+            if Path(refreshed.log_path).exists()
+            else ""
+        )
+        status["readiness"] = _readiness_state_from_log(
+            agent_name=refreshed.name,
+            log_text=log_text,
+        )
         statuses.append(status)
     return statuses
 

--- a/scripts/swarm_session_mux.py
+++ b/scripts/swarm_session_mux.py
@@ -5,6 +5,10 @@ import json
 from pathlib import Path
 import sys
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from aragora.swarm import session_mux
 
 
@@ -48,10 +52,14 @@ def _print_json(payload: object) -> None:
 
 
 def _print_status_text(status: dict[str, object]) -> None:
+    readiness = status.get("readiness")
+    phase = "-"
+    if isinstance(readiness, dict):
+        phase = str(readiness.get("phase") or "-")
     line = (
         f"{status['name']}: running={status['running']} "
         f"tmux={status['tmux_target']} branch={status.get('branch') or '-'} "
-        f"worktree={status.get('worktree_path') or '-'}"
+        f"worktree={status.get('worktree_path') or '-'} readiness={phase}"
     )
     sys.stdout.write(f"{line}\n")
 

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -26,6 +26,21 @@ TMUX_SESSION="aragora"
 LOG_DIR="${HOME}/.aragora/tmux-sessions"
 mkdir -p "${LOG_DIR}"
 
+send_prompt_to_target() {
+    local target="$1"
+    local prompt="$2"
+    if [[ "$(echo "${prompt}" | wc -l)" -gt 1 ]]; then
+        local buffer_name="aragora-prompt-launch-${NAME}-$$-$(date +%s%N)"
+        tmux set-buffer -b "${buffer_name}" "${prompt}"
+        tmux paste-buffer -b "${buffer_name}" -t "${target}"
+        tmux send-keys -t "${target}" "" Enter
+        tmux delete-buffer -b "${buffer_name}" 2>/dev/null || true
+    else
+        tmux send-keys -t "${target}" "${prompt}" Enter
+    fi
+    echo "Prompt sent to '${NAME}' (${#prompt} chars)"
+}
+
 wait_for_agent_ready() {
     local agent="$1"
     local log_file="$2"
@@ -178,22 +193,23 @@ if [[ -n "${PROMPT_FILE}" && -f "${PROMPT_FILE}" ]]; then
 fi
 
 # Create new tmux window with logging
-tmux new-window -t "${TMUX_SESSION}" -n "${NAME}"
-tmux pipe-pane -t "${TMUX_SESSION}:${NAME}" -o "cat >> '${LOG_FILE}'"
+WINDOW_TARGET="$(tmux new-window -P -F '#{window_id}' -t "${TMUX_SESSION}" -n "${NAME}")"
+tmux pipe-pane -t "${WINDOW_TARGET}" -o "cat >> '${LOG_FILE}'"
 
 # Send the launch command
-tmux send-keys -t "${TMUX_SESSION}:${NAME}" "${LAUNCH_CMD}" Enter
+tmux send-keys -t "${WINDOW_TARGET}" "${LAUNCH_CMD}" Enter
 
 # Write metadata (avoid embedding prompt content in Python literal)
-python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" <<'PYEOF'
+python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" <<'PYEOF'
 import json, datetime, sys
-name, agent, log_file, repo_root, prompt_file, meta_file, has_prompt = sys.argv[1:8]
+name, agent, log_file, repo_root, prompt_file, meta_file, has_prompt, window_target = sys.argv[1:9]
 meta = {
     "name": name,
     "agent": agent,
     "started": datetime.datetime.now().isoformat(),
     "log_file": log_file,
     "repo_root": repo_root,
+    "tmux_window_target": window_target,
     "prompt_file": prompt_file or None,
     "has_prompt": bool(has_prompt),
 }
@@ -208,11 +224,18 @@ echo "  Meta: ${META_FILE}"
 # If there's a prompt to send, wait for the session to initialize then send it
 if [[ -n "${PROMPT}" ]]; then
     INIT_WAIT_SECONDS="${ARAGORA_TMUX_INIT_WAIT_SECONDS:-$(default_init_wait_seconds "${AGENT}")}"
+    SEND_ON_TIMEOUT="${ARAGORA_TMUX_SEND_ON_TIMEOUT:-0}"
     echo "Waiting up to ${INIT_WAIT_SECONDS}s for ${AGENT} readiness before sending prompt..."
     if wait_for_agent_ready "${AGENT}" "${LOG_FILE}" "${INIT_WAIT_SECONDS}"; then
         echo "Readiness markers detected for ${NAME}."
+        send_prompt_to_target "${WINDOW_TARGET}" "${PROMPT}"
     else
-        echo "Timed out waiting for readiness markers for ${NAME}; sending prompt anyway."
+        if [[ "${SEND_ON_TIMEOUT}" == "1" ]]; then
+            echo "Timed out waiting for readiness markers for ${NAME}; sending prompt anyway because ARAGORA_TMUX_SEND_ON_TIMEOUT=1."
+            send_prompt_to_target "${WINDOW_TARGET}" "${PROMPT}"
+        else
+            echo "Timed out waiting for readiness markers for ${NAME}; prompt not sent."
+            echo "Re-send once ready with: ${SCRIPT_DIR}/tmux_send_prompt.sh --name ${NAME} --prompt '...'"
+        fi
     fi
-    "${SCRIPT_DIR}/tmux_send_prompt.sh" --name "${NAME}" --prompt "${PROMPT}"
 fi

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -35,7 +35,7 @@ wait_for_agent_ready() {
 
     case "${agent}" in
         codex)
-            pattern='OpenAI Codex|Use /skills to list available skills|Improve documentation in @filename'
+            pattern='OpenAI Codex|Use /skills to list available skills|Improve documentation in @filename|Find and fix a bug in @filename|Explain this codebase|Use /rename to rename your threads'
             ;;
         claude)
             pattern='Claude Code|ctrl\+g to edit in VS Code|don'"'"'t ask on'
@@ -55,6 +55,21 @@ wait_for_agent_ready() {
     done
 
     return 1
+}
+
+default_init_wait_seconds() {
+    local agent="$1"
+    case "${agent}" in
+        codex)
+            echo "60"
+            ;;
+        claude)
+            echo "30"
+            ;;
+        *)
+            echo "30"
+            ;;
+    esac
 }
 
 # --- argument parsing ---
@@ -192,7 +207,7 @@ echo "  Meta: ${META_FILE}"
 
 # If there's a prompt to send, wait for the session to initialize then send it
 if [[ -n "${PROMPT}" ]]; then
-    INIT_WAIT_SECONDS="${ARAGORA_TMUX_INIT_WAIT_SECONDS:-30}"
+    INIT_WAIT_SECONDS="${ARAGORA_TMUX_INIT_WAIT_SECONDS:-$(default_init_wait_seconds "${AGENT}")}"
     echo "Waiting up to ${INIT_WAIT_SECONDS}s for ${AGENT} readiness before sending prompt..."
     if wait_for_agent_ready "${AGENT}" "${LOG_FILE}" "${INIT_WAIT_SECONDS}"; then
         echo "Readiness markers detected for ${NAME}."

--- a/tests/scripts/test_swarm_session_mux.py
+++ b/tests/scripts/test_swarm_session_mux.py
@@ -50,6 +50,9 @@ def test_launch_command_creates_registry_entry(monkeypatch, tmp_path: Path, caps
 
 
 def test_list_command_prints_json(monkeypatch, tmp_path: Path, capsys) -> None:
+    log_path = tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("OpenAI Codex\n", encoding="utf-8")
     registry = session_mux.SessionMuxRegistry(tmp_path)
     registry.upsert(
         session_mux.SessionRecord(
@@ -59,7 +62,7 @@ def test_list_command_prints_json(monkeypatch, tmp_path: Path, capsys) -> None:
             tmux_pane="0",
             launcher_command="codex",
             started_at="2026-04-13T18:00:00Z",
-            log_path=str(tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"),
+            log_path=str(log_path),
         )
     )
 
@@ -81,6 +84,7 @@ def test_list_command_prints_json(monkeypatch, tmp_path: Path, capsys) -> None:
     output = capsys.readouterr().out
     assert '"name": "codex-1"' in output
     assert '"running": true' in output
+    assert '"phase": "ready"' in output
 
 
 def test_send_command_updates_prompt_marker(monkeypatch, tmp_path: Path, capsys) -> None:
@@ -164,3 +168,40 @@ def test_capture_command_reads_log_since_last_prompt(monkeypatch, tmp_path: Path
 
     assert exit_code == 0
     assert capsys.readouterr().out.strip() == "captured line"
+
+
+def test_status_command_prints_readiness_phase(monkeypatch, tmp_path: Path, capsys) -> None:
+    log_path = tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("OpenAI Codex\n[Pasted Content 42 chars]\n", encoding="utf-8")
+    registry = session_mux.SessionMuxRegistry(tmp_path)
+    registry.upsert(
+        session_mux.SessionRecord(
+            name="codex-1",
+            tmux_session="codex-1",
+            tmux_window="0",
+            tmux_pane="0",
+            launcher_command="codex",
+            started_at="2026-04-13T18:00:00Z",
+            log_path=str(log_path),
+        )
+    )
+
+    def fake_run(cmd: list[str], **kwargs) -> SimpleNamespace:  # noqa: ANN003
+        if cmd[:3] == ["tmux", "has-session", "-t"]:
+            return _completed(returncode=0)
+        if cmd[:2] == ["tmux", "list-panes"]:
+            return _completed(stdout="0\t0\t/tmp/codex-worktree\n")
+        if cmd[:3] == ["git", "-C", "/tmp/codex-worktree"]:
+            return _completed(stdout="codex/demo\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(cli, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(session_mux.subprocess, "run", fake_run)
+
+    exit_code = cli.main(["status", "--name", "codex-1", "--json"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert '"phase": "prompt_accepted"' in output
+    assert '"prompt_accepted": true' in output

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -28,7 +28,10 @@ if cmd[:3] == ["has-session", "-t", "aragora"]:
 if cmd[:3] == ["list-windows", "-t", "aragora"]:
     print("0 {window_name}")
     raise SystemExit(0)
-if cmd[:2] in (["new-session", "-d"], ["new-window", "-t"], ["pipe-pane", "-t"]):
+if cmd[:2] == ["new-window", "-P"]:
+    print("@17")
+    raise SystemExit(0)
+if cmd[:2] in (["new-session", "-d"], ["pipe-pane", "-t"]):
     raise SystemExit(0)
 if cmd[:2] in (["send-keys", "-t"], ["set-buffer", "-b"], ["paste-buffer", "-b"], ["delete-buffer", "-b"]):
     raise SystemExit(0)
@@ -124,8 +127,12 @@ def test_tmux_session_launcher_waits_for_readiness_marker_before_prompt_send(
 
     assert "Readiness markers detected for testpane." in result.stdout
     calls = _load_tmux_calls(env)
-    assert any(call[:2] == ["new-window", "-t"] for call in calls)
-    assert any("hello from launcher" in call for call in calls if call[:2] == ["send-keys", "-t"])
+    assert any(call[:2] == ["new-window", "-P"] for call in calls)
+    assert any(call[:2] == ["pipe-pane", "-t"] and call[2] == "@17" for call in calls)
+    assert any(
+        call[:2] == ["send-keys", "-t"] and call[2] == "@17" and "hello from launcher" in call
+        for call in calls
+    )
 
 
 def test_tmux_session_launcher_accepts_new_codex_readiness_markers(tmp_path: Path) -> None:
@@ -159,3 +166,75 @@ def test_tmux_session_launcher_accepts_new_codex_readiness_markers(tmp_path: Pat
     )
 
     assert "Readiness markers detected for testpane." in result.stdout
+
+
+def test_tmux_session_launcher_does_not_send_prompt_before_readiness_by_default(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+
+    log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
+    log_dir.mkdir(parents=True)
+    (log_dir / "testpane.log").write_text("boot only\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "testpane",
+            "--agent",
+            "codex",
+            "--prompt",
+            "do not send yet",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "prompt not sent" in result.stdout
+    calls = _load_tmux_calls(env)
+    assert not any(call[:2] == ["send-keys", "-t"] and "do not send yet" in call for call in calls)
+
+
+def test_tmux_session_launcher_can_send_prompt_on_timeout_when_explicitly_enabled(
+    tmp_path: Path,
+) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+    env["ARAGORA_TMUX_SEND_ON_TIMEOUT"] = "1"
+
+    log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
+    log_dir.mkdir(parents=True)
+    (log_dir / "testpane.log").write_text("boot only\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "testpane",
+            "--agent",
+            "codex",
+            "--prompt",
+            "send despite timeout",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "sending prompt anyway because ARAGORA_TMUX_SEND_ON_TIMEOUT=1" in result.stdout
+    calls = _load_tmux_calls(env)
+    assert any(
+        call[:2] == ["send-keys", "-t"] and call[2] == "@17" and "send despite timeout" in call
+        for call in calls
+    )

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -126,3 +126,36 @@ def test_tmux_session_launcher_waits_for_readiness_marker_before_prompt_send(
     calls = _load_tmux_calls(env)
     assert any(call[:2] == ["new-window", "-t"] for call in calls)
     assert any("hello from launcher" in call for call in calls if call[:2] == ["send-keys", "-t"])
+
+
+def test_tmux_session_launcher_accepts_new_codex_readiness_markers(tmp_path: Path) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+
+    log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
+    log_dir.mkdir(parents=True)
+    (log_dir / "testpane.log").write_text(
+        "boot\nFind and fix a bug in @filename\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "testpane",
+            "--agent",
+            "codex",
+            "--prompt",
+            "hello from launcher",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Readiness markers detected for testpane." in result.stdout

--- a/tests/swarm/test_session_mux.py
+++ b/tests/swarm/test_session_mux.py
@@ -138,3 +138,31 @@ def test_capture_output_uses_last_prompt_marker(tmp_path: Path) -> None:
     captured = mod.capture_output(tmp_path, name="codex-1", tail_lines=1)
 
     assert captured == "recent line 2"
+
+
+def test_readiness_state_reports_booting_ready_and_prompt_accepted() -> None:
+    booting = mod._readiness_state_from_log(agent_name="codex-1", log_text="starting...\n")
+    ready = mod._readiness_state_from_log(
+        agent_name="codex-1",
+        log_text="OpenAI Codex\nUse /skills to list available skills\n",
+    )
+    accepted = mod._readiness_state_from_log(
+        agent_name="codex-1",
+        log_text="OpenAI Codex\n[Pasted Content 123 chars]\n",
+    )
+
+    assert booting == {
+        "ready": False,
+        "prompt_accepted": False,
+        "phase": "booting",
+    }
+    assert ready == {
+        "ready": True,
+        "prompt_accepted": False,
+        "phase": "ready",
+    }
+    assert accepted == {
+        "ready": True,
+        "prompt_accepted": True,
+        "phase": "prompt_accepted",
+    }


### PR DESCRIPTION
## Summary
- broaden tmux launcher readiness detection for Codex and make initial wait agent-specific
- expose readiness phase in session mux status and allow direct script execution without PYTHONPATH
- add focused regression coverage for readiness detection and mux status output

## Validation
- python3 -m pytest tests/scripts/test_tmux_transport_scripts.py tests/scripts/test_swarm_session_mux.py tests/swarm/test_session_mux.py -q
- python3 -m ruff check scripts/swarm_session_mux.py aragora/swarm/session_mux.py tests/scripts/test_tmux_transport_scripts.py tests/scripts/test_swarm_session_mux.py tests/swarm/test_session_mux.py
- bash -n scripts/tmux_session_launcher.sh scripts/tmux_send_prompt.sh
- python3 scripts/swarm_session_mux.py --help
- bash scripts/automation_pr_preflight.sh origin/main HEAD