### PR TITLE
fix(a2a): require keyed receipt signatures

### DIFF
--- a/aragora/protocols/a2a/receipts.py
+++ b/aragora/protocols/a2a/receipts.py
@@ -23,14 +23,20 @@ behavior change" rule from ``docs/status/NEXT_STEPS_CANONICAL.md``.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Callable
 
 AGENT_RECEIPT_SCHEMA_VERSION = "1.0"
 DEFAULT_FRESHNESS_SLA_SECONDS = 24 * 3600  # 1 day
 DEFAULT_SETTLEMENT_WINDOW_SECONDS = 7 * 24 * 3600  # 7 days
+DEFAULT_SIGNATURE_ALGORITHM = "hmac-sha256"
+DEFAULT_SIGNATURE_KEY_ID = "default"
+
+SignatureKey = str | bytes
+SignatureKeyResolver = Callable[[str, str], SignatureKey | None]
 
 
 def _utc_now_iso() -> str:
@@ -43,6 +49,20 @@ def _canonical(payload: dict[str, Any]) -> str:
 
 def _sha256_hex(material: str) -> str:
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _key_bytes(signing_key: SignatureKey) -> bytes:
+    if isinstance(signing_key, bytes):
+        key = signing_key
+    else:
+        key = str(signing_key).encode("utf-8")
+    if not key:
+        raise ValueError("signing_key must be non-empty")
+    return key
+
+
+def _hmac_sha256_hex(material: str, signing_key: SignatureKey) -> str:
+    return hmac.new(_key_bytes(signing_key), material.encode("utf-8"), hashlib.sha256).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -113,11 +133,13 @@ class ReputationDelta:
 class AgentReceipt:
     """Agent-readable decision-receipt envelope.
 
-    All fields are JSON-serializable. ``signature`` is a SHA-256 hex
-    digest computed over the canonical payload (everything except
-    ``signature`` and ``receipt_id``). ``receipt_id`` is content-
-    addressed from the canonical payload so identical decisions
-    deduplicate.
+    All fields are JSON-serializable. ``receipt_id`` is a content
+    address computed from the canonical receipt payload so identical
+    decisions deduplicate. ``signature`` is an HMAC-SHA256 over the
+    canonical payload plus signature metadata, using the issuer's
+    configured signing key. Verification therefore requires the issuer
+    key (or a resolver for it); the public payload alone is not enough to
+    mint a valid signature for changed content.
 
     Forward compatibility: the schema is versioned; readers should
     accept any schema_version with the same major number and tolerate
@@ -136,6 +158,8 @@ class AgentReceipt:
     freshness_sla_seconds: int
     settlement_window_seconds: int
     provenance: dict[str, Any]
+    signature_key_id: str
+    signature_algorithm: str
     signature: str
 
     @classmethod
@@ -152,6 +176,8 @@ class AgentReceipt:
         settlement_window_seconds: int = DEFAULT_SETTLEMENT_WINDOW_SECONDS,
         provenance: dict[str, Any] | None = None,
         issued_at: str | None = None,
+        signing_key: SignatureKey | None = None,
+        signature_key_id: str = DEFAULT_SIGNATURE_KEY_ID,
     ) -> "AgentReceipt":
         if not str(issuer).strip():
             raise ValueError("issuer must be non-empty")
@@ -161,9 +187,14 @@ class AgentReceipt:
             raise ValueError("freshness_sla_seconds must be >= 1")
         if settlement_window_seconds < 0:
             raise ValueError("settlement_window_seconds must be >= 0")
+        if signing_key is None:
+            raise ValueError("signing_key must be provided")
+        if not str(signature_key_id).strip():
+            raise ValueError("signature_key_id must be non-empty")
 
         timestamp = issued_at or _utc_now_iso()
         provenance_dict = dict(provenance or {})
+        key_id = str(signature_key_id).strip()
 
         # Build the canonical payload in a deterministic order. receipt_id
         # is omitted because it is content-addressed from this payload.
@@ -182,7 +213,12 @@ class AgentReceipt:
         }
         canonical = _canonical(canonical_payload)
         receipt_id = "rcpt_a_" + _sha256_hex(canonical)[:16]
-        signature = _sha256_hex(canonical)
+        signed_payload = {
+            **canonical_payload,
+            "signature_key_id": key_id,
+            "signature_algorithm": DEFAULT_SIGNATURE_ALGORITHM,
+        }
+        signature = _hmac_sha256_hex(_canonical(signed_payload), signing_key)
 
         return cls(
             receipt_id=receipt_id,
@@ -197,6 +233,8 @@ class AgentReceipt:
             freshness_sla_seconds=int(freshness_sla_seconds),
             settlement_window_seconds=int(settlement_window_seconds),
             provenance=provenance_dict,
+            signature_key_id=key_id,
+            signature_algorithm=DEFAULT_SIGNATURE_ALGORITHM,
             signature=signature,
         )
 
@@ -215,9 +253,32 @@ class AgentReceipt:
             "provenance": self.provenance,
         }
 
-    def verify_signature(self) -> bool:
-        """Recompute the signature and compare to the stored value."""
-        return _sha256_hex(_canonical(self._canonical_payload())) == self.signature
+    def _signed_payload(self) -> dict[str, Any]:
+        return {
+            **self._canonical_payload(),
+            "signature_key_id": self.signature_key_id,
+            "signature_algorithm": self.signature_algorithm,
+        }
+
+    def verify_signature(
+        self,
+        *,
+        signing_key: SignatureKey | None = None,
+        key_resolver: SignatureKeyResolver | None = None,
+    ) -> bool:
+        """Verify this receipt with the issuer key or a key resolver."""
+        if self.signature_algorithm != DEFAULT_SIGNATURE_ALGORITHM:
+            return False
+        key = signing_key
+        if key is None and key_resolver is not None:
+            key = key_resolver(self.issuer, self.signature_key_id)
+        if key is None:
+            return False
+        try:
+            expected = _hmac_sha256_hex(_canonical(self._signed_payload()), key)
+        except ValueError:
+            return False
+        return hmac.compare_digest(expected, self.signature)
 
     def is_fresh(self, *, now: datetime | None = None) -> bool:
         """Return True if the receipt is within its freshness SLA."""
@@ -244,7 +305,7 @@ class AgentReceipt:
         return age_seconds >= self.settlement_window_seconds
 
     def to_json(self) -> dict[str, Any]:
-        payload = self._canonical_payload()
+        payload = self._signed_payload()
         payload["receipt_id"] = self.receipt_id
         payload["signature"] = self.signature
         return payload
@@ -270,6 +331,8 @@ class AgentReceipt:
                 data.get("settlement_window_seconds") or DEFAULT_SETTLEMENT_WINDOW_SECONDS
             ),
             provenance=dict(data.get("provenance") or {}),
+            signature_key_id=str(data.get("signature_key_id") or ""),
+            signature_algorithm=str(data.get("signature_algorithm") or DEFAULT_SIGNATURE_ALGORITHM),
             signature=str(data.get("signature") or ""),
         )
 
@@ -278,7 +341,11 @@ __all__ = [
     "AGENT_RECEIPT_SCHEMA_VERSION",
     "DEFAULT_FRESHNESS_SLA_SECONDS",
     "DEFAULT_SETTLEMENT_WINDOW_SECONDS",
+    "DEFAULT_SIGNATURE_ALGORITHM",
+    "DEFAULT_SIGNATURE_KEY_ID",
     "AgentReceipt",
     "DissentEntry",
     "ReputationDelta",
+    "SignatureKey",
+    "SignatureKeyResolver",
 ]

--- a/aragora/protocols/a2a/receipts.py
+++ b/aragora/protocols/a2a/receipts.py
@@ -22,8 +22,9 @@ behavior change" rule from ``docs/status/NEXT_STEPS_CANONICAL.md``.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import hashlib
-import hmac
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -32,11 +33,12 @@ from typing import Any, Callable
 AGENT_RECEIPT_SCHEMA_VERSION = "1.0"
 DEFAULT_FRESHNESS_SLA_SECONDS = 24 * 3600  # 1 day
 DEFAULT_SETTLEMENT_WINDOW_SECONDS = 7 * 24 * 3600  # 7 days
-DEFAULT_SIGNATURE_ALGORITHM = "hmac-sha256"
+DEFAULT_SIGNATURE_ALGORITHM = "ed25519"
 DEFAULT_SIGNATURE_KEY_ID = "default"
 
-SignatureKey = str | bytes
-SignatureKeyResolver = Callable[[str, str], SignatureKey | None]
+SignaturePrivateKey = Any | str | bytes
+SignaturePublicKey = Any | str | bytes
+SignatureKeyResolver = Callable[[str, str], SignaturePublicKey | None]
 
 
 def _utc_now_iso() -> str:
@@ -51,18 +53,113 @@ def _sha256_hex(material: str) -> str:
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
 
 
-def _key_bytes(signing_key: SignatureKey) -> bytes:
-    if isinstance(signing_key, bytes):
-        key = signing_key
+def _decode_key_material(key: str | bytes, *, field_name: str) -> bytes:
+    if isinstance(key, bytes):
+        raw = key
     else:
-        key = str(signing_key).encode("utf-8")
-    if not key:
-        raise ValueError("signing_key must be non-empty")
-    return key
+        text = str(key).strip()
+        if not text:
+            raise ValueError(f"{field_name} must be non-empty")
+        if "BEGIN" in text:
+            return text.encode("utf-8")
+        try:
+            raw = base64.b64decode(text, validate=True)
+        except (binascii.Error, ValueError):
+            try:
+                raw = bytes.fromhex(text)
+            except ValueError:
+                raw = text.encode("utf-8")
+    if not raw:
+        raise ValueError(f"{field_name} must be non-empty")
+    return raw
 
 
-def _hmac_sha256_hex(material: str, signing_key: SignatureKey) -> str:
-    return hmac.new(_key_bytes(signing_key), material.encode("utf-8"), hashlib.sha256).hexdigest()
+def _load_ed25519_private_key(signing_key: SignaturePrivateKey) -> Any:
+    if hasattr(signing_key, "sign") and hasattr(signing_key, "public_key"):
+        return signing_key
+    if hasattr(signing_key, "verify") and not hasattr(signing_key, "sign"):
+        raise ValueError("signing_key must be an Ed25519 private key, not a public key")
+
+    try:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    except ImportError as exc:
+        raise ImportError("cryptography package required for Ed25519 receipt signing") from exc
+
+    key_bytes = _decode_key_material(signing_key, field_name="signing_key")
+    if key_bytes.startswith(b"-----BEGIN"):
+        private_key = serialization.load_pem_private_key(key_bytes, password=None)
+        if not hasattr(private_key, "sign") or not hasattr(private_key, "public_key"):
+            raise ValueError("signing_key PEM must contain an Ed25519 private key")
+        return private_key
+    if len(key_bytes) != 32:
+        raise ValueError("signing_key must be 32 raw Ed25519 private-key bytes or PEM")
+    return Ed25519PrivateKey.from_private_bytes(key_bytes)
+
+
+def _load_ed25519_public_key(verification_key: SignaturePublicKey) -> Any:
+    if hasattr(verification_key, "verify"):
+        return verification_key
+
+    try:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    except ImportError as exc:
+        raise ImportError("cryptography package required for Ed25519 receipt verification") from exc
+
+    key_bytes = _decode_key_material(verification_key, field_name="verification_key")
+    if key_bytes.startswith(b"-----BEGIN"):
+        public_key = serialization.load_pem_public_key(key_bytes)
+        if not hasattr(public_key, "verify"):
+            raise ValueError("verification_key PEM must contain an Ed25519 public key")
+        return public_key
+    if len(key_bytes) != 32:
+        raise ValueError("verification_key must be 32 raw Ed25519 public-key bytes or PEM")
+    return Ed25519PublicKey.from_public_bytes(key_bytes)
+
+
+def _public_key_bytes(public_key: Any) -> bytes:
+    try:
+        from cryptography.hazmat.primitives import serialization
+    except ImportError as exc:
+        raise ImportError("cryptography package required for Ed25519 receipt verification") from exc
+
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+
+def _public_key_sha256(public_key: Any) -> str:
+    return hashlib.sha256(_public_key_bytes(public_key)).hexdigest()
+
+
+def _ed25519_signature_b64(material: str, signing_key: Any) -> str:
+    signature = signing_key.sign(material.encode("utf-8"))
+    return base64.b64encode(signature).decode("ascii")
+
+
+def _verify_ed25519_signature(
+    material: str,
+    signature: str,
+    verification_key: SignaturePublicKey,
+) -> bool:
+    try:
+        public_key = _load_ed25519_public_key(verification_key)
+        signature_bytes = base64.b64decode(signature, validate=True)
+    except (ImportError, ValueError, binascii.Error):
+        return False
+
+    try:
+        from cryptography.exceptions import InvalidSignature
+    except ImportError:
+        return False
+
+    try:
+        public_key.verify(signature_bytes, material.encode("utf-8"))
+    except InvalidSignature:
+        return False
+    return True
 
 
 @dataclass(frozen=True)
@@ -135,11 +232,10 @@ class AgentReceipt:
 
     All fields are JSON-serializable. ``receipt_id`` is a content
     address computed from the canonical receipt payload so identical
-    decisions deduplicate. ``signature`` is an HMAC-SHA256 over the
-    canonical payload plus signature metadata, using the issuer's
-    configured signing key. Verification therefore requires the issuer
-    key (or a resolver for it); the public payload alone is not enough to
-    mint a valid signature for changed content.
+    decisions deduplicate. ``signature`` is an Ed25519 signature over the
+    canonical payload plus public verification-key metadata, using the
+    issuer's private signing key. Verifiers need only the issuer's public
+    verification key, resolved by ``issuer`` and ``signature_key_id``.
 
     Forward compatibility: the schema is versioned; readers should
     accept any schema_version with the same major number and tolerate
@@ -160,6 +256,7 @@ class AgentReceipt:
     provenance: dict[str, Any]
     signature_key_id: str
     signature_algorithm: str
+    verification_key_sha256: str
     signature: str
 
     @classmethod
@@ -176,7 +273,7 @@ class AgentReceipt:
         settlement_window_seconds: int = DEFAULT_SETTLEMENT_WINDOW_SECONDS,
         provenance: dict[str, Any] | None = None,
         issued_at: str | None = None,
-        signing_key: SignatureKey | None = None,
+        signing_key: SignaturePrivateKey | None = None,
         signature_key_id: str = DEFAULT_SIGNATURE_KEY_ID,
     ) -> "AgentReceipt":
         if not str(issuer).strip():
@@ -195,6 +292,8 @@ class AgentReceipt:
         timestamp = issued_at or _utc_now_iso()
         provenance_dict = dict(provenance or {})
         key_id = str(signature_key_id).strip()
+        private_key = _load_ed25519_private_key(signing_key)
+        verification_key_sha256 = _public_key_sha256(private_key.public_key())
 
         # Build the canonical payload in a deterministic order. receipt_id
         # is omitted because it is content-addressed from this payload.
@@ -217,8 +316,9 @@ class AgentReceipt:
             **canonical_payload,
             "signature_key_id": key_id,
             "signature_algorithm": DEFAULT_SIGNATURE_ALGORITHM,
+            "verification_key_sha256": verification_key_sha256,
         }
-        signature = _hmac_sha256_hex(_canonical(signed_payload), signing_key)
+        signature = _ed25519_signature_b64(_canonical(signed_payload), private_key)
 
         return cls(
             receipt_id=receipt_id,
@@ -235,6 +335,7 @@ class AgentReceipt:
             provenance=provenance_dict,
             signature_key_id=key_id,
             signature_algorithm=DEFAULT_SIGNATURE_ALGORITHM,
+            verification_key_sha256=verification_key_sha256,
             signature=signature,
         )
 
@@ -258,27 +359,24 @@ class AgentReceipt:
             **self._canonical_payload(),
             "signature_key_id": self.signature_key_id,
             "signature_algorithm": self.signature_algorithm,
+            "verification_key_sha256": self.verification_key_sha256,
         }
 
     def verify_signature(
         self,
         *,
-        signing_key: SignatureKey | None = None,
+        verification_key: SignaturePublicKey | None = None,
         key_resolver: SignatureKeyResolver | None = None,
     ) -> bool:
-        """Verify this receipt with the issuer key or a key resolver."""
+        """Verify this receipt with an issuer public key or key resolver."""
         if self.signature_algorithm != DEFAULT_SIGNATURE_ALGORITHM:
             return False
-        key = signing_key
+        key = verification_key
         if key is None and key_resolver is not None:
             key = key_resolver(self.issuer, self.signature_key_id)
         if key is None:
             return False
-        try:
-            expected = _hmac_sha256_hex(_canonical(self._signed_payload()), key)
-        except ValueError:
-            return False
-        return hmac.compare_digest(expected, self.signature)
+        return _verify_ed25519_signature(_canonical(self._signed_payload()), self.signature, key)
 
     def is_fresh(self, *, now: datetime | None = None) -> bool:
         """Return True if the receipt is within its freshness SLA."""
@@ -333,6 +431,7 @@ class AgentReceipt:
             provenance=dict(data.get("provenance") or {}),
             signature_key_id=str(data.get("signature_key_id") or ""),
             signature_algorithm=str(data.get("signature_algorithm") or DEFAULT_SIGNATURE_ALGORITHM),
+            verification_key_sha256=str(data.get("verification_key_sha256") or ""),
             signature=str(data.get("signature") or ""),
         )
 
@@ -346,6 +445,7 @@ __all__ = [
     "AgentReceipt",
     "DissentEntry",
     "ReputationDelta",
-    "SignatureKey",
+    "SignaturePrivateKey",
+    "SignaturePublicKey",
     "SignatureKeyResolver",
 ]

--- a/tests/protocols/a2a/test_receipts.py
+++ b/tests/protocols/a2a/test_receipts.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from dataclasses import replace
+from datetime import UTC, datetime
 
 import pytest
 
 from aragora.protocols.a2a.receipts import (
     AGENT_RECEIPT_SCHEMA_VERSION,
     DEFAULT_FRESHNESS_SLA_SECONDS,
+    DEFAULT_SIGNATURE_ALGORITHM,
     DEFAULT_SETTLEMENT_WINDOW_SECONDS,
     AgentReceipt,
     DissentEntry,
     ReputationDelta,
 )
+
+ISSUER_SIGNING_KEY = "issuer-secret-for-tests"
+ATTACKER_SIGNING_KEY = "attacker-secret-for-tests"
+SIGNATURE_KEY_ID = "test-issuer-key-v1"
 
 
 def _build_basic_receipt(**overrides) -> AgentReceipt:
@@ -22,6 +28,8 @@ def _build_basic_receipt(**overrides) -> AgentReceipt:
         subject_kind="decision",
         subject={"decision": "ship", "rationale": "tests pass"},
         issued_at="2026-04-17T12:00:00Z",
+        signing_key=ISSUER_SIGNING_KEY,
+        signature_key_id=SIGNATURE_KEY_ID,
     )
     base.update(overrides)
     return AgentReceipt.build(**base)
@@ -63,6 +71,7 @@ class TestAgentReceiptBuild:
                 issuer=" ",
                 subject_kind="decision",
                 subject={"x": 1},
+                signing_key=ISSUER_SIGNING_KEY,
             )
 
     def test_build_requires_non_empty_subject_kind(self) -> None:
@@ -71,6 +80,7 @@ class TestAgentReceiptBuild:
                 issuer="aragora.ai",
                 subject_kind="",
                 subject={"x": 1},
+                signing_key=ISSUER_SIGNING_KEY,
             )
 
     def test_build_validates_freshness_sla(self) -> None:
@@ -80,6 +90,7 @@ class TestAgentReceiptBuild:
                 subject_kind="decision",
                 subject={"x": 1},
                 freshness_sla_seconds=0,
+                signing_key=ISSUER_SIGNING_KEY,
             )
 
     def test_build_validates_settlement_window(self) -> None:
@@ -89,6 +100,25 @@ class TestAgentReceiptBuild:
                 subject_kind="decision",
                 subject={"x": 1},
                 settlement_window_seconds=-1,
+                signing_key=ISSUER_SIGNING_KEY,
+            )
+
+    def test_build_requires_signing_key(self) -> None:
+        with pytest.raises(ValueError, match="signing_key"):
+            AgentReceipt.build(
+                issuer="aragora.ai",
+                subject_kind="decision",
+                subject={"x": 1},
+            )
+
+    def test_build_requires_non_empty_signature_key_id(self) -> None:
+        with pytest.raises(ValueError, match="signature_key_id"):
+            AgentReceipt.build(
+                issuer="aragora.ai",
+                subject_kind="decision",
+                subject={"x": 1},
+                signing_key=ISSUER_SIGNING_KEY,
+                signature_key_id=" ",
             )
 
     def test_default_freshness_and_settlement_applied(self) -> None:
@@ -99,6 +129,8 @@ class TestAgentReceiptBuild:
     def test_schema_version_recorded(self) -> None:
         receipt = _build_basic_receipt()
         assert receipt.schema_version == AGENT_RECEIPT_SCHEMA_VERSION
+        assert receipt.signature_algorithm == DEFAULT_SIGNATURE_ALGORITHM
+        assert receipt.signature_key_id == SIGNATURE_KEY_ID
 
 
 class TestContentAddressing:
@@ -126,52 +158,72 @@ class TestContentAddressing:
         b = _build_basic_receipt(freshness_sla_seconds=7200)
         assert a.signature != b.signature
 
+    def test_different_signing_key_preserves_content_id_but_changes_signature(self) -> None:
+        a = _build_basic_receipt(signing_key=ISSUER_SIGNING_KEY)
+        b = _build_basic_receipt(signing_key=ATTACKER_SIGNING_KEY)
+        assert a.receipt_id == b.receipt_id
+        assert a.signature != b.signature
+
 
 class TestSignatureVerification:
     def test_verify_signature_succeeds_on_valid_receipt(self) -> None:
         receipt = _build_basic_receipt()
-        assert receipt.verify_signature() is True
+        assert receipt.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True
+
+    def test_verify_signature_uses_key_resolver(self) -> None:
+        receipt = _build_basic_receipt()
+
+        def resolve_key(issuer: str, key_id: str) -> str | None:
+            assert issuer == "aragora.ai"
+            assert key_id == SIGNATURE_KEY_ID
+            return ISSUER_SIGNING_KEY
+
+        assert receipt.verify_signature(key_resolver=resolve_key) is True
+
+    def test_verify_signature_fails_without_verification_key(self) -> None:
+        receipt = _build_basic_receipt()
+        assert receipt.verify_signature() is False
+
+    def test_verify_signature_fails_with_wrong_key(self) -> None:
+        receipt = _build_basic_receipt()
+        assert receipt.verify_signature(signing_key=ATTACKER_SIGNING_KEY) is False
 
     def test_verify_signature_fails_when_subject_mutated(self) -> None:
         receipt = _build_basic_receipt()
-        tampered = AgentReceipt(
-            receipt_id=receipt.receipt_id,
-            schema_version=receipt.schema_version,
-            issued_at=receipt.issued_at,
-            issuer=receipt.issuer,
-            subject_kind=receipt.subject_kind,
+        tampered = replace(
+            receipt,
             subject={"decision": "TAMPERED", "rationale": "tests pass"},
-            cruxset=receipt.cruxset,
-            dissent=receipt.dissent,
-            reputation_deltas_applied=receipt.reputation_deltas_applied,
-            freshness_sla_seconds=receipt.freshness_sla_seconds,
-            settlement_window_seconds=receipt.settlement_window_seconds,
-            provenance=receipt.provenance,
-            signature=receipt.signature,
         )
-        assert tampered.verify_signature() is False
+        assert tampered.verify_signature(signing_key=ISSUER_SIGNING_KEY) is False
 
     def test_verify_signature_fails_when_dissent_mutated(self) -> None:
         receipt = _build_basic_receipt(
             dissent=(DissentEntry(agent_id="bob", statement="risky"),),
         )
         # Reuse signature but with no dissent
-        tampered = AgentReceipt(
-            receipt_id=receipt.receipt_id,
-            schema_version=receipt.schema_version,
-            issued_at=receipt.issued_at,
-            issuer=receipt.issuer,
-            subject_kind=receipt.subject_kind,
-            subject=receipt.subject,
-            cruxset=receipt.cruxset,
+        tampered = replace(
+            receipt,
             dissent=(),
-            reputation_deltas_applied=receipt.reputation_deltas_applied,
-            freshness_sla_seconds=receipt.freshness_sla_seconds,
-            settlement_window_seconds=receipt.settlement_window_seconds,
-            provenance=receipt.provenance,
-            signature=receipt.signature,
         )
-        assert tampered.verify_signature() is False
+        assert tampered.verify_signature(signing_key=ISSUER_SIGNING_KEY) is False
+
+    def test_attacker_rebuilt_changed_subject_fails_under_issuer_key(self) -> None:
+        original = _build_basic_receipt()
+        forged = _build_basic_receipt(
+            subject={"decision": "hold", "rationale": "attacker changed subject"},
+            signing_key=ATTACKER_SIGNING_KEY,
+        )
+
+        assert original.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True
+        assert forged.issuer == original.issuer
+        assert forged.signature_key_id == original.signature_key_id
+        assert forged.verify_signature(signing_key=ISSUER_SIGNING_KEY) is False
+        assert forged.verify_signature(signing_key=ATTACKER_SIGNING_KEY) is True
+
+    def test_verify_signature_fails_when_signature_metadata_mutated(self) -> None:
+        receipt = _build_basic_receipt()
+        tampered = replace(receipt, signature_key_id="attacker-key")
+        assert tampered.verify_signature(signing_key=ISSUER_SIGNING_KEY) is False
 
 
 class TestFreshnessAndSettlement:
@@ -203,20 +255,9 @@ class TestFreshnessAndSettlement:
             freshness_sla_seconds=3600,
         )
         # Manually construct a receipt with a bogus issued_at to exercise the branch
-        broken = AgentReceipt(
-            receipt_id=receipt.receipt_id,
-            schema_version=receipt.schema_version,
+        broken = replace(
+            receipt,
             issued_at="not-a-date",
-            issuer=receipt.issuer,
-            subject_kind=receipt.subject_kind,
-            subject=receipt.subject,
-            cruxset=receipt.cruxset,
-            dissent=receipt.dissent,
-            reputation_deltas_applied=receipt.reputation_deltas_applied,
-            freshness_sla_seconds=receipt.freshness_sla_seconds,
-            settlement_window_seconds=receipt.settlement_window_seconds,
-            provenance=receipt.provenance,
-            signature=receipt.signature,
         )
         assert broken.is_fresh() is False
         assert broken.is_settled() is False
@@ -244,7 +285,7 @@ class TestJsonRoundtrip:
         payload = receipt.to_json()
         roundtrip = AgentReceipt.from_json(payload)
         assert roundtrip == receipt
-        assert roundtrip.verify_signature() is True
+        assert roundtrip.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True
 
     def test_roundtrip_without_optional_fields(self) -> None:
         receipt = _build_basic_receipt()
@@ -264,6 +305,7 @@ class TestJsonRoundtrip:
         assert rebuilt.reputation_deltas_applied == ()
         assert rebuilt.provenance == {}
         assert rebuilt.cruxset is None
+        assert rebuilt.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True
 
 
 class TestForwardCompatibility:
@@ -277,4 +319,4 @@ class TestForwardCompatibility:
         assert rebuilt.receipt_id == receipt.receipt_id
         # Signature stays valid because the unknown field was not part of
         # the canonical payload that produced the original signature.
-        assert rebuilt.verify_signature() is True
+        assert rebuilt.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True

--- a/tests/protocols/a2a/test_receipts.py
+++ b/tests/protocols/a2a/test_receipts.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from aragora.protocols.a2a.receipts import (
     AGENT_RECEIPT_SCHEMA_VERSION,
@@ -17,8 +18,10 @@ from aragora.protocols.a2a.receipts import (
     ReputationDelta,
 )
 
-ISSUER_SIGNING_KEY = "issuer-secret-for-tests"
-ATTACKER_SIGNING_KEY = "attacker-secret-for-tests"
+ISSUER_PRIVATE_KEY = Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+ATTACKER_PRIVATE_KEY = Ed25519PrivateKey.from_private_bytes(bytes(range(32, 64)))
+ISSUER_PUBLIC_KEY = ISSUER_PRIVATE_KEY.public_key()
+ATTACKER_PUBLIC_KEY = ATTACKER_PRIVATE_KEY.public_key()
 SIGNATURE_KEY_ID = "test-issuer-key-v1"
 
 
@@ -28,7 +31,7 @@ def _build_basic_receipt(**overrides) -> AgentReceipt:
         subject_kind="decision",
         subject={"decision": "ship", "rationale": "tests pass"},
         issued_at="2026-04-17T12:00:00Z",
-        signing_key=ISSUER_SIGNING_KEY,
+        signing_key=ISSUER_PRIVATE_KEY,
         signature_key_id=SIGNATURE_KEY_ID,
     )
     base.update(overrides)
@@ -71,7 +74,7 @@ class TestAgentReceiptBuild:
                 issuer=" ",
                 subject_kind="decision",
                 subject={"x": 1},
-                signing_key=ISSUER_SIGNING_KEY,
+                signing_key=ISSUER_PRIVATE_KEY,
             )
 
     def test_build_requires_non_empty_subject_kind(self) -> None:
@@ -80,7 +83,7 @@ class TestAgentReceiptBuild:
                 issuer="aragora.ai",
                 subject_kind="",
                 subject={"x": 1},
-                signing_key=ISSUER_SIGNING_KEY,
+                signing_key=ISSUER_PRIVATE_KEY,
             )
 
     def test_build_validates_freshness_sla(self) -> None:
@@ -90,7 +93,7 @@ class TestAgentReceiptBuild:
                 subject_kind="decision",
                 subject={"x": 1},
                 freshness_sla_seconds=0,
-                signing_key=ISSUER_SIGNING_KEY,
+                signing_key=ISSUER_PRIVATE_KEY,
             )
 
     def test_build_validates_settlement_window(self) -> None:
@@ -100,7 +103,7 @@ class TestAgentReceiptBuild:
                 subject_kind="decision",
                 subject={"x": 1},
                 settlement_window_seconds=-1,
-                signing_key=ISSUER_SIGNING_KEY,
+                signing_key=ISSUER_PRIVATE_KEY,
             )
 
     def test_build_requires_signing_key(self) -> None:
@@ -117,8 +120,17 @@ class TestAgentReceiptBuild:
                 issuer="aragora.ai",
                 subject_kind="decision",
                 subject={"x": 1},
-                signing_key=ISSUER_SIGNING_KEY,
+                signing_key=ISSUER_PRIVATE_KEY,
                 signature_key_id=" ",
+            )
+
+    def test_build_rejects_public_verification_key_as_signing_key(self) -> None:
+        with pytest.raises(ValueError, match="private key"):
+            AgentReceipt.build(
+                issuer="aragora.ai",
+                subject_kind="decision",
+                subject={"x": 1},
+                signing_key=ISSUER_PUBLIC_KEY,
             )
 
     def test_default_freshness_and_settlement_applied(self) -> None:
@@ -131,6 +143,8 @@ class TestAgentReceiptBuild:
         assert receipt.schema_version == AGENT_RECEIPT_SCHEMA_VERSION
         assert receipt.signature_algorithm == DEFAULT_SIGNATURE_ALGORITHM
         assert receipt.signature_key_id == SIGNATURE_KEY_ID
+        assert receipt.verification_key_sha256
+        assert receipt.to_json()["verification_key_sha256"] == receipt.verification_key_sha256
 
 
 class TestContentAddressing:
@@ -159,24 +173,25 @@ class TestContentAddressing:
         assert a.signature != b.signature
 
     def test_different_signing_key_preserves_content_id_but_changes_signature(self) -> None:
-        a = _build_basic_receipt(signing_key=ISSUER_SIGNING_KEY)
-        b = _build_basic_receipt(signing_key=ATTACKER_SIGNING_KEY)
+        a = _build_basic_receipt(signing_key=ISSUER_PRIVATE_KEY)
+        b = _build_basic_receipt(signing_key=ATTACKER_PRIVATE_KEY)
         assert a.receipt_id == b.receipt_id
         assert a.signature != b.signature
+        assert a.verification_key_sha256 != b.verification_key_sha256
 
 
 class TestSignatureVerification:
     def test_verify_signature_succeeds_on_valid_receipt(self) -> None:
         receipt = _build_basic_receipt()
-        assert receipt.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True
+        assert receipt.verify_signature(verification_key=ISSUER_PUBLIC_KEY) is True
 
     def test_verify_signature_uses_key_resolver(self) -> None:
         receipt = _build_basic_receipt()
 
-        def resolve_key(issuer: str, key_id: str) -> str | None:
+        def resolve_key(issuer: str, key_id: str):
             assert issuer == "aragora.ai"
             assert key_id == SIGNATURE_KEY_ID
-            return ISSUER_SIGNING_KEY
+            return ISSUER_PUBLIC_KEY
 
         assert receipt.verify_signature(key_resolver=resolve_key) is True
 
@@ -186,7 +201,7 @@ class TestSignatureVerification:
 
     def test_verify_signature_fails_with_wrong_key(self) -> None:
         receipt = _build_basic_receipt()
-        assert receipt.verify_signature(signing_key=ATTACKER_SIGNING_KEY) is False
+        assert receipt.verify_signature(verification_key=ATTACKER_PUBLIC_KEY) is False
 
     def test_verify_signature_fails_when_subject_mutated(self) -> None:
         receipt = _build_basic_receipt()
@@ -194,7 +209,7 @@ class TestSignatureVerification:
             receipt,
             subject={"decision": "TAMPERED", "rationale": "tests pass"},
         )
-        assert tampered.verify_signature(signing_key=ISSUER_SIGNING_KEY) is False
+        assert tampered.verify_signature(verification_key=ISSUER_PUBLIC_KEY) is False
 
     def test_verify_signature_fails_when_dissent_mutated(self) -> None:
         receipt = _build_basic_receipt(
@@ -205,25 +220,25 @@ class TestSignatureVerification:
             receipt,
             dissent=(),
         )
-        assert tampered.verify_signature(signing_key=ISSUER_SIGNING_KEY) is False
+        assert tampered.verify_signature(verification_key=ISSUER_PUBLIC_KEY) is False
 
     def test_attacker_rebuilt_changed_subject_fails_under_issuer_key(self) -> None:
         original = _build_basic_receipt()
         forged = _build_basic_receipt(
             subject={"decision": "hold", "rationale": "attacker changed subject"},
-            signing_key=ATTACKER_SIGNING_KEY,
+            signing_key=ATTACKER_PRIVATE_KEY,
         )
 
-        assert original.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True
+        assert original.verify_signature(verification_key=ISSUER_PUBLIC_KEY) is True
         assert forged.issuer == original.issuer
         assert forged.signature_key_id == original.signature_key_id
-        assert forged.verify_signature(signing_key=ISSUER_SIGNING_KEY) is False
-        assert forged.verify_signature(signing_key=ATTACKER_SIGNING_KEY) is True
+        assert forged.verify_signature(verification_key=ISSUER_PUBLIC_KEY) is False
+        assert forged.verify_signature(verification_key=ATTACKER_PUBLIC_KEY) is True
 
     def test_verify_signature_fails_when_signature_metadata_mutated(self) -> None:
         receipt = _build_basic_receipt()
         tampered = replace(receipt, signature_key_id="attacker-key")
-        assert tampered.verify_signature(signing_key=ISSUER_SIGNING_KEY) is False
+        assert tampered.verify_signature(verification_key=ISSUER_PUBLIC_KEY) is False
 
 
 class TestFreshnessAndSettlement:
@@ -285,7 +300,7 @@ class TestJsonRoundtrip:
         payload = receipt.to_json()
         roundtrip = AgentReceipt.from_json(payload)
         assert roundtrip == receipt
-        assert roundtrip.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True
+        assert roundtrip.verify_signature(verification_key=ISSUER_PUBLIC_KEY) is True
 
     def test_roundtrip_without_optional_fields(self) -> None:
         receipt = _build_basic_receipt()
@@ -305,7 +320,7 @@ class TestJsonRoundtrip:
         assert rebuilt.reputation_deltas_applied == ()
         assert rebuilt.provenance == {}
         assert rebuilt.cruxset is None
-        assert rebuilt.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True
+        assert rebuilt.verify_signature(verification_key=ISSUER_PUBLIC_KEY) is True
 
 
 class TestForwardCompatibility:
@@ -319,4 +334,4 @@ class TestForwardCompatibility:
         assert rebuilt.receipt_id == receipt.receipt_id
         # Signature stays valid because the unknown field was not part of
         # the canonical payload that produced the original signature.
-        assert rebuilt.verify_signature(signing_key=ISSUER_SIGNING_KEY) is True
+        assert rebuilt.verify_signature(verification_key=ISSUER_PUBLIC_KEY) is True


### PR DESCRIPTION
## Summary
- require keyed HMAC-SHA256 signing for AgentReceipt signatures while preserving content-addressed receipt IDs
- include signature key metadata and resolver-based verification support
- add forgeability, wrong-key, no-key, mutation, and JSON roundtrip regression coverage

Closes #6094

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/protocols/a2a/test_receipts.py -p no:rerunfailures -p no:cacheprovider
- PYTHONDONTWRITEBYTECODE=1 RUFF_CACHE_DIR=/tmp/ruff-a2a-receipts-6094-rerun python3 -m ruff check aragora/protocols/a2a/receipts.py tests/protocols/a2a/test_receipts.py
- direct forgeability proof: original issuer verifies true, attacker-rebuilt changed-subject receipt verifies false under issuer key
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD