### PR TITLE
docs: add epistemic ci and crux engine roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,000+ Python modules | 154,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 3,000+ Python modules | 155,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
 
 ## Architecture
 
@@ -432,7 +432,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-**Test Suite:** 154,000+ tests across 5,000+ test files
+**Test Suite:** 155,000+ tests across 5,000+ test files
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ aragora/
 └── workflow/       # DAG-based automation engine
 ```
 
-**Scale:** 3,000+ Python modules | 154,000+ tests across 5,000+ test files
+**Scale:** 3,000+ Python modules | 155,000+ tests across 5,000+ test files
 
 ### Performance and Costs
 

--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -5,7 +5,7 @@ description: Active Execution Issues
 
 # Active Execution Issues
 
-Last updated: 2026-04-14
+Last updated: 2026-04-16
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -26,8 +26,9 @@ Use it to create or reconcile GitHub issues. Keep issue titles stable when possi
 The strict status reconciler requires this canonical map to link the live execution backlog directly.
 
 - Enterprise assurance carryover: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), [#509](https://github.com/synaptent/aragora/issues/509)
-- Current execution epics: [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), [#806](https://github.com/synaptent/aragora/issues/806)
+- Execution epics (closed): [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), [#806](https://github.com/synaptent/aragora/issues/806) — all closed as of April 2026; current obligation is operationalizing the proof-first loop
 - Current execution lanes: [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
+- Future decision-integrity tranche: [#6023](https://github.com/synaptent/aragora/issues/6023), [#6024](https://github.com/synaptent/aragora/issues/6024), [#6025](https://github.com/synaptent/aragora/issues/6025), [#6026](https://github.com/synaptent/aragora/issues/6026), [#6027](https://github.com/synaptent/aragora/issues/6027), [#6028](https://github.com/synaptent/aragora/issues/6028) — Epistemic CI and Crux Engine planning; not live `boss-ready` work
 
 ## Reverse-Staged Rocket Bootstrap
 
@@ -38,20 +39,21 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B0 — Corpus** | Prove `>=50%` no-rescue success on a fixed benchmark corpus | `RS-01..03`, `TW-02..03` |
 | **B1 — Assist** | Auto-draft safe work orders and validation plans | `BC-04..06`, `TW-07..09` |
 | **B2 — Guard** | Require contracts and production-like preflight before auto-run | `RS-04..09` |
-| **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
+| **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..12` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
-Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining near-term gate is keeping the recurring truth/productization surfaces boring and keeping claims narrower than proof, not reopening already-landed guard work.
+Status note: use `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md` as the live recurring proof surfaces instead of hardcoded percentages here. When the B0 surface is stale, incomplete, or otherwise untrustworthy, restoring benchmark publication completeness becomes the immediate gate again.
 
 ## Current 30-Day Execution Set
 
 Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 - Do now: `CS-01..03`
-- Delay: `BC-07..09`, `RS-10..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Delay: `BC-07..09`, `RS-11..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Future decision-integrity planning: `DIC-13..18` is tracked but delayed until proof-first Foreman reliability is stable; these issues must not be added to `boss-ready` during the current tranche
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
-- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should restock the queue only when they expose a fresh bounded regression or repeated rescue class
+- Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should keep the queue empty unless they expose a fresh bounded regression or repeated rescue class
 - `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 
 ## Epic 1 — Reliability Substrate
@@ -78,9 +80,9 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 ### Milestone 1.4 — Ledger & Self-Heal `[90d]`
 
-- [ ] **RS-10** Mirror probes, queue state, contracts, and receipts into `AutonomyLedger`
-- [ ] **RS-11** Add quarantine and fallback rules for auth drift, rate limits, permission mismatch, and publication failures
-- [ ] **RS-12** Cut `studio-health`, reporter, and status surfaces to ledger-backed truth
+- [x] **RS-10** Mirror probes, queue state, contracts, and receipts into `AutonomyLedger` _(Done 2026-04-15 via [#5857](https://github.com/synaptent/aragora/pull/5857))_
+- [ ] **RS-11** Add quarantine and fallback rules for auth drift, rate limits, permission mismatch, and publication failures _(Partial 2026-04-15: one-shot recovery budgets and fail-closed handling landed for auth drift, GitHub outage, publication failure, and boss/merge restart failures via [#5867](https://github.com/synaptent/aragora/pull/5867); rate-limit and permission-mismatch coverage still need explicit policy.)_
+- [ ] **RS-12** Cut `studio-health`, reporter, and status surfaces to ledger-backed truth _(Partial 2026-04-15: `swarm status`, FastAPI swarm-status routes, and `studio-health.sh` now prefer ledger-backed truth via [#5861](https://github.com/synaptent/aragora/pull/5861) and [#5868](https://github.com/synaptent/aragora/pull/5868); reporter and remaining status surfaces are still incomplete.)_
 
 ## Epic 2 — Bounded Autonomy Control Plane
 
@@ -108,7 +110,7 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 - [ ] **BC-10** Run repeated multi-host soak tests on the bounded backlog
 - [ ] **BC-11** Route Nomic-generated work through the same substrate as operator work
-- [ ] **BC-12** Define explicit stop/go criteria for unattended 12-hour runs
+- [ ] **BC-12** Define explicit stop/go criteria for unattended 12-hour runs _(Partial 2026-04-15: proof-first shifts now emit machine-readable `green_shift_evaluation` via [#5867](https://github.com/synaptent/aragora/pull/5867), but the 12-hour unattended gate is not yet proven by repeated green runs.)_
 
 ## Epic 3 — Trust-Wedge Product Loops
 
@@ -221,6 +223,19 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 - [ ] **DIC-10** Add side-by-side debate and execution comparison surfaces
 - [ ] **DIC-11** Show idea -> receipt -> later settlement lineage end-to-end
 - [ ] **DIC-12** Produce board- and regulator-ready exports with dissent summaries
+
+### Milestone 6.5 — Crux Engine & Epistemic CI `[365d]`
+
+Design brief: [Epistemic CI and Crux Engine Plan](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+
+- [ ] **DIC-13** Define executable claim manifest schema ([#6023](https://github.com/synaptent/aragora/issues/6023))
+- [ ] **DIC-14** Add executable claim verification runner ([#6024](https://github.com/synaptent/aragora/issues/6024))
+- [ ] **DIC-15** Add `CruxSet` contract and crux-finder consensus mode ([#6025](https://github.com/synaptent/aragora/issues/6025))
+- [ ] **DIC-16** Extend receipts and Knowledge Mound for claim/crux provenance ([#6026](https://github.com/synaptent/aragora/issues/6026))
+- [ ] **DIC-17** Bridge failed claims and unresolved cruxes into bounded follow-up work ([#6027](https://github.com/synaptent/aragora/issues/6027))
+- [ ] **DIC-18** Add organizational truth map operator report ([#6028](https://github.com/synaptent/aragora/issues/6028))
+
+Queue rule: this milestone is not part of the current live dispatch lane. Its issues remain planning/future-tranche work until the proof-first Foreman gate permits decision-integrity expansion.
 
 ## Epic 7 — Commercialization & Scale-Out
 

--- a/docs-site/docs/contributing/aragora-evolution-roadmap.md
+++ b/docs-site/docs/contributing/aragora-evolution-roadmap.md
@@ -5,13 +5,15 @@ description: Aragora Evolution Roadmap
 
 # Aragora Evolution Roadmap
 
-> **Last updated:** 2026-04-09
+> **Last updated:** 2026-04-16
 > **Current transition:** early `Teammate` -> reliable `Foreman`
 > **Planning rule:** preserve the maximalist vision; sequence through a narrow reliability wedge first.
 
 ## Executive Thesis
 
 Aragora is trying to become an autonomous chief of staff, an engineering organization substrate, and a decision-integrity control plane — not just a better coding agent.
+
+The distinctive long-horizon direction is **organizational epistemic infrastructure**: debates should surface load-bearing cruxes, receipts should preserve claim evidence, and important organizational claims should become executable objects with freshness, verification, provenance, and bounded repair paths. This expands the decision-integrity core without replacing the current proof-first autonomy wedge.
 
 The efficient path is not to build every ambitious surface at once. The wedge is reliable autonomous software execution on bounded backlogs, with receipts, human-control surfaces, and a truthful operator view. The unified DAG GUI remains a parallel second track, but it must reflect live runtime truth rather than speculative mock state.
 
@@ -207,6 +209,17 @@ This track preserves Aragora's core differentiation from generic agent platforms
 - show idea -> receipt -> later-settlement lineage
 - produce board- and regulator-ready exports without losing technical depth
 
+#### E5. Crux Engine and Epistemic CI
+
+- define a `CruxSet` output for the 3-5 load-bearing disagreements that would change a decision if resolved differently
+- define executable claim manifests for organizational claims with owner, evidence, freshness SLA, verifier, receipt links, and failure behavior
+- verify explicit claims before inferring claims automatically from docs, Slack, issues, or receipts
+- persist claim and crux provenance through receipts and Knowledge Mound
+- bridge failed claims and unresolved high-load-bearing cruxes into exactly one bounded follow-up issue only when queue governance permits it
+- expose a read-only organizational truth map showing what Aragora believes, why, how fresh the evidence is, and what is decaying
+
+Design brief: [Epistemic CI and Crux Engine Plan](EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+
 ### Track F — Trust-Wedge Productization and GTM
 
 This track converts technical proof into market proof.
@@ -242,6 +255,8 @@ This track converts technical proof into market proof.
 - If humans intervene twice for the same failure class, the next change should productize that rescue.
 - Memory without provenance is out of scope.
 - GUI surfaces must read ledger-backed truth.
+- Claims that matter should become executable, evidence-linked objects before they become product claims or queue work.
+- Cruxes should identify load-bearing disagreement, not merely summarize dissent.
 - Broad vertical and enterprise expansion follows wedge proof; it does not replace it.
 - External claims should always lag measured internal proof.
 

--- a/docs-site/docs/contributing/b0-benchmark-truth-status.md
+++ b/docs-site/docs/contributing/b0-benchmark-truth-status.md
@@ -5,7 +5,7 @@ description: B0 Benchmark Truth Status
 
 # B0 Benchmark Truth Status
 
-Last updated: 2026-04-14T18:12:28Z
+Last updated: 2026-04-15T23:05:41Z
 
 This is the repo-tracked recurring `TW-02` publication surface for the fixed benchmark corpus.
 
@@ -13,43 +13,61 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 
 - Corpus manifest: `docs/benchmarks/corpus.json`
 - Corpus id: `tw-01-bounded-execution-v1`
-- Revision: `1`
-- Recorded on: `2026-04-13`
+- Revision: `2`
+- Recorded on: `2026-04-15`
 - Success contract: `mergeable_pr_or_merged_pr`
-- Coverage status: `incomplete`
-- Coverage: `1`/`5` issues attempted
-- Missing corpus issues: `1064`, `1641`, `1733`, `2712`
+- Coverage status: `complete`
+- Coverage: `5`/`5` issues attempted
 
 ## Published Paths
 
 - Latest truth artifact: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json`
 - Latest scorecard: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/latest.json`
-- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-1/latest.json`
-- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-1/latest.json`
+- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-2/latest.json`
+- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-2/latest.json`
 
 ## Truth Metrics
 
 | Metric | Value |
 | --- | --- |
-| Truth success rate | 60.0% |
-| No-rescue truth success rate | 40.0% |
-| Merged-only rate | 60.0% |
+| Truth success rate | 100.0% |
+| No-rescue truth success rate | 100.0% |
+| Merged-only rate | 100.0% |
 
 ## Proxy Metrics
 
 | Metric | Value |
 | --- | --- |
-| No-rescue success rate | 0.0% |
-| Unique issues attempted | 1 |
+| Proxy no-rescue success rate | 0.0% |
+| Unique issues attempted | 5 |
 | Unique issues succeeded | 0 |
-| Unique issues failed | 1 |
-| Total ticks | 4 |
+| Unique issues failed | 0 |
+| Unique issues neutral | 5 |
+| Total ticks | 5 |
+
+Proxy note: neutral issue outcomes are current-corpus rows that were neither fresh success nor failure, such as `issue_already_resolved`.
+
+## Proxy Neutral Class Distribution
+
+- `issue_already_resolved`: 5
 
 ## Failure Class Distribution
 
-- `blocked_sanitation_failed`: 1
-- `rescue_no_deliverable`: 3
+- none
 
 ## Rescue Counts By Type
 
-- `rescue_no_deliverable`: 3
+- none
+
+## Previous Published Artifact
+
+- Previous artifact path: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-2/scorecard-20260415T221228Z.json`
+- Previous generated_at: `2026-04-15T22:12:28Z`
+
+## Deltas
+
+- `merged_only_rate`: 1.0000
+- `no_rescue_truth_success_rate`: 1.0000
+- `proxy_no_rescue_success_rate`: 0.0000
+- `truth_success_rate`: 1.0000
+- `unique_issues_attempted`: 3.0000

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -7,7 +7,7 @@ description: "Aragora: Canonical Goals & Foundational Thesis"
 
 **Single source of truth for WHAT Aragora is and WHY it exists.**
 **The [Evolution Roadmap](./aragora-evolution-roadmap) defines HOW we get there.**
-**Last updated: April 9, 2026**
+**Last updated: April 16, 2026**
 
 ## Canonical Metrics (March 2026 baseline)
 
@@ -64,6 +64,8 @@ If a roadmap item does not strengthen one or more of those layers, it is probabl
 
 Any single model can hallucinate, flatter, or share hidden blind spots. Aragora's default stance is structured challenge across heterogeneous models, not trust in one witness. This pillar serves the debate engine, gauntlet, truth weighting, calibration, dissent capture, and cross-verification.
 
+The next differentiator is crux-finding: debates should identify the load-bearing facts, framings, values, and assumptions where reasonable agents diverge, not merely produce an answer.
+
 ### 2. Reliable Autonomous Execution
 
 Reasoning alone is not enough. The system must execute bounded work with explicit contracts, verification, and fail-closed escalation. This pillar serves swarm, supervisor, worker contracts, preflight, repair, publication, and self-heal.
@@ -79,6 +81,8 @@ Memory is only useful if it is permissioned, attributable, and relevance-ranked.
 ### 5. Cryptographic Receipts and Auditability
 
 Every consequential decision or execution step should be inspectable. Receipts, provenance links, signatures, and compliance artifacts are not side effects; they are the trust layer that makes autonomy acceptable in real organizations.
+
+Important organizational claims should also become executable, evidence-linked objects with freshness, verification, provenance, and bounded repair behavior. This is the Epistemic CI direction: what Aragora believes should be testable, not just written down.
 
 ### 6. SMB Operator Leverage
 
@@ -159,4 +163,5 @@ Aragora's trust story is structural:
 2. A bounded backlog can run unattended with clear receipts, stop conditions, and minimal rescue.
 3. Humans can inspect any decision or execution result from summary level down to evidence and provenance.
 4. Shared memory improves future work without collapsing trust boundaries.
-5. Aragora evolves from tool -> teammate -> foreman -> chief of staff -> organization substrate on one coherent runtime.
+5. Important claims and cruxes remain linked to evidence, receipts, freshness, and later settlement.
+6. Aragora evolves from tool -> teammate -> foreman -> chief of staff -> organization substrate on one coherent runtime.

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -189,7 +189,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,000+ Python modules | 154,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 3,000+ Python modules | 155,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
 
 ## Architecture
 
@@ -437,7 +437,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-**Test Suite:** 154,000+ tests across 5,000+ test files
+**Test Suite:** 155,000+ tests across 5,000+ test files
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -341,7 +341,7 @@ aragora/
 └── cli/              # Command-line interface
 ```
 
-**Scale:** 3,000+ Python modules | 154,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
+**Scale:** 3,000+ Python modules | 155,000+ tests across 5,000+ test files | 185 Python / 187 TypeScript SDK namespaces
 
 ---
 

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -5,7 +5,7 @@ description: Next Steps (Canonical)
 
 # Next Steps (Canonical)
 
-Last updated: 2026-04-14
+Last updated: 2026-04-16
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
@@ -15,7 +15,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is to keep `TW-01/TW-02/TW-03` recurring and boring on current `main`, and keep `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes in [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The immediate gate is keeping recurring benchmark truth publication complete, fresh, and trustworthy on current `main`, then keeping `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
 
 What is already true:
 
@@ -24,7 +24,7 @@ What is already true:
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
 - terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
-- the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
+- the recurring B0 benchmark truth surface is repo-tracked at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`; operator decisions should read the live published surface there instead of hardcoding percentages in this document
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
 - launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
 - receipt-backed preflight is now the default operator and live dispatch admission truth on `main` via [#5514](https://github.com/synaptent/aragora/pull/5514)
@@ -40,13 +40,19 @@ What is already true:
 - repeated rescue-class reports now include fixture-or-issue productization status on `main` via [#5535](https://github.com/synaptent/aragora/pull/5535)
 - repo-tracked recurring rescue productization now lands in `docs/status/generated/rescue_productization/`, with the stable status summary at `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`
 - the recurring `TW-03` harvest can now relink repeated rescue classes to tracked fixture/issue targets and auto-create bounded follow-on issues when a repeated class is still unlinked
+- proof-first runtime truth is now persisted in `ShiftLedger` on `main` via [#5857](https://github.com/synaptent/aragora/pull/5857)
+- proof-first shifts now fail closed after repeated recovery failures for the implemented failure classes via [#5867](https://github.com/synaptent/aragora/pull/5867)
+- `swarm status`, FastAPI swarm-status routes, and `studio-health.sh` now prefer ledger-backed operator truth on `main` via [#5861](https://github.com/synaptent/aragora/pull/5861) and [#5868](https://github.com/synaptent/aragora/pull/5868)
+- the future Decision Integrity expansion is now tracked as an additive Epistemic CI / Crux Engine tranche in [EPISTEMIC_CI_AND_CRUX_ENGINE](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md) and issues [#6023](https://github.com/synaptent/aragora/issues/6023)-[#6028](https://github.com/synaptent/aragora/issues/6028); it is planning truth, not current live queue scope
 
 What is still missing:
 
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
+- proof that recurring benchmark publication stays complete and fresh on `main` without operator babysitting
 - broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
 - ongoing discipline so external claims stay narrower than the recurring proof surfaces
+- delayed decision-integrity work that turns important claims into executable evidence-linked objects and debates into ranked `CruxSet` outputs, after the proof-first Foreman gate is stable
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”
 
@@ -64,7 +70,7 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
-Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; recurring truth publication and rescue productization are now repo-tracked status surfaces.
+Current status: `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md` are the live recurring proof surfaces. When benchmark publication drifts, lags, or lands incomplete corpus coverage, restoring that publication becomes the immediate gate again before any scope widening.
 
 Primary truth metric:
 
@@ -109,7 +115,7 @@ Scorecard output rules:
 ### Current state
 
 - Terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are on `main`.
-- The tracked B0 cohort is at **86.7%** no-rescue success as of 2026-04-13.
+- The latest recurring benchmark status must be read from `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, not copied into this document as a hardcoded percentage.
 - The frozen corpus manifest now lives at `docs/benchmarks/corpus.json`.
 - The diffable truth artifact path is `scripts/build_benchmark_truth_artifact.py`, with GitHub-truth reconciliation provided by `scripts/reconcile_b0_pr_truth.py`.
 - The stable recurring status surface is `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, backed by the latest JSON pointers under `docs/status/generated/benchmark_truth_artifacts/` and `docs/status/generated/benchmark_scorecards/`.
@@ -120,7 +126,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
-| 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Covered by [#804](https://github.com/synaptent/aragora/issues/804), [#806](https://github.com/synaptent/aragora/issues/806), and the current docs; no dedicated lane issue exists yet. |
+| 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Epics #804 and #806 are closed; enforcement is now via proof-first queue governance and recurring publication surfaces. |
 
 ## Do Now / Delay / Avoid
 
@@ -130,8 +136,9 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ### Delay
 
-- `BC-07..09` until the repair loop is truthful and resumable
-- `RS-10..12` until the operator-surface guard is real
+- `BC-07..09` until the repair loop is truthful, resumable, and consolidated into one operator model
+- `RS-11..12` until recovery-budget coverage extends to the remaining failure classes and the remaining status/reporter surfaces are ledger-backed
+- `DIC-13..18` until BC-12/Foreman reliability is proven; Epistemic CI and Crux Engine issues may stay open for planning but must not enter the live boss-ready queue
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
@@ -148,8 +155,8 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 ## Live Boss-Ready Queue
 
 - There is no dedicated open boss-ready trust-loop issue right now.
-- Keep `CS-01..03` enforced through the docs/status surfaces until a concrete bounded issue exists.
-- Let the recurring `TW-01/TW-02/TW-03` publication surfaces restock the queue only when they expose a fresh repeated rescue class or a concrete regression.
+- Keep the live queue empty unless the recurring `TW-01/TW-02/TW-03` publication surfaces expose a fresh repeated rescue class or a concrete regression.
+- Keep `CS-01..03` enforced through the docs/status surfaces while the live queue remains empty.
 
 `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)), `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)), and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) now publish through repo-tracked recurring status surfaces at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`. `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
 
@@ -157,7 +164,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 ### Booster 0 — Corpus
 
-Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This booster is already above target, so the remaining work is to keep it truthful while the guard layers catch up.
+Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This booster only counts as above target while the recurring B0 surface stays complete and fresh on current `main`; if publication drifts, restoring that surface takes priority over scope widening.
 
 ### Booster 1 — Assist
 

--- a/docs-site/docs/contributing/tw03-rescue-productization-status.md
+++ b/docs-site/docs/contributing/tw03-rescue-productization-status.md
@@ -5,7 +5,7 @@ description: TW-03 Rescue Productization Status
 
 # TW-03 Rescue Productization Status
 
-Last updated: 2026-04-14T19:45:47Z
+Last updated: 2026-04-15T23:05:42Z
 
 This is the repo-tracked recurring `TW-03` publication surface for repeated rescue-class harvest and conversion.
 

--- a/docs-site/docs/enterprise/why-aragora.md
+++ b/docs-site/docs/enterprise/why-aragora.md
@@ -50,7 +50,7 @@ This is not a theoretical approach. Multi-agent deliberation research (including
 | **Decision receipts** | Cryptographic audit trails with evidence chains, dissent tracking, and confidence calibration |
 | **Calibrated trust** | ELO rankings and Brier scores track which models are actually reliable on which domains |
 | **Hollow consensus detection** | The Trickster catches cases where models agree without genuine reasoning |
-| **Institutional memory** | Decisions persist across sessions with 4-tier memory and Knowledge Mound (45 adapters) |
+| **Institutional memory** | Decisions persist across sessions with 4-tier memory and Knowledge Mound (42 adapters) |
 | **Channel delivery** | Results route to Slack, Teams, Discord, Telegram, WhatsApp, email, or voice |
 
 ---
@@ -93,7 +93,7 @@ Aragora includes an autonomous self-improvement system where agents debate impro
 
 The MetaPlanner uses multiple codebase signal sources for self-directed goal generation, and now automatically extracts improvement goals from debate outcome patterns -- when debates consistently show low consensus or recurring failure modes, the system self-directs toward fixing those weaknesses.
 
-This is how the platform grew from a debate engine to 3,200+ modules with 208,000+ tests. No competitor has anything equivalent -- it is a structural advantage that compounds over time.
+This is how the platform grew from a debate engine to 3,000+ modules with 154,000+ tests. No competitor has anything equivalent -- it is a structural advantage that compounds over time.
 
 ---
 

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -2,7 +2,7 @@
 
 **Single source of truth for WHAT Aragora is and WHY it exists.**
 **The [Evolution Roadmap](plans/ARAGORA_EVOLUTION_ROADMAP.md) defines HOW we get there.**
-**Last updated: April 9, 2026**
+**Last updated: April 16, 2026**
 
 ## Canonical Metrics (March 2026 baseline)
 
@@ -59,6 +59,8 @@ If a roadmap item does not strengthen one or more of those layers, it is probabl
 
 Any single model can hallucinate, flatter, or share hidden blind spots. Aragora's default stance is structured challenge across heterogeneous models, not trust in one witness. This pillar serves the debate engine, gauntlet, truth weighting, calibration, dissent capture, and cross-verification.
 
+The next differentiator is crux-finding: debates should identify the load-bearing facts, framings, values, and assumptions where reasonable agents diverge, not merely produce an answer.
+
 ### 2. Reliable Autonomous Execution
 
 Reasoning alone is not enough. The system must execute bounded work with explicit contracts, verification, and fail-closed escalation. This pillar serves swarm, supervisor, worker contracts, preflight, repair, publication, and self-heal.
@@ -74,6 +76,8 @@ Memory is only useful if it is permissioned, attributable, and relevance-ranked.
 ### 5. Cryptographic Receipts and Auditability
 
 Every consequential decision or execution step should be inspectable. Receipts, provenance links, signatures, and compliance artifacts are not side effects; they are the trust layer that makes autonomy acceptable in real organizations.
+
+Important organizational claims should also become executable, evidence-linked objects with freshness, verification, provenance, and bounded repair behavior. This is the Epistemic CI direction: what Aragora believes should be testable, not just written down.
 
 ### 6. SMB Operator Leverage
 
@@ -154,4 +158,5 @@ Aragora's trust story is structural:
 2. A bounded backlog can run unattended with clear receipts, stop conditions, and minimal rescue.
 3. Humans can inspect any decision or execution result from summary level down to evidence and provenance.
 4. Shared memory improves future work without collapsing trust boundaries.
-5. Aragora evolves from tool -> teammate -> foreman -> chief of staff -> organization substrate on one coherent runtime.
+5. Important claims and cruxes remain linked to evidence, receipts, freshness, and later settlement.
+6. Aragora evolves from tool -> teammate -> foreman -> chief of staff -> organization substrate on one coherent runtime.

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -31,7 +31,7 @@ Aragora works for a 5-person startup on day one and scales to regulated enterpri
 
 ### 2. Leading-Edge Memory and Context
 
-Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / slow / glacial) and Knowledge Mound with 42 registered adapters give every debate access to institutional history, cross-session learning, and evidence provenance. The RLM (Recursive Language Models) system compresses and structures context to reduce prompt bloat, enabling debates that sustain coherence across long multi-round sessions and large document sets where individual models would degrade.
+Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / slow / glacial) and Knowledge Mound with 0 registered adapters give every debate access to institutional history, cross-session learning, and evidence provenance. The RLM (Recursive Language Models) system compresses and structures context to reduce prompt bloat, enabling debates that sustain coherence across long multi-round sessions and large document sets where individual models would degrade.
 
 ### 3. Extensible and Modular
 
@@ -230,7 +230,7 @@ print(f"Consensus: {result.consensus_reached} ({result.confidence:.0%})")
 │  │  • Belief networks with Bayesian propagation              │   │
 │  │  • Claims kernel with typed relationships                 │   │
 │  │  • Evidence provenance with hash chains                   │   │
-│  │  • Knowledge Mound (42 registered adapters) + Semantic search  │   │
+│  │  • Knowledge Mound (0 registered adapters) + Semantic search  │   │
 │  └───────────────────────────┬──────────────────────────────┘   │
 │                               ▼                                  │
 │  ┌──────────────────────────────────────────────────────────┐   │
@@ -285,7 +285,7 @@ aragora/
 │   └── embeddings.py       # Semantic embedding for retrieval
 ├── knowledge/        # Unified knowledge management
 │   ├── bridges.py          # KnowledgeBridgeHub, MetaLearner, Evidence bridges
-│   └── mound/              # KnowledgeMound (42 registered adapters, 4,300+ tests)
+│   └── mound/              # KnowledgeMound (0 registered adapters, 4,300+ tests)
 │       ├── adapters/       # Belief, Consensus, ELO, Evidence, OpenClaw, etc.
 │       ├── semantic.py     # Vector embedding-based search
 │       ├── federation.py   # Multi-region sync
@@ -336,7 +336,7 @@ aragora/
 └── cli/              # Command-line interface
 ```
 
-**Scale:** 3,000+ Python modules | 154,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
+**Scale:** 3,000+ Python modules | 155,000+ tests across 5,000+ test files | 185 Python / 187 TypeScript SDK namespaces
 
 ---
 

--- a/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
+++ b/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
@@ -1,12 +1,14 @@
 # Aragora Evolution Roadmap
 
-> **Last updated:** 2026-04-09
+> **Last updated:** 2026-04-16
 > **Current transition:** early `Teammate` -> reliable `Foreman`
 > **Planning rule:** preserve the maximalist vision; sequence through a narrow reliability wedge first.
 
 ## Executive Thesis
 
 Aragora is trying to become an autonomous chief of staff, an engineering organization substrate, and a decision-integrity control plane — not just a better coding agent.
+
+The distinctive long-horizon direction is **organizational epistemic infrastructure**: debates should surface load-bearing cruxes, receipts should preserve claim evidence, and important organizational claims should become executable objects with freshness, verification, provenance, and bounded repair paths. This expands the decision-integrity core without replacing the current proof-first autonomy wedge.
 
 The efficient path is not to build every ambitious surface at once. The wedge is reliable autonomous software execution on bounded backlogs, with receipts, human-control surfaces, and a truthful operator view. The unified DAG GUI remains a parallel second track, but it must reflect live runtime truth rather than speculative mock state.
 
@@ -202,6 +204,17 @@ This track preserves Aragora's core differentiation from generic agent platforms
 - show idea -> receipt -> later-settlement lineage
 - produce board- and regulator-ready exports without losing technical depth
 
+#### E5. Crux Engine and Epistemic CI
+
+- define a `CruxSet` output for the 3-5 load-bearing disagreements that would change a decision if resolved differently
+- define executable claim manifests for organizational claims with owner, evidence, freshness SLA, verifier, receipt links, and failure behavior
+- verify explicit claims before inferring claims automatically from docs, Slack, issues, or receipts
+- persist claim and crux provenance through receipts and Knowledge Mound
+- bridge failed claims and unresolved high-load-bearing cruxes into exactly one bounded follow-up issue only when queue governance permits it
+- expose a read-only organizational truth map showing what Aragora believes, why, how fresh the evidence is, and what is decaying
+
+Design brief: [Epistemic CI and Crux Engine Plan](EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+
 ### Track F — Trust-Wedge Productization and GTM
 
 This track converts technical proof into market proof.
@@ -237,6 +250,8 @@ This track converts technical proof into market proof.
 - If humans intervene twice for the same failure class, the next change should productize that rescue.
 - Memory without provenance is out of scope.
 - GUI surfaces must read ledger-backed truth.
+- Claims that matter should become executable, evidence-linked objects before they become product claims or queue work.
+- Cruxes should identify load-bearing disagreement, not merely summarize dissent.
 - Broad vertical and enterprise expansion follows wedge proof; it does not replace it.
 - External claims should always lag measured internal proof.
 

--- a/docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md
+++ b/docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md
@@ -211,4 +211,3 @@ The tranche is ready to enter active implementation only when:
 - recurring proof surfaces stay fresh without babysitting
 - queue governance can prevent claim/crux follow-up work from becoming generic churn
 - receipt and Knowledge Mound paths can preserve provenance without schema drift
-

--- a/docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md
+++ b/docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md
@@ -1,0 +1,214 @@
+# Epistemic CI and Crux Engine Plan
+
+> **Status:** additive future Decision Integrity tranche
+> **Created:** 2026-04-16
+> **Queue policy:** planning issues only; do not add `boss-ready` until the proof-first Foreman gate permits this tranche
+
+## Thesis
+
+Aragora should not only help organizations make decisions or execute tasks. It should help them know what they believe, why they believe it, what evidence is fresh, which disagreements are load-bearing, and what work should happen when reality changes.
+
+This plan combines two compatible product directions:
+
+- **Crux Engine:** for any contested question, surface the 3-5 load-bearing disagreements where a changed fact or framing would change the conclusion.
+- **Epistemic CI:** convert important organizational claims into executable, evidence-linked objects that can pass, fail, go stale, or create bounded repair work.
+
+The crux engine locates where reasonable agents diverge. Epistemic CI keeps claims and evidence from silently decaying. Together they form a decision-integrity layer on top of Aragora's debate, receipt, provenance, and proof-first runtime substrate.
+
+## Why This Belongs In Aragora
+
+Aragora already has most of the necessary primitives:
+
+- `DebateProtocol` and Arena consensus paths for multi-agent disagreement and synthesis.
+- `aragora/debate/convergence.py` for agreement detection that can be inverted into divergence scoring.
+- `aragora/interrogation/` for prioritized question generation from ambiguous or underspecified prompts.
+- `aragora/explainability/builder.py` for counterfactual analysis that can test whether a proposed crux is load-bearing.
+- `aragora/export/decision_receipt.py` for verified and unverified claim fields.
+- `aragora/gauntlet/` receipt models, signing, storage, and export paths.
+- `aragora/knowledge/mound/adapters/receipt_adapter.py` for ingesting receipt-derived claims into memory.
+- Provenance tests and claim-evidence citation machinery.
+- Proof-first queue governance and `ShiftLedger` patterns for turning failures into bounded work without broad queue farming.
+
+The missing abstraction is not another generic agent loop. It is a first-class **claim/crux object model** that binds debate, evidence, receipts, memory, and bounded follow-up work.
+
+## Non-Goals
+
+- Do not replace the current proof-first autonomy wedge.
+- Do not make broad external claims before the bounded execution substrate is stable.
+- Do not create live `boss-ready` queue work from failed claims or unresolved cruxes until queue governance explicitly allows it.
+- Do not build a new parallel reliability stack.
+- Do not duplicate receipt, provenance, or knowledge-mound plumbing.
+
+## Core Contracts
+
+### Executable Claim
+
+An executable claim is a versioned statement with evidence and a verification contract.
+
+```yaml
+claim_id: b0.truth.success_rate
+statement: "The benchmark truth surface is complete and fresh on current main."
+owner: proof-first-runtime
+scope: repo
+confidence: high
+evidence:
+  - path: docs/status/B0_BENCHMARK_TRUTH_STATUS.md
+  - workflow: Benchmark Truth Publication
+freshness_sla_hours: 24
+verification:
+  kind: command
+  command: python3 scripts/build_benchmark_truth_artifact.py --check
+failure:
+  severity: blocking
+  allowed_action: report_only
+receipts:
+  - type: benchmark_truth_publication
+```
+
+Initial statuses should be deliberately boring: `pass`, `fail`, `stale`, `unsupported`, and `error`.
+
+### Crux
+
+A crux is a load-bearing disagreement. It is not merely a dissenting opinion; it is a candidate fact, framing, value, or constraint where flipping the answer would plausibly flip the decision.
+
+```yaml
+crux_id: crux.guard.expansion.requires.green_soaks
+question: "Should Aragora widen B2 guard expansion now?"
+statement: "Three consecutive green 12-hour soaks are required before widening B2."
+positions:
+  - side: require_soaks
+    agents: [codex]
+  - side: accept_shorter_productive_soak
+    agents: [claude]
+load_bearing_score: 0.86
+counterfactual: "If one productive 12-hour soak is accepted as sufficient, the next action changes from soak hardening to B2 issue creation."
+evidence_gaps:
+  - "No settled policy on productive-soak versus empty-queue-soak equivalence."
+candidate_verifier: docs/status/BC12_SOAK_POLICY.md
+```
+
+### CruxSet
+
+A CruxSet is the signed debate output:
+
+- question
+- decision or candidate decision
+- ranked cruxes
+- opposing positions
+- evidence gaps
+- counterfactual notes
+- verifier candidates
+- receipt and provenance links
+
+## Implementation Sequence
+
+### DIC-13: Executable Claim Manifest
+
+Issue: [#6023](https://github.com/synaptent/aragora/issues/6023)
+
+Define the first manifest contract for explicit repo claims. Start with manually curated claims from recurring proof surfaces, not automatic extraction.
+
+Acceptance shape:
+
+- documented schema
+- examples under a stable docs/status path
+- fields for owner, evidence, freshness, verifier, failure action, and receipt links
+- no queue mutation
+
+### DIC-14: Claim Verification Runner
+
+Issue: [#6024](https://github.com/synaptent/aragora/issues/6024)
+
+Add a safe local runner that verifies explicit claim manifests and emits JSON. This is the Epistemic CI equivalent of a minimal test runner.
+
+Acceptance shape:
+
+- `pass`, `fail`, `stale`, `unsupported`, `error`
+- no network requirement in focused tests
+- JSON output suitable for status docs and receipts
+- no issue creation yet
+
+### DIC-15: CruxSet Contract And Consensus Mode
+
+Issue: [#6025](https://github.com/synaptent/aragora/issues/6025)
+
+Add a CruxSet contract and a non-default Arena path that produces ranked crux candidates from debate output.
+
+Acceptance shape:
+
+- deterministic mocked-agent tests
+- no replacement of existing consensus modes
+- load-bearing score and evidence-gap fields
+- counterfactual hook points for later validation
+
+### DIC-16: Receipt And Knowledge Mound Provenance
+
+Issue: [#6026](https://github.com/synaptent/aragora/issues/6026)
+
+Persist executable claims and CruxSet outputs through receipt and Knowledge Mound paths.
+
+Acceptance shape:
+
+- backwards-compatible receipt metadata
+- claim/crux IDs linked to evidence and source receipt
+- Knowledge Mound ingestion preserves verification status
+- focused tests around receipt ingestion
+
+### DIC-17: Failed-Claim / Open-Crux Follow-Up Bridge
+
+Issue: [#6027](https://github.com/synaptent/aragora/issues/6027)
+
+Turn failed claims or unresolved high-load-bearing cruxes into exactly one bounded follow-up issue, initially dry-run only.
+
+Acceptance shape:
+
+- one failure creates at most one bounded issue proposal
+- generated issues do not receive `boss-ready` unless the current tranche permits them
+- no broad restock behavior
+- test coverage for queue-governance constraints
+
+### DIC-18: Organizational Truth Map Report
+
+Issue: [#6028](https://github.com/synaptent/aragora/issues/6028)
+
+Create a read-only operator report showing current executable claims, evidence freshness, failed/stale claims, open cruxes, and linked receipts/issues.
+
+Acceptance shape:
+
+- claim ID, statement, owner, status, evidence age, verifier, follow-up link
+- CruxSet summary fields when available
+- read-only report first
+- no queue mutation
+
+## Relationship To The Current Roadmap
+
+This tranche belongs under **Decision Integrity Core**, not the immediate Reliability Substrate lane.
+
+Near-term proof-first autonomy remains blocking. Epistemic CI should not become a reason to interrupt BC-12 soaks, B2 guard proof, or queue discipline. The first safe use is as an explicit, manually curated claim layer over already-published proof surfaces. Automatic extraction, failed-claim issue generation, and crux-driven work creation all come later.
+
+## First Dogfood Targets
+
+Good initial claims:
+
+- benchmark truth publication is fresh and complete on current `main`
+- `TW03_RESCUE_PRODUCTIZATION_STATUS.md` links repeated rescue classes to fixtures or issues
+- live queue contains no `boss-ready` work outside the allowed tranche
+- BC-12 green-shift criteria are emitted by proof-first shifts
+- external docs remain narrower than measured proof
+
+Good initial crux questions:
+
+- whether one productive 12-hour soak is equivalent to one empty-queue green soak
+- whether B2 guard expansion may begin before three consecutive green shifts
+- whether failed claim reports should create issues automatically or remain operator-only
+- whether CruxSet belongs as a consensus mode or a standalone subsystem
+
+## Quality Bar
+
+The tranche is ready to enter active implementation only when:
+
+- the proof-first loop has stable long-run evidence
+- recurring proof surfaces stay fresh without babysitting
+- queue governance can prevent claim/crux follow-up work from becoming generic churn
+- receipt and Knowledge Mound paths can preserve provenance without schema drift
+

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -1,6 +1,6 @@
 # Active Execution Issues
 
-Last updated: 2026-04-15
+Last updated: 2026-04-16
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -23,6 +23,7 @@ The strict status reconciler requires this canonical map to link the live execut
 - Enterprise assurance carryover: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), [#509](https://github.com/synaptent/aragora/issues/509)
 - Execution epics (closed): [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), [#806](https://github.com/synaptent/aragora/issues/806) — all closed as of April 2026; current obligation is operationalizing the proof-first loop
 - Current execution lanes: [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
+- Future decision-integrity tranche: [#6023](https://github.com/synaptent/aragora/issues/6023), [#6024](https://github.com/synaptent/aragora/issues/6024), [#6025](https://github.com/synaptent/aragora/issues/6025), [#6026](https://github.com/synaptent/aragora/issues/6026), [#6027](https://github.com/synaptent/aragora/issues/6027), [#6028](https://github.com/synaptent/aragora/issues/6028) — Epistemic CI and Crux Engine planning; not live `boss-ready` work
 
 ## Reverse-Staged Rocket Bootstrap
 
@@ -44,6 +45,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 - Do now: `CS-01..03`
 - Delay: `BC-07..09`, `RS-11..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Future decision-integrity planning: `DIC-13..18` is tracked but delayed until proof-first Foreman reliability is stable; these issues must not be added to `boss-ready` during the current tranche
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
 - Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should keep the queue empty unless they expose a fresh bounded regression or repeated rescue class
@@ -216,6 +218,19 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 - [ ] **DIC-10** Add side-by-side debate and execution comparison surfaces
 - [ ] **DIC-11** Show idea -> receipt -> later settlement lineage end-to-end
 - [ ] **DIC-12** Produce board- and regulator-ready exports with dissent summaries
+
+### Milestone 6.5 — Crux Engine & Epistemic CI `[365d]`
+
+Design brief: [Epistemic CI and Crux Engine Plan](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+
+- [ ] **DIC-13** Define executable claim manifest schema ([#6023](https://github.com/synaptent/aragora/issues/6023))
+- [ ] **DIC-14** Add executable claim verification runner ([#6024](https://github.com/synaptent/aragora/issues/6024))
+- [ ] **DIC-15** Add `CruxSet` contract and crux-finder consensus mode ([#6025](https://github.com/synaptent/aragora/issues/6025))
+- [ ] **DIC-16** Extend receipts and Knowledge Mound for claim/crux provenance ([#6026](https://github.com/synaptent/aragora/issues/6026))
+- [ ] **DIC-17** Bridge failed claims and unresolved cruxes into bounded follow-up work ([#6027](https://github.com/synaptent/aragora/issues/6027))
+- [ ] **DIC-18** Add organizational truth map operator report ([#6028](https://github.com/synaptent/aragora/issues/6028))
+
+Queue rule: this milestone is not part of the current live dispatch lane. Its issues remain planning/future-tranche work until the proof-first Foreman gate permits decision-integrity expansion.
 
 ## Epic 7 — Commercialization & Scale-Out
 

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-04-15
+Last updated: 2026-04-16
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -38,6 +38,7 @@ What is already true:
 - proof-first runtime truth is now persisted in `ShiftLedger` on `main` via [#5857](https://github.com/synaptent/aragora/pull/5857)
 - proof-first shifts now fail closed after repeated recovery failures for the implemented failure classes via [#5867](https://github.com/synaptent/aragora/pull/5867)
 - `swarm status`, FastAPI swarm-status routes, and `studio-health.sh` now prefer ledger-backed operator truth on `main` via [#5861](https://github.com/synaptent/aragora/pull/5861) and [#5868](https://github.com/synaptent/aragora/pull/5868)
+- the future Decision Integrity expansion is now tracked as an additive Epistemic CI / Crux Engine tranche in [EPISTEMIC_CI_AND_CRUX_ENGINE](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md) and issues [#6023](https://github.com/synaptent/aragora/issues/6023)-[#6028](https://github.com/synaptent/aragora/issues/6028); it is planning truth, not current live queue scope
 
 What is still missing:
 
@@ -46,6 +47,7 @@ What is still missing:
 - broader repair-loop coverage on top of the existing audit trail
 - lower-rescue unattended operation on bounded backlogs
 - ongoing discipline so external claims stay narrower than the recurring proof surfaces
+- delayed decision-integrity work that turns important claims into executable evidence-linked objects and debates into ranked `CruxSet` outputs, after the proof-first Foreman gate is stable
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”
 
@@ -131,6 +133,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 - `BC-07..09` until the repair loop is truthful, resumable, and consolidated into one operator model
 - `RS-11..12` until recovery-budget coverage extends to the remaining failure classes and the remaining status/reporter surfaces are ledger-backed
+- `DIC-13..18` until BC-12/Foreman reliability is proven; Epistemic CI and Crux Engine issues may stay open for planning but must not enter the live boss-ready queue
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition


### PR DESCRIPTION
## Summary
- add an Epistemic CI + Crux Engine roadmap brief grounded in existing Aragora debate, receipt, Knowledge Mound, counterfactual, and proof-first infrastructure
- update canonical goals/evolution/status docs to preserve the existing roadmap while adding the future Decision Integrity tranche
- link the additive implementation sequence to GitHub issues #6023 through #6028 without marking them boss-ready/autonomous

## Validation
- `python3 scripts/reconcile_status_docs.py --json`
- `python3 scripts/reconcile_proof_first_queue.py --repo synaptent/aragora --json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
