### PR TITLE
feat(reputation): AGT-05 stub — claim/stake/resolution/delta flow

### DIFF
--- a/aragora/reputation/__init__.py
+++ b/aragora/reputation/__init__.py
@@ -1,0 +1,60 @@
+"""AGT-05 reputation flow — claim → stake → resolution → delta.
+
+This package is the in-memory Python layer of the AGT-05 spec in
+``docs/plans/SKIN_IN_THE_GAME_REPUTATION.md``. It unifies the AGT-04
+synthetic-market resolution stream and (in a later PR) the AGT-01
+CruxSet resolution stream into a single shape — :class:`StakeableClaim`
+plus :class:`ResolvedClaim` — from which :func:`settle_claim` computes
+a :class:`ReputationDelta` using a proper scoring rule.
+
+The on-chain anchoring via
+:class:`aragora.blockchain.contracts.reputation.ReputationRegistry`
+lives in a downstream PR. This package computes deltas in memory and
+leaves the registry write to callers, so the flow can be tested and
+validated before touching chain state.
+
+Feature flag: ``ARAGORA_REPUTATION_FLOW_ENABLED``. Dormant by default.
+"""
+
+from __future__ import annotations
+
+import os
+
+from aragora.reputation.bridge import bridge_from_market_position
+from aragora.reputation.settlement import settle_claim
+from aragora.reputation.types import (
+    DOMAIN_CODE_PR,
+    DOMAIN_CRUX_RESOLUTION,
+    DOMAIN_DEBATE_POSITION,
+    DOMAIN_KM_CONTRIBUTION,
+    DOMAIN_PREDICTION_MARKET,
+    ReputationDelta,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+__all__ = [
+    "DOMAIN_CODE_PR",
+    "DOMAIN_CRUX_RESOLUTION",
+    "DOMAIN_DEBATE_POSITION",
+    "DOMAIN_KM_CONTRIBUTION",
+    "DOMAIN_PREDICTION_MARKET",
+    "ReputationDelta",
+    "ResolvedClaim",
+    "StakeableClaim",
+    "bridge_from_market_position",
+    "enable_reputation_flow",
+    "reputation_flow_enabled",
+    "settle_claim",
+]
+
+
+def reputation_flow_enabled() -> bool:
+    """Return True if the AGT-05 reputation flow is enabled."""
+    raw = str(os.environ.get("ARAGORA_REPUTATION_FLOW_ENABLED") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_reputation_flow() -> None:
+    """Enable the AGT-05 reputation flow for the current process."""
+    os.environ["ARAGORA_REPUTATION_FLOW_ENABLED"] = "1"

--- a/aragora/reputation/bridge.py
+++ b/aragora/reputation/bridge.py
@@ -1,0 +1,97 @@
+"""Bridges from AGT-04 market events to AGT-05 reputation types.
+
+This module converts a (:class:`aragora.markets.MarketPosition`,
+:class:`aragora.markets.Market`, :class:`aragora.markets.ResolutionEvent`)
+tuple — the shape AGT-04 produces when a synthetic GitHub market
+resolves — into the unified AGT-05 (:class:`StakeableClaim`,
+:class:`ResolvedClaim`) pair that the settlement function consumes.
+
+The CruxSet bridge lives in a follow-up PR once DIC-17 (failed-claim /
+open-crux → bounded follow-up) is wired.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aragora.reputation.types import (
+    DOMAIN_PREDICTION_MARKET,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+if TYPE_CHECKING:
+    from aragora.markets.types import (
+        Market,
+        MarketPosition,
+        ResolutionEvent,
+    )
+
+
+def bridge_from_market_position(
+    position: "MarketPosition",
+    market: "Market",
+    resolution: "ResolutionEvent",
+    *,
+    resolution_source: str = "synthetic_github",
+) -> tuple[StakeableClaim, ResolvedClaim]:
+    """Convert an AGT-04 market position + resolution to AGT-05 claim + resolved.
+
+    The returned tuple feeds directly into
+    :func:`aragora.reputation.settlement.settle_claim`.
+
+    Mapping choices:
+
+    - ``domain`` is always ``DOMAIN_PREDICTION_MARKET`` — even for
+      synthetic GitHub markets, the structure is identical to external
+      prediction markets (probability-over-binary-outcome).
+    - ``position`` is ``"yes"`` if ``predicted_probability >= 0.5``
+      else ``"no"``. This lets binary scoring work too if a caller
+      prefers that rule.
+    - ``predicted_probability`` is carried through for Brier scoring.
+    - ``resolution_id`` is the market_id (stable across runs because
+      markets are content-addressed).
+    - ``provenance`` carries the market target (repo, number/ref),
+      position_id, and market_id so operators can audit the path.
+    """
+    if position.market_id != market.market_id:
+        raise ValueError(
+            f"market_id mismatch: position={position.market_id!r} vs market={market.market_id!r}"
+        )
+    if resolution.market_id != market.market_id:
+        raise ValueError(
+            f"market_id mismatch: resolution={resolution.market_id!r} vs market={market.market_id!r}"
+        )
+
+    derived_position = "yes" if position.probability >= 0.5 else "no"
+    claim = StakeableClaim.create(
+        agent_id=position.agent_id,
+        domain=DOMAIN_PREDICTION_MARKET,
+        statement=market.description or market.market_id,
+        position=derived_position,
+        predicted_probability=position.probability,
+        stake_units=position.stake,
+        stake_policy="forfeit_on_loss",
+        resolution_source=resolution_source,
+        resolution_id=market.market_id,
+        provenance={
+            "market_id": market.market_id,
+            "position_id": position.position_id,
+            "question_kind": market.question_kind,
+            "target": dict(market.target),
+            "submitted_at": position.submitted_at,
+        },
+        created_at=position.submitted_at,
+    )
+
+    resolved = ResolvedClaim(
+        claim_id=claim.claim_id,
+        outcome=resolution.outcome,
+        resolved_at=resolution.resolved_at,
+        resolution_source=resolution.resolution_source,
+        evidence=dict(resolution.evidence),
+    )
+    return claim, resolved
+
+
+__all__ = ["bridge_from_market_position"]

--- a/aragora/reputation/settlement.py
+++ b/aragora/reputation/settlement.py
@@ -1,0 +1,115 @@
+"""AGT-05 settlement — compute ReputationDelta from StakeableClaim + ResolvedClaim.
+
+The two scoring rules implemented here match the AGT-05 spec in
+``docs/plans/SKIN_IN_THE_GAME_REPUTATION.md``:
+
+- ``brier_proper`` — incentive-compatible for probabilistic claims.
+  ``delta = stake * (1 - 2 * brier)`` where
+  ``brier = (predicted_probability - realized) ** 2``. A perfectly
+  calibrated 0/1 prediction returns +stake; a maximally wrong one
+  returns -stake; the symmetric break-even point is a prediction of
+  0.5, which returns half of the stake.
+- ``binary`` — for domains where a probability is not reported and
+  a typed ``position`` is compared to the outcome. Returns +stake if
+  correct, -stake if wrong.
+
+Inconclusive and invalid outcomes always return zero delta: under
+``refund_on_inconclusive`` semantics the stake is returned; under
+``forfeit_on_loss`` the caller may separately decide to forfeit.
+This module only computes the delta.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from typing import Any
+
+from aragora.reputation.types import (
+    ReputationDelta,
+    ResolvedClaim,
+    ScoringRule,
+    StakeableClaim,
+)
+
+
+class SettlementError(RuntimeError):
+    """Raised when a settlement cannot be computed."""
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _delta_id(agent_id: str, domain: str, claim_id: str, resolution_id: str) -> str:
+    material = f"{agent_id}|{domain}|{claim_id}|{resolution_id}"
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
+    return f"rep_{digest}"
+
+
+def settle_claim(
+    claim: StakeableClaim,
+    resolved: ResolvedClaim,
+    *,
+    scoring_rule: ScoringRule = "brier_proper",
+    decay_half_life_days: float | None = 30.0,
+    applied_at: str | None = None,
+) -> ReputationDelta:
+    """Compute the reputation delta for a resolved claim.
+
+    Raises :class:`SettlementError` if the claim and resolution do not
+    refer to the same ``claim_id``, or if the scoring rule is not
+    supported for the given claim shape.
+    """
+    if claim.claim_id != resolved.claim_id:
+        raise SettlementError(
+            f"claim_id mismatch: claim={claim.claim_id!r} vs resolved={resolved.claim_id!r}"
+        )
+
+    reason: dict[str, Any] = {
+        "claim_id": claim.claim_id,
+        "resolution_id": claim.resolution_id,
+        "resolution_source": claim.resolution_source,
+        "scoring_rule": scoring_rule,
+        "outcome": resolved.outcome,
+        "stake_units": claim.stake_units,
+    }
+
+    if resolved.outcome in {"inconclusive", "invalid"}:
+        delta = 0.0
+    elif scoring_rule == "brier_proper":
+        if claim.predicted_probability is None:
+            raise SettlementError("brier_proper requires predicted_probability on the claim")
+        realized = 1.0 if resolved.outcome == "yes" else 0.0
+        brier = (claim.predicted_probability - realized) ** 2
+        # Symmetric payout around break-even at Brier=0.5
+        payout_fraction = 1.0 - 2.0 * brier
+        delta = payout_fraction * float(claim.stake_units)
+        reason["brier"] = brier
+        reason["payout_fraction"] = payout_fraction
+    elif scoring_rule == "binary":
+        correct = (
+            (resolved.outcome == "yes" and claim.position == "yes")
+            or (resolved.outcome == "no" and claim.position == "no")
+            or (resolved.outcome == claim.position)
+        )
+        delta = float(claim.stake_units) * (1.0 if correct else -1.0)
+        reason["correct"] = correct
+    else:  # pragma: no cover - exhaustiveness
+        raise SettlementError(f"unsupported scoring rule: {scoring_rule!r}")
+
+    return ReputationDelta(
+        delta_id=_delta_id(claim.agent_id, claim.domain, claim.claim_id, claim.resolution_id),
+        agent_id=claim.agent_id,
+        domain=claim.domain,
+        claim_id=claim.claim_id,
+        resolution_id=claim.resolution_id,
+        delta=delta,
+        scoring_rule=scoring_rule,
+        applied_at=applied_at or _utc_now_iso(),
+        decay_half_life_days=decay_half_life_days,
+        reason=reason,
+    )
+
+
+__all__ = ["SettlementError", "settle_claim"]

--- a/aragora/reputation/types.py
+++ b/aragora/reputation/types.py
@@ -1,0 +1,287 @@
+"""Core AGT-05 reputation-flow types.
+
+Normalized shapes for claims, resolutions, and reputation deltas that
+work across domains (prediction markets, debate positions, code PRs,
+KM contributions, crux resolutions). These types are the in-memory
+layer; on-chain anchoring via
+``aragora.blockchain.contracts.reputation.ReputationRegistry`` is
+deferred.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+# Canonical domain names — matches the AGT-05 spec in
+# docs/plans/SKIN_IN_THE_GAME_REPUTATION.md
+DOMAIN_PREDICTION_MARKET = "prediction_market"
+DOMAIN_DEBATE_POSITION = "debate_position"
+DOMAIN_CODE_PR = "code_pr"
+DOMAIN_KM_CONTRIBUTION = "km_contribution"
+DOMAIN_CRUX_RESOLUTION = "crux_resolution"
+
+KNOWN_DOMAINS = frozenset(
+    {
+        DOMAIN_PREDICTION_MARKET,
+        DOMAIN_DEBATE_POSITION,
+        DOMAIN_CODE_PR,
+        DOMAIN_KM_CONTRIBUTION,
+        DOMAIN_CRUX_RESOLUTION,
+    }
+)
+
+StakePolicy = Literal["forfeit_on_loss", "scaled", "refund_on_inconclusive"]
+ClaimOutcome = Literal["yes", "no", "inconclusive", "invalid"]
+ScoringRule = Literal["brier_proper", "binary"]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _content_id(prefix: str, material: dict[str, Any]) -> str:
+    canonical = json.dumps(material, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}_{digest}"
+
+
+@dataclass(frozen=True)
+class StakeableClaim:
+    """A claim the agent has committed compute-credit stake to.
+
+    - ``claim_id``: content-addressed from agent + domain + statement + resolution_source
+    - ``predicted_probability`` is meaningful only for probabilistic
+      claims; binary stances set it to None and rely on ``position``.
+    """
+
+    claim_id: str
+    agent_id: str
+    domain: str
+    statement: str
+    position: str
+    predicted_probability: float | None
+    stake_units: int
+    stake_policy: StakePolicy
+    resolution_source: str
+    resolution_id: str
+    provenance: dict[str, Any]
+    created_at: str
+
+    def __post_init__(self) -> None:
+        if self.domain not in KNOWN_DOMAINS:
+            raise ValueError(
+                f"unknown domain: {self.domain!r}; expected one of {sorted(KNOWN_DOMAINS)}"
+            )
+        if not str(self.agent_id).strip():
+            raise ValueError("agent_id must be non-empty")
+        if not str(self.statement).strip():
+            raise ValueError("statement must be non-empty")
+        if not str(self.position).strip():
+            raise ValueError("position must be non-empty")
+        if self.stake_units < 1:
+            raise ValueError("stake_units must be >= 1")
+        if self.predicted_probability is not None:
+            if not (0.0 <= self.predicted_probability <= 1.0):
+                raise ValueError("predicted_probability must be in [0, 1] when provided")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        agent_id: str,
+        domain: str,
+        statement: str,
+        position: str,
+        stake_units: int,
+        resolution_source: str,
+        resolution_id: str,
+        predicted_probability: float | None = None,
+        stake_policy: StakePolicy = "forfeit_on_loss",
+        provenance: dict[str, Any] | None = None,
+        created_at: str | None = None,
+    ) -> "StakeableClaim":
+        provenance_dict = dict(provenance or {})
+        timestamp = created_at or _utc_now_iso()
+        claim_id = _content_id(
+            "clm",
+            {
+                "agent_id": agent_id,
+                "domain": domain,
+                "statement": statement,
+                "position": position,
+                "resolution_source": resolution_source,
+                "resolution_id": resolution_id,
+            },
+        )
+        return cls(
+            claim_id=claim_id,
+            agent_id=agent_id,
+            domain=domain,
+            statement=statement,
+            position=position,
+            predicted_probability=(
+                float(predicted_probability) if predicted_probability is not None else None
+            ),
+            stake_units=int(stake_units),
+            stake_policy=stake_policy,
+            resolution_source=resolution_source,
+            resolution_id=resolution_id,
+            provenance=provenance_dict,
+            created_at=timestamp,
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            "agent_id": self.agent_id,
+            "domain": self.domain,
+            "statement": self.statement,
+            "position": self.position,
+            "predicted_probability": self.predicted_probability,
+            "stake_units": self.stake_units,
+            "stake_policy": self.stake_policy,
+            "resolution_source": self.resolution_source,
+            "resolution_id": self.resolution_id,
+            "provenance": self.provenance,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "StakeableClaim":
+        return cls(
+            claim_id=str(data["claim_id"]),
+            agent_id=str(data["agent_id"]),
+            domain=str(data["domain"]),
+            statement=str(data["statement"]),
+            position=str(data["position"]),
+            predicted_probability=(
+                float(data["predicted_probability"])
+                if data.get("predicted_probability") is not None
+                else None
+            ),
+            stake_units=int(data["stake_units"]),
+            stake_policy=data.get("stake_policy") or "forfeit_on_loss",
+            resolution_source=str(data["resolution_source"]),
+            resolution_id=str(data["resolution_id"]),
+            provenance=dict(data.get("provenance") or {}),
+            created_at=str(data["created_at"]),
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedClaim:
+    """A claim's resolution event — what actually happened.
+
+    ``outcome`` is the unified ternary shape used across domains;
+    ``evidence`` carries the raw payload that decided the outcome
+    (GitHub state for markets, verifier result for cruxes, etc.).
+    """
+
+    claim_id: str
+    outcome: ClaimOutcome
+    resolved_at: str
+    resolution_source: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.outcome not in {"yes", "no", "inconclusive", "invalid"}:
+            raise ValueError(f"unsupported outcome: {self.outcome!r}")
+        if not str(self.claim_id).strip():
+            raise ValueError("claim_id must be non-empty")
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            "outcome": self.outcome,
+            "resolved_at": self.resolved_at,
+            "resolution_source": self.resolution_source,
+            "evidence": dict(self.evidence),
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "ResolvedClaim":
+        return cls(
+            claim_id=str(data["claim_id"]),
+            outcome=data["outcome"],
+            resolved_at=str(data["resolved_at"]),
+            resolution_source=str(data["resolution_source"]),
+            evidence=dict(data.get("evidence") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class ReputationDelta:
+    """The computed reputation change for one resolved claim.
+
+    - ``delta`` is signed and stake-weighted, typically in the range
+      ``[-stake_units, +stake_units]`` for proper Brier and ``±stake_units``
+      for binary scoring.
+    - ``decay_half_life_days`` is forward-compatible with the AGT-05
+      90-day rolling window spec; consumers apply the decay on read.
+    - ``reason`` carries the full settlement provenance so the delta
+      can be verified or re-opened later.
+    """
+
+    delta_id: str
+    agent_id: str
+    domain: str
+    claim_id: str
+    resolution_id: str
+    delta: float
+    scoring_rule: ScoringRule
+    applied_at: str
+    decay_half_life_days: float | None
+    reason: dict[str, Any]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "delta_id": self.delta_id,
+            "agent_id": self.agent_id,
+            "domain": self.domain,
+            "claim_id": self.claim_id,
+            "resolution_id": self.resolution_id,
+            "delta": round(self.delta, 6),
+            "scoring_rule": self.scoring_rule,
+            "applied_at": self.applied_at,
+            "decay_half_life_days": self.decay_half_life_days,
+            "reason": dict(self.reason),
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "ReputationDelta":
+        return cls(
+            delta_id=str(data["delta_id"]),
+            agent_id=str(data["agent_id"]),
+            domain=str(data["domain"]),
+            claim_id=str(data["claim_id"]),
+            resolution_id=str(data["resolution_id"]),
+            delta=float(data["delta"]),
+            scoring_rule=data["scoring_rule"],
+            applied_at=str(data["applied_at"]),
+            decay_half_life_days=(
+                float(data["decay_half_life_days"])
+                if data.get("decay_half_life_days") is not None
+                else None
+            ),
+            reason=dict(data.get("reason") or {}),
+        )
+
+
+__all__ = [
+    "DOMAIN_CODE_PR",
+    "DOMAIN_CRUX_RESOLUTION",
+    "DOMAIN_DEBATE_POSITION",
+    "DOMAIN_KM_CONTRIBUTION",
+    "DOMAIN_PREDICTION_MARKET",
+    "KNOWN_DOMAINS",
+    "ClaimOutcome",
+    "ReputationDelta",
+    "ResolvedClaim",
+    "ScoringRule",
+    "StakePolicy",
+    "StakeableClaim",
+]

--- a/tests/reputation/test_bridge.py
+++ b/tests/reputation/test_bridge.py
@@ -1,0 +1,127 @@
+"""Tests for aragora.reputation.bridge — AGT-04 → AGT-05 conversion."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from aragora.markets.types import Market, MarketPosition, ResolutionEvent as MarketResolution
+from aragora.reputation.bridge import bridge_from_market_position
+from aragora.reputation.settlement import settle_claim
+from aragora.reputation.types import DOMAIN_PREDICTION_MARKET
+
+
+def _market_position_resolution(
+    *,
+    probability: float = 0.7,
+    stake: int = 40,
+    outcome: str = "yes",
+) -> tuple[Market, MarketPosition, MarketResolution]:
+    market = Market.create(
+        question_kind="pr_merge",
+        target={"repo": "synaptent/aragora", "number": 5959},
+        description="will #5959 merge",
+        resolution_window_days=7,
+        created_at=datetime(2026, 4, 10, tzinfo=UTC),
+    )
+    position = MarketPosition.create(
+        market_id=market.market_id,
+        agent_id="alice",
+        probability=probability,
+        stake=stake,
+        submitted_at=datetime(2026, 4, 11, tzinfo=UTC),
+    )
+    resolution = (
+        MarketResolution.yes(
+            market_id=market.market_id,
+            resolution_source="github_pr_state",
+            resolved_at=datetime(2026, 4, 17, tzinfo=UTC),
+            evidence={"merged": True},
+        )
+        if outcome == "yes"
+        else MarketResolution.no(
+            market_id=market.market_id,
+            resolution_source="github_pr_state",
+            resolved_at=datetime(2026, 4, 17, tzinfo=UTC),
+            evidence={"merged": False},
+        )
+        if outcome == "no"
+        else MarketResolution.inconclusive(
+            market_id=market.market_id,
+            resolution_source="github_pr_state",
+            resolved_at=datetime(2026, 4, 17, tzinfo=UTC),
+            evidence={"state": "OPEN"},
+        )
+    )
+    return market, position, resolution
+
+
+class TestBridgeFromMarketPosition:
+    def test_produces_prediction_market_claim(self) -> None:
+        market, position, resolution = _market_position_resolution()
+        claim, resolved = bridge_from_market_position(position, market, resolution)
+        assert claim.domain == DOMAIN_PREDICTION_MARKET
+        assert claim.agent_id == "alice"
+        assert claim.predicted_probability == pytest.approx(0.7)
+        assert claim.stake_units == 40
+        assert claim.resolution_id == market.market_id
+        assert claim.position == "yes"  # probability >= 0.5
+
+    def test_position_below_half_maps_to_no(self) -> None:
+        market, position, resolution = _market_position_resolution(probability=0.3)
+        claim, _ = bridge_from_market_position(position, market, resolution)
+        assert claim.position == "no"
+
+    def test_provenance_carries_market_context(self) -> None:
+        market, position, resolution = _market_position_resolution()
+        claim, _ = bridge_from_market_position(position, market, resolution)
+        assert claim.provenance["market_id"] == market.market_id
+        assert claim.provenance["position_id"] == position.position_id
+        assert claim.provenance["question_kind"] == "pr_merge"
+        assert claim.provenance["target"]["repo"] == "synaptent/aragora"
+
+    def test_resolved_claim_carries_outcome_and_evidence(self) -> None:
+        market, position, resolution = _market_position_resolution(outcome="yes")
+        claim, resolved = bridge_from_market_position(position, market, resolution)
+        assert resolved.claim_id == claim.claim_id
+        assert resolved.outcome == "yes"
+        assert resolved.evidence["merged"] is True
+
+    def test_market_id_mismatch_raises(self) -> None:
+        market, position, resolution = _market_position_resolution()
+        # Construct a divergent resolution
+        bad_resolution = MarketResolution.yes(
+            market_id="mkt_other",
+            resolution_source="github_pr_state",
+            resolved_at=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+        with pytest.raises(ValueError):
+            bridge_from_market_position(position, market, bad_resolution)
+
+
+class TestEndToEndFlow:
+    def test_market_win_via_brier_proper_returns_positive_delta(self) -> None:
+        # Probability 0.9 on YES, outcome YES → Brier=0.01, +48 expected
+        market, position, resolution = _market_position_resolution(
+            probability=0.9, stake=50, outcome="yes"
+        )
+        claim, resolved = bridge_from_market_position(position, market, resolution)
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        assert delta.delta == pytest.approx(49.0)  # (1 - 2*0.01) * 50
+        assert delta.domain == DOMAIN_PREDICTION_MARKET
+
+    def test_market_loss_returns_negative_delta(self) -> None:
+        # Probability 0.9 on YES, outcome NO → Brier=0.81, -31 expected (rounded)
+        market, position, resolution = _market_position_resolution(
+            probability=0.9, stake=50, outcome="no"
+        )
+        claim, resolved = bridge_from_market_position(position, market, resolution)
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        assert delta.delta == pytest.approx(-31.0)  # (1 - 2*0.81) * 50
+
+    def test_inconclusive_market_returns_zero_delta(self) -> None:
+        market, position, resolution = _market_position_resolution(outcome="inconclusive")
+        claim, resolved = bridge_from_market_position(position, market, resolution)
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        assert delta.delta == 0.0

--- a/tests/reputation/test_init.py
+++ b/tests/reputation/test_init.py
@@ -1,0 +1,49 @@
+"""Tests for the aragora.reputation package entry point and feature flag."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from aragora import reputation
+
+
+def test_feature_flag_default_off(monkeypatch) -> None:
+    monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+    assert reputation.reputation_flow_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE"])
+def test_truthy_values_enable_flow(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", value)
+    assert reputation.reputation_flow_enabled() is True
+
+
+def test_enable_helper_flips_flag(monkeypatch) -> None:
+    monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+    assert reputation.reputation_flow_enabled() is False
+    reputation.enable_reputation_flow()
+    try:
+        assert reputation.reputation_flow_enabled() is True
+    finally:
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+
+
+def test_public_exports_present() -> None:
+    expected = {
+        "StakeableClaim",
+        "ResolvedClaim",
+        "ReputationDelta",
+        "settle_claim",
+        "bridge_from_market_position",
+        "DOMAIN_PREDICTION_MARKET",
+        "reputation_flow_enabled",
+        "enable_reputation_flow",
+    }
+    missing = expected - set(reputation.__all__)
+    assert not missing, f"missing public exports: {missing}"
+
+
+def test_module_reimports_cleanly() -> None:
+    importlib.reload(reputation)

--- a/tests/reputation/test_settlement.py
+++ b/tests/reputation/test_settlement.py
@@ -1,0 +1,131 @@
+"""Tests for aragora.reputation.settlement."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.reputation.settlement import SettlementError, settle_claim
+from aragora.reputation.types import (
+    DOMAIN_DEBATE_POSITION,
+    DOMAIN_PREDICTION_MARKET,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+
+def _claim(
+    *,
+    probability: float | None = 0.7,
+    position: str = "yes",
+    stake: int = 50,
+    domain: str = DOMAIN_PREDICTION_MARKET,
+) -> StakeableClaim:
+    return StakeableClaim.create(
+        agent_id="alice",
+        domain=domain,
+        statement="X will happen",
+        position=position,
+        stake_units=stake,
+        resolution_source="synthetic_github",
+        resolution_id="mkt_x",
+        predicted_probability=probability,
+    )
+
+
+def _resolved(claim: StakeableClaim, outcome: str) -> ResolvedClaim:
+    return ResolvedClaim(
+        claim_id=claim.claim_id,
+        outcome=outcome,  # type: ignore[arg-type]
+        resolved_at="2026-04-24T12:00:00Z",
+        resolution_source="synthetic_github",
+    )
+
+
+class TestBrierProper:
+    def test_perfect_prediction_returns_plus_stake(self) -> None:
+        claim = _claim(probability=1.0, stake=50)
+        resolved = _resolved(claim, "yes")
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        assert delta.delta == pytest.approx(50.0)
+        assert delta.scoring_rule == "brier_proper"
+        assert delta.reason["brier"] == pytest.approx(0.0)
+
+    def test_maximally_wrong_returns_minus_stake(self) -> None:
+        claim = _claim(probability=0.0, stake=50)
+        resolved = _resolved(claim, "yes")
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        assert delta.delta == pytest.approx(-50.0)
+
+    def test_calibrated_prior_breaks_even_at_half_stake(self) -> None:
+        claim = _claim(probability=0.5, stake=50)
+        resolved = _resolved(claim, "yes")
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        # Brier=0.25 → fraction=0.5 → delta=25
+        assert delta.delta == pytest.approx(25.0)
+
+    def test_requires_probability(self) -> None:
+        claim = _claim(probability=None, position="yes")
+        resolved = _resolved(claim, "yes")
+        with pytest.raises(SettlementError):
+            settle_claim(claim, resolved, scoring_rule="brier_proper")
+
+
+class TestBinary:
+    def test_correct_binary_position_returns_plus_stake(self) -> None:
+        claim = _claim(probability=None, position="yes", domain=DOMAIN_DEBATE_POSITION)
+        resolved = _resolved(claim, "yes")
+        delta = settle_claim(claim, resolved, scoring_rule="binary")
+        assert delta.delta == pytest.approx(50.0)
+        assert delta.reason["correct"] is True
+
+    def test_wrong_binary_position_returns_minus_stake(self) -> None:
+        claim = _claim(probability=None, position="no", domain=DOMAIN_DEBATE_POSITION)
+        resolved = _resolved(claim, "yes")
+        delta = settle_claim(claim, resolved, scoring_rule="binary")
+        assert delta.delta == pytest.approx(-50.0)
+        assert delta.reason["correct"] is False
+
+
+class TestInconclusive:
+    def test_inconclusive_outcome_zero_delta(self) -> None:
+        claim = _claim(probability=0.7, stake=50)
+        resolved = _resolved(claim, "inconclusive")
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        assert delta.delta == 0.0
+
+    def test_invalid_outcome_zero_delta(self) -> None:
+        claim = _claim(probability=0.7, stake=50)
+        resolved = _resolved(claim, "invalid")
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        assert delta.delta == 0.0
+
+
+class TestMismatch:
+    def test_claim_id_mismatch_raises(self) -> None:
+        claim = _claim()
+        resolved = ResolvedClaim(
+            claim_id="clm_other",
+            outcome="yes",
+            resolved_at="2026-04-24T12:00:00Z",
+            resolution_source="x",
+        )
+        with pytest.raises(SettlementError):
+            settle_claim(claim, resolved, scoring_rule="brier_proper")
+
+
+class TestDeltaProvenance:
+    def test_delta_id_is_deterministic(self) -> None:
+        claim = _claim(probability=0.7)
+        resolved = _resolved(claim, "yes")
+        a = settle_claim(claim, resolved)
+        b = settle_claim(claim, resolved)
+        assert a.delta_id == b.delta_id
+
+    def test_reason_carries_full_provenance(self) -> None:
+        claim = _claim(probability=0.7, stake=50)
+        resolved = _resolved(claim, "yes")
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        assert delta.reason["claim_id"] == claim.claim_id
+        assert delta.reason["resolution_id"] == claim.resolution_id
+        assert delta.reason["stake_units"] == 50
+        assert delta.reason["scoring_rule"] == "brier_proper"

--- a/tests/reputation/test_types.py
+++ b/tests/reputation/test_types.py
@@ -1,0 +1,164 @@
+"""Tests for aragora.reputation.types."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.reputation.types import (
+    DOMAIN_PREDICTION_MARKET,
+    ReputationDelta,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+
+class TestStakeableClaim:
+    def test_create_builds_valid_claim(self) -> None:
+        claim = StakeableClaim.create(
+            agent_id="alice",
+            domain=DOMAIN_PREDICTION_MARKET,
+            statement="will PR #5959 merge",
+            position="yes",
+            stake_units=50,
+            resolution_source="synthetic_github",
+            resolution_id="mkt_pr_merge_abc",
+            predicted_probability=0.72,
+        )
+        assert claim.agent_id == "alice"
+        assert claim.domain == DOMAIN_PREDICTION_MARKET
+        assert claim.predicted_probability == pytest.approx(0.72)
+        assert claim.claim_id.startswith("clm_")
+
+    def test_identical_inputs_produce_same_claim_id(self) -> None:
+        a = StakeableClaim.create(
+            agent_id="alice",
+            domain=DOMAIN_PREDICTION_MARKET,
+            statement="will PR #1 merge",
+            position="yes",
+            stake_units=10,
+            resolution_source="synthetic_github",
+            resolution_id="mkt_x",
+        )
+        b = StakeableClaim.create(
+            agent_id="alice",
+            domain=DOMAIN_PREDICTION_MARKET,
+            statement="will PR #1 merge",
+            position="yes",
+            stake_units=10,
+            resolution_source="synthetic_github",
+            resolution_id="mkt_x",
+        )
+        assert a.claim_id == b.claim_id
+
+    def test_rejects_unknown_domain(self) -> None:
+        with pytest.raises(ValueError):
+            StakeableClaim.create(
+                agent_id="alice",
+                domain="made_up_domain",
+                statement="x",
+                position="yes",
+                stake_units=10,
+                resolution_source="x",
+                resolution_id="y",
+            )
+
+    def test_rejects_invalid_probability(self) -> None:
+        with pytest.raises(ValueError):
+            StakeableClaim.create(
+                agent_id="alice",
+                domain=DOMAIN_PREDICTION_MARKET,
+                statement="x",
+                position="yes",
+                stake_units=10,
+                resolution_source="x",
+                resolution_id="y",
+                predicted_probability=1.5,
+            )
+
+    def test_rejects_non_positive_stake(self) -> None:
+        with pytest.raises(ValueError):
+            StakeableClaim.create(
+                agent_id="alice",
+                domain=DOMAIN_PREDICTION_MARKET,
+                statement="x",
+                position="yes",
+                stake_units=0,
+                resolution_source="x",
+                resolution_id="y",
+            )
+
+    def test_rejects_empty_agent_or_statement(self) -> None:
+        with pytest.raises(ValueError):
+            StakeableClaim.create(
+                agent_id=" ",
+                domain=DOMAIN_PREDICTION_MARKET,
+                statement="x",
+                position="yes",
+                stake_units=1,
+                resolution_source="x",
+                resolution_id="y",
+            )
+
+    def test_json_roundtrip(self) -> None:
+        claim = StakeableClaim.create(
+            agent_id="alice",
+            domain=DOMAIN_PREDICTION_MARKET,
+            statement="will X happen",
+            position="yes",
+            stake_units=25,
+            resolution_source="manifold",
+            resolution_id="mkt_m1",
+            predicted_probability=0.4,
+            provenance={"debate_id": "d1"},
+        )
+        rt = StakeableClaim.from_json(claim.to_json())
+        assert rt == claim
+
+
+class TestResolvedClaim:
+    def test_rejects_unknown_outcome(self) -> None:
+        with pytest.raises(ValueError):
+            ResolvedClaim(
+                claim_id="clm_x",
+                outcome="maybe",  # type: ignore[arg-type]
+                resolved_at="2026-04-17T12:00:00Z",
+                resolution_source="x",
+            )
+
+    def test_requires_claim_id(self) -> None:
+        with pytest.raises(ValueError):
+            ResolvedClaim(
+                claim_id=" ",
+                outcome="yes",
+                resolved_at="2026-04-17T12:00:00Z",
+                resolution_source="x",
+            )
+
+    def test_json_roundtrip(self) -> None:
+        resolved = ResolvedClaim(
+            claim_id="clm_x",
+            outcome="yes",
+            resolved_at="2026-04-17T12:00:00Z",
+            resolution_source="synthetic_github",
+            evidence={"state": "MERGED", "merged": True},
+        )
+        rt = ResolvedClaim.from_json(resolved.to_json())
+        assert rt == resolved
+
+
+class TestReputationDelta:
+    def test_json_roundtrip(self) -> None:
+        delta = ReputationDelta(
+            delta_id="rep_abcdef",
+            agent_id="alice",
+            domain=DOMAIN_PREDICTION_MARKET,
+            claim_id="clm_x",
+            resolution_id="mkt_x",
+            delta=12.5,
+            scoring_rule="brier_proper",
+            applied_at="2026-04-17T12:05:00Z",
+            decay_half_life_days=30.0,
+            reason={"brier": 0.09, "stake_units": 50},
+        )
+        rt = ReputationDelta.from_json(delta.to_json())
+        assert rt == delta


### PR DESCRIPTION
## Summary

- Adds `aragora/reputation/` — in-memory Python layer of the AGT-05 spec in `docs/plans/SKIN_IN_THE_GAME_REPUTATION.md`.
- Unifies AGT-04 synthetic-market events into a normalized `StakeableClaim + ResolvedClaim` shape that `settle_claim()` turns into a stake-weighted `ReputationDelta` using a proper scoring rule.
- 39 new tests pass; full markets/reasoning/reputation suites (145 tests) clean. **Zero modification** to existing `aragora/blockchain/contracts/` or any production path.

## What this gives the AGT track

The flow:
```
position+market+resolution → bridge_from_market_position() → (claim, resolved) → settle_claim() → ReputationDelta
```

This is the architectural keystone that turns AGT-04 (synthetic markets, merged) and AGT-01 (CruxSet emission, in CI) into something that actually changes agent reputation. On-chain anchoring via `aragora.blockchain.contracts.reputation.ReputationRegistry` is a downstream PR — this lands the in-memory flow first so it can be validated.

## Components

| Module | Purpose |
|---|---|
| `reputation/types.py` | `StakeableClaim` (content-addressed, domain-typed, optionally probabilistic), `ResolvedClaim`, `ReputationDelta` |
| `reputation/settlement.py` | `settle_claim()` with `brier_proper` (incentive-compatible) and `binary` rules |
| `reputation/bridge.py` | `bridge_from_market_position()` converts AGT-04 events to AGT-05 shape |
| `reputation/__init__.py` | Feature flag `ARAGORA_REPUTATION_FLOW_ENABLED` (default OFF) |

## Scoring rules

- **brier_proper**: `delta = stake * (1 - 2 * brier)`. Perfect prediction → +stake; maximally wrong → -stake; calibrated 0.5 prior → +half-stake (break-even at Brier=0.5). Incentive-compatible.
- **binary**: `delta = ±stake` based on position correctness. For domains where a probability is not reported.
- Inconclusive/invalid outcomes always return zero delta. The caller decides whether to refund or forfeit the stake.

## Test plan

- [x] 39 new tests covering: schema validation, content-addressed ids, JSON roundtrip, all scoring rule extremes, claim_id mismatch detection, deterministic delta_id, full provenance in `reason`, bridge domain mapping + position derivation + provenance preservation + mismatch rejection, end-to-end win/loss/inconclusive flow
- [x] Full markets/, reasoning/cruxset, reputation/ suites pass (145 tests)
- [x] Zero changes to existing blockchain contracts or production code paths

## What this PR does NOT do

- No on-chain writes — computation is in-memory only
- No CruxSet bridge yet — depends on DIC-17 (#6027) for crux verification
- No auto-application on any code path — flag default off
- No CLI — comes in Phase 9
- No log_loss scoring rule (deferred; Brier and binary cover the AGT-05 spec)

## Refs

- AGT-05: #6066 | AGT epic: #6068 | Vision: #6061
- Sibling AGT PRs: #6080 substrate (merged), #6082 markets (merged), #6084 cruxset contract (merged), #6086 VIAH (merged), #6088 receipts (merged), #6110 cruxset wiring (in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)