### PR TITLE
fix(swarm): prevent decomposer queue leakage and re-attempt spam

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1394,6 +1394,17 @@ class BossLoop:
         if not issue:
             return
 
+        # Idempotency guard — if the issue is already marked boss-stuck, skip.
+        # Without this, stale feed caches or concurrent boss-loop instances can
+        # re-enter this function and post duplicate "exhausted N attempts..."
+        # comments (see issue #5894 for field observation).
+        if "boss-stuck" in (issue.labels or []):
+            logger.debug(
+                "Skipping auto-decomposition for #%s: already marked boss-stuck.",
+                issue.number,
+            )
+            return
+
         lineage_root, decomposition_depth = self._decomposition_lineage(issue)
         roadmap_priority = self._roadmap_priority_match_for_issue_lineage(
             issue=issue,
@@ -1637,6 +1648,11 @@ class BossLoop:
                         f"- Under 100 lines of new or changed code\n"
                         f"- Estimated complexity: {subtask.estimated_complexity}\n"
                     )
+                    # Child issues are created without `boss-ready` to respect
+                    # the canonical queue policy (see NEXT_STEPS_CANONICAL.md):
+                    # only CS-01..03 carry `boss-ready` until Foreman reliability
+                    # is proven. A separate promotion step adds the label when
+                    # the lane is opened.
                     try:
                         proc = subprocess.run(
                             [
@@ -1649,8 +1665,6 @@ class BossLoop:
                                 title,
                                 "--body",
                                 body,
-                                "--label",
-                                "boss-ready",
                             ],
                             capture_output=True,
                             text=True,
@@ -1669,7 +1683,7 @@ class BossLoop:
         if sub_issues_created > 0:
             comment = (
                 f"Boss loop exhausted {self.config.max_retries_per_issue} attempts. "
-                f"Auto-decomposed into {sub_issues_created} smaller sub-issues with `boss-ready` label."
+                f"Auto-decomposed into {sub_issues_created} smaller sub-issues."
             )
         elif decomposition_candidates > 0 and covered_candidates == decomposition_candidates:
             comment = (

--- a/tests/swarm/test_boss_decomposition_depth.py
+++ b/tests/swarm/test_boss_decomposition_depth.py
@@ -8,6 +8,18 @@ import pytest
 from aragora.swarm.boss_loop import BossLoop, BossLoopConfig, GitHubIssue
 
 
+def _fake_gh_subprocess(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    """Return a subprocess.run side_effect that emulates gh CLI success."""
+
+    def side_effect(args, **_kwargs):
+        if isinstance(args, list):
+            if "issue" in args and "list" in args:
+                return SimpleNamespace(returncode=returncode, stdout="[]", stderr=stderr)
+        return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    return side_effect
+
+
 @pytest.mark.parametrize(
     ("depth", "should_decompose"), [(0, True), (1, True), (2, True), (3, False)]
 )
@@ -27,21 +39,122 @@ def test_auto_decompose_stuck_issue_caps_depth(depth: int, should_decompose: boo
         should_decompose=True,
         subtasks=[
             SimpleNamespace(
-                title="Child", description="desc", file_scope=[], estimated_complexity="low"
+                title="Child task",
+                description=(
+                    "A sufficiently long sub-task description to pass the "
+                    "minimum length gate in the decomposer."
+                ),
+                file_scope=["aragora/swarm/boss_loop.py"],
+                estimated_complexity="low",
             )
         ],
     )
 
     with (
         patch("aragora.nomic.task_decomposer.TaskDecomposer", return_value=decomposer),
-        patch("subprocess.run", return_value=SimpleNamespace(returncode=0, stdout="", stderr="")),
+        patch("subprocess.run", side_effect=_fake_gh_subprocess()),
         patch.object(BossLoop, "_label_boss_stuck") as label_stuck,
     ):
         loop._auto_decompose_stuck_issue(issue.number, [issue])
 
     if should_decompose:
         decomposer.analyze.assert_called_once()
-        label_stuck.assert_not_called()
     else:
         decomposer.analyze.assert_not_called()
-        label_stuck.assert_called_once()
+    # `_label_boss_stuck` is always called once at function exit (or the
+    # early-return at the depth cap). Asserting call-count guards against
+    # regressions that spam the parent with repeated stuck-labels.
+    label_stuck.assert_called_once()
+
+
+def test_auto_decompose_skips_when_issue_already_boss_stuck() -> None:
+    """Idempotency guard: if the issue is already boss-stuck, do nothing.
+
+    Without this guard, the boss loop can re-enter `_auto_decompose_stuck_issue`
+    on the same issue (via stale feed caches or concurrent loops) and post
+    duplicate "exhausted N attempts..." comments. See issue #5894 for the
+    field observation (4 such comments in 13 minutes).
+    """
+    issue = GitHubIssue(
+        number=5894,
+        title="[TW-02] Already-stuck issue",
+        body="Body text",
+        labels=["autonomous", "boss-stuck"],
+        url="https://github.com/synaptent/aragora/issues/5894",
+        state="OPEN",
+        created_at="2026-04-16T03:22:33Z",
+    )
+    loop = BossLoop(BossLoopConfig(repo="synaptent/aragora"))
+    decomposer = MagicMock()
+
+    with (
+        patch("aragora.nomic.task_decomposer.TaskDecomposer", return_value=decomposer),
+        patch("subprocess.run") as mock_subprocess,
+        patch.object(BossLoop, "_label_boss_stuck") as label_stuck,
+    ):
+        loop._auto_decompose_stuck_issue(issue.number, [issue])
+
+    decomposer.analyze.assert_not_called()
+    label_stuck.assert_not_called()
+    assert mock_subprocess.call_count == 0, (
+        "No gh CLI calls should fire when the issue is already boss-stuck; "
+        f"saw {mock_subprocess.call_count} calls."
+    )
+
+
+def test_auto_decompose_does_not_label_children_boss_ready() -> None:
+    """Canonical queue policy: decomposer children must not inherit `boss-ready`.
+
+    Per docs/status/NEXT_STEPS_CANONICAL.md, only CS-01..03 work carries
+    `boss-ready` until Foreman reliability is proven. Historically the
+    decomposer auto-applied `boss-ready` to every child it spawned, which
+    leaked the queue.
+    """
+    issue = GitHubIssue(
+        number=100,
+        title="Parent task",
+        body="Decompose me",
+        labels=["boss-ready", "autonomous"],
+        url="https://github.com/synaptent/aragora/issues/100",
+        state="OPEN",
+        created_at="2026-04-10T00:00:00Z",
+    )
+    loop = BossLoop(BossLoopConfig(repo="synaptent/aragora", max_retries_per_issue=2))
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = SimpleNamespace(
+        should_decompose=True,
+        subtasks=[
+            SimpleNamespace(
+                title="Child task",
+                description=(
+                    "A sufficiently long sub-task description to pass the "
+                    "minimum length gate in the decomposer."
+                ),
+                file_scope=["aragora/swarm/boss_loop.py"],
+                estimated_complexity="low",
+            )
+        ],
+    )
+
+    with (
+        patch("aragora.nomic.task_decomposer.TaskDecomposer", return_value=decomposer),
+        patch("subprocess.run", side_effect=_fake_gh_subprocess()) as mock_run,
+        patch.object(BossLoop, "_label_boss_stuck"),
+    ):
+        loop._auto_decompose_stuck_issue(issue.number, [issue])
+
+    create_calls = [
+        call
+        for call in mock_run.call_args_list
+        if call.args
+        and isinstance(call.args[0], list)
+        and "issue" in call.args[0]
+        and "create" in call.args[0]
+    ]
+    assert len(create_calls) == 1, (
+        f"expected exactly one `gh issue create` call, got {len(create_calls)}"
+    )
+    cmd = create_calls[0].args[0]
+    assert "boss-ready" not in cmd, (
+        f"decomposer children must not be auto-labeled boss-ready: {cmd}"
+    )


### PR DESCRIPTION
## Summary

Two bugs in [aragora/swarm/boss_loop.py](aragora/swarm/boss_loop.py) `_auto_decompose_stuck_issue` caused the four `an0mium` "exhausted 3 attempts" comments on [#5894](https://github.com/synaptent/aragora/issues/5894) within 13 minutes, and leaked `boss-ready` to every decomposer child in violation of the canonical queue policy.

- **Idempotency guard** — early-return when the parent already has `boss-stuck`. Prevents re-entry by stale feed caches or concurrent boss-loops from posting duplicate "exhausted N attempts…" comments.
- **Queue leakage fix** — stop auto-applying `--label boss-ready` to sub-issues the decomposer creates. Per [NEXT_STEPS_CANONICAL.md](docs/status/NEXT_STEPS_CANONICAL.md), only `CS-01..03` carry `boss-ready` until Foreman reliability is proven; a dedicated promotion step now decides when the lane is reopened.
- **Test hygiene** — `test_auto_decompose_stuck_issue_caps_depth` was asserting `_label_boss_stuck.assert_not_called()` at shallow depths even though the code always calls it at function exit, so three of four parametrizations were failing on main. Fixed the assertion and added two new regression tests (idempotency and no-boss-ready-on-children).

## Field observation

Timeline on [#5894](https://github.com/synaptent/aragora/issues/5894) (2026-04-16):

```
14:25:42  "Auto-decomposed into 1 smaller sub-issues with `boss-ready` label."
14:30:52  "All decomposition candidates are already covered..."
14:33:24  "All decomposition candidates are already covered..."
14:38:12  "All decomposition candidates are already covered..."
```

First tick marked the parent `boss-stuck` and dropped `boss-ready`. Three subsequent ticks still re-ran the whole coverage check (5→3→5 min apart) and posted duplicate comments. With the idempotency guard they would now bail at entry.

## Deferred to follow-ups

- **Lineage-aware merged-PR detection.** The current `gh pr list --search "#N"` misses the case where a PR closes a descendant rather than the root — e.g. [#6017](https://github.com/synaptent/aragora/pull/6017) closed #6000 (descendant of #5894), but #5894 itself is still open as zombie. Real change, separate scope.
- **Operational cleanup** of the existing #5894 chain and ~20 zombie `except swallowing` tickets whose work is already merged.

## Test plan

- [x] `pytest tests/swarm/test_boss_decomposition_depth.py -v` — 6/6 green (was 1/4).
- [x] `pytest tests/swarm/test_boss_loop.py -k "decompose or boss_ready or ready_label" --timeout=30` — 9/9 relevant tests green. The one failure (`test_boss_loop_batch_auto_decomposes_maxed_retry_issue`) is a pre-existing selector-timeout flake on `main` — confirmed by running the same test on unmodified `main`.
- [x] `ruff check` — clean.
- [ ] Verify on one real boss-stuck issue that decomposer now bails without comment spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)