### PR TITLE
test(swarm): cover roadmap priority policy

### DIFF
--- a/tests/swarm/test_roadmap_priority.py
+++ b/tests/swarm/test_roadmap_priority.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from aragora.swarm.roadmap_priority import (
     RoadmapPriority,
+    RoadmapPriorityPolicy,
     expand_roadmap_token,
     extract_roadmap_codes,
     load_roadmap_priority_policy,
@@ -14,11 +15,77 @@ def test_expand_roadmap_token_handles_ranges() -> None:
     assert expand_roadmap_token("BC-07..09") == ("BC-07", "BC-08", "BC-09")
     assert expand_roadmap_token("CS-01..03") == ("CS-01", "CS-02", "CS-03")
     assert expand_roadmap_token("RS-07") == ("RS-07",)
+    assert expand_roadmap_token("BC-09..07") == ("BC-09..07",)
+    assert expand_roadmap_token("") == ()
 
 
 def test_extract_roadmap_codes_deduplicates_and_expands() -> None:
     text = "Refs: (`RS-07`), delayed `BC-07..08`, plus repeated `RS-07`."
     assert extract_roadmap_codes(text) == ("RS-07", "BC-07", "BC-08")
+
+
+def test_extract_roadmap_codes_preserves_first_seen_order_across_text_noise() -> None:
+    text = """
+    Follow `TW-01`, lowercase tw-02 is prose only, then `CS-01..03`.
+    Repeating `CS-02` must not duplicate, and malformed `BC-09..07` stays atomic.
+    """
+
+    assert extract_roadmap_codes(text) == (
+        "TW-01",
+        "CS-01",
+        "CS-02",
+        "CS-03",
+        "BC-09..07",
+    )
+
+
+def test_priority_policy_prefers_blocking_sections_and_reports_blocked_codes() -> None:
+    policy = RoadmapPriorityPolicy(
+        do_now=frozenset({"RS-07", "TW-01"}),
+        delay=frozenset({"BC-07", "CS-02"}),
+        avoid=frozenset({"UDW-08", "CS-03"}),
+    )
+
+    avoid = policy.priority_for_text("Do `RS-07`, delay `BC-07`, but avoid `UDW-08`.")
+    assert avoid.priority == RoadmapPriority.AVOID
+    assert avoid.codes == ("RS-07", "BC-07", "UDW-08")
+    assert avoid.blocked_codes == ("UDW-08",)
+    assert not policy.allows_boss_ready("Do `RS-07`, but avoid `UDW-08`.")
+
+    delay = policy.priority_for_text("Do `TW-01`, but delay `BC-07`.")
+    assert delay.priority == RoadmapPriority.DELAY
+    assert delay.blocked_codes == ("BC-07",)
+    assert not policy.allows_boss_ready("Delay `CS-02`.")
+
+    do_now = policy.priority_for_text("Continue `RS-07`.")
+    assert do_now.priority == RoadmapPriority.DO_NOW
+    assert do_now.blocked_codes == ()
+    assert policy.allows_boss_ready("Continue `RS-07`.")
+
+
+def test_priority_policy_unknown_codes_do_not_block_boss_ready() -> None:
+    policy = RoadmapPriorityPolicy(
+        do_now=frozenset({"RS-07"}),
+        delay=frozenset({"BC-07"}),
+        avoid=frozenset({"UDW-08"}),
+    )
+
+    match = policy.priority_for_text("Unclassified `ZZ-99`.")
+
+    assert match.priority == RoadmapPriority.UNKNOWN
+    assert match.codes == ("ZZ-99",)
+    assert match.blocked_codes == ()
+    assert policy.allows_boss_ready("Unclassified `ZZ-99`.")
+    assert not RoadmapPriority.DO_NOW.blocks_boss_ready
+    assert not RoadmapPriority.UNKNOWN.blocks_boss_ready
+    assert RoadmapPriority.DELAY.blocks_boss_ready
+    assert RoadmapPriority.AVOID.blocks_boss_ready
+
+
+def test_load_priority_policy_returns_none_when_canonical_file_is_missing(
+    tmp_path: Path,
+) -> None:
+    assert load_roadmap_priority_policy(tmp_path) is None
 
 
 def test_load_priority_policy_parses_canonical_sections(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- expand roadmap priority coverage for malformed ranges, empty tokens, and first-seen ordering
- exercise `RoadmapPriorityPolicy` blocking behavior and unknown-code handling
- cover missing canonical file behavior so the priority loader fails safely

## Validation
- `python3 -m pytest tests/swarm/test_roadmap_priority.py -q`
- `ruff check tests/swarm/test_roadmap_priority.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Closes #5903
Closes #6092
