### PR TITLE
fix(tmux): harden launcher readiness and mux registration

### DIFF
--- a/aragora/swarm/session_mux.py
+++ b/aragora/swarm/session_mux.py
@@ -265,6 +265,17 @@ def build_tmux_list_panes_cmd(tmux_session: str) -> list[str]:
     ]
 
 
+def build_tmux_list_window_panes_cmd(*, tmux_session: str, tmux_window: str) -> list[str]:
+    return [
+        "tmux",
+        "list-panes",
+        "-t",
+        f"{tmux_session}:{tmux_window}",
+        "-F",
+        "#{window_index}\t#{pane_index}\t#{pane_current_path}",
+    ]
+
+
 def build_tmux_pipe_pane_cmd(*, target: str, log_path: Path) -> list[str]:
     sink = f"cat >> {shlex.quote(str(log_path))}"
     return ["tmux", "pipe-pane", "-o", "-t", target, sink]
@@ -319,6 +330,28 @@ def _primary_pane(tmux_session: str) -> dict[str, str]:
     }
 
 
+def _window_pane(*, tmux_session: str, tmux_window: str) -> dict[str, str]:
+    result = _run_tmux(
+        build_tmux_list_window_panes_cmd(tmux_session=tmux_session, tmux_window=tmux_window)
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise RuntimeError(
+            f"Unable to inspect tmux panes for window {tmux_session}:{tmux_window}: {result.stderr.strip()}"
+        )
+    line = result.stdout.strip().splitlines()[0]
+    parts = line.split("\t")
+    if len(parts) != 3:
+        raise RuntimeError(
+            f"Unexpected tmux pane format for window {tmux_session}:{tmux_window}: {line}"
+        )
+    window, pane, current_path = parts
+    return {
+        "window": window,
+        "pane": pane,
+        "current_path": current_path,
+    }
+
+
 def _read_json(path: Path) -> dict[str, Any]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -364,7 +397,7 @@ def _git_branch(path: Path) -> str | None:
 def refresh_session_record(repo_root: Path, record: SessionRecord) -> SessionRecord:
     refreshed = SessionRecord.from_dict(record.to_dict())
     if _tmux_session_exists(refreshed.tmux_session):
-        pane = _primary_pane(refreshed.tmux_session)
+        pane = _window_pane(tmux_session=refreshed.tmux_session, tmux_window=refreshed.tmux_window)
         refreshed.tmux_window = pane["window"]
         refreshed.tmux_pane = pane["pane"]
         current_path = pane["current_path"].strip()

--- a/aragora/swarm/session_mux.py
+++ b/aragora/swarm/session_mux.py
@@ -154,6 +154,8 @@ class SessionRecord:
 
     @property
     def tmux_target(self) -> str:
+        if self.tmux_window.startswith("@"):
+            return f"{self.tmux_window}.{self.tmux_pane}"
         return f"{self.tmux_session}:{self.tmux_window}.{self.tmux_pane}"
 
     def to_dict(self) -> dict[str, Any]:
@@ -266,11 +268,12 @@ def build_tmux_list_panes_cmd(tmux_session: str) -> list[str]:
 
 
 def build_tmux_list_window_panes_cmd(*, tmux_session: str, tmux_window: str) -> list[str]:
+    target = tmux_window if tmux_window.startswith("@") else f"{tmux_session}:{tmux_window}"
     return [
         "tmux",
         "list-panes",
         "-t",
-        f"{tmux_session}:{tmux_window}",
+        target,
         "-F",
         "#{window_index}\t#{pane_index}\t#{pane_current_path}",
     ]
@@ -439,10 +442,16 @@ def list_sessions(repo_root: Path) -> list[dict[str, Any]]:
     registry = SessionMuxRegistry(repo_root)
     statuses: list[dict[str, Any]] = []
     for record in registry.list():
-        refreshed = refresh_session_record(repo_root, record)
-        registry.upsert(refreshed)
-        status = refreshed.to_dict()
-        status["running"] = _tmux_session_exists(refreshed.tmux_session)
+        try:
+            refreshed = refresh_session_record(repo_root, record)
+            registry.upsert(refreshed)
+            status = refreshed.to_dict()
+            status["running"] = _tmux_session_exists(refreshed.tmux_session)
+        except RuntimeError as exc:
+            status = record.to_dict()
+            status["running"] = False
+            status["error"] = str(exc)
+            refreshed = record
         status["tmux_target"] = refreshed.tmux_target
         log_text = (
             Path(refreshed.log_path).read_text(encoding="utf-8")

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -159,6 +159,7 @@ fi
 
 LOG_FILE="${LOG_DIR}/${NAME}.log"
 META_FILE="${LOG_DIR}/${NAME}.meta.json"
+REGISTRY_REPO_ROOT="${ARAGORA_TMUX_REGISTRY_REPO_ROOT:-${REPO_ROOT}}"
 
 # Ensure tmux session exists
 if ! tmux has-session -t "${TMUX_SESSION}" 2>/dev/null; then
@@ -172,9 +173,9 @@ fi
 #   - Codex gets --full-auto approval mode
 if [[ "${AGENT}" == "codex" ]]; then
     if [[ "${AUTONOMOUS}" == "1" ]]; then
-        LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/codex_session.sh --agent codex --base main --full-auto"
+        LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/codex_session.sh --agent '${NAME}' --base main --full-auto"
     else
-        LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/codex_session.sh --agent codex --base main"
+        LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/codex_session.sh --agent '${NAME}' --base main"
     fi
 elif [[ "${AGENT}" == "claude" ]]; then
     if [[ "${AUTONOMOUS}" == "1" ]]; then
@@ -194,27 +195,58 @@ fi
 
 # Create new tmux window with logging
 WINDOW_TARGET="$(tmux new-window -P -F '#{window_id}' -t "${TMUX_SESSION}" -n "${NAME}")"
+PANE_INDEX="$(tmux list-panes -t "${WINDOW_TARGET}" -F '#{pane_index}' | head -1)"
 tmux pipe-pane -t "${WINDOW_TARGET}" -o "cat >> '${LOG_FILE}'"
 
 # Send the launch command
 tmux send-keys -t "${WINDOW_TARGET}" "${LAUNCH_CMD}" Enter
 
 # Write metadata (avoid embedding prompt content in Python literal)
-python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" <<'PYEOF'
-import json, datetime, sys
-name, agent, log_file, repo_root, prompt_file, meta_file, has_prompt, window_target = sys.argv[1:9]
+python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" "${TMUX_SESSION}" "${PANE_INDEX}" "${LAUNCH_CMD}" "${REGISTRY_REPO_ROOT}" <<'PYEOF'
+import datetime
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+name, agent, log_file, repo_root, prompt_file, meta_file, has_prompt, window_target, tmux_session, pane_index, launch_cmd, registry_repo_root = sys.argv[1:13]
+started_at = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 meta = {
     "name": name,
     "agent": agent,
-    "started": datetime.datetime.now().isoformat(),
+    "started": started_at,
     "log_file": log_file,
     "repo_root": repo_root,
+    "tmux_session": tmux_session,
     "tmux_window_target": window_target,
+    "tmux_pane_index": pane_index,
     "prompt_file": prompt_file or None,
     "has_prompt": bool(has_prompt),
 }
-with open(meta_file, "w") as f:
-    json.dump(meta, f, indent=2)
+Path(meta_file).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+try:
+    module_path = Path(repo_root) / "aragora" / "swarm" / "session_mux.py"
+    spec = importlib.util.spec_from_file_location("aragora_swarm_session_mux", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load session_mux module from {module_path}")
+    session_mux = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = session_mux
+    spec.loader.exec_module(session_mux)
+
+    record = session_mux.SessionRecord(
+        name=name,
+        tmux_session=tmux_session,
+        tmux_window=window_target,
+        tmux_pane=pane_index or "0",
+        launcher_command=launch_cmd,
+        started_at=started_at,
+        log_path=log_file,
+        meta_path=meta_file,
+    )
+    session_mux.SessionMuxRegistry(Path(registry_repo_root)).upsert(record)
+except Exception as exc:  # pragma: no cover - launcher should still succeed if registry sync fails
+    print(f"warning: failed to register launcher session: {exc}", file=sys.stderr)
 PYEOF
 
 echo "Launched '${NAME}' (${AGENT}) in tmux session '${TMUX_SESSION}'"

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -226,6 +226,7 @@ def test_tmux_session_launcher_can_send_prompt_on_timeout_when_explicitly_enable
     env = _fake_tmux_env(tmp_path)
     env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
     env["ARAGORA_TMUX_SEND_ON_TIMEOUT"] = "1"
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
 
     log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
     log_dir.mkdir(parents=True)

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -28,6 +28,9 @@ if cmd[:3] == ["has-session", "-t", "aragora"]:
 if cmd[:3] == ["list-windows", "-t", "aragora"]:
     print("0 {window_name}")
     raise SystemExit(0)
+if cmd[:2] == ["list-panes", "-t"]:
+    print("0")
+    raise SystemExit(0)
 if cmd[:2] == ["new-window", "-P"]:
     print("@17")
     raise SystemExit(0)
@@ -102,6 +105,7 @@ def test_tmux_session_launcher_waits_for_readiness_marker_before_prompt_send(
     _write_fake_tmux(tmp_path)
     env = _fake_tmux_env(tmp_path)
     env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
 
     log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
     log_dir.mkdir(parents=True)
@@ -133,12 +137,24 @@ def test_tmux_session_launcher_waits_for_readiness_marker_before_prompt_send(
         call[:2] == ["send-keys", "-t"] and call[2] == "@17" and "hello from launcher" in call
         for call in calls
     )
+    assert any(
+        call[:2] == ["send-keys", "-t"]
+        and call[2] == "@17"
+        and "./scripts/codex_session.sh --agent 'testpane'" in call[3]
+        for call in calls
+    )
+    registry_payload = json.loads(
+        (tmp_path / ".aragora" / "session_mux" / "registry.json").read_text()
+    )
+    assert "testpane" in registry_payload["sessions"]
+    assert registry_payload["sessions"]["testpane"]["tmux_window"] == "@17"
 
 
 def test_tmux_session_launcher_accepts_new_codex_readiness_markers(tmp_path: Path) -> None:
     _write_fake_tmux(tmp_path)
     env = _fake_tmux_env(tmp_path)
     env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
 
     log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
     log_dir.mkdir(parents=True)
@@ -174,6 +190,7 @@ def test_tmux_session_launcher_does_not_send_prompt_before_readiness_by_default(
     _write_fake_tmux(tmp_path)
     env = _fake_tmux_env(tmp_path)
     env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
 
     log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
     log_dir.mkdir(parents=True)

--- a/tests/swarm/test_session_mux.py
+++ b/tests/swarm/test_session_mux.py
@@ -114,7 +114,7 @@ def test_refresh_session_record_targets_registered_window(monkeypatch, tmp_path:
         if cmd[:3] == ["tmux", "has-session", "-t"]:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if cmd[:2] == ["tmux", "list-panes"]:
-            assert cmd[3] == "aragora:@17"
+            assert cmd[3] == "@17"
             return SimpleNamespace(returncode=0, stdout="4\t0\t/tmp/target-worktree\n", stderr="")
         if cmd[:3] == ["git", "-C", "/tmp/target-worktree"]:
             return SimpleNamespace(returncode=0, stdout="codex/target\n", stderr="")
@@ -137,7 +137,42 @@ def test_refresh_session_record_targets_registered_window(monkeypatch, tmp_path:
     assert refreshed.tmux_pane == "0"
     assert refreshed.worktree_path == "/tmp/target-worktree"
     assert refreshed.branch == "codex/target"
+    assert refreshed.tmux_target == "aragora:4.0"
     assert any(cmd[:2] == ["tmux", "list-panes"] for cmd in commands)
+
+
+def test_list_sessions_marks_stale_window_without_aborting(monkeypatch, tmp_path: Path) -> None:
+    registry = mod.SessionMuxRegistry(tmp_path)
+    log_path = tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("booting\n", encoding="utf-8")
+    registry.upsert(
+        mod.SessionRecord(
+            name="codex-1",
+            tmux_session="aragora",
+            tmux_window="@17",
+            tmux_pane="0",
+            launcher_command="codex",
+            started_at="2026-04-13T18:00:00Z",
+            log_path=str(log_path),
+        )
+    )
+
+    def fake_run(cmd: list[str], **kwargs) -> SimpleNamespace:  # noqa: ANN003
+        if cmd[:3] == ["tmux", "has-session", "-t"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:2] == ["tmux", "list-panes"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr="can't find window: @17")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    statuses = mod.list_sessions(tmp_path)
+
+    assert len(statuses) == 1
+    assert statuses[0]["name"] == "codex-1"
+    assert statuses[0]["running"] is False
+    assert "can't find window" in str(statuses[0]["error"])
 
 
 def test_capture_output_uses_last_prompt_marker(tmp_path: Path) -> None:

--- a/tests/swarm/test_session_mux.py
+++ b/tests/swarm/test_session_mux.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 from aragora.swarm import session_mux as mod
 
@@ -103,6 +104,40 @@ def test_refresh_session_record_harvests_codex_metadata(monkeypatch, tmp_path: P
     assert refreshed.branch == "codex/branch"
     assert refreshed.launcher_log_path == "/tmp/codex-worktree/.codex_session.log"
     assert refreshed.meta_path == str(meta_path)
+
+
+def test_refresh_session_record_targets_registered_window(monkeypatch, tmp_path: Path) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs) -> SimpleNamespace:  # noqa: ANN003
+        commands.append(cmd)
+        if cmd[:3] == ["tmux", "has-session", "-t"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:2] == ["tmux", "list-panes"]:
+            assert cmd[3] == "aragora:@17"
+            return SimpleNamespace(returncode=0, stdout="4\t0\t/tmp/target-worktree\n", stderr="")
+        if cmd[:3] == ["git", "-C", "/tmp/target-worktree"]:
+            return SimpleNamespace(returncode=0, stdout="codex/target\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    record = mod.SessionRecord(
+        name="codex-1",
+        tmux_session="aragora",
+        tmux_window="@17",
+        tmux_pane="0",
+        launcher_command="codex",
+        started_at="2026-04-13T18:00:00Z",
+        log_path=str(tmp_path / ".aragora" / "session_mux" / "logs" / "codex-1.log"),
+    )
+
+    refreshed = mod.refresh_session_record(tmp_path, record)
+
+    assert refreshed.tmux_window == "4"
+    assert refreshed.tmux_pane == "0"
+    assert refreshed.worktree_path == "/tmp/target-worktree"
+    assert refreshed.branch == "codex/target"
+    assert any(cmd[:2] == ["tmux", "list-panes"] for cmd in commands)
 
 
 def test_capture_output_uses_last_prompt_marker(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- broaden tmux launcher readiness handling and fail closed before prompt injection
- register launcher-created sessions in the mux registry and target shared-session windows correctly
- add focused regression coverage for launcher registration, readiness, and shared-window refresh behavior

## Validation
- python3 -m pytest tests/scripts/test_tmux_transport_scripts.py tests/scripts/test_swarm_session_mux.py tests/swarm/test_session_mux.py -q
- python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/swarm/session_mux.py
- python3 -m ruff check aragora/swarm/session_mux.py scripts/swarm_session_mux.py tests/scripts/test_tmux_transport_scripts.py tests/scripts/test_swarm_session_mux.py tests/swarm/test_session_mux.py
- bash -n scripts/tmux_session_launcher.sh scripts/tmux_send_prompt.sh
- bash scripts/automation_pr_preflight.sh origin/main HEAD