### PR TITLE
feat(debate): wire flag-gated CruxSet emission into winner_selector

### DIFF
--- a/aragora/debate/phases/winner_selector.py
+++ b/aragora/debate/phases/winner_selector.py
@@ -386,6 +386,37 @@ class WinnerSelector:
                 )
                 logger.info("belief_cruxes_identified count=%s", len(analysis.cruxes))
 
+                # AGT-01: optionally emit a signed CruxSet alongside the legacy
+                # `cruxes` list. Dormant unless ARAGORA_CRUXSET_EMISSION_ENABLED
+                # is set; the emitter swallows its own errors so a CruxSet
+                # build failure cannot crash the debate.
+                try:
+                    from aragora.reasoning.cruxset_emission import maybe_emit_cruxset
+
+                    question_text = ""
+                    debate_id = ""
+                    env = getattr(ctx, "env", None)
+                    if env is not None:
+                        question_text = str(getattr(env, "task", "") or "")
+                    debate_id = str(getattr(ctx, "debate_id", "") or "")
+
+                    if question_text:
+                        cruxset = maybe_emit_cruxset(
+                            question=question_text,
+                            analysis_payload=analysis.to_dict(),
+                            decision=str(getattr(result, "winner", "") or "") or None,
+                            provenance={"debate_id": debate_id} if debate_id else None,
+                        )
+                        if cruxset is not None:
+                            setattr(result, "cruxset", cruxset.to_json())
+                            logger.info(
+                                "cruxset_emitted cruxset_id=%s cruxes=%d",
+                                cruxset.cruxset_id,
+                                len(cruxset.cruxes),
+                            )
+                except (RuntimeError, AttributeError, ImportError, ValueError) as exc:  # noqa: BLE001
+                    logger.debug("CruxSet emission skipped: %s", exc)
+
         except (RuntimeError, AttributeError, ImportError) as e:  # noqa: BLE001
             logger.debug("Belief network analysis failed: %s", e)
 

--- a/tests/debate/phases/test_winner_selector.py
+++ b/tests/debate/phases/test_winner_selector.py
@@ -789,3 +789,117 @@ class TestAnalyzeBeliefNetwork:
         with patch.dict("sys.modules", {"aragora.reasoning.crux_detector": mock_crux_module}):
             # Should not raise
             selector.analyze_belief_network(ctx)
+
+
+# ===========================================================================
+# AGT-01: CruxSet emission alongside legacy cruxes
+# ===========================================================================
+
+
+def _patch_crux_module_for_cruxset(monkeypatch, crux_score: float = 0.85):
+    """Install a mocked CruxDetector that returns a JSON-able analysis payload."""
+    payload = {
+        "cruxes": [
+            {
+                "claim_id": "msg_0_agent_a",
+                "statement": "key disagreement",
+                "author": "agent_a",
+                "crux_score": crux_score,
+                "contesting_agents": ["agent_b"],
+                "resolution_impact": 0.4,
+            }
+        ],
+        "average_uncertainty": 0.5,
+        "convergence_barrier": 0.3,
+        "recommended_focus": ["msg_0_agent_a"],
+    }
+
+    real_crux = MagicMock()
+    real_crux.statement = "key disagreement"
+    real_crux.crux_score = crux_score
+    real_crux.contesting_agents = ["agent_b"]
+
+    real_analysis = MagicMock()
+    real_analysis.cruxes = [real_crux]
+    real_analysis.to_dict.return_value = payload
+
+    detector = MagicMock()
+    detector.detect_cruxes.return_value = real_analysis
+
+    crux_module = MagicMock(CruxDetector=MagicMock(return_value=detector))
+    monkeypatch.setitem(__import__("sys").modules, "aragora.reasoning.crux_detector", crux_module)
+    return crux_module, payload
+
+
+class TestCruxSetEmission:
+    """Tests for the AGT-01 CruxSet emission seam wired in winner_selector."""
+
+    def test_no_cruxset_attribute_when_flag_off(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_CRUXSET_EMISSION_ENABLED", raising=False)
+        _patch_crux_module_for_cruxset(monkeypatch)
+
+        mock_bn_cls = MagicMock(return_value=MagicMock())
+        selector = _make_selector(
+            get_belief_analyzer=MagicMock(return_value=(mock_bn_cls, MagicMock()))
+        )
+        ctx = _make_ctx(messages=[FakeMessage("proposer", "agent_a", "claim")])
+        selector.analyze_belief_network(ctx)
+
+        # Legacy `cruxes` is still set
+        assert hasattr(ctx.result, "cruxes")
+        # CruxSet is NOT emitted when the flag is off
+        assert not hasattr(ctx.result, "cruxset")
+
+    def test_cruxset_emitted_when_flag_on(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_CRUXSET_EMISSION_ENABLED", "1")
+        _patch_crux_module_for_cruxset(monkeypatch)
+
+        mock_bn_cls = MagicMock(return_value=MagicMock())
+        selector = _make_selector(
+            get_belief_analyzer=MagicMock(return_value=(mock_bn_cls, MagicMock()))
+        )
+        result = FakeResult(winner="agent_a")
+        result.messages = [FakeMessage("proposer", "agent_a", "claim")]
+        ctx = FakeCtx(result=result)
+        selector.analyze_belief_network(ctx)
+
+        # Both legacy cruxes and the new CruxSet are present
+        assert hasattr(ctx.result, "cruxes")
+        assert hasattr(ctx.result, "cruxset")
+        cruxset_payload = ctx.result.cruxset
+        assert isinstance(cruxset_payload, dict)
+        assert cruxset_payload["question"] == "Design a rate limiter"
+        assert cruxset_payload["decision"] == "agent_a"
+        assert cruxset_payload["schema_version"] == "1.0"
+        assert len(cruxset_payload["cruxes"]) == 1
+        # Checksum must be present and verifiable round-trip
+        assert cruxset_payload["checksum"]
+        from aragora.reasoning.cruxset import CruxSet
+
+        assert CruxSet.from_json(cruxset_payload).verify_checksum()
+
+    def test_cruxset_emission_failure_swallowed(self, monkeypatch):
+        """If the emitter raises, the debate path must not crash and cruxes stays set."""
+        monkeypatch.setenv("ARAGORA_CRUXSET_EMISSION_ENABLED", "1")
+        _patch_crux_module_for_cruxset(monkeypatch)
+
+        # Patch maybe_emit_cruxset itself to raise
+        from aragora.reasoning import cruxset_emission
+
+        def _boom(**kwargs):
+            raise RuntimeError("emitter exploded")
+
+        monkeypatch.setattr(cruxset_emission, "maybe_emit_cruxset", _boom)
+
+        mock_bn_cls = MagicMock(return_value=MagicMock())
+        selector = _make_selector(
+            get_belief_analyzer=MagicMock(return_value=(mock_bn_cls, MagicMock()))
+        )
+        result = FakeResult()
+        result.messages = [FakeMessage("proposer", "agent_a", "claim")]
+        ctx = FakeCtx(result=result)
+        # Must not raise
+        selector.analyze_belief_network(ctx)
+        # Legacy cruxes still set; cruxset attribute absent
+        assert hasattr(ctx.result, "cruxes")
+        assert not hasattr(ctx.result, "cruxset")


### PR DESCRIPTION
## Summary

- Converts the dormant AGT-01 CruxSet contract into actual usage on the production debate path.
- In `WinnerSelector.analyze_belief_network()`, after the existing CruxDetector analysis succeeds, we now additionally call `maybe_emit_cruxset()`. When `ARAGORA_CRUXSET_EMISSION_ENABLED` is set, the resulting CruxSet (as JSON) is attached to `result.cruxset` alongside the legacy `result.cruxes` list.
- **Default OFF**: zero behavior change. 46 existing winner_selector tests still pass. 3 new tests cover flag-on / flag-off / emitter-failure paths.

## Behavior matrix

| Flag state | `result.cruxes` | `result.cruxset` |
|---|---|---|
| Unset / 0 / false (default) | set (legacy) | absent |
| 1 / true / yes / on | set (legacy) | **set** — signed CruxSet.to_json() |
| Emitter crashes | set (legacy) | absent (error swallowed) |

## Why this matters

AGT-01 contract landed in PR #6084; this PR makes it *live* (under flag). When an operator or CI sets `ARAGORA_CRUXSET_EMISSION_ENABLED=1`, every debate with belief-analysis-identified cruxes now produces a content-addressed, SHA-256-signed CruxSet that:

- AGT-05 (#6066) can ingest as a `StakeableClaim` of domain `crux_resolution`
- AGT-02 consumer surface (#6088) can embed in an `AgentReceipt` `cruxset` field
- DIC-16 (#6026) can persist through the receipt path

## Test plan

- [x] 3 new tests in `TestCruxSetEmission`: flag-off absence, flag-on presence with correct schema + verifiable checksum, emitter-failure swallowed without crashing debate
- [x] 46 existing winner_selector tests pass unchanged
- [x] Reuses `analysis.to_dict()` — CruxDetector is NOT invoked twice per debate
- [x] Error handling is scoped: CruxSet emission failures cannot crash belief analysis, which itself cannot crash the debate

## What this PR does NOT do

- No schema or signature change to `result.cruxes` (legacy consumers unaffected)
- No on-chain anchoring (AGT-05 / DIC-16 territory)
- No flag enabled anywhere in CI or production
- No server endpoints exposing CruxSet to A2A consumers (future follow-up)

## Refs

- AGT-01: #6062 | AGT epic: #6068 | DIC-15: #6025 | Vision: #6061
- Sibling AGT PRs (all merged): #6080 substrate, #6082 markets, #6084 cruxset contract, #6086 VIAH, #6088 receipts

🤖 Generated with [Claude Code](https://claude.com/claude-code)