### PR TITLE
fix(autonomy): wait through launchd spawn throttle

### DIFF
--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -35,6 +35,8 @@ DEFAULT_BOSS_LABEL = "com.aragora.swarm-boss-loop"
 DEFAULT_MERGE_LABEL = "com.aragora.swarm-merge-arbiter"
 DEFAULT_BOSS_PROCESS_PATTERN = r"aragora\.cli\.main swarm boss-loop|run_boss_cycle\.sh"
 DEFAULT_MERGE_PROCESS_PATTERN = r"aragora\.cli\.main swarm merge-arbiter"
+DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS = 45.0
+LAUNCHD_THROTTLE_GRACE_SECONDS = 60.0
 AUTH_FAILURE_STOP_AFTER = 2
 PUBLICATION_FAILURE_STOP_AFTER = 2
 RUNTIME_FAILURE_STOP_AFTER = 1
@@ -119,6 +121,13 @@ class ProofFirstRuntimeState:
     recovery_attempt_counts: dict[str, int] = field(default_factory=dict)
     last_benchmark_run_id: int | None = None
     last_triggered_benchmark_run_id: int | None = None
+
+
+@dataclass(frozen=True)
+class LaunchdServiceStatus:
+    state: str = ""
+    minimum_runtime_seconds: int | None = None
+    detail: str = ""
 
 
 def _utc_now() -> datetime:
@@ -526,6 +535,54 @@ def process_running(pattern: str) -> bool:
     return proc.returncode == 0 and bool(proc.stdout.strip())
 
 
+def inspect_launchd_service(label: str) -> LaunchdServiceStatus:
+    """Inspect launchd state without failing the shift when launchctl is unavailable."""
+    uid = os.getuid()
+    try:
+        proc = subprocess.run(
+            ["launchctl", "print", f"gui/{uid}/{label}"],
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return LaunchdServiceStatus(detail=f"launchctl print timed out for {label}")
+    detail = "\n".join(part.strip() for part in (proc.stdout, proc.stderr) if part.strip())
+    if proc.returncode != 0:
+        return LaunchdServiceStatus(detail=detail or f"launchctl print failed for {label}")
+
+    state = ""
+    minimum_runtime_seconds: int | None = None
+    for raw_line in detail.splitlines():
+        line = raw_line.strip()
+        if line.startswith("state = ") and not state:
+            state = line.removeprefix("state = ").strip()
+        elif line.startswith("minimum runtime = "):
+            value = line.removeprefix("minimum runtime = ").strip()
+            if value.isdigit():
+                minimum_runtime_seconds = int(value)
+    return LaunchdServiceStatus(
+        state=state,
+        minimum_runtime_seconds=minimum_runtime_seconds,
+        detail=detail,
+    )
+
+
+def launchd_start_timeout_seconds(
+    status: LaunchdServiceStatus,
+    *,
+    fallback_seconds: float = DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS,
+) -> float:
+    """Return a process wait long enough for launchd throttle-backed spawns."""
+    if status.state == "spawn scheduled" and status.minimum_runtime_seconds:
+        return max(
+            fallback_seconds,
+            float(status.minimum_runtime_seconds) + LAUNCHD_THROTTLE_GRACE_SECONDS,
+        )
+    return fallback_seconds
+
+
 def wait_for_process(
     pattern: str, *, timeout_seconds: float = 45.0, interval_seconds: float = 1.0
 ) -> bool:
@@ -575,10 +632,24 @@ def restart_service_via_launchd(
     *,
     label: str,
     process_pattern: str,
-    start_timeout_seconds: float = 45.0,
+    start_timeout_seconds: float | None = None,
 ) -> tuple[bool, str]:
+    initial_status = (
+        inspect_launchd_service(label) if start_timeout_seconds is None else LaunchdServiceStatus()
+    )
+    wait_timeout_seconds = (
+        launchd_start_timeout_seconds(initial_status)
+        if start_timeout_seconds is None
+        else start_timeout_seconds
+    )
     kicked, detail = kickstart_launchd(label)
-    if wait_for_process(process_pattern, timeout_seconds=start_timeout_seconds):
+    if start_timeout_seconds is None:
+        current_status = inspect_launchd_service(label)
+        wait_timeout_seconds = max(
+            wait_timeout_seconds,
+            launchd_start_timeout_seconds(current_status),
+        )
+    if wait_for_process(process_pattern, timeout_seconds=wait_timeout_seconds):
         return True, "" if kicked else detail
     if kicked:
         return (

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -231,6 +231,26 @@ def test_restart_service_treats_kickstart_timeout_as_success_when_process_appear
     assert detail == "launchctl timed out"
 
 
+def test_restart_service_waits_through_launchd_spawn_schedule() -> None:
+    status = mod.LaunchdServiceStatus(state="spawn scheduled", minimum_runtime_seconds=300)
+    with (
+        patch("scripts.run_proof_first_shift.inspect_launchd_service", return_value=status),
+        patch(
+            "scripts.run_proof_first_shift.kickstart_launchd",
+            return_value=(False, "launchctl timed out"),
+        ),
+        patch("scripts.run_proof_first_shift.wait_for_process", return_value=True) as wait_mock,
+    ):
+        ok, detail = mod.restart_service_via_launchd(
+            label="com.aragora.swarm-boss-loop",
+            process_pattern="boss-loop",
+        )
+
+    assert ok is True
+    assert detail == "launchctl timed out"
+    assert wait_mock.call_args.kwargs["timeout_seconds"] >= 360
+
+
 def test_restart_service_waits_for_successful_kickstart_process_start() -> None:
     with (
         patch("scripts.run_proof_first_shift.kickstart_launchd", return_value=(True, "")),
@@ -245,6 +265,38 @@ def test_restart_service_waits_for_successful_kickstart_process_start() -> None:
 
     assert ok is True
     assert detail == ""
+
+
+def test_launchd_start_timeout_uses_default_for_non_throttled_state() -> None:
+    assert (
+        mod.launchd_start_timeout_seconds(mod.LaunchdServiceStatus(state="running"))
+        == mod.DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS
+    )
+
+
+def test_inspect_launchd_service_keeps_top_level_state() -> None:
+    output = """
+gui/501/com.aragora.swarm-boss-loop = {
+    state = spawn scheduled
+    minimum runtime = 300
+    resource coalition = {
+        state = active
+    }
+}
+"""
+    with patch(
+        "scripts.run_proof_first_shift.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["launchctl", "print", "gui/501/com.aragora.swarm-boss-loop"],
+            returncode=0,
+            stdout=output,
+            stderr="",
+        ),
+    ):
+        status = mod.inspect_launchd_service("com.aragora.swarm-boss-loop")
+
+    assert status.state == "spawn scheduled"
+    assert status.minimum_runtime_seconds == 300
 
 
 def test_run_shift_cycle_exhausts_restart_budget_within_shift_window() -> None:


### PR DESCRIPTION
## Summary\n- inspect launchd service state before/after kickstart\n- wait through spawn-scheduled throttle windows using launchd minimum runtime plus grace\n- keep top-level launchd state parsing from being overwritten by nested coalition states\n\n## Validation\n- python3 -m pytest tests/scripts/test_run_proof_first_shift.py -q\n- python3 -m ruff check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD