### PR TITLE
feat(spec-upgrader): v1.1 — Seam B contract-drift wiring

### DIFF
--- a/aragora/swarm/boss_worker_lifecycle.py
+++ b/aragora/swarm/boss_worker_lifecycle.py
@@ -900,7 +900,47 @@ async def dispatch_issue(
         claimed_runner_id,
     )
     if gate_result is not None:
-        return with_sanitizer_metadata(gate_result)
+        # Seam B: attempt one drift-feedback upgrade and re-enter the gate once
+        # before terminating with ``blocked_not_dispatch_bounded``.
+        # ``dispatch_contract_gate`` released ``claimed_runner_id`` on failure;
+        # clear our handle so we don't double-release.
+        claimed_runner_id = None
+        upgraded_spec_on_drift = dispatch_followups_mod.maybe_upgrade_on_contract_drift(
+            gate_result=gate_result,
+            spec=spec,
+            issue_number=int(issue.number),
+            issue_title=str(issue.title or ""),
+            issue_body=sanitized_issue_body,
+            repo_root=Path.cwd(),
+            metrics_path=Path(
+                loop.config.metrics_jsonl_path or ".aragora/overnight/boss_metrics.jsonl"
+            ),
+            llm_client=None,
+        )
+        if upgraded_spec_on_drift is not None:
+            spec = upgraded_spec_on_drift
+            selected_runner, claimed_runner_id = loop._claim_runner_for_dispatch(
+                freshness,
+                requested_target_agent=requested_target_agent,
+            )
+            if selected_runner is None:
+                selected_runner = loop._selected_runner_for_dispatch(
+                    freshness,
+                    requested_target_agent=requested_target_agent,
+                )
+            gate_result = dispatch_contract_gate(
+                loop,
+                issue,
+                spec,
+                selected_runner,
+                requested_target_agent,
+                refinement_worker_env,
+                claimed_runner_id,
+            )
+            if gate_result is not None:
+                claimed_runner_id = None
+        if gate_result is not None:
+            return with_sanitizer_metadata(gate_result)
 
     try:
         result = await dispatch_bounded_spec(

--- a/aragora/swarm/dispatch_followups.py
+++ b/aragora/swarm/dispatch_followups.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import Any
@@ -12,8 +13,11 @@ from aragora.swarm.spec import SwarmSpec
 from aragora.swarm.spec_upgrader import (
     SpecUpgraderUnavailable,
     UpgradeFailureContext,
+    extract_drift_diagnostic,
     upgrade_spec,
 )
+
+logger = logging.getLogger(__name__)
 
 _MARKDOWN_BULLET_RE = re.compile(r"^[-*]\s+(?:\[[ xX]\]\s+)?(?P<text>.+)$")
 
@@ -187,10 +191,62 @@ def upgrade_on_contract_drift(
     return None
 
 
+def maybe_upgrade_on_contract_drift(
+    *,
+    gate_result: Any,
+    spec: SwarmSpec,
+    issue_number: int,
+    issue_title: str,
+    issue_body: str,
+    repo_root: Path,
+    metrics_path: Path,
+    llm_client: Any = None,
+) -> SwarmSpec | None:
+    """Seam B wiring helper -- extract drift from a failed contract-gate result.
+
+    Given the dict returned by
+    :func:`aragora.swarm.dispatch_contract_gate.dispatch_contract_gate` when
+    admission fails, pull out a drift diagnostic (if any), seed
+    ``expected.files`` from the spec's scope hints so the drift translator can
+    emit a concrete scoping criterion, and invoke
+    :func:`upgrade_on_contract_drift`.
+
+    Returns the upgraded :class:`SwarmSpec` when the upgrade produced a
+    dispatch-bounded spec; ``None`` when there was no drift to act on, the
+    upgrader escalated, or the LLM infrastructure was transiently unavailable.
+    """
+    drift = extract_drift_diagnostic(gate_result)
+    if drift is None:
+        return None
+    scope = [str(path).strip() for path in (spec.file_scope_hints or []) if str(path).strip()]
+    if scope:
+        expected = drift.setdefault("expected", {})
+        if not expected.get("files"):
+            expected["files"] = scope
+    try:
+        return upgrade_on_contract_drift(
+            spec,
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            preflight_diff=drift,
+            repo_root=repo_root,
+            metrics_path=metrics_path,
+            llm_client=llm_client,
+        )
+    except SpecUpgraderUnavailable:
+        logger.warning(
+            "spec_upgrader_unavailable_on_contract_drift issue=#%s",
+            issue_number,
+        )
+        return None
+
+
 __all__ = [
     "SpecUpgraderUnavailable",
     "annotate_result_with_conductor",
     "maybe_upgrade_dispatch_spec",
+    "maybe_upgrade_on_contract_drift",
     "upgrade_on_contract_drift",
     "upgrade_unbounded_spec",
 ]

--- a/aragora/swarm/spec_upgrader.py
+++ b/aragora/swarm/spec_upgrader.py
@@ -7,6 +7,7 @@ Public entry point: ``upgrade_spec()``. See
 from __future__ import annotations
 
 import json
+import logging
 import re
 import subprocess
 import time
@@ -16,6 +17,8 @@ from pathlib import Path
 from typing import Any, Literal
 
 from aragora.swarm.spec import SwarmSpec
+
+logger = logging.getLogger(__name__)
 
 UpgradePath = Literal["deterministic", "llm", "deterministic+llm"]
 UpgradeStatus = Literal["upgraded", "escalated"]
@@ -124,21 +127,148 @@ def _infer_track_scope(track_tag: str | None, *, issue_body: str, repo_root: Pat
 def _drift_to_acceptance_criterion(drift: dict | None) -> str | None:
     """Translate preflight contract drift into an actionable acceptance criterion.
 
-    Returns ``None`` if drift is absent or the expected and actual files match.
+    Returns ``None`` when drift is absent or no actionable signal is present.
+    The criterion is produced when either:
+    1. ``expected.files`` and ``actual.files`` mismatch (Seam-B plan shape), or
+    2. ``drift_signals`` is non-empty and ``expected.files`` is populated
+       (Seam-B v1.1 shape -- file-level diff is not surfaced, but the caller
+       has seeded ``expected.files`` from the spec's scope hints so we can
+       still emit a scoping criterion).
     """
     if not drift:
         return None
     expected = drift.get("expected", {}) or {}
     actual = drift.get("actual", {}) or {}
-    expected_files = list(expected.get("files", []))
-    actual_files = set(actual.get("files", []))
-    if not expected_files or set(expected_files) == actual_files:
+    expected_files = [str(f) for f in expected.get("files", []) if str(f).strip()]
+    actual_files = {str(f) for f in actual.get("files", []) if str(f).strip()}
+    drift_signals = drift.get("drift_signals") or []
+
+    files_mismatch = bool(expected_files) and set(expected_files) != actual_files
+    has_signals = bool(expected_files) and bool(drift_signals)
+    if not (files_mismatch or has_signals):
         return None
     files_str = ", ".join(f"`{f}`" for f in expected_files)
     return (
         f"Worker must scope changes strictly to: {files_str}. "
         "Reject any edits to files outside this list during preflight."
     )
+
+
+# Check names in ``preflight_receipts[].failed_checks[].name`` that indicate
+# contract drift rather than credential/runner/commit problems. ``contract_preflight``
+# is a catch-all for RuntimeError strings bubbled from ``_enforce_expected_contract``
+# in ``aragora/swarm/preflight.py`` -- we filter by ``detail`` substring as well.
+_DRIFT_CHECK_NAMES = frozenset(
+    {
+        "worker_contract_checksum",
+        "dispatch_gate",
+        "contract_preflight",
+    }
+)
+_DRIFT_DETAIL_SUBSTRINGS = ("drift", "drifted", "mismatch", "contract_drift")
+
+
+def _is_drift_check(name: str, detail: str) -> bool:
+    """Return True when a failed preflight check signals contract drift."""
+    normalized_name = (name or "").strip()
+    normalized_detail = (detail or "").strip().lower()
+    if normalized_name in _DRIFT_CHECK_NAMES:
+        # ``contract_preflight`` is a generic exception bucket. Require a
+        # drift-related substring in the detail to avoid over-triggering
+        # (e.g. unrelated runtime errors should not masquerade as drift).
+        if normalized_name == "contract_preflight":
+            return any(s in normalized_detail for s in _DRIFT_DETAIL_SUBSTRINGS)
+        return True
+    return False
+
+
+def extract_drift_diagnostic(contract_gate_result: Any) -> dict | None:
+    """Extract a drift diagnostic from a ``dispatch_contract_gate`` failure result.
+
+    The concrete shape of the gate result is defined in
+    ``aragora/swarm/dispatch_contract_gate.py`` -- the failure path returns::
+
+        {
+          "status": "needs_human",
+          "outcome": "blocked" | "blocked_auth_failure" | "blocked_no_runner",
+          "reasons": [...],
+          "next_actions": [...],
+          "dispatch_contract": {
+              "target_agent": str,
+              "contract_valid": bool,
+              "missing_slices": [...],
+              "credential_envelope": {...},
+              "required_receipts": [...],
+              "preflight_receipts": [
+                  {
+                      "check_type": str,
+                      "receipt_id": str,
+                      "passed": bool,
+                      "failure_terminal_class": str,
+                      "failed_checks": [{"name": str, "detail": str}, ...],
+                  },
+                  ...
+              ],
+          },
+        }
+
+    Contract drift is not surfaced as an explicit expected/actual file diff;
+    it surfaces as failed checks inside ``preflight_receipts`` -- specifically
+    ``worker_contract_checksum`` (checksum mismatch), ``dispatch_gate``
+    (admission verdict drift) and ``contract_preflight`` RuntimeError strings
+    mentioning "drifted" emitted by ``_enforce_expected_contract()`` in
+    ``aragora/swarm/preflight.py``.
+
+    Returns a dict with at least ``{"expected": {...}, "actual": {...}}`` shape
+    -- compatible with :func:`_drift_to_acceptance_criterion` -- plus
+    ``drift_signals`` summarising each surfaced signal. Returns ``None`` when
+    the input is malformed or no drift signals are present.
+    """
+    if not isinstance(contract_gate_result, dict):
+        logger.debug("extract_drift_diagnostic: non-dict input (%s)", type(contract_gate_result))
+        return None
+    dispatch_contract = contract_gate_result.get("dispatch_contract")
+    if not isinstance(dispatch_contract, dict):
+        logger.debug("extract_drift_diagnostic: no dispatch_contract section")
+        return None
+    preflight_receipts = dispatch_contract.get("preflight_receipts")
+    if not isinstance(preflight_receipts, list):
+        logger.debug(
+            "extract_drift_diagnostic: preflight_receipts is %s, expected list",
+            type(preflight_receipts),
+        )
+        return None
+
+    signals: list[dict[str, str]] = []
+    actual_details: list[str] = []
+    for receipt in preflight_receipts:
+        if not isinstance(receipt, dict) or bool(receipt.get("passed", False)):
+            continue
+        failed_checks = receipt.get("failed_checks")
+        if not isinstance(failed_checks, list):
+            logger.debug(
+                "extract_drift_diagnostic: failed_checks is %s, expected list",
+                type(failed_checks),
+            )
+            return None
+        for check in failed_checks:
+            if not isinstance(check, dict):
+                continue
+            name = str(check.get("name", "") or "").strip()
+            detail = str(check.get("detail", "") or "").strip()
+            if _is_drift_check(name, detail):
+                signals.append({"check": name, "detail": detail})
+                if detail:
+                    actual_details.append(detail)
+
+    if not signals:
+        return None
+
+    return {
+        "expected": {"files": []},
+        "actual": {"files": [], "details": actual_details},
+        "drift_signals": signals,
+    }
 
 
 def _tier1_enrich(

--- a/docs/plans/2026-04-17-spec-upgrader-design.md
+++ b/docs/plans/2026-04-17-spec-upgrader-design.md
@@ -6,6 +6,11 @@ Convert Aragora's boss-loop dispatch pipeline from a gate (rejects weak specs) t
 
 v1 addresses the narrow production blocker. The mechanism generalises to other integration points (CLI, pipeline stages) in follow-ups.
 
+### Status
+
+- **v1 (PR #6125, commit `efaeea6ef`)** — Seam A live via `dispatch_followups.upgrade_unbounded_spec()`. Seam B helper (`dispatch_followups.upgrade_on_contract_drift`) landed but runtime wiring deferred pending clarity on the concrete `dispatch_contract_gate()` return shape.
+- **v1.1 (this branch)** — Seam B runtime wiring shipped via `dispatch_followups.maybe_upgrade_on_contract_drift`, which extracts drift signals from `dispatch_contract_gate()`'s nested `preflight_receipts[].failed_checks` structure (see `aragora/swarm/spec_upgrader.py:extract_drift_diagnostic`) and seeds `expected.files` from the spec scope so the drift-to-acceptance-criterion translator can emit a concrete scoping constraint. `boss_worker_lifecycle.dispatch_issue()` now re-enters the contract gate once per drift, subject to the shared `max_attempts=2` budget.
+
 ## Context
 
 Current behaviour on dispatch:

--- a/tests/swarm/test_spec_upgrader.py
+++ b/tests/swarm/test_spec_upgrader.py
@@ -639,3 +639,183 @@ def test_upgrade_spec_llm_unavailable_bubbles(tmp_path):
                 metrics_path=metrics,
                 llm_client=mock_client,
             )
+
+
+# -------- extract_drift_diagnostic tests (Seam B v1.1) --------
+
+from aragora.swarm.spec_upgrader import extract_drift_diagnostic
+
+
+def _gate_result_with_failed_checks(
+    failed_checks: list[dict],
+    *,
+    check_type: str = "scratch",
+    outcome: str = "blocked",
+) -> dict:
+    """Build a realistic ``dispatch_contract_gate`` failure result."""
+    return {
+        "status": "needs_human",
+        "outcome": outcome,
+        "reasons": ["synthetic drift"],
+        "next_actions": ["retry"],
+        "dispatch_contract": {
+            "target_agent": "codex",
+            "contract_valid": True,
+            "missing_slices": [],
+            "credential_envelope": {},
+            "required_receipts": [check_type],
+            "preflight_receipts": [
+                {
+                    "check_type": check_type,
+                    "receipt_id": "rcpt-1",
+                    "passed": False,
+                    "expires_at": "",
+                    "failure_terminal_class": "BLOCKED_NOT_DISPATCH_BOUNDED",
+                    "failed_checks": failed_checks,
+                }
+            ],
+        },
+    }
+
+
+def test_extract_drift_diagnostic_checksum_drift():
+    gate = _gate_result_with_failed_checks(
+        [
+            {
+                "name": "worker_contract_checksum",
+                "detail": "abc123 != expected def456",
+            }
+        ]
+    )
+    diag = extract_drift_diagnostic(gate)
+    assert diag is not None
+    assert "expected" in diag and "actual" in diag
+    # Shape compatibility with _drift_to_acceptance_criterion.
+    assert isinstance(diag["expected"], dict)
+    assert isinstance(diag["actual"], dict)
+    # Drift signal captured.
+    signals = diag.get("drift_signals") or []
+    assert any(s.get("check") == "worker_contract_checksum" for s in signals)
+
+
+def test_extract_drift_diagnostic_dispatch_gate_drift():
+    gate = _gate_result_with_failed_checks(
+        [
+            {
+                "name": "dispatch_gate",
+                "detail": "verdict=BLOCKED failure_class=contract_drift",
+            }
+        ]
+    )
+    diag = extract_drift_diagnostic(gate)
+    assert diag is not None
+    signals = diag["drift_signals"]
+    assert any(s["check"] == "dispatch_gate" for s in signals)
+
+
+def test_extract_drift_diagnostic_contract_preflight_drift_detail():
+    gate = _gate_result_with_failed_checks(
+        [
+            {
+                "name": "contract_preflight",
+                "detail": "Preflight worker emitted a contract that drifted from the expected contract.",
+            }
+        ]
+    )
+    diag = extract_drift_diagnostic(gate)
+    assert diag is not None
+    assert diag["drift_signals"]
+
+
+def test_extract_drift_diagnostic_no_drift_signals_returns_none():
+    # A receipt with failed checks that are auth-related, not drift.
+    gate = _gate_result_with_failed_checks(
+        [
+            {
+                "name": "worker_commit",
+                "detail": "worker produced no commit",
+            }
+        ]
+    )
+    assert extract_drift_diagnostic(gate) is None
+
+
+def test_extract_drift_diagnostic_all_receipts_passed_returns_none():
+    # When every receipt passed, there is no drift to surface.
+    gate = _gate_result_with_failed_checks([])
+    gate["dispatch_contract"]["preflight_receipts"][0]["passed"] = True
+    assert extract_drift_diagnostic(gate) is None
+
+
+def test_extract_drift_diagnostic_no_dispatch_contract_returns_none():
+    gate = {"status": "needs_human", "outcome": "blocked"}
+    assert extract_drift_diagnostic(gate) is None
+
+
+def test_extract_drift_diagnostic_non_dict_returns_none():
+    assert extract_drift_diagnostic(None) is None  # type: ignore[arg-type]
+    assert extract_drift_diagnostic("not a dict") is None  # type: ignore[arg-type]
+    assert extract_drift_diagnostic([1, 2, 3]) is None  # type: ignore[arg-type]
+
+
+def test_extract_drift_diagnostic_malformed_receipts_returns_none():
+    gate = {
+        "status": "needs_human",
+        "dispatch_contract": {"preflight_receipts": "not a list"},
+    }
+    assert extract_drift_diagnostic(gate) is None
+
+
+def test_extract_drift_diagnostic_missing_failed_checks_returns_none():
+    gate = {
+        "status": "needs_human",
+        "dispatch_contract": {
+            "preflight_receipts": [
+                {"check_type": "scratch", "passed": False, "failed_checks": "bogus"}
+            ]
+        },
+    }
+    assert extract_drift_diagnostic(gate) is None
+
+
+def test_extract_drift_diagnostic_multiple_signals_aggregated():
+    gate = _gate_result_with_failed_checks(
+        [
+            {"name": "worker_contract_checksum", "detail": "mismatch"},
+            {"name": "dispatch_gate", "detail": "verdict=BLOCKED"},
+            {"name": "worker_commit", "detail": "no commit"},  # not a drift signal
+        ]
+    )
+    diag = extract_drift_diagnostic(gate)
+    assert diag is not None
+    checks = {s["check"] for s in diag["drift_signals"]}
+    assert checks == {"worker_contract_checksum", "dispatch_gate"}
+
+
+def test_extract_drift_diagnostic_missing_slices_only_returns_none():
+    # Missing slices are auth/credential issues -- not spec drift.
+    gate = {
+        "status": "needs_human",
+        "outcome": "blocked_auth_failure",
+        "dispatch_contract": {
+            "missing_slices": ["runner"],
+            "preflight_receipts": [],
+        },
+    }
+    assert extract_drift_diagnostic(gate) is None
+
+
+def test_drift_to_acceptance_criterion_accepts_drift_signals():
+    """Drift dicts without explicit files but with drift_signals should still yield a criterion."""
+    from aragora.swarm.spec_upgrader import _drift_to_acceptance_criterion
+
+    drift = {
+        "expected": {"files": ["aragora/swarm/boss_loop.py"]},
+        "actual": {"files": []},
+        "drift_signals": [
+            {"check": "worker_contract_checksum", "detail": "mismatch"},
+        ],
+    }
+    crit = _drift_to_acceptance_criterion(drift)
+    assert crit is not None
+    assert "aragora/swarm/boss_loop.py" in crit

--- a/tests/swarm/test_spec_upgrader_integration.py
+++ b/tests/swarm/test_spec_upgrader_integration.py
@@ -166,3 +166,223 @@ def test_e2e_issue_5903_gets_bounded(tmp_path, monkeypatch):
         )
     assert result is not None, "Tier 1 should bound #5903 via CS-01 track hints and body file refs"
     assert result.is_dispatch_bounded()
+
+
+# -------- Seam B v1.1 integration tests --------
+
+
+def _gate_failure_with_checksum_drift() -> dict:
+    """Realistic ``dispatch_contract_gate()`` failure return with drift signals."""
+    return {
+        "status": "needs_human",
+        "outcome": "blocked",
+        "reasons": ["Issue failed contract admission"],
+        "next_actions": ["retry"],
+        "dispatch_contract": {
+            "target_agent": "codex",
+            "contract_valid": True,
+            "missing_slices": [],
+            "credential_envelope": {},
+            "required_receipts": ["scratch"],
+            "preflight_receipts": [
+                {
+                    "check_type": "scratch",
+                    "receipt_id": "rcpt-1",
+                    "passed": False,
+                    "expires_at": "",
+                    "failure_terminal_class": "BLOCKED_NOT_DISPATCH_BOUNDED",
+                    "failed_checks": [
+                        {
+                            "name": "worker_contract_checksum",
+                            "detail": "worker_checksum != expected (drifted)",
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
+def test_maybe_upgrade_on_contract_drift_extracts_and_calls(tmp_path):
+    """``maybe_upgrade_on_contract_drift`` must extract drift then call
+    ``upgrade_on_contract_drift`` with the drift diagnostic populated."""
+    from aragora.swarm.dispatch_followups import maybe_upgrade_on_contract_drift
+
+    (tmp_path / "aragora" / "swarm").mkdir(parents=True)
+    (tmp_path / "aragora" / "swarm" / "boss_loop.py").write_text("")
+    metrics = tmp_path / "boss_metrics.jsonl"
+
+    spec = SwarmSpec(
+        raw_goal="Fix a thing",
+        refined_goal="Fix a thing",
+        acceptance_criteria=["Do it"],
+        constraints=[],
+        file_scope_hints=["aragora/swarm/boss_loop.py"],
+        work_orders=[],
+    )
+    gate = _gate_failure_with_checksum_drift()
+
+    sentinel_spec = SwarmSpec(
+        raw_goal="Fix a thing",
+        refined_goal="Fix a thing",
+        acceptance_criteria=["Do it", "Scope criterion"],
+        constraints=[],
+        file_scope_hints=["aragora/swarm/boss_loop.py"],
+        work_orders=[],
+    )
+
+    with patch(
+        "aragora.swarm.dispatch_followups.upgrade_on_contract_drift",
+        return_value=sentinel_spec,
+    ) as mock_upgrade:
+        result = maybe_upgrade_on_contract_drift(
+            gate_result=gate,
+            spec=spec,
+            issue_number=5898,
+            issue_title="[TW-02] Fix",
+            issue_body="Fix `aragora/swarm/boss_loop.py`.",
+            repo_root=Path(tmp_path),
+            metrics_path=metrics,
+            llm_client=None,
+        )
+
+    assert result is sentinel_spec
+    mock_upgrade.assert_called_once()
+    call_kwargs = mock_upgrade.call_args.kwargs
+    passed_diff = call_kwargs["preflight_diff"]
+    assert passed_diff["drift_signals"]  # extractor produced signals
+    assert any(s["check"] == "worker_contract_checksum" for s in passed_diff["drift_signals"])
+    # Expected.files seeded from spec.file_scope_hints by the helper.
+    assert passed_diff["expected"]["files"] == ["aragora/swarm/boss_loop.py"]
+
+
+def test_maybe_upgrade_on_contract_drift_no_drift_returns_none(tmp_path):
+    """When the gate failure has no drift signals, the helper returns None without calling upgrader."""
+    from aragora.swarm.dispatch_followups import maybe_upgrade_on_contract_drift
+
+    spec = SwarmSpec(
+        raw_goal="x",
+        refined_goal="x",
+        acceptance_criteria=["do"],
+        constraints=[],
+        file_scope_hints=["x.py"],
+        work_orders=[],
+    )
+    gate_no_drift = {
+        "status": "needs_human",
+        "outcome": "blocked_auth_failure",
+        "dispatch_contract": {
+            "missing_slices": ["runner"],
+            "preflight_receipts": [],
+        },
+    }
+    with patch("aragora.swarm.dispatch_followups.upgrade_on_contract_drift") as mock_upgrade:
+        result = maybe_upgrade_on_contract_drift(
+            gate_result=gate_no_drift,
+            spec=spec,
+            issue_number=5898,
+            issue_title="X",
+            issue_body="",
+            repo_root=Path(tmp_path),
+            metrics_path=tmp_path / "metrics.jsonl",
+        )
+    assert result is None
+    mock_upgrade.assert_not_called()
+
+
+def test_maybe_upgrade_on_contract_drift_handles_unavailable(tmp_path):
+    """Transient LLM infrastructure failure must swallow cleanly to None."""
+    from aragora.swarm.dispatch_followups import (
+        SpecUpgraderUnavailable,
+        maybe_upgrade_on_contract_drift,
+    )
+
+    spec = SwarmSpec(
+        raw_goal="x",
+        refined_goal="x",
+        acceptance_criteria=["do"],
+        constraints=[],
+        file_scope_hints=["x.py"],
+        work_orders=[],
+    )
+    gate = _gate_failure_with_checksum_drift()
+    with patch(
+        "aragora.swarm.dispatch_followups.upgrade_on_contract_drift",
+        side_effect=SpecUpgraderUnavailable("llm down"),
+    ):
+        result = maybe_upgrade_on_contract_drift(
+            gate_result=gate,
+            spec=spec,
+            issue_number=5898,
+            issue_title="X",
+            issue_body="",
+            repo_root=Path(tmp_path),
+            metrics_path=tmp_path / "metrics.jsonl",
+        )
+    assert result is None
+
+
+def test_seam_b_retry_flow_end_to_end(tmp_path):
+    """Simulate the boss_worker_lifecycle double-gate flow: first gate returns drift,
+    upgrader bounds spec, second gate passes (None). This mirrors the wiring."""
+    from aragora.swarm.dispatch_followups import maybe_upgrade_on_contract_drift
+
+    (tmp_path / "aragora" / "swarm").mkdir(parents=True)
+    (tmp_path / "aragora" / "swarm" / "boss_loop.py").write_text("")
+    metrics = tmp_path / "boss_metrics.jsonl"
+
+    spec = SwarmSpec(
+        raw_goal="Fix",
+        refined_goal="Fix",
+        acceptance_criteria=["Do it"],
+        constraints=[],
+        file_scope_hints=["aragora/swarm/boss_loop.py"],
+        work_orders=[],
+    )
+
+    # Mocked contract gate: first call returns drift, second call passes (returns None).
+    gate_returns = [_gate_failure_with_checksum_drift(), None]
+    gate_calls: list[tuple] = []
+
+    def fake_gate(*args, **kwargs):
+        gate_calls.append((args, kwargs))
+        return gate_returns.pop(0) if gate_returns else None
+
+    # Run the equivalent wiring inline.
+    with patch("aragora.swarm.spec_upgrader.AuditPersistence") as AP:
+        AP.return_value.read_attempt_count.return_value = (0, True)
+        AP.return_value.upsert.return_value = True
+
+        first_gate_result = fake_gate(spec)
+        assert first_gate_result is not None  # drift surfaced
+        upgraded = maybe_upgrade_on_contract_drift(
+            gate_result=first_gate_result,
+            spec=spec,
+            issue_number=5898,
+            issue_title="[TW-02] Fix",
+            issue_body="Fix `aragora/swarm/boss_loop.py`.",
+            repo_root=Path(tmp_path),
+            metrics_path=metrics,
+            llm_client=None,
+        )
+
+    assert upgraded is not None, "Upgrader should have bounded the drift-feedback spec"
+    # Scoping criterion should be synthesized from seeded expected.files.
+    assert any("aragora/swarm/boss_loop.py" in c for c in upgraded.acceptance_criteria)
+
+    # Second gate call passes -> dispatch proceeds.
+    second_gate_result = fake_gate(upgraded)
+    assert second_gate_result is None
+    assert len(gate_calls) == 2
+
+
+def test_seam_b_wiring_integrated_in_boss_worker_lifecycle():
+    """Smoke-level check: ``boss_worker_lifecycle`` imports the helper and
+    dispatch_followups exports it. Prevents silent wiring regressions."""
+    from aragora.swarm import boss_worker_lifecycle, dispatch_followups
+
+    assert hasattr(dispatch_followups, "maybe_upgrade_on_contract_drift")
+    source = Path(boss_worker_lifecycle.__file__).read_text()
+    assert "maybe_upgrade_on_contract_drift" in source, (
+        "boss_worker_lifecycle.py must call maybe_upgrade_on_contract_drift (Seam B)"
+    )


### PR DESCRIPTION
## Summary

Ships Seam B runtime wiring for the SpecUpgrader -- the drift-feedback repair that was
explicitly deferred in the v1 merge (PR #6125, commit `efaeea6ef`) because the actual
`dispatch_contract_gate()` return shape embeds drift inside nested receipt structures
without an explicit expected/actual file diff.

## Seam B v1.1 changes

- **`extract_drift_diagnostic()`** in `aragora/swarm/spec_upgrader.py` parses the real
  gate-failure shape: drift surfaces as failed checks inside
  `dispatch_contract.preflight_receipts[].failed_checks` with names
  `worker_contract_checksum` (checksum mismatch),
  `dispatch_gate` (admission verdict drift) and
  `contract_preflight` (RuntimeError strings from `_enforce_expected_contract()`
  mentioning "drifted"). Returns a dict compatible with
  `_drift_to_acceptance_criterion()`, or `None` for malformed input /
  non-drift failures (auth, commit, etc.) with debug-level logging.
- **`_drift_to_acceptance_criterion()`** extended: emits a scoping criterion
  when `drift_signals` is present and the caller has seeded `expected.files`
  from the spec's scope (the gate result does not surface the actual files
  the worker touched).
- **`dispatch_followups.maybe_upgrade_on_contract_drift()`** composes the
  extractor with `upgrade_on_contract_drift()`, seeding `expected.files`
  from the spec's scope hints so the drift translator can emit a concrete
  criterion.
- **`boss_worker_lifecycle.dispatch_issue()`** now re-enters
  `dispatch_contract_gate()` once per drift after a successful upgrade,
  subject to the shared `max_attempts=2` budget. The runner-claim
  re-acquisition path handles the gate's internal release on failure.

## Guarantees preserved

- Shared attempt budget across Seam A + Seam B (durable via
  `[spec-upgraded]` audit marker).
- `SpecUpgraderUnavailable` on transient LLM infra errors is swallowed to
  `None` (caller skips for this tick, does not consume an attempt).
- No drift or malformed gate result → `maybe_upgrade_on_contract_drift`
  returns `None` without calling the upgrader, dispatch falls through to
  the existing `blocked_not_dispatch_bounded` termination.

## LOC ratchet

`boss_worker_lifecycle.py` goes from 996 → 1036 (+40 LOC), well under the 5400
hard limit. The extraction + helper design keeps the call-site wiring small;
the incremental LOC mostly covers runner-claim re-acquisition.

## Tests

- `tests/swarm/test_spec_upgrader.py` — 12 new unit tests covering drift
  extraction across checksum, dispatch-gate, and `contract_preflight` signals,
  plus malformed-input handling.
- `tests/swarm/test_spec_upgrader_integration.py` — 4 new integration tests
  covering `maybe_upgrade_on_contract_drift` behavior (extract + call,
  no-drift short-circuit, unavailable handling) and a double-gate
  retry-flow scenario that mirrors the `boss_worker_lifecycle` wiring,
  plus a smoke-level assertion that `boss_worker_lifecycle.py` imports
  the helper.

All 56 spec-upgrader + integration tests pass; all 177 touched-module tests
(`test_boss_worker_lifecycle.py`, `test_dispatch_contract_gate.py`,
`test_dispatch_followups.py`) pass. ruff clean; mypy introduces no new errors
on the three touched modules.

## Test plan checklist

- [x] Unit: `pytest tests/swarm/test_spec_upgrader.py` (52 passed)
- [x] Integration: `pytest tests/swarm/test_spec_upgrader_integration.py` (9 passed)
- [x] Regression: `pytest tests/swarm/test_boss_worker_lifecycle.py tests/swarm/test_dispatch_contract_gate.py tests/swarm/test_dispatch_followups.py` (177 passed)
- [x] ruff clean on touched files
- [x] mypy clean on touched files (no new errors vs baseline)
- [x] LOC ratchet: `boss_worker_lifecycle.py` 1036 LOC (< 5400)

## Design

See `docs/plans/2026-04-17-spec-upgrader-design.md` (amended with a Status
section recording v1 → v1.1) and `docs/plans/2026-04-17-spec-upgrader-plan.md`
(original Task 14).