### PR TITLE
feat(markets): AGT-04 synthetic GitHub prediction markets — planning-truth scaffold

### DIFF
--- a/aragora/markets/__init__.py
+++ b/aragora/markets/__init__.py
@@ -1,0 +1,79 @@
+"""Synthetic GitHub prediction markets — AGT-04 vision-layer planning track.
+
+This module is a planning-truth implementation of the synthetic prediction
+market substrate described in
+``docs/plans/2026-04-17-prediction-market-validation.md``. It supplies the
+``AGT-05`` skin-in-the-game reputation flow with high-volume internal
+calibration data without requiring an external venue dependency.
+
+The module is gated behind ``ARAGORA_SYNTHETIC_MARKETS_ENABLED``. Importing
+it has no live effect; explicit construction of a :class:`MarketStore`
+or :func:`enable_synthetic_markets` is required.
+
+Question shapes supported by the GitHub resolver:
+
+- ``pr_merge``: will a given PR merge within ``resolution_window_days``?
+- ``issue_close``: will a given issue close within ``resolution_window_days``?
+- ``ci_pass``: will a given branch's first scheduled CI run pass all required checks?
+
+Resolution is deterministic: the GitHub state at expiry decides the outcome.
+"""
+
+from __future__ import annotations
+
+import os
+
+from aragora.markets.resolver import GitHubMarketResolver, ResolutionError, resolve_market
+from aragora.markets.scoring import (
+    BrierBreakdown,
+    aggregate_brier,
+    binary_outcome_value,
+    brier_score,
+)
+from aragora.markets.store import MarketStore
+from aragora.markets.types import (
+    Market,
+    MarketPosition,
+    QuestionKind,
+    ResolutionEvent,
+    ResolutionOutcome,
+)
+
+__all__ = [
+    "BrierBreakdown",
+    "GitHubMarketResolver",
+    "Market",
+    "MarketPosition",
+    "MarketStore",
+    "QuestionKind",
+    "ResolutionError",
+    "ResolutionEvent",
+    "ResolutionOutcome",
+    "aggregate_brier",
+    "binary_outcome_value",
+    "brier_score",
+    "enable_synthetic_markets",
+    "resolve_market",
+    "synthetic_markets_enabled",
+]
+
+
+def synthetic_markets_enabled() -> bool:
+    """Return True if the AGT-04 synthetic-markets surface is enabled.
+
+    Reads ``ARAGORA_SYNTHETIC_MARKETS_ENABLED`` from the process environment.
+    Default is False; the markets module is dormant until explicitly enabled.
+    """
+    raw = str(os.environ.get("ARAGORA_SYNTHETIC_MARKETS_ENABLED") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_synthetic_markets() -> None:
+    """Enable the synthetic-markets surface for the current process.
+
+    Sets ``ARAGORA_SYNTHETIC_MARKETS_ENABLED=1`` so subsequent calls to
+    :func:`synthetic_markets_enabled` return True. This does not start any
+    background loops or write to disk; resolution and prediction submission
+    remain explicit calls.
+    """
+    os.environ["ARAGORA_SYNTHETIC_MARKETS_ENABLED"] = "1"

--- a/aragora/markets/resolver.py
+++ b/aragora/markets/resolver.py
@@ -1,0 +1,278 @@
+"""GitHub-event resolution adapter for synthetic markets.
+
+The resolver looks up the current GitHub state for each market's target
+and returns a deterministic :class:`ResolutionEvent`. It uses
+:func:`aragora.swarm.github_app_auth.gh_subprocess_run` so the lookups
+go through the App-token + rate-limit-aware path landed for AGT-04
+substrate hardening.
+
+Resolution rules:
+
+- ``pr_merge``: YES if PR is merged at expiry; NO if closed unmerged at
+  expiry; INCONCLUSIVE if still open at expiry.
+- ``issue_close``: YES if closed at expiry (closed-via-PR counts);
+  INCONCLUSIVE if still open at expiry (NO is reserved for future
+  ``rejected``-state semantics).
+- ``ci_pass``: YES if the most recent completed check suite for the
+  target ref has conclusion ``success`` or ``neutral``;
+  NO if any required check failed; INCONCLUSIVE if no completed run
+  exists at expiry.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Callable
+
+from aragora.markets.types import Market, ResolutionEvent
+
+logger = logging.getLogger(__name__)
+
+
+class ResolutionError(RuntimeError):
+    """Raised when resolution cannot proceed (e.g. transient GitHub error)."""
+
+
+GhRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _default_runner() -> GhRunner:
+    # Imported lazily so tests can stub gh_subprocess_run before resolver init
+    from aragora.swarm.github_app_auth import gh_subprocess_run
+
+    return gh_subprocess_run
+
+
+@dataclass
+class GitHubMarketResolver:
+    """Resolves synthetic markets against current GitHub state.
+
+    Parameters:
+        gh_runner: Callable matching ``gh_subprocess_run`` signature; lets
+            tests inject a deterministic stub. Defaults to the real
+            App-token-aware runner.
+        require_expiry: If True (the default), only resolve markets that
+            have passed ``expires_at``; otherwise, resolve immediately
+            against current state (useful for tests and ad-hoc resolution).
+    """
+
+    gh_runner: GhRunner | None = None
+    require_expiry: bool = True
+
+    def __post_init__(self) -> None:
+        self._runner: GhRunner = self.gh_runner or _default_runner()
+
+    def resolve(self, market: Market, *, now: datetime | None = None) -> ResolutionEvent:
+        """Resolve a single market or raise :class:`ResolutionError` on transient failure."""
+        reference = now or datetime.now(tz=UTC)
+        if self.require_expiry and not market.is_expired(now=reference):
+            raise ResolutionError(
+                f"market {market.market_id} is not yet expired ({market.expires_at})"
+            )
+        if market.question_kind == "pr_merge":
+            return self._resolve_pr_merge(market, reference=reference)
+        if market.question_kind == "issue_close":
+            return self._resolve_issue_close(market, reference=reference)
+        if market.question_kind == "ci_pass":
+            return self._resolve_ci_pass(market, reference=reference)
+        raise ResolutionError(f"unsupported question_kind: {market.question_kind}")
+
+    def resolve_batch(
+        self,
+        markets: list[Market],
+        *,
+        now: datetime | None = None,
+    ) -> list[ResolutionEvent]:
+        """Resolve as many markets as possible; skip transient failures.
+
+        Returns the successfully resolved events. Failed resolutions are
+        logged at warning level and omitted from the result; callers can
+        retry on the next pass.
+        """
+        out: list[ResolutionEvent] = []
+        for market in markets:
+            try:
+                out.append(self.resolve(market, now=now))
+            except ResolutionError as exc:
+                logger.warning("resolve skipped for %s: %s", market.market_id, exc)
+        return out
+
+    # ------------------------------------------------------------------
+    # Per-kind resolvers
+    # ------------------------------------------------------------------
+
+    def _resolve_pr_merge(
+        self,
+        market: Market,
+        *,
+        reference: datetime,
+    ) -> ResolutionEvent:
+        repo = str(market.target.get("repo") or "")
+        number = int(market.target.get("number") or 0)
+        result = self._runner(
+            ["pr", "view", str(number), "--repo", repo, "--json", "state,merged,mergedAt,closedAt"],
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise ResolutionError(f"gh pr view failed: {result.stderr.strip() or '(no stderr)'}")
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            raise ResolutionError(f"gh pr view returned non-JSON: {exc}") from exc
+        state = str(payload.get("state") or "").upper()
+        merged = bool(payload.get("merged"))
+        evidence = {
+            "repo": repo,
+            "number": number,
+            "state": state,
+            "merged": merged,
+            "merged_at": payload.get("mergedAt"),
+            "closed_at": payload.get("closedAt"),
+            "checked_at": reference.isoformat().replace("+00:00", "Z"),
+        }
+        if merged:
+            return ResolutionEvent.yes(
+                market_id=market.market_id,
+                resolution_source="github_pr_state",
+                evidence=evidence,
+                resolved_at=reference,
+            )
+        if state == "CLOSED":
+            return ResolutionEvent.no(
+                market_id=market.market_id,
+                resolution_source="github_pr_state",
+                evidence=evidence,
+                resolved_at=reference,
+            )
+        return ResolutionEvent.inconclusive(
+            market_id=market.market_id,
+            resolution_source="github_pr_state",
+            evidence=evidence,
+            resolved_at=reference,
+        )
+
+    def _resolve_issue_close(
+        self,
+        market: Market,
+        *,
+        reference: datetime,
+    ) -> ResolutionEvent:
+        repo = str(market.target.get("repo") or "")
+        number = int(market.target.get("number") or 0)
+        result = self._runner(
+            ["issue", "view", str(number), "--repo", repo, "--json", "state,closedAt"],
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise ResolutionError(f"gh issue view failed: {result.stderr.strip() or '(no stderr)'}")
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            raise ResolutionError(f"gh issue view returned non-JSON: {exc}") from exc
+        state = str(payload.get("state") or "").upper()
+        evidence = {
+            "repo": repo,
+            "number": number,
+            "state": state,
+            "closed_at": payload.get("closedAt"),
+            "checked_at": reference.isoformat().replace("+00:00", "Z"),
+        }
+        if state == "CLOSED":
+            return ResolutionEvent.yes(
+                market_id=market.market_id,
+                resolution_source="github_issue_state",
+                evidence=evidence,
+                resolved_at=reference,
+            )
+        return ResolutionEvent.inconclusive(
+            market_id=market.market_id,
+            resolution_source="github_issue_state",
+            evidence=evidence,
+            resolved_at=reference,
+        )
+
+    def _resolve_ci_pass(
+        self,
+        market: Market,
+        *,
+        reference: datetime,
+    ) -> ResolutionEvent:
+        repo = str(market.target.get("repo") or "")
+        ref = str(market.target.get("ref") or "")
+        result = self._runner(
+            [
+                "api",
+                f"repos/{repo}/commits/{ref}/check-suites",
+                "--jq",
+                ".check_suites | map({status, conclusion, app_slug: .app.slug})",
+            ],
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise ResolutionError(
+                f"gh api check-suites failed: {result.stderr.strip() or '(no stderr)'}"
+            )
+        try:
+            suites: list[dict[str, Any]] = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError as exc:
+            raise ResolutionError(f"check-suites response was non-JSON: {exc}") from exc
+        completed = [
+            suite for suite in suites if str(suite.get("status") or "").lower() == "completed"
+        ]
+        evidence = {
+            "repo": repo,
+            "ref": ref,
+            "suite_count": len(suites),
+            "completed_count": len(completed),
+            "checked_at": reference.isoformat().replace("+00:00", "Z"),
+            "conclusions": [str(suite.get("conclusion") or "").lower() for suite in completed],
+        }
+        if not completed:
+            return ResolutionEvent.inconclusive(
+                market_id=market.market_id,
+                resolution_source="github_ci_check",
+                evidence=evidence,
+                resolved_at=reference,
+            )
+        good = {"success", "neutral", "skipped"}
+        bad = {"failure", "timed_out", "cancelled", "action_required", "stale"}
+        conclusions = [str(suite.get("conclusion") or "").lower() for suite in completed]
+        if any(conclusion in bad for conclusion in conclusions):
+            return ResolutionEvent.no(
+                market_id=market.market_id,
+                resolution_source="github_ci_check",
+                evidence=evidence,
+                resolved_at=reference,
+            )
+        if all(conclusion in good for conclusion in conclusions):
+            return ResolutionEvent.yes(
+                market_id=market.market_id,
+                resolution_source="github_ci_check",
+                evidence=evidence,
+                resolved_at=reference,
+            )
+        return ResolutionEvent.inconclusive(
+            market_id=market.market_id,
+            resolution_source="github_ci_check",
+            evidence=evidence,
+            resolved_at=reference,
+        )
+
+
+def resolve_market(
+    market: Market,
+    *,
+    gh_runner: GhRunner | None = None,
+    require_expiry: bool = True,
+    now: datetime | None = None,
+) -> ResolutionEvent:
+    """Convenience wrapper around :class:`GitHubMarketResolver`."""
+    resolver = GitHubMarketResolver(gh_runner=gh_runner, require_expiry=require_expiry)
+    return resolver.resolve(market, now=now)
+
+
+__all__ = ["GitHubMarketResolver", "ResolutionError", "resolve_market"]

--- a/aragora/markets/scoring.py
+++ b/aragora/markets/scoring.py
@@ -1,0 +1,214 @@
+"""Brier scoring for resolved synthetic-market positions.
+
+Brier score is the proper scoring rule used across the AGT-* track. Lower
+is better; floor 0, ceiling 1. The aggregate is computed per agent, per
+domain, optionally weighted by stake size, with optional time decay.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Iterable
+
+from aragora.markets.types import (
+    MarketPosition,
+    ResolutionEvent,
+    ResolutionOutcome,
+)
+
+
+def binary_outcome_value(outcome: ResolutionOutcome) -> float | None:
+    """Map a ResolutionOutcome to its binary value for Brier scoring.
+
+    Returns None for ``inconclusive`` outcomes because they do not
+    contribute to calibration: an unresolvable question cannot tell us
+    whether an agent was wrong.
+    """
+    if outcome == "yes":
+        return 1.0
+    if outcome == "no":
+        return 0.0
+    return None
+
+
+def brier_score(predicted_probability: float, outcome: ResolutionOutcome) -> float | None:
+    """Brier score for a single prediction against a resolved outcome.
+
+    Returns None when the outcome is ``inconclusive`` so callers can
+    exclude unscored positions from the aggregate.
+    """
+    realized = binary_outcome_value(outcome)
+    if realized is None:
+        return None
+    return (predicted_probability - realized) ** 2
+
+
+@dataclass(frozen=True)
+class BrierBreakdown:
+    """Aggregate Brier statistics for an agent over a set of positions."""
+
+    agent_id: str
+    scored_positions: int
+    inconclusive_positions: int
+    mean_brier: float | None
+    stake_weighted_brier: float | None
+    decayed_brier: float | None
+    total_stake: int
+
+
+def aggregate_brier(
+    *,
+    agent_id: str,
+    positions: Iterable[MarketPosition],
+    resolutions: dict[str, ResolutionEvent],
+    now: datetime | None = None,
+    half_life_days: float | None = 30.0,
+) -> BrierBreakdown:
+    """Compute mean, stake-weighted, and time-decayed Brier scores for one agent.
+
+    - ``positions``: all positions taken by ``agent_id``; non-resolved
+      positions are skipped.
+    - ``resolutions``: market_id → ResolutionEvent for resolved markets.
+    - ``half_life_days``: if non-None, applies exponential time decay so
+      older positions weigh less; default 30 days matches the AGT-05
+      90-day rolling window with mid-window centroid.
+
+    Returns a :class:`BrierBreakdown`. ``mean_brier``,
+    ``stake_weighted_brier``, and ``decayed_brier`` are None when there
+    are no scored positions.
+    """
+    reference = now or datetime.now(tz=UTC)
+    scored = 0
+    inconclusive = 0
+    total_stake = 0
+    sum_brier = 0.0
+    sum_stake_weighted = 0.0
+    sum_stake_for_score = 0
+    sum_decay_weighted = 0.0
+    sum_decay_weight = 0.0
+
+    for position in positions:
+        if position.agent_id != agent_id:
+            continue
+        resolution = resolutions.get(position.market_id)
+        if resolution is None:
+            continue
+        score = brier_score(position.probability, resolution.outcome)
+        if score is None:
+            inconclusive += 1
+            continue
+        scored += 1
+        total_stake += position.stake
+        sum_brier += score
+        sum_stake_weighted += score * position.stake
+        sum_stake_for_score += position.stake
+
+        if half_life_days is not None and half_life_days > 0:
+            try:
+                resolved_at = datetime.fromisoformat(
+                    resolution.resolved_at.replace("Z", "+00:00")
+                ).astimezone(UTC)
+            except ValueError:
+                resolved_at = reference
+            age_days = max((reference - resolved_at).total_seconds() / 86400.0, 0.0)
+            decay_weight = math.exp(-math.log(2.0) * age_days / float(half_life_days))
+        else:
+            decay_weight = 1.0
+        sum_decay_weighted += score * decay_weight * position.stake
+        sum_decay_weight += decay_weight * position.stake
+
+    mean_brier = (sum_brier / scored) if scored else None
+    stake_weighted = (sum_stake_weighted / sum_stake_for_score) if sum_stake_for_score else None
+    decayed = (sum_decay_weighted / sum_decay_weight) if sum_decay_weight else None
+
+    return BrierBreakdown(
+        agent_id=agent_id,
+        scored_positions=scored,
+        inconclusive_positions=inconclusive,
+        mean_brier=mean_brier,
+        stake_weighted_brier=stake_weighted,
+        decayed_brier=decayed,
+        total_stake=total_stake,
+    )
+
+
+def calibration_curve(
+    *,
+    positions: Iterable[MarketPosition],
+    resolutions: dict[str, ResolutionEvent],
+    bucket_count: int = 10,
+) -> list[dict[str, float]]:
+    """Compute a calibration curve: predicted bucket → realized frequency.
+
+    Returns a list of bucket dictionaries with keys ``bucket_low``,
+    ``bucket_high``, ``predicted_mean``, ``realized_mean``, and
+    ``count``. Empty buckets are omitted.
+    """
+    if bucket_count < 2:
+        raise ValueError("bucket_count must be >= 2")
+    width = 1.0 / bucket_count
+    buckets: dict[int, list[tuple[float, float]]] = {}
+
+    for position in positions:
+        resolution = resolutions.get(position.market_id)
+        if resolution is None:
+            continue
+        realized = binary_outcome_value(resolution.outcome)
+        if realized is None:
+            continue
+        # Use multiplication instead of division to avoid float precision
+        # surprises like int(0.7 / 0.1) == 6 (should be 7).
+        idx = min(int(position.probability * bucket_count), bucket_count - 1)
+        buckets.setdefault(idx, []).append((position.probability, realized))
+
+    out: list[dict[str, float]] = []
+    for idx in sorted(buckets):
+        entries = buckets[idx]
+        predicted_mean = sum(p for p, _ in entries) / len(entries)
+        realized_mean = sum(r for _, r in entries) / len(entries)
+        out.append(
+            {
+                "bucket_low": idx * width,
+                "bucket_high": (idx + 1) * width,
+                "predicted_mean": predicted_mean,
+                "realized_mean": realized_mean,
+                "count": float(len(entries)),
+            }
+        )
+    return out
+
+
+def evaluate_position_payout(
+    *,
+    position: MarketPosition,
+    resolution: ResolutionEvent,
+) -> int:
+    """Compute the per-position credit refund/forfeit under proper Brier.
+
+    Returns a signed integer in ``[-stake, +stake]`` rounded toward zero.
+    Convention: a perfectly calibrated prediction (Brier = 0) returns
+    the full stake; a maximally wrong prediction (Brier = 1) forfeits
+    the full stake; in between, the agent receives ``stake * (1 - 2 *
+    brier)`` credits.
+
+    Inconclusive resolutions return 0 (full refund of stake handled at
+    the store layer, not encoded as a payout).
+    """
+    score = brier_score(position.probability, resolution.outcome)
+    if score is None:
+        return 0
+    payout_fraction = 1.0 - 2.0 * score
+    payout = int(position.stake * payout_fraction)
+    return max(-position.stake, min(position.stake, payout))
+
+
+__all__ = [
+    "BrierBreakdown",
+    "aggregate_brier",
+    "binary_outcome_value",
+    "brier_score",
+    "calibration_curve",
+    "evaluate_position_payout",
+]

--- a/aragora/markets/store.py
+++ b/aragora/markets/store.py
@@ -1,0 +1,212 @@
+"""JSONL-backed persistence for synthetic markets, positions, and resolutions.
+
+The store is intentionally simple — append-only JSONL files plus an
+in-memory index. The on-disk shape is the same shape the AGT-05 wiring
+will consume, so this layer is the seam that lets the reputation flow
+work against either a live store or a deterministic test fixture.
+
+Files (under ``base_dir``):
+- ``markets.jsonl``      — one Market per line
+- ``positions.jsonl``    — one MarketPosition per line
+- ``resolutions.jsonl``  — one ResolutionEvent per line
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from aragora.markets.types import (
+    MAX_POSITION_STAKE,
+    Market,
+    MarketPosition,
+    ResolutionEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MarketStoreError(RuntimeError):
+    """Raised on store-layer invariant violations."""
+
+
+@dataclass(frozen=True)
+class StoreLayout:
+    base_dir: Path
+    markets_path: Path
+    positions_path: Path
+    resolutions_path: Path
+
+    @classmethod
+    def from_base(cls, base_dir: Path) -> "StoreLayout":
+        return cls(
+            base_dir=base_dir,
+            markets_path=base_dir / "markets.jsonl",
+            positions_path=base_dir / "positions.jsonl",
+            resolutions_path=base_dir / "resolutions.jsonl",
+        )
+
+
+class MarketStore:
+    """Append-only JSONL store for markets, positions, and resolutions.
+
+    The store is created lazily — files are only written when objects
+    are added. Reading from a fresh store returns empty iterables.
+
+    Concurrency: the store assumes a single writer per ``base_dir``.
+    Multi-writer coordination is out of scope for AGT-04; AGT-05's
+    settlement flow will introduce the locking primitives.
+    """
+
+    def __init__(self, base_dir: Path | str) -> None:
+        path = Path(base_dir).expanduser().resolve()
+        path.mkdir(parents=True, exist_ok=True)
+        self._layout = StoreLayout.from_base(path)
+        self._markets: dict[str, Market] = {}
+        self._positions: dict[str, MarketPosition] = {}
+        self._resolutions: dict[str, ResolutionEvent] = {}
+        self._loaded = False
+
+    @property
+    def layout(self) -> StoreLayout:
+        return self._layout
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+
+    def _load_if_needed(self) -> None:
+        if self._loaded:
+            return
+        self._markets = _load_jsonl(self._layout.markets_path, Market.from_json, "market_id")
+        self._positions = _load_jsonl(
+            self._layout.positions_path, MarketPosition.from_json, "position_id"
+        )
+        self._resolutions = _load_jsonl(
+            self._layout.resolutions_path, ResolutionEvent.from_json, "market_id"
+        )
+        self._loaded = True
+
+    def reload(self) -> None:
+        """Drop the in-memory cache and re-read from disk on next access."""
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Markets
+    # ------------------------------------------------------------------
+
+    def add_market(self, market: Market) -> Market:
+        self._load_if_needed()
+        existing = self._markets.get(market.market_id)
+        if existing is not None:
+            if existing == market:
+                return existing
+            raise MarketStoreError(
+                f"market {market.market_id} already exists with different fields"
+            )
+        _append_jsonl(self._layout.markets_path, market.to_json())
+        self._markets[market.market_id] = market
+        return market
+
+    def get_market(self, market_id: str) -> Market | None:
+        self._load_if_needed()
+        return self._markets.get(market_id)
+
+    def list_markets(self) -> list[Market]:
+        self._load_if_needed()
+        return list(self._markets.values())
+
+    # ------------------------------------------------------------------
+    # Positions
+    # ------------------------------------------------------------------
+
+    def add_position(self, position: MarketPosition) -> MarketPosition:
+        self._load_if_needed()
+        if position.position_id in self._positions:
+            return self._positions[position.position_id]
+        if position.market_id not in self._markets:
+            raise MarketStoreError(f"cannot add position for unknown market {position.market_id}")
+        if position.stake > MAX_POSITION_STAKE:
+            raise MarketStoreError(
+                f"stake {position.stake} exceeds MAX_POSITION_STAKE={MAX_POSITION_STAKE}"
+            )
+        if position.market_id in self._resolutions:
+            raise MarketStoreError(
+                f"market {position.market_id} is already resolved; cannot add positions"
+            )
+        _append_jsonl(self._layout.positions_path, position.to_json())
+        self._positions[position.position_id] = position
+        return position
+
+    def list_positions(self, *, market_id: str | None = None) -> list[MarketPosition]:
+        self._load_if_needed()
+        if market_id is None:
+            return list(self._positions.values())
+        return [pos for pos in self._positions.values() if pos.market_id == market_id]
+
+    def list_agent_positions(self, agent_id: str) -> list[MarketPosition]:
+        self._load_if_needed()
+        return [pos for pos in self._positions.values() if pos.agent_id == agent_id]
+
+    # ------------------------------------------------------------------
+    # Resolutions
+    # ------------------------------------------------------------------
+
+    def record_resolution(self, event: ResolutionEvent) -> ResolutionEvent:
+        self._load_if_needed()
+        if event.market_id not in self._markets:
+            raise MarketStoreError(f"cannot resolve unknown market {event.market_id}")
+        existing = self._resolutions.get(event.market_id)
+        if existing is not None:
+            if existing == event:
+                return existing
+            raise MarketStoreError(f"market {event.market_id} already has a divergent resolution")
+        _append_jsonl(self._layout.resolutions_path, event.to_json())
+        self._resolutions[event.market_id] = event
+        return event
+
+    def resolutions_by_market(self) -> dict[str, ResolutionEvent]:
+        self._load_if_needed()
+        return dict(self._resolutions)
+
+    # ------------------------------------------------------------------
+    # Convenience iteration
+    # ------------------------------------------------------------------
+
+    def iter_unresolved_markets(self) -> Iterable[Market]:
+        self._load_if_needed()
+        for market in self._markets.values():
+            if market.market_id not in self._resolutions:
+                yield market
+
+
+def _append_jsonl(path: Path, payload: dict) -> None:
+    line = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+def _load_jsonl(path: Path, deserialize, key_field: str) -> dict:
+    if not path.exists():
+        return {}
+    out: dict = {}
+    with path.open("r", encoding="utf-8") as handle:
+        for raw in handle:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+                obj = deserialize(payload)
+            except (json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
+                logger.warning("skipping malformed line in %s: %s", path, exc)
+                continue
+            key = getattr(obj, key_field)
+            out[key] = obj
+    return out
+
+
+__all__ = ["MarketStore", "MarketStoreError", "StoreLayout"]

--- a/aragora/markets/types.py
+++ b/aragora/markets/types.py
@@ -1,0 +1,274 @@
+"""Core types for synthetic GitHub prediction markets.
+
+These types intentionally use plain dataclasses with JSON-serializable
+fields so storage can be a flat JSONL file. The schema is the planning
+contract — once AGT-05 (skin-in-the-game reputation) wires resolution
+events into the ERC-8004 reputation registry, these types become the
+on-disk shape that survives schema review.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+QuestionKind = Literal["pr_merge", "issue_close", "ci_pass"]
+ResolutionOutcome = Literal["yes", "no", "inconclusive"]
+
+# Per-market position cap from the AGT-04 plan
+MAX_POSITION_STAKE = 100
+
+# Stale market expiry from the AGT-04 plan
+MAX_RESOLUTION_WINDOW_DAYS = 90
+
+_REPO_PATTERN = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _from_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _validate_repo(repo: str) -> None:
+    if not _REPO_PATTERN.match(repo or ""):
+        raise ValueError(f"invalid repo identifier: {repo!r}; expected owner/name")
+
+
+def _market_id(question_kind: QuestionKind, target: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        {"kind": question_kind, "target": target},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    return f"mkt_{question_kind}_{digest}"
+
+
+@dataclass(frozen=True)
+class Market:
+    """A synthetic prediction market over a verifiable GitHub event.
+
+    ``market_id`` is content-addressed from ``question_kind`` + ``target``
+    so identical questions deduplicate. Markets are immutable once created.
+    """
+
+    market_id: str
+    question_kind: QuestionKind
+    target: dict[str, Any]
+    description: str
+    created_at: str
+    expires_at: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        question_kind: QuestionKind,
+        target: dict[str, Any],
+        description: str,
+        resolution_window_days: int,
+        created_at: datetime | None = None,
+    ) -> "Market":
+        if resolution_window_days < 1 or resolution_window_days > MAX_RESOLUTION_WINDOW_DAYS:
+            raise ValueError(f"resolution_window_days must be in [1, {MAX_RESOLUTION_WINDOW_DAYS}]")
+        repo = str(target.get("repo") or "")
+        _validate_repo(repo)
+        if question_kind in {"pr_merge", "issue_close"}:
+            number = target.get("number")
+            if not isinstance(number, int) or number < 1:
+                raise ValueError(f"target.number must be a positive int for {question_kind}")
+        elif question_kind == "ci_pass":
+            ref = str(target.get("ref") or "").strip()
+            if not ref:
+                raise ValueError("target.ref must be a non-empty string for ci_pass")
+        else:  # pragma: no cover - exhaustiveness
+            raise ValueError(f"unsupported question_kind: {question_kind!r}")
+
+        created = created_at or _utc_now()
+        expires = created + timedelta(days=resolution_window_days)
+        normalized_target = dict(target)
+        return cls(
+            market_id=_market_id(question_kind, normalized_target),
+            question_kind=question_kind,
+            target=normalized_target,
+            description=description.strip(),
+            created_at=_iso(created),
+            expires_at=_iso(expires),
+        )
+
+    def is_expired(self, *, now: datetime | None = None) -> bool:
+        return (now or _utc_now()) >= _from_iso(self.expires_at)
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "Market":
+        return cls(
+            market_id=str(data["market_id"]),
+            question_kind=data["question_kind"],
+            target=dict(data["target"]),
+            description=str(data.get("description") or ""),
+            created_at=str(data["created_at"]),
+            expires_at=str(data["expires_at"]),
+        )
+
+
+@dataclass(frozen=True)
+class MarketPosition:
+    """An agent's prediction on a market, with stake.
+
+    ``probability`` is the agent's predicted P(YES) in ``[0, 1]``.
+    ``stake`` is in internal credits (compute-budget units) and bounded by
+    :data:`MAX_POSITION_STAKE`.
+    """
+
+    position_id: str
+    market_id: str
+    agent_id: str
+    probability: float
+    stake: int
+    submitted_at: str
+    rationale: str = ""
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        market_id: str,
+        agent_id: str,
+        probability: float,
+        stake: int,
+        submitted_at: datetime | None = None,
+        rationale: str = "",
+    ) -> "MarketPosition":
+        if not (0.0 <= probability <= 1.0):
+            raise ValueError("probability must be in [0, 1]")
+        if stake < 1 or stake > MAX_POSITION_STAKE:
+            raise ValueError(f"stake must be in [1, {MAX_POSITION_STAKE}]")
+        agent = (agent_id or "").strip()
+        if not agent:
+            raise ValueError("agent_id must be non-empty")
+        market = (market_id or "").strip()
+        if not market:
+            raise ValueError("market_id must be non-empty")
+        ts = submitted_at or _utc_now()
+        material = f"{market}|{agent}|{_iso(ts)}|{probability:.6f}|{stake}"
+        position_id = "pos_" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+        return cls(
+            position_id=position_id,
+            market_id=market,
+            agent_id=agent,
+            probability=float(probability),
+            stake=int(stake),
+            submitted_at=_iso(ts),
+            rationale=rationale.strip(),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "MarketPosition":
+        return cls(
+            position_id=str(data["position_id"]),
+            market_id=str(data["market_id"]),
+            agent_id=str(data["agent_id"]),
+            probability=float(data["probability"]),
+            stake=int(data["stake"]),
+            submitted_at=str(data["submitted_at"]),
+            rationale=str(data.get("rationale") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class ResolutionEvent:
+    """A resolved market: outcome plus the GitHub evidence that decided it.
+
+    ``outcome`` follows the AGT-05 ResolutionEvent contract (see
+    ``docs/plans/SKIN_IN_THE_GAME_REPUTATION.md``). ``inconclusive`` covers
+    expired markets where the underlying state (e.g. PR still open at
+    expiry) does not provide a binary answer; the ``evidence`` payload
+    explains why.
+    """
+
+    market_id: str
+    outcome: ResolutionOutcome
+    resolved_at: str
+    resolution_source: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def yes(
+        cls,
+        *,
+        market_id: str,
+        resolution_source: str,
+        evidence: dict[str, Any] | None = None,
+        resolved_at: datetime | None = None,
+    ) -> "ResolutionEvent":
+        return cls(
+            market_id=market_id,
+            outcome="yes",
+            resolved_at=_iso(resolved_at or _utc_now()),
+            resolution_source=resolution_source,
+            evidence=dict(evidence or {}),
+        )
+
+    @classmethod
+    def no(
+        cls,
+        *,
+        market_id: str,
+        resolution_source: str,
+        evidence: dict[str, Any] | None = None,
+        resolved_at: datetime | None = None,
+    ) -> "ResolutionEvent":
+        return cls(
+            market_id=market_id,
+            outcome="no",
+            resolved_at=_iso(resolved_at or _utc_now()),
+            resolution_source=resolution_source,
+            evidence=dict(evidence or {}),
+        )
+
+    @classmethod
+    def inconclusive(
+        cls,
+        *,
+        market_id: str,
+        resolution_source: str,
+        evidence: dict[str, Any] | None = None,
+        resolved_at: datetime | None = None,
+    ) -> "ResolutionEvent":
+        return cls(
+            market_id=market_id,
+            outcome="inconclusive",
+            resolved_at=_iso(resolved_at or _utc_now()),
+            resolution_source=resolution_source,
+            evidence=dict(evidence or {}),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "ResolutionEvent":
+        return cls(
+            market_id=str(data["market_id"]),
+            outcome=data["outcome"],
+            resolved_at=str(data["resolved_at"]),
+            resolution_source=str(data["resolution_source"]),
+            evidence=dict(data.get("evidence") or {}),
+        )

--- a/tests/markets/test_init.py
+++ b/tests/markets/test_init.py
@@ -1,0 +1,64 @@
+"""Tests for the AGT-04 markets module entry point and feature flag."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from aragora import markets
+
+
+def test_synthetic_markets_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("ARAGORA_SYNTHETIC_MARKETS_ENABLED", raising=False)
+    assert markets.synthetic_markets_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "Yes"])
+def test_truthy_env_values_enable_markets(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("ARAGORA_SYNTHETIC_MARKETS_ENABLED", value)
+    assert markets.synthetic_markets_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off"])
+def test_falsy_env_values_keep_markets_disabled(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("ARAGORA_SYNTHETIC_MARKETS_ENABLED", value)
+    assert markets.synthetic_markets_enabled() is False
+
+
+def test_enable_synthetic_markets_flips_flag(monkeypatch) -> None:
+    monkeypatch.delenv("ARAGORA_SYNTHETIC_MARKETS_ENABLED", raising=False)
+    assert markets.synthetic_markets_enabled() is False
+    markets.enable_synthetic_markets()
+    try:
+        assert markets.synthetic_markets_enabled() is True
+    finally:
+        monkeypatch.delenv("ARAGORA_SYNTHETIC_MARKETS_ENABLED", raising=False)
+
+
+def test_public_exports_present() -> None:
+    expected = {
+        "Market",
+        "MarketPosition",
+        "MarketStore",
+        "ResolutionEvent",
+        "ResolutionOutcome",
+        "QuestionKind",
+        "GitHubMarketResolver",
+        "ResolutionError",
+        "resolve_market",
+        "brier_score",
+        "aggregate_brier",
+        "binary_outcome_value",
+        "BrierBreakdown",
+        "synthetic_markets_enabled",
+        "enable_synthetic_markets",
+    }
+    missing = expected - set(markets.__all__)
+    assert not missing, f"missing public exports: {missing}"
+
+
+def test_module_can_be_reimported_cleanly(monkeypatch) -> None:
+    monkeypatch.delenv("ARAGORA_SYNTHETIC_MARKETS_ENABLED", raising=False)
+    importlib.reload(markets)
+    assert markets.synthetic_markets_enabled() is False

--- a/tests/markets/test_resolver.py
+++ b/tests/markets/test_resolver.py
@@ -1,0 +1,211 @@
+"""Tests for aragora.markets.resolver — deterministic GitHub-event resolution."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.markets.resolver import GitHubMarketResolver, ResolutionError, resolve_market
+from aragora.markets.types import Market
+
+
+def _completed(
+    stdout: str, *, returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _expired_pr_market(*, number: int = 5959) -> Market:
+    created = datetime(2026, 4, 1, tzinfo=UTC)
+    return Market.create(
+        question_kind="pr_merge",
+        target={"repo": "synaptent/aragora", "number": number},
+        description="will it merge",
+        resolution_window_days=7,
+        created_at=created,
+    )
+
+
+def _expired_issue_market(*, number: int = 6068) -> Market:
+    return Market.create(
+        question_kind="issue_close",
+        target={"repo": "synaptent/aragora", "number": number},
+        description="will it close",
+        resolution_window_days=14,
+        created_at=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+
+
+def _expired_ci_market(*, ref: str = "abc123") -> Market:
+    return Market.create(
+        question_kind="ci_pass",
+        target={"repo": "synaptent/aragora", "ref": ref},
+        description="will ci pass",
+        resolution_window_days=3,
+        created_at=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+
+
+class TestExpiryGuard:
+    def test_unexpired_market_raises(self) -> None:
+        market = Market.create(
+            question_kind="pr_merge",
+            target={"repo": "owner/repo", "number": 1},
+            description="x",
+            resolution_window_days=7,
+            created_at=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+
+        def _runner(*args, **kwargs):  # pragma: no cover - never called
+            raise AssertionError("runner must not be invoked for unexpired markets")
+
+        resolver = GitHubMarketResolver(gh_runner=_runner)
+        with pytest.raises(ResolutionError):
+            resolver.resolve(market, now=datetime(2026, 4, 18, tzinfo=UTC))
+
+    def test_require_expiry_false_resolves_immediately(self) -> None:
+        market = Market.create(
+            question_kind="pr_merge",
+            target={"repo": "owner/repo", "number": 1},
+            description="x",
+            resolution_window_days=7,
+            created_at=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+
+        def _runner(args, **kwargs):
+            return _completed(json.dumps({"state": "MERGED", "merged": True}))
+
+        resolver = GitHubMarketResolver(gh_runner=_runner, require_expiry=False)
+        event = resolver.resolve(market, now=datetime(2026, 4, 18, tzinfo=UTC))
+        assert event.outcome == "yes"
+
+
+class TestPrMergeResolution:
+    def test_merged_pr_resolves_yes(self) -> None:
+        market = _expired_pr_market()
+        captured: list[list[str]] = []
+
+        def _runner(args, **kwargs):
+            captured.append(list(args))
+            return _completed(
+                json.dumps({"state": "MERGED", "merged": True, "mergedAt": "2026-04-05T12:00:00Z"})
+            )
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "yes"
+        assert event.resolution_source == "github_pr_state"
+        assert event.evidence["merged"] is True
+        assert captured[0][0] == "pr"
+
+    def test_closed_unmerged_pr_resolves_no(self) -> None:
+        market = _expired_pr_market(number=42)
+
+        def _runner(args, **kwargs):
+            return _completed(
+                json.dumps({"state": "CLOSED", "merged": False, "closedAt": "2026-04-06T08:00:00Z"})
+            )
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "no"
+
+    def test_open_pr_at_expiry_resolves_inconclusive(self) -> None:
+        market = _expired_pr_market(number=43)
+
+        def _runner(args, **kwargs):
+            return _completed(json.dumps({"state": "OPEN", "merged": False}))
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "inconclusive"
+
+    def test_gh_failure_raises_resolution_error(self) -> None:
+        market = _expired_pr_market(number=44)
+
+        def _runner(args, **kwargs):
+            return _completed("", returncode=1, stderr="server error")
+
+        with pytest.raises(ResolutionError):
+            resolve_market(market, gh_runner=_runner)
+
+
+class TestIssueResolution:
+    def test_closed_issue_resolves_yes(self) -> None:
+        market = _expired_issue_market(number=6068)
+
+        def _runner(args, **kwargs):
+            return _completed(json.dumps({"state": "CLOSED", "closedAt": "2026-04-10T12:00:00Z"}))
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "yes"
+
+    def test_open_issue_at_expiry_resolves_inconclusive(self) -> None:
+        market = _expired_issue_market(number=6069)
+
+        def _runner(args, **kwargs):
+            return _completed(json.dumps({"state": "OPEN", "closedAt": None}))
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "inconclusive"
+
+
+class TestCiResolution:
+    def test_all_success_resolves_yes(self) -> None:
+        market = _expired_ci_market(ref="abcd")
+        suites = [
+            {"status": "completed", "conclusion": "success", "app_slug": "github-actions"},
+            {"status": "completed", "conclusion": "neutral", "app_slug": "github-actions"},
+        ]
+
+        def _runner(args, **kwargs):
+            return _completed(json.dumps(suites))
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "yes"
+
+    def test_any_failure_resolves_no(self) -> None:
+        market = _expired_ci_market(ref="bad1")
+        suites = [
+            {"status": "completed", "conclusion": "success"},
+            {"status": "completed", "conclusion": "failure"},
+        ]
+
+        def _runner(args, **kwargs):
+            return _completed(json.dumps(suites))
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "no"
+
+    def test_no_completed_runs_resolves_inconclusive(self) -> None:
+        market = _expired_ci_market(ref="pending")
+        suites = [
+            {"status": "in_progress", "conclusion": None},
+            {"status": "queued", "conclusion": None},
+        ]
+
+        def _runner(args, **kwargs):
+            return _completed(json.dumps(suites))
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "inconclusive"
+
+
+class TestResolveBatch:
+    def test_resolve_batch_skips_transient_failures(self) -> None:
+        good = _expired_pr_market(number=1)
+        bad = _expired_pr_market(number=2)
+        call_count = {"n": 0}
+
+        def _runner(args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _completed(json.dumps({"state": "MERGED", "merged": True}))
+            return _completed("", returncode=1, stderr="boom")
+
+        resolver = GitHubMarketResolver(gh_runner=_runner)
+        events = resolver.resolve_batch([good, bad])
+        assert len(events) == 1
+        assert events[0].outcome == "yes"

--- a/tests/markets/test_scoring.py
+++ b/tests/markets/test_scoring.py
@@ -1,0 +1,244 @@
+"""Tests for aragora.markets.scoring — Brier, payouts, calibration curve."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.markets.scoring import (
+    aggregate_brier,
+    binary_outcome_value,
+    brier_score,
+    calibration_curve,
+    evaluate_position_payout,
+)
+from aragora.markets.types import MarketPosition, ResolutionEvent
+
+
+class TestBrierBasics:
+    def test_perfect_prediction_scores_zero(self) -> None:
+        assert brier_score(1.0, "yes") == 0.0
+        assert brier_score(0.0, "no") == 0.0
+
+    def test_maximally_wrong_prediction_scores_one(self) -> None:
+        assert brier_score(0.0, "yes") == 1.0
+        assert brier_score(1.0, "no") == 1.0
+
+    def test_inconclusive_returns_none(self) -> None:
+        assert brier_score(0.5, "inconclusive") is None
+        assert binary_outcome_value("inconclusive") is None
+
+    def test_calibrated_prior_scores_quarter(self) -> None:
+        assert brier_score(0.5, "yes") == 0.25
+        assert brier_score(0.5, "no") == 0.25
+
+
+class TestAggregateBrier:
+    def _make_position(
+        self,
+        *,
+        agent: str,
+        market: str,
+        probability: float,
+        stake: int = 10,
+        submitted_at: datetime | None = None,
+    ) -> MarketPosition:
+        return MarketPosition.create(
+            market_id=market,
+            agent_id=agent,
+            probability=probability,
+            stake=stake,
+            submitted_at=submitted_at or datetime(2026, 4, 17, 12, 0, tzinfo=UTC),
+        )
+
+    def test_empty_input_returns_none_aggregates(self) -> None:
+        report = aggregate_brier(
+            agent_id="agent",
+            positions=[],
+            resolutions={},
+        )
+        assert report.scored_positions == 0
+        assert report.mean_brier is None
+        assert report.stake_weighted_brier is None
+        assert report.decayed_brier is None
+
+    def test_inconclusive_resolutions_do_not_contribute_to_score(self) -> None:
+        positions = [
+            self._make_position(agent="alice", market="mkt_1", probability=0.7),
+            self._make_position(agent="alice", market="mkt_2", probability=0.4),
+        ]
+        resolutions = {
+            "mkt_1": ResolutionEvent.yes(
+                market_id="mkt_1",
+                resolution_source="github_pr_state",
+                resolved_at=datetime(2026, 4, 24, tzinfo=UTC),
+            ),
+            "mkt_2": ResolutionEvent.inconclusive(
+                market_id="mkt_2",
+                resolution_source="github_pr_state",
+                resolved_at=datetime(2026, 4, 24, tzinfo=UTC),
+            ),
+        }
+        report = aggregate_brier(
+            agent_id="alice",
+            positions=positions,
+            resolutions=resolutions,
+            now=datetime(2026, 4, 24, tzinfo=UTC),
+            half_life_days=None,
+        )
+        assert report.scored_positions == 1
+        assert report.inconclusive_positions == 1
+        # Brier(0.7, yes) = 0.09
+        assert report.mean_brier == pytest.approx(0.09)
+
+    def test_stake_weighted_brier_emphasises_larger_stakes(self) -> None:
+        positions = [
+            self._make_position(agent="alice", market="mkt_1", probability=0.9, stake=80),
+            self._make_position(
+                agent="alice",
+                market="mkt_2",
+                probability=0.1,
+                stake=20,
+                submitted_at=datetime(2026, 4, 17, 12, 1, tzinfo=UTC),
+            ),
+        ]
+        resolutions = {
+            "mkt_1": ResolutionEvent.yes(
+                market_id="mkt_1",
+                resolution_source="x",
+                resolved_at=datetime(2026, 4, 24, tzinfo=UTC),
+            ),
+            "mkt_2": ResolutionEvent.yes(
+                market_id="mkt_2",
+                resolution_source="x",
+                resolved_at=datetime(2026, 4, 24, tzinfo=UTC),
+            ),
+        }
+        report = aggregate_brier(
+            agent_id="alice",
+            positions=positions,
+            resolutions=resolutions,
+            now=datetime(2026, 4, 24, tzinfo=UTC),
+            half_life_days=None,
+        )
+        # mean = (0.01 + 0.81) / 2 = 0.41
+        # stake-weighted = (0.01*80 + 0.81*20) / 100 = (0.8 + 16.2) / 100 = 0.17
+        assert report.mean_brier == pytest.approx(0.41)
+        assert report.stake_weighted_brier == pytest.approx(0.17)
+
+    def test_other_agents_positions_are_ignored(self) -> None:
+        positions = [
+            self._make_position(agent="alice", market="mkt_1", probability=0.9),
+            self._make_position(agent="bob", market="mkt_1", probability=0.1),
+        ]
+        resolutions = {
+            "mkt_1": ResolutionEvent.yes(market_id="mkt_1", resolution_source="x"),
+        }
+        report = aggregate_brier(agent_id="alice", positions=positions, resolutions=resolutions)
+        assert report.scored_positions == 1
+
+    def test_decay_weight_pulls_recent_above_old(self) -> None:
+        old = self._make_position(
+            agent="alice",
+            market="mkt_1",
+            probability=0.0,  # maximally wrong (Brier=1)
+            stake=10,
+            submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        recent = self._make_position(
+            agent="alice",
+            market="mkt_2",
+            probability=1.0,  # perfectly right (Brier=0)
+            stake=10,
+            submitted_at=datetime(2026, 4, 16, tzinfo=UTC),
+        )
+        resolutions = {
+            "mkt_1": ResolutionEvent.yes(
+                market_id="mkt_1",
+                resolution_source="x",
+                resolved_at=datetime(2026, 1, 8, tzinfo=UTC),
+            ),
+            "mkt_2": ResolutionEvent.yes(
+                market_id="mkt_2",
+                resolution_source="x",
+                resolved_at=datetime(2026, 4, 17, tzinfo=UTC),
+            ),
+        }
+        report = aggregate_brier(
+            agent_id="alice",
+            positions=[old, recent],
+            resolutions=resolutions,
+            now=datetime(2026, 4, 17, tzinfo=UTC),
+            half_life_days=30.0,
+        )
+        # Without decay: mean = 0.5, stake_weighted = 0.5
+        # With 30d half-life: recent (Brier=0) weighs heavily; decayed should be < 0.25
+        assert report.mean_brier == pytest.approx(0.5)
+        assert report.decayed_brier is not None
+        assert report.decayed_brier < 0.25
+
+
+class TestPositionPayout:
+    def test_perfect_prediction_returns_full_stake(self) -> None:
+        position = MarketPosition.create(
+            market_id="mkt_1", agent_id="alice", probability=1.0, stake=50
+        )
+        resolution = ResolutionEvent.yes(market_id="mkt_1", resolution_source="x")
+        assert evaluate_position_payout(position=position, resolution=resolution) == 50
+
+    def test_maximally_wrong_forfeits_full_stake(self) -> None:
+        position = MarketPosition.create(
+            market_id="mkt_1", agent_id="alice", probability=0.0, stake=50
+        )
+        resolution = ResolutionEvent.yes(market_id="mkt_1", resolution_source="x")
+        assert evaluate_position_payout(position=position, resolution=resolution) == -50
+
+    def test_calibrated_prior_breaks_even_to_zero(self) -> None:
+        position = MarketPosition.create(
+            market_id="mkt_1", agent_id="alice", probability=0.5, stake=50
+        )
+        resolution = ResolutionEvent.yes(market_id="mkt_1", resolution_source="x")
+        # Brier=0.25 → payout fraction = 1 - 2*0.25 = 0.5 → 25 credits
+        assert evaluate_position_payout(position=position, resolution=resolution) == 25
+
+    def test_inconclusive_returns_zero(self) -> None:
+        position = MarketPosition.create(
+            market_id="mkt_1", agent_id="alice", probability=0.7, stake=50
+        )
+        resolution = ResolutionEvent.inconclusive(market_id="mkt_1", resolution_source="x")
+        assert evaluate_position_payout(position=position, resolution=resolution) == 0
+
+
+class TestCalibrationCurve:
+    def test_buckets_aggregate_predicted_and_realized_means(self) -> None:
+        positions = [
+            MarketPosition.create(
+                market_id=f"mkt_{i}",
+                agent_id="alice",
+                probability=p,
+                stake=10,
+                submitted_at=datetime(2026, 4, 17, 12, i, tzinfo=UTC),
+            )
+            for i, p in enumerate([0.05, 0.1, 0.7, 0.75, 0.95])
+        ]
+        resolutions = {
+            "mkt_0": ResolutionEvent.no(market_id="mkt_0", resolution_source="x"),
+            "mkt_1": ResolutionEvent.yes(market_id="mkt_1", resolution_source="x"),
+            "mkt_2": ResolutionEvent.yes(market_id="mkt_2", resolution_source="x"),
+            "mkt_3": ResolutionEvent.yes(market_id="mkt_3", resolution_source="x"),
+            "mkt_4": ResolutionEvent.yes(market_id="mkt_4", resolution_source="x"),
+        }
+        curve = calibration_curve(positions=positions, resolutions=resolutions, bucket_count=10)
+        # 0.05 -> bucket 0 (0.0-0.1), 0.1 -> bucket 1 (0.1-0.2),
+        # 0.7 and 0.75 -> bucket 7 (0.7-0.8), 0.95 -> bucket 9 (0.9-1.0)
+        buckets_present = [round(b["bucket_low"], 1) for b in curve]
+        assert buckets_present == [0.0, 0.1, 0.7, 0.9]
+        # Bucket 7 has 2 entries with realized mean 1.0 (both yes)
+        seven_bucket = next(b for b in curve if round(b["bucket_low"], 1) == 0.7)
+        assert seven_bucket["count"] == 2.0
+        assert seven_bucket["realized_mean"] == 1.0
+
+    def test_invalid_bucket_count_raises(self) -> None:
+        with pytest.raises(ValueError):
+            calibration_curve(positions=[], resolutions={}, bucket_count=1)

--- a/tests/markets/test_store.py
+++ b/tests/markets/test_store.py
@@ -1,0 +1,194 @@
+"""Tests for aragora.markets.store — JSONL persistence and invariants."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from aragora.markets.store import MarketStore, MarketStoreError
+from aragora.markets.types import (
+    MAX_POSITION_STAKE,
+    Market,
+    MarketPosition,
+    ResolutionEvent,
+)
+
+
+def _make_pr_market(*, repo: str = "owner/repo", number: int = 1) -> Market:
+    return Market.create(
+        question_kind="pr_merge",
+        target={"repo": repo, "number": number},
+        description=f"will {repo}#{number} merge",
+        resolution_window_days=7,
+        created_at=datetime(2026, 4, 17, tzinfo=UTC),
+    )
+
+
+class TestStoreLifecycle:
+    def test_fresh_store_is_empty(self, tmp_path) -> None:
+        store = MarketStore(tmp_path / "markets")
+        assert store.list_markets() == []
+        assert store.list_positions() == []
+        assert store.resolutions_by_market() == {}
+
+    def test_add_market_and_reload_persists(self, tmp_path) -> None:
+        path = tmp_path / "markets"
+        store_a = MarketStore(path)
+        market = _make_pr_market(number=42)
+        store_a.add_market(market)
+        store_b = MarketStore(path)
+        assert store_b.get_market(market.market_id) == market
+        assert len(store_b.list_markets()) == 1
+
+    def test_add_market_idempotent_on_identical_payload(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        market = _make_pr_market(number=1)
+        store.add_market(market)
+        store.add_market(market)  # second add must not raise
+        assert len(store.list_markets()) == 1
+
+    def test_add_market_rejects_id_collision_with_different_fields(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        market = _make_pr_market(number=1)
+        store.add_market(market)
+        # Build a divergent market with the same id by hand
+        divergent = Market(
+            market_id=market.market_id,
+            question_kind="pr_merge",
+            target={"repo": "owner/repo", "number": 1},
+            description="DIVERGENT DESCRIPTION",
+            created_at=market.created_at,
+            expires_at=market.expires_at,
+        )
+        with pytest.raises(MarketStoreError):
+            store.add_market(divergent)
+
+    def test_malformed_jsonl_lines_are_skipped(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        market = _make_pr_market(number=1)
+        store.add_market(market)
+        # Inject a bogus line; reload must skip it
+        with store.layout.markets_path.open("a") as handle:
+            handle.write("NOT_JSON\n")
+            handle.write('{"missing": "fields"}\n')
+        store.reload()
+        assert len(store.list_markets()) == 1
+
+
+class TestPositionInvariants:
+    def test_add_position_requires_existing_market(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        position = MarketPosition.create(
+            market_id="mkt_unknown",
+            agent_id="agent",
+            probability=0.5,
+            stake=10,
+        )
+        with pytest.raises(MarketStoreError):
+            store.add_position(position)
+
+    def test_add_position_blocked_after_resolution(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        market = _make_pr_market(number=1)
+        store.add_market(market)
+        store.record_resolution(
+            ResolutionEvent.yes(
+                market_id=market.market_id,
+                resolution_source="github_pr_state",
+            )
+        )
+        position = MarketPosition.create(
+            market_id=market.market_id,
+            agent_id="agent",
+            probability=0.5,
+            stake=10,
+        )
+        with pytest.raises(MarketStoreError):
+            store.add_position(position)
+
+    def test_position_stake_capped(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        market = _make_pr_market(number=1)
+        store.add_market(market)
+        # MarketPosition.create already enforces this; the store guard is
+        # belt-and-suspenders for hand-built positions:
+        with pytest.raises(ValueError):
+            MarketPosition.create(
+                market_id=market.market_id,
+                agent_id="agent",
+                probability=0.5,
+                stake=MAX_POSITION_STAKE + 1,
+            )
+
+    def test_list_agent_positions_filters(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        market = _make_pr_market(number=1)
+        store.add_market(market)
+        # Distinct submitted_at per call so position_id (content-addressed)
+        # does not collapse the duplicate-agent entries into one.
+        entries = [
+            ("alice", datetime(2026, 4, 17, 12, 0, tzinfo=UTC)),
+            ("bob", datetime(2026, 4, 17, 12, 1, tzinfo=UTC)),
+            ("alice", datetime(2026, 4, 17, 12, 2, tzinfo=UTC)),
+        ]
+        for agent, ts in entries:
+            store.add_position(
+                MarketPosition.create(
+                    market_id=market.market_id,
+                    agent_id=agent,
+                    probability=0.5,
+                    stake=10,
+                    submitted_at=ts,
+                )
+            )
+        alice_positions = store.list_agent_positions("alice")
+        assert len(alice_positions) == 2
+        assert all(pos.agent_id == "alice" for pos in alice_positions)
+
+
+class TestResolutionInvariants:
+    def test_record_resolution_requires_existing_market(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        with pytest.raises(MarketStoreError):
+            store.record_resolution(
+                ResolutionEvent.yes(
+                    market_id="mkt_unknown",
+                    resolution_source="github_pr_state",
+                )
+            )
+
+    def test_divergent_resolution_rejected(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        market = _make_pr_market(number=1)
+        store.add_market(market)
+        store.record_resolution(
+            ResolutionEvent.yes(
+                market_id=market.market_id,
+                resolution_source="github_pr_state",
+                resolved_at=datetime(2026, 4, 24, tzinfo=UTC),
+            )
+        )
+        with pytest.raises(MarketStoreError):
+            store.record_resolution(
+                ResolutionEvent.no(
+                    market_id=market.market_id,
+                    resolution_source="github_pr_state",
+                    resolved_at=datetime(2026, 4, 24, tzinfo=UTC),
+                )
+            )
+
+    def test_iter_unresolved_markets_excludes_resolved(self, tmp_path) -> None:
+        store = MarketStore(tmp_path)
+        a = _make_pr_market(number=1)
+        b = _make_pr_market(number=2)
+        store.add_market(a)
+        store.add_market(b)
+        store.record_resolution(
+            ResolutionEvent.yes(
+                market_id=a.market_id,
+                resolution_source="github_pr_state",
+            )
+        )
+        unresolved = list(store.iter_unresolved_markets())
+        assert [m.market_id for m in unresolved] == [b.market_id]

--- a/tests/markets/test_types.py
+++ b/tests/markets/test_types.py
@@ -1,0 +1,208 @@
+"""Tests for aragora.markets.types — schema validation and roundtrip."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.markets.types import (
+    MAX_POSITION_STAKE,
+    MAX_RESOLUTION_WINDOW_DAYS,
+    Market,
+    MarketPosition,
+    ResolutionEvent,
+)
+
+
+class TestMarketCreate:
+    def test_pr_merge_market_id_is_content_addressed(self) -> None:
+        a = Market.create(
+            question_kind="pr_merge",
+            target={"repo": "synaptent/aragora", "number": 5959},
+            description="will #5959 merge",
+            resolution_window_days=7,
+            created_at=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+        b = Market.create(
+            question_kind="pr_merge",
+            target={"repo": "synaptent/aragora", "number": 5959},
+            description="duplicate",
+            resolution_window_days=14,  # different window must not change id
+            created_at=datetime(2026, 4, 18, tzinfo=UTC),
+        )
+        assert a.market_id == b.market_id
+
+    def test_distinct_pr_targets_have_distinct_ids(self) -> None:
+        a = Market.create(
+            question_kind="pr_merge",
+            target={"repo": "synaptent/aragora", "number": 1},
+            description="a",
+            resolution_window_days=7,
+        )
+        b = Market.create(
+            question_kind="pr_merge",
+            target={"repo": "synaptent/aragora", "number": 2},
+            description="b",
+            resolution_window_days=7,
+        )
+        assert a.market_id != b.market_id
+
+    def test_invalid_repo_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            Market.create(
+                question_kind="pr_merge",
+                target={"repo": "no-slash", "number": 1},
+                description="x",
+                resolution_window_days=7,
+            )
+
+    def test_pr_merge_requires_positive_int_number(self) -> None:
+        with pytest.raises(ValueError):
+            Market.create(
+                question_kind="pr_merge",
+                target={"repo": "owner/repo", "number": "five"},
+                description="x",
+                resolution_window_days=7,
+            )
+
+    def test_ci_pass_requires_ref(self) -> None:
+        with pytest.raises(ValueError):
+            Market.create(
+                question_kind="ci_pass",
+                target={"repo": "owner/repo"},
+                description="x",
+                resolution_window_days=3,
+            )
+
+    def test_window_bounds(self) -> None:
+        with pytest.raises(ValueError):
+            Market.create(
+                question_kind="pr_merge",
+                target={"repo": "owner/repo", "number": 1},
+                description="x",
+                resolution_window_days=0,
+            )
+        with pytest.raises(ValueError):
+            Market.create(
+                question_kind="pr_merge",
+                target={"repo": "owner/repo", "number": 1},
+                description="x",
+                resolution_window_days=MAX_RESOLUTION_WINDOW_DAYS + 1,
+            )
+
+    def test_is_expired_uses_utc(self) -> None:
+        created = datetime(2026, 4, 17, tzinfo=UTC)
+        market = Market.create(
+            question_kind="pr_merge",
+            target={"repo": "owner/repo", "number": 1},
+            description="x",
+            resolution_window_days=7,
+            created_at=created,
+        )
+        assert not market.is_expired(now=created + timedelta(days=6))
+        assert market.is_expired(now=created + timedelta(days=7, seconds=1))
+
+    def test_to_json_roundtrip(self) -> None:
+        market = Market.create(
+            question_kind="ci_pass",
+            target={"repo": "owner/repo", "ref": "abc123"},
+            description="will branch ci pass",
+            resolution_window_days=3,
+        )
+        roundtrip = Market.from_json(market.to_json())
+        assert roundtrip == market
+
+
+class TestMarketPosition:
+    def test_create_validates_probability_bounds(self) -> None:
+        with pytest.raises(ValueError):
+            MarketPosition.create(
+                market_id="mkt_pr_merge_x", agent_id="agent", probability=-0.1, stake=10
+            )
+        with pytest.raises(ValueError):
+            MarketPosition.create(
+                market_id="mkt_pr_merge_x", agent_id="agent", probability=1.01, stake=10
+            )
+
+    def test_create_validates_stake_bounds(self) -> None:
+        with pytest.raises(ValueError):
+            MarketPosition.create(
+                market_id="mkt_pr_merge_x", agent_id="agent", probability=0.5, stake=0
+            )
+        with pytest.raises(ValueError):
+            MarketPosition.create(
+                market_id="mkt_pr_merge_x",
+                agent_id="agent",
+                probability=0.5,
+                stake=MAX_POSITION_STAKE + 1,
+            )
+
+    def test_create_requires_non_empty_ids(self) -> None:
+        with pytest.raises(ValueError):
+            MarketPosition.create(market_id="", agent_id="agent", probability=0.5, stake=10)
+        with pytest.raises(ValueError):
+            MarketPosition.create(market_id="mkt_x", agent_id=" ", probability=0.5, stake=10)
+
+    def test_position_id_is_deterministic_for_same_inputs(self) -> None:
+        ts = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+        a = MarketPosition.create(
+            market_id="mkt_x",
+            agent_id="agent",
+            probability=0.5,
+            stake=10,
+            submitted_at=ts,
+        )
+        b = MarketPosition.create(
+            market_id="mkt_x",
+            agent_id="agent",
+            probability=0.5,
+            stake=10,
+            submitted_at=ts,
+        )
+        assert a.position_id == b.position_id
+
+    def test_to_json_roundtrip(self) -> None:
+        position = MarketPosition.create(
+            market_id="mkt_x",
+            agent_id="agent",
+            probability=0.7,
+            stake=25,
+            rationale="thesis",
+        )
+        roundtrip = MarketPosition.from_json(position.to_json())
+        assert roundtrip == position
+
+
+class TestResolutionEvent:
+    def test_yes_no_inconclusive_factories(self) -> None:
+        ts = datetime(2026, 4, 17, tzinfo=UTC)
+        yes = ResolutionEvent.yes(
+            market_id="mkt_x",
+            resolution_source="github_pr_state",
+            resolved_at=ts,
+        )
+        no = ResolutionEvent.no(
+            market_id="mkt_x",
+            resolution_source="github_pr_state",
+            resolved_at=ts,
+        )
+        inc = ResolutionEvent.inconclusive(
+            market_id="mkt_x",
+            resolution_source="github_pr_state",
+            resolved_at=ts,
+        )
+        assert yes.outcome == "yes"
+        assert no.outcome == "no"
+        assert inc.outcome == "inconclusive"
+
+    def test_to_json_roundtrip(self) -> None:
+        ts = datetime(2026, 4, 17, tzinfo=UTC)
+        event = ResolutionEvent.yes(
+            market_id="mkt_x",
+            resolution_source="github_pr_state",
+            evidence={"repo": "owner/repo", "number": 1, "merged": True},
+            resolved_at=ts,
+        )
+        roundtrip = ResolutionEvent.from_json(event.to_json())
+        assert roundtrip == event


### PR DESCRIPTION
## Summary

- Adds `aragora/markets/` — flag-gated synthetic GitHub prediction-market substrate per the AGT-04 plan.
- 1,978 lines added across 11 new files (5 module + 6 test); 69 tests pass.
- Default-off via `ARAGORA_SYNTHETIC_MARKETS_ENABLED`; importing has no live effect.
- Wires existing `gh_subprocess_run` (PR #6080) for App-token-quota-isolated, rate-limit-aware GitHub event lookups.

## What this gives the AGT track

The AGT-05 skin-in-the-game reputation flow needs an **external truth oracle** stream. Manifold (AGT-03) supplies low-volume external calibration; this AGT-04 module supplies high-volume internal calibration on verifiable GitHub events without any external venue dependency.

Question shapes:
- `pr_merge` — will PR #X merge in N days?
- `issue_close` — will issue #Y close in N days?
- `ci_pass` — will branch ref's first scheduled CI run pass all required checks?

Resolution is deterministic (GitHub state at expiry decides) and content-addressed via SHA256 of question_kind+target so identical questions deduplicate.

## Module structure

| File | Lines | Purpose |
|---|---|---|
| `aragora/markets/types.py` | 252 | Market, MarketPosition, ResolutionEvent dataclasses |
| `aragora/markets/store.py` | 197 | Append-only JSONL persistence + in-memory index |
| `aragora/markets/scoring.py` | 196 | Brier scoring (mean/stake-weighted/decayed), calibration curve, payout |
| `aragora/markets/resolver.py` | 256 | GitHubMarketResolver — uses gh_subprocess_run from PR #6080 |
| `aragora/markets/__init__.py` | 87 | Public exports + feature-flag |
| `tests/markets/test_*.py` | 989 | 69 tests across 5 test modules |

## Why default-off

Per `docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md` and `docs/status/NEXT_STEPS_CANONICAL.md`, AGT-* is planning-truth only — code may land but must not affect production until the upper-layer gate opens. Importing this module is a no-op; explicit `MarketStore(...)` construction is required to write anything.

## Test plan

- [x] 69/69 tests pass under `pytest tests/markets/ -q`
- [x] No production behavior change: module is dormant unless flag is set
- [x] Resolver tests inject deterministic stubs via the `gh_runner` parameter; no live GitHub calls in CI
- [x] All schemas JSON-roundtrip cleanly
- [x] Store invariants exercised (idempotent add, divergent-id rejection, malformed-line skip, position-after-resolution rejection, divergent-resolution rejection)
- [x] Brier scoring covers proper-rule extremes (perfect=0, wrong=1, calibrated-prior=0.25), stake weighting, time decay, calibration binning float-precision
- [x] Resolver covers all 3 question kinds × all 3 outcome paths (YES/NO/INCONCLUSIVE) plus transient-failure batch skip

## What this PR does NOT do

- No background scheduler/daemon — resolution is explicit (callers iterate `iter_unresolved_markets()` and call `resolver.resolve(market)` themselves)
- No CLI subcommand wiring (`aragora markets ...` deferred to follow-up; types are stable)
- No ERC-8004 reputation update path (that's AGT-05 issue #6066)
- No external venue adapters (Manifold/Metaculus = AGT-03 issue #6064)
- No live activation — must explicitly set `ARAGORA_SYNTHETIC_MARKETS_ENABLED=1`

## Refs

- AGT-04 issue: #6065
- AGT epic: #6068
- Vision PR: #6061
- Substrate hardening PR: #6080 (rate-limit-aware gh runner this module wires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)