### PR TITLE
docs(vision): agent-civilization substrate as additive vision-layer planning track

### DIFF
--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -89,6 +89,14 @@ Aragora must be useful to founders, operators, and small teams with limited time
 
 Nomic, swarm, and user-facing execution should converge on the same contract, ledger, memory, and control-plane surfaces. We do not want multiple autonomy stacks drifting apart. Repeated rescue classes should become benchmark fixtures and product work, not tribal knowledge.
 
+### 8. Agents and Humans as Co-Equal Consumers
+
+Software agents are about to become first-rate consumers of decisionmaking, memory, capability marketplaces, and reputation surfaces — alongside humans, not replacing them. Every consumer surface (registration, capability discovery, billing, decision receipts, reputation reads) ships in two forms, agent-readable and human-readable, backed by the same runtime truth.
+
+This pillar pulls the existing identity, reputation, staking, validation, A2A, marketplace, and receipt primitives into a unified consumer surface so the substrate Aragora is building can serve the emerging agent population without forking into a separate stack. The design constraint is parity: nothing humans can do through the platform should be unavailable to agents, and nothing agents can do should be unavailable to humans.
+
+The vision-layer planning for this pillar lives in [plans/AGENT_CIVILIZATION_SUBSTRATE.md](plans/AGENT_CIVILIZATION_SUBSTRATE.md) with sibling specs [plans/AGENT_CONSUMER_SURFACE.md](plans/AGENT_CONSUMER_SURFACE.md), [plans/SKIN_IN_THE_GAME_REPUTATION.md](plans/SKIN_IN_THE_GAME_REPUTATION.md), and [plans/2026-04-17-prediction-market-validation.md](plans/2026-04-17-prediction-market-validation.md). Live queue scope continues to follow the substrate-first gate in [status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md); these plans are planning truth, not active dispatch scope.
+
 ## Architectural Doctrine
 
 ### Aragora Is the Terrarium, Not the Organism
@@ -162,3 +170,4 @@ Aragora's trust story is structural:
 4. Shared memory improves future work without collapsing trust boundaries.
 5. Important claims and cruxes remain linked to evidence, receipts, freshness, and later settlement.
 6. Aragora evolves from tool -> teammate -> foreman -> chief of staff -> organization substrate on one coherent runtime.
+7. Agents and humans participate in the same substrate as co-equal consumers, with portable reputation tied to objectively verifiable outcomes through external truth oracles (prediction markets, public verifiable streams, synthetic in-repo markets) rather than to internal agreement.

--- a/docs/plans/2026-04-17-prediction-market-validation.md
+++ b/docs/plans/2026-04-17-prediction-market-validation.md
@@ -1,0 +1,211 @@
+# Prediction-Market Validation Plan — Manifold, Metaculus, and Synthetic GitHub Markets
+
+> **Status:** vision-layer planning track (`AGT-03` Manifold, `AGT-04` synthetic GH, downstream Metaculus); not boss-ready until queue governance permits the upper-layer tranche.
+> **Created:** 2026-04-17
+> **Parent:** [AGENT_CIVILIZATION_SUBSTRATE](AGENT_CIVILIZATION_SUBSTRATE.md)
+> **Sibling:** [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md)
+
+## Why this plan exists
+
+The skin-in-the-game reputation flow needs an **external truth oracle**. Without one, the reputation system collapses into agents agreeing with agents — a closed loop with no signal. Public verifiable streams supply the bite without requiring a sales motion.
+
+This plan specifies the venue stack, integration architecture, risk controls, and graduation path for using prediction markets as the primary external resolution source for `AGT-05`.
+
+## Why prediction markets are the right fit
+
+The user's intuition is correct: prediction markets are open-ended, verifiable, time-bounded, and provide real skin-in-the-game without requiring real money in the early phases. The properties that make them appropriate:
+
+| Property | Why it matters |
+|---|---|
+| Open-ended | Works for any domain reputation we want to build, not just one vertical |
+| Verifiable | Resolutions are public, signed, and auditable |
+| Time-bounded | Each market has a resolution date, so reputation updates close out |
+| Real skin-in-the-game (where elected) | Stakes create real cost for being wrong |
+| Adversarial | Other traders apply real pressure, which makes the test meaningful |
+| Public APIs | Manifold and Metaculus both expose stable bot-friendly APIs |
+| Calibration-native | The whole field is built around scoring rules (Brier, log loss) |
+
+## Why other models warned against this (and why those warnings don't apply here)
+
+Most model-warned objections pattern-match "automated" + "trading" + "real money" → CFTC/SEC/gambling regulatory risk + alignment concerns about autonomous financial agents. Those concerns are legitimate **for real-money trading**. They are not legitimate for the validation-environment use case proposed here, because:
+
+1. The early phases use **only play-money** venues (Manifold mana, Metaculus points).
+2. The goal is **calibration measurement**, not profit extraction.
+3. Stake sizing and position limits are bounded explicitly so even a bug cannot cause meaningful adverse market impact.
+4. Real-money venues are **deferred** until calibration is stable and proper compliance setup is in place.
+
+The signal worth extracting from the warnings: don't move to real-money venues casually; treat the regulatory step as a deliberate graduation event with legal review.
+
+## Venue stack (in order of adoption)
+
+### Phase 1: Manifold Markets (AGT-03 primary)
+
+- **Money model:** play money (mana)
+- **Regulatory exposure:** none
+- **Why first:** designed for bots from day one, hundreds of bots already trade there, full public API, welcoming community
+- **What we measure:** rolling Brier score per agent, calibration curve, market-impact footprint
+- **Position limits:** start at 50 mana per market, scale only after observing impact patterns
+
+### Phase 2: Metaculus
+
+- **Money model:** none (forecasting platform with calibration scoring)
+- **Regulatory exposure:** none
+- **Why second:** pure calibration-focused community, established Brier/log-loss leaderboards, longer-horizon questions complement Manifold's short cycle
+- **What we measure:** community-relative calibration, novel-question performance
+- **Constraints:** Metaculus does not allow undisclosed bots in some categories; ensure compliance with their bot policy
+
+### Phase 3: Synthetic GitHub markets (AGT-04, runs in parallel from start)
+
+- **Money model:** internal (compute credits via `aragora/blockchain/compute_budget.py`)
+- **Regulatory exposure:** none (internal)
+- **Why parallel:** fully owned, fastest cycle, no platform dependency
+- **Question shapes:**
+  - Will PR #X merge in 7 days?
+  - Will issue #Y close within 30 days?
+  - Will CI pipeline #Z pass on first run for a given branch?
+  - Will a given OSS dependency release within target window?
+- **Resolution:** automatic via GitHub API + receipt-anchored settlement
+- **What we measure:** high-volume calibration on a controlled corpus, complementing the lower-volume external venues
+
+### Phase 4 (deferred): Kalshi
+
+- **Money model:** real (USD)
+- **Regulatory exposure:** CFTC-regulated, requires entity setup, KYC, legal review
+- **When:** only after Phase 1-3 calibration is stable, the reputation flow is proven, and there is a deliberate decision to move to real-money signal
+- **Compliance notes:** Kalshi requires US-resident users; entity-level participation requires onboarding process
+
+### Phase 5 (deferred indefinitely): Polymarket / Augur / Limitless
+
+- **Money model:** crypto (USDC/etc)
+- **Regulatory exposure:** geo-restricted in US, regulatory weather changes frequently
+- **When:** not in the visible horizon; revisit if regulatory landscape stabilizes
+
+## Architecture
+
+```
+┌──────────────────────┐    ┌─────────────────┐    ┌──────────────────────┐
+│ Aragora prediction   │--->│ Venue API       │--->│ Position taken       │
+│ engine (per agent)   │    │ adapter         │    │ Receipt anchored     │
+└──────────────────────┘    └─────────────────┘    └──────────────────────┘
+         │                                                    │
+         │  reads CruxSet, Arena debate, KM evidence          ▼
+         ▼                                          ┌──────────────────────┐
+┌──────────────────────┐                            │ Resolution ingestion │
+│ StakeableClaim       │<────────────────────-------│ ResolutionEvent      │
+│ schema (AGT-05)      │                            │ ↓                    │
+└──────────────────────┘                            │ Reputation Δ (AGT-05)│
+                                                    └──────────────────────┘
+```
+
+Each venue gets one adapter under `aragora/connectors/prediction_markets/`:
+
+- `manifold.py` — Manifold API client + market discovery + position taking
+- `metaculus.py` — Metaculus API client + question discovery + prediction submission
+- `synthetic_github.py` — internal market creation + GitHub API resolution
+
+All adapters emit a unified `MarketPosition` event consumed by AGT-05 settlement.
+
+## Stake sizing and risk controls
+
+### Manifold
+
+- per-market position cap: 50 mana initially, 200 mana after 30 days of stable behavior
+- per-day total cap: 1000 mana
+- avoid >5% of market liquidity in any single position
+- never trade markets with <30 day resolution windows in initial phase (avoid noisy short-cycle calibration)
+
+### Metaculus
+
+- follow Metaculus bot policy strictly; disclosed-bot status only
+- one prediction per question per day
+- target categories with clear resolution criteria; avoid subjective questions in initial phase
+
+### Synthetic GitHub markets
+
+- per-market position cap: 100 internal credits
+- limit to publicly observable repos to keep resolution unambiguous
+- expire stale unresolved markets after 90 days
+
+## Calibration metric and reporting
+
+Per agent, per venue, weekly:
+
+| Metric | Definition |
+|---|---|
+| Brier score (rolling 90d) | Lower is better; floor is 0 |
+| Calibration curve | Predicted probability vs. realized frequency, bucketed |
+| Resolution count | Number of markets resolved in window |
+| Stake-weighted Brier | Brier weighted by position size |
+| Market-impact footprint | Average % of market liquidity moved per position |
+| Dispute rate | Fraction of resolutions challenged by other traders |
+
+These metrics feed AGT-05 ReputationDelta computation. The reputation delta scoring rule is **proper Brier**, so honest probability reporting is the maximum-reward strategy.
+
+## Resolution lag and short-cycle markets
+
+Many interesting markets resolve months out. To keep the calibration-update loop fast enough to be useful for dispatch decisions, mix in short-cycle markets:
+
+- **Daily:** sports outcomes, weather targets, daily price thresholds
+- **Weekly:** scheduled events, weekly OSS releases, weekly economic data
+- **Monthly:** PR merges, issue closures, monthly milestones
+- **Quarterly+:** elections, scientific replications, long-horizon predictions
+
+The reputation calculation weights short-cycle and long-cycle markets differently to avoid Goodharting on quick-resolving but low-value calibration.
+
+## Selection bias
+
+Easy markets reward narrow agents. To exercise the full debate-to-decision pipeline:
+
+- enforce a quota of "open-ended judgement" markets per agent per week (e.g. Metaculus essay-style questions)
+- prevent farming of pure consensus markets where every reasonable trader agrees
+- include cross-domain markets so an agent's reputation is not concentrated in a single category
+
+## Adversarial pressure
+
+This is a **feature** for skin-in-the-game testing. Other traders will reverse-engineer agent strategies, copy good predictions, and exploit predictable behavior. The reputation system gets to learn under that pressure. Operationally:
+
+- expect strategy decay over time as patterns are recognized
+- treat exploited strategies as a signal that the agent's reasoning was not novel enough
+- include red-team agents internally that intentionally counter-trade detected patterns
+
+## Public exposure of agent reasoning
+
+If receipts and reasoning are posted publicly, expect them to be analyzed and copied. This is acceptable for the validation purpose. For competitive lanes (later, real-money), reasoning would be partial-veiled.
+
+## Sequencing
+
+| Code | Step | Deliverable |
+|---|---|---|
+| AGT-03.1 | Manifold adapter (read-only) | discover markets, fetch resolutions |
+| AGT-03.2 | Manifold adapter (write) | submit predictions, anchor receipts |
+| AGT-03.3 | Brier score computation per agent | weekly rolling 90d Brier reported |
+| AGT-04.1 | Synthetic market schema | internal market objects with resolution criteria |
+| AGT-04.2 | GitHub event resolution | automatic resolution against GitHub API |
+| AGT-04.3 | Internal credit bookkeeping | stake forfeit/refund through compute_budget |
+| Metaculus | Bot-policy compliance + read adapter | discovered after AGT-03.1, before AGT-03.3 |
+| Metaculus | Write adapter | optional follow-up to AGT-03.3 |
+
+## What this plan does NOT do
+
+- Does not enable real-money trading.
+- Does not move AGT-03/AGT-04 issues into `boss-ready` until queue governance permits the upper-layer tranche.
+- Does not introduce a new wallet or settlement layer; uses existing `aragora/blockchain/`.
+- Does not bypass venue terms of service; all bot activity must comply with venue policies.
+- Does not commit to a Polymarket/Kalshi integration timeline.
+
+## Risks and tempering
+
+- **Venue policy change.** Venues may change bot policies or rate limits. Mitigation: keep adapters thin; design AGT-05 to function across venue switches.
+- **Calibration ≠ usefulness.** A perfectly calibrated agent may still be uninteresting. Calibration is necessary but not sufficient; CruxSet quality is the parallel signal.
+- **Time sink.** Building rich integrations for low-value venues. Mitigation: each venue must contribute >100 resolved predictions per agent per quarter to remain wired.
+- **Reputation laundering.** An agent could farm easy markets to inflate aggregate reputation. Mitigation: per-domain reputation; aggregate is a weighted sum that surfaces the breakdown to operators.
+
+## References
+
+- [AGENT_CIVILIZATION_SUBSTRATE](AGENT_CIVILIZATION_SUBSTRATE.md)
+- [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md)
+- [AGENT_CONSUMER_SURFACE](AGENT_CONSUMER_SURFACE.md)
+- [EPISTEMIC_CI_AND_CRUX_ENGINE](EPISTEMIC_CI_AND_CRUX_ENGINE.md)
+- Manifold API: <https://docs.manifold.markets/api>
+- Metaculus API: <https://www.metaculus.com/api/>
+- Code: `aragora/blockchain/`, `aragora/connectors/` (new `prediction_markets/` subdirectory), `aragora/reasoning/`

--- a/docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md
+++ b/docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md
@@ -1,0 +1,187 @@
+# Aragora as Substrate for Agent Civilization
+
+> **Status:** additive long-horizon vision synthesis — extends but does not replace [CANONICAL_GOALS](../CANONICAL_GOALS.md), [ARAGORA_EVOLUTION_ROADMAP](ARAGORA_EVOLUTION_ROADMAP.md), [EPISTEMIC_CI_AND_CRUX_ENGINE](EPISTEMIC_CI_AND_CRUX_ENGINE.md), and [COMMERCIAL_OVERVIEW](../COMMERCIAL_OVERVIEW.md).
+> **Created:** 2026-04-17
+> **Queue policy:** planning truth only. None of the AGT-* gates below may carry `boss-ready` until the proof-first Foreman gate permits the upper-layer tranche, in line with the existing rule that delays `DIC-13..22`.
+
+## Why this document exists
+
+CANONICAL_GOALS already names crux-finding, cryptographic receipts, the terrarium-not-organism doctrine, and the Tool→Teammate→Foreman→Chief-of-Staff→Organization-Substrate stage model. The Evolution Roadmap already names Track E (Decision Integrity Core) including E5 (Crux Engine, Epistemic CI, Epistemic Runtime). EPISTEMIC_CI_AND_CRUX_ENGINE.md plans DIC-13..22 in detail.
+
+What is **not yet explicit** in those documents:
+
+1. The long-horizon thesis that Aragora is the **substrate for agent civilization**, not only for human-operated organizations.
+2. The treatment of **agents as first-rate consumers** alongside humans, with their own registration, capability discovery, billing, receipts, and reputation surfaces.
+3. The mechanism by which **skin-in-the-game accountability** turns the existing `aragora/blockchain/contracts/{identity,reputation,staking,validation}.py` primitives into a live reputation flow tied to resolved cruxes and time-bounded predictions.
+4. How **external truth oracles** (prediction markets, public verifiable streams, synthetic GitHub markets) supply the ground-truth signal the reputation flow needs without requiring a sales motion.
+5. A **productivity metric** to replace empty-queue stability soaks once substrate stability is proven.
+6. **Capability checkpoints** for the booster-rocket thesis so the meta-system is required to graduate from substrate to surface.
+
+This document captures those six extensions and sequences them as a vision-layer planning track (`AGT-01..AGT-06`) that runs in parallel to the substrate-first execution gate.
+
+## Thesis
+
+The decision-grade autonomy substrate Aragora is building — heterogeneous-model debate, cryptographically attested receipts, verifiable provenance, fail-closed admission, ledger-backed truth, crux detection — is a useful platform for human-operated organizations. It is also the missing platform for an emerging population of software agents that need to make consequential, auditable, time-bounded decisions on each other's behalf and on humans' behalf.
+
+The model labs will build coding agents and personal assistants. They are unlikely to build:
+
+- multi-agent crux resolution that surfaces the load-bearing disagreement
+- cryptographically attested decision provenance with later-settlement preservation
+- skin-in-the-game agent reputation tied to objectively verifiable outcomes
+- a consumer surface that lets agents register, stake, transact, and earn reputation
+- an environment whose physics rewards evidence, verification, and explicit dissent over fluent assertion
+
+That is the layer Aragora is uniquely positioned to occupy. It is also the layer that compounds: as the substrate stabilizes and the verifiable-outcome corpus grows, the calibration data on every participating agent becomes itself a moat.
+
+## Why this is compatible with the substrate-first gate
+
+The current execution obligation in NEXT_STEPS_CANONICAL is to make bounded unattended execution boring before widening claims. That obligation is **not** in tension with this vision. Three compatibility points:
+
+1. **Substrate is foundation, not competitor.** Boss loop, merge arbiter, queue governance, ShiftLedger, proof-first publication, BC-12 soaks — these are the load-bearing primitives that everything in this document depends on. None of the AGT-* work would function without them.
+2. **Planning truth is allowed; live queue scope is not widened.** The same rule that governs DIC-13..22 (open issues, design work, schema definition allowed; no `boss-ready` until permitted) applies here. The proof-first reconciler will continue to strip `boss-ready` from any AGT-* issue until the gate explicitly opens.
+3. **The vision sharpens the substrate metric.** A move from "did the controller crash for 12 hours?" to "did the system produce N verifiable improvements per agent-hour without rescue?" is itself a tightening of the substrate gate, not a relaxation. Empty-queue stability proves the meta-system did not regress; verifiable productivity proves the meta-system is paying for its own existence.
+
+## What the vision adds (beyond what is already canonical)
+
+### 1. Agents as first-rate consumers
+
+The product surface today assumes humans are the consumer. The substrate is general enough to serve agents directly, but the registration, capability discovery, billing, receipt, and reputation surfaces still need explicit agent-readable shapes.
+
+Concretely:
+
+- agent registration through the existing identity primitives (`aragora/blockchain/contracts/identity.py`)
+- capability discovery through the A2A protocol (`aragora/protocols/a2a/`) plus marketplace catalog (`aragora/marketplace/`)
+- billing primitives that meter compute, debate cost, and verifier cost per agent
+- agent-readable decision receipts (machine-parseable, signature-verifiable) emitted by the existing `aragora/export/decision_receipt.py` path
+- reputation read/write surfaces that read from and write to the ERC-8004 reputation registry (`aragora/blockchain/contracts/reputation.py`)
+
+This work is detailed in [AGENT_CONSUMER_SURFACE](AGENT_CONSUMER_SURFACE.md).
+
+### 2. Skin-in-the-game accountability
+
+The reputation primitives exist. The flow that turns resolved outcomes into reputation deltas does not.
+
+The unified flow is:
+
+```
+claim or stance → stake (compute, capital, or reputation) → resolution event → settlement → reputation update → dispatch eligibility update
+```
+
+Each stage maps to existing modules:
+
+- **claim/stance:** `aragora/reasoning/claims.py`, `aragora/reasoning/crux_detector.py`, Arena debate output
+- **stake:** `aragora/blockchain/contracts/staking.py`, `aragora/blockchain/compute_budget.py`
+- **resolution event:** Manifold/Metaculus/synthetic-market resolution, `aragora/blockchain/receipt_settlement.py`
+- **settlement:** existing `Time Is Part of Settlement` doctrine in CANONICAL_GOALS
+- **reputation update:** `aragora/blockchain/contracts/reputation.py`, `aragora/knowledge/mound/adapters/erc8004_adapter.py`
+- **dispatch eligibility:** debate `team_selector`, calibration tracker, ELO
+
+This work is detailed in [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md).
+
+### 3. External truth oracles via prediction markets
+
+Without design partners, the reputation flow has no external ground-truth source. The system would optimize agents on agreement with each other, which is a closed loop and a doom-loop risk.
+
+Public verifiable streams supply external ground truth without requiring a sales motion:
+
+- **Manifold Markets** — play money, full API, zero regulatory exposure, designed for bots
+- **Metaculus** — calibration tracking, public API, no trading mechanics
+- **Synthetic GitHub markets** — predict PR merges, issue resolutions, CI outcomes
+- **Kalshi** — graduate to real-money markets only after calibration is stable
+- **Polymarket / Augur / Limitless** — defer; regulatory weather varies
+
+This work is detailed in [2026-04-17-prediction-market-validation](2026-04-17-prediction-market-validation.md).
+
+### 4. Productivity metric replacing empty-queue idle soaks
+
+Empty-queue BC-12 soaks prove the controller did not crash. They do not prove the system produces value. Once the substrate is stable enough to sustain itself, the gating metric should shift to something the booster-rocket thesis is required to lift.
+
+Proposed metric: **verifiable improvements per agent-hour (VIAH)**.
+
+```
+VIAH = (
+    (merged_autonomous_prs * 1.0)
+    + (cruxes_correctly_detected_pre_resolution * 0.5)
+    + (predictions_resolved_above_brier_threshold * 0.5)
+    - (rescues_required * 0.5)
+    - (failed_claims_promoted_without_repair * 1.0)
+) / agent_hours
+```
+
+VIAH is computed weekly, persisted to ShiftLedger, and surfaced through the existing operator-truth path. It supplements, not replaces, the no-rescue success rate from TW-02. The substrate is paying for itself when VIAH trends up week-over-week without operator babysitting.
+
+### 5. Capability checkpoints for the booster-rocket thesis
+
+The booster-rocket investment in autonomous infrastructure is defensible if and only if the boosters actually lift. Without explicit checkpoints, scaffolding work becomes open-ended and self-reinforcing.
+
+Proposed checkpoints (target dates relative to gate-open):
+
+| Checkpoint | Window | Pass condition | Action if not met |
+|---|---|---|---|
+| **CP-1: Sustained substrate** | gate-open + 4 weeks | 3 consecutive green BC-12 soaks (1 idle + 2 productive); no LaunchAgent respawn-failure incidents requiring human kickstart | Pause AGT-* planning work; debug substrate self-healing |
+| **CP-2: Live crux activation** | CP-1 + 4 weeks | CruxDetector emits ranked CruxSet on >=20 real debates per week; at least one CruxSet linked to a follow-up issue or claim | Reduce AGT scope to crux-only and re-evaluate |
+| **CP-3: External truth signal** | CP-2 + 4 weeks | Manifold + Metaculus integration produces >=100 resolved predictions per agent per week; calibration curve is stable | Defer reputation wiring; debug prediction pipeline |
+| **CP-4: Reputation flow live** | CP-3 + 4 weeks | At least one agent has reputation delta drive a real dispatch-eligibility change in production | Reduce to read-only reputation surface; revisit policy |
+| **CP-5: Productivity-positive** | CP-4 + 4 weeks | VIAH trends positive over rolling 4-week window without operator rescue spike | Pause new boosters; consolidate existing layers |
+
+Failing any checkpoint does not kill the vision. It downscales the next investment until the underlying booster is proven.
+
+### 6. Wire-vs-shelve discipline (preserves existing breadth)
+
+The user's preference is integrate over cut. The risk is that 230+ features bit-rot. The compromise is explicit classification per subsystem rather than deletion:
+
+- **(A) Substrate path** — actively maintained, on the critical path to the self-improving organism
+- **(B) Showcase application** — demonstrates the platform end-to-end (Inbox Trust Wedge, autonomy benchmarks, prediction-market validation, A2A consumer surface)
+- **(C) Shelved with revisit pointer** — preserved in repo, maintenance suspended, README link to the doc that will revive it
+
+`docs/STRANDED_FEATURES_AUDIT.md` is the existing inventory; this discipline extends it. Nothing is deleted; bit-rot risk is contained by suspending maintenance with explicit revival criteria.
+
+## AGT-* sequencing (vision-layer planning track)
+
+These codes mirror the existing `CS-*`, `BC-*`, `RS-*`, `DIC-*` taxonomy. They are planning truth, not live queue scope. The proof-first reconciler MUST strip `boss-ready` from AGT-* issues until queue governance permits this tranche, exactly as it does for `DIC-13..22`.
+
+| Code | Title | Depends on | First milestone |
+|------|-------|-----------|-----------------|
+| `AGT-01` | Activate CruxDetector in live Arena debates | DIC-15 (#6025), Issue [#6035](https://github.com/synaptent/aragora/issues/6035) | CruxDetector emits ranked CruxSet on production debate path under flag |
+| `AGT-02` | A2A consumer surface (registration, capability discovery, billing, agent receipts) | existing `aragora/protocols/a2a/`, `aragora/marketplace/` | Agents can register, discover capabilities, transact, and consume receipts via documented A2A endpoints |
+| `AGT-03` | Manifold integration with rolling Brier scoring | AGT-02 | Aragora agents predict on Manifold, store predictions/resolutions, emit per-agent Brier scores |
+| `AGT-04` | Synthetic GitHub prediction markets | none (internal) | Internal market predicts PR merges and issue closures with verifiable resolution within 30 days |
+| `AGT-05` | ERC-8004 reputation flow wiring (claims→predictions→resolution→reputation→dispatch) | AGT-03, AGT-04, DIC-16, existing `aragora/blockchain/contracts/reputation.py` | Resolved prediction or crux outcome produces a reputation delta visible to team_selector |
+| `AGT-06` | Verifiable improvements per agent-hour (VIAH) metric | RS-10 ShiftLedger | Weekly VIAH computed, persisted, and surfaced through operator-truth path |
+
+Sequencing rule: AGT-01 and AGT-04 may proceed in parallel (both internal, no external dependency). AGT-02 and AGT-03 may proceed in parallel after AGT-01 lands. AGT-05 requires both AGT-03 and AGT-04. AGT-06 requires AGT-05 to be meaningful.
+
+## What this document does NOT change
+
+- The current gate stays the proof-first substrate gate in NEXT_STEPS_CANONICAL.
+- `boss-ready` queue rules are unchanged.
+- DIC-13..22 sequencing is unchanged; this document layers on top of them.
+- BC-12 soak policy is unchanged in the short term; AGT-06 (VIAH) is the eventual replacement, not an immediate one.
+- External claims still must lag measured proof.
+- The terrarium-not-organism doctrine stands. Agents earning reputation in this substrate are operating inside a designed environment, not granted autonomy beyond it.
+
+## Tempering principles to remember
+
+These are decision aids when the substrate-vs-surface tension flares up:
+
+1. **Substrate must graduate to surface.** Permanent scaffolding is a tar pit. Each booster needs a checkpoint where it is required to produce downstream value.
+2. **External truth oracles are non-negotiable.** A reputation system without external resolution is agents agreeing with agents. Manifold/Metaculus/synthetic markets supply the bite.
+3. **Wire-vs-shelve over delete.** The 230+ features are an asset only if classified. Premature deletion is also a failure mode.
+4. **Platform with showcases, not platform alone.** Inbox Trust Wedge, autonomy benchmarks, A2A consumer surface, prediction-market validation are the showcases that prove the platform works without narrowing it to one vertical.
+5. **Agents and humans as co-equal consumers.** Every consumer surface (registration, billing, receipts, reputation) ships in agent-readable and human-readable form.
+6. **Time is part of settlement.** Receipts preserve dissent and assumptions for delayed resolution. Reputation updates can be re-opened when later evidence arrives.
+
+## References
+
+- [CANONICAL_GOALS](../CANONICAL_GOALS.md)
+- [ARAGORA_EVOLUTION_ROADMAP](ARAGORA_EVOLUTION_ROADMAP.md)
+- [EPISTEMIC_CI_AND_CRUX_ENGINE](EPISTEMIC_CI_AND_CRUX_ENGINE.md)
+- [NEXT_STEPS_CANONICAL](../status/NEXT_STEPS_CANONICAL.md)
+- [COMMERCIAL_OVERVIEW](../COMMERCIAL_OVERVIEW.md)
+- [WHY_ARAGORA](../WHY_ARAGORA.md)
+- [SELF_IMPROVING_ARAGORA](SELF_IMPROVING_ARAGORA.md)
+- [AGENT_CONSUMER_SURFACE](AGENT_CONSUMER_SURFACE.md)
+- [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md)
+- [2026-04-17-prediction-market-validation](2026-04-17-prediction-market-validation.md)
+- [2026-04-16-crux-mode-design](2026-04-16-crux-mode-design.md)
+- Existing primitives: `aragora/blockchain/contracts/`, `aragora/protocols/a2a/`, `aragora/reasoning/crux_detector.py`, `aragora/marketplace/`

--- a/docs/plans/AGENT_CONSUMER_SURFACE.md
+++ b/docs/plans/AGENT_CONSUMER_SURFACE.md
@@ -1,0 +1,141 @@
+# Agent Consumer Surface — A2A Registration, Capability, Billing, Receipts, Reputation
+
+> **Status:** vision-layer planning track (`AGT-02`); not boss-ready until queue governance permits the upper-layer tranche.
+> **Created:** 2026-04-17
+> **Parent:** [AGENT_CIVILIZATION_SUBSTRATE](AGENT_CIVILIZATION_SUBSTRATE.md)
+
+## Thesis
+
+Software agents are about to become first-rate consumers of the same kinds of services humans consume — including consequential decisionmaking with auditable provenance. The substrate Aragora is building is general enough to serve them directly, but the consumer surface today assumes humans. This plan makes the agent-as-consumer surface explicit while preserving and reusing the existing human-facing surface.
+
+The platform principle is: every consumer surface ships in **two forms**, agent-readable and human-readable, backed by the same runtime truth.
+
+## What already exists in the codebase
+
+This plan deliberately **wires** existing modules rather than introducing parallel ones.
+
+| Concern | Existing module | Status |
+|---|---|---|
+| Agent identity | `aragora/blockchain/contracts/identity.py` | ERC-8004-aligned identity primitives |
+| A2A protocol | `aragora/protocols/a2a/{client,server,types}.py` | Protocol surface defined |
+| Capability marketplace | `aragora/marketplace/{catalog,registry,service}.py` | Catalog and registry primitives |
+| Decision receipts | `aragora/export/decision_receipt.py` | Receipt schema and signing |
+| Receipt anchoring | `aragora/blockchain/receipt_anchor.py` | On-chain anchoring path |
+| Reputation registry | `aragora/blockchain/contracts/reputation.py` | ERC-8004 reputation contract |
+| Validation contracts | `aragora/blockchain/contracts/validation.py` | Validation contract surface |
+| Compute budget | `aragora/blockchain/compute_budget.py` | Per-action budget primitive |
+| KM ERC-8004 adapter | `aragora/knowledge/mound/adapters/erc8004_adapter.py` | KM-side adapter for reputation reads |
+| Wallet | `aragora/blockchain/wallet.py` | Account management |
+| Skills/installer | `aragora/skills/installer.py`, `aragora/marketplace/installer.py` | Capability installation |
+
+The work in this plan is to add the integration glue, agent-readable shapes, and operator-truth links so an external agent can register, discover, transact, prove a decision, and be reputationally accountable end-to-end.
+
+## Surfaces to ship
+
+### S1. Agent registration
+
+**Goal:** an external agent can register with Aragora, prove identity, and obtain credentials usable on the A2A protocol.
+
+Requirements:
+- registration request includes claimed identity, public key, capability scopes, billing endpoint, and acceptance of the substrate operating policy
+- registration emits a signed identity receipt and writes to `identity.py` registry
+- duplicate-identity policy: reject; do not silently merge
+- revocation endpoint backed by the same identity contract
+
+Acceptance: `aragora agent register --key <pubkey> --capabilities <scope-list>` succeeds and produces a verifiable identity receipt.
+
+### S2. Capability discovery
+
+**Goal:** an external agent can query what Aragora offers and what other registered agents offer.
+
+Requirements:
+- machine-readable catalog endpoint exposing platform capabilities (debate, prediction, claim verification, prediction-market participation, marketplace install, KM query, receipt fetch)
+- machine-readable per-agent catalog showing what each registered agent offers, with reputation summary
+- both endpoints must be agent-friendly (stable IDs, semantic versioning, JSON schema, pagination)
+
+Acceptance: `GET /api/v1/a2a/capabilities` returns a documented schema; `GET /api/v1/a2a/agents/<id>/capabilities` returns the per-agent slice with reputation.
+
+### S3. Billing primitives
+
+**Goal:** an agent can be billed and can bill, with metering tied to receipts.
+
+Requirements:
+- per-call metering across debate cost, verifier cost, KM ingestion cost, prediction-market participation cost, blockchain-anchor cost
+- prepaid compute-budget model (extends `aragora/blockchain/compute_budget.py`)
+- chargeback receipts: every billable event emits a signed receipt with the consumed budget delta
+- agent-issued invoice path for agents that provide capabilities to others
+
+Acceptance: agent A can pay agent B for a debate, with both sides emitting verifiable chargeback receipts.
+
+### S4. Agent-readable decision receipts
+
+**Goal:** receipts are usable by agents without HTML parsing or screen reading.
+
+Requirements:
+- canonical JSON schema versioned alongside the existing receipt schema
+- machine-verifiable signature path (no HTTPS-only trust)
+- includes: decision summary, ranked CruxSet (when AGT-01 active), evidence links with provenance, dissent record, freshness SLA, settlement window, agent reputation deltas applied
+- receipts are content-addressable for dedup
+
+Acceptance: an external agent can fetch a receipt, verify its signature, parse its CruxSet, and act on it without human-in-the-loop.
+
+### S5. Reputation read/write
+
+**Goal:** agents have a portable reputation that survives across decisions and that gates dispatch eligibility.
+
+Requirements:
+- per-agent reputation read endpoint backed by `reputation.py`
+- reputation write path is **mediated only by AGT-05** (claims→predictions→resolution→reputation flow); agents cannot self-promote
+- decay policy: stale reputation degrades over time without fresh outcomes
+- per-domain reputation slices (prediction calibration, debate truthfulness, code-PR success rate, KM contribution quality)
+
+Acceptance: `GET /api/v1/a2a/agents/<id>/reputation` returns per-domain reputation; reputation only changes via AGT-05 settlement.
+
+### S6. Operator parity
+
+**Goal:** every agent surface above has a human-equivalent surface, backed by the same runtime truth.
+
+Requirements:
+- registration UI mirrors the registration API
+- reputation dashboard mirrors the read endpoint
+- billing dashboard mirrors the metering surface
+- receipt viewer renders the same canonical JSON
+
+Acceptance: a human can do everything an agent can do, and vice versa, against the same backing data.
+
+## Risks and tempering
+
+- **Sybil resistance.** Without strong identity, reputation is meaningless. Initial policy: keyed identity with manual approval for production reputation effects; sandbox reputation for unapproved identities.
+- **Spam economics.** Cheap registration with paid actions is the right shape. Free reads, paid writes, paid disputes.
+- **Closed-loop reputation.** Reputation must be tied to AGT-03/AGT-04 external-truth signals, not internal agreement. AGT-05 enforces this.
+- **Privacy.** Agent activity is observable. Provide an opt-in pseudonymous mode for non-consequential capabilities; consequential decisions remain non-pseudonymous.
+- **Regulatory.** Agent-billable services may touch payment regulation. Initial phase: compute-credits only, no fiat-on-ramp; defer fiat to a later regulated lane.
+
+## Sequencing within AGT-02
+
+| Step | Deliverable | Dependencies |
+|---|---|---|
+| 1 | Agent-readable receipt schema spec | existing `decision_receipt.py` |
+| 2 | A2A registration endpoint + identity receipt emission | `identity.py`, A2A server |
+| 3 | A2A capability discovery endpoint (platform + per-agent) | `marketplace/catalog.py`, A2A server |
+| 4 | Compute-budget billing with chargeback receipts | `compute_budget.py`, receipt signer |
+| 5 | Reputation read endpoint (read-only) | `reputation.py`, KM ERC-8004 adapter |
+| 6 | Operator-parity surfaces (UI mirroring API) | existing live frontend |
+
+Reputation **write** is intentionally not in AGT-02; it lands in AGT-05 once the truth oracles are wired.
+
+## What this plan does NOT do
+
+- Does not introduce a new wallet or identity stack; uses existing `aragora/blockchain/`.
+- Does not introduce a new marketplace; extends `aragora/marketplace/`.
+- Does not modify queue governance; AGT-02 issues stay out of `boss-ready` until permitted.
+- Does not enable fiat billing; compute-credits only in this phase.
+- Does not enable autonomous reputation writes; reputation only changes via AGT-05 settlement.
+
+## References
+
+- [AGENT_CIVILIZATION_SUBSTRATE](AGENT_CIVILIZATION_SUBSTRATE.md)
+- [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md)
+- [2026-04-17-prediction-market-validation](2026-04-17-prediction-market-validation.md)
+- [EPISTEMIC_CI_AND_CRUX_ENGINE](EPISTEMIC_CI_AND_CRUX_ENGINE.md)
+- Code: `aragora/blockchain/`, `aragora/protocols/a2a/`, `aragora/marketplace/`, `aragora/skills/`, `aragora/export/decision_receipt.py`, `aragora/knowledge/mound/adapters/erc8004_adapter.py`

--- a/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
+++ b/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
@@ -219,6 +219,54 @@ This track preserves Aragora's core differentiation from generic agent platforms
 
 Design brief: [Epistemic CI, Crux Engine, and Epistemic Runtime Plan](EPISTEMIC_CI_AND_CRUX_ENGINE.md).
 
+### Track G — Agent-as-Consumer Substrate (Vision-Layer Planning)
+
+This track extends the Decision Integrity Core into a consumer surface that serves software agents as first-rate consumers alongside humans. It is **planning truth only** until queue governance permits it; it does not enter the live `boss-ready` queue. Detailed plan: [AGENT_CIVILIZATION_SUBSTRATE](AGENT_CIVILIZATION_SUBSTRATE.md).
+
+#### G1. Agent Consumer Surface (`AGT-02`)
+
+- A2A registration endpoint backed by `aragora/blockchain/contracts/identity.py`
+- capability discovery endpoint backed by `aragora/marketplace/`
+- compute-budget billing with chargeback receipts
+- agent-readable decision receipt schema with parseable CruxSet, dissent, and provenance
+- reputation read endpoints (write path lives in G3)
+- operator-parity surfaces so humans can do everything agents can do, and vice versa
+
+Detailed plan: [AGENT_CONSUMER_SURFACE](AGENT_CONSUMER_SURFACE.md).
+
+#### G2. External Truth Oracles via Prediction Markets (`AGT-03`, `AGT-04`)
+
+- Manifold Markets adapter for play-money calibration
+- Synthetic GitHub markets for high-volume internal calibration on PR/issue/CI outcomes
+- Metaculus integration following bot-policy compliance
+- per-agent rolling Brier scoring with calibration curves
+- explicit deferral of real-money venues until calibration is stable
+
+Detailed plan: [2026-04-17-prediction-market-validation](2026-04-17-prediction-market-validation.md).
+
+#### G3. Skin-in-the-Game Reputation Flow (`AGT-05`)
+
+- unified `claim → stake → resolution → settlement → reputation Δ → dispatch update` flow
+- per-domain reputation slices (prediction calibration, debate truthfulness, code-PR success, KM contribution, crux resolution)
+- soft dispatch downweighting by default; hard suspension only on explicit policy
+- settlement-window enforcement, dispute path, and reversal handling for re-opened resolutions
+
+Detailed plan: [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md).
+
+#### G4. Productivity Metric Replacing Empty-Queue Idle Soaks (`AGT-06`)
+
+- "verifiable improvements per agent-hour" (VIAH) computed weekly from ShiftLedger entries
+- merged autonomous PRs and correctly detected pre-resolution cruxes contribute positive
+- rescues required and failed claims promoted without repair contribute negative
+- supplements (does not replace) TW-02 no-rescue success rate
+- replaces empty-queue stability soaks as the gating productivity proof once substrate stability is sustained
+
+#### G5. CruxDetector Activation in Live Debates (`AGT-01`)
+
+- promote `aragora/reasoning/crux_detector.py` from latent capability to first-class debate goal
+- emit ranked CruxSet on production debate path under flag, then default-on
+- bridges to DIC-15 (CruxSet contract) and Issue [#6035](https://github.com/synaptent/aragora/issues/6035) (crux-finder mode epic)
+
 ### Track F — Trust-Wedge Productization and GTM
 
 This track converts technical proof into market proof.
@@ -258,6 +306,9 @@ This track converts technical proof into market proof.
 - Cruxes should identify load-bearing disagreement, not merely summarize dissent.
 - Broad vertical and enterprise expansion follows wedge proof; it does not replace it.
 - External claims should always lag measured internal proof.
+- Every consumer surface ships in agent-readable and human-readable form, backed by the same runtime truth.
+- Reputation only changes via external truth resolution, never via internal agreement.
+- Vision-layer planning tracks (Track G `AGT-*`) advance in planning truth without entering the live `boss-ready` queue until queue governance permits the upper-layer tranche, in line with the same rule that governs `DIC-13..22`.
 
 ## Stage Exit Criteria
 

--- a/docs/plans/SKIN_IN_THE_GAME_REPUTATION.md
+++ b/docs/plans/SKIN_IN_THE_GAME_REPUTATION.md
@@ -1,0 +1,175 @@
+# Skin-in-the-Game Reputation Flow — Claims → Predictions → Resolution → Reputation → Dispatch
+
+> **Status:** vision-layer planning track (`AGT-05`); not boss-ready until queue governance permits the upper-layer tranche.
+> **Created:** 2026-04-17
+> **Parent:** [AGENT_CIVILIZATION_SUBSTRATE](AGENT_CIVILIZATION_SUBSTRATE.md)
+> **Depends on:** AGT-02 (consumer surface), AGT-03 (Manifold), AGT-04 (synthetic GitHub markets), DIC-15 (CruxSet contract), DIC-16 (receipt/KM provenance)
+
+## Thesis
+
+A reputation system without external resolution is agents agreeing with agents. The existing `aragora/blockchain/contracts/{identity,reputation,staking,validation}.py` primitives are correctly designed but currently not wired to a live settlement loop. This plan defines the unified flow that turns each consequential agent action into a verifiable, time-bounded, cryptographically attested reputational consequence.
+
+The discipline is: **stake before you speak, settle when reality lands, lose dispatch if you are wrong too often.**
+
+## The unified flow
+
+```
+   ┌─────────────┐    ┌────────┐    ┌─────────────────┐    ┌────────────┐    ┌──────────────┐    ┌──────────────────┐
+   │ claim/stance│ -> │ stake  │ -> │ resolution event│ -> │ settlement │ -> │ reputation Δ │ -> │ dispatch update  │
+   └─────────────┘    └────────┘    └─────────────────┘    └────────────┘    └──────────────┘    └──────────────────┘
+```
+
+Each stage is a real module today. This plan wires them.
+
+| Stage | Existing module | What lands in AGT-05 |
+|---|---|---|
+| claim/stance | `aragora/reasoning/claims.py`, `aragora/reasoning/crux_detector.py`, Arena debate output, Manifold/Metaculus prediction | normalize across sources into `StakeableClaim` |
+| stake | `aragora/blockchain/contracts/staking.py`, `aragora/blockchain/compute_budget.py` | per-claim stake commitment with refund/forfeit policy |
+| resolution event | Manifold market resolution (AGT-03), Metaculus closure, synthetic GitHub event (AGT-04), DIC-14 claim verifier output, oracle attestation | unified `ResolutionEvent` shape |
+| settlement | `aragora/blockchain/receipt_settlement.py`, existing `Time Is Part of Settlement` doctrine | settlement-window enforcement, dispute path |
+| reputation Δ | `aragora/blockchain/contracts/reputation.py`, `aragora/knowledge/mound/adapters/erc8004_adapter.py` | per-domain reputation update with decay |
+| dispatch update | debate `team_selector`, calibration tracker, ELO, swarm dispatch policy | dispatch eligibility gated by per-domain reputation |
+
+## Core types
+
+### StakeableClaim
+
+```yaml
+claim_id: claim.agent.<agent>.<domain>.<hash>
+agent_id: <agent-id>
+domain: prediction_market | debate_position | code_pr | km_contribution | crux_resolution
+statement: "<machine-parseable statement>"
+position: long | short | for | against | <typed-position>
+stake:
+  budget_units: <int>
+  policy: forfeit_on_loss | scaled | refund_on_inconclusive
+resolution:
+  source: manifold | metaculus | synthetic_github | claim_verifier | oracle
+  resolution_id: <external id>
+  expected_window: { open: <iso>, close: <iso> }
+provenance:
+  receipt_id: <decision-receipt-id>
+  arena_run_id: <optional>
+  crux_id: <optional>
+```
+
+### ResolutionEvent
+
+```yaml
+resolution_id: <source-specific id>
+source: manifold | metaculus | synthetic_github | claim_verifier | oracle
+resolved_at: <iso>
+outcome: yes | no | inconclusive | invalid
+score:
+  brier: <float 0-1>           # for probabilistic predictions
+  binary_correct: <bool>        # for binary stances
+  partial_credit: <float 0-1>   # for graded outcomes
+attestation:
+  signer: <oracle-pubkey>
+  signature: <base64>
+```
+
+### ReputationDelta
+
+```yaml
+delta_id: rep.<agent>.<domain>.<resolution-id>
+agent_id: <agent>
+domain: <domain>
+delta: <signed float>
+reason:
+  resolution_id: <id>
+  claim_id: <id>
+  scoring_rule: brier_proper | log_loss | binary | flat
+applied_at: <iso>
+decay_policy:
+  half_life_days: <int>
+  floor: <float>
+  ceiling: <float>
+```
+
+## Scoring rules
+
+The system supports multiple scoring rules per domain so calibration is not collapsed into a single signal:
+
+| Domain | Default scoring rule | Notes |
+|---|---|---|
+| prediction_market | Brier (proper) | rolling 90-day window, decayed |
+| debate_position | binary correctness from CruxSet resolution | verified against later evidence |
+| code_pr | merged within window with no rollback | settlement window 30 days |
+| km_contribution | downstream usage with no contradiction event | 60-day window |
+| crux_resolution | counterfactual confirmation per DIC-15 | requires crux to be reified |
+
+Each domain decays independently. Aggregate reputation is a weighted sum visible to `team_selector`.
+
+## Dispatch eligibility
+
+Dispatch eligibility is computed from per-domain reputation against per-domain thresholds:
+
+```yaml
+dispatch_policy:
+  prediction_market:
+    floor_brier_90d: 0.20         # below this, suspend prediction-domain dispatch
+    promotion_brier_90d: 0.12     # above this, enter senior-prediction class
+  debate_position:
+    min_truth_rate_30d: 0.55
+  code_pr:
+    min_merge_rate_30d: 0.40
+    rollback_rate_30d_max: 0.10
+```
+
+Suspension is **soft by default** (downweight in selector) and **hard only** for explicitly opted-in lanes. Hard suspension always emits a receipt with reasons and reinstatement criteria.
+
+## Existing contract surface to extend
+
+The `aragora/blockchain/contracts/` directory already defines:
+
+- `identity.py` — agent identity registration
+- `reputation.py` — reputation registry (ERC-8004-shaped)
+- `staking.py` — stake commitment and slashing primitives
+- `validation.py` — validation contract surface
+
+This plan does **not** introduce new contract files. It defines the call sequence, schema versioning, and integration glue that make these contracts a live flow.
+
+## Settlement, dispute, and re-opening
+
+Following the canonical doctrine that **time is part of settlement**:
+
+- Each ResolutionEvent has a dispute window. Within the window, an agent may file a counter-attestation with stake.
+- After the window, the resolution is final unless re-opened by an explicit policy event (e.g. the oracle is later proven wrong).
+- A re-opened resolution rolls back the corresponding ReputationDelta and emits a `ReputationDeltaReversed` event.
+- Reversal events are themselves a domain agents can be reputational on (anti-fragility).
+
+## Risks and tempering
+
+- **Adversarial agents farming easy markets.** Mitigation: per-domain reputation, weighting by stake size, decay so old wins don't carry forever.
+- **Oracle compromise.** Mitigation: prefer multiple independent oracles per domain; require attestation by signer key registered through `validation.py`.
+- **Cold-start:** new agents have no reputation. Mitigation: bootstrap reputation from a sandbox lane with reduced stake limits before promoting to production dispatch.
+- **Reputation as ranked list invites Goodhart.** Mitigation: surface per-domain breakdown in operator views, not a single score.
+- **Slashing as adversarial weapon.** Mitigation: slashing requires meeting an explicit policy; protocols/coordination prevents accidental slashing on transient errors.
+
+## Sequencing within AGT-05
+
+| Step | Deliverable | Dependencies |
+|---|---|---|
+| 1 | `StakeableClaim` and `ResolutionEvent` schemas | DIC-15 CruxSet contract for crux-domain claims |
+| 2 | Stake commitment path through `staking.py` with refund/forfeit policy | existing staking primitives |
+| 3 | Resolution ingestion adapters (Manifold, Metaculus, synthetic GH) | AGT-03, AGT-04 |
+| 4 | Settlement and dispute window enforcement via `receipt_settlement.py` | existing receipt anchoring |
+| 5 | Reputation update path via `reputation.py` and ERC-8004 KM adapter | existing reputation contract |
+| 6 | Dispatch eligibility integration with `team_selector` and ELO | debate selection path |
+| 7 | Reversal/re-opening path | settlement window enforcement |
+
+## What this plan does NOT do
+
+- Does not introduce new contract files; uses existing primitives.
+- Does not enable hard slashing by default; soft downweighting is the default policy.
+- Does not auto-mutate dispatch policy; threshold values are operator-configured initially.
+- Does not move AGT-05 issues into `boss-ready` until queue governance permits the upper-layer tranche.
+
+## References
+
+- [AGENT_CIVILIZATION_SUBSTRATE](AGENT_CIVILIZATION_SUBSTRATE.md)
+- [AGENT_CONSUMER_SURFACE](AGENT_CONSUMER_SURFACE.md)
+- [2026-04-17-prediction-market-validation](2026-04-17-prediction-market-validation.md)
+- [EPISTEMIC_CI_AND_CRUX_ENGINE](EPISTEMIC_CI_AND_CRUX_ENGINE.md)
+- Code: `aragora/blockchain/contracts/`, `aragora/blockchain/receipt_settlement.py`, `aragora/reasoning/{claims,crux_detector}.py`, `aragora/knowledge/mound/adapters/erc8004_adapter.py`, debate `team_selector`

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -134,6 +134,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 - `BC-07..09` until the repair loop is truthful, resumable, and consolidated into one operator model
 - `RS-11..12` until recovery-budget coverage extends to the remaining failure classes and the remaining status/reporter surfaces are ledger-backed
 - `DIC-13..22` until BC-12/Foreman reliability is proven; Epistemic CI, Crux Engine, and Epistemic Runtime issues may stay open for planning but must not enter the live boss-ready queue
+- `AGT-01..06` until the proof-first Foreman gate permits the upper-layer tranche; agent-civilization substrate, A2A consumer surface, prediction-market validation, skin-in-the-game reputation flow, and the productivity metric (VIAH) replacing empty-queue idle soaks may stay open for planning but must not enter the live boss-ready queue
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
@@ -229,8 +230,28 @@ This tranche is complete when:
 4. at least one guarded admission path is real for the safest task class
 5. repeated rescue classes are captured as explicit product work instead of hidden labor
 
+## Vision-Layer Planning Track (`AGT-01..06`)
+
+The agent-civilization substrate work is now tracked as a parallel planning lane, mirroring the pattern used for `DIC-13..22`. Issues may be open and design work may proceed; **no `AGT-*` issue may carry `boss-ready` until the proof-first Foreman gate explicitly permits this tranche**, and the proof-first reconciler MUST strip `boss-ready` from any AGT-* issue restocked outside the permitted lane.
+
+| Code | Title | Detailed plan | Activation gate |
+|------|-------|---------------|-----------------|
+| `AGT-01` | Activate CruxDetector in live Arena debates | [crux-mode design](../plans/2026-04-16-crux-mode-design.md), Issue [#6035](https://github.com/synaptent/aragora/issues/6035), [agent-civilization substrate](../plans/AGENT_CIVILIZATION_SUBSTRATE.md) | DIC-15 CruxSet contract landed; substrate gate permits debate-path flag flip |
+| `AGT-02` | A2A consumer surface (registration, capability discovery, billing, agent receipts) | [agent consumer surface](../plans/AGENT_CONSUMER_SURFACE.md) | substrate gate permits upper-layer tranche; existing A2A and marketplace primitives stable |
+| `AGT-03` | Manifold integration with rolling Brier scoring | [prediction-market validation](../plans/2026-04-17-prediction-market-validation.md) | AGT-02 stable; rate-limit / GitHub-app token strategy in place for non-Manifold dependencies |
+| `AGT-04` | Synthetic GitHub prediction markets | [prediction-market validation](../plans/2026-04-17-prediction-market-validation.md) | none (internal); proof-first reconciler stable enough not to be disrupted by added market objects |
+| `AGT-05` | Skin-in-the-game reputation flow wiring | [skin-in-the-game reputation](../plans/SKIN_IN_THE_GAME_REPUTATION.md) | AGT-03 and AGT-04 producing resolved outcomes; DIC-16 receipt/KM provenance landed |
+| `AGT-06` | Verifiable improvements per agent-hour (VIAH) metric | [agent-civilization substrate](../plans/AGENT_CIVILIZATION_SUBSTRATE.md) §4 | RS-10 ShiftLedger stable on `main` (already true); BC-12 substrate gate decision to retire empty-queue soaks in favour of VIAH |
+
+Capability checkpoints for the booster-rocket thesis (CP-1..CP-5) live in [agent-civilization substrate §5](../plans/AGENT_CIVILIZATION_SUBSTRATE.md). Failing a checkpoint downscales the next investment rather than pausing the whole vision.
+
 ## References
 
 - [Evolution roadmap](../plans/ARAGORA_EVOLUTION_ROADMAP.md)
 - [Active execution issues](ACTIVE_EXECUTION_ISSUES.md)
 - [Commercial overview](../COMMERCIAL_OVERVIEW.md)
+- [Agent-civilization substrate](../plans/AGENT_CIVILIZATION_SUBSTRATE.md)
+- [Agent consumer surface](../plans/AGENT_CONSUMER_SURFACE.md)
+- [Skin-in-the-game reputation](../plans/SKIN_IN_THE_GAME_REPUTATION.md)
+- [Prediction-market validation](../plans/2026-04-17-prediction-market-validation.md)
+- [Epistemic CI and Crux Engine](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md)


### PR DESCRIPTION
## Summary

- Synthesizes the long-horizon vision (substrate for agent civilization, agents-as-first-rate-consumers, skin-in-the-game accountability via prediction-market-resolved reputation, productivity metric replacing empty-queue idle soaks) into permanent project artifacts.
- Adds 4 new plan documents and extends 3 existing canonical docs.
- **Strictly additive**: substrate-first execution gate is unchanged, queue policy is unchanged, no existing material is contradicted or removed.

## What this PR adds

**New planning docs:**
- `docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md` — long-horizon vision, AGT-01..06 sequencing, capability checkpoints CP-1..CP-5, wire-vs-shelve discipline, tempering principles
- `docs/plans/AGENT_CONSUMER_SURFACE.md` — A2A registration, capability discovery, billing, agent-readable receipts, reputation reads, operator parity (AGT-02)
- `docs/plans/SKIN_IN_THE_GAME_REPUTATION.md` — claim→stake→resolution→settlement→reputation flow wiring existing ERC-8004 contract primitives (AGT-05)
- `docs/plans/2026-04-17-prediction-market-validation.md` — Manifold (play money) + Metaculus (calibration) + synthetic GitHub markets as external truth oracles, with explicit deferral of real-money venues until calibration is stable (AGT-03/AGT-04)

**Extended docs:**
- `docs/CANONICAL_GOALS.md` — adds Pillar 8 (Agents and Humans as Co-Equal Consumers) and North-Star Outcome 7
- `docs/plans/ARAGORA_EVOLUTION_ROADMAP.md` — adds Track G (Agent-as-Consumer Substrate) with G1..G5 sub-tracks and three new cross-track rules
- `docs/status/NEXT_STEPS_CANONICAL.md` — adds AGT-01..06 to the Delay list under the same rule that governs DIC-13..22, plus a new Vision-Layer Planning Track section

## Companion GitHub issues filed

- Epic [#6068](https://github.com/synaptent/aragora/issues/6068) — Agent-civilization substrate (AGT-01..06)
- AGT-01 [#6062](https://github.com/synaptent/aragora/issues/6062) — Activate CruxDetector in live Arena debates
- AGT-02 [#6063](https://github.com/synaptent/aragora/issues/6063) — A2A consumer surface
- AGT-03 [#6064](https://github.com/synaptent/aragora/issues/6064) — Manifold integration with Brier scoring
- AGT-04 [#6065](https://github.com/synaptent/aragora/issues/6065) — Synthetic GitHub prediction markets
- AGT-05 [#6066](https://github.com/synaptent/aragora/issues/6066) — Skin-in-the-game reputation flow
- AGT-06 [#6067](https://github.com/synaptent/aragora/issues/6067) — VIAH productivity metric

All 7 issues are PLANNING ONLY and must NOT carry `boss-ready` until queue governance permits the upper-layer tranche.

## Why additive (compatibility with substrate-first gate)

1. **Substrate is foundation, not competitor.** Boss loop, ledger, queue governance, BC-12 — the load-bearing primitives that everything in these plans depends on.
2. **Planning truth is allowed; live queue scope is not widened.** Mirrors the rule that governs `DIC-13..22`. The proof-first reconciler MUST strip `boss-ready` from any AGT-* issue.
3. **The vision sharpens the substrate metric.** AGT-06 (verifiable improvements per agent-hour, VIAH) is the eventual replacement for empty-queue BC-12 idle soaks once substrate stability is sustained.

## Substrate primitives the new plans wire (rather than reintroduce)

- `aragora/blockchain/contracts/{identity,reputation,staking,validation}.py`
- `aragora/blockchain/{receipt_anchor,receipt_settlement,compute_budget,wallet}.py`
- `aragora/protocols/a2a/{client,server,types}.py`
- `aragora/marketplace/{catalog,registry,service,installer}.py`
- `aragora/reasoning/{crux_detector,claims}.py`
- `aragora/knowledge/mound/adapters/erc8004_adapter.py`

## Test plan

- [x] No source code modified — docs-only change
- [x] All four new docs cross-link to each other and to existing canonical docs
- [x] CANONICAL_GOALS pillar addition does not contradict existing 7 pillars
- [x] EVOLUTION_ROADMAP Track G extends but does not remove existing Tracks A-F
- [x] NEXT_STEPS_CANONICAL extension follows the existing DIC-13..22 delay-list pattern
- [x] All 6 AGT-* GitHub issues filed with explicit "PLANNING ONLY, no boss-ready" policy
- [x] Refs existing crux-finder epic (#6035) and DIC-13..22 issues (#6023-#6028, #6030-#6033)

🤖 Generated with [Claude Code](https://claude.com/claude-code)