### PR TITLE
test(debate): align DebateResult pending default

### DIFF
--- a/tests/debate/test_arena.py
+++ b/tests/debate/test_arena.py
@@ -1135,17 +1135,23 @@ class TestCoreTypes:
         assert result.task == "Test"
         assert result.confidence == 0.0
         assert result.consensus_reached is False
-        assert result.status == "completed"
+        assert result.status == "pending"
         assert result.messages == []
         assert result.debate_id != ""  # auto-generated
 
     def test_debate_result_consensus_status(self):
         """DebateResult auto-sets status based on consensus."""
         result = DebateResult(task="Test", consensus_reached=True)
-        assert result.status == "consensus_reached"
+        assert result.status == "pending"
 
         result2 = DebateResult(task="Test2", consensus_reached=False)
-        assert result2.status == "completed"
+        assert result2.status == "pending"
+
+        result3 = DebateResult(task="Test3", consensus_reached=False, debate_status="completed")
+        assert result3.status == "completed"
+
+        result4 = DebateResult(task="Test4", consensus_reached=True, debate_status="completed")
+        assert result4.status == "consensus_reached"
 
     def test_debate_result_round_sync(self):
         """DebateResult syncs rounds_used and rounds_completed."""


### PR DESCRIPTION
## Summary\n- update DebateResult default-status tests to match the canonical pending lifecycle state\n- keep explicit completed-status assertions for completed debate results\n- unblock Integration Smoke failures that expected new DebateResult objects to be completed\n\n## Validation\n- python3 -m pytest tests/debate/test_arena.py::TestCoreTypes::test_debate_result_defaults tests/debate/test_arena.py::TestCoreTypes::test_debate_result_consensus_status -q\n- python3 -m ruff check tests/debate/test_arena.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD\n- Full local Integration Smoke subset was started, but is still running slowly locally; CI will rerun the exact gate.