### PR TITLE
fix(inbox): log trust wedge JSON fallbacks

### DIFF
--- a/aragora/inbox/trust_wedge.py
+++ b/aragora/inbox/trust_wedge.py
@@ -139,6 +139,26 @@ def _json_default(value: Any) -> Any:
     return str(value)
 
 
+def _loads_receipt_json(
+    value: Any,
+    *,
+    receipt_id: str,
+    field_name: str,
+    context: str,
+) -> Any:
+    try:
+        return json.loads(value or "{}")
+    except (json.JSONDecodeError, TypeError):
+        logger.debug(
+            "Ignoring malformed inbox trust wedge %s while building %s for receipt %s",
+            field_name,
+            context,
+            receipt_id,
+            exc_info=True,
+        )
+        return {}
+
+
 def _canonical_json(payload: dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=_json_default)
 
@@ -1161,16 +1181,18 @@ class InboxTrustWedgeStore:
             ).fetchall()
         result: list[dict[str, Any]] = []
         for row in rows:
-            intent = {}
-            decision = {}
-            try:
-                intent = json.loads(row["intent_json"] or "{}")
-            except (json.JSONDecodeError, TypeError):
-                pass
-            try:
-                decision = json.loads(row["decision_json"] or "{}")
-            except (json.JSONDecodeError, TypeError):
-                pass
+            intent = _loads_receipt_json(
+                row["intent_json"],
+                receipt_id=row["receipt_id"],
+                field_name="intent_json",
+                context="review queue",
+            )
+            decision = _loads_receipt_json(
+                row["decision_json"],
+                receipt_id=row["receipt_id"],
+                field_name="decision_json",
+                context="review queue",
+            )
             result.append(
                 {
                     "receipt_id": row["receipt_id"],
@@ -1218,16 +1240,18 @@ class InboxTrustWedgeStore:
             by_action[action] = by_action.get(action, 0) + 1
             by_state[state] = by_state.get(state, 0) + 1
 
-            intent = {}
-            decision = {}
-            try:
-                intent = json.loads(row["intent_json"] or "{}")
-            except (json.JSONDecodeError, TypeError):
-                pass
-            try:
-                decision = json.loads(row["decision_json"] or "{}")
-            except (json.JSONDecodeError, TypeError):
-                pass
+            intent = _loads_receipt_json(
+                row["intent_json"],
+                receipt_id=row["receipt_id"],
+                field_name="intent_json",
+                context="digest data",
+            )
+            decision = _loads_receipt_json(
+                row["decision_json"],
+                receipt_id=row["receipt_id"],
+                field_name="decision_json",
+                context="digest data",
+            )
 
             sender = intent.get("_sender", "")
             domain = sender.split("@")[-1] if "@" in sender else sender


### PR DESCRIPTION
## Summary
- replace silent malformed receipt JSON fallbacks in trust wedge review queue/digest paths with debug logging
- preserve the existing empty-dict fallback behavior while including receipt id, field name, context, and exception info

Fixes #5824

## Validation
- ruff check aragora/inbox/trust_wedge.py
- pytest -q tests/inbox/test_trust_wedge.py tests/cli/test_inbox_wedge_command.py
- pytest -q tests/inbox/test_triage_instrumentation.py -k 'ReviewQueue or DigestData'
- direct malformed-json log probe
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD