### PR TITLE
fix(sdk): cover canvas pipeline root routes

### DIFF
--- a/sdk/python/aragora_sdk/namespaces/pipeline.py
+++ b/sdk/python/aragora_sdk/namespaces/pipeline.py
@@ -14,6 +14,10 @@ class PipelineAPI:
     def __init__(self, client: AragoraClient):
         self._client = client
 
+    def list_pipelines(self) -> dict[str, Any]:
+        """List saved canvas pipelines."""
+        return self._client.request("GET", "/api/v1/canvas/pipeline")
+
     def run(
         self,
         input_text: str,
@@ -173,6 +177,30 @@ class PipelineAPI:
         return self._client.request(
             "POST",
             f"/api/v1/canvas/pipeline/{pipeline_id}/approve-transition",
+            json=payload,
+        )
+
+    def approve_pipeline_transition(
+        self,
+        pipeline_id: str,
+        from_stage: str,
+        to_stage: str,
+        *,
+        approved: bool = True,
+        comment: str | None = None,
+    ) -> dict[str, Any]:
+        """Approve or reject a transition through the root compatibility route."""
+        payload: dict[str, Any] = {
+            "pipeline_id": pipeline_id,
+            "from_stage": from_stage,
+            "to_stage": to_stage,
+            "approved": approved,
+        }
+        if comment:
+            payload["comment"] = comment
+        return self._client.request(
+            "POST",
+            "/api/v1/canvas/pipeline/approve-transition",
             json=payload,
         )
 
@@ -867,6 +895,10 @@ class AsyncPipelineAPI:
     def __init__(self, client: AragoraAsyncClient):
         self._client = client
 
+    async def list_pipelines(self) -> dict[str, Any]:
+        """List saved canvas pipelines."""
+        return await self._client.request("GET", "/api/v1/canvas/pipeline")
+
     async def run(
         self,
         input_text: str,
@@ -1005,6 +1037,30 @@ class AsyncPipelineAPI:
         return await self._client.request(
             "POST",
             f"/api/v1/canvas/pipeline/{pipeline_id}/approve-transition",
+            json=payload,
+        )
+
+    async def approve_pipeline_transition(
+        self,
+        pipeline_id: str,
+        from_stage: str,
+        to_stage: str,
+        *,
+        approved: bool = True,
+        comment: str | None = None,
+    ) -> dict[str, Any]:
+        """Approve or reject a transition through the root compatibility route."""
+        payload: dict[str, Any] = {
+            "pipeline_id": pipeline_id,
+            "from_stage": from_stage,
+            "to_stage": to_stage,
+            "approved": approved,
+        }
+        if comment:
+            payload["comment"] = comment
+        return await self._client.request(
+            "POST",
+            "/api/v1/canvas/pipeline/approve-transition",
             json=payload,
         )
 

--- a/sdk/python/tests/test_pipeline.py
+++ b/sdk/python/tests/test_pipeline.py
@@ -1,0 +1,82 @@
+"""Tests for the Pipeline namespace API."""
+
+from __future__ import annotations
+
+from unittest.mock import call, patch
+
+import pytest
+
+from aragora_sdk.client import AragoraAsyncClient, AragoraClient
+
+
+class TestPipelineSync:
+    """Synchronous pipeline endpoint tests."""
+
+    def test_root_pipeline_routes(self) -> None:
+        with patch.object(AragoraClient, "request") as mock_request:
+            mock_request.return_value = {"ok": True}
+            client = AragoraClient(base_url="https://api.aragora.ai", api_key="test-key")
+
+            client.pipeline.list_pipelines()
+            client.pipeline.approve_pipeline_transition(
+                "pipe-1",
+                "ideas",
+                "goals",
+                approved=False,
+                comment="needs refinement",
+            )
+
+            mock_request.assert_has_calls(
+                [
+                    call("GET", "/api/v1/canvas/pipeline"),
+                    call(
+                        "POST",
+                        "/api/v1/canvas/pipeline/approve-transition",
+                        json={
+                            "pipeline_id": "pipe-1",
+                            "from_stage": "ideas",
+                            "to_stage": "goals",
+                            "approved": False,
+                            "comment": "needs refinement",
+                        },
+                    ),
+                ]
+            )
+            client.close()
+
+
+class TestPipelineAsync:
+    """Asynchronous pipeline endpoint tests."""
+
+    @pytest.mark.asyncio
+    async def test_root_pipeline_routes(self) -> None:
+        with patch.object(AragoraAsyncClient, "request") as mock_request:
+            mock_request.return_value = {"ok": True}
+            client = AragoraAsyncClient(base_url="https://api.aragora.ai", api_key="test-key")
+
+            await client.pipeline.list_pipelines()
+            await client.pipeline.approve_pipeline_transition(
+                "pipe-1",
+                "ideas",
+                "goals",
+                approved=False,
+                comment="needs refinement",
+            )
+
+            mock_request.assert_has_calls(
+                [
+                    call("GET", "/api/v1/canvas/pipeline"),
+                    call(
+                        "POST",
+                        "/api/v1/canvas/pipeline/approve-transition",
+                        json={
+                            "pipeline_id": "pipe-1",
+                            "from_stage": "ideas",
+                            "to_stage": "goals",
+                            "approved": False,
+                            "comment": "needs refinement",
+                        },
+                    ),
+                ]
+            )
+            await client.close()

--- a/sdk/typescript/src/namespaces/__tests__/cross-sdk-python-compat-routes.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/cross-sdk-python-compat-routes.test.ts
@@ -52,12 +52,31 @@ describe('Cross SDK Python Compatibility Routes', () => {
     await api.tasksToWorkflow({ pipeline_id: 'p1' });
     await api.executeTransitions({ pipeline_id: 'p1' });
     await api.getTransitionProvenance('n/1');
+    await api.listPipelines();
+    await api.approvePipelineTransition('pipe-1', 'ideas', 'goals', {
+      approved: false,
+      comment: 'needs refinement',
+    });
 
     expect(mockClient.request).toHaveBeenNthCalledWith(1, 'POST', '/api/v1/canvas/pipeline/demo', {
       body: { ideas: ['a'] },
     });
     expect(mockClient.request).toHaveBeenNthCalledWith(10, 'GET', '/api/v1/pipeline/graph/g%2F1');
     expect(mockClient.request).toHaveBeenNthCalledWith(24, 'GET', '/api/v1/pipeline/transitions/n%2F1/provenance');
+    expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/canvas/pipeline');
+    expect(mockClient.request).toHaveBeenCalledWith(
+      'POST',
+      '/api/v1/canvas/pipeline/approve-transition',
+      {
+        body: {
+          pipeline_id: 'pipe-1',
+          from_stage: 'ideas',
+          to_stage: 'goals',
+          approved: false,
+          comment: 'needs refinement',
+        },
+      }
+    );
   });
 
   it('maps costs analytics compatibility routes', async () => {

--- a/sdk/typescript/src/namespaces/pipeline.ts
+++ b/sdk/typescript/src/namespaces/pipeline.ts
@@ -95,6 +95,16 @@ export class PipelineNamespace {
   constructor(private client: AragoraClient) {}
 
   /**
+   * List saved canvas pipelines.
+   */
+  async listPipelines(): Promise<Record<string, unknown>> {
+    return this.client.request<Record<string, unknown>>(
+      'GET',
+      '/api/v1/canvas/pipeline'
+    );
+  }
+
+  /**
    * Start an async pipeline execution.
    *
    * Runs the 4-stage pipeline: ideation → goals → workflow → orchestration.
@@ -250,6 +260,30 @@ export class PipelineNamespace {
       `/api/v1/canvas/pipeline/${encodeURIComponent(pipelineId)}/approve-transition`,
       {
         body: {
+          from_stage: fromStage,
+          to_stage: toStage,
+          approved: options?.approved ?? true,
+          ...(options?.comment ? { comment: options.comment } : {}),
+        },
+      }
+    );
+  }
+
+  /**
+   * Approve or reject a pending stage transition through the root route.
+   */
+  async approvePipelineTransition(
+    pipelineId: string,
+    fromStage: string,
+    toStage: string,
+    options?: { approved?: boolean; comment?: string },
+  ): Promise<Record<string, unknown>> {
+    return this.client.request<Record<string, unknown>>(
+      'POST',
+      '/api/v1/canvas/pipeline/approve-transition',
+      {
+        body: {
+          pipeline_id: pipelineId,
           from_stage: fromStage,
           to_stage: toStage,
           approved: options?.approved ?? true,

--- a/tests/sdk/test_contract_parity.py
+++ b/tests/sdk/test_contract_parity.py
@@ -54,10 +54,12 @@ OPENCLAW_ENDPOINTS: list[tuple[str, str]] = [
 
 PIPELINE_ENDPOINTS: list[tuple[str, str]] = [
     # Pipeline execution
+    ("GET", "/api/v1/canvas/pipeline"),
     ("POST", "/api/v1/canvas/pipeline/run"),
     ("POST", "/api/v1/canvas/pipeline/from-debate"),
     ("POST", "/api/v1/canvas/pipeline/from-ideas"),
     ("POST", "/api/v1/canvas/pipeline/advance"),
+    ("POST", "/api/v1/canvas/pipeline/approve-transition"),
     ("POST", "/api/v1/canvas/pipeline/{id}/approve-transition"),
     # Pipeline queries
     ("GET", "/api/v1/canvas/pipeline/{id}"),


### PR DESCRIPTION
Adds Python and TypeScript SDK coverage for CanvasPipeline root list and approve-transition routes. Validation: pytest sdk/python/tests/test_pipeline.py tests/sdk/test_contract_parity.py; ruff; check_sdk_parity; npm typecheck; focused vitest; preflight.