### PR TITLE
fix(tmux): speed up session mux wrapper imports

### DIFF
--- a/scripts/swarm_session_mux.py
+++ b/scripts/swarm_session_mux.py
@@ -1,15 +1,33 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 from pathlib import Path
 import sys
+from types import ModuleType
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from aragora.swarm import session_mux
+
+def _load_session_mux_module() -> ModuleType:
+    module_name = "aragora_swarm_session_mux_direct"
+    existing = sys.modules.get(module_name)
+    if isinstance(existing, ModuleType):
+        return existing
+    module_path = REPO_ROOT / "aragora" / "swarm" / "session_mux.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load session mux module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+session_mux = _load_session_mux_module()
 
 
 def _repo_root() -> Path:

--- a/tests/scripts/test_swarm_session_mux.py
+++ b/tests/scripts/test_swarm_session_mux.py
@@ -11,6 +11,10 @@ def _completed(*, returncode: int = 0, stdout: str = "", stderr: str = "") -> Si
     return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
 
 
+def test_cli_uses_direct_session_mux_module() -> None:
+    assert cli.session_mux.__name__ == "aragora_swarm_session_mux_direct"
+
+
 def test_launch_command_creates_registry_entry(monkeypatch, tmp_path: Path, capsys) -> None:
     state = {"exists": False}
 


### PR DESCRIPTION
## Summary
- load `aragora/swarm/session_mux.py` directly in `scripts/swarm_session_mux.py` instead of importing the full `aragora.swarm` package
- keep the loaded module cached under a stable direct-import name for the wrapper lifecycle
- add regression coverage locking the direct-import path for the CLI wrapper

## Validation
- python3 -m pytest tests/scripts/test_swarm_session_mux.py tests/scripts/test_tmux_transport_scripts.py tests/swarm/test_session_mux.py -q
- python3 -m ruff check scripts/swarm_session_mux.py tests/scripts/test_swarm_session_mux.py tests/scripts/test_tmux_transport_scripts.py tests/swarm/test_session_mux.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/swarm_session_mux.py list --json
