### PR TITLE
feat(debate): add consensus="crux_finder" mode (Crux A1)

### DIFF
--- a/aragora/debate/consensus.py
+++ b/aragora/debate/consensus.py
@@ -1128,6 +1128,86 @@ def build_proof_from_prover_estimator(pe_result: Any) -> ConsensusProof:
     return proof
 
 
+def build_proof_from_crux_finder(result: Any) -> ConsensusProof:
+    """Build a ConsensusProof from a ``CruxFinderResult``.
+
+    Crux-finder runs are *not* verdicts: the deliverable is a ranked map of
+    load-bearing disagreements. The proof exists so downstream pipelines
+    (receipts, dashboards) see a ConsensusProof regardless of mode. Key
+    signals for consumers:
+
+    - ``final_claim`` is the ``CRUX_MAP_SENTINEL`` string — this is how a
+      caller detects "no verdict by design" and routes to the crux surface.
+    - ``consensus_reached`` is ``False`` — strictly honest about the lack
+      of a verdict.
+    - ``unresolved_tensions`` lists one tension per crux, so Arena and
+      downstream auditors can iterate the disagreements without parsing
+      the ``CruxFinderResult`` object directly.
+    - ``metadata["consensus_mode"] == "crux_finder"`` and
+      ``metadata["cruxes"]`` carries the serialized crux claims.
+    """
+    from aragora.debate.crux_mode import CRUX_MAP_SENTINEL, CruxFinderResult
+
+    if not isinstance(result, CruxFinderResult):  # pragma: no cover - defensive
+        raise TypeError(
+            f"build_proof_from_crux_finder expects a CruxFinderResult, got {type(result).__name__}"
+        )
+
+    builder = ConsensusBuilder(debate_id=result.debate_id, task=result.question)
+
+    for crux in result.analysis.cruxes:
+        claim = builder.add_claim(
+            statement=crux.statement,
+            author=crux.author,
+            confidence=float(crux.uncertainty_score),
+        )
+        builder.record_tension(
+            description=(
+                f"Crux: {crux.statement} "
+                f"(score={crux.crux_score:.3f}, "
+                f"influence={crux.influence_score:.3f}, "
+                f"disagreement={crux.disagreement_score:.3f})"
+            ),
+            agents=list(crux.contesting_agents),
+            options=[
+                f"Accept: {crux.statement}",
+                f"Reject: {crux.statement}",
+            ],
+            impact=(
+                f"Resolving this crux reduces network uncertainty by {crux.resolution_impact:.3f}."
+            ),
+            followup=(
+                f"Gather decisive evidence for claim {claim.claim_id} "
+                "or route to a specialist debate."
+            ),
+        )
+
+    proof = builder.build(
+        final_claim=CRUX_MAP_SENTINEL,
+        confidence=0.0,
+        consensus_reached=False,
+        reasoning_summary=(
+            f"crux_finder: identified {len(result.analysis.cruxes)} load-bearing "
+            f"disagreement(s) with convergence_barrier="
+            f"{result.analysis.convergence_barrier:.3f}. No verdict by design; "
+            f"see CruxReceipt for the map."
+        ),
+        rounds=result.rounds,
+    )
+
+    proof.metadata["consensus_mode"] = "crux_finder"
+    proof.metadata["approach"] = "A"
+    proof.metadata["crux_count"] = len(result.analysis.cruxes)
+    proof.metadata["convergence_barrier"] = round(result.analysis.convergence_barrier, 4)
+    proof.metadata["cruxes"] = [crux.to_dict() for crux in result.analysis.cruxes]
+    proof.metadata["counterfactuals"] = list(result.counterfactuals)
+    proof.metadata["recommended_focus"] = list(result.analysis.recommended_focus)
+    if result.metadata:
+        proof.metadata.update(result.metadata)
+
+    return proof
+
+
 def _is_actionable(text: str) -> bool:
     """Check if a statement is actionable (implementation-oriented)."""
     action_keywords = [

--- a/aragora/debate/crux_mode.py
+++ b/aragora/debate/crux_mode.py
@@ -1,0 +1,141 @@
+"""Crux-finder debate mode (Crux A1 / #6038).
+
+This module elevates existing crux detection into a first-class debate
+goal. A crux-finder run extracts the load-bearing disagreements in a
+completed debate and packages them into a `CruxFinderResult`, which a
+downstream builder in `aragora.debate.consensus` converts to a signed
+`ConsensusProof` (sentinel final claim = "no verdict by design").
+
+Only thin-wiring is implemented here (Approach A of the design doc —
+`docs/plans/2026-04-16-crux-mode-design.md`). Debate prompts are not
+shaped; cruxes are extracted from the `BeliefNetwork` the standard
+belief-analysis phase already populates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from aragora.reasoning.crux_detector import (
+    CruxAnalysisResult,
+    CruxClaim,
+    CruxDetector,
+)
+
+if TYPE_CHECKING:
+    from aragora.debate.protocol import DebateProtocol
+    from aragora.reasoning.belief import BeliefNetwork
+
+
+# Sentinel value attached to `ConsensusProof.final_claim` for crux-finder
+# runs. Downstream consumers assuming a verdict can detect this prefix and
+# route to the CruxReceipt surface instead.
+CRUX_MAP_SENTINEL = "__CRUX_MAP__: no verdict by design; see CruxReceipt.cruxes"
+
+
+@dataclass
+class CruxFinderResult:
+    """Output of a crux-finder debate.
+
+    Distinct from a `ConsensusProof` because the deliverable is *not* a
+    verdict. Carries everything needed to build both a ConsensusProof (for
+    protocol compatibility) and a CruxReceipt (for signed export, landing
+    in a follow-up under DIC-16 / #6026).
+    """
+
+    debate_id: str
+    question: str
+    analysis: CruxAnalysisResult
+    counterfactuals: list[dict[str, Any]] = field(default_factory=list)
+    agents: list[str] = field(default_factory=list)
+    rounds: int = 0
+    raw_claims: list[dict[str, Any]] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def top_cruxes(self) -> list[CruxClaim]:
+        return self.analysis.cruxes
+
+    def convergence_barrier(self) -> float:
+        return self.analysis.convergence_barrier
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "debate_id": self.debate_id,
+            "question": self.question,
+            "analysis": self.analysis.to_dict(),
+            "counterfactuals": list(self.counterfactuals),
+            "agents": list(self.agents),
+            "rounds": self.rounds,
+            "raw_claims": list(self.raw_claims),
+            "metadata": dict(self.metadata),
+        }
+
+
+def build_crux_finder_result(
+    *,
+    belief_network: BeliefNetwork | None,
+    protocol: DebateProtocol,
+    debate_id: str,
+    question: str,
+    agents: list[str],
+    rounds: int = 0,
+    raw_claims: list[dict[str, Any]] | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> CruxFinderResult:
+    """Detect cruxes in a populated belief network and package the result.
+
+    Raises:
+        RuntimeError: if `belief_network` is None. The A1 design makes this
+            an explicit failure rather than a silent fallback — a missing
+            network means the belief-analysis phase was not run, and a
+            crux-finder answer without it would not be trustworthy.
+    """
+    if belief_network is None:
+        raise RuntimeError(
+            "crux_finder mode requires a populated belief network. "
+            "Check that the belief_analysis phase ran before consensus."
+        )
+
+    detector = CruxDetector(network=belief_network)
+    analysis = detector.detect_cruxes(
+        top_k=int(protocol.crux_finder_top_k),
+        min_score=float(protocol.crux_finder_min_score),
+    )
+
+    counterfactuals: list[dict[str, Any]] = []
+    if protocol.crux_finder_counterfactual_validation:
+        for crux in analysis.cruxes:
+            counterfactuals.append(
+                {
+                    "claim_id": crux.claim_id,
+                    "condition": f"Resolve '{crux.statement}' to high confidence",
+                    "outcome_change": (
+                        f"Reduces total network uncertainty by {crux.resolution_impact:.3f}"
+                    ),
+                    "likelihood": round(float(crux.uncertainty_score), 4),
+                    "affected_claims": list(crux.affected_claims),
+                }
+            )
+
+    metadata: dict[str, Any] = {"mode": "crux_finder", "approach": "A"}
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    return CruxFinderResult(
+        debate_id=debate_id,
+        question=question,
+        analysis=analysis,
+        counterfactuals=counterfactuals,
+        agents=list(agents),
+        rounds=rounds,
+        raw_claims=list(raw_claims or []),
+        metadata=metadata,
+    )
+
+
+__all__ = [
+    "CRUX_MAP_SENTINEL",
+    "CruxFinderResult",
+    "build_crux_finder_result",
+]

--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -480,6 +480,8 @@ class ConsensusPhase:
             await self._handle_byzantine_consensus(ctx)
         elif consensus_mode == "prover_estimator":
             await self._handle_prover_estimator_consensus(ctx)
+        elif consensus_mode == "crux_finder":
+            await self._handle_crux_finder_consensus(ctx)
         else:
             logger.warning("Unknown consensus mode: %s, using none", consensus_mode)
             await self._handle_none_consensus(ctx)
@@ -1264,6 +1266,78 @@ class ConsensusPhase:
         except (RuntimeError, ValueError, TypeError, AttributeError) as e:
             logger.error("prover_estimator_error: %s", e, exc_info=True)
             await self._handle_majority_consensus(ctx)
+
+    async def _handle_crux_finder_consensus(self, ctx: "DebateContext") -> None:
+        """Handle `crux_finder` consensus mode.
+
+        Extracts load-bearing disagreements from the populated belief network
+        and stores a ConsensusProof whose ``final_claim`` is the
+        ``__CRUX_MAP__`` sentinel so downstream consumers can detect
+        "no verdict by design" and route to the crux surface. On missing
+        belief network — an explicit design choice to fail closed — we fall
+        back to majority consensus to preserve the debate's protocol
+        compatibility.
+        """
+        from aragora.debate.consensus import build_proof_from_crux_finder
+        from aragora.debate.crux_mode import build_crux_finder_result
+
+        result = ctx.result
+        belief_network = getattr(ctx, "belief_network", None)
+
+        if belief_network is None:
+            logger.warning("crux_finder_skipped reason=no_belief_network falling_back=majority")
+            await self._handle_majority_consensus(ctx)
+            return
+
+        question = ctx.env.task if ctx.env else ""
+        agent_names = [getattr(a, "name", "unknown") for a in ctx.agents]
+
+        try:
+            crux_result = build_crux_finder_result(
+                belief_network=belief_network,
+                protocol=self.protocol,
+                debate_id=ctx.debate_id or result.debate_id or "",
+                question=question,
+                agents=agent_names,
+                rounds=getattr(result, "rounds_used", 0) or self.protocol.rounds,
+            )
+            proof = build_proof_from_crux_finder(crux_result)
+        except (RuntimeError, ValueError, TypeError, AttributeError) as exc:
+            logger.error("crux_finder_error: %s", exc, exc_info=True)
+            await self._handle_majority_consensus(ctx)
+            return
+
+        result.consensus_proof = proof
+        result.consensus_reached = False
+        result.final_answer = proof.final_claim
+        result.consensus_strength = "weak"
+
+        if result.formal_verification is None:
+            result.formal_verification = {}
+        result.formal_verification["crux_finder"] = {
+            "crux_count": len(crux_result.analysis.cruxes),
+            "convergence_barrier": round(crux_result.analysis.convergence_barrier, 4),
+            "recommended_focus": list(crux_result.analysis.recommended_focus),
+            "counterfactual_validation_enabled": bool(
+                self.protocol.crux_finder_counterfactual_validation
+            ),
+        }
+
+        logger.info(
+            "crux_finder_complete cruxes=%s convergence_barrier=%.3f",
+            len(crux_result.analysis.cruxes),
+            crux_result.analysis.convergence_barrier,
+        )
+
+        if self._notify_spectator:
+            self._notify_spectator(
+                "consensus",
+                details=(
+                    f"Crux-finder: {len(crux_result.analysis.cruxes)} cruxes, "
+                    f"barrier={crux_result.analysis.convergence_barrier:.2f}"
+                ),
+                metric=float(crux_result.analysis.convergence_barrier),
+            )
 
     async def _collect_votes(self, ctx: "DebateContext") -> list["Vote"]:
         """Collect votes from all agents with outer timeout protection."""

--- a/aragora/debate/protocol.py
+++ b/aragora/debate/protocol.py
@@ -225,6 +225,7 @@ class DebateProtocol:
         "any",
         "byzantine",
         "prover_estimator",
+        "crux_finder",
     ] = "judge"
     consensus_threshold: float = 0.6  # fraction needed for majority
     allow_abstain: bool = True
@@ -233,6 +234,12 @@ class DebateProtocol:
     # Prover-Estimator protocol settings
     prover_estimator_max_rounds: int = 2
     prover_estimator_context: str = ""
+
+    # Crux-finder mode settings (see docs/plans/2026-04-16-crux-mode-design.md).
+    # Defaults mirror CruxDetector.detect_cruxes + the KM-sync threshold.
+    crux_finder_top_k: int = 5
+    crux_finder_min_score: float = 0.3
+    crux_finder_counterfactual_validation: bool = True
     # Participation quorum: minimum fraction/count of agents that must vote
     min_participation_ratio: float = 0.5
     min_participation_count: int = 2

--- a/tests/debate/test_crux_mode.py
+++ b/tests/debate/test_crux_mode.py
@@ -1,0 +1,316 @@
+"""Tests for the crux_finder consensus mode (Crux A1 / #6038).
+
+The mode elevates existing CruxDetector output into a first-class debate
+goal via a new `consensus="crux_finder"` setting. The deliverable is not a
+verdict — it is a ranked map of load-bearing disagreements that, if
+resolved, would most change the answer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.debate.consensus import (
+    ConsensusProof,
+    build_proof_from_crux_finder,
+)
+from aragora.debate.crux_mode import CruxFinderResult, build_crux_finder_result
+from aragora.debate.protocol import DebateProtocol
+from aragora.reasoning.belief import BeliefNetwork
+from aragora.reasoning.claims import RelationType
+from aragora.reasoning.crux_detector import CruxAnalysisResult, CruxClaim
+
+
+# ---------------------------------------------------------------------------
+# 1. Protocol surface
+# ---------------------------------------------------------------------------
+
+
+def test_crux_finder_literal_accepted() -> None:
+    """`DebateProtocol(consensus="crux_finder")` must construct without error.
+
+    Protects the Literal extension from silent regressions (previous values
+    only included the eight pre-CruxEngine modes).
+    """
+    proto = DebateProtocol(consensus="crux_finder")
+    assert proto.consensus == "crux_finder"
+    # Defaults should mirror CruxDetector.detect_cruxes + KM sync threshold.
+    assert proto.crux_finder_top_k == 5
+    assert proto.crux_finder_min_score == 0.3
+    assert proto.crux_finder_counterfactual_validation is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Result dataclass
+# ---------------------------------------------------------------------------
+
+
+def _sample_analysis() -> CruxAnalysisResult:
+    return CruxAnalysisResult(
+        cruxes=[
+            CruxClaim(
+                claim_id="c1",
+                statement="Is the claim sound?",
+                author="agent-alpha",
+                crux_score=0.82,
+                influence_score=0.7,
+                disagreement_score=0.6,
+                uncertainty_score=0.5,
+                centrality_score=0.8,
+                affected_claims=["c2"],
+                contesting_agents=["agent-alpha", "agent-beta"],
+                resolution_impact=0.4,
+            )
+        ],
+        total_claims=3,
+        total_disagreements=1,
+        average_uncertainty=0.5,
+        convergence_barrier=0.6,
+        recommended_focus=["c1"],
+    )
+
+
+def test_crux_finder_result_serialization_round_trips() -> None:
+    """`CruxFinderResult.to_dict()` must round-trip losslessly through JSON."""
+    import json
+
+    result = CruxFinderResult(
+        debate_id="debate-xyz",
+        question="Should we adopt X?",
+        analysis=_sample_analysis(),
+        counterfactuals=[
+            {
+                "claim_id": "c1",
+                "condition": "Resolve 'Is the claim sound?' to high confidence",
+                "outcome_change": "Reduces total network uncertainty by 0.400",
+                "likelihood": 0.5,
+                "affected_claims": ["c2"],
+            }
+        ],
+        agents=["agent-alpha", "agent-beta"],
+        rounds=3,
+        raw_claims=[{"claim_id": "c1", "statement": "Is the claim sound?"}],
+        metadata={"mode": "crux_finder", "approach": "A"},
+    )
+
+    payload = json.loads(json.dumps(result.to_dict()))
+    assert payload["debate_id"] == "debate-xyz"
+    assert payload["question"] == "Should we adopt X?"
+    assert payload["analysis"]["total_claims"] == 3
+    assert payload["analysis"]["cruxes"][0]["claim_id"] == "c1"
+    assert payload["counterfactuals"][0]["affected_claims"] == ["c2"]
+    assert payload["agents"] == ["agent-alpha", "agent-beta"]
+    assert payload["rounds"] == 3
+    assert payload["metadata"]["mode"] == "crux_finder"
+
+
+def test_crux_finder_result_exposes_top_cruxes_and_barrier() -> None:
+    result = CruxFinderResult(
+        debate_id="d",
+        question="q",
+        analysis=_sample_analysis(),
+        counterfactuals=[],
+        agents=[],
+        rounds=0,
+    )
+    assert result.top_cruxes() == result.analysis.cruxes
+    assert result.convergence_barrier() == result.analysis.convergence_barrier
+
+
+# ---------------------------------------------------------------------------
+# 3. Proof builder
+# ---------------------------------------------------------------------------
+
+
+def test_build_proof_from_crux_finder_carries_sentinel_final_claim() -> None:
+    """The proof's `final_claim` must be the `__CRUX_MAP__` sentinel.
+
+    Downstream consumers that assume a verdict can detect this sentinel and
+    route to the crux receipt instead. Any change to the sentinel string is
+    breaking and must be caught by this test.
+    """
+    result = CruxFinderResult(
+        debate_id="d1",
+        question="What should we do?",
+        analysis=_sample_analysis(),
+        counterfactuals=[],
+        agents=["agent-alpha", "agent-beta"],
+        rounds=3,
+    )
+    proof = build_proof_from_crux_finder(result)
+
+    assert isinstance(proof, ConsensusProof)
+    assert proof.debate_id == "d1"
+    assert proof.task == "What should we do?"
+    assert proof.final_claim.startswith("__CRUX_MAP__")
+    assert proof.consensus_reached is False, (
+        "A crux-finder run is NOT a verdict by design; consensus_reached must "
+        "be False so downstream gating treats it as 'no answer'."
+    )
+    assert proof.metadata.get("consensus_mode") == "crux_finder"
+    # Cruxes surface as unresolved tensions.
+    assert len(proof.unresolved_tensions) == len(result.analysis.cruxes)
+    # Proof checksum must be stable / computable for signing.
+    assert isinstance(proof.checksum, str) and len(proof.checksum) > 0
+
+
+def test_build_proof_from_crux_finder_handles_empty_analysis() -> None:
+    """An empty crux list must still produce a valid, serializable proof."""
+    empty = CruxAnalysisResult(
+        cruxes=[],
+        total_claims=0,
+        total_disagreements=0,
+        average_uncertainty=0.0,
+        convergence_barrier=0.0,
+        recommended_focus=[],
+    )
+    result = CruxFinderResult(
+        debate_id="d-empty",
+        question="Trivial question",
+        analysis=empty,
+        counterfactuals=[],
+        agents=[],
+        rounds=0,
+    )
+    proof = build_proof_from_crux_finder(result)
+
+    assert proof.final_claim.startswith("__CRUX_MAP__")
+    assert proof.unresolved_tensions == []
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end integration against a small BeliefNetwork
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def contested_network() -> BeliefNetwork:
+    """Build a network with a heavily contested, influence-rich root claim.
+
+    c1 has two downstream claims (so influence is high) and is connected
+    to opposing claims from a different author (so disagreement is high).
+    The CruxDetector should rank c1 near the top.
+    """
+    network = BeliefNetwork(debate_id="integration-test")
+    network.add_claim("c1", "Load-bearing contested claim", "agent-alpha", 0.55)
+    network.add_claim("c2", "Depends on c1", "agent-alpha", 0.7)
+    network.add_claim("c3", "Also depends on c1", "agent-alpha", 0.4)
+    network.add_claim("c4", "Counter-evidence against c1", "agent-beta", 0.6)
+    network.add_claim("c5", "Supporting evidence for c1", "agent-gamma", 0.5)
+    network.add_factor("c1", "c2", RelationType.SUPPORTS)
+    network.add_factor("c1", "c3", RelationType.SUPPORTS)
+    network.add_factor("c4", "c1", RelationType.CONTRADICTS)
+    network.add_factor("c5", "c1", RelationType.SUPPORTS)
+    return network
+
+
+def test_build_crux_finder_result_produces_ranked_cruxes(
+    contested_network: BeliefNetwork,
+) -> None:
+    protocol = DebateProtocol(consensus="crux_finder")
+    result = build_crux_finder_result(
+        belief_network=contested_network,
+        protocol=protocol,
+        debate_id="d-integration",
+        question="Should we trust the contested claim?",
+        agents=["agent-alpha", "agent-beta"],
+        rounds=3,
+    )
+
+    assert isinstance(result, CruxFinderResult)
+    assert result.debate_id == "d-integration"
+    # A contested, influence-rich network must surface at least one crux.
+    assert len(result.analysis.cruxes) >= 1
+    # Ranked output — first crux score should dominate or equal the rest.
+    scores = [c.crux_score for c in result.analysis.cruxes]
+    assert scores == sorted(scores, reverse=True)
+    # Counterfactual validation produces one record per crux.
+    if protocol.crux_finder_counterfactual_validation:
+        assert len(result.counterfactuals) == len(result.analysis.cruxes)
+        for cf in result.counterfactuals:
+            assert {"claim_id", "condition", "outcome_change", "likelihood"} <= cf.keys()
+
+
+def test_build_crux_finder_result_requires_non_none_network() -> None:
+    """Guard against silent fallback — design decision from Track A1."""
+    protocol = DebateProtocol(consensus="crux_finder")
+    with pytest.raises(RuntimeError, match="belief network"):
+        build_crux_finder_result(
+            belief_network=None,  # type: ignore[arg-type]
+            protocol=protocol,
+            debate_id="d",
+            question="q",
+            agents=[],
+            rounds=0,
+        )
+
+
+def test_build_crux_finder_result_skips_counterfactuals_when_disabled(
+    contested_network: BeliefNetwork,
+) -> None:
+    protocol = DebateProtocol(
+        consensus="crux_finder",
+        crux_finder_counterfactual_validation=False,
+    )
+    result = build_crux_finder_result(
+        belief_network=contested_network,
+        protocol=protocol,
+        debate_id="d",
+        question="q",
+        agents=[],
+        rounds=0,
+    )
+    assert result.counterfactuals == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Dispatcher routing inside the consensus phase
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_consensus_phase_dispatches_to_crux_finder(
+    contested_network: BeliefNetwork,
+) -> None:
+    """`ConsensusPhase._execute_consensus("crux_finder")` must run the
+    crux-finder handler end-to-end and attach a ConsensusProof + the
+    formal_verification["crux_finder"] summary to `ctx.result`.
+    """
+    from types import SimpleNamespace
+    from aragora.debate.phases.consensus_phase import ConsensusPhase
+
+    protocol = DebateProtocol(consensus="crux_finder")
+
+    # Minimal stub `ctx` — only the fields the handler reads.
+    result = SimpleNamespace(
+        debate_id="d-dispatcher",
+        rounds_used=3,
+        consensus_proof=None,
+        consensus_reached=None,
+        final_answer=None,
+        consensus_strength=None,
+        formal_verification=None,
+    )
+    env = SimpleNamespace(task="Should we adopt X?")
+    ctx = SimpleNamespace(
+        env=env,
+        agents=[SimpleNamespace(name="agent-alpha"), SimpleNamespace(name="agent-beta")],
+        result=result,
+        debate_id="d-dispatcher",
+        belief_network=contested_network,
+    )
+
+    phase = ConsensusPhase.__new__(ConsensusPhase)
+    phase.protocol = protocol
+    phase._notify_spectator = None
+    phase.hooks = {}
+
+    await phase._execute_consensus(ctx, "crux_finder")
+
+    assert result.consensus_proof is not None
+    assert result.consensus_proof.final_claim.startswith("__CRUX_MAP__")
+    assert result.consensus_reached is False
+    assert isinstance(result.formal_verification, dict)
+    crux_summary = result.formal_verification["crux_finder"]
+    assert crux_summary["crux_count"] >= 1
+    assert "convergence_barrier" in crux_summary


### PR DESCRIPTION
Implements [#6038](https://github.com/synaptent/aragora/issues/6038) — the A1 thin-wiring slice of the [crux-finder design doc](docs/plans/2026-04-16-crux-mode-design.md). Elevates existing `CruxDetector` output into a first-class debate goal via a new consensus mode.

## What changes

Additive only — no existing mode is touched.

- **Protocol surface.** `DebateProtocol.consensus` Literal gains `"crux_finder"`; three config fields (`crux_finder_top_k=5`, `crux_finder_min_score=0.3`, `crux_finder_counterfactual_validation=True`) mirror `CruxDetector.detect_cruxes` + the KM-sync threshold.
- **New module [aragora/debate/crux_mode.py](aragora/debate/crux_mode.py).** `CruxFinderResult` dataclass and a pure `build_crux_finder_result(...)` helper that operates on a populated `BeliefNetwork`. Explicitly raises on a `None` network — no silent fallback, per the design doc's \"belief_analysis phase must be active\" choice.
- **Proof builder.** [aragora/debate/consensus.py](aragora/debate/consensus.py) gains `build_proof_from_crux_finder(result)`, mirroring `build_proof_from_prover_estimator`. The proof's `final_claim` carries the stable sentinel `__CRUX_MAP__: no verdict by design; see CruxReceipt.cruxes`, and `consensus_reached=False`. Cruxes are surfaced as unresolved tensions so auditors can iterate them without parsing the result object. Metadata retains the serialized cruxes, recommended focus, counterfactuals, and convergence barrier — ready for the DIC-16 CruxReceipt slice ([#6026](https://github.com/synaptent/aragora/issues/6026)).
- **Dispatcher + handler.** [aragora/debate/phases/consensus_phase.py](aragora/debate/phases/consensus_phase.py) routes `\"crux_finder\"` to a new `_handle_crux_finder_consensus(ctx)` that pulls `ctx.belief_network`, calls the helpers above, and attaches the proof plus a compact `formal_verification[\"crux_finder\"]` summary (`crux_count`, `convergence_barrier`, `recommended_focus`, `counterfactual_validation_enabled`) to `ctx.result`. Missing belief network falls back to majority — logged explicitly, never silent.

## Acceptance (from #6038)

- [x] `DebateProtocol(consensus=\"crux_finder\")` constructs without error.
- [x] Dispatcher routes to the crux-finder handler.
- [x] `build_proof_from_crux_finder` returns a valid `ConsensusProof` with sentinel `final_claim`.
- [x] `pytest tests/debate/test_crux_mode.py` passes (9/9).
- [x] No regressions in `tests/debate/` (sample: 177/177 passing across `test_crux_mode`, `test_prover_estimator_contract`, `test_consensus`, `test_adaptive_consensus`, `tests/reasoning/test_crux_detector`, `tests/reasoning/test_crux_detection`, and `phases/test_consensus_phase`).

## Not in this PR

- **Track A2 — CruxReceipt export** ([#6036](https://github.com/synaptent/aragora/issues/6036)): the signed, exportable receipt artifact. The proof's metadata already carries everything the receipt builder will need.
- **Track A3 — `aragora crux <question>` CLI** ([#6039](https://github.com/synaptent/aragora/issues/6039)).
- **Track B — crux-shaping prompt templates**: gated on dogfood signal per the design doc.

## Test plan

- [x] \`python3 -m pytest tests/debate/test_crux_mode.py -v\`
- [x] \`python3 -m pytest tests/debate/test_prover_estimator_contract.py tests/debate/phases/test_consensus_phase.py\`
- [x] \`python3 -m pytest tests/reasoning/test_crux_detector.py tests/reasoning/test_crux_detection.py tests/debate/test_consensus.py tests/debate/test_adaptive_consensus.py\`
- [x] \`ruff check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)