### PR TITLE
fix(autonomy): parse multiline github app keys

### DIFF
--- a/aragora/swarm/github_app_auth.py
+++ b/aragora/swarm/github_app_auth.py
@@ -16,6 +16,7 @@ DEFAULT_AUTOMATION_ENV_FILE = Path.home() / ".aragora" / ".env.automation"
 GITHUB_API_VERSION = "2022-11-28"
 GITHUB_API_HOST = "api.github.com"
 _TOKEN_CACHE: dict[tuple[str, str, str], "GitHubAppToken"] = {}
+_PRIVATE_KEY_ENV_KEYS = ("GITHUB_APP_PRIVATE_KEY", "ARAGORA_GITHUB_APP_KEY")
 
 
 @dataclass(frozen=True)
@@ -36,6 +37,36 @@ def clear_github_app_token_cache() -> None:
     _TOKEN_CACHE.clear()
 
 
+def _strip_matching_quotes(value: str) -> str:
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        return stripped[1:-1]
+    return stripped
+
+
+def _parse_env_value(lines: list[str], start_index: int, raw_value: str) -> tuple[str, int]:
+    value = raw_value.strip()
+    if not value:
+        return "", start_index
+
+    quote = value[0]
+    if quote not in {"'", '"'}:
+        return _strip_matching_quotes(value), start_index
+
+    current = value[1:]
+    parts: list[str] = []
+    index = start_index
+    while True:
+        if current.endswith(quote):
+            parts.append(current[:-1])
+            return "\n".join(parts), index
+        parts.append(current)
+        index += 1
+        if index >= len(lines):
+            return "\n".join(parts), index - 1
+        current = lines[index].rstrip()
+
+
 def _read_env_file(path: Path) -> dict[str, str]:
     if not path.exists():
         return {}
@@ -50,43 +81,35 @@ def _read_env_file(path: Path) -> dict[str, str]:
             continue
         key, value = line.split("=", 1)
         key = key.strip()
-        value = value.strip()
-        if not key:
-            index += 1
-            continue
-
-        if value.startswith(("'", '"')):
-            quote = value[0]
-            value = value[1:]
-            if value.endswith(quote):
-                values[key] = value[:-1]
-                index += 1
-                continue
-
-            parts = [value]
-            index += 1
-            while index < len(lines):
-                next_line = lines[index]
-                if next_line.endswith(quote):
-                    parts.append(next_line[:-1])
-                    index += 1
-                    break
-                parts.append(next_line)
-                index += 1
-            values[key] = "\n".join(parts)
-            continue
-
-        values[key] = value
+        if key:
+            values[key], index = _parse_env_value(lines, index, value)
         index += 1
     return values
 
 
-def _first_value(values: Mapping[str, str], keys: tuple[str, ...]) -> str:
+def _first_named_value(values: Mapping[str, str], keys: tuple[str, ...]) -> tuple[str, str]:
     for key in keys:
         value = str(values.get(key) or "").strip()
         if value:
-            return value
-    return ""
+            return key, value
+    return "", ""
+
+
+def _first_value(values: Mapping[str, str], keys: tuple[str, ...]) -> str:
+    _, value = _first_named_value(values, keys)
+    return value
+
+
+def _normalize_private_key(value: str) -> str:
+    stripped = _strip_matching_quotes(value)
+    return stripped.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\r", "\n").strip()
+
+
+def _first_private_key(values: Mapping[str, str]) -> tuple[str, str]:
+    key, value = _first_named_value(values, _PRIVATE_KEY_ENV_KEYS)
+    if not value:
+        return "", ""
+    return key, _normalize_private_key(value)
 
 
 def _automation_env_file(env: Mapping[str, str]) -> Path:
@@ -99,12 +122,6 @@ def _automation_env_file(env: Mapping[str, str]) -> Path:
         ),
     )
     return Path(configured).expanduser() if configured else DEFAULT_AUTOMATION_ENV_FILE
-
-
-def _normalize_private_key(value: str) -> str:
-    if "\\n" in value:
-        return value.replace("\\n", "\n")
-    return value
 
 
 def load_github_app_config(env: Mapping[str, str] | None = None) -> GitHubAppConfig | None:
@@ -121,10 +138,8 @@ def load_github_app_config(env: Mapping[str, str] | None = None) -> GitHubAppCon
             "ARAGORA_GITHUB_INSTALLATION_ID",
         ),
     )
-    private_key = _first_value(values, ("GITHUB_APP_PRIVATE_KEY", "ARAGORA_GITHUB_APP_KEY"))
-    private_key_source = "env:GITHUB_APP_PRIVATE_KEY" if private_key else ""
-    if private_key:
-        private_key = _normalize_private_key(private_key)
+    private_key_name, private_key = _first_private_key(values)
+    private_key_source = f"env:{private_key_name}" if private_key else ""
     if not private_key:
         key_path = _first_value(
             values,

--- a/tests/swarm/test_github_app_auth.py
+++ b/tests/swarm/test_github_app_auth.py
@@ -3,7 +3,25 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from urllib.request import Request
 
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
 from aragora.swarm import github_app_auth as mod
+
+
+def _rsa_private_key_pem() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+
+def _assert_private_key_signs(private_key: str) -> None:
+    encoded = jwt.encode({"iss": "123"}, private_key, algorithm="RS256")
+    assert encoded
 
 
 def test_load_github_app_config_reads_automation_env_file(tmp_path) -> None:
@@ -30,16 +48,15 @@ def test_load_github_app_config_reads_automation_env_file(tmp_path) -> None:
     assert config.private_key_source == str(key_path)
 
 
-def test_load_github_app_config_reads_multiline_private_key(tmp_path) -> None:
+def test_load_github_app_config_reads_multiline_private_key_from_env_file(tmp_path) -> None:
+    private_key = _rsa_private_key_pem().rstrip("\n")
     env_path = tmp_path / ".env.automation"
     env_path.write_text(
         "\n".join(
             [
                 "GITHUB_APP_ID=123",
                 "GITHUB_APP_INSTALLATION_ID=456",
-                'GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----',
-                "key-body",
-                '-----END RSA PRIVATE KEY-----"',
+                f'GITHUB_APP_PRIVATE_KEY="{private_key}"',
             ]
         ),
         encoding="utf-8",
@@ -48,25 +65,27 @@ def test_load_github_app_config_reads_multiline_private_key(tmp_path) -> None:
     config = mod.load_github_app_config({"ARAGORA_AUTOMATION_ENV_FILE": str(env_path)})
 
     assert config is not None
-    assert config.private_key == (
-        "-----BEGIN RSA PRIVATE KEY-----\nkey-body\n-----END RSA PRIVATE KEY-----"
-    )
+    assert config.private_key == private_key
+    assert config.private_key_source == "env:GITHUB_APP_PRIVATE_KEY"
+    _assert_private_key_signs(config.private_key)
 
 
-def test_load_github_app_config_decodes_escaped_newline_private_key() -> None:
+def test_load_github_app_config_decodes_escaped_newline_private_key_env() -> None:
+    private_key = _rsa_private_key_pem()
+
     config = mod.load_github_app_config(
         {
-            "ARAGORA_AUTOMATION_ENV_FILE": "/missing",
             "GITHUB_APP_ID": "123",
             "GITHUB_APP_INSTALLATION_ID": "456",
-            "GITHUB_APP_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\\nkey-body\\n-----END RSA PRIVATE KEY-----",
+            "ARAGORA_GITHUB_APP_KEY": private_key.replace("\n", "\\n"),
+            "ARAGORA_AUTOMATION_ENV_FILE": "/missing",
         }
     )
 
     assert config is not None
-    assert config.private_key == (
-        "-----BEGIN RSA PRIVATE KEY-----\nkey-body\n-----END RSA PRIVATE KEY-----"
-    )
+    assert config.private_key == private_key.strip()
+    assert config.private_key_source == "env:ARAGORA_GITHUB_APP_KEY"
+    _assert_private_key_signs(config.private_key)
 
 
 def test_github_cli_env_prefers_installation_token(monkeypatch, tmp_path) -> None:
@@ -105,6 +124,31 @@ def test_github_cli_env_prefers_installation_token(monkeypatch, tmp_path) -> Non
     assert env["GH_TOKEN"] == "installation-token"
     assert env["GITHUB_TOKEN"] == "installation-token"
     assert env["ARAGORA_GITHUB_AUTH_SOURCE"] == "github_app_installation"
+
+
+def test_github_cli_env_falls_back_when_inline_private_key_is_malformed(tmp_path) -> None:
+    mod.clear_github_app_token_cache()
+    env_path = tmp_path / ".env.automation"
+    env_path.write_text(
+        "\n".join(
+            [
+                "GITHUB_APP_ID=123",
+                "GITHUB_APP_INSTALLATION_ID=456",
+                'GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    env = mod.github_cli_env(
+        {"PATH": "/usr/bin", "ARAGORA_AUTOMATION_ENV_FILE": str(env_path), "GH_TOKEN": "user"}
+    )
+
+    assert env == {
+        "PATH": "/usr/bin",
+        "ARAGORA_AUTOMATION_ENV_FILE": str(env_path),
+        "GH_TOKEN": "user",
+    }
 
 
 def test_github_cli_env_falls_back_when_unconfigured() -> None:


### PR DESCRIPTION
## Summary
- harden automation GitHub App env parsing for quoted multiline private keys
- support alternate Aragora private-key env names with accurate source reporting
- add signing-backed regression coverage for env-file and escaped-newline private keys

## Validation
- pytest -q tests/swarm/test_github_app_auth.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD