### PR TITLE
fix(canvas): read pipeline JSON bodies

### DIFF
--- a/aragora/server/handlers/canvas_pipeline.py
+++ b/aragora/server/handlers/canvas_pipeline.py
@@ -789,51 +789,62 @@ class CanvasPipelineHandler:
     @staticmethod
     def _get_request_body(handler: Any) -> dict[str, Any]:
         """Extract JSON body from the request handler."""
+        request = getattr(handler, "request", None)
+        if request is not None:
+            raw = getattr(request, "body", None)
+            if raw and not callable(raw):
+                return CanvasPipelineHandler._decode_request_body(raw)
 
-        def parse_raw(raw: Any) -> dict[str, Any]:
-            if not raw:
-                return {}
-            if isinstance(raw, bytes | bytearray):
-                raw = bytes(raw).decode("utf-8")
-            parsed = json.loads(raw) if isinstance(raw, str) else raw
-            return parsed if isinstance(parsed, dict) else {}
+        if hasattr(handler, "_body"):
+            return CanvasPipelineHandler._decode_request_body(getattr(handler, "_body", None))
 
-        def header_value(name: str) -> str | None:
-            headers = getattr(handler, "headers", None)
-            if not headers or not hasattr(headers, "get"):
-                return None
-            return headers.get(name) or headers.get(name.lower()) or headers.get(name.title())
+        content_length = CanvasPipelineHandler._get_content_length(handler)
+        if content_length <= 0:
+            return {}
 
-        try:
-            if hasattr(handler, "request") and hasattr(handler.request, "body"):
-                raw = handler.request.body
-                if raw is not None:
-                    return parse_raw(raw)
-        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
-            pass
+        rfile = getattr(handler, "rfile", None)
+        if rfile is None:
+            return {}
 
         try:
-            if hasattr(handler, "_body"):
-                raw = handler._body
-                if raw is not None:
-                    return parse_raw(raw)
-        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
-            pass
+            return CanvasPipelineHandler._decode_request_body(rfile.read(content_length))
+        except (OSError, ValueError):
+            return {}
+
+    @staticmethod
+    def _decode_request_body(raw: Any) -> dict[str, Any]:
+        if not raw:
+            return {}
 
         try:
-            length = int(header_value("Content-Length") or "0")
-            if length <= 0 or not hasattr(handler, "rfile"):
-                return {}
-            return parse_raw(handler.rfile.read(length))
-        except (
-            ValueError,
-            TypeError,
-            json.JSONDecodeError,
-            UnicodeDecodeError,
-            AttributeError,
-        ):
-            pass
-        return {}
+            if isinstance(raw, bytearray):
+                raw = bytes(raw)
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8")
+            if isinstance(raw, dict):
+                return raw
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+    @staticmethod
+    def _get_content_length(handler: Any) -> int:
+        raw_length: Any = None
+        get_header = getattr(handler, "get_header", None)
+        if callable(get_header):
+            raw_length = get_header("Content-Length")
+
+        headers = getattr(handler, "headers", None)
+        if raw_length is None and headers is not None:
+            get = getattr(headers, "get", None)
+            if callable(get):
+                raw_length = get("Content-Length") or get("content-length")
+
+        try:
+            return int(raw_length or 0)
+        except (TypeError, ValueError):
+            return 0
 
     async def handle_from_debate(self, request_data: dict[str, Any]) -> HandlerResult:
         """POST /api/v1/canvas/pipeline/from-debate

--- a/aragora/server/handlers/canvas_pipeline.py
+++ b/aragora/server/handlers/canvas_pipeline.py
@@ -789,12 +789,49 @@ class CanvasPipelineHandler:
     @staticmethod
     def _get_request_body(handler: Any) -> dict[str, Any]:
         """Extract JSON body from the request handler."""
+
+        def parse_raw(raw: Any) -> dict[str, Any]:
+            if not raw:
+                return {}
+            if isinstance(raw, bytes | bytearray):
+                raw = bytes(raw).decode("utf-8")
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
+            return parsed if isinstance(parsed, dict) else {}
+
+        def header_value(name: str) -> str | None:
+            headers = getattr(handler, "headers", None)
+            if not headers or not hasattr(headers, "get"):
+                return None
+            return headers.get(name) or headers.get(name.lower()) or headers.get(name.title())
+
         try:
             if hasattr(handler, "request") and hasattr(handler.request, "body"):
                 raw = handler.request.body
-                if raw:
-                    return json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+                if raw is not None:
+                    return parse_raw(raw)
         except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            pass
+
+        try:
+            if hasattr(handler, "_body"):
+                raw = handler._body
+                if raw is not None:
+                    return parse_raw(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            pass
+
+        try:
+            length = int(header_value("Content-Length") or "0")
+            if length <= 0 or not hasattr(handler, "rfile"):
+                return {}
+            return parse_raw(handler.rfile.read(length))
+        except (
+            ValueError,
+            TypeError,
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            AttributeError,
+        ):
             pass
         return {}
 

--- a/tests/server/handlers/test_canvas_pipeline_endpoints.py
+++ b/tests/server/handlers/test_canvas_pipeline_endpoints.py
@@ -596,6 +596,13 @@ class TestRequestBodyParsing:
 
         assert handler._get_request_body(http) == {"source": "request"}
 
+    def test_get_request_body_ignores_callable_request_body(self, handler):
+        http = _CompatFakeHandler({"source": "cached"})
+        http.request = SimpleNamespace(body=lambda: b'{"source": "callable"}')
+        http.rfile = _UnreadableRfile()
+
+        assert handler._get_request_body(http) == {"source": "cached"}
+
     def test_get_request_body_reads_fastapi_cached_body(self, handler):
         http = _CompatFakeHandler({"source": "cached"})
         http.rfile = _UnreadableRfile()

--- a/tests/server/handlers/test_canvas_pipeline_endpoints.py
+++ b/tests/server/handlers/test_canvas_pipeline_endpoints.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -18,6 +21,27 @@ def _body(result) -> dict:
     if isinstance(result, dict):
         return result
     return json.loads(result.body)
+
+
+class _UnreadableRfile:
+    def read(self, *_args, **_kwargs):
+        raise AssertionError("cached body should avoid rfile reads")
+
+
+class _CompatFakeHandler:
+    """Small stand-in for fastapi.compat._FakeHandler."""
+
+    def __init__(self, body: dict[str, object] | bytes, *, include_cached_body: bool = True):
+        raw = body if isinstance(body, bytes) else json.dumps(body).encode("utf-8")
+        self.headers = {
+            "Content-Length": str(len(raw)),
+            "Content-Type": "application/json",
+        }
+        self.command = "POST"
+        self.path = ""
+        if include_cached_body:
+            self._body = raw
+        self.rfile = BytesIO(raw)
 
 
 @pytest.fixture(autouse=True)
@@ -559,6 +583,37 @@ class TestHandleListOrLatest:
 
 
 # =========================================================================
+# Request body parsing
+# =========================================================================
+
+
+class TestRequestBodyParsing:
+    def test_get_request_body_reads_request_body_first(self, handler):
+        http = _CompatFakeHandler({"ignored": True})
+        http.request = SimpleNamespace(body=b'{"source": "request"}')
+        http._body = b'{"source": "cached"}'
+        http.rfile = _UnreadableRfile()
+
+        assert handler._get_request_body(http) == {"source": "request"}
+
+    def test_get_request_body_reads_fastapi_cached_body(self, handler):
+        http = _CompatFakeHandler({"source": "cached"})
+        http.rfile = _UnreadableRfile()
+
+        assert handler._get_request_body(http) == {"source": "cached"}
+
+    def test_get_request_body_reads_legacy_rfile_with_content_length(self, handler):
+        http = _CompatFakeHandler({"source": "rfile"}, include_cached_body=False)
+
+        assert handler._get_request_body(http) == {"source": "rfile"}
+
+    def test_get_request_body_invalid_json_returns_empty_dict(self, handler):
+        http = _CompatFakeHandler(b"not-json", include_cached_body=False)
+
+        assert handler._get_request_body(http) == {}
+
+
+# =========================================================================
 # handle_approve_transition — root path with pipeline_id in body
 # =========================================================================
 
@@ -581,6 +636,41 @@ class TestHandleApproveTransitionRootPath:
             },
         )
         return pipeline_id
+
+    @pytest.mark.asyncio
+    async def test_root_approve_transition_reads_fastapi_cached_body(self, handler):
+        http = _CompatFakeHandler({"pipeline_id": "pipe-fastapi-body"})
+
+        with patch.object(CanvasPipelineHandler, "_check_permission", return_value=None):
+            result = handler.handle_post(
+                "/api/v1/canvas/pipeline/approve-transition",
+                {},
+                http,
+            )
+            if hasattr(result, "__await__"):
+                result = await result
+
+        assert result.status_code == 404
+        assert _body(result)["error"] == "Pipeline pipe-fastapi-body not found"
+
+    @pytest.mark.asyncio
+    async def test_from_ideas_reads_fastapi_cached_body(self, handler):
+        http = _CompatFakeHandler(
+            {
+                "ideas": ["Turn founder review into a bounded pipeline"],
+                "auto_advance": False,
+            }
+        )
+
+        with patch.object(CanvasPipelineHandler, "_check_permission", return_value=None):
+            result = handler.handle_post("/api/v1/canvas/pipeline/from-ideas", {}, http)
+            if hasattr(result, "__await__"):
+                result = await result
+
+        body = _body(result)
+        assert result.status_code == 201
+        assert body["pipeline_id"].startswith("pipe-")
+        assert body["result"]["stage_status"]["actions"] == "pending"
 
     @pytest.mark.asyncio
     async def test_approve_transition_defaults_to_approved(self, handler, sample_cartographer_data):


### PR DESCRIPTION
## Summary
- read CanvasPipelineHandler JSON bodies from request.body, FastAPI cached _body, and legacy rfile/Content-Length
- preserve cached-body priority so FastAPI shim bodies are not double-read
- add regression coverage for parser order plus approve-transition and from-ideas handle_post flows

## Validation
- python3 -m pytest -q tests/server/handlers/test_canvas_pipeline_endpoints.py -p no:rerunfailures
- python3 -m ruff check aragora/server/handlers/canvas_pipeline.py tests/server/handlers/test_canvas_pipeline_endpoints.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD