### PR TITLE
fix(benchmarks): require in-progress issues to graduate

### DIFF
--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 90 commands | 43.2% |
+| **CLI** | 93 commands | 43.2% |
 | **SDK (Python)** | 187 namespaces | 70.3% |
 | **SDK (TypeScript)** | 186 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 90 commands | 43.2% |
+| **CLI** | 93 commands | 43.2% |
 | **SDK (Python)** | 187 namespaces | 70.3% |
 | **SDK (TypeScript)** | 186 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import sys
 from collections import Counter
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -226,6 +227,23 @@ def _corpus_freshness(
         "linkage_error_count": len(linkage_errors),
         "linkage_errors": linkage_errors,
     }
+
+
+def _normalize_in_progress_truth_record(
+    record: IssueTruthRecord,
+    *,
+    expected_status: str,
+) -> IssueTruthRecord:
+    if expected_status != EXPECTED_STATUS_IN_PROGRESS:
+        return record
+    if record.issue_state == "CLOSED":
+        return record
+    return replace(
+        record,
+        truth_state="in_progress_open",
+        truth_success=False,
+        no_rescue_truth_success=False,
+    )
 
 
 def load_corpus_freshness_map_payload(path: Path) -> dict[str, Any]:
@@ -789,7 +807,15 @@ def build_benchmark_truth_artifact(
                 )
             )
             continue
-        records.append(reconcile_issue_truth(repo, aggregate, truth_client))
+        records.append(
+            _normalize_in_progress_truth_record(
+                reconcile_issue_truth(repo, aggregate, truth_client),
+                expected_status=expected_by_number.get(
+                    aggregate.issue_number,
+                    EXPECTED_STATUS_VERIFIED,
+                ),
+            )
+        )
 
     def _is_verified_number(issue_number: int) -> bool:
         return (

--- a/tests/scripts/test_build_benchmark_truth_artifact.py
+++ b/tests/scripts/test_build_benchmark_truth_artifact.py
@@ -277,6 +277,117 @@ def test_build_benchmark_truth_artifact_does_not_count_historical_truth_for_unat
     ]
 
 
+def test_build_benchmark_truth_artifact_does_not_graduate_open_in_progress_issue_from_corpus_pr(
+    tmp_path: Path,
+) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "issue_number": 1064,
+                        "issue_title": "Verified dependency bump",
+                        "terminal_class": "issue_already_resolved",
+                        "worker_outcome": "issue_already_resolved",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "issue_number": 5814,
+                        "issue_title": "Open in-progress test task",
+                        "terminal_class": "blocked_not_dispatch_bounded",
+                        "worker_outcome": "blocked",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 3,
+            "recorded_on": "2026-04-17",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [
+                {
+                    "issue_id": 1064,
+                    "title": "Verified dependency bump",
+                    "expected_status": "verified",
+                },
+                {
+                    "issue_id": 5814,
+                    "title": "Open in-progress test task",
+                    "expected_status": "in_progress",
+                },
+            ],
+        },
+    )
+    client = FakeGitHubTruthClient(
+        issues={
+            1064: {
+                "title": "Verified dependency bump",
+                "state": "CLOSED",
+                "closedAt": "2026-04-16T12:00:00Z",
+                "comments": [{"body": "PR: https://github.com/synaptent/aragora/pull/6001"}],
+            },
+            5814: {
+                "title": "Open in-progress test task",
+                "state": "OPEN",
+                "comments": [{"body": "Seeded by https://github.com/synaptent/aragora/pull/6079"}],
+            },
+        },
+        prs={
+            6001: {
+                "number": 6001,
+                "title": "merged fix",
+                "url": "https://github.com/synaptent/aragora/pull/6001",
+                "state": "MERGED",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": "2026-04-16T12:00:00Z",
+                "isDraft": False,
+            },
+            6079: {
+                "number": 6079,
+                "title": "corpus v3",
+                "url": "https://github.com/synaptent/aragora/pull/6079",
+                "state": "MERGED",
+                "mergeable": "UNKNOWN",
+                "mergeStateStatus": "UNKNOWN",
+                "mergedAt": "2026-04-17T12:07:40Z",
+                "isDraft": False,
+            },
+        },
+    )
+
+    artifact = mod.build_benchmark_truth_artifact(
+        repo="synaptent/aragora",
+        metrics_file=metrics_path,
+        corpus_path=corpus_path,
+        client=client,
+        generated_at="2026-04-17T13:00:00Z",
+    )
+
+    assert artifact["run_status"] == "complete"
+    assert artifact["coverage"]["attempted_issue_count"] == 2
+    assert artifact["primary_metrics"]["truth_success_rate_verified"] == 1.0
+    assert artifact["primary_metrics"]["truth_success_rate"] == 0.5
+    assert artifact["primary_metrics"]["no_rescue_truth_success_rate"] == 0.5
+    assert artifact["primary_metrics"]["merged_only_rate"] == 0.5
+    assert artifact["in_flight_metrics"]["in_progress_attempted_count"] == 1
+    assert artifact["in_flight_metrics"]["in_progress_success_count"] == 0
+    assert artifact["in_flight_metrics"]["in_progress_graduation_rate"] == 0.0
+    assert [issue["truth_state"] for issue in artifact["issues"]] == [
+        "merged_pr",
+        "in_progress_open",
+    ]
+    assert artifact["issues"][1]["truth_success"] is False
+
+
 def test_build_benchmark_truth_artifact_reports_stale_closed_corpus_issues(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary\n- Prevent open in-progress corpus issues from being counted as successful just because a corpus-management PR referenced them\n- Keep closed in-progress issues eligible for normal truth reconciliation\n- Add regression coverage for corpus PR references on open in-progress issues\n\n## Validation\n- python3 -m pytest tests/scripts/test_build_benchmark_truth_artifact.py -q\n- python3 -m ruff check scripts/build_benchmark_truth_artifact.py tests/scripts/test_build_benchmark_truth_artifact.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD