### PR TITLE
fix(autonomy): reset recovery budgets per proof-first shift

### DIFF
--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -337,8 +337,15 @@ def list_open_prs(*, repo_root: Path, repo: str) -> list[dict[str, Any]]:
 
 def count_automation_backlog(prs: list[dict[str, Any]]) -> int:
     return sum(
-        1 for pr in prs if str(pr.get("headRefName") or "").startswith(AUTOMATION_BRANCH_PREFIXES)
+        1
+        for pr in prs
+        if not bool(pr.get("isDraft"))
+        and str(pr.get("headRefName") or "").startswith(AUTOMATION_BRANCH_PREFIXES)
     )
+
+
+def actionable_open_prs(prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [pr for pr in prs if not bool(pr.get("isDraft"))]
 
 
 def has_open_benchmark_publication_pr(prs: list[dict[str, Any]]) -> bool:
@@ -748,8 +755,10 @@ def run_shift_cycle(
         }
     snapshot = collect_boss_lane_snapshot(repo_root=repo_root, repo=repo)
     prs = list_open_prs(repo_root=repo_root, repo=repo)
-    automation_backlog = count_automation_backlog(prs)
-    open_pr_count = len(prs)
+    actionable_prs = actionable_open_prs(prs)
+    automation_backlog = count_automation_backlog(actionable_prs)
+    open_pr_count = len(actionable_prs)
+    draft_pr_count = len(prs) - open_pr_count
     canonical_queue_count = len(queue_report["kept"])
 
     boss_running = process_running(DEFAULT_BOSS_PROCESS_PATTERN)
@@ -1023,6 +1032,8 @@ def run_shift_cycle(
         "queue_report": queue_report,
         "snapshot": snapshot,
         "open_pr_count": open_pr_count,
+        "draft_pr_count": draft_pr_count,
+        "total_open_pr_count": len(prs),
         "automation_backlog": automation_backlog,
         "latest_benchmark_run": latest_run,
         "actions": actions,

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -107,6 +107,7 @@ RECOVERY_STOP_REASONS = {
 
 @dataclass
 class ProofFirstRuntimeState:
+    recovery_shift_id: str | None = None
     boss_restart_count: int = 0
     merge_restart_count: int = 0
     auth_failure_count: int = 0
@@ -151,6 +152,9 @@ def load_runtime_state(path: Path) -> ProofFirstRuntimeState:
     if not isinstance(payload, dict):
         return ProofFirstRuntimeState()
     return ProofFirstRuntimeState(
+        recovery_shift_id=(
+            str(payload["recovery_shift_id"]) if payload.get("recovery_shift_id") else None
+        ),
         boss_restart_count=int(payload.get("boss_restart_count", 0) or 0),
         merge_restart_count=int(payload.get("merge_restart_count", 0) or 0),
         auth_failure_count=int(payload.get("auth_failure_count", 0) or 0),
@@ -176,6 +180,25 @@ def load_runtime_state(path: Path) -> ProofFirstRuntimeState:
 def save_runtime_state(path: Path, state: ProofFirstRuntimeState) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(asdict(state), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def reset_recovery_budget_state(state: ProofFirstRuntimeState) -> None:
+    state.boss_restart_count = 0
+    state.merge_restart_count = 0
+    state.auth_failure_count = 0
+    state.publication_failure_count = 0
+    state.rate_limit_failure_count = 0
+    state.permission_mismatch_count = 0
+    state.runtime_failure_count = 0
+    state.github_outage_count = 0
+    state.recovery_attempt_counts = _default_recovery_attempt_counts()
+
+
+def bind_runtime_state_to_shift(state: ProofFirstRuntimeState, shift_id: str) -> None:
+    if state.recovery_shift_id == shift_id:
+        return
+    reset_recovery_budget_state(state)
+    state.recovery_shift_id = shift_id
 
 
 def recovery_budget_remaining(runtime_state: ProofFirstRuntimeState, failure_class: str) -> int:
@@ -1061,6 +1084,10 @@ async def _run_shift(args: argparse.Namespace) -> dict[str, Any]:
         await controller.resume_after_refresh(shift_id)
     elif restored.status != "running":
         await controller.start_shift(assessment_id=shift_id)
+
+    active_shift_id = controller.state.shift_id if controller.state is not None else shift_id
+    bind_runtime_state_to_shift(runtime_state, active_shift_id)
+    save_runtime_state(runtime_state_path, runtime_state)
 
     # Record shift start in ledger
     ledger.record_shift_start(

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -99,6 +99,17 @@ def test_should_trigger_benchmark_rerun_respects_backlog_cap() -> None:
     assert reason == "automation_backlog_full"
 
 
+def test_count_automation_backlog_ignores_draft_prs() -> None:
+    prs = [
+        {"headRefName": "codex/draft", "isDraft": True},
+        {"headRefName": "codex/ready", "isDraft": False},
+        {"headRefName": "feature/manual", "isDraft": False},
+    ]
+
+    assert mod.count_automation_backlog(prs) == 1
+    assert mod.actionable_open_prs(prs) == prs[1:]
+
+
 def test_should_restart_service_requires_pending_work_and_budget() -> None:
     assert (
         mod.should_restart_service(

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -152,6 +152,55 @@ def test_kickstart_launchd_returns_timeout_detail_instead_of_raising() -> None:
     assert detail == "launchctl timed out"
 
 
+def test_bind_runtime_state_to_shift_resets_recovery_budgets_for_new_shift() -> None:
+    state = mod.ProofFirstRuntimeState(
+        recovery_shift_id="old-shift",
+        boss_restart_count=1,
+        merge_restart_count=1,
+        auth_failure_count=1,
+        publication_failure_count=1,
+        rate_limit_failure_count=1,
+        permission_mismatch_count=1,
+        runtime_failure_count=1,
+        github_outage_count=1,
+        recovery_attempt_counts={
+            mod.BOSS_RESTART_FAILURE: 1,
+            mod.MERGE_RESTART_FAILURE: 1,
+            mod.RATE_LIMIT_FAILURE: 1,
+        },
+        last_benchmark_run_id=123,
+        last_triggered_benchmark_run_id=456,
+    )
+
+    mod.bind_runtime_state_to_shift(state, "new-shift")
+
+    assert state.recovery_shift_id == "new-shift"
+    assert state.boss_restart_count == 0
+    assert state.merge_restart_count == 0
+    assert state.auth_failure_count == 0
+    assert state.publication_failure_count == 0
+    assert state.rate_limit_failure_count == 0
+    assert state.permission_mismatch_count == 0
+    assert state.runtime_failure_count == 0
+    assert state.github_outage_count == 0
+    assert all(count == 0 for count in state.recovery_attempt_counts.values())
+    assert state.last_benchmark_run_id == 123
+    assert state.last_triggered_benchmark_run_id == 456
+
+
+def test_bind_runtime_state_to_shift_preserves_recovery_budgets_for_same_shift() -> None:
+    state = mod.ProofFirstRuntimeState(
+        recovery_shift_id="same-shift",
+        boss_restart_count=1,
+        recovery_attempt_counts={mod.BOSS_RESTART_FAILURE: 1},
+    )
+
+    mod.bind_runtime_state_to_shift(state, "same-shift")
+
+    assert state.boss_restart_count == 1
+    assert state.recovery_attempt_counts[mod.BOSS_RESTART_FAILURE] == 1
+
+
 def test_restart_service_treats_kickstart_timeout_as_success_when_process_appears() -> None:
     with (
         patch(


### PR DESCRIPTION
## Summary\n- Scope proof-first recovery budget counters to the active shift id.\n- Reset restart/auth/publication/rate/permission/runtime/GitHub counters for a new shift while preserving benchmark run memory.\n- Add focused tests for new-shift reset and same-shift preservation.\n\n## Validation\n- python3 -m pytest tests/scripts/test_run_proof_first_shift.py -q\n- python3 -m ruff check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD