### PR TITLE
docs: add epistemic runtime roadmap layer

### DIFF
--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -28,7 +28,7 @@ The strict status reconciler requires this canonical map to link the live execut
 - Enterprise assurance carryover: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), [#509](https://github.com/synaptent/aragora/issues/509)
 - Execution epics (closed): [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), [#806](https://github.com/synaptent/aragora/issues/806) — all closed as of April 2026; current obligation is operationalizing the proof-first loop
 - Current execution lanes: [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
-- Future decision-integrity tranche: [#6023](https://github.com/synaptent/aragora/issues/6023), [#6024](https://github.com/synaptent/aragora/issues/6024), [#6025](https://github.com/synaptent/aragora/issues/6025), [#6026](https://github.com/synaptent/aragora/issues/6026), [#6027](https://github.com/synaptent/aragora/issues/6027), [#6028](https://github.com/synaptent/aragora/issues/6028) — Epistemic CI and Crux Engine planning; not live `boss-ready` work
+- Future decision-integrity tranche: [#6023](https://github.com/synaptent/aragora/issues/6023), [#6024](https://github.com/synaptent/aragora/issues/6024), [#6025](https://github.com/synaptent/aragora/issues/6025), [#6026](https://github.com/synaptent/aragora/issues/6026), [#6027](https://github.com/synaptent/aragora/issues/6027), [#6028](https://github.com/synaptent/aragora/issues/6028), [#6030](https://github.com/synaptent/aragora/issues/6030), [#6031](https://github.com/synaptent/aragora/issues/6031), [#6032](https://github.com/synaptent/aragora/issues/6032), [#6033](https://github.com/synaptent/aragora/issues/6033) — Epistemic CI, Crux Engine, and Epistemic Runtime planning; not live `boss-ready` work
 
 ## Reverse-Staged Rocket Bootstrap
 
@@ -50,7 +50,7 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
 - Do now: `CS-01..03`
 - Delay: `BC-07..09`, `RS-11..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
-- Future decision-integrity planning: `DIC-13..18` is tracked but delayed until proof-first Foreman reliability is stable; these issues must not be added to `boss-ready` during the current tranche
+- Future decision-integrity planning: `DIC-13..22` is tracked but delayed until proof-first Foreman reliability is stable; these issues must not be added to `boss-ready` during the current tranche
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
 - Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should keep the queue empty unless they expose a fresh bounded regression or repeated rescue class
@@ -224,9 +224,9 @@ Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 - [ ] **DIC-11** Show idea -> receipt -> later settlement lineage end-to-end
 - [ ] **DIC-12** Produce board- and regulator-ready exports with dissent summaries
 
-### Milestone 6.5 — Crux Engine & Epistemic CI `[365d]`
+### Milestone 6.5 — Crux Engine, Epistemic CI & Epistemic Runtime `[365d]`
 
-Design brief: [Epistemic CI and Crux Engine Plan](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+Design brief: [Epistemic CI, Crux Engine, and Epistemic Runtime Plan](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md).
 
 - [ ] **DIC-13** Define executable claim manifest schema ([#6023](https://github.com/synaptent/aragora/issues/6023))
 - [ ] **DIC-14** Add executable claim verification runner ([#6024](https://github.com/synaptent/aragora/issues/6024))
@@ -234,6 +234,10 @@ Design brief: [Epistemic CI and Crux Engine Plan](../plans/EPISTEMIC_CI_AND_CRUX
 - [ ] **DIC-16** Extend receipts and Knowledge Mound for claim/crux provenance ([#6026](https://github.com/synaptent/aragora/issues/6026))
 - [ ] **DIC-17** Bridge failed claims and unresolved cruxes into bounded follow-up work ([#6027](https://github.com/synaptent/aragora/issues/6027))
 - [ ] **DIC-18** Add organizational truth map operator report ([#6028](https://github.com/synaptent/aragora/issues/6028))
+- [ ] **DIC-19** Define proof-carrying code unit constraint graph ([#6030](https://github.com/synaptent/aragora/issues/6030))
+- [ ] **DIC-20** Add epistemic decay monitor for proof-carrying code ([#6031](https://github.com/synaptent/aragora/issues/6031))
+- [ ] **DIC-21** Add fail-closed quarantine policy for decayed code proofs ([#6032](https://github.com/synaptent/aragora/issues/6032))
+- [ ] **DIC-22** Add verified replacement pipeline for decayed proof-carrying code ([#6033](https://github.com/synaptent/aragora/issues/6033))
 
 Queue rule: this milestone is not part of the current live dispatch lane. Its issues remain planning/future-tranche work until the proof-first Foreman gate permits decision-integrity expansion.
 

--- a/docs-site/docs/contributing/aragora-evolution-roadmap.md
+++ b/docs-site/docs/contributing/aragora-evolution-roadmap.md
@@ -209,7 +209,7 @@ This track preserves Aragora's core differentiation from generic agent platforms
 - show idea -> receipt -> later-settlement lineage
 - produce board- and regulator-ready exports without losing technical depth
 
-#### E5. Crux Engine and Epistemic CI
+#### E5. Crux Engine, Epistemic CI, and Epistemic Runtime
 
 - define a `CruxSet` output for the 3-5 load-bearing disagreements that would change a decision if resolved differently
 - define executable claim manifests for organizational claims with owner, evidence, freshness SLA, verifier, receipt links, and failure behavior
@@ -217,8 +217,12 @@ This track preserves Aragora's core differentiation from generic agent platforms
 - persist claim and crux provenance through receipts and Knowledge Mound
 - bridge failed claims and unresolved high-load-bearing cruxes into exactly one bounded follow-up issue only when queue governance permits it
 - expose a read-only organizational truth map showing what Aragora believes, why, how fresh the evidence is, and what is decaying
+- define proof-carrying code units that link routes, functions, scripts, and policies to their assumptions, claims, receipts, verifiers, decay policy, and fallback policy
+- detect epistemic decay when proof-carrying code assumptions become stale, contradicted, or unsupported by fresh evidence
+- fail closed through report-only, degrade, fallback, quarantine, or repair-required policies before any live runtime mutation
+- route decayed proof into verified replacement candidates through Arena debate, receipt capture, formal-verifier hooks where available, and PR or shadow output before considering opt-in hot-swap classes
 
-Design brief: [Epistemic CI and Crux Engine Plan](EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+Design brief: [Epistemic CI, Crux Engine, and Epistemic Runtime Plan](EPISTEMIC_CI_AND_CRUX_ENGINE.md).
 
 ### Track F — Trust-Wedge Productization and GTM
 

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -84,6 +84,8 @@ Every consequential decision or execution step should be inspectable. Receipts, 
 
 Important organizational claims should also become executable, evidence-linked objects with freshness, verification, provenance, and bounded repair behavior. This is the Epistemic CI direction: what Aragora believes should be testable, not just written down.
 
+The same trust model should eventually apply to code paths themselves. Proof-carrying code units should link functions, routes, scripts, and policies to the claims, assumptions, receipts, verifiers, and fallback rules that justify them. When the evidence behind a code path decays, Aragora should detect that decay, fail safely, and produce a verified repair candidate before any opt-in runtime replacement is considered.
+
 ### 6. SMB Operator Leverage
 
 Aragora must be useful to founders, operators, and small teams with limited time, uneven specs, and real consequences. The product should not require elite prompt discipline to be valuable. That constraint shapes UX, packaging, and scope decisions.

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -43,7 +43,7 @@ What is already true:
 - proof-first runtime truth is now persisted in `ShiftLedger` on `main` via [#5857](https://github.com/synaptent/aragora/pull/5857)
 - proof-first shifts now fail closed after repeated recovery failures for the implemented failure classes via [#5867](https://github.com/synaptent/aragora/pull/5867)
 - `swarm status`, FastAPI swarm-status routes, and `studio-health.sh` now prefer ledger-backed operator truth on `main` via [#5861](https://github.com/synaptent/aragora/pull/5861) and [#5868](https://github.com/synaptent/aragora/pull/5868)
-- the future Decision Integrity expansion is now tracked as an additive Epistemic CI / Crux Engine tranche in [EPISTEMIC_CI_AND_CRUX_ENGINE](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md) and issues [#6023](https://github.com/synaptent/aragora/issues/6023)-[#6028](https://github.com/synaptent/aragora/issues/6028); it is planning truth, not current live queue scope
+- the future Decision Integrity expansion is now tracked as an additive Epistemic CI / Crux Engine / Epistemic Runtime tranche in [EPISTEMIC_CI_AND_CRUX_ENGINE](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md) and issues [#6023](https://github.com/synaptent/aragora/issues/6023)-[#6028](https://github.com/synaptent/aragora/issues/6028) plus [#6030](https://github.com/synaptent/aragora/issues/6030)-[#6033](https://github.com/synaptent/aragora/issues/6033); it is planning truth, not current live queue scope
 
 What is still missing:
 
@@ -138,7 +138,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 - `BC-07..09` until the repair loop is truthful, resumable, and consolidated into one operator model
 - `RS-11..12` until recovery-budget coverage extends to the remaining failure classes and the remaining status/reporter surfaces are ledger-backed
-- `DIC-13..18` until BC-12/Foreman reliability is proven; Epistemic CI and Crux Engine issues may stay open for planning but must not enter the live boss-ready queue
+- `DIC-13..22` until BC-12/Foreman reliability is proven; Epistemic CI, Crux Engine, and Epistemic Runtime issues may stay open for planning but must not enter the live boss-ready queue
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -79,6 +79,8 @@ Every consequential decision or execution step should be inspectable. Receipts, 
 
 Important organizational claims should also become executable, evidence-linked objects with freshness, verification, provenance, and bounded repair behavior. This is the Epistemic CI direction: what Aragora believes should be testable, not just written down.
 
+The same trust model should eventually apply to code paths themselves. Proof-carrying code units should link functions, routes, scripts, and policies to the claims, assumptions, receipts, verifiers, and fallback rules that justify them. When the evidence behind a code path decays, Aragora should detect that decay, fail safely, and produce a verified repair candidate before any opt-in runtime replacement is considered.
+
 ### 6. SMB Operator Leverage
 
 Aragora must be useful to founders, operators, and small teams with limited time, uneven specs, and real consequences. The product should not require elite prompt discipline to be valuable. That constraint shapes UX, packaging, and scope decisions.

--- a/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
+++ b/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
@@ -204,7 +204,7 @@ This track preserves Aragora's core differentiation from generic agent platforms
 - show idea -> receipt -> later-settlement lineage
 - produce board- and regulator-ready exports without losing technical depth
 
-#### E5. Crux Engine and Epistemic CI
+#### E5. Crux Engine, Epistemic CI, and Epistemic Runtime
 
 - define a `CruxSet` output for the 3-5 load-bearing disagreements that would change a decision if resolved differently
 - define executable claim manifests for organizational claims with owner, evidence, freshness SLA, verifier, receipt links, and failure behavior
@@ -212,8 +212,12 @@ This track preserves Aragora's core differentiation from generic agent platforms
 - persist claim and crux provenance through receipts and Knowledge Mound
 - bridge failed claims and unresolved high-load-bearing cruxes into exactly one bounded follow-up issue only when queue governance permits it
 - expose a read-only organizational truth map showing what Aragora believes, why, how fresh the evidence is, and what is decaying
+- define proof-carrying code units that link routes, functions, scripts, and policies to their assumptions, claims, receipts, verifiers, decay policy, and fallback policy
+- detect epistemic decay when proof-carrying code assumptions become stale, contradicted, or unsupported by fresh evidence
+- fail closed through report-only, degrade, fallback, quarantine, or repair-required policies before any live runtime mutation
+- route decayed proof into verified replacement candidates through Arena debate, receipt capture, formal-verifier hooks where available, and PR or shadow output before considering opt-in hot-swap classes
 
-Design brief: [Epistemic CI and Crux Engine Plan](EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+Design brief: [Epistemic CI, Crux Engine, and Epistemic Runtime Plan](EPISTEMIC_CI_AND_CRUX_ENGINE.md).
 
 ### Track F — Trust-Wedge Productization and GTM
 

--- a/docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md
+++ b/docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md
@@ -1,4 +1,4 @@
-# Epistemic CI and Crux Engine Plan
+# Epistemic CI, Crux Engine, and Epistemic Runtime Plan
 
 > **Status:** additive future Decision Integrity tranche
 > **Created:** 2026-04-16
@@ -8,12 +8,13 @@
 
 Aragora should not only help organizations make decisions or execute tasks. It should help them know what they believe, why they believe it, what evidence is fresh, which disagreements are load-bearing, and what work should happen when reality changes.
 
-This plan combines two compatible product directions:
+This plan combines three compatible product directions:
 
 - **Crux Engine:** for any contested question, surface the 3-5 load-bearing disagreements where a changed fact or framing would change the conclusion.
 - **Epistemic CI:** convert important organizational claims into executable, evidence-linked objects that can pass, fail, go stale, or create bounded repair work.
+- **Epistemic Runtime:** treat code as a living argument by attaching assumptions, debate receipts, evidence, and verifier contracts to code units, then detecting epistemic decay when reality changes.
 
-The crux engine locates where reasonable agents diverge. Epistemic CI keeps claims and evidence from silently decaying. Together they form a decision-integrity layer on top of Aragora's debate, receipt, provenance, and proof-first runtime substrate.
+The crux engine locates where reasonable agents diverge. Epistemic CI keeps claims and evidence from silently decaying. The Epistemic Runtime extends that discipline to code paths: if the assumptions behind a function, route, script, or policy surface decay, Aragora should know, fail safely, and produce bounded repair work with new receipts. Together they form a decision-integrity layer on top of Aragora's debate, receipt, provenance, and proof-first runtime substrate.
 
 ## Why This Belongs In Aragora
 
@@ -29,7 +30,7 @@ Aragora already has most of the necessary primitives:
 - Provenance tests and claim-evidence citation machinery.
 - Proof-first queue governance and `ShiftLedger` patterns for turning failures into bounded work without broad queue farming.
 
-The missing abstraction is not another generic agent loop. It is a first-class **claim/crux object model** that binds debate, evidence, receipts, memory, and bounded follow-up work.
+The missing abstraction is not another generic agent loop. It is a first-class **claim/crux/proof-carrying-code object model** that binds debate, evidence, receipts, memory, runtime safety, and bounded follow-up work.
 
 ## Non-Goals
 
@@ -38,6 +39,7 @@ The missing abstraction is not another generic agent loop. It is a first-class *
 - Do not create live `boss-ready` queue work from failed claims or unresolved cruxes until queue governance explicitly allows it.
 - Do not build a new parallel reliability stack.
 - Do not duplicate receipt, provenance, or knowledge-mound plumbing.
+- Do not introduce unsupervised production hot-swapping. The first runtime shape is report-only, then guarded fallback/quarantine, then shadow replacement or pull-request generation. Any live hot-swap behavior must remain opt-in, receipt-backed, and limited to explicitly allowlisted demo or pure-policy surfaces until a later safety gate permits more.
 
 ## Core Contracts
 
@@ -99,6 +101,58 @@ A CruxSet is the signed debate output:
 - counterfactual notes
 - verifier candidates
 - receipt and provenance links
+
+### Proof-Carrying Code Unit
+
+A proof-carrying code unit is a code path with an attached argument for why it is safe, useful, and still true.
+
+```yaml
+code_unit_id: proof_first.shift.green_criteria
+symbol: scripts.run_proof_first_shift.evaluate_green_shift
+source_path: scripts/run_proof_first_shift.py
+owner: proof-first-runtime
+decision_receipts:
+  - receipt_id: decision.bc12.green_shift_criteria
+claims:
+  - claim_id: bc12.benchmark_surface_fresh
+  - claim_id: bc12.queue_canonical_or_empty
+assumptions:
+  - "Benchmark freshness can be determined from the published proof surface."
+  - "Queue can be considered intentionally idle only when no canonical work is eligible."
+verifiers:
+  - kind: command
+    command: python3 -m pytest tests/scripts/test_run_proof_first_shift.py -q
+freshness_sla_hours: 24
+decay_policy:
+  failed_claim: repair_required
+  stale_evidence: report_only
+fallback_policy:
+  default: fail_closed
+  operator_message: "Green-shift criteria are stale or unsupported; do not widen guard scope."
+```
+
+The initial proof-carrying-code layer should be manifest-based and read-only. It attaches receipts, claims, and verifiers to code; it does not rewrite code at runtime.
+
+### Epistemic Decay Signal
+
+An epistemic decay signal is the runtime or CI observation that a code unit's proof is weakening.
+
+```yaml
+decay_id: decay.proof_first.shift.green_criteria.2026-04-16
+code_unit_id: proof_first.shift.green_criteria
+integrity_score: 0.42
+reasons:
+  - failed_claim: bc12.benchmark_surface_fresh
+  - unresolved_crux: crux.soak_equivalence
+recommended_action: repair_required
+quarantine_policy: report_only
+evidence:
+  - docs/status/B0_BENCHMARK_TRUTH_STATUS.md
+  - docs/status/NEXT_STEPS_CANONICAL.md
+receipt_required: true
+```
+
+Decay signals are deliberately narrower than generic alerts: they explain which assumption, claim, receipt, verifier, or unresolved crux weakened a code path's justification.
 
 ## Implementation Sequence
 
@@ -180,11 +234,64 @@ Acceptance shape:
 - read-only report first
 - no queue mutation
 
+### DIC-19: Proof-Carrying Code Unit Constraint Graph
+
+Issue: [#6030](https://github.com/synaptent/aragora/issues/6030)
+
+Define the manifest and constraint graph for code paths that carry their assumptions, evidence, receipts, freshness requirements, verifier commands, decay policy, and fallback policy.
+
+Acceptance shape:
+
+- schema for code unit ID, source path, symbol, owner, linked claims, assumptions, receipts, verifiers, freshness SLA, decay policy, and fallback policy
+- at least one low-risk example tied to an existing proof-first code path
+- compatibility with executable claim and CruxSet identifiers
+- read-only behavior first; no runtime mutation
+
+### DIC-20: Epistemic Decay Monitor
+
+Issue: [#6031](https://github.com/synaptent/aragora/issues/6031)
+
+Evaluate proof-carrying code units against claim verification results, freshness, receipt availability, unresolved cruxes, and synthetic world-state events.
+
+Acceptance shape:
+
+- machine-readable integrity score and decay reasons
+- reason classes such as `stale_evidence`, `failed_claim`, `unresolved_crux`, `missing_receipt`, and `verifier_error`
+- no queue mutation
+- focused tests with synthetic dependency/API/CVE-like invalidation events
+
+### DIC-21: Fail-Closed Quarantine Policy
+
+Issue: [#6032](https://github.com/synaptent/aragora/issues/6032)
+
+Define how proof decay maps to report-only, degrade, fallback, quarantine, or repair-required actions before any live behavior changes.
+
+Acceptance shape:
+
+- policy model keyed by decay severity and code-unit class
+- receipt/provenance output for every non-report-only recommendation
+- live routing or production hot-swap prohibited unless an explicit allowlist enables it
+- ambiguous or over-budget decay fails closed
+
+### DIC-22: Verified Replacement Pipeline
+
+Issue: [#6033](https://github.com/synaptent/aragora/issues/6033)
+
+Turn decayed proof into a bounded repair candidate through Arena debate, verifier hooks, receipt generation, and shadow or pull-request output.
+
+Acceptance shape:
+
+- decay signal produces a bounded repair spec with linked claims, cruxes, validation commands, and receipt context
+- replacement debate captures a new decision or CruxSet receipt
+- formal-verifier hook is available where constraints can be expressed
+- default output is a patch, PR, or shadow candidate, not in-memory production hot-swap
+- tests prove the no-hot-swap guardrail
+
 ## Relationship To The Current Roadmap
 
 This tranche belongs under **Decision Integrity Core**, not the immediate Reliability Substrate lane.
 
-Near-term proof-first autonomy remains blocking. Epistemic CI should not become a reason to interrupt BC-12 soaks, B2 guard proof, or queue discipline. The first safe use is as an explicit, manually curated claim layer over already-published proof surfaces. Automatic extraction, failed-claim issue generation, and crux-driven work creation all come later.
+Near-term proof-first autonomy remains blocking. Epistemic CI, Crux Engine, and Epistemic Runtime work should not become a reason to interrupt BC-12 soaks, B2 guard proof, or queue discipline. The first safe use is as an explicit, manually curated claim layer over already-published proof surfaces. Automatic extraction, failed-claim issue generation, crux-driven work creation, proof-carrying code enforcement, quarantine, and verified replacement all come later.
 
 ## First Dogfood Targets
 
@@ -203,6 +310,13 @@ Good initial crux questions:
 - whether failed claim reports should create issues automatically or remain operator-only
 - whether CruxSet belongs as a consensus mode or a standalone subsystem
 
+Good initial proof-carrying code units:
+
+- proof-first green-shift criteria in `scripts/run_proof_first_shift.py`
+- benchmark truth publication checks that gate proof-first expansion
+- queue-governance rules that prevent non-canonical `boss-ready` restock
+- status-doc reconciliation paths that prevent external claims from exceeding proof
+
 ## Quality Bar
 
 The tranche is ready to enter active implementation only when:
@@ -211,3 +325,4 @@ The tranche is ready to enter active implementation only when:
 - recurring proof surfaces stay fresh without babysitting
 - queue governance can prevent claim/crux follow-up work from becoming generic churn
 - receipt and Knowledge Mound paths can preserve provenance without schema drift
+- runtime safety policy can distinguish report-only decay from fallback, quarantine, repair-required, and any future opt-in hot-swap class

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -23,7 +23,7 @@ The strict status reconciler requires this canonical map to link the live execut
 - Enterprise assurance carryover: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), [#509](https://github.com/synaptent/aragora/issues/509)
 - Execution epics (closed): [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), [#806](https://github.com/synaptent/aragora/issues/806) — all closed as of April 2026; current obligation is operationalizing the proof-first loop
 - Current execution lanes: [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
-- Future decision-integrity tranche: [#6023](https://github.com/synaptent/aragora/issues/6023), [#6024](https://github.com/synaptent/aragora/issues/6024), [#6025](https://github.com/synaptent/aragora/issues/6025), [#6026](https://github.com/synaptent/aragora/issues/6026), [#6027](https://github.com/synaptent/aragora/issues/6027), [#6028](https://github.com/synaptent/aragora/issues/6028) — Epistemic CI and Crux Engine planning; not live `boss-ready` work
+- Future decision-integrity tranche: [#6023](https://github.com/synaptent/aragora/issues/6023), [#6024](https://github.com/synaptent/aragora/issues/6024), [#6025](https://github.com/synaptent/aragora/issues/6025), [#6026](https://github.com/synaptent/aragora/issues/6026), [#6027](https://github.com/synaptent/aragora/issues/6027), [#6028](https://github.com/synaptent/aragora/issues/6028), [#6030](https://github.com/synaptent/aragora/issues/6030), [#6031](https://github.com/synaptent/aragora/issues/6031), [#6032](https://github.com/synaptent/aragora/issues/6032), [#6033](https://github.com/synaptent/aragora/issues/6033) — Epistemic CI, Crux Engine, and Epistemic Runtime planning; not live `boss-ready` work
 
 ## Reverse-Staged Rocket Bootstrap
 
@@ -45,7 +45,7 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 - Do now: `CS-01..03`
 - Delay: `BC-07..09`, `RS-11..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
-- Future decision-integrity planning: `DIC-13..18` is tracked but delayed until proof-first Foreman reliability is stable; these issues must not be added to `boss-ready` during the current tranche
+- Future decision-integrity planning: `DIC-13..22` is tracked but delayed until proof-first Foreman reliability is stable; these issues must not be added to `boss-ready` during the current tranche
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
 - Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should keep the queue empty unless they expose a fresh bounded regression or repeated rescue class
@@ -219,9 +219,9 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 - [ ] **DIC-11** Show idea -> receipt -> later settlement lineage end-to-end
 - [ ] **DIC-12** Produce board- and regulator-ready exports with dissent summaries
 
-### Milestone 6.5 — Crux Engine & Epistemic CI `[365d]`
+### Milestone 6.5 — Crux Engine, Epistemic CI & Epistemic Runtime `[365d]`
 
-Design brief: [Epistemic CI and Crux Engine Plan](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+Design brief: [Epistemic CI, Crux Engine, and Epistemic Runtime Plan](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md).
 
 - [ ] **DIC-13** Define executable claim manifest schema ([#6023](https://github.com/synaptent/aragora/issues/6023))
 - [ ] **DIC-14** Add executable claim verification runner ([#6024](https://github.com/synaptent/aragora/issues/6024))
@@ -229,6 +229,10 @@ Design brief: [Epistemic CI and Crux Engine Plan](../plans/EPISTEMIC_CI_AND_CRUX
 - [ ] **DIC-16** Extend receipts and Knowledge Mound for claim/crux provenance ([#6026](https://github.com/synaptent/aragora/issues/6026))
 - [ ] **DIC-17** Bridge failed claims and unresolved cruxes into bounded follow-up work ([#6027](https://github.com/synaptent/aragora/issues/6027))
 - [ ] **DIC-18** Add organizational truth map operator report ([#6028](https://github.com/synaptent/aragora/issues/6028))
+- [ ] **DIC-19** Define proof-carrying code unit constraint graph ([#6030](https://github.com/synaptent/aragora/issues/6030))
+- [ ] **DIC-20** Add epistemic decay monitor for proof-carrying code ([#6031](https://github.com/synaptent/aragora/issues/6031))
+- [ ] **DIC-21** Add fail-closed quarantine policy for decayed code proofs ([#6032](https://github.com/synaptent/aragora/issues/6032))
+- [ ] **DIC-22** Add verified replacement pipeline for decayed proof-carrying code ([#6033](https://github.com/synaptent/aragora/issues/6033))
 
 Queue rule: this milestone is not part of the current live dispatch lane. Its issues remain planning/future-tranche work until the proof-first Foreman gate permits decision-integrity expansion.
 

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -38,7 +38,7 @@ What is already true:
 - proof-first runtime truth is now persisted in `ShiftLedger` on `main` via [#5857](https://github.com/synaptent/aragora/pull/5857)
 - proof-first shifts now fail closed after repeated recovery failures for the implemented failure classes via [#5867](https://github.com/synaptent/aragora/pull/5867)
 - `swarm status`, FastAPI swarm-status routes, and `studio-health.sh` now prefer ledger-backed operator truth on `main` via [#5861](https://github.com/synaptent/aragora/pull/5861) and [#5868](https://github.com/synaptent/aragora/pull/5868)
-- the future Decision Integrity expansion is now tracked as an additive Epistemic CI / Crux Engine tranche in [EPISTEMIC_CI_AND_CRUX_ENGINE](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md) and issues [#6023](https://github.com/synaptent/aragora/issues/6023)-[#6028](https://github.com/synaptent/aragora/issues/6028); it is planning truth, not current live queue scope
+- the future Decision Integrity expansion is now tracked as an additive Epistemic CI / Crux Engine / Epistemic Runtime tranche in [EPISTEMIC_CI_AND_CRUX_ENGINE](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md) and issues [#6023](https://github.com/synaptent/aragora/issues/6023)-[#6028](https://github.com/synaptent/aragora/issues/6028) plus [#6030](https://github.com/synaptent/aragora/issues/6030)-[#6033](https://github.com/synaptent/aragora/issues/6033); it is planning truth, not current live queue scope
 
 What is still missing:
 
@@ -133,7 +133,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 
 - `BC-07..09` until the repair loop is truthful, resumable, and consolidated into one operator model
 - `RS-11..12` until recovery-budget coverage extends to the remaining failure classes and the remaining status/reporter surfaces are ledger-backed
-- `DIC-13..18` until BC-12/Foreman reliability is proven; Epistemic CI and Crux Engine issues may stay open for planning but must not enter the live boss-ready queue
+- `DIC-13..22` until BC-12/Foreman reliability is proven; Epistemic CI, Crux Engine, and Epistemic Runtime issues may stay open for planning but must not enter the live boss-ready queue
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition


### PR DESCRIPTION
## Summary
- Extends the existing Epistemic CI / Crux Engine plan with the Gemini 3.1 Epistemic Runtime / Dialectical VM concept as a staged Decision Integrity layer.
- Adds proof-carrying code units, epistemic decay signals, fail-closed quarantine policy, and verified replacement as PR or shadow output before any opt-in hot-swap class.
- Updates roadmap, canonical goals, status docs, and docs-site mirrors without adding live boss-ready dispatch scope.

## Issues
- Adds planning issues #6030, #6031, #6032, and #6033.
- These are future-tranche issues only and do not carry boss-ready or autonomous labels.

## Validation
- python3 scripts/reconcile_status_docs.py --json
- python3 scripts/reconcile_proof_first_queue.py --repo synaptent/aragora --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD