### PR TITLE
fix(autonomy): use GitHub App token for proof queue

### DIFF
--- a/aragora/swarm/boss_feed.py
+++ b/aragora/swarm/boss_feed.py
@@ -193,7 +193,7 @@ class GitHubIssueFeed:
         if not isinstance(raw_issues, list):
             return []
 
-        issues: list[GitHubIssue] = []
+        fetched_issues: list[GitHubIssue] = []
         for item in raw_issues:
             if not isinstance(item, dict):
                 continue
@@ -203,7 +203,7 @@ class GitHubIssueFeed:
                 for lbl in labels_raw
                 if str(lbl.get("name", "") if isinstance(lbl, dict) else lbl).strip()
             ]
-            issues.append(
+            fetched_issues.append(
                 GitHubIssue(
                     number=int(item.get("number", 0)),
                     title=str(item.get("title", "")).strip(),
@@ -214,7 +214,7 @@ class GitHubIssueFeed:
                     created_at=str(item.get("createdAt", "")).strip(),
                 )
             )
-        return issues
+        return fetched_issues
 
     def _fetch_issue(self, number: int, *, allow_closed: bool = False) -> GitHubIssue | None:
         cmd = [

--- a/aragora/swarm/boss_feed.py
+++ b/aragora/swarm/boss_feed.py
@@ -16,6 +16,7 @@ from fnmatch import fnmatch
 from typing import Any
 
 from aragora.swarm.boss_validation import assess_issue_body_sanitation
+from aragora.swarm.github_app_auth import github_cli_env
 
 logger = logging.getLogger(__name__)
 _SCOPE_ROOT_PREFIXES = (
@@ -173,6 +174,7 @@ class GitHubIssueFeed:
                 capture_output=True,
                 timeout=30,
                 check=False,
+                env=github_cli_env(),
             )
         except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
             logger.warning("gh issue list failed: %s", exc)
@@ -233,6 +235,7 @@ class GitHubIssueFeed:
                 capture_output=True,
                 timeout=30,
                 check=False,
+                env=github_cli_env(),
             )
         except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
             logger.warning("gh issue view failed: %s", exc)

--- a/aragora/swarm/github_app_auth.py
+++ b/aragora/swarm/github_app_auth.py
@@ -1,0 +1,194 @@
+"""GitHub App installation-token support for automation-owned GitHub calls."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Mapping
+
+DEFAULT_AUTOMATION_ENV_FILE = Path.home() / ".aragora" / ".env.automation"
+GITHUB_API_VERSION = "2022-11-28"
+_TOKEN_CACHE: dict[tuple[str, str, str], "GitHubAppToken"] = {}
+
+
+@dataclass(frozen=True)
+class GitHubAppConfig:
+    app_id: str
+    installation_id: str
+    private_key: str
+    private_key_source: str
+
+
+@dataclass(frozen=True)
+class GitHubAppToken:
+    token: str
+    expires_at: datetime
+
+
+def clear_github_app_token_cache() -> None:
+    _TOKEN_CACHE.clear()
+
+
+def _read_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip("'\"")
+        if key:
+            values[key] = value
+    return values
+
+
+def _first_value(values: Mapping[str, str], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = str(values.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _automation_env_file(env: Mapping[str, str]) -> Path:
+    configured = _first_value(
+        env,
+        (
+            "ARAGORA_AUTOMATION_ENV_FILE",
+            "GITHUB_APP_ENV_FILE",
+            "ARAGORA_GITHUB_APP_ENV_FILE",
+        ),
+    )
+    return Path(configured).expanduser() if configured else DEFAULT_AUTOMATION_ENV_FILE
+
+
+def load_github_app_config(env: Mapping[str, str] | None = None) -> GitHubAppConfig | None:
+    base_env = dict(os.environ if env is None else env)
+    file_env = _read_env_file(_automation_env_file(base_env))
+    values = {**file_env, **base_env}
+
+    app_id = _first_value(values, ("GITHUB_APP_ID", "GH_APP_ID", "ARAGORA_GITHUB_APP_ID"))
+    installation_id = _first_value(
+        values,
+        (
+            "GITHUB_APP_INSTALLATION_ID",
+            "GH_APP_INSTALLATION_ID",
+            "ARAGORA_GITHUB_INSTALLATION_ID",
+        ),
+    )
+    private_key = _first_value(values, ("GITHUB_APP_PRIVATE_KEY", "ARAGORA_GITHUB_APP_KEY"))
+    private_key_source = "env:GITHUB_APP_PRIVATE_KEY" if private_key else ""
+    if not private_key:
+        key_path = _first_value(
+            values,
+            (
+                "GITHUB_APP_PRIVATE_KEY_PATH",
+                "GH_APP_PRIVATE_KEY_PATH",
+                "ARAGORA_GITHUB_APP_PRIVATE_KEY_PATH",
+            ),
+        )
+        if key_path:
+            path = Path(key_path).expanduser()
+            if path.exists():
+                private_key = path.read_text(encoding="utf-8")
+                private_key_source = str(path)
+
+    if not app_id or not installation_id or not private_key:
+        return None
+    return GitHubAppConfig(
+        app_id=app_id,
+        installation_id=installation_id,
+        private_key=private_key,
+        private_key_source=private_key_source,
+    )
+
+
+def _mint_installation_token(config: GitHubAppConfig) -> GitHubAppToken:
+    import jwt
+
+    now = int(time.time())
+    encoded = jwt.encode(
+        {
+            "iat": now - 60,
+            "exp": now + 540,
+            "iss": config.app_id,
+        },
+        config.private_key,
+        algorithm="RS256",
+    )
+    jwt_token = encoded.decode("utf-8") if isinstance(encoded, bytes) else str(encoded)
+    request = urllib.request.Request(
+        f"https://api.github.com/app/installations/{config.installation_id}/access_tokens",
+        method="POST",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {jwt_token}",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        payload = json.loads(response.read().decode("utf-8") or "{}")
+    token = str(payload.get("token") or "").strip()
+    expires_at_raw = str(payload.get("expires_at") or "").strip()
+    if not token or not expires_at_raw:
+        raise RuntimeError("GitHub App installation token response was incomplete")
+    expires_at = datetime.fromisoformat(expires_at_raw.replace("Z", "+00:00")).astimezone(UTC)
+    return GitHubAppToken(token=token, expires_at=expires_at)
+
+
+def get_github_app_installation_token(
+    env: Mapping[str, str] | None = None,
+    *,
+    force_refresh: bool = False,
+) -> str | None:
+    base_env = dict(os.environ if env is None else env)
+    if str(base_env.get("ARAGORA_DISABLE_GITHUB_APP_TOKEN") or "").strip() in {"1", "true", "yes"}:
+        return None
+    config = load_github_app_config(base_env)
+    if config is None:
+        return None
+
+    cache_key = (config.app_id, config.installation_id, config.private_key_source)
+    now = datetime.now(tz=UTC)
+    cached = _TOKEN_CACHE.get(cache_key)
+    if cached is not None and not force_refresh:
+        if (cached.expires_at - now).total_seconds() > 120:
+            return cached.token
+
+    try:
+        token = _mint_installation_token(config)
+    except Exception:
+        if str(base_env.get("ARAGORA_GITHUB_APP_AUTH_STRICT") or "").strip() in {
+            "1",
+            "true",
+            "yes",
+        }:
+            raise
+        return None
+    _TOKEN_CACHE[cache_key] = token
+    return token.token
+
+
+def github_cli_env(
+    base_env: Mapping[str, str] | None = None,
+    *,
+    prefer_app: bool = True,
+) -> dict[str, str]:
+    env = dict(os.environ if base_env is None else base_env)
+    if not prefer_app:
+        return env
+    token = get_github_app_installation_token(env)
+    if not token:
+        return env
+    env["GH_TOKEN"] = token
+    env["GITHUB_TOKEN"] = token
+    env["ARAGORA_GITHUB_AUTH_SOURCE"] = "github_app_installation"
+    return env

--- a/aragora/swarm/issue_scanner.py
+++ b/aragora/swarm/issue_scanner.py
@@ -13,6 +13,7 @@ import json
 import hashlib
 import re
 import subprocess
+from collections.abc import Callable
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -748,7 +749,7 @@ def scan_all(
     min_success_rate: float = 0.3,
 ) -> list[BossIssueCandidate]:
     """Run all scanners and return merged, prioritized candidates."""
-    all_scanners = {
+    all_scanners: dict[str, Callable[[Path], list[BossIssueCandidate]]] = {
         "broad_exception": scan_bare_except_handlers,
         "silent_exception": scan_silent_exception_swallowing,
         "test_coverage": scan_untested_modules,

--- a/aragora/swarm/issue_scanner.py
+++ b/aragora/swarm/issue_scanner.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.github_app_auth import github_cli_env
 from aragora.swarm.outcome_learner import load_category_success_rates
 from aragora.swarm.terminal_truth import classify_from_metrics
 
@@ -117,6 +118,7 @@ def _fetch_issue_titles(
                 capture_output=True,
                 text=True,
                 timeout=20,
+                env=github_cli_env(),
             )
         except (OSError, subprocess.TimeoutExpired):
             return {}

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -9,8 +9,8 @@
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
 | **CLI** | 90 commands | 43.2% |
-| **SDK (Python)** | 186 namespaces | 70.3% |
-| **SDK (TypeScript)** | 185 namespaces | 70.3% |
+| **SDK (Python)** | 187 namespaces | 70.3% |
+| **SDK (TypeScript)** | 186 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |
 | **Capability Catalog** | 37/37 mapped | 100.0% |
 

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -9,8 +9,8 @@
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
 | **CLI** | 90 commands | 43.2% |
-| **SDK (Python)** | 186 namespaces | 70.3% |
-| **SDK (TypeScript)** | 185 namespaces | 70.3% |
+| **SDK (Python)** | 187 namespaces | 70.3% |
+| **SDK (TypeScript)** | 186 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |
 | **Capability Catalog** | 37/37 mapped | 100.0% |
 

--- a/scripts/reconcile_proof_first_queue.py
+++ b/scripts/reconcile_proof_first_queue.py
@@ -13,6 +13,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
+from aragora.swarm.github_app_auth import github_cli_env  # noqa: E402
 from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue  # noqa: E402
 
 DEFAULT_REPO = "synaptent/aragora"
@@ -21,6 +22,9 @@ DEFAULT_DOCS_ISSUE_TITLE = "[CS-01..03] Reconcile docs/status surfaces to curren
 GITHUB_CONNECTIVITY_ERROR_TOKENS = (
     "error connecting to api.github.com",
     "could not resolve host: github.com",
+    "api rate limit already exceeded",
+    "graphql: api rate limit",
+    "secondary rate limit",
 )
 
 
@@ -50,6 +54,7 @@ def list_open_queue_issues(*, repo: str, label: str) -> list[dict[str, Any]]:
         text=True,
         timeout=30,
         check=False,
+        env=github_cli_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "gh issue list failed")
@@ -75,6 +80,7 @@ def remove_queue_label(*, repo: str, issue_number: int, label: str) -> None:
         text=True,
         timeout=30,
         check=False,
+        env=github_cli_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "gh issue edit failed")
@@ -165,6 +171,7 @@ def find_existing_open_issue_by_title(*, repo: str, title: str) -> dict[str, Any
         text=True,
         timeout=30,
         check=False,
+        env=github_cli_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "gh issue list failed")
@@ -189,6 +196,7 @@ def create_issue(*, repo: str, title: str, body: str, labels: list[str]) -> dict
         text=True,
         timeout=30,
         check=False,
+        env=github_cli_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "gh issue create failed")

--- a/tests/scripts/test_reconcile_proof_first_queue.py
+++ b/tests/scripts/test_reconcile_proof_first_queue.py
@@ -163,3 +163,34 @@ def test_reconcile_proof_first_queue_reports_github_unavailable_without_crashing
         "operation": "list_open_queue_issues",
         "error": "error connecting to api.github.com\ncheck your internet connection",
     }
+
+
+def test_reconcile_proof_first_queue_treats_graphql_quota_as_github_unavailable(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "list_open_queue_issues",
+        lambda **kwargs: (_ for _ in ()).throw(
+            RuntimeError("GraphQL: API rate limit already exceeded for user ID 123")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "load_status_reconciliation_report",
+        lambda **kwargs: {"summary": {"critical": 0, "warning": 0, "info": 0}, "findings": []},
+    )
+
+    report = mod.reconcile_proof_first_queue(
+        repo="org/repo",
+        repo_root=Path("/tmp/repo"),
+        apply=True,
+    )
+
+    assert report["kept"] == []
+    assert report["removed"] == []
+    assert report["github_status"] == {
+        "available": False,
+        "operation": "list_open_queue_issues",
+        "error": "GraphQL: API rate limit already exceeded for user ID 123",
+    }

--- a/tests/swarm/test_github_app_auth.py
+++ b/tests/swarm/test_github_app_auth.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from aragora.swarm import github_app_auth as mod
+
+
+def test_load_github_app_config_reads_automation_env_file(tmp_path) -> None:
+    key_path = tmp_path / "app.pem"
+    key_path.write_text("PRIVATE KEY", encoding="utf-8")
+    env_path = tmp_path / ".env.automation"
+    env_path.write_text(
+        "\n".join(
+            [
+                "GITHUB_APP_ID=123",
+                "GITHUB_APP_INSTALLATION_ID=456",
+                f"GITHUB_APP_PRIVATE_KEY_PATH={key_path}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = mod.load_github_app_config({"ARAGORA_AUTOMATION_ENV_FILE": str(env_path)})
+
+    assert config is not None
+    assert config.app_id == "123"
+    assert config.installation_id == "456"
+    assert config.private_key == "PRIVATE KEY"
+    assert config.private_key_source == str(key_path)
+
+
+def test_github_cli_env_prefers_installation_token(monkeypatch, tmp_path) -> None:
+    mod.clear_github_app_token_cache()
+    key_path = tmp_path / "app.pem"
+    key_path.write_text("PRIVATE KEY", encoding="utf-8")
+    env_path = tmp_path / ".env.automation"
+    env_path.write_text(
+        "\n".join(
+            [
+                "GITHUB_APP_ID=123",
+                "GITHUB_APP_INSTALLATION_ID=456",
+                f"GITHUB_APP_PRIVATE_KEY_PATH={key_path}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_mint(config: mod.GitHubAppConfig) -> mod.GitHubAppToken:
+        assert config.app_id == "123"
+        return mod.GitHubAppToken(
+            token="installation-token",
+            expires_at=datetime.now(tz=UTC) + timedelta(minutes=30),
+        )
+
+    monkeypatch.setattr(mod, "_mint_installation_token", fake_mint)
+
+    env = mod.github_cli_env(
+        {
+            "ARAGORA_AUTOMATION_ENV_FILE": str(env_path),
+            "GH_TOKEN": "user-token",
+            "PATH": "/usr/bin",
+        }
+    )
+
+    assert env["GH_TOKEN"] == "installation-token"
+    assert env["GITHUB_TOKEN"] == "installation-token"
+    assert env["ARAGORA_GITHUB_AUTH_SOURCE"] == "github_app_installation"
+
+
+def test_github_cli_env_falls_back_when_unconfigured() -> None:
+    mod.clear_github_app_token_cache()
+
+    env = mod.github_cli_env({"PATH": "/usr/bin", "ARAGORA_AUTOMATION_ENV_FILE": "/missing"})
+
+    assert env == {"PATH": "/usr/bin", "ARAGORA_AUTOMATION_ENV_FILE": "/missing"}


### PR DESCRIPTION
## Summary
- add a reusable GitHub App installation-token helper that reads /Users/armand/.aragora/.env.automation when present
- run proof-first queue reconciliation and boss issue-feed reads with the app token when available, falling back to current gh auth
- treat GitHub GraphQL quota exhaustion as a recoverable GitHub-unavailable state instead of crashing the shift

## Validation
- python3 -m pytest tests/swarm/test_github_app_auth.py tests/scripts/test_reconcile_proof_first_queue.py -q
- python3 -m pytest tests/swarm/test_boss_loop.py::TestGitHubIssueFeed tests/swarm/test_github_app_auth.py tests/scripts/test_reconcile_proof_first_queue.py -q
- python3 -m ruff check aragora/swarm/github_app_auth.py aragora/swarm/boss_feed.py aragora/swarm/issue_scanner.py scripts/reconcile_proof_first_queue.py tests/swarm/test_github_app_auth.py tests/scripts/test_reconcile_proof_first_queue.py
- python3 -m ruff format --check aragora/swarm/github_app_auth.py aragora/swarm/boss_feed.py aragora/swarm/issue_scanner.py scripts/reconcile_proof_first_queue.py tests/swarm/test_github_app_auth.py tests/scripts/test_reconcile_proof_first_queue.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- live smoke: app-token gh api rate_limit reports independent 5000/5000 REST and GraphQL buckets
- live smoke: app-token gh issue list sees current boss-ready queue