### PR TITLE
fix(benchmarks): budget recurrence ticks per open issue

### DIFF
--- a/scripts/run_benchmark_corpus_recurrence.py
+++ b/scripts/run_benchmark_corpus_recurrence.py
@@ -19,6 +19,7 @@ from rotate_boss_metrics import DEFAULT_METRICS_PATH, rotate_metrics_file
 
 DEFAULT_REPO = "synaptent/aragora"
 DEFAULT_OUTCOME_LEARNER_WINDOW = 500
+DEFAULT_TICKS_PER_OPEN_ISSUE = 3
 
 
 def corpus_issue_numbers(corpus: dict[str, Any]) -> list[int]:
@@ -128,7 +129,14 @@ def build_boss_loop_command(
 ) -> list[str]:
     if not issue_numbers:
         raise ValueError("issue_numbers must not be empty")
-    effective_ticks = max_ticks if max_ticks is not None else max(len(issue_numbers) * 2, 1)
+    # BossLoop can consume one initial attempt plus two repair attempts before
+    # recording a terminal class for one issue. Budget for that full envelope so
+    # later corpus issues are not omitted from the publication window.
+    effective_ticks = (
+        max_ticks
+        if max_ticks is not None
+        else max(len(issue_numbers) * DEFAULT_TICKS_PER_OPEN_ISSUE, 1)
+    )
     return [
         sys.executable,
         "-m",

--- a/tests/scripts/test_run_benchmark_corpus_recurrence.py
+++ b/tests/scripts/test_run_benchmark_corpus_recurrence.py
@@ -59,7 +59,7 @@ def test_build_boss_loop_command_uses_explicit_issue_list_contract() -> None:
     assert command[:4] == [sys.executable, "-m", "aragora.cli.main", "swarm"]
     assert "--boss-issue-list" in command
     assert command[command.index("--boss-issue-list") + 1] == "1064,2712"
-    assert command[command.index("--max-ticks") + 1] == "4"
+    assert command[command.index("--max-ticks") + 1] == "6"
     assert command[command.index("--max-consecutive-failures") + 1] == "5"
     assert command[command.index("--autonomy") + 1] == "fire_and_forget"
 


### PR DESCRIPTION
## Summary
- budget benchmark recurrence boss-loop ticks for the full initial-plus-repair envelope per open corpus issue
- keep incomplete corpus metrics fail-closed, but avoid starving later open corpus issues
- update focused recurrence test expectation

## Validation
- python3 -m pytest tests/scripts/test_run_benchmark_corpus_recurrence.py -q
- python3 -m ruff check scripts/run_benchmark_corpus_recurrence.py tests/scripts/test_run_benchmark_corpus_recurrence.py
- python3 scripts/run_benchmark_corpus_recurrence.py --repo synaptent/aragora --dry-run --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD