### PR TITLE
fix(epistemic): fail closed on missing claim evidence

### DIFF
--- a/aragora/epistemic/claim_verifier.py
+++ b/aragora/epistemic/claim_verifier.py
@@ -160,7 +160,16 @@ class ClaimVerifier:
         freshness_sla: int = claim.get("freshness_sla_hours", 24)
         evidence: list[dict[str, Any]] = claim.get("evidence", [])
 
-        stale = self._check_stale_evidence(evidence, freshness_sla)
+        evidence_paths = self._check_path_evidence(evidence, freshness_sla)
+        missing = evidence_paths["missing"]
+        if missing:
+            return {
+                "status": ClaimStatus.ERROR,
+                "message": f"evidence path missing: {missing}",
+                "detail": {"missing_paths": missing},
+            }
+
+        stale = evidence_paths["stale"]
         if stale:
             return {
                 "status": ClaimStatus.STALE,
@@ -211,12 +220,13 @@ class ClaimVerifier:
             "detail": {"stdout": stdout[:500], "stderr": stderr[:200]},
         }
 
-    def _check_stale_evidence(
+    def _check_path_evidence(
         self,
         evidence: list[dict[str, Any]],
         freshness_sla_hours: int,
-    ) -> list[str]:
-        """Return list of path-type evidence items that exceed the SLA age."""
+    ) -> dict[str, list[str]]:
+        """Return missing and stale path-type evidence items."""
+        missing: list[str] = []
         stale: list[str] = []
         threshold_s = freshness_sla_hours * 3600
         now = time.time()
@@ -228,8 +238,9 @@ class ClaimVerifier:
             if not p.is_absolute():
                 p = self._repo_root / p
             if not p.exists():
+                missing.append(str(item["path"]))
                 continue
             age_s = now - p.stat().st_mtime
             if age_s > threshold_s:
                 stale.append(str(item["path"]))
-        return stale
+        return {"missing": missing, "stale": stale}

--- a/tests/epistemic/test_claim_verifier.py
+++ b/tests/epistemic/test_claim_verifier.py
@@ -146,15 +146,34 @@ class TestFreshnessCheck:
         result = verifier.verify_claim(claim)
         assert result.status == ClaimStatus.PASS
 
-    def test_missing_evidence_path_skipped(self) -> None:
+    def test_missing_evidence_path_errors_before_command(self) -> None:
         claim = _make_claim(
             freshness_sla_hours=1,
             evidence=[{"path": "/nonexistent/path/that/does/not/exist.json"}],
         )
-        verifier = ClaimVerifier(command_runner=_stub_pass)
+
+        ran: list[list[str]] = []
+
+        def tracking_runner(args: list[str]) -> tuple[int, str, str]:
+            ran.append(args)
+            return _stub_pass(args)
+
+        verifier = ClaimVerifier(command_runner=tracking_runner)
         result = verifier.verify_claim(claim)
-        # Missing file is not treated as stale — caller has no mtime to compare
-        assert result.status == ClaimStatus.PASS
+        assert result.status == ClaimStatus.ERROR
+        assert "evidence path missing" in result.message
+        assert result.detail["missing_paths"] == ["/nonexistent/path/that/does/not/exist.json"]
+        assert not ran, "runner should not execute when path evidence is missing"
+
+    def test_missing_relative_evidence_path_reports_manifest_path(self, tmp_path: Path) -> None:
+        claim = _make_claim(
+            freshness_sla_hours=1,
+            evidence=[{"path": "missing/claim-evidence.json"}],
+        )
+        verifier = ClaimVerifier(repo_root=tmp_path, command_runner=_stub_pass)
+        result = verifier.verify_claim(claim)
+        assert result.status == ClaimStatus.ERROR
+        assert result.detail["missing_paths"] == ["missing/claim-evidence.json"]
 
     def test_non_path_evidence_skipped(self) -> None:
         claim = _make_claim(


### PR DESCRIPTION
## Summary

- Make claim verification fail closed when declared path evidence is missing.
- Return `ClaimStatus.ERROR` with `missing_paths` detail before the command runner executes.
- Keep stale-file detection and non-path evidence handling unchanged.

## Why

The DIC-14 claim verifier could previously return `pass` when a claim's command exited 0 even if its only path evidence did not exist. That lets proof-first status claims succeed without the repository evidence they cite.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/epistemic/test_claim_verifier.py -p no:rerunfailures -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 RUFF_CACHE_DIR=/tmp/ruff-claim-verifier-missing-evidence-post python3 -m ruff check aragora/epistemic/claim_verifier.py tests/epistemic/test_claim_verifier.py`
- `git diff --check origin/main...HEAD`
- `PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY' ... ClaimVerifier().verify_manifest(Path('docs/status/claims/proof_first_claims.yaml')) ... PY`
- `PYTHONDONTWRITEBYTECODE=1 RUFF_CACHE_DIR=/tmp/ruff-claim-verifier-missing-evidence-preflight bash scripts/automation_pr_preflight.sh origin/main HEAD`
