### PR TITLE
fix(proof-first): bootstrap boss loop when launchd is missing

### DIFF
--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -7,6 +7,7 @@ import argparse
 import asyncio
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -36,6 +37,17 @@ DEFAULT_MERGE_LABEL = "com.aragora.swarm-merge-arbiter"
 DEFAULT_BOSS_PROCESS_PATTERN = r"aragora\.cli\.main swarm boss-loop|run_boss_cycle\.sh"
 DEFAULT_MERGE_PROCESS_PATTERN = r"aragora\.cli\.main swarm merge-arbiter"
 DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS = 45.0
+DEFAULT_BOSS_TARGET_BRANCH = "main"
+DEFAULT_BOSS_WORKER_MODEL = "codex"
+DEFAULT_BOSS_REVIEW_MODEL = "codex"
+DEFAULT_BOSS_LABELS = ("autonomous", "boss-ready")
+DEFAULT_BOSS_MAX_TICKS = "200"
+DEFAULT_BOSS_INTERVAL_SECONDS = "90"
+DEFAULT_BOSS_MAX_CONSECUTIVE_FAILURES = "12"
+DEFAULT_BOSS_MAX_HOURS = "8"
+DEFAULT_BOSS_MAX_PARALLEL_DISPATCHES = "1"
+DEFAULT_BOSS_AUTONOMY_MODE = "full-auto"
+DEFAULT_BOSS_BOOTSTRAP_LOG = ".aragora/overnight/proof-first-boss-loop-bootstrap.log"
 LAUNCHD_THROTTLE_GRACE_SECONDS = 60.0
 AUTH_FAILURE_STOP_AFTER = 2
 PUBLICATION_FAILURE_STOP_AFTER = 2
@@ -613,6 +625,105 @@ def should_restart_service(
     return (not is_running) and pending_count > 0 and restart_count < restart_limit
 
 
+def launchd_service_missing(status: LaunchdServiceStatus) -> bool:
+    detail = status.detail.lower()
+    return "could not find service" in detail or "launchctl print failed" in detail
+
+
+def _env_or_default(name: str, default: str) -> str:
+    value = os.getenv(name, "").strip()
+    return value or default
+
+
+def _boss_labels_from_env() -> list[str]:
+    raw = os.getenv("BOSS_LABELS", "").strip()
+    if not raw:
+        return list(DEFAULT_BOSS_LABELS)
+    labels = [label.strip() for label in raw.split(",") if label.strip()]
+    return labels or list(DEFAULT_BOSS_LABELS)
+
+
+def build_direct_boss_loop_command(*, repo: str) -> list[str]:
+    python_bin = sys.executable or shutil.which("python3") or "python3"
+    command = [
+        python_bin,
+        "-u",
+        "-m",
+        "aragora.cli.main",
+        "swarm",
+        "boss-loop",
+        "--boss-repo",
+        _env_or_default("BOSS_REPO", repo),
+        "--target-branch",
+        _env_or_default("TARGET_BRANCH", DEFAULT_BOSS_TARGET_BRANCH),
+        "--worker-model",
+        _env_or_default("WORKER_MODEL", DEFAULT_BOSS_WORKER_MODEL),
+        "--review-model",
+        _env_or_default("REVIEW_MODEL", DEFAULT_BOSS_REVIEW_MODEL),
+    ]
+    for label in _boss_labels_from_env():
+        command.extend(["--label", label])
+    command.extend(
+        [
+            "--max-ticks",
+            _env_or_default("BOSS_MAX_TICKS", DEFAULT_BOSS_MAX_TICKS),
+            "--interval",
+            _env_or_default("BOSS_INTERVAL_SECONDS", DEFAULT_BOSS_INTERVAL_SECONDS),
+            "--max-consecutive-failures",
+            _env_or_default(
+                "BOSS_MAX_CONSECUTIVE_FAILURES",
+                DEFAULT_BOSS_MAX_CONSECUTIVE_FAILURES,
+            ),
+            "--autonomy",
+            _env_or_default("BOSS_AUTONOMY_MODE", DEFAULT_BOSS_AUTONOMY_MODE),
+            "--max-hours",
+            _env_or_default("BOSS_MAX_HOURS", DEFAULT_BOSS_MAX_HOURS),
+            "--boss-max-parallel-dispatches",
+            _env_or_default(
+                "BOSS_MAX_PARALLEL_DISPATCHES",
+                DEFAULT_BOSS_MAX_PARALLEL_DISPATCHES,
+            ),
+        ]
+    )
+    return command
+
+
+def start_detached_boss_loop(
+    *,
+    repo_root: Path,
+    repo: str,
+    process_pattern: str,
+    start_timeout_seconds: float = DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS,
+) -> tuple[bool, str]:
+    log_path = repo_root / DEFAULT_BOSS_BOOTSTRAP_LOG
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    command = build_direct_boss_loop_command(repo=repo)
+    try:
+        with log_path.open("ab") as log_handle:
+            proc = subprocess.Popen(
+                command,
+                cwd=repo_root,
+                env=os.environ.copy(),
+                stdin=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+    except OSError as exc:
+        return False, f"direct boss-loop bootstrap failed: {exc}"
+
+    if wait_for_process(process_pattern, timeout_seconds=start_timeout_seconds):
+        return (
+            True,
+            f"launchd service missing; bootstrapped direct boss loop pid={proc.pid} log={log_path}",
+        )
+    return (
+        False,
+        f"launchd service missing; launched direct boss loop pid={proc.pid}, but process pattern "
+        f"{process_pattern!r} is still not running",
+    )
+
+
 def kickstart_launchd(label: str) -> tuple[bool, str]:
     uid = os.getuid()
     try:
@@ -671,6 +782,27 @@ def restart_service_via_launchd(
     if state_detail:
         return False, f"{detail}; {state_detail}"
     return False, detail
+
+
+def restart_boss_service(
+    *,
+    repo_root: Path,
+    repo: str,
+    process_pattern: str,
+) -> tuple[bool, str, str]:
+    initial_status = inspect_launchd_service(DEFAULT_BOSS_LABEL)
+    if launchd_service_missing(initial_status):
+        restarted, detail = start_detached_boss_loop(
+            repo_root=repo_root,
+            repo=repo,
+            process_pattern=process_pattern,
+        )
+        return restarted, detail, "bootstrap_boss_loop_direct"
+    restarted, detail = restart_service_via_launchd(
+        label=DEFAULT_BOSS_LABEL,
+        process_pattern=process_pattern,
+    )
+    return restarted, detail, "restart_boss_loop"
 
 
 def _read_launchd_failure_detail(label: str) -> str:
@@ -878,8 +1010,9 @@ def run_shift_cycle(
         pending_count=canonical_queue_count,
         restart_count=runtime_state.boss_restart_count,
     ):
-        restarted, detail = restart_service_via_launchd(
-            label=DEFAULT_BOSS_LABEL,
+        restarted, detail, boss_restart_action = restart_boss_service(
+            repo_root=repo_root,
+            repo=repo,
             process_pattern=DEFAULT_BOSS_PROCESS_PATTERN,
         )
         runtime_state.boss_restart_count += 1
@@ -887,17 +1020,17 @@ def run_shift_cycle(
             ledger,
             runtime_state,
             failure_class=BOSS_RESTART_FAILURE,
-            action="restart_boss_loop",
+            action=boss_restart_action,
             success=restarted,
             detail=detail,
         )
         if restarted:
             boss_running = True
-            actions.append("restart_boss_loop")
+            actions.append(boss_restart_action)
             if ledger:
-                ledger.record_service_restart(service="boss_loop", success=True)
+                ledger.record_service_restart(service="boss_loop", success=True, detail=detail)
         else:
-            actions.append("restart_boss_loop_failed")
+            actions.append(f"{boss_restart_action}_failed")
             stop_reason = f"BossRestartFailed: {detail or 'boss loop restart did not produce a running process'}"
             service_failures.append(stop_reason)
             if ledger:

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -22,15 +22,17 @@ def _run_shift_cycle(
     trigger_benchmark_side_effect: Exception | None = None,
     ledger: ShiftLedger | None = None,
 ) -> dict[str, object]:
-    restart_patch = (
+    boss_restart_patch = (
         patch(
-            "scripts.run_proof_first_shift.restart_service_via_launchd",
-            side_effect=restart_service_side_effect,
+            "scripts.run_proof_first_shift.restart_boss_service",
+            side_effect=[
+                (ok, detail, "restart_boss_loop") for ok, detail in restart_service_side_effect
+            ],
         )
         if restart_service_side_effect is not None
         else patch(
-            "scripts.run_proof_first_shift.restart_service_via_launchd",
-            return_value=(True, ""),
+            "scripts.run_proof_first_shift.restart_boss_service",
+            return_value=(True, "", "restart_boss_loop"),
         )
     )
     with (
@@ -46,7 +48,8 @@ def _run_shift_cycle(
             "scripts.run_proof_first_shift.process_running",
             side_effect=process_running_side_effect,
         ),
-        restart_patch,
+        boss_restart_patch,
+        patch("scripts.run_proof_first_shift.restart_service_via_launchd", return_value=(True, "")),
         patch("scripts.run_proof_first_shift.run_merge_arbiter_apply", return_value={"merged": []}),
         patch("scripts.run_proof_first_shift.latest_benchmark_run", return_value=latest_run),
         patch(
@@ -473,6 +476,72 @@ def test_restart_service_waits_for_successful_kickstart_process_start() -> None:
     assert detail == ""
 
 
+def test_restart_boss_service_uses_direct_bootstrap_when_launchd_service_is_missing() -> None:
+    missing = mod.LaunchdServiceStatus(
+        detail='Could not find service "com.aragora.swarm-boss-loop" in domain for user gui: 501'
+    )
+    with (
+        patch("scripts.run_proof_first_shift.inspect_launchd_service", return_value=missing),
+        patch(
+            "scripts.run_proof_first_shift.start_detached_boss_loop",
+            return_value=(True, "bootstrapped direct boss loop"),
+        ) as bootstrap_mock,
+        patch(
+            "scripts.run_proof_first_shift.restart_service_via_launchd",
+            side_effect=AssertionError(
+                "launchd restart should not run when the service is missing"
+            ),
+        ),
+    ):
+        ok, detail, action = mod.restart_boss_service(
+            repo_root=Path(".").resolve(),
+            repo="synaptent/aragora",
+            process_pattern="boss-loop",
+        )
+
+    assert ok is True
+    assert detail == "bootstrapped direct boss loop"
+    assert action == "bootstrap_boss_loop_direct"
+    assert bootstrap_mock.called
+
+
+def test_build_direct_boss_loop_command_uses_env_configuration() -> None:
+    with patch.dict(
+        "os.environ",
+        {
+            "BOSS_REPO": "synaptent/aragora",
+            "TARGET_BRANCH": "release",
+            "WORKER_MODEL": "claude",
+            "REVIEW_MODEL": "codex",
+            "BOSS_LABELS": "boss-ready,autonomous",
+            "BOSS_MAX_TICKS": "17",
+            "BOSS_INTERVAL_SECONDS": "45",
+            "BOSS_MAX_CONSECUTIVE_FAILURES": "9",
+            "BOSS_AUTONOMY_MODE": "guided",
+            "BOSS_MAX_HOURS": "6",
+            "BOSS_MAX_PARALLEL_DISPATCHES": "2",
+        },
+        clear=False,
+    ):
+        command = mod.build_direct_boss_loop_command(repo="ignored/repo")
+
+    assert command[:6] == [command[0], "-u", "-m", "aragora.cli.main", "swarm", "boss-loop"]
+    assert (
+        "--boss-repo" in command
+        and command[command.index("--boss-repo") + 1] == "synaptent/aragora"
+    )
+    assert (
+        "--target-branch" in command and command[command.index("--target-branch") + 1] == "release"
+    )
+    assert command.count("--label") == 2
+    assert command[command.index("--max-ticks") + 1] == "17"
+    assert command[command.index("--interval") + 1] == "45"
+    assert command[command.index("--max-consecutive-failures") + 1] == "9"
+    assert command[command.index("--autonomy") + 1] == "guided"
+    assert command[command.index("--max-hours") + 1] == "6"
+    assert command[command.index("--boss-max-parallel-dispatches") + 1] == "2"
+
+
 def test_launchd_start_timeout_uses_default_for_non_throttled_state() -> None:
     assert (
         mod.launchd_start_timeout_seconds(mod.LaunchdServiceStatus(state="running"))
@@ -685,6 +754,45 @@ def test_run_shift_cycle_reports_restart_failure_instead_of_crashing() -> None:
     assert report["actions"] == ["restart_boss_loop_failed"]
     assert report["stop_reason"] == "BossRestartFailed: launchctl kickstart timed out for boss loop"
     assert report["failure_policy"]["service_failure"]["will_stop"] is True
+
+
+def test_run_shift_cycle_records_direct_bootstrap_when_launchd_service_is_missing() -> None:
+    state = mod.ProofFirstRuntimeState()
+    with (
+        patch(
+            "scripts.run_proof_first_shift.restart_boss_service",
+            return_value=(
+                True,
+                "launchd service missing; bootstrapped direct boss loop pid=123",
+                "bootstrap_boss_loop_direct",
+            ),
+        ),
+        patch(
+            "scripts.run_proof_first_shift.reconcile_proof_first_queue",
+            return_value={"kept": [{"id": 1}], "removed": []},
+        ),
+        patch(
+            "scripts.run_proof_first_shift.collect_boss_lane_snapshot", return_value={"ok": True}
+        ),
+        patch("scripts.run_proof_first_shift.list_open_prs", return_value=[]),
+        patch("scripts.run_proof_first_shift.process_running", side_effect=[False, True]),
+        patch("scripts.run_proof_first_shift.restart_service_via_launchd", return_value=(True, "")),
+        patch("scripts.run_proof_first_shift.run_merge_arbiter_apply", return_value={"merged": []}),
+        patch("scripts.run_proof_first_shift.latest_benchmark_run", return_value=None),
+        patch("scripts.run_proof_first_shift.fetch_benchmark_failure_log", return_value=""),
+        patch("scripts.run_proof_first_shift.trigger_benchmark_workflow", return_value=None),
+    ):
+        report = mod.run_shift_cycle(
+            repo_root=Path(".").resolve(),
+            repo="synaptent/aragora",
+            benchmark_mode="disabled",
+            automation_backlog_limit=12,
+            runtime_state=state,
+            ledger=None,
+        )
+
+    assert report["actions"] == ["bootstrap_boss_loop_direct"]
+    assert report["stop_reason"] == ""
 
 
 def test_run_shift_cycle_stops_cleanly_when_github_is_unavailable(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- detect when the boss-loop LaunchAgent is absent instead of treating it like a generic kickstart failure
- bootstrap a detached boss loop directly from the proof-first shift in that narrow missing-service case using env-aligned boss-loop settings
- cover the new direct-bootstrap path in focused proof-first shift tests

## Validation
- python3 -m ruff check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py
- python3 -m pytest tests/scripts/test_run_proof_first_shift.py -q
- python3 -m pytest tests/swarm/test_shift_ledger.py -q
- bash scripts/automation_pr_preflight.sh origin/main HEAD
