### PR TITLE
fix(swarm): generate_boss_issues honors boss-loop label contract

### DIFF
--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -388,23 +388,40 @@ def maybe_decompose_candidates(
     return expanded
 
 
-def create_github_issue(repo: str, title: str, body: str, label: str) -> bool:
-    """Create a GitHub issue and return success."""
+def create_github_issue(
+    repo: str,
+    title: str,
+    body: str,
+    label: str,
+    *,
+    extra_labels: list[str] | None = None,
+) -> bool:
+    """Create a GitHub issue and return success.
+
+    ``extra_labels`` lets callers pass additional labels (e.g. ``autonomous``)
+    so issues meet the boss-loop dispatch contract that requires both
+    ``boss-ready`` and ``autonomous`` labels (#5997 followup).
+    """
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        title,
+        "--body",
+        body,
+        "--label",
+        label,
+    ]
+    for extra in extra_labels or []:
+        extra = extra.strip()
+        if extra and extra != label:
+            cmd.extend(["--label", extra])
     try:
         result = subprocess.run(
-            [
-                "gh",
-                "issue",
-                "create",
-                "--repo",
-                repo,
-                "--title",
-                title,
-                "--body",
-                body,
-                "--label",
-                label,
-            ],
+            cmd,
             capture_output=True,
             text=True,
             timeout=30,
@@ -422,7 +439,16 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="Preview without creating")
     parser.add_argument("--max-issues", type=int, default=20, help="Max issues to create")
     parser.add_argument("--categories", nargs="*", help="Filter to specific categories")
-    parser.add_argument("--label", default="boss-ready", help="Label for created issues")
+    parser.add_argument("--label", default="boss-ready", help="Primary label for created issues")
+    parser.add_argument(
+        "--extra-labels",
+        default="autonomous",
+        help=(
+            "Comma-separated additional labels appended to each created issue. "
+            "Default 'autonomous' satisfies the boss-loop dispatch contract that "
+            "requires both 'boss-ready' and 'autonomous'. Pass empty string to disable."
+        ),
+    )
     parser.add_argument(
         "--min-success-rate",
         type=float,
@@ -565,7 +591,16 @@ def main() -> None:
         failed = 0
         for i, (candidate, body) in enumerate(to_create, 1):
             print(f"  [{i}/{len(to_create)}] Creating: {candidate.title}...", end=" ")
-            if create_github_issue(args.repo, candidate.title, body, args.label):
+            extra_labels = [
+                label.strip() for label in (args.extra_labels or "").split(",") if label.strip()
+            ]
+            if create_github_issue(
+                args.repo,
+                candidate.title,
+                body,
+                args.label,
+                extra_labels=extra_labels,
+            ):
                 print("OK")
                 created += 1
             else:

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -80,7 +80,9 @@ def test_main_dry_run_fetches_and_filters_like_real_mode(
     monkeypatch.setattr(
         mod,
         "create_github_issue",
-        lambda repo, title, body, label: (create_calls.append((repo, title, body, label)) or True),
+        lambda repo, title, body, label, **kwargs: (
+            create_calls.append((repo, title, body, label, kwargs.get("extra_labels", []))) or True
+        ),
     )
     monkeypatch.setattr(mod, "load_roadmap_priority_policy", lambda repo_root: None)
     monkeypatch.setattr(
@@ -134,7 +136,9 @@ def test_main_create_mode_trims_to_max_and_writes_fingerprint(
     monkeypatch.setattr(
         mod,
         "create_github_issue",
-        lambda repo, title, body, label: (created.append((repo, title, body, label)) or True),
+        lambda repo, title, body, label, **kwargs: (
+            created.append((repo, title, body, label, kwargs.get("extra_labels", []))) or True
+        ),
     )
     monkeypatch.setattr(mod.time, "sleep", lambda seconds: None)
     monkeypatch.setattr(
@@ -156,10 +160,11 @@ def test_main_create_mode_trims_to_max_and_writes_fingerprint(
     out = capsys.readouterr().out
     assert "Done: 1 created, 0 failed" in out
     assert len(created) == 1
-    repo, title, body, label = created[0]
+    repo, title, body, label, extra_labels = created[0]
     assert repo == "org/repo"
     assert title == first.title
     assert label == "lane:test"
+    assert extra_labels == ["autonomous"]
     assert f"<!-- fingerprint:{first.fingerprint} -->" in body
 
 
@@ -258,7 +263,9 @@ def test_main_non_boss_ready_label_allows_unknown_priority(monkeypatch, capsys) 
     monkeypatch.setattr(
         mod,
         "create_github_issue",
-        lambda repo, title, body, label: (created.append((repo, title, body, label)) or True),
+        lambda repo, title, body, label, **kwargs: (
+            created.append((repo, title, body, label, kwargs.get("extra_labels", []))) or True
+        ),
     )
     monkeypatch.setattr(mod.time, "sleep", lambda seconds: None)
     monkeypatch.setattr(
@@ -322,7 +329,9 @@ def test_main_boss_ready_allows_tw02_benchmark_follow_up_without_do_now_code(
     monkeypatch.setattr(
         mod,
         "create_github_issue",
-        lambda repo, title, body, label: (created.append((repo, title, body, label)) or True),
+        lambda repo, title, body, label, **kwargs: (
+            created.append((repo, title, body, label, kwargs.get("extra_labels", []))) or True
+        ),
     )
     monkeypatch.setattr(mod.time, "sleep", lambda seconds: None)
     monkeypatch.setattr(
@@ -827,3 +836,79 @@ def test_main_returns_error_when_open_pr_pagination_exhausted(monkeypatch, capsy
     assert mod.main() == 1
     out = capsys.readouterr().out
     assert "Error: open PR pagination exceeded configured cap (10 pages) for org/repo" in out
+
+
+def test_create_github_issue_passes_extra_labels_as_repeated_flags(monkeypatch) -> None:
+    """create_github_issue must add each extra label as its own --label flag.
+
+    Without this, issues created by generate_boss_issues.py only carry the
+    primary label and are skipped by the boss-loop dispatcher, which requires
+    both `boss-ready` and `autonomous` (#5997 followup).
+    """
+    captured: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+
+    def fake_run(cmd, **kwargs):
+        captured.append(list(cmd))
+        return _Result()
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    ok = mod.create_github_issue(
+        "org/repo",
+        "title",
+        "body",
+        "boss-ready",
+        extra_labels=["autonomous", "boss-ready", "  "],
+    )
+    assert ok is True
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert cmd[:3] == ["gh", "issue", "create"]
+    label_flags = [cmd[i + 1] for i, token in enumerate(cmd) if token == "--label"]
+    assert label_flags == ["boss-ready", "autonomous"]
+
+
+def test_main_omits_extra_labels_when_disabled(monkeypatch, capsys) -> None:
+    """Passing --extra-labels='' yields a single primary label only."""
+
+    eligible = _candidate("eligible_module", file_scope=["aragora/eligible_module.py"])
+    created: list[tuple] = []
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: [eligible],
+    )
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+    monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(mod, "load_roadmap_priority_policy", lambda repo_root: None)
+    monkeypatch.setattr(
+        mod,
+        "create_github_issue",
+        lambda repo, title, body, label, **kwargs: (
+            created.append((repo, title, body, label, kwargs.get("extra_labels", []))) or True
+        ),
+    )
+    monkeypatch.setattr(mod.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--repo",
+            "org/repo",
+            "--max-issues",
+            "1",
+            "--label",
+            "lane:test",
+            "--extra-labels",
+            "",
+        ],
+    )
+
+    mod.main()
+
+    assert len(created) == 1
+    assert created[0][4] == []


### PR DESCRIPTION
## Summary

Followup to #5997 / #6010.

The boss-loop dispatcher requires issues to match **all** of its `--label` filters via `require_labels.issubset(...)` ([aragora/cli/commands/swarm.py:1955-1957](https://github.com/synaptent/aragora/blob/main/aragora/cli/commands/swarm.py#L1955-L1957)). The active LaunchAgent passes `--label autonomous --label boss-ready`, and `reconcile_proof_first_queue.py` plus existing test fixtures all expect issues to carry both labels. But `generate_boss_issues.py` only attached the single `--label` value (default `boss-ready`), so freshly generated issues — like the currently open #6009 and #6000 — were silently invisible to the LaunchAgent and the queue could not drain.

## Changes

- `create_github_issue` accepts an `extra_labels` kwarg and emits one `--label` flag per label, deduplicated against the primary
- New `--extra-labels` CLI arg (comma-separated, default `autonomous`) carries the second half of the dispatch contract by default; pass `--extra-labels ""` to opt out
- Existing test mocks updated to accept the kwarg; new tests cover the subprocess flag composition and the opt-out path

## Followup needed (operator action, not in this PR)

Existing open issues #6009 and #6000 still need the `autonomous` label added manually before the LaunchAgent can pick them up — this PR only changes future generation:

```bash
gh issue edit 6009 -R synaptent/aragora --add-label autonomous
gh issue edit 6000 -R synaptent/aragora --add-label autonomous
```

## Test plan

- [x] `pytest tests/scripts/test_generate_boss_issues.py` — 26 tests pass (24 existing + 2 new)
- [x] `ruff check` clean
- [x] Verified the new test asserts both `boss-ready` and `autonomous` are emitted as separate `--label` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)