### PR TITLE
feat(metrics): AGT-06 VIAH — verifiable improvements per agent-hour

### DIFF
--- a/aragora/metrics/__init__.py
+++ b/aragora/metrics/__init__.py
@@ -1,0 +1,12 @@
+"""Aragora metrics package.
+
+Currently exposes the AGT-06 VIAH (verifiable improvements per agent-hour)
+helper. See ``docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md`` §4 and
+issue #6067 for the rationale.
+"""
+
+from __future__ import annotations
+
+from aragora.metrics.viah import ViahReport, compute_viah, viah_score
+
+__all__ = ["ViahReport", "compute_viah", "viah_score"]

--- a/aragora/metrics/viah.py
+++ b/aragora/metrics/viah.py
@@ -1,0 +1,325 @@
+"""VIAH — Verifiable Improvements per Agent-Hour.
+
+Productivity metric that the booster-rocket thesis is required to lift
+once empty-queue BC-12 idle soaks have proven substrate stability. See
+``docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md`` §4 and issue #6067.
+
+The metric:
+
+    VIAH = (
+        merged_autonomous_prs * 1.0
+        + cruxes_correctly_detected_pre_resolution * 0.5
+        + predictions_resolved_above_brier_threshold * 0.5
+        - rescues_required * 0.5
+        - failed_claims_promoted_without_repair * 1.0
+    ) / agent_hours
+
+Inputs are derived from the existing :class:`aragora.swarm.shift_ledger.
+ShiftLedger`. Signals that depend on AGT-05 wiring (crux correctness,
+prediction resolutions, failed claims) are accepted as optional sidecar
+counts so this module can land before AGT-05 settlement is live; counts
+default to zero when not supplied.
+
+The metric is **diagnostic, not gating**. It supplements (not replaces)
+the TW-02 no-rescue success rate. The substrate is paying for itself
+when VIAH trends up week-over-week without operator babysitting.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from aragora.swarm.shift_ledger import LedgerEntry, ShiftLedger
+
+logger = logging.getLogger(__name__)
+
+# Default coefficients matching the AGT-06 plan
+DEFAULT_PR_WEIGHT = 1.0
+DEFAULT_CRUX_WEIGHT = 0.5
+DEFAULT_PREDICTION_WEIGHT = 0.5
+DEFAULT_RESCUE_WEIGHT = 0.5
+DEFAULT_FAILED_CLAIM_WEIGHT = 1.0
+DEFAULT_BRIER_THRESHOLD = 0.20
+
+
+@dataclass(frozen=True)
+class ViahCoefficients:
+    """Per-signal weights for the VIAH score."""
+
+    merged_pr_weight: float = DEFAULT_PR_WEIGHT
+    crux_weight: float = DEFAULT_CRUX_WEIGHT
+    prediction_weight: float = DEFAULT_PREDICTION_WEIGHT
+    rescue_weight: float = DEFAULT_RESCUE_WEIGHT
+    failed_claim_weight: float = DEFAULT_FAILED_CLAIM_WEIGHT
+
+
+@dataclass(frozen=True)
+class ViahReport:
+    """One VIAH measurement over a time window."""
+
+    window_start: str
+    window_end: str
+    window_hours: float
+    agent_hours: float
+
+    # Positive signals
+    merged_autonomous_prs: int
+    cruxes_correctly_detected: int
+    predictions_above_brier_threshold: int
+
+    # Negative signals
+    rescues_required: int
+    failed_claims_promoted_without_repair: int
+
+    # Derived
+    viah: float | None
+    coefficients: ViahCoefficients
+
+    # Inputs detail (for audit/debug)
+    inputs: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "window_start": self.window_start,
+            "window_end": self.window_end,
+            "window_hours": self.window_hours,
+            "agent_hours": self.agent_hours,
+            "merged_autonomous_prs": self.merged_autonomous_prs,
+            "cruxes_correctly_detected": self.cruxes_correctly_detected,
+            "predictions_above_brier_threshold": self.predictions_above_brier_threshold,
+            "rescues_required": self.rescues_required,
+            "failed_claims_promoted_without_repair": (self.failed_claims_promoted_without_repair),
+            "viah": self.viah,
+            "coefficients": {
+                "merged_pr_weight": self.coefficients.merged_pr_weight,
+                "crux_weight": self.coefficients.crux_weight,
+                "prediction_weight": self.coefficients.prediction_weight,
+                "rescue_weight": self.coefficients.rescue_weight,
+                "failed_claim_weight": self.coefficients.failed_claim_weight,
+            },
+            "inputs": dict(self.inputs),
+        }
+
+
+def viah_score(
+    *,
+    merged_autonomous_prs: int,
+    cruxes_correctly_detected: int,
+    predictions_above_brier_threshold: int,
+    rescues_required: int,
+    failed_claims_promoted_without_repair: int,
+    agent_hours: float,
+    coefficients: ViahCoefficients | None = None,
+) -> float | None:
+    """Compute the raw VIAH score from the signal counts.
+
+    Returns ``None`` when ``agent_hours`` is non-positive — VIAH is
+    undefined for an empty observation window.
+    """
+    if agent_hours <= 0 or not math.isfinite(agent_hours):
+        return None
+    coef = coefficients or ViahCoefficients()
+    numerator = (
+        merged_autonomous_prs * coef.merged_pr_weight
+        + cruxes_correctly_detected * coef.crux_weight
+        + predictions_above_brier_threshold * coef.prediction_weight
+        - rescues_required * coef.rescue_weight
+        - failed_claims_promoted_without_repair * coef.failed_claim_weight
+    )
+    return numerator / agent_hours
+
+
+def compute_viah(
+    *,
+    ledger: ShiftLedger,
+    window_hours: float = 168.0,
+    now: datetime | None = None,
+    cruxes_correctly_detected: int = 0,
+    predictions_above_brier_threshold: int = 0,
+    failed_claims_promoted_without_repair: int = 0,
+    coefficients: ViahCoefficients | None = None,
+) -> ViahReport:
+    """Compute a VIAH report from a :class:`ShiftLedger` over ``window_hours``.
+
+    Signals derived from the ledger:
+
+    - ``merged_autonomous_prs``: count of ``pr_merged`` entries in the window
+    - ``rescues_required``: cumulative ``rescue_count`` payload from
+      ``cycle_tick`` entries (older shift code may set the field to 0)
+    - ``agent_hours``: sum of completed ``shift_start`` → ``shift_stop``
+      durations falling within the window, plus any in-progress shift's
+      partial duration up to ``now``
+
+    Sidecar signals (``cruxes_correctly_detected``,
+    ``predictions_above_brier_threshold``, ``failed_claims_promoted_without_repair``)
+    default to zero so this module can land before AGT-05 settlement
+    wires them; once AGT-05 is live, the AGT-05 settlement path will
+    supply these counts from resolved CruxSets and prediction-market
+    resolutions.
+
+    Returns a :class:`ViahReport`. ``ViahReport.viah`` is ``None`` when
+    the window contains no agent-hours.
+    """
+    coef = coefficients or ViahCoefficients()
+    reference = (now or datetime.now(tz=UTC)).astimezone(UTC)
+    window_start = reference - timedelta(hours=window_hours)
+
+    entries_in_window = _entries_within(
+        ledger.read_all(),
+        start=window_start,
+        end=reference,
+    )
+
+    merged = sum(1 for e in entries_in_window if e.entry_type == "pr_merged")
+    rescues = _sum_rescue_counts(entries_in_window)
+    agent_hours = _agent_hours_from_shifts(
+        ledger.read_all(),
+        start=window_start,
+        end=reference,
+    )
+
+    score = viah_score(
+        merged_autonomous_prs=merged,
+        cruxes_correctly_detected=cruxes_correctly_detected,
+        predictions_above_brier_threshold=predictions_above_brier_threshold,
+        rescues_required=rescues,
+        failed_claims_promoted_without_repair=failed_claims_promoted_without_repair,
+        agent_hours=agent_hours,
+        coefficients=coef,
+    )
+
+    return ViahReport(
+        window_start=_iso(window_start),
+        window_end=_iso(reference),
+        window_hours=window_hours,
+        agent_hours=agent_hours,
+        merged_autonomous_prs=merged,
+        cruxes_correctly_detected=cruxes_correctly_detected,
+        predictions_above_brier_threshold=predictions_above_brier_threshold,
+        rescues_required=rescues,
+        failed_claims_promoted_without_repair=failed_claims_promoted_without_repair,
+        viah=score,
+        coefficients=coef,
+        inputs={
+            "ledger_path": str(ledger.path),
+            "entries_in_window": len(entries_in_window),
+        },
+    )
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    except (ValueError, AttributeError):
+        return None
+
+
+def _entries_within(
+    entries: list[LedgerEntry],
+    *,
+    start: datetime,
+    end: datetime,
+) -> list[LedgerEntry]:
+    out: list[LedgerEntry] = []
+    for entry in entries:
+        ts = _parse_iso(entry.timestamp)
+        if ts is None:
+            continue
+        if start <= ts <= end:
+            out.append(entry)
+    return out
+
+
+def _sum_rescue_counts(entries: list[LedgerEntry]) -> int:
+    """Sum rescue_count payloads from cycle_tick entries.
+
+    Older shifts may not have written rescue_count; missing values
+    are treated as zero rather than discarded. This keeps the metric
+    defined across mixed-version ledgers.
+    """
+    total = 0
+    for entry in entries:
+        if entry.entry_type != "cycle_tick":
+            continue
+        raw = entry.payload.get("rescue_count")
+        try:
+            total += int(raw)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _agent_hours_from_shifts(
+    entries: list[LedgerEntry],
+    *,
+    start: datetime,
+    end: datetime,
+) -> float:
+    """Sum durations of shifts that fall (even partially) inside the window.
+
+    A shift's contribution is the intersection of its [start, stop]
+    interval with the [window_start, window_end] interval. Shifts that
+    are still in-progress (no shift_stop after their shift_start) are
+    treated as ending at ``end``.
+    """
+    starts: dict[str, datetime] = {}
+    pairs: list[tuple[datetime, datetime]] = []
+
+    for entry in entries:
+        ts = _parse_iso(entry.timestamp)
+        if ts is None:
+            continue
+        shift_id = str(entry.payload.get("shift_id") or "")
+        if entry.entry_type == "shift_start":
+            if shift_id:
+                starts[shift_id] = ts
+            else:
+                # Anonymous shifts: we still need to pair them; use a
+                # fallback identifier per timestamp
+                starts[f"_anon_{ts.isoformat()}"] = ts
+        elif entry.entry_type == "shift_stop":
+            key = shift_id if shift_id and shift_id in starts else None
+            if key is None:
+                # Pair with the earliest open shift if no id matches
+                if not starts:
+                    continue
+                key = next(iter(starts))
+            shift_start = starts.pop(key)
+            pairs.append((shift_start, ts))
+
+    # Treat any unmatched shift_start as still-running
+    for shift_start in starts.values():
+        pairs.append((shift_start, end))
+
+    total_hours = 0.0
+    for shift_start, shift_end in pairs:
+        if shift_end < shift_start:
+            continue
+        intersect_start = max(shift_start, start)
+        intersect_end = min(shift_end, end)
+        if intersect_end <= intersect_start:
+            continue
+        total_hours += (intersect_end - intersect_start).total_seconds() / 3600.0
+    return total_hours
+
+
+__all__ = [
+    "DEFAULT_BRIER_THRESHOLD",
+    "DEFAULT_CRUX_WEIGHT",
+    "DEFAULT_FAILED_CLAIM_WEIGHT",
+    "DEFAULT_PREDICTION_WEIGHT",
+    "DEFAULT_PR_WEIGHT",
+    "DEFAULT_RESCUE_WEIGHT",
+    "ViahCoefficients",
+    "ViahReport",
+    "compute_viah",
+    "viah_score",
+]

--- a/tests/metrics/test_viah.py
+++ b/tests/metrics/test_viah.py
@@ -1,0 +1,334 @@
+"""Tests for aragora.metrics.viah — VIAH score from ShiftLedger entries."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.metrics.viah import (
+    ViahCoefficients,
+    ViahReport,
+    compute_viah,
+    viah_score,
+)
+from aragora.swarm.shift_ledger import ShiftLedger
+
+
+def _ts(at: datetime) -> str:
+    return at.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _seed_ledger(tmp_path: Path, entries: list[dict]) -> ShiftLedger:
+    """Write a synthetic ledger to ``tmp_path`` and return a ShiftLedger over it."""
+    path = tmp_path / "shift_ledger.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, sort_keys=True) + "\n")
+    return ShiftLedger(path=path)
+
+
+class TestViahScore:
+    def test_returns_none_when_agent_hours_is_zero(self) -> None:
+        assert (
+            viah_score(
+                merged_autonomous_prs=5,
+                cruxes_correctly_detected=0,
+                predictions_above_brier_threshold=0,
+                rescues_required=0,
+                failed_claims_promoted_without_repair=0,
+                agent_hours=0,
+            )
+            is None
+        )
+
+    def test_returns_none_when_agent_hours_is_nan(self) -> None:
+        assert (
+            viah_score(
+                merged_autonomous_prs=5,
+                cruxes_correctly_detected=0,
+                predictions_above_brier_threshold=0,
+                rescues_required=0,
+                failed_claims_promoted_without_repair=0,
+                agent_hours=float("nan"),
+            )
+            is None
+        )
+
+    def test_default_coefficients_match_plan(self) -> None:
+        # 4 PRs, 2 cruxes, 2 predictions, 1 rescue, 0 failed claims, 8 agent-hours
+        # numerator = 4*1.0 + 2*0.5 + 2*0.5 - 1*0.5 - 0*1.0 = 5.5
+        # viah = 5.5 / 8 = 0.6875
+        score = viah_score(
+            merged_autonomous_prs=4,
+            cruxes_correctly_detected=2,
+            predictions_above_brier_threshold=2,
+            rescues_required=1,
+            failed_claims_promoted_without_repair=0,
+            agent_hours=8.0,
+        )
+        assert score == pytest.approx(0.6875)
+
+    def test_score_can_go_negative_when_failures_dominate(self) -> None:
+        # 1 PR, 0 cruxes/preds, 0 rescues, 5 failed claims, 4 agent-hours
+        # numerator = 1 + 0 + 0 - 0 - 5 = -4
+        # viah = -4 / 4 = -1.0
+        score = viah_score(
+            merged_autonomous_prs=1,
+            cruxes_correctly_detected=0,
+            predictions_above_brier_threshold=0,
+            rescues_required=0,
+            failed_claims_promoted_without_repair=5,
+            agent_hours=4.0,
+        )
+        assert score == pytest.approx(-1.0)
+
+    def test_custom_coefficients_apply(self) -> None:
+        score = viah_score(
+            merged_autonomous_prs=2,
+            cruxes_correctly_detected=0,
+            predictions_above_brier_threshold=0,
+            rescues_required=0,
+            failed_claims_promoted_without_repair=0,
+            agent_hours=2.0,
+            coefficients=ViahCoefficients(merged_pr_weight=2.0),
+        )
+        assert score == pytest.approx(2.0)
+
+
+class TestComputeViahFromLedger:
+    def test_empty_ledger_returns_zero_signals_and_none_viah(self, tmp_path: Path) -> None:
+        ledger = _seed_ledger(tmp_path, [])
+        report = compute_viah(
+            ledger=ledger,
+            window_hours=168.0,
+            now=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+        assert report.merged_autonomous_prs == 0
+        assert report.rescues_required == 0
+        assert report.agent_hours == 0.0
+        assert report.viah is None
+
+    def test_counts_pr_merged_within_window(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+        in_window = now - timedelta(hours=24)
+        out_of_window = now - timedelta(hours=200)
+        ledger = _seed_ledger(
+            tmp_path,
+            [
+                {
+                    "entry_type": "pr_merged",
+                    "timestamp": _ts(in_window),
+                    "payload": {"pr_number": 1, "title": "fix: x"},
+                },
+                {
+                    "entry_type": "pr_merged",
+                    "timestamp": _ts(in_window + timedelta(minutes=30)),
+                    "payload": {"pr_number": 2, "title": "fix: y"},
+                },
+                {
+                    "entry_type": "pr_merged",
+                    "timestamp": _ts(out_of_window),
+                    "payload": {"pr_number": 3, "title": "older"},
+                },
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(in_window - timedelta(hours=2)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "shift_stop",
+                    "timestamp": _ts(in_window + timedelta(hours=6)),
+                    "payload": {"shift_id": "s1"},
+                },
+            ],
+        )
+        report = compute_viah(ledger=ledger, window_hours=168.0, now=now)
+        assert report.merged_autonomous_prs == 2  # 3rd PR is out of window
+
+    def test_sums_rescue_counts_from_cycle_ticks(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+        ledger = _seed_ledger(
+            tmp_path,
+            [
+                {
+                    "entry_type": "cycle_tick",
+                    "timestamp": _ts(now - timedelta(hours=1)),
+                    "payload": {"rescue_count": 2},
+                },
+                {
+                    "entry_type": "cycle_tick",
+                    "timestamp": _ts(now - timedelta(hours=2)),
+                    "payload": {"rescue_count": 3},
+                },
+                {
+                    "entry_type": "cycle_tick",
+                    "timestamp": _ts(now - timedelta(hours=3)),
+                    "payload": {},  # missing rescue_count → treated as 0
+                },
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(now - timedelta(hours=4)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "shift_stop",
+                    "timestamp": _ts(now),
+                    "payload": {"shift_id": "s1"},
+                },
+            ],
+        )
+        report = compute_viah(ledger=ledger, window_hours=168.0, now=now)
+        assert report.rescues_required == 5
+
+    def test_agent_hours_sum_paired_shifts(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+        ledger = _seed_ledger(
+            tmp_path,
+            [
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(now - timedelta(hours=10)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "shift_stop",
+                    "timestamp": _ts(now - timedelta(hours=6)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(now - timedelta(hours=4)),
+                    "payload": {"shift_id": "s2"},
+                },
+                {
+                    "entry_type": "shift_stop",
+                    "timestamp": _ts(now - timedelta(hours=1)),
+                    "payload": {"shift_id": "s2"},
+                },
+            ],
+        )
+        report = compute_viah(ledger=ledger, window_hours=168.0, now=now)
+        assert report.agent_hours == pytest.approx(7.0)  # 4h + 3h
+
+    def test_in_progress_shift_contributes_partial_hours(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+        ledger = _seed_ledger(
+            tmp_path,
+            [
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(now - timedelta(hours=3)),
+                    "payload": {"shift_id": "s1"},
+                },
+                # No matching shift_stop — still in progress
+            ],
+        )
+        report = compute_viah(ledger=ledger, window_hours=168.0, now=now)
+        assert report.agent_hours == pytest.approx(3.0)
+
+    def test_shift_intersected_with_window_only(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+        # Window is last 4 hours; shift ran for 10 hours, ending mid-window
+        ledger = _seed_ledger(
+            tmp_path,
+            [
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(now - timedelta(hours=10)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "shift_stop",
+                    "timestamp": _ts(now - timedelta(hours=2)),
+                    "payload": {"shift_id": "s1"},
+                },
+            ],
+        )
+        report = compute_viah(ledger=ledger, window_hours=4.0, now=now)
+        # Window is [now-4h, now]; shift is [now-10h, now-2h];
+        # intersection is [now-4h, now-2h] = 2h
+        assert report.agent_hours == pytest.approx(2.0)
+
+    def test_sidecar_signals_pass_through(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+        ledger = _seed_ledger(
+            tmp_path,
+            [
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(now - timedelta(hours=2)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "shift_stop",
+                    "timestamp": _ts(now),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "pr_merged",
+                    "timestamp": _ts(now - timedelta(minutes=30)),
+                    "payload": {"pr_number": 1},
+                },
+            ],
+        )
+        report = compute_viah(
+            ledger=ledger,
+            window_hours=24.0,
+            now=now,
+            cruxes_correctly_detected=2,
+            predictions_above_brier_threshold=3,
+            failed_claims_promoted_without_repair=1,
+        )
+        # 1 PR + 2 cruxes*0.5 + 3 predictions*0.5 - 0 rescues - 1 failed*1.0
+        # = 1 + 1.0 + 1.5 - 0 - 1.0 = 2.5
+        # 2 agent-hours → VIAH = 1.25
+        assert report.viah == pytest.approx(1.25)
+        assert report.cruxes_correctly_detected == 2
+        assert report.predictions_above_brier_threshold == 3
+        assert report.failed_claims_promoted_without_repair == 1
+
+
+class TestViahReportSerialization:
+    def test_to_dict_includes_all_fields(self, tmp_path: Path) -> None:
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+        ledger = _seed_ledger(
+            tmp_path,
+            [
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(now - timedelta(hours=1)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "shift_stop",
+                    "timestamp": _ts(now),
+                    "payload": {"shift_id": "s1"},
+                },
+            ],
+        )
+        report = compute_viah(ledger=ledger, window_hours=24.0, now=now)
+        d = report.to_dict()
+        for key in (
+            "window_start",
+            "window_end",
+            "agent_hours",
+            "merged_autonomous_prs",
+            "rescues_required",
+            "viah",
+            "coefficients",
+            "inputs",
+        ):
+            assert key in d
+        assert d["coefficients"]["merged_pr_weight"] == 1.0
+        assert isinstance(d["inputs"], dict)
+
+    def test_window_start_end_are_iso8601_z(self, tmp_path: Path) -> None:
+        ledger = _seed_ledger(tmp_path, [])
+        report = compute_viah(
+            ledger=ledger, window_hours=1.0, now=datetime(2026, 4, 17, tzinfo=UTC)
+        )
+        assert report.window_end.endswith("Z")
+        assert report.window_start.endswith("Z")


### PR DESCRIPTION
## Summary

- Adds `aragora/metrics/viah.py` — productivity metric per AGT-06 plan (issue #6067).
- Consumes existing `ShiftLedger` entries for derived signals; sidecar args for AGT-05-supplied signals.
- 14 tests pass; zero modification to ShiftLedger or shift runner.

## Why this matters

Empty-queue BC-12 idle soaks prove the controller did not crash. They do not prove the system produced value. Once substrate stability is sustained, the gating productivity proof should shift to verifiable improvements per agent-hour — the booster-rocket thesis is required to lift this metric.

## Behavior

| Signal | Source | Weight |
|---|---|---|
| merged_autonomous_prs | `pr_merged` entries in window | +1.0 |
| cruxes_correctly_detected | sidecar (AGT-05) | +0.5 |
| predictions_above_brier_threshold | sidecar (AGT-05) | +0.5 |
| rescues_required | sum of `rescue_count` from `cycle_tick` | -0.5 |
| failed_claims_promoted_without_repair | sidecar (AGT-05) | -1.0 |
| agent_hours | paired shift_start/shift_stop ∩ window | denominator |

In-progress shifts (no matching `shift_stop`) credited up to `now`. Window intersection means a shift partly outside the window contributes only its in-window portion.

## Test plan

- [x] 14 tests covering: VIAH formula with default and custom coefficients, negative scores under failure dominance, `None` for zero/NaN agent-hours
- [x] Ledger consumption: empty ledger, PR windowing, rescue-count summation with missing-field tolerance, paired-shift hours, in-progress partial credit, window intersection, sidecar pass-through
- [x] `ViahReport.to_dict` and ISO-8601 Z timestamps
- [x] No regression in existing shift_ledger tests (untouched)

## What this PR does NOT do

- No scheduled computation — callers invoke `compute_viah(ledger=...)` on demand
- No CLI surface yet — deliberate follow-up
- No replacement of BC-12 idle soaks — VIAH supplements, not replaces
- No modification to `ShiftLedger` itself

## Refs

- AGT-06: #6067 | AGT epic: #6068 | Vision: #6061 | RS-10 ShiftLedger: #5857
- Sibling PRs: #6080 (substrate), #6082 (AGT-04 markets, merged), #6084 (AGT-01 cruxset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)