### PR TITLE
fix(swarm): bound and observe boss-loop launchd kickstart (#5997)

### DIFF
--- a/scripts/probe_boss_loop_launchd.py
+++ b/scripts/probe_boss_loop_launchd.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Bounded, observable probe for the boss-loop launchd LaunchAgent.
+
+Addresses #5997: `launchctl kickstart` can block indefinitely while launchd
+holds a job in `state = spawn scheduled` during its `ThrottleInterval`
+cooldown. This helper wraps kickstart with hard timeouts, then polls
+`launchctl print` to surface a truthful failure reason (state, runs,
+last_exit_code, throttle bounds) instead of leaving operators staring at a
+hung shell.
+
+Output is a JSON document on stdout; exit code 0 on confirmed restart,
+non-zero otherwise. Inherited-environment values from `launchctl print`
+(API keys, etc.) are never echoed.
+
+Usage:
+    python scripts/probe_boss_loop_launchd.py
+    python scripts/probe_boss_loop_launchd.py --label com.aragora.swarm-boss-loop
+    python scripts/probe_boss_loop_launchd.py --wait-seconds 60 --no-kickstart
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from typing import Any
+
+DEFAULT_LABEL = "com.aragora.swarm-boss-loop"
+
+_INT_FIELDS: dict[str, str] = {
+    "active count": "active_count",
+    "runs": "runs",
+    "last exit code": "last_exit_code",
+    "minimum runtime": "minimum_runtime_seconds",
+    "exit timeout": "exit_timeout_seconds",
+}
+
+
+@dataclass(frozen=True)
+class LaunchdState:
+    label: str
+    state: str
+    active_count: int
+    runs: int
+    last_exit_code: int | None
+    minimum_runtime_seconds: int | None
+    exit_timeout_seconds: int | None
+    spawn_type: str | None
+
+    @property
+    def is_running(self) -> bool:
+        return self.active_count > 0
+
+    @property
+    def is_spawn_scheduled(self) -> bool:
+        return self.state.strip() == "spawn scheduled"
+
+    def to_safe_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RestartProbeResult:
+    ok: bool
+    reason: str
+    state: LaunchdState | None
+    elapsed_seconds: float
+
+    def to_safe_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "reason": self.reason,
+            "state": self.state.to_safe_dict() if self.state else None,
+            "elapsed_seconds": round(self.elapsed_seconds, 3),
+        }
+
+
+def parse_launchd_state(text: str, *, label: str) -> LaunchdState | None:
+    """Parse `launchctl print` output for a single LaunchAgent.
+
+    Returns ``None`` when the agent is not loaded. Inherited-environment
+    blocks are skipped entirely so secrets are never returned.
+    """
+
+    if not text or "Could not find service" in text:
+        return None
+
+    fields: dict[str, Any] = {}
+    skip_block_depth = 0
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if skip_block_depth > 0:
+            if line.endswith("{"):
+                skip_block_depth += 1
+            elif line == "}":
+                skip_block_depth -= 1
+            continue
+        if line.startswith("inherited environment") or line.startswith("default environment"):
+            if line.endswith("{"):
+                skip_block_depth = 1
+            continue
+        match = re.match(r"^([^=]+?)\s*=\s*(.+?)\s*$", line)
+        if not match:
+            continue
+        key = match.group(1).strip().lower()
+        value = match.group(2).strip().rstrip(",")
+        if key in _INT_FIELDS:
+            try:
+                fields[_INT_FIELDS[key]] = int(value)
+            except ValueError:
+                continue
+        elif key == "state":
+            fields["state"] = value
+        elif key == "spawn type":
+            spawn = value.split(" ", 1)[0]
+            fields["spawn_type"] = spawn or None
+
+    if "state" not in fields:
+        return None
+
+    return LaunchdState(
+        label=label,
+        state=fields["state"],
+        active_count=int(fields.get("active_count", 0)),
+        runs=int(fields.get("runs", 0)),
+        last_exit_code=fields.get("last_exit_code"),
+        minimum_runtime_seconds=fields.get("minimum_runtime_seconds"),
+        exit_timeout_seconds=fields.get("exit_timeout_seconds"),
+        spawn_type=fields.get("spawn_type"),
+    )
+
+
+def read_launchd_state(label: str, *, timeout_seconds: float = 10.0) -> LaunchdState | None:
+    """Run `launchctl print` and return parsed state, or ``None`` on failure."""
+
+    uid = os.getuid()
+    try:
+        proc = subprocess.run(
+            ["launchctl", "print", f"gui/{uid}/{label}"],
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if proc.returncode != 0:
+        return None
+    return parse_launchd_state(proc.stdout, label=label)
+
+
+def _kickstart(label: str, *, timeout_seconds: float) -> tuple[bool, str]:
+    uid = os.getuid()
+    try:
+        proc = subprocess.run(
+            ["launchctl", "kickstart", f"gui/{uid}/{label}"],
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"launchctl kickstart timed out after {timeout_seconds:.0f}s for {label}"
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "non-zero exit"
+        return False, f"launchctl kickstart failed for {label}: {detail}"
+    return True, ""
+
+
+def _format_stuck_reason(label: str, state: LaunchdState) -> str:
+    parts = [
+        f"LaunchAgent {label} stuck in state={state.state!r}",
+        f"runs={state.runs}",
+    ]
+    if state.last_exit_code is not None:
+        parts.append(f"last_exit={state.last_exit_code}")
+    if state.minimum_runtime_seconds is not None:
+        parts.append(f"min_runtime={state.minimum_runtime_seconds}s")
+    return "; ".join(parts)
+
+
+def bounded_kickstart(
+    label: str,
+    *,
+    kickstart_timeout_seconds: float = 10.0,
+    wait_seconds: float = 30.0,
+    poll_interval_seconds: float = 1.0,
+    skip_kickstart: bool = False,
+) -> RestartProbeResult:
+    """Kickstart ``label`` with bounded waits; return truthful state on stuck."""
+
+    started = time.monotonic()
+    kicked = True
+    detail = ""
+    if not skip_kickstart:
+        kicked, detail = _kickstart(label, timeout_seconds=kickstart_timeout_seconds)
+
+    deadline = started + wait_seconds + (kickstart_timeout_seconds if not skip_kickstart else 0.0)
+    last_state: LaunchdState | None = None
+    while True:
+        last_state = read_launchd_state(label)
+        if last_state is not None and last_state.is_running:
+            return RestartProbeResult(
+                ok=True,
+                reason=(
+                    f"kickstart confirmed for {label} "
+                    f"(state={last_state.state!r}, active={last_state.active_count})"
+                ),
+                state=last_state,
+                elapsed_seconds=time.monotonic() - started,
+            )
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(poll_interval_seconds)
+
+    if last_state is None:
+        reason = detail or f"LaunchAgent {label} is not loaded or unreadable"
+        return RestartProbeResult(
+            ok=False,
+            reason=reason,
+            state=None,
+            elapsed_seconds=time.monotonic() - started,
+        )
+
+    base_reason = _format_stuck_reason(label, last_state)
+    if not kicked and detail:
+        base_reason = f"{base_reason}; kickstart_error={detail}"
+    return RestartProbeResult(
+        ok=False,
+        reason=base_reason,
+        state=last_state,
+        elapsed_seconds=time.monotonic() - started,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", default=DEFAULT_LABEL, help="LaunchAgent label to probe")
+    parser.add_argument(
+        "--kickstart-timeout-seconds",
+        type=float,
+        default=10.0,
+        help="Hard timeout for the launchctl kickstart submission",
+    )
+    parser.add_argument(
+        "--wait-seconds",
+        type=float,
+        default=30.0,
+        help="Maximum time to wait for the agent to transition into a running state",
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=1.0,
+        help="Polling interval while waiting for state transition",
+    )
+    parser.add_argument(
+        "--no-kickstart",
+        action="store_true",
+        help="Skip kickstart; only read and report current launchd state",
+    )
+    args = parser.parse_args(argv)
+
+    result = bounded_kickstart(
+        args.label,
+        kickstart_timeout_seconds=args.kickstart_timeout_seconds,
+        wait_seconds=args.wait_seconds,
+        poll_interval_seconds=args.poll_interval_seconds,
+        skip_kickstart=args.no_kickstart,
+    )
+    print(json.dumps(result.to_safe_dict(), indent=2))
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -580,12 +580,38 @@ def restart_service_via_launchd(
     kicked, detail = kickstart_launchd(label)
     if wait_for_process(process_pattern, timeout_seconds=start_timeout_seconds):
         return True, "" if kicked else detail
+    state_detail = _read_launchd_failure_detail(label)
     if kicked:
-        return (
-            False,
-            f"launchctl kickstart returned success for {label}, but process pattern {process_pattern!r} is still not running",
+        message = (
+            f"launchctl kickstart returned success for {label}, but process pattern "
+            f"{process_pattern!r} is still not running"
         )
+        if state_detail:
+            message = f"{message}; {state_detail}"
+        return False, message
+    if state_detail:
+        return False, f"{detail}; {state_detail}"
     return False, detail
+
+
+def _read_launchd_failure_detail(label: str) -> str:
+    """Return a redacted, truthful state summary for ``label`` after a stuck restart."""
+
+    try:
+        from scripts.probe_boss_loop_launchd import read_launchd_state
+    except Exception:
+        return ""
+    state = read_launchd_state(label, timeout_seconds=5.0)
+    if state is None:
+        return f"launchd state unavailable for {label}"
+    parts = [f"launchd state={state.state!r}", f"runs={state.runs}"]
+    if state.last_exit_code is not None:
+        parts.append(f"last_exit={state.last_exit_code}")
+    if state.minimum_runtime_seconds is not None:
+        parts.append(f"min_runtime={state.minimum_runtime_seconds}s")
+    if state.is_spawn_scheduled:
+        parts.append("hint=ThrottleInterval may not have elapsed")
+    return ", ".join(parts)
 
 
 def run_merge_arbiter_apply(

--- a/tests/scripts/test_probe_boss_loop_launchd.py
+++ b/tests/scripts/test_probe_boss_loop_launchd.py
@@ -1,0 +1,226 @@
+"""Tests for the boss-loop launchd probe smoke helper."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts import probe_boss_loop_launchd as probe
+
+
+SAMPLE_OUTPUT = """gui/501/com.aragora.swarm-boss-loop = {
+\tactive count = 0
+\tpath = /Users/armand/Library/LaunchAgents/com.aragora.swarm-boss-loop.plist
+\ttype = LaunchAgent
+\tstate = spawn scheduled
+
+\tprogram = /bin/bash
+\targuments = {
+\t\t/bin/bash
+\t\t-lc
+\t\tcd /tmp && exec python3 -m something
+\t}
+
+\tworking directory = /Users/armand/Development/aragora
+
+\tstdout path = /tmp/log
+\tstderr path = /tmp/log
+\tinherited environment = {
+\t\tOPENAI_API_KEY => sk-PRETEND-SECRET-MUST-NOT-LEAK
+\t\tANTHROPIC_API_KEY => sk-ant-PRETEND-SECRET
+\t}
+
+\tdefault environment = {
+\t}
+
+\t\tOSLogRateLimit => 64
+\t}
+
+\tdomain = gui/501 [100024]
+\tasid = 100024
+\tminimum runtime = 300
+\texit timeout = 5
+\truns = 224
+\tlast exit code = 0
+
+\tspawn type = daemon (3)
+\tproperties = keepalive | runatload | inferred program
+}
+"""
+
+
+def test_parse_launchd_state_extracts_safe_fields() -> None:
+    state = probe.parse_launchd_state(SAMPLE_OUTPUT, label="com.aragora.swarm-boss-loop")
+    assert state is not None
+    assert state.label == "com.aragora.swarm-boss-loop"
+    assert state.state == "spawn scheduled"
+    assert state.active_count == 0
+    assert state.runs == 224
+    assert state.last_exit_code == 0
+    assert state.minimum_runtime_seconds == 300
+    assert state.is_spawn_scheduled is True
+    assert state.is_running is False
+
+
+def test_parse_launchd_state_redacts_inherited_environment() -> None:
+    state = probe.parse_launchd_state(SAMPLE_OUTPUT, label="com.aragora.swarm-boss-loop")
+    serialized = json.dumps(state.to_safe_dict())
+    assert "PRETEND-SECRET" not in serialized
+    assert "sk-" not in serialized
+    assert "OPENAI_API_KEY" not in serialized
+
+
+def test_parse_launchd_state_returns_none_when_unloaded() -> None:
+    text = 'Could not find service "com.aragora.swarm-boss-loop" in domain for port'
+    assert probe.parse_launchd_state(text, label="com.aragora.swarm-boss-loop") is None
+
+
+def test_read_launchd_state_returns_none_on_print_failure() -> None:
+    completed = subprocess.CompletedProcess(
+        args=["launchctl", "print"], returncode=113, stdout="", stderr="not loaded"
+    )
+    with patch.object(probe.subprocess, "run", return_value=completed):
+        assert probe.read_launchd_state("com.aragora.swarm-boss-loop") is None
+
+
+def test_read_launchd_state_handles_print_timeout() -> None:
+    with patch.object(
+        probe.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(cmd=["launchctl"], timeout=5),
+    ):
+        assert probe.read_launchd_state("com.aragora.swarm-boss-loop", timeout_seconds=5) is None
+
+
+def test_bounded_kickstart_succeeds_when_state_transitions_to_running() -> None:
+    running_state = probe.LaunchdState(
+        label="x",
+        state="running",
+        active_count=1,
+        runs=10,
+        last_exit_code=None,
+        minimum_runtime_seconds=300,
+        exit_timeout_seconds=5,
+        spawn_type="daemon",
+    )
+    completed = subprocess.CompletedProcess(
+        args=["launchctl", "kickstart"], returncode=0, stdout="", stderr=""
+    )
+    with (
+        patch.object(probe.subprocess, "run", return_value=completed),
+        patch.object(probe, "read_launchd_state", side_effect=[running_state]),
+        patch.object(probe.time, "sleep", lambda _: None),
+    ):
+        result = probe.bounded_kickstart(
+            "x", kickstart_timeout_seconds=5, wait_seconds=5, poll_interval_seconds=0.01
+        )
+    assert result.ok is True
+    assert result.state is running_state
+    assert "spawn scheduled" not in result.reason
+
+
+def test_bounded_kickstart_fails_closed_when_stuck_spawn_scheduled() -> None:
+    stuck_state = probe.LaunchdState(
+        label="x",
+        state="spawn scheduled",
+        active_count=0,
+        runs=224,
+        last_exit_code=0,
+        minimum_runtime_seconds=300,
+        exit_timeout_seconds=5,
+        spawn_type="daemon",
+    )
+    completed = subprocess.CompletedProcess(
+        args=["launchctl", "kickstart"], returncode=0, stdout="", stderr=""
+    )
+    with (
+        patch.object(probe.subprocess, "run", return_value=completed),
+        patch.object(probe, "read_launchd_state", return_value=stuck_state),
+        patch.object(probe.time, "sleep", lambda _: None),
+    ):
+        result = probe.bounded_kickstart(
+            "x", kickstart_timeout_seconds=5, wait_seconds=0.05, poll_interval_seconds=0.01
+        )
+    assert result.ok is False
+    assert "spawn scheduled" in result.reason
+    assert "224" in result.reason
+    assert result.state is stuck_state
+    assert result.elapsed_seconds >= 0
+
+
+def test_bounded_kickstart_treats_kickstart_timeout_as_failure() -> None:
+    with (
+        patch.object(
+            probe.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["launchctl"], timeout=5),
+        ),
+        patch.object(probe, "read_launchd_state", return_value=None),
+    ):
+        result = probe.bounded_kickstart(
+            "x", kickstart_timeout_seconds=5, wait_seconds=0.05, poll_interval_seconds=0.01
+        )
+    assert result.ok is False
+    assert "timed out" in result.reason.lower() or "timeout" in result.reason.lower()
+
+
+def test_bounded_kickstart_fails_when_label_not_loaded() -> None:
+    completed = subprocess.CompletedProcess(
+        args=["launchctl", "kickstart"], returncode=113, stdout="", stderr="No such process"
+    )
+    with (
+        patch.object(probe.subprocess, "run", return_value=completed),
+        patch.object(probe, "read_launchd_state", return_value=None),
+    ):
+        result = probe.bounded_kickstart(
+            "x", kickstart_timeout_seconds=5, wait_seconds=0.05, poll_interval_seconds=0.01
+        )
+    assert result.ok is False
+    assert result.state is None
+
+
+def test_main_exits_zero_on_success(capsys: pytest.CaptureFixture[str]) -> None:
+    success = probe.RestartProbeResult(
+        ok=True,
+        reason="kickstart confirmed (state=running, active=1)",
+        state=None,
+        elapsed_seconds=1.2,
+    )
+    with patch.object(probe, "bounded_kickstart", return_value=success):
+        rc = probe.main(["--label", "x"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+
+
+def test_main_exits_nonzero_on_stuck(capsys: pytest.CaptureFixture[str]) -> None:
+    stuck_state = probe.LaunchdState(
+        label="x",
+        state="spawn scheduled",
+        active_count=0,
+        runs=224,
+        last_exit_code=0,
+        minimum_runtime_seconds=300,
+        exit_timeout_seconds=5,
+        spawn_type="daemon",
+    )
+    failure = probe.RestartProbeResult(
+        ok=False,
+        reason="LaunchAgent stuck in state=spawn scheduled (runs=224, last_exit=0)",
+        state=stuck_state,
+        elapsed_seconds=2.5,
+    )
+    with patch.object(probe, "bounded_kickstart", return_value=failure):
+        rc = probe.main(["--label", "x"])
+    assert rc != 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["state"]["state"] == "spawn scheduled"
+    assert payload["state"]["runs"] == 224
+    serialized = json.dumps(payload)
+    assert "OPENAI_API_KEY" not in serialized
+    assert "ANTHROPIC_API_KEY" not in serialized


### PR DESCRIPTION
## Summary

Closes #5997.

`launchctl kickstart gui/501/com.aragora.swarm-boss-loop` can hang the conductor shell while launchd holds the job in `state = spawn scheduled` during its `ThrottleInterval` cooldown, with no truthful signal back to the operator. The Python wrapper in `run_proof_first_shift.py` already bounds its own kickstart, but its failure detail just says "process not running" — leaving operators unable to tell whether to wait or escalate.

This adds `scripts/probe_boss_loop_launchd.py`: a stdlib-only smoke helper that wraps `launchctl print` + `launchctl kickstart` with hard timeouts, parses the LaunchAgent state, and exits non-zero with a truthful JSON reason (state, runs, last_exit_code, min_runtime) when the agent is stuck in `spawn scheduled`.

The parser explicitly skips `inherited environment` and `default environment` blocks so API keys inherited by the LaunchAgent never leak into output.

`restart_service_via_launchd` now calls the probe to enrich its failure detail when kickstart succeeds but `pgrep` does not see the process, including a `hint=ThrottleInterval may not have elapsed` note when `spawn scheduled` is observed.

## Acceptance per #5997

- ✅ Bounded start probe (kickstart timeout + bounded state poll).
- ✅ `run_proof_first_shift.py` reports truthful reasons via the probe.
- ✅ Smoke helper with focused coverage that fails closed on `spawn scheduled`.

Per the issue note, this PR is **intentionally not labeled `boss-ready`** until the current active soak completes.

## Test plan

- [x] `pytest tests/scripts/test_probe_boss_loop_launchd.py` — 11 new tests pass
- [x] `pytest tests/scripts/test_run_proof_first_shift.py` — 23 existing tests still pass
- [x] `ruff check` clean on all changed files
- [x] Live `python scripts/probe_boss_loop_launchd.py --no-kickstart` confirms parser handles real `launchctl print` output, returns redacted JSON, exits 0 when agent is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)