### PR TITLE
fix(openapi): discover feedback hub routes

### DIFF
--- a/aragora/server/handlers/_lazy_imports.py
+++ b/aragora/server/handlers/_lazy_imports.py
@@ -29,6 +29,7 @@ HANDLER_MODULES: dict[str, str] = {
     "AgentsHandler": "aragora.server.handlers.agents",
     "CalibrationHandler": "aragora.server.handlers.agents",
     "FeedbackHandler": "aragora.server.handlers.agents.feedback",
+    "FeedbackHubHandler": "aragora.server.handlers.feedback_hub",
     "LeaderboardViewHandler": "aragora.server.handlers.agents",
     "ProbesHandler": "aragora.server.handlers.agents",
     # analytics
@@ -579,6 +580,7 @@ ALL_HANDLER_NAMES: list[str] = [
     # agents/ sub-handlers
     "AgentRecommendationHandler",
     "FeedbackHandler",
+    "FeedbackHubHandler",
     # canvas pipeline stages
     "ActionCanvasHandler",
     "GoalCanvasHandler",

--- a/tests/server/openapi/test_live_dashboard_route_exports.py
+++ b/tests/server/openapi/test_live_dashboard_route_exports.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from aragora.server.handlers import ALL_HANDLERS
 from aragora.server.handlers.agent_evolution_dashboard import AgentEvolutionDashboardHandler
+from aragora.server.handlers.feedback_hub import FeedbackHubHandler
 from aragora.server.handlers.outcome_dashboard import OutcomeDashboardHandler
 from aragora.server.handlers.system_intelligence import SystemIntelligenceHandler
 from aragora.server.openapi import generate_openapi_schema
@@ -13,6 +14,7 @@ def test_live_dashboard_handlers_participate_in_all_handlers() -> None:
     assert SystemIntelligenceHandler in handlers
     assert OutcomeDashboardHandler in handlers
     assert AgentEvolutionDashboardHandler in handlers
+    assert FeedbackHubHandler in handlers
 
 
 def test_live_dashboard_routes_appear_in_generated_openapi() -> None:
@@ -22,3 +24,5 @@ def test_live_dashboard_routes_appear_in_generated_openapi() -> None:
     assert "/api/v1/system-intelligence/overview" in paths
     assert "/api/v1/outcome-dashboard" in paths
     assert "/api/v1/agent-evolution/timeline" in paths
+    assert "/api/v1/feedback-hub/stats" in paths
+    assert "/api/v1/feedback-hub/history" in paths


### PR DESCRIPTION
## Summary
- register `FeedbackHubHandler` in lazy handler discovery so OpenAPI generation sees the live feedback hub endpoints
- extend the existing live-route parity test to keep feedback hub handler discovery and route export locked in
- keep this PR narrow: checked-in `docs/api/*` artifacts still have broader drift and are not refreshed here

## Validation
- python3 -m pytest tests/server/openapi/test_live_dashboard_route_exports.py tests/scripts/test_validate_openapi_routes.py tests/handlers/test_feedback_hub.py -q
- python3 -m ruff check aragora/server/handlers/_lazy_imports.py tests/server/openapi/test_live_dashboard_route_exports.py
- python3 scripts/export_openapi.py --output-dir /tmp/openapi-feedback-check
- python3 - <<'PY'
import json
from pathlib import Path
spec = json.loads(Path('/tmp/openapi-feedback-check/openapi.json').read_text())
for route in ['/api/v1/feedback-hub/stats', '/api/v1/feedback-hub/history']:
    assert route in spec['paths'], route
print('feedback-hub routes exported')
PY
- bash scripts/automation_pr_preflight.sh origin/main HEAD
