### PR TITLE
fix(spec-upgrader): audit comment list uses REST for numeric IDs

### DIFF
--- a/aragora/swarm/spec_upgrader.py
+++ b/aragora/swarm/spec_upgrader.py
@@ -505,18 +505,15 @@ class AuditPersistence:
     # --- gh wrappers (seams for test mocking) ---
 
     def _gh_list_comments(self) -> list[dict]:
+        # Use REST API directly so `id` is the numeric comment ID the PATCH endpoint
+        # expects. `gh issue view --json comments` returns GraphQL node IDs
+        # (e.g. `IC_kwDO...`) which 404 when passed to `/repos/.../issues/comments/{id}`.
         out = subprocess.check_output(
             [
                 "gh",
-                "issue",
-                "view",
-                str(self.issue_number),
-                "--repo",
-                self.repo,
-                "--json",
-                "comments",
-                "--jq",
-                ".comments",
+                "api",
+                "--paginate",
+                f"/repos/{self.repo}/issues/{self.issue_number}/comments",
             ],
             text=True,
         )


### PR DESCRIPTION
## Summary
- Fixes HTTP 404 on `AuditPersistence._gh_update_comment` when updating existing `[spec-upgraded]` audit comments.
- `gh issue view --json comments` returns GraphQL node IDs (`IC_kwDO...`), but the PATCH endpoint expects numeric database IDs. Switch `_gh_list_comments` to call `gh api /repos/.../issues/{n}/comments` which returns numeric IDs.
- Observed in today's boss loop run: first create works, all subsequent updates 404 and set `upgrade_audit_failed=true`.

## Test plan
- [x] Existing tests all pass: `pytest tests/swarm/test_spec_upgrader.py tests/swarm/test_spec_upgrader_integration.py` — **61 passed**.
- [x] No change to test fixtures because tests mock `_gh_list_comments` at the method level.
- [ ] Manual: boss loop cycle with repeat dispatch produces `attempt=2` marker update with no 404 in log.

## Context
See `docs/plans/2026-04-17-spec-upgrader-design.md` (AuditPersistence section) for the full contract. This is v1.1.1, not part of v1.2 (worker drift investigation).