### PR TITLE
fix(canvas): accept transition id approvals

### DIFF
--- a/aragora/live/src/hooks/__tests__/usePipelineCanvas.test.ts
+++ b/aragora/live/src/hooks/__tests__/usePipelineCanvas.test.ts
@@ -507,4 +507,53 @@ describe('usePipelineCanvas', () => {
       expect(result.current.error).toBe('Failed to run pipeline');
     });
   });
+
+  // ---- transition approval --------------------------------------------
+
+  describe('transition approval', () => {
+    it('sends transition_id for approve-transition', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      const { result } = renderHook(() => usePipelineCanvas('test-1', MOCK_API_RESPONSE));
+
+      await act(async () => {
+        await result.current.approveTransition('trans-ideas-goals');
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://backend.test/api/v1/canvas/pipeline/test-1/approve-transition',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({
+        transition_id: 'trans-ideas-goals',
+        approved: true,
+      });
+    });
+
+    it('sends transition_id and reason for rejected transitions', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      const { result } = renderHook(() => usePipelineCanvas('test-1', MOCK_API_RESPONSE));
+
+      await act(async () => {
+        await result.current.rejectTransition('trans-ideas-goals', 'Needs clearer goals');
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://backend.test/api/v1/canvas/pipeline/test-1/approve-transition',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({
+        transition_id: 'trans-ideas-goals',
+        approved: false,
+        reason: 'Needs clearer goals',
+      });
+    });
+  });
 });

--- a/aragora/server/handlers/canvas_pipeline.py
+++ b/aragora/server/handlers/canvas_pipeline.py
@@ -2042,22 +2042,42 @@ class CanvasPipelineHandler:
 
         from_stage = request_data.get("from_stage", "")
         to_stage = request_data.get("to_stage", "")
+        transition_id = str(request_data.get("transition_id") or "")
         # Default to True when "approved" is not explicitly provided --
         # the frontend calls approve-transition without this field to
         # approve, and sets approved=false to reject.
         approved = request_data.get("approved", True)
-        comment = request_data.get("comment", "")
+        comment = request_data.get("comment", request_data.get("reason", ""))
+
+        transitions = existing.get("transitions", [])
+        if not isinstance(transitions, list):
+            transitions = []
+
+        if transition_id and (not from_stage or not to_stage):
+            for transition in transitions:
+                if not isinstance(transition, dict):
+                    continue
+                if str(transition.get("id") or "") == transition_id:
+                    from_stage = transition.get("from_stage", "")
+                    to_stage = transition.get("to_stage", "")
+                    break
+            else:
+                return error_response(f"Transition {transition_id} not found", 404)
 
         if not from_stage or not to_stage:
             return error_response("Missing required fields: from_stage, to_stage", 400)
 
         # Find and update the matching transition
-        transitions = existing.get("transitions", [])
         updated = False
         for transition in transitions:
+            if not isinstance(transition, dict):
+                continue
             t_from = transition.get("from_stage", "")
             t_to = transition.get("to_stage", "")
-            if t_from == from_stage and t_to == to_stage:
+            t_id = str(transition.get("id") or "")
+            if (transition_id and t_id == transition_id) or (
+                t_from == from_stage and t_to == to_stage
+            ):
                 transition["status"] = "approved" if approved else "rejected"
                 transition["human_comment"] = comment
                 transition["reviewed_at"] = time.time()

--- a/tests/server/handlers/test_canvas_pipeline_endpoints.py
+++ b/tests/server/handlers/test_canvas_pipeline_endpoints.py
@@ -564,6 +564,24 @@ class TestHandleListOrLatest:
 
 
 class TestHandleApproveTransitionRootPath:
+    def _save_pipeline_with_transition(self, pipeline_id: str = "pipe-transition-id") -> str:
+        _get_store().save(
+            pipeline_id,
+            {
+                "pipeline_id": pipeline_id,
+                "stage_status": {"ideas": "complete", "goals": "pending"},
+                "transitions": [
+                    {
+                        "id": "trans-ideas-goals",
+                        "from_stage": "ideas",
+                        "to_stage": "goals",
+                        "status": "pending",
+                    }
+                ],
+            },
+        )
+        return pipeline_id
+
     @pytest.mark.asyncio
     async def test_approve_transition_defaults_to_approved(self, handler, sample_cartographer_data):
         """Calling approve-transition without 'approved' field should default to True."""
@@ -602,6 +620,42 @@ class TestHandleApproveTransitionRootPath:
         body = _body(result)
         assert body["status"] == "rejected"
         assert body["comment"] == "Not ready"
+
+    @pytest.mark.asyncio
+    async def test_approve_transition_accepts_transition_id_payload(self, handler):
+        pipeline_id = self._save_pipeline_with_transition("pipe-approve-transition-id")
+
+        result = await handler.handle_approve_transition(
+            pipeline_id,
+            {
+                "transition_id": "trans-ideas-goals",
+                "approved": True,
+            },
+        )
+        body = _body(result)
+        assert body["status"] == "approved"
+        assert body["from_stage"] == "ideas"
+        assert body["to_stage"] == "goals"
+        assert body["result"]["transitions"][0]["status"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_reject_transition_accepts_transition_id_and_reason(self, handler):
+        pipeline_id = self._save_pipeline_with_transition("pipe-reject-transition-id")
+
+        result = await handler.handle_approve_transition(
+            pipeline_id,
+            {
+                "transition_id": "trans-ideas-goals",
+                "approved": False,
+                "reason": "Needs clearer goals",
+            },
+        )
+        body = _body(result)
+        assert body["status"] == "rejected"
+        assert body["comment"] == "Needs clearer goals"
+        transition = body["result"]["transitions"][0]
+        assert transition["status"] == "rejected"
+        assert transition["human_comment"] == "Needs clearer goals"
 
     @pytest.mark.asyncio
     async def test_approve_transition_returns_updated_pipeline(


### PR DESCRIPTION
## Summary
- accept the live pipeline canvas approve/reject payload that sends transition_id
- resolve transition_id to from_stage/to_stage on the backend while preserving the root from_stage/to_stage contract
- map frontend rejection reason into the stored human comment
- add backend and hook regression coverage for the contract alignment

Closes #6009.

## Validation
- python3 -m pytest tests/server/handlers/test_canvas_pipeline_endpoints.py -q
- python3 -m pytest tests/server/handlers/test_canvas_pipeline_endpoints.py tests/test_openapi_contract_core.py -q
- python3 -m ruff check aragora/server/handlers/canvas_pipeline.py tests/server/handlers/test_canvas_pipeline_endpoints.py
- python3 scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- direct probe: transition_id approve/reject both return 200

## Local gap
- npm --prefix aragora/live test -- --runInBand src/hooks/__tests__/usePipelineCanvas.test.ts could not run locally because jest is not installed in this worktree; CI should exercise the TypeScript side.