### PR TITLE
fix(autonomy): wait for launchd restart process

### DIFF
--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -496,6 +496,18 @@ def process_running(pattern: str) -> bool:
     return proc.returncode == 0 and bool(proc.stdout.strip())
 
 
+def wait_for_process(
+    pattern: str, *, timeout_seconds: float = 45.0, interval_seconds: float = 1.0
+) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        if process_running(pattern):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(interval_seconds)
+
+
 def should_restart_service(
     *,
     is_running: bool,
@@ -533,9 +545,10 @@ def restart_service_via_launchd(
     *,
     label: str,
     process_pattern: str,
+    start_timeout_seconds: float = 45.0,
 ) -> tuple[bool, str]:
     kicked, detail = kickstart_launchd(label)
-    if process_running(process_pattern):
+    if wait_for_process(process_pattern, timeout_seconds=start_timeout_seconds):
         return True, "" if kicked else detail
     if kicked:
         return (

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -152,6 +152,41 @@ def test_kickstart_launchd_returns_timeout_detail_instead_of_raising() -> None:
     assert detail == "launchctl timed out"
 
 
+def test_restart_service_treats_kickstart_timeout_as_success_when_process_appears() -> None:
+    with (
+        patch(
+            "scripts.run_proof_first_shift.kickstart_launchd",
+            return_value=(False, "launchctl timed out"),
+        ),
+        patch("scripts.run_proof_first_shift.process_running", side_effect=[False, True]),
+        patch("scripts.run_proof_first_shift.time.sleep"),
+    ):
+        ok, detail = mod.restart_service_via_launchd(
+            label="com.aragora.swarm-boss-loop",
+            process_pattern="boss-loop",
+            start_timeout_seconds=5,
+        )
+
+    assert ok is True
+    assert detail == "launchctl timed out"
+
+
+def test_restart_service_waits_for_successful_kickstart_process_start() -> None:
+    with (
+        patch("scripts.run_proof_first_shift.kickstart_launchd", return_value=(True, "")),
+        patch("scripts.run_proof_first_shift.process_running", side_effect=[False, True]),
+        patch("scripts.run_proof_first_shift.time.sleep"),
+    ):
+        ok, detail = mod.restart_service_via_launchd(
+            label="com.aragora.swarm-boss-loop",
+            process_pattern="boss-loop",
+            start_timeout_seconds=5,
+        )
+
+    assert ok is True
+    assert detail == ""
+
+
 def test_run_shift_cycle_exhausts_restart_budget_within_shift_window() -> None:
     state = mod.ProofFirstRuntimeState(boss_restart_count=1, merge_restart_count=1)
 


### PR DESCRIPTION
## Summary\n- Poll for the expected process after launchctl kickstart before declaring a restart failure.\n- Treat launchctl timeout as inconclusive when the process appears shortly after.\n- Add focused proof-first shift tests for slow LaunchAgent starts.\n\n## Validation\n- python3 -m pytest tests/scripts/test_run_proof_first_shift.py -q\n- python3 -m ruff check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD