### PR TITLE
fix(automation): harden publisher reliability

### DIFF
--- a/aragora/swarm/github_app_auth.py
+++ b/aragora/swarm/github_app_auth.py
@@ -38,15 +38,44 @@ def _read_env_file(path: Path) -> dict[str, str]:
     if not path.exists():
         return {}
     values: dict[str, str] = {}
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
+    lines = path.read_text(encoding="utf-8").splitlines()
+    index = 0
+    while index < len(lines):
+        raw_line = lines[index]
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
+            index += 1
             continue
         key, value = line.split("=", 1)
         key = key.strip()
-        value = value.strip().strip("'\"")
-        if key:
-            values[key] = value
+        value = value.strip()
+        if not key:
+            index += 1
+            continue
+
+        if value.startswith(("'", '"')):
+            quote = value[0]
+            value = value[1:]
+            if value.endswith(quote):
+                values[key] = value[:-1]
+                index += 1
+                continue
+
+            parts = [value]
+            index += 1
+            while index < len(lines):
+                next_line = lines[index]
+                if next_line.endswith(quote):
+                    parts.append(next_line[:-1])
+                    index += 1
+                    break
+                parts.append(next_line)
+                index += 1
+            values[key] = "\n".join(parts)
+            continue
+
+        values[key] = value
+        index += 1
     return values
 
 
@@ -70,6 +99,12 @@ def _automation_env_file(env: Mapping[str, str]) -> Path:
     return Path(configured).expanduser() if configured else DEFAULT_AUTOMATION_ENV_FILE
 
 
+def _normalize_private_key(value: str) -> str:
+    if "\\n" in value:
+        return value.replace("\\n", "\n")
+    return value
+
+
 def load_github_app_config(env: Mapping[str, str] | None = None) -> GitHubAppConfig | None:
     base_env = dict(os.environ if env is None else env)
     file_env = _read_env_file(_automation_env_file(base_env))
@@ -86,6 +121,8 @@ def load_github_app_config(env: Mapping[str, str] | None = None) -> GitHubAppCon
     )
     private_key = _first_value(values, ("GITHUB_APP_PRIVATE_KEY", "ARAGORA_GITHUB_APP_KEY"))
     private_key_source = "env:GITHUB_APP_PRIVATE_KEY" if private_key else ""
+    if private_key:
+        private_key = _normalize_private_key(private_key)
     if not private_key:
         key_path = _first_value(
             values,

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -26,6 +26,7 @@ DEFAULT_LABELS = ("boss-ready",)
 DEFAULT_LIMIT = 2
 DEFAULT_MAX_OPEN_ISSUES = 12
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
+MAX_ISSUE_BODY_CHARS = 60_000
 DEFAULT_AUTOMATION_IDS = (
     "founder-review",
     "founder-triage",
@@ -433,7 +434,7 @@ def _create_issue(
         "--title",
         handoff.task_title,
         "--body",
-        handoff.body,
+        _fit_issue_body(handoff.body),
     ]
     for label in labels:
         args.extend(["--label", label])
@@ -443,6 +444,17 @@ def _create_issue(
     url = str(proc.stdout or "").strip().splitlines()[-1].strip()
     _add_issue_labels(repo_root, repo, url, labels)
     return url
+
+
+def _fit_issue_body(body: str) -> str:
+    if len(body) <= MAX_ISSUE_BODY_CHARS:
+        return body
+    suffix = (
+        "\n\n---\n"
+        "Automation publisher truncated this issue body because it exceeded "
+        "GitHub's size limit. See the source automation memory path above for full evidence."
+    )
+    return body[: MAX_ISSUE_BODY_CHARS - len(suffix)].rstrip() + suffix
 
 
 def _issue_number_from_url(url: str) -> str | None:

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -25,6 +25,7 @@ DEFAULT_REPO = "synaptent/aragora"
 DEFAULT_LABELS = ("boss-ready",)
 DEFAULT_LIMIT = 2
 DEFAULT_MAX_OPEN_ISSUES = 12
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
 DEFAULT_AUTOMATION_IDS = (
     "founder-review",
     "founder-triage",
@@ -66,6 +67,17 @@ STOPWORDS = {
     "with",
 }
 
+try:
+    from aragora.swarm.github_app_auth import github_cli_env
+except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
+
+    def github_cli_env(
+        base_env: dict[str, str] | None = None,
+        *,
+        prefer_app: bool = True,
+    ) -> dict[str, str]:
+        return dict(os.environ if base_env is None else base_env)
+
 
 @dataclass(frozen=True)
 class Handoff:
@@ -89,7 +101,25 @@ class PublishDecision:
 
 
 def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False)
+    env = github_cli_env(os.environ) if args and args[0] == "gh" else None
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        message = (
+            stderr
+            or f"command timed out after {DEFAULT_COMMAND_TIMEOUT_SECONDS}s: {' '.join(args)}"
+        )
+        return subprocess.CompletedProcess(args=args, returncode=124, stdout=stdout, stderr=message)
 
 
 def _codex_home(value: str | None) -> Path:
@@ -410,7 +440,28 @@ def _create_issue(
     proc = _run(args, cwd=repo_root)
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh issue create failed")
-    return str(proc.stdout or "").strip().splitlines()[-1].strip()
+    url = str(proc.stdout or "").strip().splitlines()[-1].strip()
+    _add_issue_labels(repo_root, repo, url, labels)
+    return url
+
+
+def _issue_number_from_url(url: str) -> str | None:
+    match = re.search(r"/issues/(\d+)(?:$|[/?#])", url)
+    return match.group(1) if match else None
+
+
+def _add_issue_labels(repo_root: Path, repo: str, issue_url: str, labels: list[str]) -> None:
+    if not labels:
+        return
+    number = _issue_number_from_url(issue_url)
+    if not number:
+        return
+    proc = _run(
+        ["gh", "issue", "edit", number, "--repo", repo, "--add-label", ",".join(labels)],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        return
 
 
 def decide_handoffs(

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -22,6 +23,9 @@ UTC = timezone.utc
 DEFAULT_SINCE_HOURS = 72
 DEFAULT_PUBLISH_LIMIT = 1
 DEFAULT_MAX_OPEN_PRS = 1
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
+DEFAULT_GIT_TIMEOUT_SECONDS = 15
+DEFAULT_SCAN_LIMIT = 12
 CODEX_BRANCH_PREFIX = "codex/"
 DEFAULT_PREFLIGHT_SCRIPT = "scripts/automation_pr_preflight.sh"
 ACTIVE_SESSION_FILES = (
@@ -29,6 +33,17 @@ ACTIVE_SESSION_FILES = (
     ".codex_session_active",
     ".nomic-session-active",
 )
+
+try:
+    from aragora.swarm.github_app_auth import github_cli_env
+except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
+
+    def github_cli_env(
+        base_env: dict[str, str] | None = None,
+        *,
+        prefer_app: bool = True,
+    ) -> dict[str, str]:
+        return dict(os.environ if base_env is None else base_env)
 
 
 @dataclass(frozen=True)
@@ -69,13 +84,25 @@ def _run(
     cwd: Path,
     check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        args,
-        cwd=cwd,
-        text=True,
-        capture_output=True,
-        check=check,
+    env = github_cli_env(os.environ) if args and args[0] == "gh" else None
+    timeout = (
+        DEFAULT_COMMAND_TIMEOUT_SECONDS if args and args[0] == "gh" else DEFAULT_GIT_TIMEOUT_SECONDS
     )
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=check,
+            timeout=timeout,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        message = stderr or f"command timed out after {timeout}s: {' '.join(args)}"
+        return subprocess.CompletedProcess(args=args, returncode=124, stdout=stdout, stderr=message)
 
 
 def _parse_git_dt(value: str) -> datetime:
@@ -109,6 +136,14 @@ def _branch_unique_commit_count(repo_root: Path, base: str, branch: str) -> int:
 def _branch_is_merged(repo_root: Path, base: str, branch: str) -> bool:
     proc = _run(["git", "merge-base", "--is-ancestor", branch, base], cwd=repo_root)
     return proc.returncode == 0
+
+
+def _branch_patch_equivalent_to_base(repo_root: Path, base: str, branch: str) -> bool:
+    proc = _run(["git", "cherry", base, branch], cwd=repo_root)
+    if proc.returncode != 0:
+        return False
+    statuses = [line[:1] for line in proc.stdout.splitlines() if line.strip()]
+    return bool(statuses) and all(status == "-" for status in statuses)
 
 
 def _local_codex_branches(repo_root: Path) -> list[BranchSnapshot]:
@@ -155,7 +190,11 @@ def _worktree_is_dirty(path: Path) -> bool:
     return bool(proc.stdout.strip())
 
 
-def _list_worktrees(repo_root: Path) -> list[WorktreeSnapshot]:
+def _list_worktrees(
+    repo_root: Path,
+    *,
+    branch_filter: set[str] | None = None,
+) -> list[WorktreeSnapshot]:
     proc = _run(["git", "worktree", "list", "--porcelain"], cwd=repo_root)
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or "failed to list worktrees")
@@ -167,6 +206,8 @@ def _list_worktrees(repo_root: Path) -> list[WorktreeSnapshot]:
 
     def flush() -> None:
         if current_path is None:
+            return
+        if branch_filter is not None and current_branch not in branch_filter:
             return
         snapshots.append(
             WorktreeSnapshot(
@@ -264,6 +305,7 @@ def select_publishable_branches(
     cutoff: datetime,
     base: str,
     is_merged: dict[str, bool] | None = None,
+    is_patch_equivalent: dict[str, bool] | None = None,
     historical_pr_branches: set[str] | None = None,
 ) -> list[PublishDecision]:
     worktrees_by_branch: dict[str, list[WorktreeSnapshot]] = {}
@@ -272,6 +314,7 @@ def select_publishable_branches(
             worktrees_by_branch.setdefault(worktree.branch, []).append(worktree)
 
     merged_lookup = is_merged or {}
+    patch_equivalent_lookup = is_patch_equivalent or {}
     historical_lookup = historical_pr_branches or set()
     decisions: list[PublishDecision] = []
 
@@ -281,6 +324,8 @@ def select_publishable_branches(
 
         if merged_lookup.get(branch.branch, False):
             reason = "already_merged"
+        elif patch_equivalent_lookup.get(branch.branch, False):
+            reason = "patch_equivalent_to_base"
         elif branch.unique_commit_count <= 0:
             reason = "no_unique_commits"
         elif branch.committed_at < cutoff:
@@ -512,6 +557,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Restrict evaluation to one or more explicit branch names",
     )
     parser.add_argument(
+        "--scan-limit",
+        type=int,
+        default=DEFAULT_SCAN_LIMIT,
+        help="Maximum recent local codex branches to inspect when --branch is not provided.",
+    )
+    parser.add_argument(
         "--label",
         action="append",
         dest="labels",
@@ -555,10 +606,22 @@ def main(argv: list[str] | None = None) -> int:
     if args.branches:
         requested = set(args.branches)
         branches = [branch for branch in branches if branch.branch in requested]
+    else:
+        branches = sorted(
+            [branch for branch in branches if branch.committed_at >= cutoff],
+            key=lambda branch: branch.committed_at,
+            reverse=True,
+        )[: max(args.scan_limit, 0)]
 
-    worktrees = _list_worktrees(repo_root)
+    branch_names = {branch.branch for branch in branches}
+    worktrees = _list_worktrees(repo_root, branch_filter=branch_names)
     merged_lookup = {
         branch.branch: _branch_is_merged(repo_root, args.base, branch.branch) for branch in branches
+    }
+    patch_equivalent_lookup = {
+        branch.branch: _branch_patch_equivalent_to_base(repo_root, args.base, branch.branch)
+        for branch in branches
+        if not merged_lookup.get(branch.branch, False)
     }
     hydrated_branches = [
         BranchSnapshot(
@@ -585,6 +648,7 @@ def main(argv: list[str] | None = None) -> int:
         cutoff=cutoff,
         base=args.base,
         is_merged=merged_lookup,
+        is_patch_equivalent=patch_equivalent_lookup,
         historical_pr_branches=historical_pr_branches,
     )
 

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -25,15 +25,27 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! gh auth status >/dev/null 2>&1; then
-  echo "$(STAMP) [codex-automation-publisher] gh auth unavailable; skipping publish pass"
-  exit 0
+if ! git fetch --no-write-fetch-head --prune origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1; then
+  echo "$(STAMP) [codex-automation-publisher] origin refresh failed; continuing with cached refs"
 fi
 
 echo "$(STAMP) [codex-automation-publisher] starting handoff publish pass"
-python3 scripts/publish_automation_handoffs.py --apply --limit 1 --max-open-issues 12 --json
-echo "$(STAMP) [codex-automation-publisher] handoff publish pass complete"
+if python3 scripts/publish_automation_handoffs.py --apply --limit 1 --max-open-issues 12 --json; then
+  echo "$(STAMP) [codex-automation-publisher] handoff publish pass complete"
+else
+  echo "$(STAMP) [codex-automation-publisher] handoff publish pass failed; continuing"
+fi
 
 echo "$(STAMP) [codex-automation-publisher] starting branch publish pass"
-python3 scripts/publish_codex_automation_branches.py --apply --limit 1 --max-open-prs 1 --json
+if python3 scripts/publish_codex_automation_branches.py \
+  --base origin/main \
+  --apply \
+  --limit 1 \
+  --max-open-prs 1 \
+  --json; then
+  echo "$(STAMP) [codex-automation-publisher] branch publish pass complete"
+else
+  echo "$(STAMP) [codex-automation-publisher] branch publish pass failed"
+fi
+
 echo "$(STAMP) [codex-automation-publisher] publish pass complete"

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -292,3 +292,34 @@ def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: 
         "--add-label",
         "boss-ready,autonomous",
     ]
+
+
+def test_create_issue_truncates_oversized_body(monkeypatch: Any, tmp_path: Path) -> None:
+    bodies: list[str] = []
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "create"]:
+            bodies.append(args[args.index("--body") + 1])
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/synaptent/aragora/issues/6000\n", ""
+            )
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    mod._create_issue(
+        tmp_path,
+        "synaptent/aragora",
+        Handoff(
+            source_file=str(tmp_path / "memory.md"),
+            task_title="Long issue body",
+            priority="HIGH",
+            body="x" * (mod.MAX_ISSUE_BODY_CHARS + 1000),
+            labels={},
+            expires_at=None,
+        ),
+        labels=["boss-ready"],
+    )
+
+    assert len(bodies[0]) <= mod.MAX_ISSUE_BODY_CHARS
+    assert "truncated this issue body" in bodies[0]

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -282,3 +282,13 @@ def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: 
     assert published[0].created_issue_url == "https://github.com/synaptent/aragora/issues/5890"
     assert created[0][:3] == ["gh", "issue", "create"]
     assert created[0].count("--label") == 2
+    assert created[1] == [
+        "gh",
+        "issue",
+        "edit",
+        "5890",
+        "--repo",
+        "synaptent/aragora",
+        "--add-label",
+        "boss-ready,autonomous",
+    ]

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -70,6 +70,7 @@ def test_parser_defaults_to_single_branch_publish_budget() -> None:
 
     assert args.limit == 1
     assert args.max_open_prs == 1
+    assert args.scan_limit == mod.DEFAULT_SCAN_LIMIT
     assert args.skip_preflight is False
     assert args.preflight_script == mod.DEFAULT_PREFLIGHT_SCRIPT
 
@@ -80,6 +81,7 @@ def test_select_publishable_branches_skips_open_pr_and_old_or_merged_branches() 
             _branch("codex/already-open"),
             _branch("codex/old", hours_ago=200),
             _branch("codex/merged"),
+            _branch("codex/cherry-picked"),
             _branch("codex/no-unique", unique_commit_count=0),
         ],
         [],
@@ -90,8 +92,10 @@ def test_select_publishable_branches_skips_open_pr_and_old_or_merged_branches() 
             "codex/already-open": False,
             "codex/old": False,
             "codex/merged": True,
+            "codex/cherry-picked": False,
             "codex/no-unique": False,
         },
+        is_patch_equivalent={"codex/cherry-picked": True},
         historical_pr_branches=set(),
     )
 
@@ -99,6 +103,7 @@ def test_select_publishable_branches_skips_open_pr_and_old_or_merged_branches() 
     assert by_branch["codex/already-open"].reason == "open_pr_exists"
     assert by_branch["codex/old"].reason == "older_than_cutoff"
     assert by_branch["codex/merged"].reason == "already_merged"
+    assert by_branch["codex/cherry-picked"].reason == "patch_equivalent_to_base"
     assert by_branch["codex/no-unique"].reason == "no_unique_commits"
 
 
@@ -200,6 +205,39 @@ def test_worktree_is_dirty_ignores_untracked_files(tmp_path: Path) -> None:
 
     tracked.write_text("changed\n", encoding="utf-8")
     assert _worktree_is_dirty(repo) is True
+
+
+def test_list_worktrees_filters_before_dirty_checks(monkeypatch: Any, tmp_path: Path) -> None:
+    payload = """
+worktree /tmp/codex-a
+HEAD abc123
+branch refs/heads/codex/a
+
+worktree /tmp/codex-b
+HEAD def456
+branch refs/heads/codex/b
+""".strip()
+    dirty_checked: list[str] = []
+
+    monkeypatch.setattr(
+        mod,
+        "_run",
+        lambda args, cwd, check=False: subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=payload, stderr=""
+        ),
+    )
+    monkeypatch.setattr(mod, "_has_active_session", lambda path: False)
+
+    def fake_dirty(path: Path) -> bool:
+        dirty_checked.append(str(path))
+        return False
+
+    monkeypatch.setattr(mod, "_worktree_is_dirty", fake_dirty)
+
+    snapshots = mod._list_worktrees(tmp_path, branch_filter={"codex/b"})
+
+    assert [snapshot.branch for snapshot in snapshots] == ["codex/b"]
+    assert dirty_checked == [str(Path("/tmp/codex-b").resolve())]
 
 
 def test_publish_decisions_respects_open_pr_cap(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/swarm/test_github_app_auth.py
+++ b/tests/swarm/test_github_app_auth.py
@@ -29,6 +29,45 @@ def test_load_github_app_config_reads_automation_env_file(tmp_path) -> None:
     assert config.private_key_source == str(key_path)
 
 
+def test_load_github_app_config_reads_multiline_private_key(tmp_path) -> None:
+    env_path = tmp_path / ".env.automation"
+    env_path.write_text(
+        "\n".join(
+            [
+                "GITHUB_APP_ID=123",
+                "GITHUB_APP_INSTALLATION_ID=456",
+                'GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----',
+                "key-body",
+                '-----END RSA PRIVATE KEY-----"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = mod.load_github_app_config({"ARAGORA_AUTOMATION_ENV_FILE": str(env_path)})
+
+    assert config is not None
+    assert config.private_key == (
+        "-----BEGIN RSA PRIVATE KEY-----\nkey-body\n-----END RSA PRIVATE KEY-----"
+    )
+
+
+def test_load_github_app_config_decodes_escaped_newline_private_key() -> None:
+    config = mod.load_github_app_config(
+        {
+            "ARAGORA_AUTOMATION_ENV_FILE": "/missing",
+            "GITHUB_APP_ID": "123",
+            "GITHUB_APP_INSTALLATION_ID": "456",
+            "GITHUB_APP_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\\nkey-body\\n-----END RSA PRIVATE KEY-----",
+        }
+    )
+
+    assert config is not None
+    assert config.private_key == (
+        "-----BEGIN RSA PRIVATE KEY-----\nkey-body\n-----END RSA PRIVATE KEY-----"
+    )
+
+
 def test_github_cli_env_prefers_installation_token(monkeypatch, tmp_path) -> None:
     mod.clear_github_app_token_cache()
     key_path = tmp_path / "app.pem"


### PR DESCRIPTION
## Summary
- let automation publisher gh calls use GitHub App installation-token env when configured
- make the publisher bridge continue branch publishing if handoff publishing fails, refresh refs without FETCH_HEAD writes, and compare against origin/main
- bound publisher command latency, scan only recent candidate branches, skip patch-equivalent stale branches, and reapply issue labels after issue creation
- support documented multiline and escaped-newline GitHub App private keys

## Validation
- python3 -m pytest tests/swarm/test_github_app_auth.py tests/scripts/test_publish_automation_handoffs.py tests/scripts/test_publish_codex_automation_branches.py -q
- python3 -m ruff check aragora/swarm/github_app_auth.py scripts/publish_automation_handoffs.py scripts/publish_codex_automation_branches.py tests/swarm/test_github_app_auth.py tests/scripts/test_publish_automation_handoffs.py tests/scripts/test_publish_codex_automation_branches.py
- bash -n scripts/run_codex_automation_publisher.sh
- python3 scripts/publish_automation_handoffs.py --repo . --github-repo synaptent/aragora --limit 1 --max-open-issues 12 --json
- python3 scripts/publish_codex_automation_branches.py --repo . --github-repo synaptent/aragora --base origin/main --limit 1 --max-open-prs 1 --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD


Fixes #6002
