### PR TITLE
fix(autonomy): strip app tokens from queue writes

### DIFF
--- a/scripts/reconcile_proof_first_queue.py
+++ b/scripts/reconcile_proof_first_queue.py
@@ -39,8 +39,14 @@ def github_read_env() -> dict[str, str]:
 
 def github_write_env() -> dict[str, str]:
     # The installation token is intentionally read-optimized for quota isolation.
-    # Label mutation and issue creation still need the user's gh credentials.
-    return github_cli_env(prefer_app=False)
+    # Label mutation and issue creation must fall back to the user's gh
+    # credentials, even when this process inherited an app-token gh env.
+    env = github_cli_env(prefer_app=False)
+    if str(env.get("ARAGORA_GITHUB_AUTH_SOURCE") or "").strip() == "github_app_installation":
+        env.pop("GH_TOKEN", None)
+        env.pop("GITHUB_TOKEN", None)
+        env.pop("ARAGORA_GITHUB_AUTH_SOURCE", None)
+    return env
 
 
 def list_open_queue_issues(*, repo: str, label: str) -> list[dict[str, Any]]:

--- a/tests/scripts/test_reconcile_proof_first_queue.py
+++ b/tests/scripts/test_reconcile_proof_first_queue.py
@@ -219,6 +219,45 @@ def test_queue_reads_prefer_app_env_and_label_removal_uses_user_env(monkeypatch)
     assert calls[1]["env"] == {"AUTH_SOURCE": "user"}
 
 
+def test_github_write_env_strips_inherited_app_token_env(monkeypatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", "app-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "app-token")
+    monkeypatch.setenv("ARAGORA_GITHUB_AUTH_SOURCE", "github_app_installation")
+    monkeypatch.setenv("KEEP_ME", "value")
+
+    env = mod.github_write_env()
+
+    assert "GH_TOKEN" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert "ARAGORA_GITHUB_AUTH_SOURCE" not in env
+    assert env["KEEP_ME"] == "value"
+
+
+def test_write_subprocesses_strip_inherited_app_token_env(monkeypatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", "app-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "app-token")
+    monkeypatch.setenv("ARAGORA_GITHUB_AUTH_SOURCE", "github_app_installation")
+    monkeypatch.setenv("KEEP_ME", "value")
+    calls: list[dict[str, Any]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any):
+        calls.append({"cmd": cmd, "env": kwargs.get("env")})
+        return mod.subprocess.CompletedProcess(cmd, 0, "https://github.com/org/repo/issues/1\n", "")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    mod.remove_queue_label(repo="org/repo", issue_number=1, label="boss-ready")
+    mod.create_issue(repo="org/repo", title="Title", body="Body", labels=["boss-ready"])
+
+    assert len(calls) == 2
+    for call in calls:
+        env = call["env"]
+        assert "GH_TOKEN" not in env
+        assert "GITHUB_TOKEN" not in env
+        assert "ARAGORA_GITHUB_AUTH_SOURCE" not in env
+        assert env["KEEP_ME"] == "value"
+
+
 def test_create_issue_uses_user_env(monkeypatch) -> None:
     calls: list[dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary
- Strip inherited GitHub App token env vars before proof-queue write subprocesses use gh
- Keep proof-queue reads on the app-token path
- Add focused regressions for github_write_env, label removal, and docs issue creation write envs

## Validation
- origin/main repro: github_write_env preserved GH_TOKEN/GITHUB_TOKEN when ARAGORA_GITHUB_AUTH_SOURCE=github_app_installation
- branch repro: github_write_env strips GH_TOKEN/GITHUB_TOKEN/ARAGORA_GITHUB_AUTH_SOURCE while preserving KEEP_ME
- python3 -m pytest -q -p no:cacheprovider tests/scripts/test_reconcile_proof_first_queue.py
- python3 -m ruff check scripts/reconcile_proof_first_queue.py tests/scripts/test_reconcile_proof_first_queue.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Dry run
- python3 scripts/reconcile_proof_first_queue.py --json completed; GitHub issue listing still degrades with api.github.com connectivity, no local docs drift.