### PR TITLE
fix(automation): normalize branch dedupe subjects

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -36,6 +36,7 @@ STOPWORDS = {
     "autonomy",
     "branches",
     "chore",
+    "codex",
     "covered",
     "docs",
     "feat",
@@ -330,6 +331,8 @@ def _ordered_subject_tokens(subject: str) -> list[str]:
     tokens: list[str] = []
     seen: set[str] = set()
     for token in re.findall(r"[a-z0-9]+", subject.lower()):
+        if len(token) > 4 and token.endswith("s"):
+            token = token[:-1]
         if len(token) < 3 or token in STOPWORDS or token in seen:
             continue
         seen.add(token)

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -156,6 +156,10 @@ def test_related_subjects_match_resolved_github_items() -> None:
         "fix(playground): preserve mock debate receipts",
         "Support multiline GitHub App keys in automation env",
     )
+    assert mod._looks_related_subject(
+        "[codex] Restore prompt engine SDK contract",
+        "fix(sdk): restore prompt engine contracts",
+    )
 
 
 def test_related_search_queries_include_stable_nouns() -> None:


### PR DESCRIPTION
## Summary
- ignore `[codex]` noise when comparing branch subjects to resolved GitHub work
- normalize simple plurals so `contract` and `contracts` dedupe correctly

## Validation
- python3 -m pytest tests/scripts/test_publish_codex_automation_branches.py -q
- python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD