### PR TITLE
fix(automation): publish freshest handoff memory

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -43,6 +43,11 @@ REQUIRED_LABELS = (
 )
 OPTIONAL_LABELS = ("Backup Task",)
 ALL_LABELS = REQUIRED_LABELS + OPTIONAL_LABELS
+BLOCK_TIMESTAMP_KEY = "__block_timestamp"
+BLOCK_POSITION_KEY = "__block_position"
+BLOCK_TIMESTAMP_PATTERN = re.compile(
+    r"(?m)(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)"
+)
 STOPWORDS = {
     "a",
     "an",
@@ -121,6 +126,29 @@ def _label_matches(text: str) -> list[re.Match[str]]:
     return list(re.finditer(rf"(?m)^({label_pattern}):\s*", text))
 
 
+def _timestamp_before(text: str, position: int) -> str | None:
+    """Return the closest preceding full ISO timestamp for a memory handoff block."""
+
+    matches = list(BLOCK_TIMESTAMP_PATTERN.finditer(text[:position]))
+    if not matches:
+        return None
+    return matches[-1].group(1)
+
+
+def _parse_block_datetime(values: dict[str, str]) -> datetime | None:
+    raw_timestamp = values.get(BLOCK_TIMESTAMP_KEY)
+    if not raw_timestamp:
+        return None
+    normalized = raw_timestamp.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
 def _parse_blocks(text: str) -> list[dict[str, str]]:
     matches = _label_matches(text)
     blocks: list[dict[str, str]] = []
@@ -144,6 +172,8 @@ def _parse_blocks(text: str) -> list[dict[str, str]]:
             values[item.group(1)] = text[item.end() : next_start].strip()
 
         if all(label in values and values[label] for label in REQUIRED_LABELS):
+            values[BLOCK_TIMESTAMP_KEY] = _timestamp_before(text, match.start()) or ""
+            values[BLOCK_POSITION_KEY] = str(match.start())
             blocks.append(values)
     return blocks
 
@@ -156,9 +186,10 @@ def _expiration(values: dict[str, str], source_file: Path) -> str | None:
         return None
     if hours <= 0:
         return None
-    expires_at = datetime.fromtimestamp(source_file.stat().st_mtime, tz=UTC) + timedelta(
-        hours=hours
+    reference_time = _parse_block_datetime(values) or datetime.fromtimestamp(
+        source_file.stat().st_mtime, tz=UTC
     )
+    expires_at = reference_time + timedelta(hours=hours)
     return expires_at.isoformat()
 
 
@@ -180,6 +211,18 @@ def _format_body(values: dict[str, str], source_file: Path) -> str:
     return "\n".join(lines).strip()
 
 
+def _latest_block(parsed_blocks: list[dict[str, str]]) -> dict[str, str]:
+    def key(values: dict[str, str]) -> tuple[datetime, int]:
+        block_time = _parse_block_datetime(values) or datetime.min.replace(tzinfo=UTC)
+        try:
+            position = int(values.get(BLOCK_POSITION_KEY, "0"))
+        except ValueError:
+            position = 0
+        return (block_time, position)
+
+    return max(parsed_blocks, key=key)
+
+
 def load_handoffs(
     codex_home: Path,
     *,
@@ -196,7 +239,7 @@ def load_handoffs(
         parsed_blocks = _parse_blocks(text)
         if not parsed_blocks:
             continue
-        values = parsed_blocks[-1]
+        values = _latest_block(parsed_blocks)
         priority = values["Priority"].strip()
         task_title = values["Task Title"].strip()
         expires_at = _expiration(values, memory_file)
@@ -241,6 +284,14 @@ def _looks_duplicate(candidate: str, existing: str) -> bool:
     existing_tokens = _title_tokens(existing)
     if not candidate_tokens or not existing_tokens:
         return candidate.strip().lower() == existing.strip().lower()
+    candidate_handlers = {token for token in candidate_tokens if token.endswith("handler")}
+    existing_handlers = {token for token in existing_tokens if token.endswith("handler")}
+    if (
+        candidate_handlers
+        and existing_handlers
+        and candidate_handlers.isdisjoint(existing_handlers)
+    ):
+        return False
     overlap = candidate_tokens & existing_tokens
     return len(overlap) >= min(3, len(candidate_tokens))
 

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -75,6 +75,50 @@ def test_load_handoffs_uses_latest_structured_block_per_memory(tmp_path: Path) -
     assert [handoff.task_title for handoff in handoffs] == ["Fresh decision task"]
 
 
+def test_load_handoffs_uses_newest_timestamp_when_memory_is_out_of_order(
+    tmp_path: Path,
+) -> None:
+    _memory(
+        tmp_path,
+        "founder-review",
+        "\n\n".join(
+            [
+                "2026-04-16T08:14:42-05:00 - Founder review\n\n"
+                + _handoff("Fresh modular dispatch task"),
+                "2026-04-16T06:11:29-05:00 - Founder review\n\n"
+                + _handoff("Older sqlite lock task"),
+            ]
+        ),
+    )
+
+    handoffs = mod.load_handoffs(tmp_path, now=datetime(2026, 4, 16, 14, 0, tzinfo=timezone.utc))
+
+    assert [handoff.task_title for handoff in handoffs] == ["Fresh modular dispatch task"]
+
+
+def test_load_handoffs_expires_from_block_timestamp_not_file_mtime(tmp_path: Path) -> None:
+    memory = _memory(
+        tmp_path,
+        "founder-review",
+        "2026-04-15T08:14:42-05:00 - Founder review\n\n" + _handoff("Expired task"),
+    )
+    text = memory.read_text(encoding="utf-8").replace("Expiration Hours: 72", "Expiration Hours: 1")
+    memory.write_text(text, encoding="utf-8")
+    fresh_time = datetime(2026, 4, 16, 13, 59, tzinfo=timezone.utc).timestamp()
+    os.utime(memory, (fresh_time, fresh_time))
+
+    handoffs = mod.load_handoffs(tmp_path, now=datetime(2026, 4, 16, 14, 20, tzinfo=timezone.utc))
+
+    assert handoffs == []
+
+
+def test_looks_duplicate_does_not_conflate_distinct_handlers() -> None:
+    assert not mod._looks_duplicate(
+        "Restore PromptEngineHandler OpenAPI and SDK contract",
+        "Restore TaskQueueHandler OpenAPI and SDK contract",
+    )
+
+
 def test_decide_handoffs_marks_duplicate_issue(monkeypatch: Any, tmp_path: Path) -> None:
     handoff = Handoff(
         source_file=str(tmp_path / "memory.md"),


### PR DESCRIPTION
## Summary
- choose structured automation handoffs by newest preceding ISO timestamp instead of last file position
- expire handoffs relative to their block timestamp when available
- avoid treating distinct `*Handler` contract handoffs as duplicates just because their generic OpenAPI/SDK words overlap

## Why
Automation memory files can be out of chronological order. The bridge was sometimes selecting an older structured handoff and missing fresher verified work. During recovery, this caused the publisher to see older founder-review/founder-triage items before the current decision-analytics/PromptEngineHandler handoffs.

## Validation
- `python3 -m pytest tests/scripts/test_publish_automation_handoffs.py tests/scripts/test_publish_codex_automation_branches.py -q` => 20 passed
- `python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` => passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` => passed
- live dry-run now resolves PromptEngineHandler as a distinct handoff and dedupes already-landed agent-evolution / decision-analytics handoffs to PRs

## Recovery proof
Using this patched bridge from the worktree created issue #5960 for the fresh PromptEngineHandler handoff and correctly deduped the already recovered work against #5954 and #5959.
