### PR TITLE
feat(epistemic): DIC-17 follow-up bridge — CruxSet/failed-claim → bounded issue proposals

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -1,5 +1,57 @@
-"""Epistemic CI: executable claim verification and decay detection."""
+"""Epistemic CI and crux-engine helpers (DIC-13..22 tranche).
+
+Exposes:
+- DIC-14: executable claim verification (:class:`ClaimVerifier`)
+- DIC-17: follow-up-issue bridge for load-bearing cruxes and
+  sharply-losing claims (:class:`FollowupProposal`,
+  :func:`propose_followup_for_crux`, :func:`propose_followup_for_cruxset`,
+  :func:`propose_followup_for_failed_claim`)
+
+See ``docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md`` for the full
+DIC-13..22 sequence and ``docs/status/NEXT_STEPS_CANONICAL.md`` for
+the queue-governance activation gate.
+"""
+
+from __future__ import annotations
+
+import os
 
 from .claim_verifier import ClaimResult, ClaimStatus, ClaimVerifier
+from .followup import (
+    DEFAULT_CRUX_LOAD_BEARING_THRESHOLD,
+    DEFAULT_DELTA_LOSS_THRESHOLD,
+    FollowupProposal,
+    propose_followup_for_crux,
+    propose_followup_for_cruxset,
+    propose_followup_for_failed_claim,
+)
 
-__all__ = ["ClaimResult", "ClaimStatus", "ClaimVerifier"]
+__all__ = [
+    "ClaimResult",
+    "ClaimStatus",
+    "ClaimVerifier",
+    "DEFAULT_CRUX_LOAD_BEARING_THRESHOLD",
+    "DEFAULT_DELTA_LOSS_THRESHOLD",
+    "FollowupProposal",
+    "enable_epistemic_followup",
+    "epistemic_followup_enabled",
+    "propose_followup_for_crux",
+    "propose_followup_for_cruxset",
+    "propose_followup_for_failed_claim",
+]
+
+
+def epistemic_followup_enabled() -> bool:
+    """Return True if callers should act on DIC-17 follow-up proposals.
+
+    Reads ``ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED`` from the process
+    environment. Default is False; construction of proposals is
+    always safe, but filing them on GitHub must be gated.
+    """
+    raw = str(os.environ.get("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_epistemic_followup() -> None:
+    """Enable the DIC-17 follow-up bridge for the current process."""
+    os.environ["ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED"] = "1"

--- a/aragora/epistemic/followup.py
+++ b/aragora/epistemic/followup.py
@@ -1,0 +1,341 @@
+"""DIC-17: follow-up-issue proposals from load-bearing cruxes and failed claims.
+
+This module is the bridge between the AGT-01 CruxSet output and the
+AGT-05 failed-claim output on one side, and the swarm's boss-ready
+queue on the other. It **proposes** follow-up issues — it does not
+file them. Filing is an explicit separate step gated on both
+``ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED`` and whatever queue-governance
+the caller enforces.
+
+Acceptance shape per docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md
+§DIC-17:
+
+- one failure (crux or losing claim) creates AT MOST one bounded
+  proposal — the caller is responsible for dedup via ``source_key``
+- generated proposals DO NOT receive ``boss-ready`` unless the
+  current tranche permits them (we always emit without that label;
+  the proof-first reconciler in scripts/reconcile_proof_first_queue.py
+  will strip it if anything else ever adds it)
+- no broad restock behavior — a proposal is a single targeted issue
+  with specific body text linking back to the originating crux/claim
+- test coverage for queue-governance constraints
+
+The module is shape-only. It imports :class:`Crux` and :class:`CruxSet`
+from :mod:`aragora.reasoning.cruxset`, and :class:`StakeableClaim`,
+:class:`ResolvedClaim`, :class:`ReputationDelta` from
+:mod:`aragora.reputation.types` (lazy-imported to avoid pulling those
+modules just to construct a proposal shape).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aragora.reasoning.cruxset import Crux, CruxSet
+    from aragora.reputation.types import (
+        ReputationDelta,
+        ResolvedClaim,
+        StakeableClaim,
+    )
+
+# DIC-17 default thresholds
+DEFAULT_CRUX_LOAD_BEARING_THRESHOLD = 0.6
+DEFAULT_DELTA_LOSS_THRESHOLD = -10.0
+MAX_BODY_STATEMENT_CHARS = 800
+
+
+@dataclass(frozen=True)
+class FollowupProposal:
+    """A proposed bounded follow-up issue.
+
+    - ``source_kind``: ``"crux"`` or ``"failed_claim"``
+    - ``source_key``: stable dedup key; callers should skip proposals
+      whose source_key they have already filed
+    - ``labels``: intentionally excludes ``boss-ready`` by default;
+      the proof-first reconciler strips it anyway if it is added by
+      mistake
+    - ``rationale``: short human-readable reason for the proposal
+    - ``provenance``: machine-readable links back to the originating
+      artifact (cruxset_id, crux_id, claim_id, resolution_id)
+    """
+
+    source_kind: str
+    source_key: str
+    title: str
+    body: str
+    labels: tuple[str, ...]
+    rationale: str
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.source_kind not in {"crux", "failed_claim"}:
+            raise ValueError(f"unsupported source_kind: {self.source_kind!r}")
+        if not str(self.source_key).strip():
+            raise ValueError("source_key must be non-empty")
+        if not str(self.title).strip():
+            raise ValueError("title must be non-empty")
+        if not str(self.body).strip():
+            raise ValueError("body must be non-empty")
+        if "boss-ready" in self.labels:
+            raise ValueError(
+                "follow-up proposals must NOT carry boss-ready label (queue-governance invariant)"
+            )
+
+    def to_gh_create_args(self, *, repo: str) -> list[str]:
+        """Return the gh-CLI arguments that would file this proposal.
+
+        Intended for callers that choose to file. This method does NOT
+        invoke gh itself — it returns the args as a list so callers
+        have full control over whether/when to file.
+        """
+        args = ["issue", "create", "--repo", repo, "--title", self.title, "--body", self.body]
+        for label in self.labels:
+            args.extend(["--label", label])
+        return args
+
+
+# ---------------------------------------------------------------------------
+# Crux → proposal
+# ---------------------------------------------------------------------------
+
+
+def _source_key(prefix: str, identifier: str) -> str:
+    material = f"{prefix}|{identifier}"
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
+    return f"{prefix}_{digest}"
+
+
+def _truncate(text: str, limit: int = MAX_BODY_STATEMENT_CHARS) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def propose_followup_for_crux(
+    crux: "Crux",
+    *,
+    cruxset_id: str = "",
+    question: str = "",
+    load_bearing_threshold: float = DEFAULT_CRUX_LOAD_BEARING_THRESHOLD,
+    extra_labels: tuple[str, ...] = (),
+) -> FollowupProposal | None:
+    """Propose exactly one bounded follow-up issue for a single crux, or None.
+
+    Returns ``None`` when ``crux.load_bearing_score`` is below
+    ``load_bearing_threshold`` — not all cruxes merit a bounded
+    follow-up issue; only the load-bearing ones.
+    """
+    if not (0.0 <= load_bearing_threshold <= 1.0):
+        raise ValueError("load_bearing_threshold must be in [0, 1]")
+    if crux.load_bearing_score < load_bearing_threshold:
+        return None
+
+    statement = _truncate(str(crux.statement))
+    title = f"[DIC-17] Resolve load-bearing crux: {statement[:80]}".strip()
+    if len(title) > 140:
+        title = title[:139] + "…"
+
+    body_lines = [
+        "## Goal",
+        "Resolve a load-bearing crux surfaced by the Arena debate path.",
+        "",
+        "## Crux",
+        f"- statement: {statement}",
+        f"- load_bearing_score: {crux.load_bearing_score:.3f}",
+    ]
+    if crux.counterfactual:
+        body_lines.extend(
+            [
+                "",
+                "## Counterfactual",
+                crux.counterfactual.strip(),
+            ]
+        )
+    if crux.evidence_gaps:
+        body_lines.extend(["", "## Evidence gaps"])
+        body_lines.extend(f"- {gap.strip()}" for gap in crux.evidence_gaps if gap.strip())
+    if crux.candidate_verifier:
+        body_lines.extend(
+            [
+                "",
+                "## Candidate verifier",
+                crux.candidate_verifier.strip(),
+            ]
+        )
+    body_lines.extend(
+        [
+            "",
+            "## Provenance",
+            "- source: DIC-17 crux follow-up bridge",
+            f"- crux_id: {crux.crux_id}",
+            f"- cruxset_id: {cruxset_id or '(n/a)'}",
+            f"- question: {_truncate(question, 200) or '(n/a)'}",
+            "",
+            "## Queue policy",
+            "This issue is a DIC-17 proposal. It MUST NOT carry `boss-ready` unless the "
+            "current tranche in `docs/status/NEXT_STEPS_CANONICAL.md` explicitly permits "
+            "it. The proof-first reconciler in `scripts/reconcile_proof_first_queue.py` "
+            "will strip the label if it is added outside the permitted lane.",
+        ]
+    )
+
+    labels = tuple(sorted({"epistemic", "crux", *extra_labels} - {"boss-ready"}))
+    source_key = _source_key("crux", f"{cruxset_id}|{crux.crux_id}" if cruxset_id else crux.crux_id)
+
+    return FollowupProposal(
+        source_kind="crux",
+        source_key=source_key,
+        title=title,
+        body="\n".join(body_lines),
+        labels=labels,
+        rationale=(
+            f"load_bearing_score={crux.load_bearing_score:.3f} >= {load_bearing_threshold:.3f}"
+        ),
+        provenance={
+            "crux_id": crux.crux_id,
+            "cruxset_id": cruxset_id,
+            "load_bearing_score": round(crux.load_bearing_score, 6),
+        },
+    )
+
+
+def propose_followup_for_cruxset(
+    cruxset: "CruxSet",
+    *,
+    top_k: int = 1,
+    load_bearing_threshold: float = DEFAULT_CRUX_LOAD_BEARING_THRESHOLD,
+    extra_labels: tuple[str, ...] = (),
+) -> list[FollowupProposal]:
+    """Propose up to ``top_k`` bounded follow-ups for the top cruxes in a set.
+
+    Cruxes in a :class:`CruxSet` are already sorted by
+    ``load_bearing_score`` descending; this function walks the first
+    ``top_k`` and emits a proposal for each that clears the threshold.
+    """
+    if top_k < 1:
+        raise ValueError("top_k must be >= 1")
+    out: list[FollowupProposal] = []
+    for crux in cruxset.cruxes[:top_k]:
+        proposal = propose_followup_for_crux(
+            crux,
+            cruxset_id=cruxset.cruxset_id,
+            question=cruxset.question,
+            load_bearing_threshold=load_bearing_threshold,
+            extra_labels=extra_labels,
+        )
+        if proposal is not None:
+            out.append(proposal)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Failed claim → proposal
+# ---------------------------------------------------------------------------
+
+
+def propose_followup_for_failed_claim(
+    claim: "StakeableClaim",
+    resolved: "ResolvedClaim",
+    delta: "ReputationDelta",
+    *,
+    delta_loss_threshold: float = DEFAULT_DELTA_LOSS_THRESHOLD,
+    extra_labels: tuple[str, ...] = (),
+) -> FollowupProposal | None:
+    """Propose exactly one bounded follow-up issue for a failed claim, or None.
+
+    Returns ``None`` unless:
+    - ``resolved.outcome`` is ``"yes"`` or ``"no"`` (inconclusive /
+      invalid outcomes do not merit follow-up)
+    - ``delta.delta <= delta_loss_threshold`` (only sharp losses
+      trigger a follow-up; small miscalibrations do not)
+
+    The proposal captures the claim, resolution, delta, and scoring
+    rule so an operator can decide whether to turn it into actionable
+    work or mark it as a known-hard domain.
+    """
+    if resolved.outcome not in {"yes", "no"}:
+        return None
+    if delta.delta > delta_loss_threshold:
+        return None
+
+    title = f"[DIC-17] Investigate high-loss prediction: {claim.agent_id}/{claim.domain}"
+    if len(title) > 140:
+        title = title[:139] + "…"
+
+    body_lines = [
+        "## Goal",
+        "Investigate a sharply-losing prediction from the AGT-05 settlement flow.",
+        "",
+        "## Claim",
+        f"- agent_id: {claim.agent_id}",
+        f"- domain: {claim.domain}",
+        f"- statement: {_truncate(claim.statement)}",
+        f"- position: {claim.position}",
+    ]
+    if claim.predicted_probability is not None:
+        body_lines.append(f"- predicted_probability: {claim.predicted_probability:.3f}")
+    body_lines.extend(
+        [
+            f"- stake_units: {claim.stake_units}",
+            f"- resolution_source: {claim.resolution_source}",
+            f"- resolution_id: {claim.resolution_id}",
+            "",
+            "## Resolution",
+            f"- outcome: {resolved.outcome}",
+            f"- resolved_at: {resolved.resolved_at}",
+            f"- source: {resolved.resolution_source}",
+            "",
+            "## Settlement",
+            f"- scoring_rule: {delta.scoring_rule}",
+            f"- delta: {delta.delta:+.3f} (threshold: <= {delta_loss_threshold:+.1f})",
+            f"- delta_id: {delta.delta_id}",
+            "",
+            "## Provenance",
+            "- source: DIC-17 failed-claim follow-up bridge",
+            f"- claim_id: {claim.claim_id}",
+            "",
+            "## Queue policy",
+            "This issue is a DIC-17 proposal. It MUST NOT carry `boss-ready` unless the "
+            "current tranche in `docs/status/NEXT_STEPS_CANONICAL.md` explicitly permits "
+            "it. The proof-first reconciler in `scripts/reconcile_proof_first_queue.py` "
+            "will strip the label if it is added outside the permitted lane.",
+        ]
+    )
+
+    labels = tuple(sorted({"epistemic", "failed-claim", *extra_labels} - {"boss-ready"}))
+    source_key = _source_key("failed_claim", delta.delta_id)
+
+    return FollowupProposal(
+        source_kind="failed_claim",
+        source_key=source_key,
+        title=title,
+        body="\n".join(body_lines),
+        labels=labels,
+        rationale=(
+            f"delta={delta.delta:+.3f} <= {delta_loss_threshold:+.1f} "
+            f"(agent {claim.agent_id} in {claim.domain})"
+        ),
+        provenance={
+            "claim_id": claim.claim_id,
+            "resolution_id": claim.resolution_id,
+            "delta_id": delta.delta_id,
+            "agent_id": claim.agent_id,
+            "domain": claim.domain,
+            "delta": round(delta.delta, 6),
+        },
+    )
+
+
+__all__ = [
+    "DEFAULT_CRUX_LOAD_BEARING_THRESHOLD",
+    "DEFAULT_DELTA_LOSS_THRESHOLD",
+    "FollowupProposal",
+    "MAX_BODY_STATEMENT_CHARS",
+    "propose_followup_for_crux",
+    "propose_followup_for_cruxset",
+    "propose_followup_for_failed_claim",
+]

--- a/tests/epistemic/test_followup.py
+++ b/tests/epistemic/test_followup.py
@@ -1,0 +1,322 @@
+"""Tests for DIC-17 follow-up proposal bridge."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.followup import (
+    DEFAULT_CRUX_LOAD_BEARING_THRESHOLD,
+    DEFAULT_DELTA_LOSS_THRESHOLD,
+    FollowupProposal,
+    propose_followup_for_crux,
+    propose_followup_for_cruxset,
+    propose_followup_for_failed_claim,
+)
+from aragora.reasoning.cruxset import Crux, CruxPosition, CruxSet
+from aragora.reputation.settlement import settle_claim
+from aragora.reputation.types import (
+    DOMAIN_PREDICTION_MARKET,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+
+def _make_crux(*, score: float = 0.85, crux_id: str = "c1") -> Crux:
+    return Crux(
+        crux_id=crux_id,
+        statement="X is load-bearing",
+        positions=(
+            CruxPosition(side="for", agents=("alice",)),
+            CruxPosition(side="against", agents=("bob",)),
+        ),
+        load_bearing_score=score,
+        evidence_gaps=("no benchmark for X",),
+        counterfactual="if X is false, decision flips",
+        candidate_verifier="docs/spec.md",
+    )
+
+
+def _make_failed_settlement(
+    *,
+    probability: float = 0.95,
+    stake: int = 50,
+    outcome: str = "no",
+) -> tuple[StakeableClaim, ResolvedClaim, object]:
+    claim = StakeableClaim.create(
+        agent_id="alice",
+        domain=DOMAIN_PREDICTION_MARKET,
+        statement="will PR #1 merge",
+        position="yes",
+        stake_units=stake,
+        resolution_source="synthetic_github",
+        resolution_id="mkt_x",
+        predicted_probability=probability,
+    )
+    resolved = ResolvedClaim(
+        claim_id=claim.claim_id,
+        outcome=outcome,  # type: ignore[arg-type]
+        resolved_at="2026-04-24T12:00:00Z",
+        resolution_source="synthetic_github",
+    )
+    delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+    return claim, resolved, delta
+
+
+class TestFollowupProposalValidation:
+    def test_rejects_unknown_source_kind(self) -> None:
+        with pytest.raises(ValueError):
+            FollowupProposal(
+                source_kind="something",
+                source_key="k",
+                title="t",
+                body="b",
+                labels=(),
+                rationale="r",
+            )
+
+    def test_rejects_empty_source_key_or_title_or_body(self) -> None:
+        for field in ("source_key", "title", "body"):
+            kwargs = dict(
+                source_kind="crux",
+                source_key="k",
+                title="t",
+                body="b",
+                labels=(),
+                rationale="r",
+            )
+            kwargs[field] = " "
+            with pytest.raises(ValueError):
+                FollowupProposal(**kwargs)  # type: ignore[arg-type]
+
+    def test_rejects_boss_ready_label(self) -> None:
+        with pytest.raises(ValueError):
+            FollowupProposal(
+                source_kind="crux",
+                source_key="k",
+                title="t",
+                body="b",
+                labels=("epistemic", "boss-ready"),
+                rationale="r",
+            )
+
+    def test_to_gh_create_args_shape(self) -> None:
+        proposal = FollowupProposal(
+            source_kind="crux",
+            source_key="k",
+            title="t",
+            body="b",
+            labels=("epistemic", "crux"),
+            rationale="r",
+        )
+        args = proposal.to_gh_create_args(repo="owner/repo")
+        assert args[:2] == ["issue", "create"]
+        assert "--repo" in args
+        assert "owner/repo" in args
+        assert "--title" in args and "t" in args
+        assert args.count("--label") == 2
+        assert "boss-ready" not in args
+
+
+class TestCruxProposal:
+    def test_below_threshold_returns_none(self) -> None:
+        low = _make_crux(score=0.3)
+        assert propose_followup_for_crux(low) is None
+
+    def test_above_threshold_produces_proposal(self) -> None:
+        crux = _make_crux(score=0.85)
+        proposal = propose_followup_for_crux(
+            crux,
+            cruxset_id="crxset_abc",
+            question="should we ship?",
+        )
+        assert proposal is not None
+        assert proposal.source_kind == "crux"
+        assert "DIC-17" in proposal.title
+        assert "X is load-bearing" in proposal.body
+        assert "crxset_abc" in proposal.body
+        assert "should we ship?" in proposal.body
+        assert "Evidence gaps" in proposal.body
+        assert "counterfactual" in proposal.body.lower()
+        assert "boss-ready" not in proposal.labels
+        assert "epistemic" in proposal.labels
+        assert "crux" in proposal.labels
+        assert proposal.provenance["crux_id"] == "c1"
+
+    def test_long_statement_truncated_in_body(self) -> None:
+        long = Crux(
+            crux_id="c_long",
+            statement="x " * 1000,
+            positions=(CruxPosition(side="for", agents=("alice",)),),
+            load_bearing_score=0.9,
+        )
+        proposal = propose_followup_for_crux(long)
+        assert proposal is not None
+        assert "…" in proposal.body  # truncation indicator present
+
+    def test_title_length_capped(self) -> None:
+        crux = Crux(
+            crux_id="c_title",
+            statement="Z" * 300,
+            positions=(CruxPosition(side="for", agents=("alice",)),),
+            load_bearing_score=0.9,
+        )
+        proposal = propose_followup_for_crux(crux)
+        assert proposal is not None
+        assert len(proposal.title) <= 140
+
+    def test_extra_labels_added_but_boss_ready_stripped(self) -> None:
+        crux = _make_crux()
+        proposal = propose_followup_for_crux(
+            crux,
+            extra_labels=("p1", "boss-ready"),
+        )
+        assert proposal is not None
+        assert "p1" in proposal.labels
+        assert "boss-ready" not in proposal.labels
+
+    def test_invalid_threshold_raises(self) -> None:
+        crux = _make_crux()
+        with pytest.raises(ValueError):
+            propose_followup_for_crux(crux, load_bearing_threshold=1.5)
+
+    def test_source_key_deterministic(self) -> None:
+        crux = _make_crux()
+        a = propose_followup_for_crux(crux, cruxset_id="crxset_a")
+        b = propose_followup_for_crux(crux, cruxset_id="crxset_a")
+        assert a is not None and b is not None
+        assert a.source_key == b.source_key
+
+
+class TestCruxSetProposal:
+    def _cs(self) -> CruxSet:
+        return CruxSet.build(
+            question="should we ship?",
+            cruxes=[
+                _make_crux(crux_id="c1", score=0.9),
+                _make_crux(crux_id="c2", score=0.75),
+                _make_crux(crux_id="c3", score=0.3),  # below threshold
+            ],
+        )
+
+    def test_top_k_caps_output_and_respects_threshold(self) -> None:
+        cs = self._cs()
+        proposals = propose_followup_for_cruxset(cs, top_k=3)
+        # c1 and c2 clear threshold; c3 does not
+        assert len(proposals) == 2
+        assert [p.provenance["crux_id"] for p in proposals] == ["c1", "c2"]
+
+    def test_top_k_smaller_than_load_bearing_count(self) -> None:
+        cs = self._cs()
+        proposals = propose_followup_for_cruxset(cs, top_k=1)
+        assert len(proposals) == 1
+        assert proposals[0].provenance["crux_id"] == "c1"
+
+    def test_invalid_top_k_raises(self) -> None:
+        cs = self._cs()
+        with pytest.raises(ValueError):
+            propose_followup_for_cruxset(cs, top_k=0)
+
+
+class TestFailedClaimProposal:
+    def test_large_loss_produces_proposal(self) -> None:
+        claim, resolved, delta = _make_failed_settlement(probability=0.95, stake=50, outcome="no")
+        # Brier = 0.95^2 = 0.9025 → payout = 1 - 2*0.9025 = -0.805 → delta ≈ -40.25
+        assert delta.delta <= DEFAULT_DELTA_LOSS_THRESHOLD
+        proposal = propose_followup_for_failed_claim(claim, resolved, delta)
+        assert proposal is not None
+        assert proposal.source_kind == "failed_claim"
+        assert "high-loss prediction" in proposal.title
+        assert "alice" in proposal.title
+        assert claim.claim_id in proposal.body
+        assert delta.delta_id in proposal.body
+        assert "brier_proper" in proposal.body
+        assert "boss-ready" not in proposal.labels
+
+    def test_small_loss_below_threshold_returns_none(self) -> None:
+        # Probability 0.8 on YES outcome NO: Brier=0.64, payout=-0.28, delta=-10*0.28=-2.8
+        claim, resolved, delta = _make_failed_settlement(probability=0.8, stake=10, outcome="no")
+        # Sanity: delta is negative but small
+        assert -3.0 < delta.delta < 0.0
+        # At a generous threshold the proposal fires
+        lax = propose_followup_for_failed_claim(claim, resolved, delta, delta_loss_threshold=-1.0)
+        assert lax is not None
+        assert lax.source_kind == "failed_claim"
+        # At a strict threshold it does not
+        strict = propose_followup_for_failed_claim(
+            claim, resolved, delta, delta_loss_threshold=-50.0
+        )
+        assert strict is None
+
+    def test_inconclusive_outcome_returns_none(self) -> None:
+        claim = StakeableClaim.create(
+            agent_id="alice",
+            domain=DOMAIN_PREDICTION_MARKET,
+            statement="x",
+            position="yes",
+            stake_units=50,
+            resolution_source="synthetic_github",
+            resolution_id="mkt_x",
+            predicted_probability=0.7,
+        )
+        resolved = ResolvedClaim(
+            claim_id=claim.claim_id,
+            outcome="inconclusive",
+            resolved_at="2026-04-24T12:00:00Z",
+            resolution_source="synthetic_github",
+        )
+        delta = settle_claim(claim, resolved, scoring_rule="brier_proper")
+        # Inconclusive → delta == 0 regardless of threshold
+        assert delta.delta == 0.0
+        assert propose_followup_for_failed_claim(claim, resolved, delta) is None
+
+
+class TestQueueGovernanceInvariants:
+    """Regression guards for the DIC-17 acceptance shape."""
+
+    def test_crux_proposal_never_carries_boss_ready(self) -> None:
+        crux = _make_crux()
+        # Even if the caller tries to inject boss-ready
+        proposal = propose_followup_for_crux(
+            crux, extra_labels=("boss-ready", "boss-ready", "epistemic")
+        )
+        assert proposal is not None
+        assert "boss-ready" not in proposal.labels
+
+    def test_failed_claim_proposal_never_carries_boss_ready(self) -> None:
+        claim, resolved, delta = _make_failed_settlement()
+        proposal = propose_followup_for_failed_claim(
+            claim, resolved, delta, extra_labels=("boss-ready",)
+        )
+        assert proposal is not None
+        assert "boss-ready" not in proposal.labels
+
+    def test_proposals_are_deduplicable_by_source_key(self) -> None:
+        # Same crux + cruxset_id → same source_key (deterministic dedup)
+        crux = _make_crux()
+        a = propose_followup_for_crux(crux, cruxset_id="crxset_a")
+        b = propose_followup_for_crux(crux, cruxset_id="crxset_a")
+        assert a is not None and b is not None
+        assert a.source_key == b.source_key
+        # Different cruxset_id → different source_key
+        c = propose_followup_for_crux(crux, cruxset_id="crxset_b")
+        assert c is not None
+        assert a.source_key != c.source_key
+
+
+class TestFeatureFlag:
+    def test_disabled_by_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", raising=False)
+        from aragora.epistemic import epistemic_followup_enabled
+
+        assert epistemic_followup_enabled() is False
+
+    def test_enable_helper(self, monkeypatch) -> None:
+        monkeypatch.delenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", raising=False)
+        from aragora.epistemic import enable_epistemic_followup, epistemic_followup_enabled
+
+        assert epistemic_followup_enabled() is False
+        enable_epistemic_followup()
+        try:
+            assert epistemic_followup_enabled() is True
+        finally:
+            monkeypatch.delenv("ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED", raising=False)


### PR DESCRIPTION
## Summary

- Adds `aragora/epistemic/followup.py` — DIC-17 bridge (#6027) between AGT-01 CruxSet output, AGT-05 failed-claim output, and the swarm's follow-up-issue queue.
- **Proposes, does not file.** Construction is always safe; filing is an explicit separate step gated on both `ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED` and caller-enforced queue governance.
- 22 new tests + 117 across related suites all pass. **Dataclass invariant:** proposals cannot be constructed with the `boss-ready` label (raises ValueError).

## What this closes

The loop between 'we identified a load-bearing crux' and 'we generated work to resolve it.' Previously AGT-01 CruxSets were read-only artifacts and AGT-05 failed settlements were compute-only. This PR converts sharp signals in both streams into specific, bounded proposals an operator (or autonomous workflow, once permitted) can file.

## API

```python
from aragora.epistemic import (
    propose_followup_for_crux,
    propose_followup_for_cruxset,
    propose_followup_for_failed_claim,
    FollowupProposal,
)

# Crux → proposal (only above load_bearing threshold, default 0.6)
proposal = propose_followup_for_crux(crux, cruxset_id=..., question=...)

# CruxSet → up to top_k proposals
proposals = propose_followup_for_cruxset(cruxset, top_k=1)

# Failed claim → proposal (only on yes/no + delta <= loss threshold, default -10)
proposal = propose_followup_for_failed_claim(claim, resolved, delta)

# File (caller-controlled):
args = proposal.to_gh_create_args(repo="owner/repo")  # gh issue create ...
```

## Acceptance shape (per DIC-17)

- [x] One failure (crux or losing claim) creates AT MOST one bounded proposal. `source_key` is content-addressed for dedup.
- [x] Generated proposals DO NOT receive `boss-ready`. The `FollowupProposal` dataclass rejects the label in `__post_init__`; even if `extra_labels` includes it, it's stripped by set subtraction before construction. As a defense-in-depth, the proof-first reconciler will strip it if anything else adds it.
- [x] No broad restock behavior — each proposal is a single targeted issue with body text linking back to the originating artifact.
- [x] Test coverage for queue-governance invariants.

## Test plan

- [x] 22 new tests covering: FollowupProposal validation (unknown source_kind, empty field rejection, boss-ready rejection, gh_create_args shape), crux proposals (threshold boundary, body content, truncation, title cap, boss-ready stripping from extra_labels, invalid threshold, source_key determinism), cruxset (top_k + threshold interaction, invalid top_k), failed-claim (large loss, small-loss-below-threshold, inconclusive → None), queue-governance regression guards, feature flag default/enable
- [x] 117 tests pass across reputation/reasoning/epistemic suites — no regressions
- [x] Uses TYPE_CHECKING imports so the module can be loaded without forcing cruxset/reputation module loads

## What this PR does NOT do

- Does NOT file proposals on GitHub (caller decides via `to_gh_create_args`)
- Does NOT auto-enable on any code path (`ARAGORA_EPISTEMIC_FOLLOWUP_ENABLED` default off)
- Does NOT bridge from CruxSet → StakeableClaim in `aragora.reputation.bridge` — the proposal is the follow-up surface; reputation-side integration lives in AGT-05 settlement wiring
- Does NOT add a CLI verb (deferred; proposals are the contract)

## Refs

- DIC-17: #6027 | DIC-15: #6025 | DIC-16: #6026 | Vision: #6061
- Sibling AGT PRs all merged: #6080, #6082, #6084, #6086, #6088, #6110, #6112, #6114, #6116

🤖 Generated with [Claude Code](https://claude.com/claude-code)