### PR TITLE
feat(a2a): AGT-02 agent-readable decision receipt envelope

### DIFF
--- a/aragora/protocols/a2a/receipts.py
+++ b/aragora/protocols/a2a/receipts.py
@@ -1,0 +1,284 @@
+"""Agent-readable decision receipts for the A2A consumer surface.
+
+This module is the AGT-02 sub-deliverable that gives external software
+agents a canonical, signed, machine-parseable shape they can fetch,
+verify, parse, and act on without HTML scraping. See
+``docs/plans/AGENT_CONSUMER_SURFACE.md`` §S4 and issue #6063.
+
+The :class:`AgentReceipt` is a thin envelope that wraps any decision
+artifact (decision text, CruxSet, claim, prediction outcome, debate
+result) in a versioned, content-addressed, signature-verifiable
+container. The wrapped artifact lives in ``subject``; the optional
+:class:`aragora.reasoning.cruxset.CruxSet` (when AGT-01 emission is
+enabled) lives in ``cruxset``; reputation deltas applied as a
+consequence of this receipt (when AGT-05 settlement is wired) live in
+``reputation_deltas_applied``.
+
+Activation: this module is contract-only. Nothing publishes or signs
+receipts automatically. Server endpoints that emit AgentReceipts will
+land in a follow-up PR and remain gated behind the same AGT-* "no live
+behavior change" rule from ``docs/status/NEXT_STEPS_CANONICAL.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+AGENT_RECEIPT_SCHEMA_VERSION = "1.0"
+DEFAULT_FRESHNESS_SLA_SECONDS = 24 * 3600  # 1 day
+DEFAULT_SETTLEMENT_WINDOW_SECONDS = 7 * 24 * 3600  # 7 days
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _canonical(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_hex(material: str) -> str:
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class DissentEntry:
+    """One dissenting view captured in a receipt."""
+
+    agent_id: str
+    statement: str
+    confidence: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.confidence <= 1.0):
+            raise ValueError("confidence must be in [0, 1]")
+        if not str(self.agent_id).strip():
+            raise ValueError("agent_id must be non-empty")
+        if not str(self.statement).strip():
+            raise ValueError("statement must be non-empty")
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "statement": self.statement,
+            "confidence": round(self.confidence, 6),
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "DissentEntry":
+        return cls(
+            agent_id=str(data["agent_id"]),
+            statement=str(data["statement"]),
+            confidence=float(data.get("confidence") or 0.0),
+        )
+
+
+@dataclass(frozen=True)
+class ReputationDelta:
+    """A reputation change applied by AGT-05 settlement.
+
+    This shape is forward-compatible with the
+    :mod:`aragora.blockchain.contracts.reputation` registry; the
+    actual on-chain anchoring lives in AGT-05 (issue #6066).
+    """
+
+    agent_id: str
+    domain: str
+    delta: float
+    reason: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "domain": self.domain,
+            "delta": round(self.delta, 6),
+            "reason": self.reason,
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "ReputationDelta":
+        return cls(
+            agent_id=str(data["agent_id"]),
+            domain=str(data["domain"]),
+            delta=float(data["delta"]),
+            reason=str(data.get("reason") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class AgentReceipt:
+    """Agent-readable decision-receipt envelope.
+
+    All fields are JSON-serializable. ``signature`` is a SHA-256 hex
+    digest computed over the canonical payload (everything except
+    ``signature`` and ``receipt_id``). ``receipt_id`` is content-
+    addressed from the canonical payload so identical decisions
+    deduplicate.
+
+    Forward compatibility: the schema is versioned; readers should
+    accept any schema_version with the same major number and tolerate
+    unknown fields rather than rejecting them.
+    """
+
+    receipt_id: str
+    schema_version: str
+    issued_at: str
+    issuer: str
+    subject_kind: str
+    subject: dict[str, Any]
+    cruxset: dict[str, Any] | None
+    dissent: tuple[DissentEntry, ...]
+    reputation_deltas_applied: tuple[ReputationDelta, ...]
+    freshness_sla_seconds: int
+    settlement_window_seconds: int
+    provenance: dict[str, Any]
+    signature: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        issuer: str,
+        subject_kind: str,
+        subject: dict[str, Any],
+        cruxset: dict[str, Any] | None = None,
+        dissent: tuple[DissentEntry, ...] = (),
+        reputation_deltas_applied: tuple[ReputationDelta, ...] = (),
+        freshness_sla_seconds: int = DEFAULT_FRESHNESS_SLA_SECONDS,
+        settlement_window_seconds: int = DEFAULT_SETTLEMENT_WINDOW_SECONDS,
+        provenance: dict[str, Any] | None = None,
+        issued_at: str | None = None,
+    ) -> "AgentReceipt":
+        if not str(issuer).strip():
+            raise ValueError("issuer must be non-empty")
+        if not str(subject_kind).strip():
+            raise ValueError("subject_kind must be non-empty")
+        if freshness_sla_seconds < 1:
+            raise ValueError("freshness_sla_seconds must be >= 1")
+        if settlement_window_seconds < 0:
+            raise ValueError("settlement_window_seconds must be >= 0")
+
+        timestamp = issued_at or _utc_now_iso()
+        provenance_dict = dict(provenance or {})
+
+        # Build the canonical payload in a deterministic order. receipt_id
+        # is omitted because it is content-addressed from this payload.
+        canonical_payload: dict[str, Any] = {
+            "schema_version": AGENT_RECEIPT_SCHEMA_VERSION,
+            "issued_at": timestamp,
+            "issuer": issuer,
+            "subject_kind": subject_kind,
+            "subject": subject,
+            "cruxset": cruxset,
+            "dissent": [d.to_json() for d in dissent],
+            "reputation_deltas_applied": [r.to_json() for r in reputation_deltas_applied],
+            "freshness_sla_seconds": int(freshness_sla_seconds),
+            "settlement_window_seconds": int(settlement_window_seconds),
+            "provenance": provenance_dict,
+        }
+        canonical = _canonical(canonical_payload)
+        receipt_id = "rcpt_a_" + _sha256_hex(canonical)[:16]
+        signature = _sha256_hex(canonical)
+
+        return cls(
+            receipt_id=receipt_id,
+            schema_version=AGENT_RECEIPT_SCHEMA_VERSION,
+            issued_at=timestamp,
+            issuer=issuer,
+            subject_kind=subject_kind,
+            subject=dict(subject),
+            cruxset=(dict(cruxset) if cruxset is not None else None),
+            dissent=tuple(dissent),
+            reputation_deltas_applied=tuple(reputation_deltas_applied),
+            freshness_sla_seconds=int(freshness_sla_seconds),
+            settlement_window_seconds=int(settlement_window_seconds),
+            provenance=provenance_dict,
+            signature=signature,
+        )
+
+    def _canonical_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "issued_at": self.issued_at,
+            "issuer": self.issuer,
+            "subject_kind": self.subject_kind,
+            "subject": self.subject,
+            "cruxset": self.cruxset,
+            "dissent": [d.to_json() for d in self.dissent],
+            "reputation_deltas_applied": [r.to_json() for r in self.reputation_deltas_applied],
+            "freshness_sla_seconds": self.freshness_sla_seconds,
+            "settlement_window_seconds": self.settlement_window_seconds,
+            "provenance": self.provenance,
+        }
+
+    def verify_signature(self) -> bool:
+        """Recompute the signature and compare to the stored value."""
+        return _sha256_hex(_canonical(self._canonical_payload())) == self.signature
+
+    def is_fresh(self, *, now: datetime | None = None) -> bool:
+        """Return True if the receipt is within its freshness SLA."""
+        try:
+            issued = datetime.fromisoformat(self.issued_at.replace("Z", "+00:00")).astimezone(UTC)
+        except (ValueError, AttributeError):
+            return False
+        reference = (now or datetime.now(tz=UTC)).astimezone(UTC)
+        age_seconds = (reference - issued).total_seconds()
+        return age_seconds < self.freshness_sla_seconds
+
+    def is_settled(self, *, now: datetime | None = None) -> bool:
+        """Return True if the settlement window has elapsed.
+
+        Once settled, a receipt's underlying outcome is considered
+        final unless explicitly re-opened by a policy event.
+        """
+        try:
+            issued = datetime.fromisoformat(self.issued_at.replace("Z", "+00:00")).astimezone(UTC)
+        except (ValueError, AttributeError):
+            return False
+        reference = (now or datetime.now(tz=UTC)).astimezone(UTC)
+        age_seconds = (reference - issued).total_seconds()
+        return age_seconds >= self.settlement_window_seconds
+
+    def to_json(self) -> dict[str, Any]:
+        payload = self._canonical_payload()
+        payload["receipt_id"] = self.receipt_id
+        payload["signature"] = self.signature
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "AgentReceipt":
+        return cls(
+            receipt_id=str(data["receipt_id"]),
+            schema_version=str(data.get("schema_version") or AGENT_RECEIPT_SCHEMA_VERSION),
+            issued_at=str(data["issued_at"]),
+            issuer=str(data["issuer"]),
+            subject_kind=str(data["subject_kind"]),
+            subject=dict(data.get("subject") or {}),
+            cruxset=(dict(data["cruxset"]) if data.get("cruxset") is not None else None),
+            dissent=tuple(DissentEntry.from_json(d) for d in (data.get("dissent") or [])),
+            reputation_deltas_applied=tuple(
+                ReputationDelta.from_json(r) for r in (data.get("reputation_deltas_applied") or [])
+            ),
+            freshness_sla_seconds=int(
+                data.get("freshness_sla_seconds") or DEFAULT_FRESHNESS_SLA_SECONDS
+            ),
+            settlement_window_seconds=int(
+                data.get("settlement_window_seconds") or DEFAULT_SETTLEMENT_WINDOW_SECONDS
+            ),
+            provenance=dict(data.get("provenance") or {}),
+            signature=str(data.get("signature") or ""),
+        )
+
+
+__all__ = [
+    "AGENT_RECEIPT_SCHEMA_VERSION",
+    "DEFAULT_FRESHNESS_SLA_SECONDS",
+    "DEFAULT_SETTLEMENT_WINDOW_SECONDS",
+    "AgentReceipt",
+    "DissentEntry",
+    "ReputationDelta",
+]

--- a/tests/protocols/a2a/test_receipts.py
+++ b/tests/protocols/a2a/test_receipts.py
@@ -1,0 +1,280 @@
+"""Tests for the A2A agent-readable decision receipt envelope (AGT-02 sub-deliverable)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.protocols.a2a.receipts import (
+    AGENT_RECEIPT_SCHEMA_VERSION,
+    DEFAULT_FRESHNESS_SLA_SECONDS,
+    DEFAULT_SETTLEMENT_WINDOW_SECONDS,
+    AgentReceipt,
+    DissentEntry,
+    ReputationDelta,
+)
+
+
+def _build_basic_receipt(**overrides) -> AgentReceipt:
+    base = dict(
+        issuer="aragora.ai",
+        subject_kind="decision",
+        subject={"decision": "ship", "rationale": "tests pass"},
+        issued_at="2026-04-17T12:00:00Z",
+    )
+    base.update(overrides)
+    return AgentReceipt.build(**base)
+
+
+class TestDissentEntry:
+    def test_validates_confidence(self) -> None:
+        with pytest.raises(ValueError):
+            DissentEntry(agent_id="a", statement="x", confidence=1.5)
+        with pytest.raises(ValueError):
+            DissentEntry(agent_id="a", statement="x", confidence=-0.1)
+
+    def test_requires_non_empty_fields(self) -> None:
+        with pytest.raises(ValueError):
+            DissentEntry(agent_id=" ", statement="x")
+        with pytest.raises(ValueError):
+            DissentEntry(agent_id="a", statement="")
+
+    def test_json_roundtrip(self) -> None:
+        d = DissentEntry(agent_id="alice", statement="x is risky", confidence=0.4)
+        assert DissentEntry.from_json(d.to_json()) == d
+
+
+class TestReputationDelta:
+    def test_json_roundtrip(self) -> None:
+        delta = ReputationDelta(
+            agent_id="alice",
+            domain="prediction_market",
+            delta=-0.12,
+            reason="manifold resolution wrong",
+        )
+        assert ReputationDelta.from_json(delta.to_json()) == delta
+
+
+class TestAgentReceiptBuild:
+    def test_build_requires_non_empty_issuer(self) -> None:
+        with pytest.raises(ValueError):
+            AgentReceipt.build(
+                issuer=" ",
+                subject_kind="decision",
+                subject={"x": 1},
+            )
+
+    def test_build_requires_non_empty_subject_kind(self) -> None:
+        with pytest.raises(ValueError):
+            AgentReceipt.build(
+                issuer="aragora.ai",
+                subject_kind="",
+                subject={"x": 1},
+            )
+
+    def test_build_validates_freshness_sla(self) -> None:
+        with pytest.raises(ValueError):
+            AgentReceipt.build(
+                issuer="aragora.ai",
+                subject_kind="decision",
+                subject={"x": 1},
+                freshness_sla_seconds=0,
+            )
+
+    def test_build_validates_settlement_window(self) -> None:
+        with pytest.raises(ValueError):
+            AgentReceipt.build(
+                issuer="aragora.ai",
+                subject_kind="decision",
+                subject={"x": 1},
+                settlement_window_seconds=-1,
+            )
+
+    def test_default_freshness_and_settlement_applied(self) -> None:
+        receipt = _build_basic_receipt()
+        assert receipt.freshness_sla_seconds == DEFAULT_FRESHNESS_SLA_SECONDS
+        assert receipt.settlement_window_seconds == DEFAULT_SETTLEMENT_WINDOW_SECONDS
+
+    def test_schema_version_recorded(self) -> None:
+        receipt = _build_basic_receipt()
+        assert receipt.schema_version == AGENT_RECEIPT_SCHEMA_VERSION
+
+
+class TestContentAddressing:
+    def test_identical_inputs_yield_identical_receipt_id(self) -> None:
+        a = _build_basic_receipt()
+        b = _build_basic_receipt()
+        assert a.receipt_id == b.receipt_id
+        assert a.signature == b.signature
+
+    def test_different_subject_yields_different_receipt_id(self) -> None:
+        a = _build_basic_receipt(subject={"decision": "ship", "rationale": "tests pass"})
+        b = _build_basic_receipt(subject={"decision": "hold", "rationale": "tests pass"})
+        assert a.receipt_id != b.receipt_id
+        assert a.signature != b.signature
+
+    def test_different_dissent_changes_signature(self) -> None:
+        a = _build_basic_receipt()
+        b = _build_basic_receipt(
+            dissent=(DissentEntry(agent_id="bob", statement="risky", confidence=0.6),),
+        )
+        assert a.signature != b.signature
+
+    def test_different_freshness_sla_changes_signature(self) -> None:
+        a = _build_basic_receipt(freshness_sla_seconds=3600)
+        b = _build_basic_receipt(freshness_sla_seconds=7200)
+        assert a.signature != b.signature
+
+
+class TestSignatureVerification:
+    def test_verify_signature_succeeds_on_valid_receipt(self) -> None:
+        receipt = _build_basic_receipt()
+        assert receipt.verify_signature() is True
+
+    def test_verify_signature_fails_when_subject_mutated(self) -> None:
+        receipt = _build_basic_receipt()
+        tampered = AgentReceipt(
+            receipt_id=receipt.receipt_id,
+            schema_version=receipt.schema_version,
+            issued_at=receipt.issued_at,
+            issuer=receipt.issuer,
+            subject_kind=receipt.subject_kind,
+            subject={"decision": "TAMPERED", "rationale": "tests pass"},
+            cruxset=receipt.cruxset,
+            dissent=receipt.dissent,
+            reputation_deltas_applied=receipt.reputation_deltas_applied,
+            freshness_sla_seconds=receipt.freshness_sla_seconds,
+            settlement_window_seconds=receipt.settlement_window_seconds,
+            provenance=receipt.provenance,
+            signature=receipt.signature,
+        )
+        assert tampered.verify_signature() is False
+
+    def test_verify_signature_fails_when_dissent_mutated(self) -> None:
+        receipt = _build_basic_receipt(
+            dissent=(DissentEntry(agent_id="bob", statement="risky"),),
+        )
+        # Reuse signature but with no dissent
+        tampered = AgentReceipt(
+            receipt_id=receipt.receipt_id,
+            schema_version=receipt.schema_version,
+            issued_at=receipt.issued_at,
+            issuer=receipt.issuer,
+            subject_kind=receipt.subject_kind,
+            subject=receipt.subject,
+            cruxset=receipt.cruxset,
+            dissent=(),
+            reputation_deltas_applied=receipt.reputation_deltas_applied,
+            freshness_sla_seconds=receipt.freshness_sla_seconds,
+            settlement_window_seconds=receipt.settlement_window_seconds,
+            provenance=receipt.provenance,
+            signature=receipt.signature,
+        )
+        assert tampered.verify_signature() is False
+
+
+class TestFreshnessAndSettlement:
+    def test_is_fresh_within_window(self) -> None:
+        receipt = _build_basic_receipt(
+            issued_at="2026-04-17T12:00:00Z",
+            freshness_sla_seconds=3600,
+        )
+        assert receipt.is_fresh(now=datetime(2026, 4, 17, 12, 30, tzinfo=UTC)) is True
+
+    def test_is_stale_after_window(self) -> None:
+        receipt = _build_basic_receipt(
+            issued_at="2026-04-17T12:00:00Z",
+            freshness_sla_seconds=3600,
+        )
+        assert receipt.is_fresh(now=datetime(2026, 4, 17, 14, 0, tzinfo=UTC)) is False
+
+    def test_is_settled_after_settlement_window(self) -> None:
+        receipt = _build_basic_receipt(
+            issued_at="2026-04-17T12:00:00Z",
+            settlement_window_seconds=3600,
+        )
+        assert receipt.is_settled(now=datetime(2026, 4, 17, 11, 0, tzinfo=UTC)) is False
+        assert receipt.is_settled(now=datetime(2026, 4, 17, 13, 1, tzinfo=UTC)) is True
+
+    def test_freshness_returns_false_on_unparseable_timestamp(self) -> None:
+        receipt = _build_basic_receipt(
+            issued_at="2026-04-17T12:00:00Z",
+            freshness_sla_seconds=3600,
+        )
+        # Manually construct a receipt with a bogus issued_at to exercise the branch
+        broken = AgentReceipt(
+            receipt_id=receipt.receipt_id,
+            schema_version=receipt.schema_version,
+            issued_at="not-a-date",
+            issuer=receipt.issuer,
+            subject_kind=receipt.subject_kind,
+            subject=receipt.subject,
+            cruxset=receipt.cruxset,
+            dissent=receipt.dissent,
+            reputation_deltas_applied=receipt.reputation_deltas_applied,
+            freshness_sla_seconds=receipt.freshness_sla_seconds,
+            settlement_window_seconds=receipt.settlement_window_seconds,
+            provenance=receipt.provenance,
+            signature=receipt.signature,
+        )
+        assert broken.is_fresh() is False
+        assert broken.is_settled() is False
+
+
+class TestJsonRoundtrip:
+    def test_roundtrip_preserves_signature_and_fields(self) -> None:
+        receipt = _build_basic_receipt(
+            cruxset={
+                "cruxset_id": "crxset_a",
+                "checksum": "deadbeef",
+                "cruxes": [{"crux_id": "c1"}],
+            },
+            dissent=(
+                DissentEntry(agent_id="bob", statement="risky", confidence=0.6),
+                DissentEntry(agent_id="carol", statement="overspecified"),
+            ),
+            reputation_deltas_applied=(
+                ReputationDelta(agent_id="alice", domain="debate_position", delta=0.05),
+            ),
+            freshness_sla_seconds=600,
+            settlement_window_seconds=3600,
+            provenance={"debate_id": "d1", "arena_run_id": "r1"},
+        )
+        payload = receipt.to_json()
+        roundtrip = AgentReceipt.from_json(payload)
+        assert roundtrip == receipt
+        assert roundtrip.verify_signature() is True
+
+    def test_roundtrip_without_optional_fields(self) -> None:
+        receipt = _build_basic_receipt()
+        roundtrip = AgentReceipt.from_json(receipt.to_json())
+        assert roundtrip == receipt
+
+    def test_from_json_tolerates_missing_optional_fields(self) -> None:
+        # Build a minimal payload by hand; from_json should populate defaults
+        receipt = _build_basic_receipt()
+        payload = receipt.to_json()
+        del payload["dissent"]
+        del payload["reputation_deltas_applied"]
+        del payload["provenance"]
+        del payload["cruxset"]
+        rebuilt = AgentReceipt.from_json(payload)
+        assert rebuilt.dissent == ()
+        assert rebuilt.reputation_deltas_applied == ()
+        assert rebuilt.provenance == {}
+        assert rebuilt.cruxset is None
+
+
+class TestForwardCompatibility:
+    def test_ignores_unknown_top_level_fields_when_loading(self) -> None:
+        receipt = _build_basic_receipt()
+        payload = receipt.to_json()
+        payload["future_field_we_do_not_know"] = {"speculative": True}
+        rebuilt = AgentReceipt.from_json(payload)
+        # Round-trip works; the unknown field is dropped (the contract is
+        # explicit about what we serialize), but loading does not crash.
+        assert rebuilt.receipt_id == receipt.receipt_id
+        # Signature stays valid because the unknown field was not part of
+        # the canonical payload that produced the original signature.
+        assert rebuilt.verify_signature() is True


### PR DESCRIPTION
## Summary

- Adds `aragora/protocols/a2a/receipts.py` — canonical, signed, machine-parseable decision-receipt envelope for external software agents.
- One sub-deliverable of AGT-02 (#6063); see `docs/plans/AGENT_CONSUMER_SURFACE.md` §S4.
- 25 new tests pass; full protocols/ suite (294 tests) clean; **zero modification** to existing receipt or A2A modules.

## What this gives the AGT track

External agents need a fetchable, verifiable, parseable decision receipt that doesn't require HTML scraping. `AgentReceipt` is that envelope: SHA-256-signed canonical payload, content-addressed receipt_id, optional embedded CruxSet (from AGT-01) and reputation_deltas (from AGT-05), explicit freshness SLA and settlement window.

## Shape

```python
AgentReceipt(
    receipt_id="rcpt_a_<sha256[:16]>",         # content-addressed
    schema_version="1.0",
    issued_at="2026-04-17T12:00:00Z",
    issuer="aragora.ai",
    subject_kind="decision",                    # or "cruxset", "claim", "prediction"
    subject={...},                              # the artifact
    cruxset={...} | None,                       # optional embedded CruxSet
    dissent=(DissentEntry(...), ...),
    reputation_deltas_applied=(ReputationDelta(...), ...),
    freshness_sla_seconds=86400,                # default 1 day
    settlement_window_seconds=604800,           # default 7 days
    provenance={...},
    signature="<sha256>",
)
```

## Test plan

- [x] 25 tests covering: validation, content-addressing, signature stability, signature tamper detection (subject + dissent mutation), freshness/settlement temporal predicates, full JSON roundtrip including optional fields and unknown-field forward compatibility
- [x] 294 protocols/ tests pass — zero regressions
- [x] Receipt is fully JSON-serializable; `from_json` tolerates missing optional fields and unknown top-level fields

## What this PR does NOT do

- No server endpoints that emit AgentReceipts (deliberate follow-up)
- No on-chain anchoring (AGT-05 territory)
- No changes to existing receipt models (`aragora.export.decision_receipt`, `aragora.gauntlet.receipt_models` untouched)
- No changes to `aragora/protocols/a2a/{client,server,types}.py`

## Refs

- AGT-02: #6063 | AGT epic: #6068 | Vision PR: #6061
- Sibling AGT PRs: #6080 (substrate, merged), #6082 (AGT-04 markets, merged), #6084 (AGT-01 cruxset, merged), #6086 (AGT-06 VIAH, in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)