### PR TITLE
fix(sdk): cover agent evolution dashboard routes

### DIFF
--- a/sdk/python/aragora_sdk/namespaces/evolution.py
+++ b/sdk/python/aragora_sdk/namespaces/evolution.py
@@ -72,6 +72,44 @@ class EvolutionAPI:
         """
         return self._client.request("GET", "/api/v1/evolution")
 
+    def get_agent_evolution_timeline(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Get agent evolution dashboard timeline events."""
+        return self._client.request(
+            "GET",
+            "/api/v1/agent-evolution/timeline",
+            params={"limit": limit, "offset": offset},
+        )
+
+    def get_agent_evolution_elo_trends(self, period: str = "7d") -> dict[str, Any]:
+        """Get agent evolution ELO trend data."""
+        return self._client.request(
+            "GET",
+            "/api/v1/agent-evolution/elo-trends",
+            params={"period": period},
+        )
+
+    def get_agent_evolution_pending(self) -> dict[str, Any]:
+        """Get pending agent evolution changes."""
+        return self._client.request("GET", "/api/v1/agent-evolution/pending")
+
+    def approve_agent_evolution_change(self, change_id: str) -> dict[str, Any]:
+        """Approve a pending agent evolution change."""
+        return self._client.request(
+            "POST",
+            f"/api/v1/agent-evolution/pending/{change_id}/approve",
+        )
+
+    def reject_agent_evolution_change(self, change_id: str) -> dict[str, Any]:
+        """Reject a pending agent evolution change."""
+        return self._client.request(
+            "POST",
+            f"/api/v1/agent-evolution/pending/{change_id}/reject",
+        )
+
 
 class AsyncEvolutionAPI:
     """Asynchronous Evolution API for agent evolution tracking."""
@@ -128,3 +166,41 @@ class AsyncEvolutionAPI:
     async def get_overview(self) -> dict[str, Any]:
         """Get evolution overview."""
         return await self._client.request("GET", "/api/v1/evolution")
+
+    async def get_agent_evolution_timeline(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Get agent evolution dashboard timeline events."""
+        return await self._client.request(
+            "GET",
+            "/api/v1/agent-evolution/timeline",
+            params={"limit": limit, "offset": offset},
+        )
+
+    async def get_agent_evolution_elo_trends(self, period: str = "7d") -> dict[str, Any]:
+        """Get agent evolution ELO trend data."""
+        return await self._client.request(
+            "GET",
+            "/api/v1/agent-evolution/elo-trends",
+            params={"period": period},
+        )
+
+    async def get_agent_evolution_pending(self) -> dict[str, Any]:
+        """Get pending agent evolution changes."""
+        return await self._client.request("GET", "/api/v1/agent-evolution/pending")
+
+    async def approve_agent_evolution_change(self, change_id: str) -> dict[str, Any]:
+        """Approve a pending agent evolution change."""
+        return await self._client.request(
+            "POST",
+            f"/api/v1/agent-evolution/pending/{change_id}/approve",
+        )
+
+    async def reject_agent_evolution_change(self, change_id: str) -> dict[str, Any]:
+        """Reject a pending agent evolution change."""
+        return await self._client.request(
+            "POST",
+            f"/api/v1/agent-evolution/pending/{change_id}/reject",
+        )

--- a/sdk/python/tests/test_evolution.py
+++ b/sdk/python/tests/test_evolution.py
@@ -1,0 +1,75 @@
+"""Tests for Evolution namespace API."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+
+from aragora_sdk.client import AragoraAsyncClient, AragoraClient
+
+
+class TestAgentEvolutionDashboard:
+    """Tests for /api/v1/agent-evolution dashboard endpoints."""
+
+    def test_agent_evolution_dashboard_endpoints(self) -> None:
+        with patch.object(AragoraClient, "request") as mock_request:
+            mock_request.return_value = {"data": {}}
+            client = AragoraClient(base_url="https://api.aragora.ai", api_key="test-key")
+
+            client.evolution.get_agent_evolution_timeline(limit=10, offset=5)
+            client.evolution.get_agent_evolution_elo_trends(period="30d")
+            client.evolution.get_agent_evolution_pending()
+            client.evolution.approve_agent_evolution_change("change-1")
+            client.evolution.reject_agent_evolution_change("change-2")
+
+            expected_calls = [
+                call(
+                    "GET",
+                    "/api/v1/agent-evolution/timeline",
+                    params={"limit": 10, "offset": 5},
+                ),
+                call(
+                    "GET",
+                    "/api/v1/agent-evolution/elo-trends",
+                    params={"period": "30d"},
+                ),
+                call("GET", "/api/v1/agent-evolution/pending"),
+                call("POST", "/api/v1/agent-evolution/pending/change-1/approve"),
+                call("POST", "/api/v1/agent-evolution/pending/change-2/reject"),
+            ]
+            mock_request.assert_has_calls(expected_calls)
+            assert mock_request.call_count == 5
+            client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_agent_evolution_dashboard_endpoints(self) -> None:
+        with patch.object(AragoraAsyncClient, "request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"data": {}}
+            async with AragoraAsyncClient(
+                base_url="https://api.aragora.ai",
+                api_key="test-key",
+            ) as client:
+                await client.evolution.get_agent_evolution_timeline(limit=10, offset=5)
+                await client.evolution.get_agent_evolution_elo_trends(period="30d")
+                await client.evolution.get_agent_evolution_pending()
+                await client.evolution.approve_agent_evolution_change("change-1")
+                await client.evolution.reject_agent_evolution_change("change-2")
+
+            expected_calls = [
+                call(
+                    "GET",
+                    "/api/v1/agent-evolution/timeline",
+                    params={"limit": 10, "offset": 5},
+                ),
+                call(
+                    "GET",
+                    "/api/v1/agent-evolution/elo-trends",
+                    params={"period": "30d"},
+                ),
+                call("GET", "/api/v1/agent-evolution/pending"),
+                call("POST", "/api/v1/agent-evolution/pending/change-1/approve"),
+                call("POST", "/api/v1/agent-evolution/pending/change-2/reject"),
+            ]
+            mock_request.assert_has_awaits(expected_calls)
+            assert mock_request.await_count == 5

--- a/sdk/typescript/src/namespaces/__tests__/evolution.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/evolution.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { EvolutionAPI } from '../evolution';
+
+interface MockClient {
+  request: Mock;
+}
+
+describe('EvolutionAPI', () => {
+  let api: EvolutionAPI;
+  let mockClient: MockClient;
+
+  beforeEach(() => {
+    mockClient = {
+      request: vi.fn(),
+    };
+    api = new EvolutionAPI(mockClient as any);
+  });
+
+  it('maps agent evolution dashboard routes', async () => {
+    mockClient.request.mockResolvedValue({ data: {} });
+
+    await api.getAgentEvolutionTimeline({ limit: 10, offset: 5 });
+    await api.getAgentEvolutionEloTrends({ period: '30d' });
+    await api.getAgentEvolutionPending();
+    await api.approveAgentEvolutionChange('change/1');
+    await api.rejectAgentEvolutionChange('change/2');
+
+    expect(mockClient.request).toHaveBeenNthCalledWith(
+      1,
+      'GET',
+      '/api/v1/agent-evolution/timeline',
+      { params: { limit: 10, offset: 5 } }
+    );
+    expect(mockClient.request).toHaveBeenNthCalledWith(
+      2,
+      'GET',
+      '/api/v1/agent-evolution/elo-trends',
+      { params: { period: '30d' } }
+    );
+    expect(mockClient.request).toHaveBeenNthCalledWith(
+      3,
+      'GET',
+      '/api/v1/agent-evolution/pending'
+    );
+    expect(mockClient.request).toHaveBeenNthCalledWith(
+      4,
+      'POST',
+      '/api/v1/agent-evolution/pending/change%2F1/approve'
+    );
+    expect(mockClient.request).toHaveBeenNthCalledWith(
+      5,
+      'POST',
+      '/api/v1/agent-evolution/pending/change%2F2/reject'
+    );
+  });
+});

--- a/sdk/typescript/src/namespaces/evolution.ts
+++ b/sdk/typescript/src/namespaces/evolution.ts
@@ -69,6 +69,15 @@ export interface CreateABTestRequest {
   config?: Record<string, unknown>;
 }
 
+export interface AgentEvolutionTimelineOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export interface AgentEvolutionEloTrendsOptions {
+  period?: '24h' | '7d' | '30d' | '90d' | string;
+}
+
 interface EvolutionClientInterface {
   request<T = unknown>(
     method: string,
@@ -152,5 +161,40 @@ export class EvolutionAPI {
   /** Get evolution overview. */
   async getOverview(): Promise<Record<string, unknown>> {
     return this.client.request('GET', '/api/v1/evolution');
+  }
+
+  /** Get agent evolution dashboard timeline events. */
+  async getAgentEvolutionTimeline(params?: AgentEvolutionTimelineOptions): Promise<Record<string, unknown>> {
+    return this.client.request('GET', '/api/v1/agent-evolution/timeline', {
+      params: params as Record<string, unknown>,
+    });
+  }
+
+  /** Get agent evolution ELO trend data. */
+  async getAgentEvolutionEloTrends(params?: AgentEvolutionEloTrendsOptions): Promise<Record<string, unknown>> {
+    return this.client.request('GET', '/api/v1/agent-evolution/elo-trends', {
+      params: params as Record<string, unknown>,
+    });
+  }
+
+  /** Get pending agent evolution changes. */
+  async getAgentEvolutionPending(): Promise<Record<string, unknown>> {
+    return this.client.request('GET', '/api/v1/agent-evolution/pending');
+  }
+
+  /** Approve a pending agent evolution change. */
+  async approveAgentEvolutionChange(changeId: string): Promise<Record<string, unknown>> {
+    return this.client.request(
+      'POST',
+      `/api/v1/agent-evolution/pending/${encodeURIComponent(changeId)}/approve`
+    );
+  }
+
+  /** Reject a pending agent evolution change. */
+  async rejectAgentEvolutionChange(changeId: string): Promise<Record<string, unknown>> {
+    return this.client.request(
+      'POST',
+      `/api/v1/agent-evolution/pending/${encodeURIComponent(changeId)}/reject`
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Add Python sync/async SDK methods for the five /api/v1/agent-evolution dashboard routes.
- Add TypeScript EvolutionAPI methods for timeline, ELO trends, pending changes, approve, and reject.
- Add focused Python and TypeScript namespace tests asserting exact request paths.

## Validation
- python3 -m ruff check sdk/python/aragora_sdk/namespaces/evolution.py sdk/python/tests/test_evolution.py
- python3 -m pytest -q -p no:rerunfailures sdk/python/tests/test_evolution.py
- python3 scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json
- npm --prefix sdk/typescript run typecheck
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Note: local TypeScript vitest and eslint commands could not run because this sandbox lacks the vitest/eslint binaries.