### PR TITLE
fix(swarm): parse launchd probe top-level state

### DIFF
--- a/scripts/probe_boss_loop_launchd.py
+++ b/scripts/probe_boss_loop_launchd.py
@@ -91,34 +91,42 @@ def parse_launchd_state(text: str, *, label: str) -> LaunchdState | None:
         return None
 
     fields: dict[str, Any] = {}
-    skip_block_depth = 0
+    entered_service = False
+    block_depth = 0
     for raw_line in text.splitlines():
         line = raw_line.strip()
-        if skip_block_depth > 0:
-            if line.endswith("{"):
-                skip_block_depth += 1
-            elif line == "}":
-                skip_block_depth -= 1
+        if not line:
             continue
-        if line.startswith("inherited environment") or line.startswith("default environment"):
-            if line.endswith("{"):
-                skip_block_depth = 1
+
+        if line == "}":
+            if entered_service:
+                block_depth = max(0, block_depth - 1)
+                if block_depth == 0:
+                    break
             continue
-        match = re.match(r"^([^=]+?)\s*=\s*(.+?)\s*$", line)
-        if not match:
-            continue
-        key = match.group(1).strip().lower()
-        value = match.group(2).strip().rstrip(",")
-        if key in _INT_FIELDS:
-            try:
-                fields[_INT_FIELDS[key]] = int(value)
-            except ValueError:
-                continue
-        elif key == "state":
-            fields["state"] = value
-        elif key == "spawn type":
-            spawn = value.split(" ", 1)[0]
-            fields["spawn_type"] = spawn or None
+
+        if entered_service and block_depth == 1:
+            match = re.match(r"^([^=]+?)\s*=\s*(.+?)\s*$", line)
+            if match:
+                key = match.group(1).strip().lower()
+                value = match.group(2).strip().rstrip(",")
+                if key in _INT_FIELDS:
+                    try:
+                        fields[_INT_FIELDS[key]] = int(value)
+                    except ValueError:
+                        pass
+                elif key == "state":
+                    fields["state"] = value
+                elif key == "spawn type":
+                    spawn = value.split(" ", 1)[0]
+                    fields["spawn_type"] = spawn or None
+
+        opens = line.count("{")
+        closes = line.count("}")
+        if opens:
+            entered_service = True
+        if entered_service:
+            block_depth = max(0, block_depth + opens - closes)
 
     if "state" not in fields:
         return None

--- a/tests/scripts/test_probe_boss_loop_launchd.py
+++ b/tests/scripts/test_probe_boss_loop_launchd.py
@@ -37,6 +37,7 @@ SAMPLE_OUTPUT = """gui/501/com.aragora.swarm-boss-loop = {
 \tdefault environment = {
 \t}
 
+\tenvironment = {
 \t\tOSLogRateLimit => 64
 \t}
 
@@ -51,6 +52,29 @@ SAMPLE_OUTPUT = """gui/501/com.aragora.swarm-boss-loop = {
 \tproperties = keepalive | runatload | inferred program
 }
 """
+
+SAMPLE_OUTPUT_WITH_NESTED_ACTIVE_COALITIONS = SAMPLE_OUTPUT.replace(
+    "\tspawn type = daemon (3)\n\tproperties = keepalive | runatload | inferred program\n",
+    """\tresource coalition = {
+\t\tID = 266983
+\t\ttype = resource
+\t\tstate = active
+\t\tactive count = 1
+\t\tname = com.aragora.swarm-boss-loop
+\t}
+
+\tjetsam coalition = {
+\t\tID = 266984
+\t\ttype = jetsam
+\t\tstate = active
+\t\tactive count = 1
+\t\tname = com.aragora.swarm-boss-loop
+\t}
+
+\tspawn type = daemon (3)
+\tproperties = keepalive | runatload | inferred program
+""",
+)
 
 
 def test_parse_launchd_state_extracts_safe_fields() -> None:
@@ -72,6 +96,18 @@ def test_parse_launchd_state_redacts_inherited_environment() -> None:
     assert "PRETEND-SECRET" not in serialized
     assert "sk-" not in serialized
     assert "OPENAI_API_KEY" not in serialized
+
+
+def test_parse_launchd_state_ignores_nested_coalition_state() -> None:
+    state = probe.parse_launchd_state(
+        SAMPLE_OUTPUT_WITH_NESTED_ACTIVE_COALITIONS,
+        label="com.aragora.swarm-boss-loop",
+    )
+    assert state is not None
+    assert state.state == "spawn scheduled"
+    assert state.active_count == 0
+    assert state.is_running is False
+    assert state.is_spawn_scheduled is True
 
 
 def test_parse_launchd_state_returns_none_when_unloaded() -> None:


### PR DESCRIPTION
## Summary
- parse only the top-level LaunchAgent body from `launchctl print`
- prevent nested resource/jetsam coalition `state=active` and `active count=1` fields from overriding top-level job state
- add a regression covering top-level `spawn scheduled` with nested active coalitions

## Validation
- `pytest tests/scripts/test_probe_boss_loop_launchd.py -q`
- `ruff check scripts/probe_boss_loop_launchd.py tests/scripts/test_probe_boss_loop_launchd.py`
- `python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes scripts/probe_boss_loop_launchd.py`
- `python3 scripts/probe_boss_loop_launchd.py --no-kickstart || true`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Live probe check
Before this fix, the redacted probe could report `ok=true` by reading nested coalition state. With this branch, the live no-kickstart probe fails closed against the current LaunchAgent state:

```json
{
  "ok": false,
  "reason": "LaunchAgent com.aragora.swarm-boss-loop stuck in state='spawn scheduled'; runs=340; min_runtime=300s",
  "state": {
    "label": "com.aragora.swarm-boss-loop",
    "state": "spawn scheduled",
    "active_count": 0,
    "runs": 340,
    "minimum_runtime_seconds": 300,
    "exit_timeout_seconds": 5,
    "spawn_type": "daemon"
  }
}
```
