### PR TITLE
fix(automation): use github base names for PR create

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -490,6 +490,10 @@ def _ensure_gh_auth(repo_root: Path) -> None:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh auth failed")
 
 
+def _github_base_ref(base: str) -> str:
+    return base.removeprefix("origin/")
+
+
 def _push_branch(repo_root: Path, branch: str, upstream: str | None) -> None:
     args = ["git", "push"]
     if upstream:
@@ -502,6 +506,7 @@ def _push_branch(repo_root: Path, branch: str, upstream: str | None) -> None:
 
 
 def _existing_pr_number(repo_root: Path, repo: str, branch: str, base: str) -> int | None:
+    github_base = _github_base_ref(base)
     proc = _run(
         [
             "gh",
@@ -512,7 +517,7 @@ def _existing_pr_number(repo_root: Path, repo: str, branch: str, base: str) -> i
             "--head",
             branch,
             "--base",
-            base,
+            github_base,
             "--state",
             "open",
             "--json",
@@ -532,6 +537,7 @@ def _existing_pr_number(repo_root: Path, repo: str, branch: str, base: str) -> i
 
 
 def _create_pr(repo_root: Path, repo: str, branch: str, base: str) -> int:
+    github_base = _github_base_ref(base)
     proc = _run(
         [
             "gh",
@@ -540,7 +546,7 @@ def _create_pr(repo_root: Path, repo: str, branch: str, base: str) -> int:
             "--repo",
             repo,
             "--base",
-            base,
+            github_base,
             "--head",
             branch,
             "--fill",

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -169,6 +169,11 @@ def test_related_search_queries_include_stable_nouns() -> None:
     ]
 
 
+def test_github_base_ref_strips_remote_tracking_prefix() -> None:
+    assert mod._github_base_ref("origin/main") == "main"
+    assert mod._github_base_ref("main") == "main"
+
+
 def test_open_pr_heads_counts_only_codex_branches(monkeypatch: Any, tmp_path: Path) -> None:
     payload = """
     [


### PR DESCRIPTION
## Summary
- keep `origin/main` usable for local branch publisher diff/preflight
- strip `origin/` before calling `gh pr list` or `gh pr create`, which require GitHub branch names like `main`

## Validation
- python3 -m pytest tests/scripts/test_publish_codex_automation_branches.py -q
- python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD