### PR TITLE
fix(sdk): cover slack bot webhook routes

### DIFF
--- a/sdk/python/aragora_sdk/namespaces/bots.py
+++ b/sdk/python/aragora_sdk/namespaces/bots.py
@@ -29,6 +29,15 @@ class BotsAPI:
         """Get Slack integration status."""
         return self._client.request("GET", "/api/v1/bots/slack/status")
 
+    def slack_commands(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._client.request("POST", "/api/v1/bots/slack/commands", json=payload)
+
+    def slack_events(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._client.request("POST", "/api/v1/bots/slack/events", json=payload)
+
+    def slack_interactions(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._client.request("POST", "/api/v1/bots/slack/interactions", json=payload)
+
     def discord_interactions(self, payload: dict[str, Any]) -> dict[str, Any]:
         return self._client.request("POST", "/api/v1/bots/discord/interactions", json=payload)
 
@@ -75,6 +84,15 @@ class AsyncBotsAPI:
     async def slack_status(self) -> dict[str, Any]:
         """Get Slack integration status."""
         return await self._client.request("GET", "/api/v1/bots/slack/status")
+
+    async def slack_commands(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._client.request("POST", "/api/v1/bots/slack/commands", json=payload)
+
+    async def slack_events(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._client.request("POST", "/api/v1/bots/slack/events", json=payload)
+
+    async def slack_interactions(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._client.request("POST", "/api/v1/bots/slack/interactions", json=payload)
 
     async def discord_interactions(self, payload: dict[str, Any]) -> dict[str, Any]:
         return await self._client.request("POST", "/api/v1/bots/discord/interactions", json=payload)

--- a/sdk/python/tests/test_bots.py
+++ b/sdk/python/tests/test_bots.py
@@ -9,6 +9,28 @@ import pytest
 from aragora_sdk.client import AragoraAsyncClient, AragoraClient
 
 
+@pytest.mark.parametrize(
+    ("method_name", "path"),
+    [
+        ("slack_commands", "/api/v1/bots/slack/commands"),
+        ("slack_events", "/api/v1/bots/slack/events"),
+        ("slack_interactions", "/api/v1/bots/slack/interactions"),
+    ],
+)
+def test_slack_webhook_routes_sync(method_name: str, path: str) -> None:
+    """Route Slack bot webhook helpers through the bots namespace."""
+    payload = {"team_id": "T123", "event": {"type": "message"}}
+
+    with patch.object(AragoraClient, "request") as mock_request:
+        mock_request.return_value = {"ok": True}
+
+        client = AragoraClient(base_url="https://api.aragora.ai")
+        getattr(client.bots, method_name)(payload)
+
+        mock_request.assert_called_once_with("POST", path, json=payload)
+        client.close()
+
+
 def test_slack_status_sync() -> None:
     """Get Slack bot status through bots namespace."""
     with patch.object(AragoraClient, "request") as mock_request:
@@ -19,6 +41,28 @@ def test_slack_status_sync() -> None:
 
         mock_request.assert_called_once_with("GET", "/api/v1/bots/slack/status")
         client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "path"),
+    [
+        ("slack_commands", "/api/v1/bots/slack/commands"),
+        ("slack_events", "/api/v1/bots/slack/events"),
+        ("slack_interactions", "/api/v1/bots/slack/interactions"),
+    ],
+)
+async def test_slack_webhook_routes_async(method_name: str, path: str) -> None:
+    """Route async Slack bot webhook helpers through the bots namespace."""
+    payload = {"team_id": "T123", "event": {"type": "app_mention"}}
+
+    with patch.object(AragoraAsyncClient, "request", new_callable=AsyncMock) as mock_request:
+        mock_request.return_value = {"ok": True}
+
+        async with AragoraAsyncClient(base_url="https://api.aragora.ai") as client:
+            await getattr(client.bots, method_name)(payload)
+
+        mock_request.assert_awaited_once_with("POST", path, json=payload)
 
 
 @pytest.mark.asyncio

--- a/sdk/typescript/src/namespaces/__tests__/bots.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/bots.test.ts
@@ -18,6 +18,7 @@ import { BotsAPI } from '../bots';
 interface MockClient {
   post: Mock;
   get: Mock;
+  request: Mock;
 }
 
 describe('BotsAPI Namespace', () => {
@@ -28,6 +29,7 @@ describe('BotsAPI Namespace', () => {
     mockClient = {
       post: vi.fn(),
       get: vi.fn(),
+      request: vi.fn(),
     };
     api = new BotsAPI(mockClient as any);
   });
@@ -302,6 +304,24 @@ describe('BotsAPI Namespace', () => {
       expect(mockClient.get).toHaveBeenCalledWith('/api/v1/bots/slack/status');
       expect(result.workspaces).toBe(10);
       expect(result.channels).toBe(150);
+    });
+
+    it.each([
+      ['slackCommands', '/api/v1/bots/slack/commands'],
+      ['slackEvents', '/api/v1/bots/slack/events'],
+      ['slackInteractions', '/api/v1/bots/slack/interactions'],
+    ] as const)('should route %s webhook payloads', async (methodName, path) => {
+      const payload = {
+        team_id: 'T123',
+        event: { type: 'app_mention' },
+      };
+      const mockResponse = { ok: true };
+      mockClient.request.mockResolvedValue(mockResponse);
+
+      const result = await api[methodName](payload);
+
+      expect(mockClient.request).toHaveBeenCalledWith('POST', path, { json: payload });
+      expect(result).toBe(mockResponse);
     });
   });
 

--- a/sdk/typescript/src/namespaces/bots.ts
+++ b/sdk/typescript/src/namespaces/bots.ts
@@ -22,6 +22,7 @@
 interface BotsClientInterface {
   post<T>(path: string, body?: unknown): Promise<T>;
   get<T>(path: string): Promise<T>;
+  request<T = unknown>(method: string, path: string, options?: Record<string, unknown>): Promise<T>;
 }
 
 /**
@@ -246,6 +247,27 @@ export class BotsAPI {
    */
   async slackStatus(): Promise<SlackStatus> {
     return this.client.get('/api/v1/bots/slack/status');
+  }
+
+  /**
+   * Handle Slack slash command payloads.
+   */
+  async slackCommands(payload: Record<string, unknown>): Promise<unknown> {
+    return this.client.request('POST', '/api/v1/bots/slack/commands', { json: payload });
+  }
+
+  /**
+   * Handle Slack Events API payloads.
+   */
+  async slackEvents(payload: Record<string, unknown>): Promise<unknown> {
+    return this.client.request('POST', '/api/v1/bots/slack/events', { json: payload });
+  }
+
+  /**
+   * Handle Slack interaction payloads.
+   */
+  async slackInteractions(payload: Record<string, unknown>): Promise<unknown> {
+    return this.client.request('POST', '/api/v1/bots/slack/interactions', { json: payload });
   }
 
   // ===========================================================================


### PR DESCRIPTION
## Summary
- add Python sync/async bots SDK helpers for Slack commands, events, and interactions
- add TypeScript bots SDK helpers for the same Slack webhook routes using the parity-visible request path
- add focused Python and TypeScript route-mapping tests

## Validation
- python3 -m pytest -q sdk/python/tests/test_bots.py -p no:rerunfailures
- python3 -m pytest -q tests/handlers/social/_slack_impl/test_handler.py -k 'bot_commands_alias_route or bot_interactions_alias_route or bot_events_alias_route' -p no:rerunfailures
- python3 -m ruff check sdk/python/aragora_sdk/namespaces/bots.py sdk/python/tests/test_bots.py
- npm --prefix sdk/typescript run typecheck
- python3 scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json
- python3 scripts/verify_sdk_contracts.py --strict --baseline scripts/baselines/verify_sdk_contracts.json
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Note: local TypeScript vitest run could not execute because vitest is not installed in this worktree.