### PR TITLE
[DIC-19] Proof-carrying code unit schema and validator

### DIFF
--- a/aragora/epistemic/proof_unit.py
+++ b/aragora/epistemic/proof_unit.py
@@ -1,0 +1,148 @@
+"""Proof-Carrying Code Unit schema and loader (DIC-19 / #6030).
+
+Links a code path to the assumptions, evidence, claim IDs, verifier
+commands, and decay/fallback policies that justify it.  Schema-only and
+read-only: no runtime mutation, quarantine, or issue creation.
+
+Field names for ``claims``, ``verifiers``, and ``decision_receipts`` are
+aligned with the DIC-13 claim manifest schema and the AGT-01 CruxSet
+receipt model so downstream tooling can join across all three.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_DECAY_ACTIONS = frozenset({"report_only", "repair_required", "fail_closed"})
+_FALLBACK_ACTIONS = frozenset({"fail_closed", "degrade", "report_only"})
+
+
+@dataclass
+class DecayPolicy:
+    failed_claim: str = "report_only"
+    stale_evidence: str = "report_only"
+    unresolved_crux: str = "report_only"
+
+    def validate(self) -> list[str]:
+        return [
+            f"decay_policy.{attr}: invalid action {val!r}"
+            for attr, val in (
+                ("failed_claim", self.failed_claim),
+                ("stale_evidence", self.stale_evidence),
+                ("unresolved_crux", self.unresolved_crux),
+            )
+            if val not in _DECAY_ACTIONS
+        ]
+
+
+@dataclass
+class FallbackPolicy:
+    default: str = "fail_closed"
+    operator_message: str = ""
+
+    def validate(self) -> list[str]:
+        if self.default not in _FALLBACK_ACTIONS:
+            return [f"fallback_policy.default: invalid action {self.default!r}"]
+        return []
+
+
+@dataclass
+class ProofCarryingCodeUnit:
+    """Code path annotated with the proof that justifies it.
+
+    Compatible with DIC-13 claim manifests (``claims`` IDs) and
+    AGT-01 CruxSet receipts (``linked_crux_ids``).
+    """
+
+    code_unit_id: str
+    symbol: str
+    source_path: str
+    owner: str
+    decision_receipts: list[str]
+    claims: list[str]
+    assumptions: list[str]
+    verifiers: list[dict[str, str]]
+    freshness_sla_hours: int
+    decay_policy: DecayPolicy
+    fallback_policy: FallbackPolicy
+    linked_crux_ids: list[str] = field(default_factory=list)
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        if not self.code_unit_id:
+            errors.append("code_unit_id must not be empty")
+        if not self.source_path:
+            errors.append("source_path must not be empty")
+        if self.freshness_sla_hours < 1:
+            errors.append(f"freshness_sla_hours must be >= 1, got {self.freshness_sla_hours}")
+        errors.extend(self.decay_policy.validate())
+        errors.extend(self.fallback_policy.validate())
+        return errors
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code_unit_id": self.code_unit_id,
+            "symbol": self.symbol,
+            "source_path": self.source_path,
+            "owner": self.owner,
+            "decision_receipts": self.decision_receipts,
+            "claims": self.claims,
+            "assumptions": self.assumptions,
+            "verifiers": self.verifiers,
+            "freshness_sla_hours": self.freshness_sla_hours,
+            "decay_policy": {
+                "failed_claim": self.decay_policy.failed_claim,
+                "stale_evidence": self.decay_policy.stale_evidence,
+                "unresolved_crux": self.decay_policy.unresolved_crux,
+            },
+            "fallback_policy": {
+                "default": self.fallback_policy.default,
+                "operator_message": self.fallback_policy.operator_message,
+            },
+            "linked_crux_ids": self.linked_crux_ids,
+        }
+
+
+def load_proof_unit(data: dict[str, Any]) -> ProofCarryingCodeUnit:
+    """Deserialise a dict (e.g. parsed YAML) into a :class:`ProofCarryingCodeUnit`."""
+    decay = data.get("decay_policy") or {}
+    fallback = data.get("fallback_policy") or {}
+    return ProofCarryingCodeUnit(
+        code_unit_id=data.get("code_unit_id", ""),
+        symbol=data.get("symbol", ""),
+        source_path=data.get("source_path", ""),
+        owner=data.get("owner", ""),
+        decision_receipts=list(data.get("decision_receipts") or []),
+        claims=list(data.get("claims") or []),
+        assumptions=list(data.get("assumptions") or []),
+        verifiers=list(data.get("verifiers") or []),
+        freshness_sla_hours=int(data.get("freshness_sla_hours", 24)),
+        decay_policy=DecayPolicy(
+            failed_claim=decay.get("failed_claim", "report_only"),
+            stale_evidence=decay.get("stale_evidence", "report_only"),
+            unresolved_crux=decay.get("unresolved_crux", "report_only"),
+        ),
+        fallback_policy=FallbackPolicy(
+            default=fallback.get("default", "fail_closed"),
+            operator_message=fallback.get("operator_message", ""),
+        ),
+        linked_crux_ids=list(data.get("linked_crux_ids") or []),
+    )
+
+
+def load_proof_unit_from_yaml(path: Path) -> ProofCarryingCodeUnit:
+    """Load and validate a :class:`ProofCarryingCodeUnit` from YAML.
+
+    Raises :class:`ValueError` if validation fails.
+    """
+    with path.open() as fh:
+        data = yaml.safe_load(fh)
+    unit = load_proof_unit(data)
+    errors = unit.validate()
+    if errors:
+        raise ValueError(f"Invalid proof unit at {path}: {errors}")
+    return unit

--- a/docs/status/proof_units/proof_first_shift.yaml
+++ b/docs/status/proof_units/proof_first_shift.yaml
@@ -1,0 +1,35 @@
+code_unit_id: proof_first.shift.green_criteria
+symbol: scripts.run_proof_first_shift.evaluate_green_shift
+source_path: scripts/run_proof_first_shift.py
+owner: proof-first-runtime
+
+decision_receipts:
+  - decision.bc12.green_shift_criteria
+
+claims:
+  - b0.benchmark_truth.complete_current_corpus
+  - docs.proof_first_queue_policy.current
+
+assumptions:
+  - "Benchmark freshness can be determined from the published proof surface."
+  - "Queue can be considered intentionally idle only when no canonical work is eligible."
+
+verifiers:
+  - kind: command
+    command: "python3 -m pytest tests/scripts/test_run_proof_first_shift.py -q"
+
+freshness_sla_hours: 24
+
+decay_policy:
+  failed_claim: repair_required
+  stale_evidence: report_only
+  unresolved_crux: report_only
+
+fallback_policy:
+  default: fail_closed
+  operator_message: >-
+    Green-shift criteria are stale or unsupported; do not widen guard scope
+    until the benchmark truth surface is restored and the queue policy claim
+    is confirmed.
+
+linked_crux_ids: []

--- a/tests/epistemic/test_proof_unit.py
+++ b/tests/epistemic/test_proof_unit.py
@@ -123,8 +123,7 @@ class TestSerialization:
 class TestYamlLoading:
     def test_load_proof_first_shift_example(self) -> None:
         path = PROOF_UNITS_DIR / "proof_first_shift.yaml"
-        if not path.exists():
-            pytest.skip("proof_first_shift.yaml not found")
+        assert path.exists(), f"example fixture missing: {path}"
         unit = load_proof_unit_from_yaml(path)
         assert unit.code_unit_id == "proof_first.shift.green_criteria"
         assert "b0.benchmark_truth.complete_current_corpus" in unit.claims

--- a/tests/epistemic/test_proof_unit.py
+++ b/tests/epistemic/test_proof_unit.py
@@ -1,0 +1,149 @@
+"""Tests for aragora.epistemic.proof_unit (DIC-19 / #6030).
+
+Pure schema/validation — no network, no subprocess, no queue mutation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aragora.epistemic.proof_unit import (
+    DecayPolicy,
+    FallbackPolicy,
+    ProofCarryingCodeUnit,
+    load_proof_unit,
+    load_proof_unit_from_yaml,
+)
+
+PROOF_UNITS_DIR = Path(__file__).parents[2] / "docs" / "status" / "proof_units"
+
+
+def _unit(**overrides: object) -> dict:
+    base: dict = {
+        "code_unit_id": "test.unit.alpha",
+        "symbol": "aragora.epistemic.proof_unit.load_proof_unit",
+        "source_path": "aragora/epistemic/proof_unit.py",
+        "owner": "epistemic-ci",
+        "decision_receipts": ["receipt.test.001"],
+        "claims": ["b0.benchmark_truth.complete_current_corpus"],
+        "assumptions": ["Assumption A holds."],
+        "verifiers": [{"kind": "command", "command": "echo ok"}],
+        "freshness_sla_hours": 24,
+        "decay_policy": {
+            "failed_claim": "report_only",
+            "stale_evidence": "report_only",
+            "unresolved_crux": "report_only",
+        },
+        "fallback_policy": {"default": "fail_closed", "operator_message": "Stop."},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestLoad:
+    def test_load_round_trips_code_unit_id(self) -> None:
+        assert load_proof_unit(_unit()).code_unit_id == "test.unit.alpha"
+
+    def test_linked_crux_ids_defaults_to_empty(self) -> None:
+        assert load_proof_unit(_unit()).linked_crux_ids == []
+
+    def test_freshness_sla_coerced_to_int(self) -> None:
+        assert load_proof_unit(_unit(freshness_sla_hours="48")).freshness_sla_hours == 48
+
+    def test_decay_and_fallback_typed(self) -> None:
+        unit = load_proof_unit(_unit())
+        assert isinstance(unit.decay_policy, DecayPolicy)
+        assert isinstance(unit.fallback_policy, FallbackPolicy)
+
+
+class TestValidation:
+    def test_valid_unit_has_no_errors(self) -> None:
+        assert load_proof_unit(_unit()).validate() == []
+
+    def test_empty_code_unit_id_invalid(self) -> None:
+        errors = load_proof_unit(_unit(code_unit_id="")).validate()
+        assert any("code_unit_id" in e for e in errors)
+
+    def test_zero_freshness_sla_invalid(self) -> None:
+        errors = load_proof_unit(_unit(freshness_sla_hours=0)).validate()
+        assert any("freshness_sla_hours" in e for e in errors)
+
+    def test_invalid_decay_action_reported(self) -> None:
+        data = _unit()
+        data["decay_policy"]["failed_claim"] = "do_nothing_forever"
+        errors = load_proof_unit(data).validate()
+        assert any("decay_policy.failed_claim" in e for e in errors)
+
+    def test_invalid_fallback_action_reported(self) -> None:
+        data = _unit()
+        data["fallback_policy"]["default"] = "yolo"
+        errors = load_proof_unit(data).validate()
+        assert any("fallback_policy.default" in e for e in errors)
+
+    def test_all_valid_decay_actions_accepted(self) -> None:
+        for action in ("report_only", "repair_required", "fail_closed"):
+            data = _unit()
+            data["decay_policy"]["failed_claim"] = action
+            assert load_proof_unit(data).validate() == []
+
+    def test_all_valid_fallback_actions_accepted(self) -> None:
+        for action in ("fail_closed", "degrade", "report_only"):
+            data = _unit()
+            data["fallback_policy"]["default"] = action
+            assert load_proof_unit(data).validate() == []
+
+
+class TestSerialization:
+    def test_to_dict_has_expected_keys(self) -> None:
+        d = load_proof_unit(_unit()).to_dict()
+        assert {
+            "code_unit_id", "symbol", "source_path", "owner",
+            "decision_receipts", "claims", "assumptions", "verifiers",
+            "freshness_sla_hours", "decay_policy", "fallback_policy",
+            "linked_crux_ids",
+        } == set(d)
+
+    def test_roundtrip_via_load(self) -> None:
+        original = load_proof_unit(_unit())
+        reloaded = load_proof_unit(original.to_dict())
+        assert reloaded.code_unit_id == original.code_unit_id
+        assert reloaded.decay_policy.failed_claim == original.decay_policy.failed_claim
+
+
+class TestYamlLoading:
+    def test_load_proof_first_shift_example(self) -> None:
+        path = PROOF_UNITS_DIR / "proof_first_shift.yaml"
+        if not path.exists():
+            pytest.skip("proof_first_shift.yaml not found")
+        unit = load_proof_unit_from_yaml(path)
+        assert unit.code_unit_id == "proof_first.shift.green_criteria"
+        assert "b0.benchmark_truth.complete_current_corpus" in unit.claims
+        assert unit.decay_policy.failed_claim == "repair_required"
+        assert unit.fallback_policy.default == "fail_closed"
+        assert unit.validate() == []
+
+    def test_invalid_yaml_raises_value_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(
+            "code_unit_id: x\nsymbol: x\nsource_path: x.py\nowner: ci\n"
+            "decision_receipts: []\nclaims: []\nassumptions: []\nverifiers: []\n"
+            "freshness_sla_hours: 0\n"
+            "decay_policy: {failed_claim: report_only, stale_evidence: report_only, unresolved_crux: report_only}\n"
+            "fallback_policy: {default: fail_closed, operator_message: ''}\n"
+        )
+        with pytest.raises(ValueError, match="freshness_sla_hours"):
+            load_proof_unit_from_yaml(bad)
+
+    def test_valid_yaml_round_trips(self, tmp_path: Path) -> None:
+        path = tmp_path / "unit.yaml"
+        path.write_text(
+            "code_unit_id: test.unit.alpha\nsymbol: aragora.epistemic.proof_unit.load_proof_unit\n"
+            "source_path: aragora/epistemic/proof_unit.py\nowner: ci\n"
+            "decision_receipts: [r.1]\nclaims: [c.1]\nassumptions: [A.]\n"
+            "verifiers: [{kind: command, command: 'echo ok'}]\nfreshness_sla_hours: 24\n"
+            "decay_policy: {failed_claim: report_only, stale_evidence: report_only, unresolved_crux: report_only}\n"
+            "fallback_policy: {default: fail_closed, operator_message: stop}\n"
+        )
+        assert load_proof_unit_from_yaml(path).validate() == []

--- a/tests/epistemic/test_proof_unit.py
+++ b/tests/epistemic/test_proof_unit.py
@@ -99,9 +99,17 @@ class TestSerialization:
     def test_to_dict_has_expected_keys(self) -> None:
         d = load_proof_unit(_unit()).to_dict()
         assert {
-            "code_unit_id", "symbol", "source_path", "owner",
-            "decision_receipts", "claims", "assumptions", "verifiers",
-            "freshness_sla_hours", "decay_policy", "fallback_policy",
+            "code_unit_id",
+            "symbol",
+            "source_path",
+            "owner",
+            "decision_receipts",
+            "claims",
+            "assumptions",
+            "verifiers",
+            "freshness_sla_hours",
+            "decay_policy",
+            "fallback_policy",
             "linked_crux_ids",
         } == set(d)
 


### PR DESCRIPTION
## Slice
Adds `ProofCarryingCodeUnit` — a code path annotated with the DIC-13 claim IDs, decision receipts, verifier commands, decay policy, and fallback policy that justify it. Includes one concrete example tied to the proof-first green-shift criteria script, and 16 focused tests.

## Gating
- Default: OFF (schema-only module; nothing calls it unless explicitly imported)
- Live queue effect: none — no boss loop, dispatch, or swarm supervisor changes
- Advances issue: #6030 (DIC-19)

## Tests
- `TestLoad` (4 tests): load/round-trip, linked_crux_ids default, int coercion, type assertions
- `TestValidation` (7 tests): valid unit passes, empty code_unit_id, zero freshness_sla, invalid decay/fallback actions, all valid action values accepted
- `TestSerialization` (2 tests): to_dict key set, round-trip via load
- `TestYamlLoading` (3 tests): real proof_first_shift.yaml integration, invalid YAML raises ValueError, valid YAML round-trips

## Validation
- `pytest tests/epistemic/test_proof_unit.py --noconftest` — 16 passed
- `ruff check aragora/epistemic/proof_unit.py tests/epistemic/test_proof_unit.py` — clean
- `mypy aragora/epistemic/proof_unit.py --ignore-missing-imports` — no errors in touched module (yaml `import-untyped` is a pre-existing pattern in workflow/schema.py and verticals/config.py)

## Compatibility note
Field names (`claims`, `verifiers`, `decision_receipts`, `linked_crux_ids`) are deliberately aligned with the DIC-13 claim manifest schema (`docs/status/claims/executable_claim_manifest.schema.json`) and the AGT-01 CruxSet receipt model so downstream tooling can join across all three without translation.

## Out of scope
- DIC-20 (Epistemic Decay Monitor): evaluates proof units against live claim verification results — future slice
- DIC-21 (Fail-Closed Quarantine Policy): maps decay severity to runtime actions — future slice
- DIC-22 (Verified Replacement Pipeline): produces bounded repair candidates — future slice
- CLI entry point for `aragora proof-unit verify` — deferred to a later slice once DIC-20 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)