### PR TITLE
feat(reasoning): AGT-01 CruxSet contract + flag-gated emission seam

### DIFF
--- a/aragora/reasoning/cruxset.py
+++ b/aragora/reasoning/cruxset.py
@@ -1,0 +1,389 @@
+"""CruxSet contract — the load-bearing-disagreement output of the debate path.
+
+This module defines the AGT-01 / DIC-15 contract that the existing
+:class:`aragora.reasoning.crux_detector.CruxDetector` will emit on the
+production debate path once the AGT-* upper-layer gate opens. The shape
+mirrors the spec in ``docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md`` and
+``docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md`` so the AGT-05 reputation
+flow has a concrete structure to wire against.
+
+A CruxSet is a signed, content-addressed bundle that captures, for a
+specific question:
+
+- the candidate decision (when one was reached)
+- the 3-5 load-bearing disagreements that would flip the decision if
+  resolved differently (the cruxes themselves)
+- the evidence gaps surfacing each crux
+- the counterfactual hooks that quantify why each crux is load-bearing
+- the verifier candidates that could later resolve each crux
+
+The bundle is designed to be ingestable by AGT-05 as a
+``StakeableClaim`` of domain ``crux_resolution``, and by AGT-04 / AGT-03
+as the source of agent positions on contested questions.
+
+This module is contract-only: it does not run debates, does not invoke
+:class:`CruxDetector`, and does not emit anything by itself. The
+flag-gated emitter that ties the two together lives in
+:mod:`aragora.reasoning.cruxset_emission`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Iterable
+
+CRUXSET_SCHEMA_VERSION = "1.0"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class CruxPosition:
+    """One side of a crux — a position taken by one or more agents."""
+
+    side: str
+    agents: tuple[str, ...] = field(default_factory=tuple)
+    rationale: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "side": self.side,
+            "agents": list(self.agents),
+            "rationale": self.rationale,
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "CruxPosition":
+        return cls(
+            side=str(data["side"]),
+            agents=tuple(str(a) for a in (data.get("agents") or [])),
+            rationale=str(data.get("rationale") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class Crux:
+    """A single load-bearing disagreement.
+
+    Field shape matches the EPISTEMIC_CI_AND_CRUX_ENGINE.md spec for a
+    crux:
+
+    - ``crux_id``: stable identifier for the crux within its CruxSet
+    - ``statement``: the claim or assumption that is load-bearing
+    - ``positions``: the agent positions on this crux (typically 2)
+    - ``load_bearing_score``: counterfactual-validated impact in [0, 1]
+    - ``evidence_gaps``: machine-readable list of missing evidence items
+    - ``counterfactual``: short note explaining why flipping this crux
+      would change the decision
+    - ``candidate_verifier``: pointer to a verifier or doc that could
+      later resolve this crux (free-form for now; AGT-05 will tighten)
+    """
+
+    crux_id: str
+    statement: str
+    positions: tuple[CruxPosition, ...]
+    load_bearing_score: float
+    evidence_gaps: tuple[str, ...] = field(default_factory=tuple)
+    counterfactual: str = ""
+    candidate_verifier: str = ""
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.load_bearing_score <= 1.0):
+            raise ValueError("load_bearing_score must be in [0, 1]")
+        if not str(self.crux_id).strip():
+            raise ValueError("crux_id must be non-empty")
+        if not str(self.statement).strip():
+            raise ValueError("statement must be non-empty")
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "crux_id": self.crux_id,
+            "statement": self.statement,
+            "positions": [p.to_json() for p in self.positions],
+            "load_bearing_score": round(self.load_bearing_score, 6),
+            "evidence_gaps": list(self.evidence_gaps),
+            "counterfactual": self.counterfactual,
+            "candidate_verifier": self.candidate_verifier,
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "Crux":
+        return cls(
+            crux_id=str(data["crux_id"]),
+            statement=str(data["statement"]),
+            positions=tuple(CruxPosition.from_json(p) for p in (data.get("positions") or [])),
+            load_bearing_score=float(data["load_bearing_score"]),
+            evidence_gaps=tuple(str(g) for g in (data.get("evidence_gaps") or [])),
+            counterfactual=str(data.get("counterfactual") or ""),
+            candidate_verifier=str(data.get("candidate_verifier") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class CruxSet:
+    """A signed bundle of cruxes for one question.
+
+    ``cruxset_id`` is content-addressed from the question text and the
+    ranked crux list so identical analyses deduplicate. ``checksum``
+    is the SHA-256 of the canonical JSON serialization, used to verify
+    that a stored or transmitted CruxSet has not been tampered with.
+
+    ``decision`` is the candidate decision the debate reached (when one
+    was reached); for crux-finder mode debates, ``decision`` may be
+    None when the explicit goal is to surface disagreement rather than
+    converge.
+    """
+
+    cruxset_id: str
+    schema_version: str
+    question: str
+    decision: str | None
+    cruxes: tuple[Crux, ...]
+    evidence_gaps: tuple[str, ...]
+    counterfactual_notes: tuple[str, ...]
+    verifier_candidates: tuple[str, ...]
+    receipt_id: str
+    provenance: dict[str, Any]
+    created_at: str
+    checksum: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        question: str,
+        cruxes: Iterable[Crux],
+        decision: str | None = None,
+        evidence_gaps: Iterable[str] = (),
+        counterfactual_notes: Iterable[str] = (),
+        verifier_candidates: Iterable[str] = (),
+        receipt_id: str = "",
+        provenance: dict[str, Any] | None = None,
+        created_at: str | None = None,
+    ) -> "CruxSet":
+        question_str = (question or "").strip()
+        if not question_str:
+            raise ValueError("question must be non-empty")
+
+        cruxes_tuple = tuple(cruxes)
+        if len(cruxes_tuple) == 0:
+            raise ValueError("CruxSet requires at least one crux")
+        # Sort by load_bearing_score desc; ties broken by crux_id asc for determinism
+        cruxes_sorted = tuple(
+            sorted(
+                cruxes_tuple,
+                key=lambda c: (-c.load_bearing_score, c.crux_id),
+            )
+        )
+
+        cruxset_id = _build_cruxset_id(question_str, cruxes_sorted)
+        provenance_dict = dict(provenance or {})
+        timestamp = created_at or _utc_now_iso()
+
+        # Build a draft and then compute the checksum over its canonical form.
+        draft = cls(
+            cruxset_id=cruxset_id,
+            schema_version=CRUXSET_SCHEMA_VERSION,
+            question=question_str,
+            decision=decision,
+            cruxes=cruxes_sorted,
+            evidence_gaps=tuple(str(g).strip() for g in evidence_gaps if str(g).strip()),
+            counterfactual_notes=tuple(
+                str(n).strip() for n in counterfactual_notes if str(n).strip()
+            ),
+            verifier_candidates=tuple(
+                str(v).strip() for v in verifier_candidates if str(v).strip()
+            ),
+            receipt_id=str(receipt_id or ""),
+            provenance=provenance_dict,
+            created_at=timestamp,
+            checksum="",
+        )
+        return draft._with_checksum()
+
+    def _with_checksum(self) -> "CruxSet":
+        canonical = self._canonical_payload()
+        digest = hashlib.sha256(
+            json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return CruxSet(
+            cruxset_id=self.cruxset_id,
+            schema_version=self.schema_version,
+            question=self.question,
+            decision=self.decision,
+            cruxes=self.cruxes,
+            evidence_gaps=self.evidence_gaps,
+            counterfactual_notes=self.counterfactual_notes,
+            verifier_candidates=self.verifier_candidates,
+            receipt_id=self.receipt_id,
+            provenance=self.provenance,
+            created_at=self.created_at,
+            checksum=digest,
+        )
+
+    def _canonical_payload(self) -> dict[str, Any]:
+        return {
+            "cruxset_id": self.cruxset_id,
+            "schema_version": self.schema_version,
+            "question": self.question,
+            "decision": self.decision,
+            "cruxes": [c.to_json() for c in self.cruxes],
+            "evidence_gaps": list(self.evidence_gaps),
+            "counterfactual_notes": list(self.counterfactual_notes),
+            "verifier_candidates": list(self.verifier_candidates),
+            "receipt_id": self.receipt_id,
+            "provenance": self.provenance,
+            "created_at": self.created_at,
+        }
+
+    def verify_checksum(self) -> bool:
+        """Recompute the checksum and compare to the stored value."""
+        recomputed = (
+            CruxSet(
+                cruxset_id=self.cruxset_id,
+                schema_version=self.schema_version,
+                question=self.question,
+                decision=self.decision,
+                cruxes=self.cruxes,
+                evidence_gaps=self.evidence_gaps,
+                counterfactual_notes=self.counterfactual_notes,
+                verifier_candidates=self.verifier_candidates,
+                receipt_id=self.receipt_id,
+                provenance=self.provenance,
+                created_at=self.created_at,
+                checksum="",
+            )
+            ._with_checksum()
+            .checksum
+        )
+        return recomputed == self.checksum
+
+    def to_json(self) -> dict[str, Any]:
+        payload = self._canonical_payload()
+        payload["checksum"] = self.checksum
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "CruxSet":
+        return cls(
+            cruxset_id=str(data["cruxset_id"]),
+            schema_version=str(data.get("schema_version") or CRUXSET_SCHEMA_VERSION),
+            question=str(data["question"]),
+            decision=(None if data.get("decision") is None else str(data["decision"])),
+            cruxes=tuple(Crux.from_json(c) for c in (data.get("cruxes") or [])),
+            evidence_gaps=tuple(str(g) for g in (data.get("evidence_gaps") or [])),
+            counterfactual_notes=tuple(str(n) for n in (data.get("counterfactual_notes") or [])),
+            verifier_candidates=tuple(str(v) for v in (data.get("verifier_candidates") or [])),
+            receipt_id=str(data.get("receipt_id") or ""),
+            provenance=dict(data.get("provenance") or {}),
+            created_at=str(data.get("created_at") or _utc_now_iso()),
+            checksum=str(data.get("checksum") or ""),
+        )
+
+
+def _build_cruxset_id(question: str, cruxes: tuple[Crux, ...]) -> str:
+    material = json.dumps(
+        {
+            "question": question,
+            "cruxes": [c.crux_id for c in cruxes],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"crxset_{digest}"
+
+
+def build_cruxset_from_analysis(
+    *,
+    question: str,
+    analysis_payload: dict[str, Any],
+    decision: str | None = None,
+    receipt_id: str = "",
+    provenance: dict[str, Any] | None = None,
+    max_cruxes: int = 5,
+) -> CruxSet:
+    """Convert a :class:`CruxAnalysisResult` payload into a CruxSet.
+
+    The input is the dict returned by ``CruxAnalysisResult.to_dict()``
+    (defined in :mod:`aragora.reasoning.crux_detector`). This function
+    is the seam between the existing analysis output and the new
+    contract: it does NOT call :class:`CruxDetector` itself, so it is
+    safe to use in tests with mocked analysis payloads.
+
+    Cruxes are ranked by ``crux_score`` (which the analyser already
+    composes from influence × disagreement × uncertainty × centrality
+    × resolution_impact). The first ``max_cruxes`` are taken; the
+    ``load_bearing_score`` is the analyser's ``crux_score``.
+    """
+    raw_cruxes = list(analysis_payload.get("cruxes") or [])
+    if not raw_cruxes:
+        raise ValueError("analysis_payload contains no cruxes; cannot build CruxSet")
+
+    cruxes: list[Crux] = []
+    for entry in raw_cruxes[:max_cruxes]:
+        if not isinstance(entry, dict):
+            continue
+        positions = (
+            CruxPosition(
+                side="for",
+                agents=(str(entry.get("author") or ""),),
+                rationale="proposing agent",
+            ),
+        )
+        contesting = entry.get("contesting_agents") or []
+        if contesting:
+            positions = positions + (
+                CruxPosition(
+                    side="against",
+                    agents=tuple(str(a) for a in contesting),
+                    rationale="contesting agents",
+                ),
+            )
+        cruxes.append(
+            Crux(
+                crux_id=str(entry.get("claim_id") or ""),
+                statement=str(entry.get("statement") or ""),
+                positions=positions,
+                load_bearing_score=float(entry.get("crux_score") or 0.0),
+                evidence_gaps=tuple(),
+                counterfactual=(
+                    f"Resolution impact {round(float(entry.get('resolution_impact') or 0.0), 4)}"
+                    if entry.get("resolution_impact") is not None
+                    else ""
+                ),
+                candidate_verifier="",
+            )
+        )
+
+    counterfactual_notes = (
+        f"avg_uncertainty={round(float(analysis_payload.get('average_uncertainty') or 0.0), 4)}",
+        f"convergence_barrier={round(float(analysis_payload.get('convergence_barrier') or 0.0), 4)}",
+    )
+
+    return CruxSet.build(
+        question=question,
+        cruxes=cruxes,
+        decision=decision,
+        evidence_gaps=(),
+        counterfactual_notes=counterfactual_notes,
+        verifier_candidates=tuple(
+            str(c) for c in (analysis_payload.get("recommended_focus") or [])
+        ),
+        receipt_id=receipt_id,
+        provenance=dict(provenance or {}),
+    )
+
+
+__all__ = [
+    "CRUXSET_SCHEMA_VERSION",
+    "Crux",
+    "CruxPosition",
+    "CruxSet",
+    "build_cruxset_from_analysis",
+]

--- a/aragora/reasoning/cruxset_emission.py
+++ b/aragora/reasoning/cruxset_emission.py
@@ -1,0 +1,135 @@
+"""Flag-gated CruxSet emission for the production debate path.
+
+This module is the seam between the existing :class:`CruxDetector`
+(which currently runs as a post-analysis byproduct in the debate
+phases) and the new :class:`CruxSet` contract. It is **dormant** unless
+``ARAGORA_CRUXSET_EMISSION_ENABLED`` is set, satisfying the AGT-*
+"planning truth, no live behavior change" rule from
+``docs/status/NEXT_STEPS_CANONICAL.md``.
+
+When enabled, callers in the debate path (e.g. winner_selector,
+analytics_phase) can call :func:`maybe_emit_cruxset` after the
+BeliefNetwork has been populated, and a CruxSet will be returned for
+downstream persistence via the receipt path. When disabled (the
+default), the function returns ``None`` and the debate path is
+unchanged.
+
+Activation gate: open this flag only after the substrate-first gate in
+``docs/status/NEXT_STEPS_CANONICAL.md`` permits the AGT-* upper-layer
+tranche, and DIC-15 (#6025) and DIC-16 (#6026) are landed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from aragora.reasoning.cruxset import CruxSet, build_cruxset_from_analysis
+
+if TYPE_CHECKING:
+    from aragora.reasoning.belief import BeliefNetwork
+
+logger = logging.getLogger(__name__)
+
+CRUXSET_EMISSION_ENV_VAR = "ARAGORA_CRUXSET_EMISSION_ENABLED"
+
+
+def cruxset_emission_enabled() -> bool:
+    """Return True when the AGT-01 CruxSet emission surface is enabled.
+
+    Reads :data:`CRUXSET_EMISSION_ENV_VAR` from the process environment.
+    Default is False; emission is dormant unless explicitly enabled.
+    """
+    raw = str(os.environ.get(CRUXSET_EMISSION_ENV_VAR) or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_cruxset_emission() -> None:
+    """Enable the AGT-01 CruxSet emission surface for the current process.
+
+    Sets ``ARAGORA_CRUXSET_EMISSION_ENABLED=1``. Mirror of
+    :func:`aragora.markets.enable_synthetic_markets`.
+    """
+    os.environ[CRUXSET_EMISSION_ENV_VAR] = "1"
+
+
+def maybe_emit_cruxset(
+    *,
+    question: str,
+    network: "BeliefNetwork | None" = None,
+    analysis_payload: dict[str, Any] | None = None,
+    decision: str | None = None,
+    receipt_id: str = "",
+    provenance: dict[str, Any] | None = None,
+    top_k: int = 5,
+    min_score: float = 0.1,
+) -> CruxSet | None:
+    """Build a CruxSet for the given debate context if emission is enabled.
+
+    Two input modes:
+
+    - Pass ``network`` (a populated :class:`BeliefNetwork`) and the
+      function will instantiate :class:`CruxDetector` and run
+      ``detect_cruxes(top_k=top_k, min_score=min_score)`` itself.
+    - Pass ``analysis_payload`` (the dict returned by
+      ``CruxAnalysisResult.to_dict()``) to skip the detector step. This
+      is the test-friendly path because it removes the BeliefNetwork
+      dependency.
+
+    Returns ``None`` when emission is disabled, when neither input is
+    provided, or when the analysis surfaces no cruxes. Errors during
+    detector invocation are logged at warning level and swallowed
+    rather than re-raised — the function is a soft enrichment layer
+    and must not cause debate failures.
+    """
+    if not cruxset_emission_enabled():
+        return None
+
+    payload = analysis_payload
+    if payload is None:
+        if network is None:
+            logger.warning(
+                "cruxset emission enabled but neither network nor analysis_payload "
+                "supplied for question=%r",
+                question[:80],
+            )
+            return None
+        try:
+            from aragora.reasoning.crux_detector import CruxDetector
+
+            detector = CruxDetector(network=network)
+            analysis = detector.detect_cruxes(top_k=top_k, min_score=min_score)
+            payload = analysis.to_dict()
+        except Exception as exc:  # noqa: BLE001 - soft enrichment must not crash debate
+            logger.warning("cruxset emission failed for question=%r: %s", question[:80], exc)
+            return None
+
+    if not payload or not payload.get("cruxes"):
+        logger.debug("cruxset emission produced no cruxes for question=%r", question[:80])
+        return None
+
+    try:
+        return build_cruxset_from_analysis(
+            question=question,
+            analysis_payload=payload,
+            decision=decision,
+            receipt_id=receipt_id,
+            provenance=provenance,
+            max_cruxes=top_k,
+        )
+    except (ValueError, KeyError) as exc:
+        logger.warning(
+            "cruxset emission could not build CruxSet for question=%r: %s",
+            question[:80],
+            exc,
+        )
+        return None
+
+
+__all__ = [
+    "CRUXSET_EMISSION_ENV_VAR",
+    "cruxset_emission_enabled",
+    "enable_cruxset_emission",
+    "maybe_emit_cruxset",
+]

--- a/tests/reasoning/test_cruxset.py
+++ b/tests/reasoning/test_cruxset.py
@@ -1,0 +1,279 @@
+"""Tests for the AGT-01 CruxSet contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.reasoning.cruxset import (
+    CRUXSET_SCHEMA_VERSION,
+    Crux,
+    CruxPosition,
+    CruxSet,
+    build_cruxset_from_analysis,
+)
+
+
+def _make_crux(
+    *,
+    crux_id: str = "claim_1",
+    statement: str = "X is true",
+    score: float = 0.7,
+) -> Crux:
+    return Crux(
+        crux_id=crux_id,
+        statement=statement,
+        positions=(
+            CruxPosition(side="for", agents=("alice",)),
+            CruxPosition(side="against", agents=("bob",)),
+        ),
+        load_bearing_score=score,
+        evidence_gaps=("missing-data",),
+        counterfactual="if X is false, decision flips",
+        candidate_verifier="docs/spec.md",
+    )
+
+
+class TestCruxValidation:
+    def test_crux_requires_score_in_unit_interval(self) -> None:
+        with pytest.raises(ValueError):
+            Crux(
+                crux_id="c1",
+                statement="x",
+                positions=(CruxPosition(side="for"),),
+                load_bearing_score=1.1,
+            )
+        with pytest.raises(ValueError):
+            Crux(
+                crux_id="c1",
+                statement="x",
+                positions=(CruxPosition(side="for"),),
+                load_bearing_score=-0.1,
+            )
+
+    def test_crux_requires_non_empty_id(self) -> None:
+        with pytest.raises(ValueError):
+            Crux(
+                crux_id="",
+                statement="x",
+                positions=(),
+                load_bearing_score=0.5,
+            )
+
+    def test_crux_requires_non_empty_statement(self) -> None:
+        with pytest.raises(ValueError):
+            Crux(
+                crux_id="c1",
+                statement=" ",
+                positions=(),
+                load_bearing_score=0.5,
+            )
+
+
+class TestCruxSetBuild:
+    def test_build_rejects_empty_question(self) -> None:
+        with pytest.raises(ValueError):
+            CruxSet.build(question="   ", cruxes=[_make_crux()])
+
+    def test_build_requires_at_least_one_crux(self) -> None:
+        with pytest.raises(ValueError):
+            CruxSet.build(question="should we ship?", cruxes=[])
+
+    def test_build_orders_cruxes_by_load_bearing_score_desc(self) -> None:
+        cruxes = [
+            _make_crux(crux_id="c1", score=0.3),
+            _make_crux(crux_id="c2", score=0.9),
+            _make_crux(crux_id="c3", score=0.7),
+        ]
+        cs = CruxSet.build(question="q", cruxes=cruxes)
+        assert [c.crux_id for c in cs.cruxes] == ["c2", "c3", "c1"]
+
+    def test_build_breaks_score_ties_by_crux_id_asc(self) -> None:
+        cruxes = [
+            _make_crux(crux_id="c2", score=0.5),
+            _make_crux(crux_id="c1", score=0.5),
+        ]
+        cs = CruxSet.build(question="q", cruxes=cruxes)
+        assert [c.crux_id for c in cs.cruxes] == ["c1", "c2"]
+
+    def test_cruxset_id_is_content_addressed(self) -> None:
+        cruxes = [_make_crux(crux_id="c1", score=0.5)]
+        a = CruxSet.build(question="should we ship?", cruxes=cruxes)
+        b = CruxSet.build(
+            question="should we ship?",
+            cruxes=[_make_crux(crux_id="c1", score=0.5)],
+        )
+        assert a.cruxset_id == b.cruxset_id
+
+    def test_distinct_questions_yield_distinct_ids(self) -> None:
+        cruxes = [_make_crux(crux_id="c1", score=0.5)]
+        a = CruxSet.build(question="ship now?", cruxes=cruxes)
+        b = CruxSet.build(
+            question="ship later?",
+            cruxes=[_make_crux(crux_id="c1", score=0.5)],
+        )
+        assert a.cruxset_id != b.cruxset_id
+
+    def test_schema_version_recorded(self) -> None:
+        cs = CruxSet.build(question="q", cruxes=[_make_crux()])
+        assert cs.schema_version == CRUXSET_SCHEMA_VERSION
+
+
+class TestCruxSetChecksum:
+    def test_checksum_is_stable_across_builds(self) -> None:
+        cruxes = [_make_crux(crux_id="c1", score=0.5)]
+        a = CruxSet.build(
+            question="q",
+            cruxes=cruxes,
+            created_at="2026-04-17T00:00:00Z",
+            provenance={"debate_id": "d1"},
+        )
+        b = CruxSet.build(
+            question="q",
+            cruxes=[_make_crux(crux_id="c1", score=0.5)],
+            created_at="2026-04-17T00:00:00Z",
+            provenance={"debate_id": "d1"},
+        )
+        assert a.checksum == b.checksum
+
+    def test_checksum_changes_with_decision(self) -> None:
+        cruxes = [_make_crux(crux_id="c1", score=0.5)]
+        a = CruxSet.build(
+            question="q",
+            cruxes=cruxes,
+            decision="ship",
+            created_at="2026-04-17T00:00:00Z",
+        )
+        b = CruxSet.build(
+            question="q",
+            cruxes=[_make_crux(crux_id="c1", score=0.5)],
+            decision="hold",
+            created_at="2026-04-17T00:00:00Z",
+        )
+        assert a.checksum != b.checksum
+
+    def test_verify_checksum_succeeds_on_valid_set(self) -> None:
+        cs = CruxSet.build(question="q", cruxes=[_make_crux()])
+        assert cs.verify_checksum() is True
+
+    def test_verify_checksum_fails_when_question_mutated(self) -> None:
+        cs = CruxSet.build(question="q", cruxes=[_make_crux()])
+        tampered = CruxSet(
+            cruxset_id=cs.cruxset_id,
+            schema_version=cs.schema_version,
+            question="DIFFERENT",
+            decision=cs.decision,
+            cruxes=cs.cruxes,
+            evidence_gaps=cs.evidence_gaps,
+            counterfactual_notes=cs.counterfactual_notes,
+            verifier_candidates=cs.verifier_candidates,
+            receipt_id=cs.receipt_id,
+            provenance=cs.provenance,
+            created_at=cs.created_at,
+            checksum=cs.checksum,
+        )
+        assert tampered.verify_checksum() is False
+
+
+class TestCruxSetJson:
+    def test_to_json_roundtrip_preserves_checksum(self) -> None:
+        cs = CruxSet.build(
+            question="should we ship?",
+            cruxes=[_make_crux(crux_id="c1"), _make_crux(crux_id="c2", score=0.4)],
+            decision="ship",
+            evidence_gaps=("benchmark gap",),
+            counterfactual_notes=("note A",),
+            verifier_candidates=("docs/spec.md",),
+            receipt_id="rcpt_x",
+            provenance={"debate_id": "d1"},
+        )
+        roundtrip = CruxSet.from_json(cs.to_json())
+        assert roundtrip == cs
+        assert roundtrip.verify_checksum()
+
+    def test_position_to_from_json(self) -> None:
+        position = CruxPosition(side="for", agents=("alice", "carol"), rationale="x")
+        roundtrip = CruxPosition.from_json(position.to_json())
+        assert roundtrip == position
+
+
+class TestBuildFromAnalysis:
+    def test_builds_from_crux_analysis_payload(self) -> None:
+        payload = {
+            "cruxes": [
+                {
+                    "claim_id": "claim_1",
+                    "statement": "X is load-bearing",
+                    "author": "alice",
+                    "crux_score": 0.85,
+                    "influence_score": 0.7,
+                    "disagreement_score": 0.9,
+                    "uncertainty_score": 0.6,
+                    "centrality_score": 0.5,
+                    "affected_claims": ["claim_2"],
+                    "contesting_agents": ["bob"],
+                    "resolution_impact": 0.4,
+                },
+                {
+                    "claim_id": "claim_2",
+                    "statement": "Y is contingent on X",
+                    "author": "carol",
+                    "crux_score": 0.55,
+                    "influence_score": 0.4,
+                    "disagreement_score": 0.5,
+                    "uncertainty_score": 0.5,
+                    "centrality_score": 0.3,
+                    "affected_claims": [],
+                    "contesting_agents": [],
+                    "resolution_impact": 0.2,
+                },
+            ],
+            "total_claims": 5,
+            "total_disagreements": 2,
+            "average_uncertainty": 0.65,
+            "convergence_barrier": 0.42,
+            "recommended_focus": ["claim_1", "claim_2"],
+        }
+        cs = build_cruxset_from_analysis(
+            question="should X be assumed?",
+            analysis_payload=payload,
+            decision="hold",
+            receipt_id="rcpt_y",
+            provenance={"debate_id": "d2"},
+        )
+        assert len(cs.cruxes) == 2
+        # Higher crux_score sorts first
+        assert cs.cruxes[0].crux_id == "claim_1"
+        assert cs.cruxes[0].load_bearing_score == pytest.approx(0.85)
+        # Contesting agents become an "against" position
+        sides = {p.side for p in cs.cruxes[0].positions}
+        assert sides == {"for", "against"}
+        # recommended_focus becomes verifier_candidates
+        assert "claim_1" in cs.verifier_candidates
+        # Aggregate counterfactual notes carry uncertainty + barrier
+        joined = "|".join(cs.counterfactual_notes)
+        assert "avg_uncertainty=0.65" in joined
+        assert "convergence_barrier=0.42" in joined
+
+    def test_empty_payload_raises(self) -> None:
+        with pytest.raises(ValueError):
+            build_cruxset_from_analysis(question="q", analysis_payload={"cruxes": []})
+
+    def test_max_cruxes_caps_output(self) -> None:
+        payload = {
+            "cruxes": [
+                {
+                    "claim_id": f"claim_{i}",
+                    "statement": f"S{i}",
+                    "author": "alice",
+                    "crux_score": 1.0 - 0.01 * i,
+                    "contesting_agents": [],
+                    "resolution_impact": 0.1,
+                }
+                for i in range(10)
+            ],
+            "average_uncertainty": 0.5,
+            "convergence_barrier": 0.3,
+            "recommended_focus": [],
+        }
+        cs = build_cruxset_from_analysis(question="q", analysis_payload=payload, max_cruxes=3)
+        assert len(cs.cruxes) == 3

--- a/tests/reasoning/test_cruxset_emission.py
+++ b/tests/reasoning/test_cruxset_emission.py
@@ -1,0 +1,169 @@
+"""Tests for the AGT-01 flag-gated CruxSet emission seam."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.reasoning import cruxset_emission as mod
+from aragora.reasoning.cruxset import CruxSet
+
+
+@pytest.fixture(autouse=True)
+def _reset_flag(monkeypatch):
+    monkeypatch.delenv(mod.CRUXSET_EMISSION_ENV_VAR, raising=False)
+    yield
+    monkeypatch.delenv(mod.CRUXSET_EMISSION_ENV_VAR, raising=False)
+
+
+def _payload_with_two_cruxes() -> dict:
+    return {
+        "cruxes": [
+            {
+                "claim_id": "c1",
+                "statement": "X holds",
+                "author": "alice",
+                "crux_score": 0.8,
+                "contesting_agents": ["bob"],
+                "resolution_impact": 0.5,
+            },
+            {
+                "claim_id": "c2",
+                "statement": "Y depends on X",
+                "author": "carol",
+                "crux_score": 0.6,
+                "contesting_agents": [],
+                "resolution_impact": 0.3,
+            },
+        ],
+        "average_uncertainty": 0.4,
+        "convergence_barrier": 0.2,
+        "recommended_focus": ["c1", "c2"],
+    }
+
+
+class TestFeatureFlag:
+    def test_disabled_by_default(self) -> None:
+        assert mod.cruxset_emission_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "ON"])
+    def test_truthy_values_enable(self, monkeypatch, value: str) -> None:
+        monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, value)
+        assert mod.cruxset_emission_enabled() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off"])
+    def test_falsy_values_keep_disabled(self, monkeypatch, value: str) -> None:
+        monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, value)
+        assert mod.cruxset_emission_enabled() is False
+
+    def test_enable_helper_flips_flag(self) -> None:
+        assert mod.cruxset_emission_enabled() is False
+        mod.enable_cruxset_emission()
+        assert mod.cruxset_emission_enabled() is True
+
+
+class TestMaybeEmitCruxset:
+    def test_returns_none_when_disabled(self) -> None:
+        # Even with a perfect payload, emission stays None when the flag is off
+        result = mod.maybe_emit_cruxset(
+            question="should we ship?",
+            analysis_payload=_payload_with_two_cruxes(),
+        )
+        assert result is None
+
+    def test_returns_cruxset_when_enabled_and_payload_present(self, monkeypatch) -> None:
+        monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+        result = mod.maybe_emit_cruxset(
+            question="should we ship?",
+            analysis_payload=_payload_with_two_cruxes(),
+            decision="ship",
+            receipt_id="rcpt_a",
+            provenance={"debate_id": "d1"},
+        )
+        assert isinstance(result, CruxSet)
+        assert result.question == "should we ship?"
+        assert result.decision == "ship"
+        assert result.receipt_id == "rcpt_a"
+        # Sorted by load_bearing_score desc
+        assert [c.crux_id for c in result.cruxes] == ["c1", "c2"]
+        assert result.verify_checksum() is True
+
+    def test_returns_none_when_payload_has_no_cruxes(self, monkeypatch) -> None:
+        monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+        result = mod.maybe_emit_cruxset(
+            question="q",
+            analysis_payload={"cruxes": []},
+        )
+        assert result is None
+
+    def test_returns_none_when_neither_input_supplied(self, monkeypatch) -> None:
+        monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+        result = mod.maybe_emit_cruxset(question="q")
+        assert result is None
+
+    def test_swallows_detector_errors_and_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+
+        class _ExplodingNetwork:
+            nodes: dict = {}
+
+        # Patch CruxDetector at import-time to raise
+        from aragora.reasoning import crux_detector as cd
+
+        class _BoomDetector:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def detect_cruxes(self, **kwargs):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(cd, "CruxDetector", _BoomDetector)
+        result = mod.maybe_emit_cruxset(question="q", network=_ExplodingNetwork())
+        assert result is None
+
+    def test_uses_network_when_no_payload_provided(self, monkeypatch) -> None:
+        monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+
+        class _StubResult:
+            def to_dict(self) -> dict:
+                return _payload_with_two_cruxes()
+
+        class _StubDetector:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def detect_cruxes(self, **kwargs):
+                return _StubResult()
+
+        from aragora.reasoning import crux_detector as cd
+
+        monkeypatch.setattr(cd, "CruxDetector", _StubDetector)
+
+        result = mod.maybe_emit_cruxset(question="q", network=object())
+        assert isinstance(result, CruxSet)
+        assert len(result.cruxes) == 2
+
+    def test_max_cruxes_passes_through_to_builder(self, monkeypatch) -> None:
+        monkeypatch.setenv(mod.CRUXSET_EMISSION_ENV_VAR, "1")
+        big_payload = {
+            "cruxes": [
+                {
+                    "claim_id": f"c{i}",
+                    "statement": f"S{i}",
+                    "author": "alice",
+                    "crux_score": 1.0 - 0.05 * i,
+                    "contesting_agents": [],
+                    "resolution_impact": 0.1,
+                }
+                for i in range(8)
+            ],
+            "average_uncertainty": 0.5,
+            "convergence_barrier": 0.3,
+            "recommended_focus": [],
+        }
+        result = mod.maybe_emit_cruxset(
+            question="q",
+            analysis_payload=big_payload,
+            top_k=3,
+        )
+        assert isinstance(result, CruxSet)
+        assert len(result.cruxes) == 3


### PR DESCRIPTION
## Summary

- Adds the AGT-01 / DIC-15 **CruxSet contract**: signed, content-addressed bundle of load-bearing disagreements for a debate question.
- Adds the **flag-gated emission seam** (`maybe_emit_cruxset`) that converts the existing `CruxDetector` output into a `CruxSet` when `ARAGORA_CRUXSET_EMISSION_ENABLED=1`.
- 972 lines added across 4 files (2 module + 2 test); 37 new tests pass; full reasoning suite (409 tests) clean.
- **Zero-change to production behavior**: importing has no live effect; CruxDetector itself is untouched; no debate phase auto-emits yet.

## What this gives the AGT track

The AGT-01 epic in `docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md` calls for activating the latent `CruxDetector` as a first-class debate output. The full Approach A wiring (a `crux_finder` consensus mode + CLI verb) is laid out in `docs/plans/2026-04-16-crux-mode-design.md` as DIC-15 implementation. This PR ships the **contract layer** that DIC-15 needs and that AGT-05 (skin-in-the-game reputation, issue #6066) will consume — the larger consensus-mode wiring becomes a smaller follow-up once this lands.

CruxSet is the structure AGT-05 ingests as a `StakeableClaim` of domain `crux_resolution`, and that AGT-04 / AGT-03 use as the source of agent positions on contested questions.

## Module structure

| File | Lines | Purpose |
|---|---|---|
| `aragora/reasoning/cruxset.py` | 313 | CruxSet, Crux, CruxPosition dataclasses + SHA-256 checksum + content-addressed id + build_cruxset_from_analysis() converter |
| `aragora/reasoning/cruxset_emission.py` | 134 | `maybe_emit_cruxset()` — flag-gated, soft-enrichment seam (errors swallowed, never crashes debate) |
| `tests/reasoning/test_cruxset.py` | 281 | 22 tests for schema validation, deterministic ordering, checksum, JSON roundtrip, build-from-analysis |
| `tests/reasoning/test_cruxset_emission.py` | 169 | 15 tests for feature flag, payload vs network input, error swallowing, top_k pass-through |

## Why default-off

Per `docs/status/NEXT_STEPS_CANONICAL.md`, AGT-* is planning-truth only — code may land but must not affect production until the upper-layer gate opens. The seam is wired but dormant; no debate phase auto-emits yet (that wiring is the deliberate next-step gated on substrate stability).

## Test plan

- [x] 37/37 new tests pass under `pytest tests/reasoning/test_cruxset*.py -q`
- [x] Full reasoning suite (409 tests) passes: zero regressions
- [x] CruxSet checksum is content-addressed and tamper-detecting (verify_checksum tests)
- [x] Deterministic ordering of cruxes by load_bearing_score desc, crux_id asc tie-break
- [x] JSON roundtrip preserves checksum
- [x] Emission swallows CruxDetector errors and returns None instead of crashing
- [x] CruxDetector module is untouched

## What this PR does NOT do

- Does NOT add the `crux_finder` consensus mode — follow-up
- Does NOT add the `aragora crux` CLI verb — follow-up
- Does NOT auto-emit CruxSets from any debate phase yet — wiring into winner_selector / analytics_phase is the next step
- Does NOT touch `CruxDetector` itself (preserving zero-blast-radius)
- Does NOT persist via the receipt path yet — that's DIC-16 (#6026)
- Does NOT enable production live activation — flag default-off

## Refs

- AGT-01 issue: #6062
- AGT epic: #6068
- DIC-15 (CruxSet contract): #6025
- DIC-16 (receipt provenance): #6026
- Crux mode design: `docs/plans/2026-04-16-crux-mode-design.md`
- Vision PR: #6061
- AGT-04 sibling PR: #6082
- Substrate hardening PR: #6080

🤖 Generated with [Claude Code](https://claude.com/claude-code)