### PR TITLE
feat(agt): end-to-end pipeline dry-run + committed fixture + integration test

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -57,4 +57,6 @@ paths = [
     '''aragora/agents/spec\.py$''',
     '''aragora/connectors/ecommerce/.*\.py$''',
     '''aragora/connectors/advertising/.*\.py$''',
+    '''docs/status/generated/agt_e2e_trace\.json$''',
+    '''scripts/agt_pipeline_dry_run\.py$''',
 ]

--- a/docs/status/generated/agt_e2e_trace.json
+++ b/docs/status/generated/agt_e2e_trace.json
@@ -1,0 +1,455 @@
+{
+  "agent_receipt": {
+    "cruxset": {
+      "checksum": "80d12b59d74dedf8f7502cd5fa550ffeb90197439acb0ab662dabd1147d648fe",
+      "counterfactual_notes": [
+        "avg_uncertainty=0.52",
+        "convergence_barrier=0.41"
+      ],
+      "created_at": "2026-04-17T12:00:00Z",
+      "cruxes": [
+        {
+          "candidate_verifier": "docs/status/BC12_SOAK_POLICY.md (not yet written)",
+          "counterfactual": "If one productive soak is sufficient, flip order of AGT activation vs soak",
+          "crux_id": "c_benchmark_evidence",
+          "evidence_gaps": [
+            "no settled policy on productive-vs-idle soak equivalence"
+          ],
+          "load_bearing_score": 0.82,
+          "positions": [
+            {
+              "agents": [
+                "codex-strategic"
+              ],
+              "rationale": "substrate-first discipline",
+              "side": "for"
+            },
+            {
+              "agents": [
+                "claude-sonnet"
+              ],
+              "rationale": "productive soak is stronger evidence",
+              "side": "against"
+            }
+          ],
+          "statement": "Is three consecutive green BC-12 soaks the right evidence standard before flipping the upper-layer flags?"
+        },
+        {
+          "candidate_verifier": "",
+          "counterfactual": "Without a policy, AGT-05 flows cannot accept new-agent submissions",
+          "crux_id": "c_reputation_bootstrap",
+          "evidence_gaps": [
+            "no cold-start policy specified"
+          ],
+          "load_bearing_score": 0.65,
+          "positions": [
+            {
+              "agents": [
+                "claude-sonnet"
+              ],
+              "rationale": "sandbox reputation with reduced stake caps",
+              "side": "for_sandbox"
+            },
+            {
+              "agents": [
+                "codex-strategic"
+              ],
+              "rationale": "bootstrap from trusted oracle delegations",
+              "side": "for_oracle"
+            }
+          ],
+          "statement": "How do new agents earn initial reputation without prior settled claims?"
+        },
+        {
+          "candidate_verifier": "",
+          "counterfactual": "",
+          "crux_id": "c_tangential_detail",
+          "evidence_gaps": [],
+          "load_bearing_score": 0.18,
+          "positions": [
+            {
+              "agents": [
+                "claude-sonnet"
+              ],
+              "rationale": "",
+              "side": "info"
+            }
+          ],
+          "statement": "Which logger level should DIC-17 use for proposal-filing events?"
+        }
+      ],
+      "cruxset_id": "crxset_84ca9b3cb5bd263d",
+      "decision": null,
+      "evidence_gaps": [
+        "BC-12 policy gap",
+        "cold-start reputation policy gap"
+      ],
+      "provenance": {
+        "arena_run_id": "run_001",
+        "debate_id": "debate_e2e_synthetic"
+      },
+      "question": "Should Aragora activate the AGT-* upper-layer flags now?",
+      "receipt_id": "rcpt_e2e_synthetic",
+      "schema_version": "1.0",
+      "verifier_candidates": [
+        "c_benchmark_evidence",
+        "c_reputation_bootstrap"
+      ]
+    },
+    "dissent": [
+      {
+        "agent_id": "codex-strategic",
+        "confidence": 0.7,
+        "statement": "Three consecutive green soaks remain the right bar"
+      },
+      {
+        "agent_id": "claude-sonnet",
+        "confidence": 0.6,
+        "statement": "Productive soak is sufficient evidence"
+      }
+    ],
+    "freshness_sla_seconds": 86400,
+    "issued_at": "2026-04-17T12:00:00Z",
+    "issuer": "aragora.ai",
+    "provenance": {
+      "debate_id": "debate_e2e_synthetic"
+    },
+    "receipt_id": "rcpt_a_c0f1f74c2a4a6a0a",
+    "reputation_deltas_applied": [],
+    "schema_version": "1.0",
+    "settlement_window_seconds": 604800,
+    "signature": "p2B7aSY5WvL6aIj/q9MZ3lgT4i49b08Uj6BYJ07DYS+ic31N69jFAZD7CrBbbRVVV4LbvtsYJCRr+IBII+4QCw==",
+    "signature_algorithm": "ed25519",
+    "signature_key_id": "default",
+    "subject": {
+      "cruxset_id": "crxset_84ca9b3cb5bd263d",
+      "decision": null,
+      "question": "Should Aragora activate the AGT-* upper-layer flags now?"
+    },
+    "subject_kind": "debate_outcome",
+    "verification_key_sha256": "da8317fcaed070c92ccc93a34f8e1c7337dde11ec981d4b866e601d911559316"
+  },
+  "anchor_receipt": {
+    "agent_id": 42,
+    "dry_run": true,
+    "error": null,
+    "feedback_hash_hex": "df55948e4c2aafc9f5dd9d64962d5310df7c5a99d9956476422e62287d079b2a",
+    "feedback_uri": "",
+    "provenance": {
+      "agent_id_string": "alice-predictor",
+      "claim_id": "clm_ee70d4144a36c15c",
+      "delta_id": "rep_7ab0bf297436",
+      "domain": "prediction_market",
+      "resolution_id": "mkt_pr_merge_80fdf5b50479705e",
+      "scoring_rule": "brier_proper"
+    },
+    "submitted_at": "2026-04-17T12:00:00Z",
+    "tag1": "prediction_market",
+    "tag2": "brier_proper",
+    "tx_hash": null,
+    "value": 49360000,
+    "value_decimals": 6
+  },
+  "claim": {
+    "agent_id": "alice-predictor",
+    "claim_id": "clm_ee70d4144a36c15c",
+    "created_at": "2026-04-14T00:00:00Z",
+    "domain": "prediction_market",
+    "position": "yes",
+    "predicted_probability": 0.92,
+    "provenance": {
+      "market_id": "mkt_pr_merge_80fdf5b50479705e",
+      "position_id": "pos_953063247dd02a66",
+      "question_kind": "pr_merge",
+      "submitted_at": "2026-04-14T00:00:00Z",
+      "target": {
+        "number": 6116,
+        "repo": "synaptent/aragora"
+      }
+    },
+    "resolution_id": "mkt_pr_merge_80fdf5b50479705e",
+    "resolution_source": "synthetic_github",
+    "stake_policy": "forfeit_on_loss",
+    "stake_units": 50,
+    "statement": "Will the AGT CLI verbs PR merge within 3 days?"
+  },
+  "cruxset": {
+    "checksum": "80d12b59d74dedf8f7502cd5fa550ffeb90197439acb0ab662dabd1147d648fe",
+    "counterfactual_notes": [
+      "avg_uncertainty=0.52",
+      "convergence_barrier=0.41"
+    ],
+    "created_at": "2026-04-17T12:00:00Z",
+    "cruxes": [
+      {
+        "candidate_verifier": "docs/status/BC12_SOAK_POLICY.md (not yet written)",
+        "counterfactual": "If one productive soak is sufficient, flip order of AGT activation vs soak",
+        "crux_id": "c_benchmark_evidence",
+        "evidence_gaps": [
+          "no settled policy on productive-vs-idle soak equivalence"
+        ],
+        "load_bearing_score": 0.82,
+        "positions": [
+          {
+            "agents": [
+              "codex-strategic"
+            ],
+            "rationale": "substrate-first discipline",
+            "side": "for"
+          },
+          {
+            "agents": [
+              "claude-sonnet"
+            ],
+            "rationale": "productive soak is stronger evidence",
+            "side": "against"
+          }
+        ],
+        "statement": "Is three consecutive green BC-12 soaks the right evidence standard before flipping the upper-layer flags?"
+      },
+      {
+        "candidate_verifier": "",
+        "counterfactual": "Without a policy, AGT-05 flows cannot accept new-agent submissions",
+        "crux_id": "c_reputation_bootstrap",
+        "evidence_gaps": [
+          "no cold-start policy specified"
+        ],
+        "load_bearing_score": 0.65,
+        "positions": [
+          {
+            "agents": [
+              "claude-sonnet"
+            ],
+            "rationale": "sandbox reputation with reduced stake caps",
+            "side": "for_sandbox"
+          },
+          {
+            "agents": [
+              "codex-strategic"
+            ],
+            "rationale": "bootstrap from trusted oracle delegations",
+            "side": "for_oracle"
+          }
+        ],
+        "statement": "How do new agents earn initial reputation without prior settled claims?"
+      },
+      {
+        "candidate_verifier": "",
+        "counterfactual": "",
+        "crux_id": "c_tangential_detail",
+        "evidence_gaps": [],
+        "load_bearing_score": 0.18,
+        "positions": [
+          {
+            "agents": [
+              "claude-sonnet"
+            ],
+            "rationale": "",
+            "side": "info"
+          }
+        ],
+        "statement": "Which logger level should DIC-17 use for proposal-filing events?"
+      }
+    ],
+    "cruxset_id": "crxset_84ca9b3cb5bd263d",
+    "decision": null,
+    "evidence_gaps": [
+      "BC-12 policy gap",
+      "cold-start reputation policy gap"
+    ],
+    "provenance": {
+      "arena_run_id": "run_001",
+      "debate_id": "debate_e2e_synthetic"
+    },
+    "question": "Should Aragora activate the AGT-* upper-layer flags now?",
+    "receipt_id": "rcpt_e2e_synthetic",
+    "schema_version": "1.0",
+    "verifier_candidates": [
+      "c_benchmark_evidence",
+      "c_reputation_bootstrap"
+    ]
+  },
+  "dic17_proposals_from_cruxset": [
+    {
+      "labels": [
+        "crux",
+        "epistemic"
+      ],
+      "provenance": {
+        "crux_id": "c_benchmark_evidence",
+        "cruxset_id": "crxset_84ca9b3cb5bd263d",
+        "load_bearing_score": 0.82
+      },
+      "rationale": "load_bearing_score=0.820 >= 0.600",
+      "source_key": "crux_22e117e8b6bc",
+      "title": "[DIC-17] Resolve load-bearing crux: Is three consecutive green BC-12 soaks the right evidence standard before flippi"
+    },
+    {
+      "labels": [
+        "crux",
+        "epistemic"
+      ],
+      "provenance": {
+        "crux_id": "c_reputation_bootstrap",
+        "cruxset_id": "crxset_84ca9b3cb5bd263d",
+        "load_bearing_score": 0.65
+      },
+      "rationale": "load_bearing_score=0.650 >= 0.600",
+      "source_key": "crux_19f1c55d4b07",
+      "title": "[DIC-17] Resolve load-bearing crux: How do new agents earn initial reputation without prior settled claims?"
+    }
+  ],
+  "failure_branch": {
+    "dic17_proposal_for_failed_claim": {
+      "labels": [
+        "epistemic",
+        "failed-claim"
+      ],
+      "rationale": "delta=-40.250 <= -10.0 (agent bob-overconfident in prediction_market)",
+      "source_key": "failed_claim_933afbf1e337",
+      "title": "[DIC-17] Investigate high-loss prediction: bob-overconfident/prediction_market"
+    },
+    "losing_claim": {
+      "agent_id": "bob-overconfident",
+      "claim_id": "clm_489118545c69bc5e",
+      "created_at": "2026-04-14T12:00:00Z",
+      "domain": "prediction_market",
+      "position": "yes",
+      "predicted_probability": 0.95,
+      "provenance": {
+        "market_id": "mkt_pr_merge_9b4f84e154e18de5",
+        "position_id": "pos_447854693a4b7a83",
+        "question_kind": "pr_merge",
+        "submitted_at": "2026-04-14T12:00:00Z",
+        "target": {
+          "number": 9999,
+          "repo": "synaptent/aragora"
+        }
+      },
+      "resolution_id": "mkt_pr_merge_9b4f84e154e18de5",
+      "resolution_source": "synthetic_github",
+      "stake_policy": "forfeit_on_loss",
+      "stake_units": 50,
+      "statement": "Will a non-existent PR merge?"
+    },
+    "losing_delta": {
+      "agent_id": "bob-overconfident",
+      "applied_at": "2026-04-17T12:00:00Z",
+      "claim_id": "clm_489118545c69bc5e",
+      "decay_half_life_days": 30.0,
+      "delta": -40.25,
+      "delta_id": "rep_0754e7febbb9",
+      "domain": "prediction_market",
+      "reason": {
+        "brier": 0.9025,
+        "claim_id": "clm_489118545c69bc5e",
+        "outcome": "no",
+        "payout_fraction": -0.8049999999999999,
+        "resolution_id": "mkt_pr_merge_9b4f84e154e18de5",
+        "resolution_source": "synthetic_github",
+        "scoring_rule": "brier_proper",
+        "stake_units": 50
+      },
+      "resolution_id": "mkt_pr_merge_9b4f84e154e18de5",
+      "scoring_rule": "brier_proper"
+    },
+    "losing_resolved": {
+      "claim_id": "clm_489118545c69bc5e",
+      "evidence": {
+        "merged": false,
+        "state": "CLOSED"
+      },
+      "outcome": "no",
+      "resolution_source": "github_pr_state",
+      "resolved_at": "2026-04-17T12:00:00Z"
+    }
+  },
+  "generated_at": "2026-04-17T12:00:00Z",
+  "market": {
+    "created_at": "2026-04-13T12:00:00Z",
+    "description": "Will the AGT CLI verbs PR merge within 3 days?",
+    "expires_at": "2026-04-16T12:00:00Z",
+    "market_id": "mkt_pr_merge_80fdf5b50479705e",
+    "question_kind": "pr_merge",
+    "target": {
+      "number": 6116,
+      "repo": "synaptent/aragora"
+    }
+  },
+  "pipeline": "agt_e2e_dry_run",
+  "position": {
+    "agent_id": "alice-predictor",
+    "market_id": "mkt_pr_merge_80fdf5b50479705e",
+    "position_id": "pos_953063247dd02a66",
+    "probability": 0.92,
+    "rationale": "PR has all 5 checks green and admin privileges available",
+    "stake": 50,
+    "submitted_at": "2026-04-14T00:00:00Z"
+  },
+  "reputation_delta": {
+    "agent_id": "alice-predictor",
+    "applied_at": "2026-04-17T12:00:00Z",
+    "claim_id": "clm_ee70d4144a36c15c",
+    "decay_half_life_days": 30.0,
+    "delta": 49.36,
+    "delta_id": "rep_7ab0bf297436",
+    "domain": "prediction_market",
+    "reason": {
+      "brier": 0.006399999999999993,
+      "claim_id": "clm_ee70d4144a36c15c",
+      "outcome": "yes",
+      "payout_fraction": 0.9872,
+      "resolution_id": "mkt_pr_merge_80fdf5b50479705e",
+      "resolution_source": "synthetic_github",
+      "scoring_rule": "brier_proper",
+      "stake_units": 50
+    },
+    "resolution_id": "mkt_pr_merge_80fdf5b50479705e",
+    "scoring_rule": "brier_proper"
+  },
+  "resolution": {
+    "evidence": {
+      "merged": true,
+      "merged_at": "2026-04-17T05:22:00Z",
+      "state": "MERGED"
+    },
+    "market_id": "mkt_pr_merge_80fdf5b50479705e",
+    "outcome": "yes",
+    "resolution_source": "github_pr_state",
+    "resolved_at": "2026-04-17T12:00:00Z"
+  },
+  "resolved_claim": {
+    "claim_id": "clm_ee70d4144a36c15c",
+    "evidence": {
+      "merged": true,
+      "merged_at": "2026-04-17T05:22:00Z",
+      "state": "MERGED"
+    },
+    "outcome": "yes",
+    "resolution_source": "github_pr_state",
+    "resolved_at": "2026-04-17T12:00:00Z"
+  },
+  "viah_report": {
+    "agent_hours": 3.0,
+    "coefficients": {
+      "crux_weight": 0.5,
+      "failed_claim_weight": 1.0,
+      "merged_pr_weight": 1.0,
+      "prediction_weight": 0.5,
+      "rescue_weight": 0.5
+    },
+    "cruxes_correctly_detected": 0,
+    "failed_claims_promoted_without_repair": 0,
+    "inputs": {
+      "entries_in_window": 5,
+      "ledger_path": "<pinned:shift_ledger.jsonl>"
+    },
+    "merged_autonomous_prs": 2,
+    "predictions_above_brier_threshold": 0,
+    "rescues_required": 0,
+    "viah": 0.6666666666666666,
+    "window_end": "2026-04-17T12:00:00Z",
+    "window_hours": 24.0,
+    "window_start": "2026-04-16T12:00:00Z"
+  }
+}

--- a/scripts/agt_pipeline_dry_run.py
+++ b/scripts/agt_pipeline_dry_run.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""End-to-end AGT pipeline dry-run.
+
+Runs a fully synthetic trace through the 11 AGT-* modules landed
+Apr 17 2026 and writes the complete trace as JSON. This is the first
+proof that the wire works end-to-end — it exercises each module's
+output shape against the next module's input shape without any
+external dependencies (no debate LLM calls, no GitHub API, no chain).
+
+Flow:
+
+    synthetic CruxSet  ─┐
+                        ├→ AgentReceipt (AGT-02)
+                        │
+                        └→ DIC-17 FollowupProposal
+
+    synthetic Market + MarketPosition + ResolutionEvent (AGT-04)
+                        │
+                        ├→ bridge_from_market_position (AGT-05)
+                        │      ↓
+                        │  (StakeableClaim, ResolvedClaim)
+                        │      ↓
+                        │  settle_claim (AGT-05)
+                        │      ↓
+                        │  ReputationDelta
+                        │      ↓
+                        │  anchor_delta dry-run (AGT-05)
+                        │      ↓
+                        └→ AnchorReceipt
+
+    ShiftLedger fixture → compute_viah (AGT-06) → ViahReport
+
+Usage:
+    python3 scripts/agt_pipeline_dry_run.py [--out PATH]
+
+Default output: docs/status/generated/agt_e2e_trace.json
+
+The script is deterministic — given the same inputs it produces the
+same JSON (timestamps are the one exception; ``--pin-timestamp``
+forces a fixed reference time for fixture generation).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: E402
+
+from aragora.epistemic.followup import (  # noqa: E402
+    propose_followup_for_crux,
+    propose_followup_for_cruxset,
+    propose_followup_for_failed_claim,
+)
+
+# Deterministic test signing key (32 bytes, fixed for fixture reproducibility).
+# NOT for production use — this is a public, committed seed.
+_FIXTURE_SIGNING_SEED = bytes.fromhex(
+    "a3c9d1e07b2f45680123456789abcdef0123456789abcdef0123456789abcdef"
+)
+from aragora.markets.store import MarketStore  # noqa: E402
+from aragora.markets.types import (  # noqa: E402
+    Market,
+    MarketPosition,
+    ResolutionEvent as MarketResolution,
+)
+from aragora.metrics.viah import ViahReport, compute_viah  # noqa: E402
+from aragora.protocols.a2a.receipts import (  # noqa: E402
+    AgentReceipt,
+    DissentEntry,
+)
+from aragora.reasoning.cruxset import Crux, CruxPosition, CruxSet  # noqa: E402
+from aragora.reputation.anchor import anchor_delta  # noqa: E402
+from aragora.reputation.bridge import bridge_from_market_position  # noqa: E402
+from aragora.reputation.settlement import settle_claim  # noqa: E402
+from aragora.swarm.shift_ledger import ShiftLedger  # noqa: E402
+
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "status" / "generated" / "agt_e2e_trace.json"
+
+
+def _pinned_now() -> datetime:
+    """A fixed reference timestamp for reproducible fixture generation."""
+    return datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+
+
+def _build_synthetic_cruxset(now: datetime) -> CruxSet:
+    """Hand-constructed CruxSet as if a real debate produced it."""
+    return CruxSet.build(
+        question="Should Aragora activate the AGT-* upper-layer flags now?",
+        cruxes=[
+            Crux(
+                crux_id="c_benchmark_evidence",
+                statement=(
+                    "Is three consecutive green BC-12 soaks the right evidence "
+                    "standard before flipping the upper-layer flags?"
+                ),
+                positions=(
+                    CruxPosition(
+                        side="for",
+                        agents=("codex-strategic",),
+                        rationale="substrate-first discipline",
+                    ),
+                    CruxPosition(
+                        side="against",
+                        agents=("claude-sonnet",),
+                        rationale="productive soak is stronger evidence",
+                    ),
+                ),
+                load_bearing_score=0.82,
+                evidence_gaps=("no settled policy on productive-vs-idle soak equivalence",),
+                counterfactual="If one productive soak is sufficient, flip order of AGT activation vs soak",
+                candidate_verifier="docs/status/BC12_SOAK_POLICY.md (not yet written)",
+            ),
+            Crux(
+                crux_id="c_reputation_bootstrap",
+                statement="How do new agents earn initial reputation without prior settled claims?",
+                positions=(
+                    CruxPosition(
+                        side="for_sandbox",
+                        agents=("claude-sonnet",),
+                        rationale="sandbox reputation with reduced stake caps",
+                    ),
+                    CruxPosition(
+                        side="for_oracle",
+                        agents=("codex-strategic",),
+                        rationale="bootstrap from trusted oracle delegations",
+                    ),
+                ),
+                load_bearing_score=0.65,
+                evidence_gaps=("no cold-start policy specified",),
+                counterfactual="Without a policy, AGT-05 flows cannot accept new-agent submissions",
+            ),
+            Crux(
+                crux_id="c_tangential_detail",
+                statement="Which logger level should DIC-17 use for proposal-filing events?",
+                positions=(CruxPosition(side="info", agents=("claude-sonnet",)),),
+                load_bearing_score=0.18,
+            ),
+        ],
+        decision=None,  # Crux-finder debates may intentionally not converge
+        evidence_gaps=("BC-12 policy gap", "cold-start reputation policy gap"),
+        counterfactual_notes=(
+            "avg_uncertainty=0.52",
+            "convergence_barrier=0.41",
+        ),
+        verifier_candidates=("c_benchmark_evidence", "c_reputation_bootstrap"),
+        receipt_id="rcpt_e2e_synthetic",
+        provenance={"debate_id": "debate_e2e_synthetic", "arena_run_id": "run_001"},
+        created_at=now.isoformat().replace("+00:00", "Z"),
+    )
+
+
+def _build_synthetic_agent_receipt(
+    cruxset: CruxSet,
+    *,
+    now: datetime,
+) -> AgentReceipt:
+    """Wrap the CruxSet in an A2A AgentReceipt envelope.
+
+    Uses a deterministic Ed25519 test key so the fixture hash is
+    reproducible across runs. Real production receipts must use a
+    properly managed signing key.
+    """
+    signing_key = Ed25519PrivateKey.from_private_bytes(_FIXTURE_SIGNING_SEED)
+    return AgentReceipt.build(
+        issuer="aragora.ai",
+        subject_kind="debate_outcome",
+        subject={
+            "question": cruxset.question,
+            "decision": cruxset.decision,
+            "cruxset_id": cruxset.cruxset_id,
+        },
+        cruxset=cruxset.to_json(),
+        dissent=(
+            DissentEntry(
+                agent_id="codex-strategic",
+                statement="Three consecutive green soaks remain the right bar",
+                confidence=0.7,
+            ),
+            DissentEntry(
+                agent_id="claude-sonnet",
+                statement="Productive soak is sufficient evidence",
+                confidence=0.6,
+            ),
+        ),
+        reputation_deltas_applied=(),
+        freshness_sla_seconds=24 * 3600,
+        settlement_window_seconds=7 * 24 * 3600,
+        provenance={"debate_id": "debate_e2e_synthetic"},
+        issued_at=now.isoformat().replace("+00:00", "Z"),
+        signing_key=signing_key,
+    )
+
+
+def _build_synthetic_market(now: datetime) -> Market:
+    return Market.create(
+        question_kind="pr_merge",
+        target={"repo": "synaptent/aragora", "number": 6116},
+        description="Will the AGT CLI verbs PR merge within 3 days?",
+        resolution_window_days=3,
+        created_at=now - timedelta(days=4),
+    )
+
+
+def _build_synthetic_position(market: Market, now: datetime) -> MarketPosition:
+    return MarketPosition.create(
+        market_id=market.market_id,
+        agent_id="alice-predictor",
+        probability=0.92,
+        stake=50,
+        submitted_at=now - timedelta(days=3, hours=12),
+        rationale="PR has all 5 checks green and admin privileges available",
+    )
+
+
+def _build_synthetic_resolution(
+    market: Market, now: datetime, outcome: str = "yes"
+) -> MarketResolution:
+    if outcome == "yes":
+        return MarketResolution.yes(
+            market_id=market.market_id,
+            resolution_source="github_pr_state",
+            evidence={"state": "MERGED", "merged": True, "merged_at": "2026-04-17T05:22:00Z"},
+            resolved_at=now,
+        )
+    return MarketResolution.no(
+        market_id=market.market_id,
+        resolution_source="github_pr_state",
+        evidence={"state": "CLOSED", "merged": False},
+        resolved_at=now,
+    )
+
+
+def _build_synthetic_ledger(now: datetime, tmp_dir: Path) -> ShiftLedger:
+    """Seed a temporary ShiftLedger with one shift worth of entries."""
+    ledger_path = tmp_dir / "shift_ledger.jsonl"
+    entries = [
+        {
+            "entry_type": "shift_start",
+            "timestamp": (now - timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "payload": {
+                "shift_id": "e2e-shift-1",
+                "max_hours": 3.0,
+                "benchmark_mode": "hybrid",
+                "queue_size": 0,
+            },
+        },
+        {
+            "entry_type": "pr_merged",
+            "timestamp": (now - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "payload": {"pr_number": 6080, "title": "substrate hardening"},
+        },
+        {
+            "entry_type": "pr_merged",
+            "timestamp": (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "payload": {"pr_number": 6116, "title": "AGT CLI verbs"},
+        },
+        {
+            "entry_type": "cycle_tick",
+            "timestamp": (now - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "payload": {
+                "queue_size": 0,
+                "queue_removed": 0,
+                "open_prs": 0,
+                "boss_running": False,
+                "merge_running": True,
+                "benchmark_fresh": True,
+                "actions": [],
+                "rescue_count": 0,
+                "stop_reason": "",
+            },
+        },
+        {
+            "entry_type": "shift_stop",
+            "timestamp": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "payload": {
+                "shift_id": "e2e-shift-1",
+                "reason": "completed",
+                "cycles": 1,
+                "duration_seconds": 10800.0,
+            },
+        },
+    ]
+    with ledger_path.open("w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, sort_keys=True) + "\n")
+    return ShiftLedger(path=ledger_path)
+
+
+def run_pipeline(*, now: datetime | None = None, tmp_dir: Path | None = None) -> dict:
+    """Execute the full AGT pipeline on synthetic inputs and return the trace."""
+    if now is None:
+        now = _pinned_now()
+    if tmp_dir is None:
+        tmp_dir = Path.cwd() / ".agt_e2e_tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    # === AGT-01: build CruxSet + wrap in AgentReceipt ===
+    cruxset = _build_synthetic_cruxset(now)
+    receipt = _build_synthetic_agent_receipt(cruxset, now=now)
+
+    # === DIC-17: propose follow-ups for load-bearing cruxes ===
+    proposals = propose_followup_for_cruxset(cruxset, top_k=3)
+
+    # === AGT-04: build market + position + resolution ===
+    market = _build_synthetic_market(now)
+    position = _build_synthetic_position(market, now)
+    resolution = _build_synthetic_resolution(market, now, outcome="yes")
+
+    store = MarketStore(tmp_dir / "markets")
+    store.add_market(market)
+    store.add_position(position)
+    store.record_resolution(resolution)
+
+    # === AGT-05: bridge → settle → anchor (dry-run) ===
+    claim, resolved = bridge_from_market_position(position, market, resolution)
+    pinned_iso = now.isoformat().replace("+00:00", "Z")
+    delta = settle_claim(claim, resolved, scoring_rule="brier_proper", applied_at=pinned_iso)
+    anchor_receipt = anchor_delta(delta, agent_id=42, dry_run=True)
+    # AnchorReceipt.submitted_at uses datetime.now() internally; normalize
+    # to the pinned reference so the trace JSON is reproducible.
+    anchor_receipt_json = anchor_receipt.to_json()
+    anchor_receipt_json["submitted_at"] = pinned_iso
+
+    # === AGT-05 failure branch: settle a losing claim, propose DIC-17 follow-up ===
+    losing_position = MarketPosition.create(
+        market_id=market.market_id + "-alt",  # avoid the "already resolved" store guard
+        agent_id="bob-overconfident",
+        probability=0.95,
+        stake=50,
+        submitted_at=now - timedelta(days=3),
+    )
+    # Fabricate a distinct market for the alt position
+    losing_market = Market.create(
+        question_kind="pr_merge",
+        target={"repo": "synaptent/aragora", "number": 9999},
+        description="Will a non-existent PR merge?",
+        resolution_window_days=3,
+        created_at=now - timedelta(days=4),
+    )
+    losing_position_real = MarketPosition.create(
+        market_id=losing_market.market_id,
+        agent_id="bob-overconfident",
+        probability=0.95,
+        stake=50,
+        submitted_at=now - timedelta(days=3),
+    )
+    losing_resolution = MarketResolution.no(
+        market_id=losing_market.market_id,
+        resolution_source="github_pr_state",
+        evidence={"state": "CLOSED", "merged": False},
+        resolved_at=now,
+    )
+    losing_claim, losing_resolved = bridge_from_market_position(
+        losing_position_real, losing_market, losing_resolution
+    )
+    losing_delta = settle_claim(
+        losing_claim, losing_resolved, scoring_rule="brier_proper", applied_at=pinned_iso
+    )
+    losing_proposal = propose_followup_for_failed_claim(
+        losing_claim, losing_resolved, losing_delta, delta_loss_threshold=-10.0
+    )
+
+    # === AGT-06: VIAH over synthetic ShiftLedger ===
+    ledger = _build_synthetic_ledger(now, tmp_dir)
+    viah = compute_viah(ledger=ledger, window_hours=24.0, now=now)
+    # Normalize the environment-dependent ledger path so the trace is
+    # reproducible across machines and tmp-dirs
+    viah_dict = viah.to_dict()
+    viah_dict["inputs"]["ledger_path"] = "<pinned:shift_ledger.jsonl>"
+
+    # === Assemble full trace ===
+    return {
+        "pipeline": "agt_e2e_dry_run",
+        "generated_at": now.isoformat().replace("+00:00", "Z"),
+        "cruxset": cruxset.to_json(),
+        "agent_receipt": receipt.to_json(),
+        "dic17_proposals_from_cruxset": [
+            {
+                "source_key": p.source_key,
+                "title": p.title,
+                "labels": list(p.labels),
+                "rationale": p.rationale,
+                "provenance": dict(p.provenance),
+            }
+            for p in proposals
+        ],
+        "market": market.to_json(),
+        "position": position.to_json(),
+        "resolution": resolution.to_json(),
+        "claim": claim.to_json(),
+        "resolved_claim": resolved.to_json(),
+        "reputation_delta": delta.to_json(),
+        "anchor_receipt": anchor_receipt_json,
+        "failure_branch": {
+            "losing_claim": losing_claim.to_json(),
+            "losing_resolved": losing_resolved.to_json(),
+            "losing_delta": losing_delta.to_json(),
+            "dic17_proposal_for_failed_claim": (
+                None
+                if losing_proposal is None
+                else {
+                    "source_key": losing_proposal.source_key,
+                    "title": losing_proposal.title,
+                    "labels": list(losing_proposal.labels),
+                    "rationale": losing_proposal.rationale,
+                }
+            ),
+        },
+        "viah_report": viah_dict,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the AGT e2e pipeline dry-run")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Trace JSON output path (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--pin-timestamp",
+        action="store_true",
+        help="Use the canonical pinned timestamp for fixture-stable output",
+    )
+    parser.add_argument(
+        "--tmp-dir",
+        type=Path,
+        default=None,
+        help="Directory for temporary market/ledger state (default: ./.agt_e2e_tmp)",
+    )
+    args = parser.parse_args()
+
+    now = _pinned_now() if args.pin_timestamp else datetime.now(tz=UTC)
+    trace = run_pipeline(now=now, tmp_dir=args.tmp_dir)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(trace, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote trace to {args.out}")
+    print(f"  cruxset_id: {trace['cruxset']['cruxset_id']}")
+    print(f"  agent_receipt: {trace['agent_receipt']['receipt_id']}")
+    print(f"  dic17 proposals (from cruxset): {len(trace['dic17_proposals_from_cruxset'])}")
+    print(f"  reputation_delta: {trace['reputation_delta']['delta']:+.3f}")
+    print(
+        f"  anchor_receipt: dry_run={trace['anchor_receipt']['dry_run']} value={trace['anchor_receipt']['value']}"
+    )
+    print(f"  viah: {trace['viah_report']['viah']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_agt_e2e_pipeline.py
+++ b/tests/integration/test_agt_e2e_pipeline.py
@@ -1,0 +1,226 @@
+"""End-to-end AGT pipeline integration test.
+
+Runs the full synthetic pipeline implemented in
+``scripts/agt_pipeline_dry_run.py`` and verifies every stage's output
+against the canonical fixture at
+``docs/status/generated/agt_e2e_trace.json``.
+
+Why this test matters:
+- Each of the 11 AGT modules has unit tests in isolation
+- This test is the only place that exercises their shapes against
+  each other — if a module tightens its input contract, this test
+  catches the integration break before downstream consumers do
+- The fixture is a committed artifact; drift is visible in a diff
+
+When the fixture legitimately needs to change (e.g. a new field
+added to a schema), regenerate it:
+    python3 scripts/agt_pipeline_dry_run.py --pin-timestamp
+
+and commit the updated JSON alongside the schema change.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from agt_pipeline_dry_run import (  # noqa: E402
+    DEFAULT_OUTPUT,
+    _pinned_now,
+    run_pipeline,
+)
+
+from aragora.reasoning.cruxset import CruxSet  # noqa: E402
+from aragora.reputation.types import ReputationDelta  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def trace(tmp_path_factory):
+    """Run the pipeline once per test module using the pinned timestamp."""
+    tmp = tmp_path_factory.mktemp("agt_e2e")
+    return run_pipeline(now=_pinned_now(), tmp_dir=tmp)
+
+
+class TestPipelineStructure:
+    def test_trace_has_all_stages(self, trace) -> None:
+        expected_keys = {
+            "pipeline",
+            "generated_at",
+            "cruxset",
+            "agent_receipt",
+            "dic17_proposals_from_cruxset",
+            "market",
+            "position",
+            "resolution",
+            "claim",
+            "resolved_claim",
+            "reputation_delta",
+            "anchor_receipt",
+            "failure_branch",
+            "viah_report",
+        }
+        assert expected_keys.issubset(trace.keys())
+
+    def test_generated_at_is_pinned(self, trace) -> None:
+        assert trace["generated_at"] == "2026-04-17T12:00:00Z"
+
+
+class TestCruxSetStage:
+    def test_cruxset_has_content_addressed_id(self, trace) -> None:
+        cruxset_id = trace["cruxset"]["cruxset_id"]
+        assert cruxset_id.startswith("crxset_")
+
+    def test_cruxset_checksum_verifies(self, trace) -> None:
+        cs = CruxSet.from_json(trace["cruxset"])
+        assert cs.verify_checksum() is True
+
+    def test_cruxset_cruxes_sorted_by_score_desc(self, trace) -> None:
+        scores = [c["load_bearing_score"] for c in trace["cruxset"]["cruxes"]]
+        assert scores == sorted(scores, reverse=True)
+
+
+class TestAgentReceiptStage:
+    def test_agent_receipt_wraps_cruxset(self, trace) -> None:
+        receipt = trace["agent_receipt"]
+        assert receipt["subject_kind"] == "debate_outcome"
+        assert receipt["cruxset"]["cruxset_id"] == trace["cruxset"]["cruxset_id"]
+
+    def test_agent_receipt_signature_present(self, trace) -> None:
+        receipt = trace["agent_receipt"]
+        # Post-PR#6095, receipts carry an Ed25519 signature string
+        assert "signature" in receipt
+        assert receipt["signature"]
+
+    def test_agent_receipt_dissent_captured(self, trace) -> None:
+        receipt = trace["agent_receipt"]
+        assert len(receipt["dissent"]) == 2
+
+
+class TestDic17FromCruxSet:
+    def test_only_load_bearing_cruxes_produce_proposals(self, trace) -> None:
+        proposals = trace["dic17_proposals_from_cruxset"]
+        # Top-k=3 with threshold 0.6 → the 2 cruxes scoring >= 0.6 clear
+        assert len(proposals) == 2
+        # Titles reference the load-bearing cruxes
+        titles = " ".join(p["title"] for p in proposals)
+        assert "benchmark" in titles.lower() or "soak" in titles.lower()
+
+    def test_proposals_never_carry_boss_ready(self, trace) -> None:
+        for proposal in trace["dic17_proposals_from_cruxset"]:
+            assert "boss-ready" not in proposal["labels"]
+
+    def test_proposals_carry_epistemic_and_crux_labels(self, trace) -> None:
+        for proposal in trace["dic17_proposals_from_cruxset"]:
+            assert "epistemic" in proposal["labels"]
+            assert "crux" in proposal["labels"]
+
+    def test_proposal_source_keys_are_deterministic(self, trace) -> None:
+        # Rerunning the pipeline with the same input must yield same source_keys
+        from agt_pipeline_dry_run import run_pipeline as rerun
+
+        rerun_trace = rerun(now=_pinned_now(), tmp_dir=Path("/tmp/agt_e2e_rerun_check"))
+        first = [p["source_key"] for p in trace["dic17_proposals_from_cruxset"]]
+        second = [p["source_key"] for p in rerun_trace["dic17_proposals_from_cruxset"]]
+        assert first == second
+
+
+class TestAgt04MarketStage:
+    def test_market_has_content_addressed_id(self, trace) -> None:
+        assert trace["market"]["market_id"].startswith("mkt_pr_merge_")
+
+    def test_resolution_outcome_matches_expected(self, trace) -> None:
+        assert trace["resolution"]["outcome"] == "yes"
+
+
+class TestAgt05SettlementStage:
+    def test_claim_bridged_from_market(self, trace) -> None:
+        claim = trace["claim"]
+        assert claim["domain"] == "prediction_market"
+        assert claim["agent_id"] == "alice-predictor"
+        assert claim["stake_units"] == 50
+
+    def test_delta_is_positive_when_agent_wins(self, trace) -> None:
+        delta = trace["reputation_delta"]
+        # probability=0.92, outcome=yes → Brier = 0.0064 → payout = ~49.4
+        assert delta["delta"] > 40.0
+        assert delta["delta"] < 50.0
+        assert delta["scoring_rule"] == "brier_proper"
+
+
+class TestAgt05AnchorStage:
+    def test_anchor_is_dry_run_by_default(self, trace) -> None:
+        receipt = trace["anchor_receipt"]
+        assert receipt["dry_run"] is True
+        assert receipt["tx_hash"] is None
+        assert receipt["error"] is None
+
+    def test_anchor_encodes_delta_as_int128(self, trace) -> None:
+        receipt = trace["anchor_receipt"]
+        delta = trace["reputation_delta"]
+        # With default value_decimals=6, value ≈ delta * 1e6
+        expected_scaled = int(round(delta["delta"] * 10**6))
+        assert abs(receipt["value"] - expected_scaled) <= 1
+
+    def test_anchor_feedback_hash_is_64_hex_chars(self, trace) -> None:
+        receipt = trace["anchor_receipt"]
+        hex_hash = receipt["feedback_hash_hex"]
+        assert len(hex_hash) == 64  # SHA-256 as hex
+        int(hex_hash, 16)  # Must parse as hex
+
+
+class TestFailureBranch:
+    def test_losing_claim_produces_negative_delta(self, trace) -> None:
+        losing = trace["failure_branch"]["losing_delta"]
+        # probability=0.95 on YES, outcome=NO → Brier = 0.9025 → delta ≈ -40.25
+        assert losing["delta"] < -10.0
+
+    def test_large_loss_produces_followup_proposal(self, trace) -> None:
+        branch = trace["failure_branch"]
+        assert branch["dic17_proposal_for_failed_claim"] is not None
+        proposal = branch["dic17_proposal_for_failed_claim"]
+        assert "boss-ready" not in proposal["labels"]
+        assert "failed-claim" in proposal["labels"]
+
+
+class TestViahStage:
+    def test_viah_computed_from_synthetic_ledger(self, trace) -> None:
+        viah = trace["viah_report"]
+        # 2 merged PRs, 0 rescues, 3 agent-hours → VIAH = 2/3
+        assert viah["merged_autonomous_prs"] == 2
+        assert viah["rescues_required"] == 0
+        assert viah["viah"] is not None
+        assert viah["viah"] == pytest.approx(2.0 / 3.0)
+
+
+class TestFixtureExists:
+    def test_committed_fixture_is_current(self, trace) -> None:
+        """The committed fixture should match what run_pipeline produces.
+
+        If this test fails after a schema change, regenerate with:
+            python3 scripts/agt_pipeline_dry_run.py --pin-timestamp
+        and commit the updated JSON.
+        """
+        fixture_path = REPO_ROOT / "docs" / "status" / "generated" / "agt_e2e_trace.json"
+        if not fixture_path.exists():
+            pytest.skip(
+                "committed fixture not present; run scripts/agt_pipeline_dry_run.py "
+                "--pin-timestamp to generate"
+            )
+        committed = json.loads(fixture_path.read_text(encoding="utf-8"))
+        # Structural equality; precise-float ok because of deterministic inputs
+        assert committed == trace
+
+
+class TestReputationDeltaSerialization:
+    def test_reputation_delta_roundtrips(self, trace) -> None:
+        delta = ReputationDelta.from_json(trace["reputation_delta"])
+        roundtrip = delta.to_json()
+        # Round-tripping shouldn't change anything
+        for key in ("delta", "scoring_rule", "agent_id", "domain"):
+            assert roundtrip[key] == trace["reputation_delta"][key]

--- a/tests/integration/test_agt_e2e_pipeline.py
+++ b/tests/integration/test_agt_e2e_pipeline.py
@@ -207,11 +207,9 @@ class TestFixtureExists:
         and commit the updated JSON.
         """
         fixture_path = REPO_ROOT / "docs" / "status" / "generated" / "agt_e2e_trace.json"
-        if not fixture_path.exists():
-            pytest.skip(
-                "committed fixture not present; run scripts/agt_pipeline_dry_run.py "
-                "--pin-timestamp to generate"
-            )
+        assert fixture_path.exists(), (
+            "committed fixture missing; run python3 scripts/agt_pipeline_dry_run.py --pin-timestamp"
+        )
         committed = json.loads(fixture_path.read_text(encoding="utf-8"))
         # Structural equality; precise-float ok because of deterministic inputs
         assert committed == trace


### PR DESCRIPTION
## Summary

First end-to-end proof that the 11 AGT-* modules landed this week wire together cleanly.

- `scripts/agt_pipeline_dry_run.py` — runnable script that exercises the full flow on synthetic inputs
- `docs/status/generated/agt_e2e_trace.json` — committed canonical fixture (byte-identical across runs with `--pin-timestamp`)
- `tests/integration/test_agt_e2e_pipeline.py` — **24 tests** covering each stage's invariants + committed-fixture consistency
- `.gitleaks.toml` — allowlist entries for fixture derived-hashes (verification_key_sha256, DIC-17 source_keys)

## Flow exercised

```
synthetic CruxSet (AGT-01) ─┐
                            ├→ AgentReceipt signed with Ed25519 (AGT-02)
                            └→ DIC-17 FollowupProposals (top-k above threshold, DIC-17)

synthetic Market + Position + Resolution (AGT-04)
        → bridge_from_market_position (AGT-05)
        → settle_claim brier_proper (AGT-05)
        → ReputationDelta
        → anchor_delta dry-run (AGT-05)
        → AnchorReceipt (value, feedback_hash, tags, provenance)

failure branch: losing claim (prob 0.95 on YES, outcome NO)
        → ReputationDelta -40.25
        → DIC-17 FollowupProposal for failed claim

synthetic ShiftLedger → compute_viah (AGT-06) → ViahReport
```

## Why this matters

Each of the 11 AGT-* modules has unit tests in isolation. **This is the only place that exercises their output shapes against each other.** Schema drift between modules (e.g. the AgentReceipt API tightening in PRs #6095 and #6100 that this PR had to accommodate) now breaks a CI test instead of silently breaking downstream consumers at runtime.

## Determinism

- Pinned timestamp (2026-04-17T12:00:00Z) for all datetime-derived fields
- Committed 32-byte Ed25519 seed for fixture-stable receipt signatures
- Environment-dependent paths redacted (`/tmp/...` → `<pinned:shift_ledger.jsonl>`)
- Running the script twice produces **byte-identical JSON**

## Test plan

- [x] 24 integration tests pass covering: pipeline structure, CruxSet checksum verification, AgentReceipt signature presence, DIC-17 labels + threshold enforcement, content-addressed market IDs, settlement scoring math, anchor dry-run default, int128 value encoding, feedback_hash shape, failure-branch negative delta, VIAH math, fixture consistency
- [x] Committed fixture matches what `run_pipeline` produces byte-for-byte
- [x] Existing AGT-* unit tests unaffected

## When the fixture legitimately needs to change

Regenerate with:
```
python3 scripts/agt_pipeline_dry_run.py --pin-timestamp
```
and commit the updated JSON alongside the schema change.

## Refs

- AGT epic: #6068 | Vision: #6061
- All 11 AGT-* PRs merged: #6080, #6082, #6084, #6086, #6088, #6110, #6112, #6114, #6116, #6122, #6126
- Accommodates: #6095 (Ed25519 receipt signing), #6100 (receipt content-id binding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)