### PR TITLE
[codex] Route decision analytics modular dispatch

### DIFF
--- a/aragora/server/handlers/decision_analytics.py
+++ b/aragora/server/handlers/decision_analytics.py
@@ -15,12 +15,14 @@ Issue: #281
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
 from aiohttp import web
 
 from aragora.server.handlers.utils.aiohttp_responses import web_error_response
+from aragora.server.handlers.utils.responses import HandlerResult
 from aragora.server.handlers.utils.rate_limit import rate_limit
 from aragora.server.handlers.api_decorators import api_endpoint
 from aragora.server.validation.query_params import safe_query_int
@@ -70,9 +72,104 @@ class DecisionAnalyticsHandler:
         "/api/decision-analytics/domains",
     ]
 
+    _GET_ROUTE_HANDLERS = {
+        "/api/v1/decision-analytics/overview": "handle_get_overview",
+        "/api/v1/decision-analytics/trends": "handle_get_trends",
+        "/api/v1/decision-analytics/outcomes": "handle_get_outcomes",
+        "/api/v1/decision-analytics/agents": "handle_get_agents",
+        "/api/v1/decision-analytics/domains": "handle_get_domains",
+        "/api/decision-analytics/overview": "handle_get_overview",
+        "/api/decision-analytics/trends": "handle_get_trends",
+        "/api/decision-analytics/outcomes": "handle_get_outcomes",
+        "/api/decision-analytics/agents": "handle_get_agents",
+        "/api/decision-analytics/domains": "handle_get_domains",
+    }
+
     def __init__(self, ctx: dict | None = None):
         """Initialize handler with optional context."""
         self.ctx = ctx or {}
+
+    def can_handle(self, path: str, method: str = "GET") -> bool:
+        """Return whether modular dispatch should route this analytics path here."""
+        return method == "GET" and path in self._GET_ROUTE_HANDLERS
+
+    def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
+        """Route modular GET dispatch through the aiohttp-style handlers."""
+        if getattr(handler, "command", "GET") != "GET":
+            return HandlerResult(
+                status_code=405,
+                content_type="application/json",
+                body=json.dumps({"error": "Method not allowed"}).encode("utf-8"),
+                headers={"Allow": "GET"},
+            )
+        return self._run_async(self._dispatch_registry_request(path, query_params, handler))
+
+    @staticmethod
+    def _run_async(coro: Any) -> HandlerResult | None:
+        """Synchronously resolve async route helpers inside modular dispatch."""
+        from aragora.server.handler_registry.core import _run_handler_coroutine
+
+        return _run_handler_coroutine(coro)
+
+    @staticmethod
+    def _build_registry_request(
+        handler: Any,
+        *,
+        query_params: dict[str, Any],
+    ) -> Any:
+        """Build the minimal aiohttp-like request object expected by these routes."""
+
+        class _RequestAdapter:
+            def __init__(self) -> None:
+                self.query = query_params
+                self.match_info: dict[str, str] = {}
+                self.headers = getattr(handler, "headers", {}) or {}
+                self.method = getattr(handler, "command", "GET")
+                self._auth_context = getattr(handler, "_auth_context", None)
+
+        return _RequestAdapter()
+
+    @staticmethod
+    def _to_handler_result(response: Any) -> HandlerResult:
+        """Normalize aiohttp and handler responses to the modular HandlerResult type."""
+        if isinstance(response, HandlerResult):
+            return response
+        body = getattr(response, "body", b"")
+        if isinstance(body, bytearray):
+            body = bytes(body)
+        elif body is None:
+            text = getattr(response, "text", "") or ""
+            body = text.encode("utf-8")
+        content_type = getattr(response, "content_type", "application/json") or "application/json"
+        headers = dict(getattr(response, "headers", {}) or {})
+        status_code = getattr(response, "status_code", None)
+        if status_code is None:
+            status_code = getattr(response, "status", 200)
+        return HandlerResult(
+            status_code=int(status_code),
+            content_type=str(content_type),
+            body=body if isinstance(body, bytes) else json.dumps(body).encode("utf-8"),
+            headers=headers,
+        )
+
+    async def _dispatch_registry_request(
+        self,
+        path: str,
+        query_params: dict[str, Any],
+        handler: Any,
+    ) -> HandlerResult:
+        """Adapt modular-dispatch calls to the aiohttp-style route handlers."""
+        handler_name = self._GET_ROUTE_HANDLERS.get(path)
+        if handler_name is None:
+            return HandlerResult(
+                status_code=404,
+                content_type="application/json",
+                body=json.dumps({"error": "Not found"}).encode("utf-8"),
+                headers={},
+            )
+        route_handler = getattr(self, handler_name)
+        request = self._build_registry_request(handler, query_params=query_params)
+        return self._to_handler_result(await route_handler(request))
 
     # =========================================================================
     # GET /api/v1/decision-analytics/overview

--- a/aragora/server/handlers/decision_analytics.py
+++ b/aragora/server/handlers/decision_analytics.py
@@ -144,7 +144,9 @@ class DecisionAnalyticsHandler:
         headers = dict(getattr(response, "headers", {}) or {})
         status_code = getattr(response, "status_code", None)
         if status_code is None:
-            status_code = getattr(response, "status", 200)
+            status_code = getattr(response, "status", None)
+        if status_code is None:
+            status_code = 200
         return HandlerResult(
             status_code=int(status_code),
             content_type=str(content_type),

--- a/tests/server/handler_registry/test_dispatch.py
+++ b/tests/server/handler_registry/test_dispatch.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import io
 import json
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from aragora.server.handlers.costs import CostHandler, CostSummary
+from aragora.server.handlers.decision_analytics import DecisionAnalyticsHandler
 from aragora.server.handler_registry import (
     HANDLER_REGISTRY,
     HANDLERS_AVAILABLE,
@@ -364,6 +366,90 @@ class TestTryModularHandler:
         payload = json.loads(instance.wfile.getvalue())
         assert payload["data"]["total_cost_usd"] == 42.5
         assert payload["data"]["budget_usd"] == 100.0
+
+    @patch("aragora.server.auth.auth_config.enabled", False)
+    @patch("aragora.server.handler_registry.HANDLERS_AVAILABLE", True)
+    @patch("aragora.server.handler_registry.get_route_index")
+    @patch("aragora.server.handler_registry.version_response_headers", return_value={})
+    def test_dispatch_get_decision_analytics_uses_modular_contract(
+        self, mock_vrh, mock_gri
+    ) -> None:
+        handler = DecisionAnalyticsHandler()
+        analytics = MagicMock()
+        analytics.get_consensus_rate = AsyncMock(return_value=0.75)
+        analytics.get_average_rounds = AsyncMock(return_value=2.5)
+        debate_analytics = MagicMock()
+        debate_analytics.get_debate_stats = AsyncMock(
+            return_value=SimpleNamespace(total_debates=8, consensus_reached=6)
+        )
+        analytics._get_debate_analytics = MagicMock(return_value=debate_analytics)
+
+        mock_index = MagicMock()
+
+        def route_lookup(candidate: str) -> tuple[str, DecisionAnalyticsHandler] | None:
+            if candidate in DecisionAnalyticsHandler.ROUTES:
+                return "_decision_analytics_handler", handler
+            return None
+
+        mock_index.get_handler.side_effect = route_lookup
+        mock_gri.return_value = mock_index
+
+        for path in (
+            "/api/v1/decision-analytics/overview",
+            "/api/decision-analytics/overview",
+        ):
+            instance = _make_mixin_instance(
+                handler=handler,
+                handler_attr="_decision_analytics_handler",
+                method="GET",
+            )
+            instance.path = f"{path}?period=30d"
+            with (
+                patch(
+                    "aragora.server.middleware.rate_limit.should_apply_default_rate_limit",
+                    return_value=False,
+                ),
+                patch(
+                    "aragora.server.handlers.decision_analytics._get_outcome_analytics",
+                    return_value=analytics,
+                ),
+            ):
+                result = instance._try_modular_handler(path, {"period": ["30d"]})
+
+            assert result is True
+            instance.send_response.assert_called_once_with(200)
+            payload = json.loads(instance.wfile.getvalue())
+            assert payload["data"]["total_decisions"] == 8
+            assert payload["data"]["consensus_reached"] == 6
+            assert payload["data"]["period"] == "30d"
+
+    @patch("aragora.server.auth.auth_config.enabled", False)
+    @patch("aragora.server.handler_registry.HANDLERS_AVAILABLE", True)
+    @patch("aragora.server.handler_registry.get_route_index")
+    @patch("aragora.server.handler_registry.version_response_headers", return_value={})
+    def test_dispatch_post_decision_analytics_returns_method_not_allowed(
+        self, mock_vrh, mock_gri
+    ) -> None:
+        handler = DecisionAnalyticsHandler()
+        instance = _make_mixin_instance(
+            handler=handler,
+            handler_attr="_decision_analytics_handler",
+            method="POST",
+        )
+        mock_index = MagicMock()
+        mock_index.get_handler = MagicMock(return_value=("_decision_analytics_handler", handler))
+        mock_gri.return_value = mock_index
+
+        with patch(
+            "aragora.server.middleware.rate_limit.should_apply_default_rate_limit",
+            return_value=False,
+        ):
+            result = instance._try_modular_handler("/api/v1/decision-analytics/overview", {})
+
+        assert result is True
+        instance.send_response.assert_called_once_with(405)
+        payload = json.loads(instance.wfile.getvalue())
+        assert payload["error"] == "Method not allowed"
 
     @patch("aragora.server.auth.auth_config.enabled", False)
     @patch("aragora.server.handler_registry.HANDLERS_AVAILABLE", True)


### PR DESCRIPTION
Decision analytics routes were documented and selected by the modular registry, but `DecisionAnalyticsHandler` only exposed aiohttp-style route methods. The versioned and legacy paths could therefore return `handler_error` before reaching the existing handler logic.

This branch adds a narrow modular-dispatch adapter for the five GET route families and a 405 guard for unsupported methods. A follow-up commit fixes the CI mypy failure by explicitly defaulting response status to `200` when both `status_code` and `status` are absent.

Validation run locally:
- `python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/server/handlers/decision_analytics.py`
- `python3 -m ruff check aragora/server/handlers/decision_analytics.py tests/server/handler_registry/test_dispatch.py`
- `python3 -m pytest -q tests/server/handler_registry/test_dispatch.py::TestTryModularHandler::test_dispatch_get_decision_analytics_uses_modular_contract tests/server/handler_registry/test_dispatch.py::TestTryModularHandler::test_dispatch_post_decision_analytics_returns_method_not_allowed tests/handlers/test_decision_analytics.py`
- `python3 -m pytest -q tests/handlers/test_decision_analytics.py tests/server/handler_registry/test_dispatch.py tests/server/openapi/test_live_dashboard_route_exports.py tests/scripts/test_generate_openapi.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Reopened after the original draft was closed for the mypy typecheck failure; head now includes commit `86173d0a9`.
