### PR TITLE
fix(openapi): register prompt engine routes

### DIFF
--- a/aragora/server/handler_registry/debates.py
+++ b/aragora/server/handler_registry/debates.py
@@ -88,6 +88,9 @@ TemplateDiscoveryHandler = _safe_import(
     "aragora.server.handlers.template_discovery", "TemplateDiscoveryHandler"
 )
 
+# Prompt engine handler
+PromptEngineHandler = _safe_import("aragora.server.handlers.prompt_engine", "PromptEngineHandler")
+
 # Composite, stats, share, interventions, settlement, spectate, receipt export
 CompositeHandler = _safe_import("aragora.server.handlers.composite", "CompositeHandler")
 DebateStatsHandler = _safe_import("aragora.server.handlers.debate_stats", "DebateStatsHandler")
@@ -152,6 +155,8 @@ DEBATE_HANDLER_REGISTRY: list[tuple[str, object]] = [
     ("_security_debate_handler", SecurityDebateHandler),
     # Template discovery
     ("_template_discovery_handler", TemplateDiscoveryHandler),
+    # Prompt engine
+    ("_prompt_engine_handler", PromptEngineHandler),
     # Composite debate
     ("_composite_handler", CompositeHandler),
     # Debate stats, share, interventions
@@ -211,6 +216,7 @@ __all__ = [
     "EmailDebateHandler",
     "SecurityDebateHandler",
     "TemplateDiscoveryHandler",
+    "PromptEngineHandler",
     "CompositeHandler",
     "DebateStatsHandler",
     "DebateShareHandler",

--- a/tests/scripts/test_validate_openapi_routes.py
+++ b/tests/scripts/test_validate_openapi_routes.py
@@ -165,3 +165,13 @@ def test_get_openapi_routes_includes_sibling_generated_snapshot(tmp_path: Path):
 
     assert "/api/v1/canonical" in routes
     assert "/api/v1/generated" in routes
+
+
+def test_validate_coverage_counts_prompt_engine_registry_routes() -> None:
+    results = validate_openapi_routes.validate_coverage(
+        "docs/api/openapi.json",
+        output_json=True,
+    )
+
+    assert "/api/v1/prompt-engine/run" not in results["orphaned_in_spec"]
+    assert "/api/v1/prompt-engine/decompose" not in results["orphaned_in_spec"]


### PR DESCRIPTION
## Summary
- register `PromptEngineHandler` in the handler registry used by route validation
- add regression coverage so prompt-engine routes are not treated as spec-only

## Validation
- python3 -m pytest -q tests/scripts/test_validate_openapi_routes.py tests/server/handlers/test_prompt_engine_handler.py
- python3 scripts/validate_openapi_routes.py --spec docs/api/openapi.json --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD