### PR TITLE
[DIC-14] Add executable claim verification runner

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -1,0 +1,5 @@
+"""Epistemic CI: executable claim verification and decay detection."""
+
+from .claim_verifier import ClaimResult, ClaimStatus, ClaimVerifier
+
+__all__ = ["ClaimResult", "ClaimStatus", "ClaimVerifier"]

--- a/aragora/epistemic/claim_verifier.py
+++ b/aragora/epistemic/claim_verifier.py
@@ -148,10 +148,7 @@ class ClaimVerifier:
         payload = {
             "schema_version": 1,
             "results": [r.to_dict() for r in results],
-            "summary": {
-                s.value: sum(1 for r in results if r.status == s)
-                for s in ClaimStatus
-            },
+            "summary": {s.value: sum(1 for r in results if r.status == s) for s in ClaimStatus},
         }
         return json.dumps(payload, indent=indent)
 

--- a/aragora/epistemic/claim_verifier.py
+++ b/aragora/epistemic/claim_verifier.py
@@ -1,0 +1,238 @@
+"""Executable claim verification runner (DIC-14 / #6024).
+
+Loads claim manifests produced by the DIC-13 schema
+(docs/status/claims/*.yaml), verifies each claim, and emits a JSON
+status report.  No network, no queue mutation, no issue creation.
+
+Verification outcomes
+---------------------
+pass        — command exited 0 and evidence paths are fresh
+fail        — command exited non-zero
+stale       — evidence path(s) are older than freshness_sla_hours
+unsupported — verification kind is ``workflow`` or ``manual``
+error       — an exception prevented verification from completing
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+import yaml
+
+
+class ClaimStatus(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    STALE = "stale"
+    UNSUPPORTED = "unsupported"
+    ERROR = "error"
+
+
+@dataclass
+class ClaimResult:
+    claim_id: str
+    status: ClaimStatus
+    message: str
+    severity: str = "info"
+    allowed_action: str = "report_only"
+    elapsed_ms: float = 0.0
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["status"] = self.status.value
+        return d
+
+
+# Injected command runner type: (args: list[str]) -> (returncode: int, stdout: str, stderr: str)
+CommandRunner = Callable[[list[str]], tuple[int, str, str]]
+
+
+def _default_command_runner(args: list[str]) -> tuple[int, str, str]:
+    """Run a subprocess with a 60-second wall-clock timeout."""
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return 1, "", "command timed out after 60s"
+    except FileNotFoundError as exc:
+        return 1, "", f"executable not found: {exc}"
+
+
+class ClaimVerifier:
+    """Verifies explicit claim manifests and emits machine-readable results.
+
+    Parameters
+    ----------
+    repo_root:
+        Absolute base path used to resolve relative evidence ``path`` values.
+        Defaults to the current working directory.
+    command_runner:
+        Overrideable hook for running verification commands.  The default
+        uses ``subprocess.run``.  Inject a stub for tests.
+    dry_run:
+        If *True*, skip command execution and return UNSUPPORTED for all
+        command-kind claims.  Useful for schema validation passes.
+    """
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path | None = None,
+        command_runner: CommandRunner | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        self._repo_root = repo_root or Path(os.getcwd())
+        self._run_command: CommandRunner = command_runner or _default_command_runner
+        self._dry_run = dry_run
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def verify_manifest(self, manifest_path: Path) -> list[ClaimResult]:
+        """Load a YAML manifest and verify every claim in it."""
+        with open(manifest_path) as fh:
+            manifest = yaml.safe_load(fh)
+        claims: list[dict[str, Any]] = manifest.get("claims", [])
+        return [self.verify_claim(c) for c in claims]
+
+    def verify_claim(self, claim: dict[str, Any]) -> ClaimResult:
+        """Verify a single claim dict and return a ClaimResult."""
+        claim_id: str = claim.get("claim_id", "<unknown>")
+        failure_cfg: dict[str, Any] = claim.get("failure", {})
+        severity = failure_cfg.get("severity", "info")
+        allowed_action = failure_cfg.get("allowed_action", "report_only")
+
+        start = time.monotonic()
+        try:
+            result = self._verify(claim)
+        except Exception as exc:  # noqa: BLE001
+            elapsed = (time.monotonic() - start) * 1000
+            return ClaimResult(
+                claim_id=claim_id,
+                status=ClaimStatus.ERROR,
+                message=f"verification raised an exception: {exc}",
+                severity=severity,
+                allowed_action=allowed_action,
+                elapsed_ms=round(elapsed, 1),
+            )
+
+        elapsed = (time.monotonic() - start) * 1000
+        return ClaimResult(
+            claim_id=claim_id,
+            status=result["status"],
+            message=result["message"],
+            severity=severity,
+            allowed_action=allowed_action,
+            elapsed_ms=round(elapsed, 1),
+            detail=result.get("detail", {}),
+        )
+
+    @staticmethod
+    def report_json(results: list[ClaimResult], *, indent: int = 2) -> str:
+        """Serialise results to a JSON string."""
+        payload = {
+            "schema_version": 1,
+            "results": [r.to_dict() for r in results],
+            "summary": {
+                s.value: sum(1 for r in results if r.status == s)
+                for s in ClaimStatus
+            },
+        }
+        return json.dumps(payload, indent=indent)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _verify(self, claim: dict[str, Any]) -> dict[str, Any]:
+        freshness_sla: int = claim.get("freshness_sla_hours", 24)
+        evidence: list[dict[str, Any]] = claim.get("evidence", [])
+
+        stale = self._check_stale_evidence(evidence, freshness_sla)
+        if stale:
+            return {
+                "status": ClaimStatus.STALE,
+                "message": f"evidence path stale (>{freshness_sla}h): {stale}",
+                "detail": {"stale_paths": stale},
+            }
+
+        verification: dict[str, Any] = claim.get("verification", {})
+        kind: str = verification.get("kind", "")
+
+        if kind in ("workflow", "manual"):
+            return {
+                "status": ClaimStatus.UNSUPPORTED,
+                "message": f"verification kind '{kind}' requires external runner",
+            }
+
+        if kind != "command":
+            return {
+                "status": ClaimStatus.UNSUPPORTED,
+                "message": f"unknown verification kind '{kind}'",
+            }
+
+        if self._dry_run:
+            return {
+                "status": ClaimStatus.UNSUPPORTED,
+                "message": "dry_run=True; command execution skipped",
+            }
+
+        command_str: str = verification.get("command", "")
+        if not command_str:
+            return {
+                "status": ClaimStatus.ERROR,
+                "message": "verification.command is empty",
+            }
+
+        args = shlex.split(command_str)
+        returncode, stdout, stderr = self._run_command(args)
+
+        if returncode == 0:
+            return {
+                "status": ClaimStatus.PASS,
+                "message": "command exited 0",
+                "detail": {"stdout": stdout[:500], "stderr": stderr[:200]},
+            }
+        return {
+            "status": ClaimStatus.FAIL,
+            "message": f"command exited {returncode}",
+            "detail": {"stdout": stdout[:500], "stderr": stderr[:200]},
+        }
+
+    def _check_stale_evidence(
+        self,
+        evidence: list[dict[str, Any]],
+        freshness_sla_hours: int,
+    ) -> list[str]:
+        """Return list of path-type evidence items that exceed the SLA age."""
+        stale: list[str] = []
+        threshold_s = freshness_sla_hours * 3600
+        now = time.time()
+        for item in evidence:
+            path_str: str | None = item.get("path")
+            if not path_str:
+                continue
+            p = Path(path_str)
+            if not p.is_absolute():
+                p = self._repo_root / p
+            if not p.exists():
+                continue
+            age_s = now - p.stat().st_mtime
+            if age_s > threshold_s:
+                stale.append(str(item["path"]))
+        return stale

--- a/tests/epistemic/test_claim_verifier.py
+++ b/tests/epistemic/test_claim_verifier.py
@@ -20,6 +20,7 @@ from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus, ClaimVeri
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 def _stub_pass(args: list[str]) -> tuple[int, str, str]:
     return 0, "ok", ""
 
@@ -59,6 +60,7 @@ def _make_claim(
 # ---------------------------------------------------------------------------
 # Status outcome tests
 # ---------------------------------------------------------------------------
+
 
 class TestClaimStatus:
     def test_pass_on_zero_exit(self) -> None:
@@ -113,12 +115,14 @@ class TestClaimStatus:
 # Freshness / staleness tests
 # ---------------------------------------------------------------------------
 
+
 class TestFreshnessCheck:
     def test_stale_when_file_exceeds_sla(self, tmp_path: Path) -> None:
         old_file = tmp_path / "old.json"
         old_file.write_text("{}")
         past = time.time() - 3601  # 1 hour 1 second ago
         import os
+
         os.utime(old_file, (past, past))
 
         claim = _make_claim(
@@ -166,6 +170,7 @@ class TestFreshnessCheck:
 # Severity and metadata propagation
 # ---------------------------------------------------------------------------
 
+
 class TestResultMetadata:
     def test_severity_propagated_on_fail(self) -> None:
         verifier = ClaimVerifier(command_runner=_stub_fail)
@@ -191,6 +196,7 @@ class TestResultMetadata:
 # ---------------------------------------------------------------------------
 # JSON report
 # ---------------------------------------------------------------------------
+
 
 class TestReportJson:
     def test_json_structure(self) -> None:
@@ -222,6 +228,7 @@ class TestReportJson:
 # Manifest loading
 # ---------------------------------------------------------------------------
 
+
 class TestVerifyManifest:
     def test_verify_manifest_from_yaml(self, tmp_path: Path) -> None:
         manifest = {
@@ -246,11 +253,7 @@ class TestVerifyManifest:
     def test_verify_real_proof_first_claims(self) -> None:
         """Smoke test: the DIC-13 manifest parses and every claim returns a result."""
         manifest_path = (
-            Path(__file__).parents[2]
-            / "docs"
-            / "status"
-            / "claims"
-            / "proof_first_claims.yaml"
+            Path(__file__).parents[2] / "docs" / "status" / "claims" / "proof_first_claims.yaml"
         )
         if not manifest_path.exists():
             pytest.skip("proof_first_claims.yaml not found")

--- a/tests/epistemic/test_claim_verifier.py
+++ b/tests/epistemic/test_claim_verifier.py
@@ -1,0 +1,263 @@
+"""Tests for aragora.epistemic.claim_verifier (DIC-14 / #6024).
+
+All tests run without network access or subprocess calls — command
+execution is injected via the ``command_runner`` hook.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus, ClaimVerifier
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _stub_pass(args: list[str]) -> tuple[int, str, str]:
+    return 0, "ok", ""
+
+
+def _stub_fail(args: list[str]) -> tuple[int, str, str]:
+    return 1, "", "something went wrong"
+
+
+def _stub_raise(args: list[str]) -> tuple[int, str, str]:
+    raise RuntimeError("injected runner error")
+
+
+def _make_claim(
+    *,
+    claim_id: str = "test.claim",
+    kind: str = "command",
+    command: str = "python3 -c 'pass'",
+    freshness_sla_hours: int = 24,
+    evidence: list[dict] | None = None,
+    severity: str = "info",
+    allowed_action: str = "report_only",
+) -> dict:
+    return {
+        "claim_id": claim_id,
+        "statement": "Test claim.",
+        "owner": "test",
+        "scope": "repo",
+        "confidence": "high",
+        "freshness_sla_hours": freshness_sla_hours,
+        "evidence": evidence or [],
+        "verification": {"kind": kind, "command": command},
+        "failure": {"severity": severity, "allowed_action": allowed_action},
+        "receipts": [{"type": "test"}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Status outcome tests
+# ---------------------------------------------------------------------------
+
+class TestClaimStatus:
+    def test_pass_on_zero_exit(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(_make_claim())
+        assert result.status == ClaimStatus.PASS
+        assert result.claim_id == "test.claim"
+
+    def test_fail_on_nonzero_exit(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_fail)
+        result = verifier.verify_claim(_make_claim())
+        assert result.status == ClaimStatus.FAIL
+        assert "1" in result.message
+
+    def test_error_when_runner_raises(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_raise)
+        result = verifier.verify_claim(_make_claim())
+        assert result.status == ClaimStatus.ERROR
+        assert "injected runner error" in result.message
+
+    def test_unsupported_workflow_kind(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(_make_claim(kind="workflow"))
+        assert result.status == ClaimStatus.UNSUPPORTED
+        assert "workflow" in result.message
+
+    def test_unsupported_manual_kind(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(_make_claim(kind="manual"))
+        assert result.status == ClaimStatus.UNSUPPORTED
+
+    def test_unsupported_unknown_kind(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(_make_claim(kind="http_probe"))
+        assert result.status == ClaimStatus.UNSUPPORTED
+        assert "http_probe" in result.message
+
+    def test_dry_run_skips_command(self) -> None:
+        ran: list[bool] = []
+
+        def tracking_runner(args: list[str]) -> tuple[int, str, str]:
+            ran.append(True)
+            return 0, "", ""
+
+        verifier = ClaimVerifier(command_runner=tracking_runner, dry_run=True)
+        result = verifier.verify_claim(_make_claim())
+        assert result.status == ClaimStatus.UNSUPPORTED
+        assert not ran, "runner should not have been called in dry_run mode"
+
+
+# ---------------------------------------------------------------------------
+# Freshness / staleness tests
+# ---------------------------------------------------------------------------
+
+class TestFreshnessCheck:
+    def test_stale_when_file_exceeds_sla(self, tmp_path: Path) -> None:
+        old_file = tmp_path / "old.json"
+        old_file.write_text("{}")
+        past = time.time() - 3601  # 1 hour 1 second ago
+        import os
+        os.utime(old_file, (past, past))
+
+        claim = _make_claim(
+            freshness_sla_hours=1,
+            evidence=[{"path": str(old_file)}],
+        )
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(claim)
+        assert result.status == ClaimStatus.STALE
+        assert str(old_file) in result.detail.get("stale_paths", [])
+
+    def test_fresh_file_does_not_stale(self, tmp_path: Path) -> None:
+        fresh_file = tmp_path / "fresh.json"
+        fresh_file.write_text("{}")
+
+        claim = _make_claim(
+            freshness_sla_hours=24,
+            evidence=[{"path": str(fresh_file)}],
+        )
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(claim)
+        assert result.status == ClaimStatus.PASS
+
+    def test_missing_evidence_path_skipped(self) -> None:
+        claim = _make_claim(
+            freshness_sla_hours=1,
+            evidence=[{"path": "/nonexistent/path/that/does/not/exist.json"}],
+        )
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(claim)
+        # Missing file is not treated as stale — caller has no mtime to compare
+        assert result.status == ClaimStatus.PASS
+
+    def test_non_path_evidence_skipped(self) -> None:
+        claim = _make_claim(
+            freshness_sla_hours=1,
+            evidence=[{"workflow": "Benchmark Truth Publication"}],
+        )
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(claim)
+        assert result.status != ClaimStatus.STALE
+
+
+# ---------------------------------------------------------------------------
+# Severity and metadata propagation
+# ---------------------------------------------------------------------------
+
+class TestResultMetadata:
+    def test_severity_propagated_on_fail(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_fail)
+        result = verifier.verify_claim(
+            _make_claim(severity="blocking", allowed_action="propose_bounded_issue")
+        )
+        assert result.severity == "blocking"
+        assert result.allowed_action == "propose_bounded_issue"
+
+    def test_elapsed_ms_positive(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(_make_claim())
+        assert result.elapsed_ms >= 0
+
+    def test_to_dict_includes_status_string(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        result = verifier.verify_claim(_make_claim())
+        d = result.to_dict()
+        assert d["status"] == "pass"
+        assert isinstance(d["elapsed_ms"], float)
+
+
+# ---------------------------------------------------------------------------
+# JSON report
+# ---------------------------------------------------------------------------
+
+class TestReportJson:
+    def test_json_structure(self) -> None:
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        results = [verifier.verify_claim(_make_claim())]
+        raw = verifier.report_json(results)
+        doc = json.loads(raw)
+        assert doc["schema_version"] == 1
+        assert "results" in doc
+        assert "summary" in doc
+        assert doc["summary"]["pass"] == 1
+        assert doc["summary"]["fail"] == 0
+
+    def test_summary_counts_all_statuses(self) -> None:
+        verifier_pass = ClaimVerifier(command_runner=_stub_pass)
+        verifier_fail = ClaimVerifier(command_runner=_stub_fail)
+        results = [
+            verifier_pass.verify_claim(_make_claim(claim_id="c1")),
+            verifier_fail.verify_claim(_make_claim(claim_id="c2")),
+            verifier_pass.verify_claim(_make_claim(claim_id="c3", kind="workflow")),
+        ]
+        doc = json.loads(ClaimVerifier.report_json(results))
+        assert doc["summary"]["pass"] == 1
+        assert doc["summary"]["fail"] == 1
+        assert doc["summary"]["unsupported"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Manifest loading
+# ---------------------------------------------------------------------------
+
+class TestVerifyManifest:
+    def test_verify_manifest_from_yaml(self, tmp_path: Path) -> None:
+        manifest = {
+            "schema_version": 1,
+            "manifest_id": "test_manifest",
+            "claims": [
+                _make_claim(claim_id="m.pass"),
+                _make_claim(claim_id="m.unsupported", kind="workflow"),
+            ],
+        }
+        path = tmp_path / "test_claims.yaml"
+        path.write_text(yaml.dump(manifest))
+
+        verifier = ClaimVerifier(command_runner=_stub_pass)
+        results = verifier.verify_manifest(path)
+        assert len(results) == 2
+        assert results[0].claim_id == "m.pass"
+        assert results[0].status == ClaimStatus.PASS
+        assert results[1].claim_id == "m.unsupported"
+        assert results[1].status == ClaimStatus.UNSUPPORTED
+
+    def test_verify_real_proof_first_claims(self) -> None:
+        """Smoke test: the DIC-13 manifest parses and every claim returns a result."""
+        manifest_path = (
+            Path(__file__).parents[2]
+            / "docs"
+            / "status"
+            / "claims"
+            / "proof_first_claims.yaml"
+        )
+        if not manifest_path.exists():
+            pytest.skip("proof_first_claims.yaml not found")
+
+        verifier = ClaimVerifier(dry_run=True)
+        results = verifier.verify_manifest(manifest_path)
+        assert len(results) >= 3
+        statuses = {r.claim_id: r.status for r in results}
+        # In dry_run all command-kind claims → unsupported (not error)
+        assert ClaimStatus.ERROR not in statuses.values()


### PR DESCRIPTION
## Slice

Adds `aragora.epistemic.ClaimVerifier`, a bounded runner that loads DIC-13 claim manifests (YAML files under `docs/status/claims/`), checks evidence freshness, executes `command`-kind verifiers via an injectable hook, and emits a JSON status report.  No queue mutation, no issue creation, no network required in tests.

## Gating

- Default: OFF — `ClaimVerifier` is only active when explicitly instantiated and called; nothing in the live queue, dispatch, or boss loop references it
- Live queue effect: none
- Advances issue: #6024 (DIC-14)

## Tests

- `TestClaimStatus` (7 tests) — pass on exit 0, fail on exit 1, error on runner exception, unsupported for `workflow`/`manual`/unknown kinds, dry_run skips execution
- `TestFreshnessCheck` (4 tests) — stale when file exceeds SLA, fresh file passes, missing/non-path evidence skipped
- `TestResultMetadata` (3 tests) — severity and allowed_action propagated, elapsed_ms positive, `to_dict` serialises status as string
- `TestReportJson` (2 tests) — JSON schema version + summary counts
- `TestVerifyManifest` (2 tests) — YAML round-trip, smoke test on real `proof_first_claims.yaml` with `dry_run=True`

## Validation

- `pytest tests/epistemic/test_claim_verifier.py --noconftest` — **18 passed**
- `ruff check aragora/epistemic/ tests/epistemic/` — **clean**
- `mypy aragora/epistemic/ tests/epistemic/ --ignore-missing-imports --disable-error-code=import-untyped` — **clean** (import-untyped suppressed: `import yaml` has no stubs in this env; same pattern as existing `aragora/audit/registry.py`)

Implementation is ~245 source LOC; tests add another ~265 LOC.  Source-only diff is within the 300 LOC guidance.

## Out of scope

- **DIC-15** (`consensus="crux_finder"` mode): covered by PR #6081
- **DIC-16** (CruxReceipt export): next natural slice after DIC-15 merges
- **DIC-17** (failed claims → bounded follow-up work): gated on DIC-14 + DIC-15 both landing
- Issue creation, queue mutation, or boss-ready label management: explicitly excluded per issue #6024 acceptance criteria
- `workflow` and `manual` verification kinds: currently return `unsupported`; later slices can add CI-runner and human-approval paths