### PR TITLE
docs(coherence): tier-1 hygiene — fix broken links, hardcoded benchmark, stale pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ receipts, provenance, and truthful gates.
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**New here?** Start with the [Quickstart Guide](docs/quickstart.md) -- you'll have a working debate in under a minute. For a deeper overview, see [Start Here](docs/START_HERE.md). For strategic framing, see [Competitive Positioning (March 2026)](docs/strategy/COMPETITIVE_POSITIONING_2026_03.md), [When To Use Aragora Vs Execution Substrates](docs/strategy/WHEN_TO_USE_ARAGORA_VS_EXECUTION_SUBSTRATES.md), and the [Terminology And Phrase Glossary](docs/strategy/TERMINOLOGY_GLOSSARY.md).
+**New here?** Start with the [Quickstart Guide](docs/quickstart.md) -- you'll have a working debate in under a minute. For a deeper overview, see [Start Here](docs/START_HERE.md). For strategic framing, see [Positioning And Messaging](docs/strategy/POSITIONING_AND_MESSAGING.md) (includes competitive positioning), [Boundaries And Scope](docs/strategy/BOUNDARIES_AND_SCOPE.md) (includes when-to-use-Aragora-vs-execution-substrates), and [Precision And Terms](docs/strategy/PRECISION_AND_TERMS.md) (includes the terminology glossary). The consolidation of earlier-dated strategy files is tracked in [STRATEGY_INDEX.md](docs/STRATEGY_INDEX.md).
 
 | I want to... | Install |
 |--------------|---------|

--- a/docs-site/docs/contributing/feature-gap-list.md
+++ b/docs-site/docs/contributing/feature-gap-list.md
@@ -6,8 +6,9 @@ description: Aragora Feature Gap List
 # Aragora Feature Gap List
 
 > **Living document** — tracks features planned, partially built, or in need of hardening. Updated as items are completed or priorities shift.
-> Active execution status now lives in [docs/status/ACTIVE_EXECUTION_ISSUES.md](./active-execution-issues) and the linked GitHub issues. This file remains the capability and productization backlog truth.
-> Last updated: March 24, 2026
+> **For current execution sequencing** (what to work on right now, what is gated, what is delayed), defer to [docs/status/NEXT_STEPS_CANONICAL.md](./next-steps-canonical). Active execution status is tracked in [docs/status/ACTIVE_EXECUTION_ISSUES.md](./active-execution-issues) and linked GitHub issues. **This file is the long-horizon capability and productization backlog** — the P0–P4 tiering expresses intended ordering, not dispatch readiness.
+> **For the unified finish-line vision and stage model**, see [docs/CANONICAL_GOALS.md](./canonical-goals). The Decision Integrity Core tranche (crux engine, executable claims, proof-carrying code) is gated on Foreman reliability per [docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md](plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+> Last updated: April 16, 2026
 > March 2026 priority reframe: product cohesion and PMF proof come before certification. Pentest / SOC 2 stay tracked, but they are no longer the first blocker lane.
 
 ## How to Read This List

--- a/docs-site/docs/enterprise/commercial-overview.md
+++ b/docs-site/docs/enterprise/commercial-overview.md
@@ -28,7 +28,7 @@ The claims below are the current proof base, not the long-term ambition.
 | Area | Current truth | Why it matters |
 |---|---|---|
 | Guarded execution substrate | Boss, supervisor, tranche, contract, and preflight paths exist on the live swarm lane. | The system can decide when a run is admissible instead of blindly attempting work. |
-| Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
+| Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is published live. **Live number lives in [docs/status/B0_BENCHMARK_TRUTH_STATUS.md](../contributing/b0-benchmark-truth-status)** — do not hardcode here (per this doc's own rule below that "external claims stay narrower than the measured proof"). | Progress claims are tied to a measured cohort instead of anecdotes. |
 | Truth artifacts | The repo has a diffable benchmark truth-artifact path, frozen-corpus binding on recurring scorecards, and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth instead of drifting with ad hoc samples. |
 | Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
 | Operator truth | Preflight receipts, blocker evidence, session-state work, recurring benchmark truth publication, and recurring rescue productization are on `main`. | This is the proof surface that turns an impressive demo into a boring reliable product lane. |

--- a/docs/COMMERCIAL_OVERVIEW.md
+++ b/docs/COMMERCIAL_OVERVIEW.md
@@ -23,7 +23,7 @@ The claims below are the current proof base, not the long-term ambition.
 | Area | Current truth | Why it matters |
 |---|---|---|
 | Guarded execution substrate | Boss, supervisor, tranche, contract, and preflight paths exist on the live swarm lane. | The system can decide when a run is admissible instead of blindly attempting work. |
-| Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. | Progress claims are tied to a measured cohort instead of anecdotes. |
+| Benchmark truth | A fixed benchmark corpus is checked into the repo, and the tracked B0 cohort is published live. **Live number lives in [docs/status/B0_BENCHMARK_TRUTH_STATUS.md](status/B0_BENCHMARK_TRUTH_STATUS.md)** — do not hardcode here (per this doc's own rule below that "external claims stay narrower than the measured proof"). | Progress claims are tied to a measured cohort instead of anecdotes. |
 | Truth artifacts | The repo has a diffable benchmark truth-artifact path, frozen-corpus binding on recurring scorecards, and GitHub-truth reconciliation scripts. | Weekly or recurring reporting can stay tied to issue-level truth instead of drifting with ad hoc samples. |
 | Repair loop progress | Resume-from-state, repair lifecycle persistence, rescue logging, and bounded recovery planning are on `main`. | Repeated failures can increasingly be resumed, diagnosed, and productized instead of re-run cold. |
 | Operator truth | Preflight receipts, blocker evidence, session-state work, recurring benchmark truth publication, and recurring rescue productization are on `main`. | This is the proof surface that turns an impressive demo into a boring reliable product lane. |

--- a/docs/FEATURE_GAP_LIST.md
+++ b/docs/FEATURE_GAP_LIST.md
@@ -1,8 +1,9 @@
 # Aragora Feature Gap List
 
 > **Living document** — tracks features planned, partially built, or in need of hardening. Updated as items are completed or priorities shift.
-> Active execution status now lives in [docs/status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md) and the linked GitHub issues. This file remains the capability and productization backlog truth.
-> Last updated: March 24, 2026
+> **For current execution sequencing** (what to work on right now, what is gated, what is delayed), defer to [docs/status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md). Active execution status is tracked in [docs/status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md) and linked GitHub issues. **This file is the long-horizon capability and productization backlog** — the P0–P4 tiering expresses intended ordering, not dispatch readiness.
+> **For the unified finish-line vision and stage model**, see [docs/CANONICAL_GOALS.md](CANONICAL_GOALS.md). The Decision Integrity Core tranche (crux engine, executable claims, proof-carrying code) is gated on Foreman reliability per [docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md](plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md).
+> Last updated: April 16, 2026
 > March 2026 priority reframe: product cohesion and PMF proof come before certification. Pentest / SOC 2 stay tracked, but they are no longer the first blocker lane.
 
 ## How to Read This List

--- a/docs/outreach/ADDISON_BRIEF.md
+++ b/docs/outreach/ADDISON_BRIEF.md
@@ -93,8 +93,8 @@ All marketing copy has been drafted in the repo:
 - `docs/outreach/DESIGN_PARTNER_ONEPAGER.md` — main value prop and proof points
 - `docs/outreach/BUYER_ANALYST_FAQ.md` — FAQ content
 - `docs/outreach/FOUNDER_PROOF_POINTS_LIBRARY.md` — evidence claims
-- `docs/strategy/NON_GOALS_LEDGER.md` — what Aragora is NOT
-- `docs/strategy/TERMINOLOGY_GLOSSARY.md` — product terminology
+- `docs/strategy/BOUNDARIES_AND_SCOPE.md` Part 1 — what Aragora is NOT (absorbed `NON_GOALS_LEDGER.md`)
+- `docs/strategy/PRECISION_AND_TERMS.md` Part 1 — product terminology (absorbed `TERMINOLOGY_GLOSSARY.md`; see `docs/STRATEGY_INDEX.md`)
 
 ---
 

--- a/docs/strategy/POSITIONING_AND_MESSAGING.md
+++ b/docs/strategy/POSITIONING_AND_MESSAGING.md
@@ -437,8 +437,7 @@ Use selectively. These are evidence atoms to support the wedge, not hero copy.
 - production debate engine with heterogeneous agent support
 - decision receipts and provenance already wired into real flows
 - bounded autonomous repo-improvement path with receipt gates
-- 216,000+ tests across 4,700+ test files
-- 42 knowledge adapters for cross-system context and learning
+- heavy automated test coverage and broad knowledge-adapter surface (exact counts in [../CANONICAL_GOALS.md](../CANONICAL_GOALS.md#canonical-metrics-march-2026-baseline) — this doc should not drift from the canonical baseline)
 
 ### Proof Points That Fit The Story
 


### PR DESCRIPTION
## Summary

Small independent hygiene fixes that remove active confusion in the docs. No content lost; all changes are pointer-level.

- **README** and **docs/outreach/ADDISON_BRIEF.md** — three strategy links pointed to files that no longer exist (COMPETITIVE_POSITIONING_2026_03, WHEN_TO_USE_ARAGORA_VS_EXECUTION_SUBSTRATES, TERMINOLOGY_GLOSSARY). Updated to the consolidated destinations (POSITIONING_AND_MESSAGING, BOUNDARIES_AND_SCOPE, PRECISION_AND_TERMS) already listed in [docs/STRATEGY_INDEX.md](https://github.com/synaptent/aragora/blob/main/docs/STRATEGY_INDEX.md).
- **docs/COMMERCIAL_OVERVIEW.md** — removed hardcoded "86.7% no-rescue success as of 2026-04-13" number. The same doc's own line already says external claims should stay narrower than measured proof; now points at the live truth surface ([docs/status/B0_BENCHMARK_TRUTH_STATUS.md](https://github.com/synaptent/aragora/blob/main/docs/status/B0_BENCHMARK_TRUTH_STATUS.md)).
- **docs/strategy/POSITIONING_AND_MESSAGING.md** — replaced specific "216,000+ tests / 42 adapters" with a pointer to CANONICAL_GOALS' canonical metrics section. Prevents drift as counts grow.
- **docs/FEATURE_GAP_LIST.md** — header now defers execution sequencing to NEXT_STEPS_CANONICAL.md and cross-references CANONICAL_GOALS.md and the new EPISTEMIC_CI_AND_CRUX_ENGINE.md tranche. Clarifies that P0-P4 tiering expresses intended ordering, not dispatch readiness.

## Also done (GitHub side, outside this PR)

- Closed duplicate Crux epic #6035 + subtasks #6036-#6039 as superseded by the canonical **DIC-13..22** sequence (#6023-#6033 / #6025-#6028) that landed today in commits 5048b7bd1 and 666e9042d.
- Re-routed my design doc from PR #6041 as implementation-level planning under **#6025 (DIC-15)**.
- PR #6041's FEATURE_GAP_LIST addition was incorrectly-tiered (P1) and will be amended separately — the correct Decision Integrity Core positioning per [EPISTEMIC_CI_AND_CRUX_ENGINE.md](https://github.com/synaptent/aragora/blob/main/docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md) is gated on Foreman proof.

## Test plan

- [ ] CI green on docs-only change (lint / typecheck / sdk-parity / Generate & Validate / TypeScript SDK Type Check should skip via path filters)
- [ ] Links in README resolve to existing files
- [ ] Markdown preview renders correctly

## Related

Follow-up to [#6041](https://github.com/synaptent/aragora/pull/6041) and the coherence analysis thread. Tier 2 (unified framing) and Tier 3.9 (absorb + deprecate OMNIVOROUS_ROADMAP + BUSINESS_SUMMARY) ship in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)