### PR TITLE
feat(cli): AGT-* operator surfaces — metrics viah, markets list, cruxset show

### DIFF
--- a/aragora/cli/commands/agt_cruxset.py
+++ b/aragora/cli/commands/agt_cruxset.py
@@ -1,0 +1,66 @@
+"""CLI command: ``aragora cruxset show``.
+
+Pretty-prints a CruxSet from a JSON file or stdin. Useful for operators
+inspecting CruxSets emitted by the AGT-01 debate-phase wiring (PR
+#6110) once the ARAGORA_CRUXSET_EMISSION_ENABLED flag is on.
+
+See aragora.reasoning.cruxset (issue #6062).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from aragora.reasoning.cruxset import CruxSet
+
+
+def cmd_cruxset_show(args: argparse.Namespace) -> int:
+    """Load a CruxSet JSON payload, verify checksum, print summary."""
+    source = getattr(args, "source", None)
+    if source and source != "-":
+        path = Path(source).expanduser()
+        if not path.exists():
+            print(f"error: {path} does not exist", file=sys.stderr)
+            return 2
+        raw = path.read_text(encoding="utf-8")
+    else:
+        raw = sys.stdin.read()
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"error: input is not JSON: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        cruxset = CruxSet.from_json(payload)
+    except (KeyError, ValueError, TypeError) as exc:
+        print(f"error: payload is not a CruxSet: {exc}", file=sys.stderr)
+        return 2
+
+    if getattr(args, "json", False):
+        print(json.dumps(cruxset.to_json(), sort_keys=True, indent=2))
+        return 0
+
+    verified = cruxset.verify_checksum()
+    print(f"CruxSet {cruxset.cruxset_id} (schema {cruxset.schema_version})")
+    print(f"  question:          {cruxset.question}")
+    print(f"  decision:          {cruxset.decision or '(none)'}")
+    print(f"  receipt_id:        {cruxset.receipt_id or '(none)'}")
+    print(f"  cruxes:            {len(cruxset.cruxes)}")
+    print(f"  evidence_gaps:     {len(cruxset.evidence_gaps)}")
+    print(f"  checksum verified: {verified}")
+    print()
+    for idx, crux in enumerate(cruxset.cruxes, start=1):
+        sides = ", ".join(p.side for p in crux.positions) or "(no positions)"
+        print(f"  [{idx}] load_bearing={crux.load_bearing_score:.3f}  sides=[{sides}]")
+        print(f"      {crux.statement}")
+        if crux.counterfactual:
+            print(f"      counterfactual: {crux.counterfactual}")
+    return 0 if verified else 3
+
+
+__all__ = ["cmd_cruxset_show"]

--- a/aragora/cli/commands/agt_markets.py
+++ b/aragora/cli/commands/agt_markets.py
@@ -1,0 +1,56 @@
+"""CLI command: ``aragora markets list``.
+
+Reads a synthetic-market store and prints a one-line summary per market.
+See aragora.markets for the AGT-04 substrate (issue #6065).
+
+This is read-only. Creating markets, taking positions, and resolving
+markets are deferred to follow-up CLI verbs once the substrate-first
+gate opens for AGT-04 production use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from aragora.markets.store import MarketStore
+
+
+def cmd_markets_list(args: argparse.Namespace) -> int:
+    """List markets in the given store directory."""
+    base_dir = Path(getattr(args, "store_dir", ".aragora_markets")).expanduser()
+    store = MarketStore(base_dir)
+    markets = store.list_markets()
+    resolutions = store.resolutions_by_market()
+
+    if getattr(args, "json", False):
+        out = []
+        for market in markets:
+            entry = market.to_json()
+            entry["resolution"] = (
+                resolutions[market.market_id].to_json() if market.market_id in resolutions else None
+            )
+            out.append(entry)
+        print(json.dumps(out, sort_keys=True, indent=2))
+        return 0
+
+    if not markets:
+        print(f"No markets found in {base_dir}")
+        return 0
+
+    print(f"{len(markets)} market(s) in {base_dir}:")
+    for market in markets:
+        outcome_str = "open"
+        if market.market_id in resolutions:
+            outcome_str = resolutions[market.market_id].outcome
+        print(
+            f"  [{outcome_str:12s}] {market.market_id}  "
+            f"{market.question_kind:<14s}  expires={market.expires_at}"
+        )
+        if market.description:
+            print(f"      {market.description}")
+    return 0
+
+
+__all__ = ["cmd_markets_list"]

--- a/aragora/cli/commands/agt_metrics.py
+++ b/aragora/cli/commands/agt_metrics.py
@@ -1,0 +1,63 @@
+"""CLI command: ``aragora metrics viah``.
+
+Reads the ShiftLedger and prints the latest VIAH (verifiable improvements
+per agent-hour) report. See aragora.metrics.viah for the metric
+definition (issue #6067).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from aragora.metrics.viah import compute_viah
+from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH, ShiftLedger
+
+
+def cmd_metrics_viah(args: argparse.Namespace) -> int:
+    """Compute and print the VIAH report over a window.
+
+    Returns 0 on success; non-zero only on argparse-level usage error
+    (which argparse handles itself before reaching here).
+    """
+    ledger_path: Path | None
+    raw_path = getattr(args, "ledger_path", None)
+    if raw_path:
+        ledger_path = Path(raw_path).expanduser()
+    else:
+        ledger_path = Path(DEFAULT_LEDGER_PATH)
+    ledger = ShiftLedger(path=ledger_path)
+
+    window_hours = float(getattr(args, "window_hours", 168.0))
+    cruxes = int(getattr(args, "cruxes_correctly_detected", 0))
+    predictions = int(getattr(args, "predictions_above_brier_threshold", 0))
+    failed_claims = int(getattr(args, "failed_claims_promoted_without_repair", 0))
+
+    report = compute_viah(
+        ledger=ledger,
+        window_hours=window_hours,
+        cruxes_correctly_detected=cruxes,
+        predictions_above_brier_threshold=predictions,
+        failed_claims_promoted_without_repair=failed_claims,
+    )
+
+    if getattr(args, "json", False):
+        print(json.dumps(report.to_dict(), sort_keys=True, indent=2))
+        return 0
+
+    viah_str = "n/a" if report.viah is None else f"{report.viah:.3f}"
+    print(f"VIAH: {viah_str} (window={window_hours:.1f}h, ledger={ledger_path})")
+    print(f"  agent_hours:                              {report.agent_hours:.2f}")
+    print(f"  merged_autonomous_prs:                    {report.merged_autonomous_prs}")
+    print(f"  cruxes_correctly_detected:                {report.cruxes_correctly_detected}")
+    print(f"  predictions_above_brier_threshold:        {report.predictions_above_brier_threshold}")
+    print(f"  rescues_required:                         {report.rescues_required}")
+    print(
+        f"  failed_claims_promoted_without_repair:    "
+        f"{report.failed_claims_promoted_without_repair}"
+    )
+    return 0
+
+
+__all__ = ["cmd_metrics_viah"]

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -204,7 +204,109 @@ Examples:
     _add_build_parser(subparsers)
     _add_essay_parser(subparsers)
 
+    # AGT-* operator surfaces (read-only)
+    _add_metrics_parser(subparsers)
+    _add_markets_parser(subparsers)
+    _add_cruxset_parser(subparsers)
+
     return parser
+
+
+# ---------------------------------------------------------------------------
+# AGT-* operator subparsers — added as part of AGT-06 / AGT-04 / AGT-01 follow-up
+# ---------------------------------------------------------------------------
+
+
+def _add_metrics_parser(subparsers) -> None:
+    """Add the 'metrics' subcommand group with a 'viah' verb."""
+    metrics_parser = subparsers.add_parser(
+        "metrics",
+        help="AGT-06: read VIAH and other operator metrics",
+        description="Operator-readable metrics derived from the ShiftLedger.",
+    )
+    metrics_sub = metrics_parser.add_subparsers(dest="metrics_cmd")
+    viah = metrics_sub.add_parser(
+        "viah",
+        help="Print verifiable improvements per agent-hour from the ShiftLedger",
+    )
+    viah.add_argument(
+        "--ledger-path",
+        default=None,
+        help="Path to the ShiftLedger JSONL (default: aragora.swarm.shift_ledger.DEFAULT_LEDGER_PATH)",
+    )
+    viah.add_argument(
+        "--window-hours",
+        type=float,
+        default=168.0,
+        help="Rolling window over which to compute VIAH (default: 168 = 7 days)",
+    )
+    viah.add_argument(
+        "--cruxes-correctly-detected",
+        type=int,
+        default=0,
+        help="Sidecar count of cruxes correctly detected pre-resolution (AGT-05)",
+    )
+    viah.add_argument(
+        "--predictions-above-brier-threshold",
+        type=int,
+        default=0,
+        help="Sidecar count of predictions with Brier below the calibration threshold (AGT-05)",
+    )
+    viah.add_argument(
+        "--failed-claims-promoted-without-repair",
+        type=int,
+        default=0,
+        help="Sidecar count of failed claims promoted without bounded repair (AGT-05)",
+    )
+    viah.add_argument("--json", action="store_true", help="Emit the report as JSON")
+    viah.set_defaults(func=_lazy("aragora.cli.commands.agt_metrics", "cmd_metrics_viah"))
+
+
+def _add_markets_parser(subparsers) -> None:
+    """Add the 'markets' subcommand group with a 'list' verb."""
+    markets_parser = subparsers.add_parser(
+        "markets",
+        help="AGT-04: inspect synthetic GitHub prediction markets",
+        description="Read-only operator surface for the synthetic-market store.",
+    )
+    markets_sub = markets_parser.add_subparsers(dest="markets_cmd")
+    lst = markets_sub.add_parser(
+        "list",
+        help="List markets in the given store directory",
+    )
+    lst.add_argument(
+        "--store-dir",
+        default=".aragora_markets",
+        help="Path to the synthetic-market JSONL store directory (default: .aragora_markets)",
+    )
+    lst.add_argument("--json", action="store_true", help="Emit the listing as JSON")
+    lst.set_defaults(func=_lazy("aragora.cli.commands.agt_markets", "cmd_markets_list"))
+
+
+def _add_cruxset_parser(subparsers) -> None:
+    """Add the 'cruxset' subcommand group with a 'show' verb."""
+    cruxset_parser = subparsers.add_parser(
+        "cruxset",
+        help="AGT-01: inspect CruxSet payloads emitted by the debate path",
+        description="Read-only operator surface for CruxSet artifacts.",
+    )
+    cruxset_sub = cruxset_parser.add_subparsers(dest="cruxset_cmd")
+    show = cruxset_sub.add_parser(
+        "show",
+        help="Pretty-print a CruxSet from a JSON file or stdin (use '-' for stdin)",
+    )
+    show.add_argument(
+        "source",
+        nargs="?",
+        default="-",
+        help="Path to a CruxSet JSON file, or '-' to read from stdin (default: stdin)",
+    )
+    show.add_argument(
+        "--json",
+        action="store_true",
+        help="Re-emit the (verified) CruxSet as JSON instead of pretty-printing",
+    )
+    show.set_defaults(func=_lazy("aragora.cli.commands.agt_cruxset", "cmd_cruxset_show"))
 
 
 def _add_ask_parser(subparsers) -> None:

--- a/tests/cli/test_agt_commands.py
+++ b/tests/cli/test_agt_commands.py
@@ -1,0 +1,244 @@
+"""Tests for the AGT-* CLI verbs (metrics viah, markets list, cruxset show)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.agt_cruxset import cmd_cruxset_show
+from aragora.cli.commands.agt_markets import cmd_markets_list
+from aragora.cli.commands.agt_metrics import cmd_metrics_viah
+from aragora.markets.store import MarketStore
+from aragora.markets.types import Market, MarketPosition, ResolutionEvent
+from aragora.reasoning.cruxset import Crux, CruxPosition, CruxSet
+from aragora.swarm.shift_ledger import ShiftLedger
+
+
+# ---------------------------------------------------------------------------
+# metrics viah
+# ---------------------------------------------------------------------------
+
+
+def _seed_ledger(path: Path, entries: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def _ts(at: datetime) -> str:
+    return at.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TestMetricsViah:
+    def test_empty_ledger_prints_na_and_returns_zero(self, tmp_path, capsys) -> None:
+        ledger_path = tmp_path / "ledger.jsonl"
+        ledger_path.write_text("", encoding="utf-8")
+        args = argparse.Namespace(
+            ledger_path=str(ledger_path),
+            window_hours=24.0,
+            cruxes_correctly_detected=0,
+            predictions_above_brier_threshold=0,
+            failed_claims_promoted_without_repair=0,
+            json=False,
+        )
+        rc = cmd_metrics_viah(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "VIAH: n/a" in out
+        assert "agent_hours:" in out
+
+    def test_populated_ledger_computes_positive_viah(self, tmp_path, capsys) -> None:
+        ledger_path = tmp_path / "ledger.jsonl"
+        now = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+        _seed_ledger(
+            ledger_path,
+            [
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(now - timedelta(hours=2)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "pr_merged",
+                    "timestamp": _ts(now - timedelta(minutes=30)),
+                    "payload": {"pr_number": 1},
+                },
+                {
+                    "entry_type": "shift_stop",
+                    "timestamp": _ts(now),
+                    "payload": {"shift_id": "s1"},
+                },
+            ],
+        )
+        args = argparse.Namespace(
+            ledger_path=str(ledger_path),
+            window_hours=24.0,
+            cruxes_correctly_detected=0,
+            predictions_above_brier_threshold=0,
+            failed_claims_promoted_without_repair=0,
+            json=True,
+        )
+        rc = cmd_metrics_viah(args)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        # Note: VIAH from this snapshot depends on `now` at runtime; we
+        # only assert structure and that PR was counted.
+        assert payload["merged_autonomous_prs"] == 1
+        assert payload["coefficients"]["merged_pr_weight"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# markets list
+# ---------------------------------------------------------------------------
+
+
+class TestMarketsList:
+    def test_empty_store_reports_no_markets(self, tmp_path, capsys) -> None:
+        args = argparse.Namespace(store_dir=str(tmp_path / "empty"), json=False)
+        rc = cmd_markets_list(args)
+        assert rc == 0
+        assert "No markets found" in capsys.readouterr().out
+
+    def test_lists_markets_with_open_status(self, tmp_path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        market = Market.create(
+            question_kind="pr_merge",
+            target={"repo": "synaptent/aragora", "number": 5959},
+            description="will it merge",
+            resolution_window_days=7,
+        )
+        store.add_market(market)
+        args = argparse.Namespace(store_dir=str(store.layout.base_dir), json=False)
+        rc = cmd_markets_list(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert market.market_id in out
+        assert "[open" in out
+        assert "pr_merge" in out
+
+    def test_lists_resolved_market_with_outcome(self, tmp_path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        market = Market.create(
+            question_kind="issue_close",
+            target={"repo": "synaptent/aragora", "number": 6068},
+            description="will it close",
+            resolution_window_days=14,
+        )
+        store.add_market(market)
+        store.record_resolution(
+            ResolutionEvent.yes(market_id=market.market_id, resolution_source="github_issue_state")
+        )
+        args = argparse.Namespace(store_dir=str(store.layout.base_dir), json=False)
+        rc = cmd_markets_list(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "[yes" in out
+
+    def test_json_mode_emits_array_with_resolution_field(self, tmp_path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        market = Market.create(
+            question_kind="ci_pass",
+            target={"repo": "synaptent/aragora", "ref": "abc123"},
+            description="will ci pass",
+            resolution_window_days=3,
+        )
+        store.add_market(market)
+        args = argparse.Namespace(store_dir=str(store.layout.base_dir), json=True)
+        rc = cmd_markets_list(args)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert isinstance(payload, list)
+        assert len(payload) == 1
+        assert payload[0]["market_id"] == market.market_id
+        assert payload[0]["resolution"] is None  # not yet resolved
+
+
+# ---------------------------------------------------------------------------
+# cruxset show
+# ---------------------------------------------------------------------------
+
+
+def _make_cruxset_payload() -> dict:
+    cruxset = CruxSet.build(
+        question="should we ship?",
+        cruxes=[
+            Crux(
+                crux_id="c1",
+                statement="Tests pass on all platforms",
+                positions=(
+                    CruxPosition(side="for", agents=("alice",)),
+                    CruxPosition(side="against", agents=("bob",)),
+                ),
+                load_bearing_score=0.85,
+                counterfactual="if false, decision flips",
+            ),
+            Crux(
+                crux_id="c2",
+                statement="No regressions in latency",
+                positions=(CruxPosition(side="for", agents=("carol",)),),
+                load_bearing_score=0.55,
+            ),
+        ],
+        decision="ship",
+        receipt_id="rcpt_abc",
+    )
+    return cruxset.to_json()
+
+
+class TestCruxsetShow:
+    def test_pretty_print_from_file(self, tmp_path, capsys) -> None:
+        path = tmp_path / "cs.json"
+        path.write_text(json.dumps(_make_cruxset_payload()), encoding="utf-8")
+        args = argparse.Namespace(source=str(path), json=False)
+        rc = cmd_cruxset_show(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "should we ship?" in out
+        assert "decision:          ship" in out
+        assert "checksum verified: True" in out
+        assert "load_bearing=0.850" in out
+
+    def test_json_mode_re_emits_payload(self, tmp_path, capsys) -> None:
+        path = tmp_path / "cs.json"
+        original = _make_cruxset_payload()
+        path.write_text(json.dumps(original), encoding="utf-8")
+        args = argparse.Namespace(source=str(path), json=True)
+        rc = cmd_cruxset_show(args)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["cruxset_id"] == original["cruxset_id"]
+        assert payload["checksum"] == original["checksum"]
+
+    def test_missing_source_returns_2(self, tmp_path, capsys) -> None:
+        args = argparse.Namespace(source=str(tmp_path / "nope.json"), json=False)
+        rc = cmd_cruxset_show(args)
+        assert rc == 2
+
+    def test_invalid_json_returns_2(self, tmp_path, capsys) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("<html>", encoding="utf-8")
+        args = argparse.Namespace(source=str(path), json=False)
+        rc = cmd_cruxset_show(args)
+        assert rc == 2
+
+    def test_payload_not_a_cruxset_returns_2(self, tmp_path, capsys) -> None:
+        path = tmp_path / "not_cs.json"
+        path.write_text(json.dumps({"hello": "world"}), encoding="utf-8")
+        args = argparse.Namespace(source=str(path), json=False)
+        rc = cmd_cruxset_show(args)
+        assert rc == 2
+
+    def test_tampered_payload_returns_3(self, tmp_path, capsys) -> None:
+        path = tmp_path / "tampered.json"
+        payload = _make_cruxset_payload()
+        payload["question"] = "TAMPERED"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        args = argparse.Namespace(source=str(path), json=False)
+        rc = cmd_cruxset_show(args)
+        assert rc == 3
+        out = capsys.readouterr().out
+        assert "checksum verified: False" in out


### PR DESCRIPTION
## Summary

Adds three read-only operator verbs covering the AGT track modules landed in this autonomous run:

| Verb | Backs | Output |
|---|---|---|
| `aragora metrics viah` | AGT-06 #6067 | Computes VIAH from ShiftLedger; supports `--window-hours`, sidecar AGT-05 counts, `--json` |
| `aragora markets list` | AGT-04 #6065 | Lists markets in a synthetic-market store with resolution status; `--json` mode emits full payloads |
| `aragora cruxset show` | AGT-01 #6062 | Pretty-prints a CruxSet from file or stdin and verifies its SHA-256 checksum; exit 3 on tamper |

All three are **read-only**; no write operations, no live activation required. They give operators an immediate way to inspect AGT-* artifacts once the substrate-first gate permits enabling the upper-layer flags.

## Test plan

- [x] 12 tests covering: VIAH on empty + populated ledger + JSON mode; markets list empty + open + resolved + JSON mode; cruxset show pretty-print + JSON mode + 4 error/tamper paths (each returning the right exit code)
- [x] Parser smoke-test confirms all three subcommands register and `--help` works
- [x] No new dependencies — stdlib + existing AGT-* modules only

## What this PR does NOT do

- No write commands (markets create/predict/resolve, cruxset emit-from-debate, metrics publish-recurring) — deferred follow-ups
- No state-mutating operations
- No flag activation — these verbs work even when their backing flags are off (they just inspect what's stored)

## Refs

- AGT-06: #6067 | AGT-04: #6065 | AGT-01: #6062 | AGT epic: #6068 | Vision: #6061
- Sibling AGT PRs all merged: #6080, #6082, #6084, #6086, #6088, #6110, #6112; #6114 in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)