### PR TITLE
fix(autonomy): use user gh auth for queue mutations

### DIFF
--- a/scripts/reconcile_proof_first_queue.py
+++ b/scripts/reconcile_proof_first_queue.py
@@ -33,6 +33,16 @@ def is_github_connectivity_error(message: str) -> bool:
     return any(token in lowered for token in GITHUB_CONNECTIVITY_ERROR_TOKENS)
 
 
+def github_read_env() -> dict[str, str]:
+    return github_cli_env()
+
+
+def github_write_env() -> dict[str, str]:
+    # The installation token is intentionally read-optimized for quota isolation.
+    # Label mutation and issue creation still need the user's gh credentials.
+    return github_cli_env(prefer_app=False)
+
+
 def list_open_queue_issues(*, repo: str, label: str) -> list[dict[str, Any]]:
     result = subprocess.run(
         [
@@ -54,7 +64,7 @@ def list_open_queue_issues(*, repo: str, label: str) -> list[dict[str, Any]]:
         text=True,
         timeout=30,
         check=False,
-        env=github_cli_env(),
+        env=github_read_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "gh issue list failed")
@@ -80,7 +90,7 @@ def remove_queue_label(*, repo: str, issue_number: int, label: str) -> None:
         text=True,
         timeout=30,
         check=False,
-        env=github_cli_env(),
+        env=github_write_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "gh issue edit failed")
@@ -171,7 +181,7 @@ def find_existing_open_issue_by_title(*, repo: str, title: str) -> dict[str, Any
         text=True,
         timeout=30,
         check=False,
-        env=github_cli_env(),
+        env=github_read_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "gh issue list failed")
@@ -196,7 +206,7 @@ def create_issue(*, repo: str, title: str, body: str, labels: list[str]) -> dict
         text=True,
         timeout=30,
         check=False,
-        env=github_cli_env(),
+        env=github_write_env(),
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "gh issue create failed")

--- a/tests/scripts/test_reconcile_proof_first_queue.py
+++ b/tests/scripts/test_reconcile_proof_first_queue.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from scripts import reconcile_proof_first_queue as mod
 
@@ -194,3 +195,44 @@ def test_reconcile_proof_first_queue_treats_graphql_quota_as_github_unavailable(
         "operation": "list_open_queue_issues",
         "error": "GraphQL: API rate limit already exceeded for user ID 123",
     }
+
+
+def test_queue_reads_prefer_app_env_and_label_removal_uses_user_env(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_github_cli_env(*, prefer_app: bool = True) -> dict[str, str]:
+        return {"AUTH_SOURCE": "app" if prefer_app else "user"}
+
+    def fake_run(cmd: list[str], **kwargs: Any):
+        calls.append({"cmd": cmd, "env": kwargs.get("env")})
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return mod.subprocess.CompletedProcess(cmd, 0, "[]", "")
+        return mod.subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mod, "github_cli_env", fake_github_cli_env)
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    mod.list_open_queue_issues(repo="org/repo", label="boss-ready")
+    mod.remove_queue_label(repo="org/repo", issue_number=1, label="boss-ready")
+
+    assert calls[0]["env"] == {"AUTH_SOURCE": "app"}
+    assert calls[1]["env"] == {"AUTH_SOURCE": "user"}
+
+
+def test_create_issue_uses_user_env(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_github_cli_env(*, prefer_app: bool = True) -> dict[str, str]:
+        return {"AUTH_SOURCE": "app" if prefer_app else "user"}
+
+    def fake_run(cmd: list[str], **kwargs: Any):
+        calls.append({"cmd": cmd, "env": kwargs.get("env")})
+        return mod.subprocess.CompletedProcess(cmd, 0, "https://github.com/org/repo/issues/1\n", "")
+
+    monkeypatch.setattr(mod, "github_cli_env", fake_github_cli_env)
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    issue = mod.create_issue(repo="org/repo", title="Title", body="Body", labels=["boss-ready"])
+
+    assert issue["url"] == "https://github.com/org/repo/issues/1"
+    assert calls[0]["env"] == {"AUTH_SOURCE": "user"}


### PR DESCRIPTION
## Summary\n- keep proof-first queue reads on the GitHub App installation token for quota isolation\n- run queue label mutations and issue creation through normal user gh credentials\n- add focused tests for read/write auth source separation\n\n## Validation\n- python3 -m pytest tests/scripts/test_reconcile_proof_first_queue.py -q\n- python3 -m ruff check scripts/reconcile_proof_first_queue.py tests/scripts/test_reconcile_proof_first_queue.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD