### PR TITLE
docs: sync docs-site roadmap mirrors

### DIFF
--- a/docs-site/docs/contributing/aragora-evolution-roadmap.md
+++ b/docs-site/docs/contributing/aragora-evolution-roadmap.md
@@ -224,6 +224,54 @@ This track preserves Aragora's core differentiation from generic agent platforms
 
 Design brief: [Epistemic CI, Crux Engine, and Epistemic Runtime Plan](EPISTEMIC_CI_AND_CRUX_ENGINE.md).
 
+### Track G — Agent-as-Consumer Substrate (Vision-Layer Planning)
+
+This track extends the Decision Integrity Core into a consumer surface that serves software agents as first-rate consumers alongside humans. It is **planning truth only** until queue governance permits it; it does not enter the live `boss-ready` queue. Detailed plan: [AGENT_CIVILIZATION_SUBSTRATE](AGENT_CIVILIZATION_SUBSTRATE.md).
+
+#### G1. Agent Consumer Surface (`AGT-02`)
+
+- A2A registration endpoint backed by `aragora/blockchain/contracts/identity.py`
+- capability discovery endpoint backed by `aragora/marketplace/`
+- compute-budget billing with chargeback receipts
+- agent-readable decision receipt schema with parseable CruxSet, dissent, and provenance
+- reputation read endpoints (write path lives in G3)
+- operator-parity surfaces so humans can do everything agents can do, and vice versa
+
+Detailed plan: [AGENT_CONSUMER_SURFACE](AGENT_CONSUMER_SURFACE.md).
+
+#### G2. External Truth Oracles via Prediction Markets (`AGT-03`, `AGT-04`)
+
+- Manifold Markets adapter for play-money calibration
+- Synthetic GitHub markets for high-volume internal calibration on PR/issue/CI outcomes
+- Metaculus integration following bot-policy compliance
+- per-agent rolling Brier scoring with calibration curves
+- explicit deferral of real-money venues until calibration is stable
+
+Detailed plan: [2026-04-17-prediction-market-validation](2026-04-17-prediction-market-validation.md).
+
+#### G3. Skin-in-the-Game Reputation Flow (`AGT-05`)
+
+- unified `claim → stake → resolution → settlement → reputation Δ → dispatch update` flow
+- per-domain reputation slices (prediction calibration, debate truthfulness, code-PR success, KM contribution, crux resolution)
+- soft dispatch downweighting by default; hard suspension only on explicit policy
+- settlement-window enforcement, dispute path, and reversal handling for re-opened resolutions
+
+Detailed plan: [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md).
+
+#### G4. Productivity Metric Replacing Empty-Queue Idle Soaks (`AGT-06`)
+
+- "verifiable improvements per agent-hour" (VIAH) computed weekly from ShiftLedger entries
+- merged autonomous PRs and correctly detected pre-resolution cruxes contribute positive
+- rescues required and failed claims promoted without repair contribute negative
+- supplements (does not replace) TW-02 no-rescue success rate
+- replaces empty-queue stability soaks as the gating productivity proof once substrate stability is sustained
+
+#### G5. CruxDetector Activation in Live Debates (`AGT-01`)
+
+- promote `aragora/reasoning/crux_detector.py` from latent capability to first-class debate goal
+- emit ranked CruxSet on production debate path under flag, then default-on
+- bridges to DIC-15 (CruxSet contract) and Issue [#6035](https://github.com/synaptent/aragora/issues/6035) (crux-finder mode epic)
+
 ### Track F — Trust-Wedge Productization and GTM
 
 This track converts technical proof into market proof.
@@ -263,6 +311,9 @@ This track converts technical proof into market proof.
 - Cruxes should identify load-bearing disagreement, not merely summarize dissent.
 - Broad vertical and enterprise expansion follows wedge proof; it does not replace it.
 - External claims should always lag measured internal proof.
+- Every consumer surface ships in agent-readable and human-readable form, backed by the same runtime truth.
+- Reputation only changes via external truth resolution, never via internal agreement.
+- Vision-layer planning tracks (Track G `AGT-*`) advance in planning truth without entering the live `boss-ready` queue until queue governance permits the upper-layer tranche, in line with the same rule that governs `DIC-13..22`.
 
 ## Stage Exit Criteria
 

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -94,6 +94,14 @@ Aragora must be useful to founders, operators, and small teams with limited time
 
 Nomic, swarm, and user-facing execution should converge on the same contract, ledger, memory, and control-plane surfaces. We do not want multiple autonomy stacks drifting apart. Repeated rescue classes should become benchmark fixtures and product work, not tribal knowledge.
 
+### 8. Agents and Humans as Co-Equal Consumers
+
+Software agents are about to become first-rate consumers of decisionmaking, memory, capability marketplaces, and reputation surfaces — alongside humans, not replacing them. Every consumer surface (registration, capability discovery, billing, decision receipts, reputation reads) ships in two forms, agent-readable and human-readable, backed by the same runtime truth.
+
+This pillar pulls the existing identity, reputation, staking, validation, A2A, marketplace, and receipt primitives into a unified consumer surface so the substrate Aragora is building can serve the emerging agent population without forking into a separate stack. The design constraint is parity: nothing humans can do through the platform should be unavailable to agents, and nothing agents can do should be unavailable to humans.
+
+The vision-layer planning for this pillar lives in [plans/AGENT_CIVILIZATION_SUBSTRATE.md](plans/AGENT_CIVILIZATION_SUBSTRATE.md) with sibling specs [plans/AGENT_CONSUMER_SURFACE.md](plans/AGENT_CONSUMER_SURFACE.md), [plans/SKIN_IN_THE_GAME_REPUTATION.md](plans/SKIN_IN_THE_GAME_REPUTATION.md), and [plans/2026-04-17-prediction-market-validation.md](plans/2026-04-17-prediction-market-validation.md). Live queue scope continues to follow the substrate-first gate in [status/NEXT_STEPS_CANONICAL.md](./next-steps-canonical); these plans are planning truth, not active dispatch scope.
+
 ## Architectural Doctrine
 
 ### Aragora Is the Terrarium, Not the Organism
@@ -167,3 +175,4 @@ Aragora's trust story is structural:
 4. Shared memory improves future work without collapsing trust boundaries.
 5. Important claims and cruxes remain linked to evidence, receipts, freshness, and later settlement.
 6. Aragora evolves from tool -> teammate -> foreman -> chief of staff -> organization substrate on one coherent runtime.
+7. Agents and humans participate in the same substrate as co-equal consumers, with portable reputation tied to objectively verifiable outcomes through external truth oracles (prediction markets, public verifiable streams, synthetic in-repo markets) rather than to internal agreement.

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -139,6 +139,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 - `BC-07..09` until the repair loop is truthful, resumable, and consolidated into one operator model
 - `RS-11..12` until recovery-budget coverage extends to the remaining failure classes and the remaining status/reporter surfaces are ledger-backed
 - `DIC-13..22` until BC-12/Foreman reliability is proven; Epistemic CI, Crux Engine, and Epistemic Runtime issues may stay open for planning but must not enter the live boss-ready queue
+- `AGT-01..06` until the proof-first Foreman gate permits the upper-layer tranche; agent-civilization substrate, A2A consumer surface, prediction-market validation, skin-in-the-game reputation flow, and the productivity metric (VIAH) replacing empty-queue idle soaks may stay open for planning but must not enter the live boss-ready queue
 - `TW-07..09` until the bounded execution wedge is boringly reliable
 - `UDW-01..06` except for thin read-only queue, receipt, lineage, replay, retry, pause, resume, and override views backed by live runtime truth
 - `MCF-01..03` until the wedge needs permissioned memory to improve bounded execution instead of broad retrieval ambition
@@ -234,8 +235,28 @@ This tranche is complete when:
 4. at least one guarded admission path is real for the safest task class
 5. repeated rescue classes are captured as explicit product work instead of hidden labor
 
+## Vision-Layer Planning Track (`AGT-01..06`)
+
+The agent-civilization substrate work is now tracked as a parallel planning lane, mirroring the pattern used for `DIC-13..22`. Issues may be open and design work may proceed; **no `AGT-*` issue may carry `boss-ready` until the proof-first Foreman gate explicitly permits this tranche**, and the proof-first reconciler MUST strip `boss-ready` from any AGT-* issue restocked outside the permitted lane.
+
+| Code | Title | Detailed plan | Activation gate |
+|------|-------|---------------|-----------------|
+| `AGT-01` | Activate CruxDetector in live Arena debates | [crux-mode design](../plans/2026-04-16-crux-mode-design.md), Issue [#6035](https://github.com/synaptent/aragora/issues/6035), [agent-civilization substrate](../plans/AGENT_CIVILIZATION_SUBSTRATE.md) | DIC-15 CruxSet contract landed; substrate gate permits debate-path flag flip |
+| `AGT-02` | A2A consumer surface (registration, capability discovery, billing, agent receipts) | [agent consumer surface](../plans/AGENT_CONSUMER_SURFACE.md) | substrate gate permits upper-layer tranche; existing A2A and marketplace primitives stable |
+| `AGT-03` | Manifold integration with rolling Brier scoring | [prediction-market validation](../plans/2026-04-17-prediction-market-validation.md) | AGT-02 stable; rate-limit / GitHub-app token strategy in place for non-Manifold dependencies |
+| `AGT-04` | Synthetic GitHub prediction markets | [prediction-market validation](../plans/2026-04-17-prediction-market-validation.md) | none (internal); proof-first reconciler stable enough not to be disrupted by added market objects |
+| `AGT-05` | Skin-in-the-game reputation flow wiring | [skin-in-the-game reputation](../plans/SKIN_IN_THE_GAME_REPUTATION.md) | AGT-03 and AGT-04 producing resolved outcomes; DIC-16 receipt/KM provenance landed |
+| `AGT-06` | Verifiable improvements per agent-hour (VIAH) metric | [agent-civilization substrate](../plans/AGENT_CIVILIZATION_SUBSTRATE.md) §4 | RS-10 ShiftLedger stable on `main` (already true); BC-12 substrate gate decision to retire empty-queue soaks in favour of VIAH |
+
+Capability checkpoints for the booster-rocket thesis (CP-1..CP-5) live in [agent-civilization substrate §5](../plans/AGENT_CIVILIZATION_SUBSTRATE.md). Failing a checkpoint downscales the next investment rather than pausing the whole vision.
+
 ## References
 
 - [Evolution roadmap](./aragora-evolution-roadmap)
 - [Active execution issues](./active-execution-issues)
 - [Commercial overview](../enterprise/commercial-overview)
+- [Agent-civilization substrate](../plans/AGENT_CIVILIZATION_SUBSTRATE.md)
+- [Agent consumer surface](../plans/AGENT_CONSUMER_SURFACE.md)
+- [Skin-in-the-game reputation](../plans/SKIN_IN_THE_GAME_REPUTATION.md)
+- [Prediction-market validation](../plans/2026-04-17-prediction-market-validation.md)
+- [Epistemic CI and Crux Engine](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md)


### PR DESCRIPTION
## Summary\n- sync generated docs-site mirrors after roadmap and canonical-goals updates\n- unblock docs build checks that fail on generated docs drift\n\n## Validation\n- python3 scripts/doc_stats.py --write\n- node docs-site/scripts/sync-docs.js\n- git diff --quiet\n- bash scripts/automation_pr_preflight.sh origin/main HEAD