### PR TITLE
docs+feat(trust-compound): joint-assessment audit + executable plan + canonical-metrics manifest

### DIFF
--- a/docs/audits/2026-04-17-codex-claude-joint-assessment.md
+++ b/docs/audits/2026-04-17-codex-claude-joint-assessment.md
@@ -1,0 +1,136 @@
+# Joint Codex + Claude Assessment of Aragora Repo State
+
+> **Date:** 2026-04-17
+> **Reviewers:** Codex (GPT-5.4 strategic) and Claude Code (Opus 4.7)
+> **Method:** independent assessment of repo, docs, recent commit history, live surfaces; comparison and synthesis
+> **Companion plan:** [docs/plans/2026-04-17-trust-compound-plan.md](../plans/2026-04-17-trust-compound-plan.md)
+
+This document is a permanent reference for the joint assessment that drove the trust-compound plan. It is not a positioning document and not a marketing artifact — it captures what two independent technical reviewers actually concluded so future sessions and external reviewers can reread the diagnosis without losing the critique.
+
+## Convergent verdict (both reviewers)
+
+> **The project does something genuinely valuable, has an unusually clear vision, and a better-than-average plan. The repo is too large and too noisy for an outsider to instantly trust the broader claims. The bounded software-execution wedge would be believed sooner than the larger platform story. The fix is to compound trust, not to subtract surface area.**
+
+Both reviewers explicitly rejected the move of **excising preserved subsystems**. The recommended posture is:
+
+- the bounded-execution wedge is the **current product**
+- the AGT-* track + Nomic loop + reputation substrate is the **forward bet**
+- the 80+ subpackages that look "extra" are **preserved optionality**, not dead weight
+
+Making that distinction explicit is the unlock.
+
+## What both reviewers rate as strong
+
+- The strategic thinking is unusually clear. README, CANONICAL_GOALS, NEXT_STEPS_CANONICAL, BOUNDARIES_AND_SCOPE, and COMMERCIAL_OVERVIEW are disciplined and self-aware.
+- Real machinery exists: swarm/supervisor/boss execution, receipts, OpenAPI/SDK generation, proof-first runbooks, benchmark truth surfaces, operator tooling.
+- Serious automation investment. 79 GitHub workflows, ~3,989 Python modules under `aragora/`, ~155k test definitions.
+- The commercial framing is more honest than average. Docs repeatedly narrow current value to bounded execution rather than pretending the whole vision is delivered.
+- The AGT-* substrate landed Apr 16-17 (PRs #6080-#6126 + #6144) is distinctive: cryptographically attested decision provenance, skin-in-the-game agent reputation, prediction-market-validated calibration, crux detection. Almost nobody else is building this layer.
+- Code hygiene: pre-commit hooks (ruff + gitleaks + format) catch issues before push; deterministic test discipline (content-addressed IDs, pinned timestamps).
+
+## What both reviewers flag as concerning
+
+### Repo sprawl with hotspot files
+
+Local counts at 2026-04-17:
+
+| File | LOC |
+|------|-----|
+| `aragora/nomic/dev_coordination.py` | ~5.3k |
+| `aragora/swarm/boss_loop.py` | ~4.5k |
+| `aragora/server/handlers/playground.py` | ~4.2k |
+| `aragora/pipeline/idea_to_execution.py` | ~4.0k |
+| `aragora/cli/parser.py` | ~3.6k |
+
+Total Python LOC: ~1.89M. An outsider reads this as "powerful, but hard to reason about and easy to regress."
+
+### Identity confusion
+
+- `pyproject.toml` declares `name = "aragora-debate"` and points to `github.com/an0mium/aragora`
+- README presents three install surfaces (`aragora`, `aragora-debate`, `aragora-sdk`) without a clear single canonical story for which is the main product
+
+### Truth-surface drift
+
+`CANONICAL_GOALS.md` claims **42** Knowledge Mound adapters; `python3 scripts/doc_stats.py` currently reports **0** registered adapters. Even if this is a counting bug, an outsider sees truth drift in a project whose core thesis is truthful gates. **This is exactly the failure class the project's own epistemic-CI doctrine is designed to prevent.**
+
+### Lint discipline is pragmatic but loose
+
+`pyproject.toml` has broad per-file ignores and wide exception patterns. Understandable at this scale; signals accumulated debt.
+
+### Generated-surface churn
+
+Open PR board has multiple merge-conflicting SDK/OpenAPI branches because generated artifacts (`docs/api/openapi*.{json,yaml}`, TS SDK files) are source-controlled. High coordination cost.
+
+### Operational truth has sharp edges
+
+- Recent fix needed to stop `probe_boss_loop_launchd.py` from false-greening service state
+- `BossRestartFailed: launchctl kickstart timed out` remains a recurring failure class (2 occurrences logged 2026-04-16) after PR #6080 eliminated the rate-limit class
+
+### Activation lag
+
+The AGT-* substrate landed this week is ~9,200 lines of code, all flag-gated default-off. The substrate-first "three consecutive green BC-12 soaks before flipping AGT flags" rule has been deferring activation. Dormant code that never runs is indistinguishable from speculative code.
+
+### Self-maintenance gravity
+
+In the last 30 days: **2,509 commits**. Top prefixes: `fix` (385), `fix(swarm)` (158), `feat(swarm)` (92), `fix(ci)` (76). A substantial fraction of recent work keeps the autonomous loop from eating itself. Classic meta-infrastructure trap.
+
+### No visible external user
+
+No case studies, no design partner logos, no "X is using Aragora to Y" anywhere in the repo or on the live surface. Everything visible is founder + agents.
+
+## What a cold inspector would conclude
+
+Per Codex:
+
+> "This is ambitious and serious."
+> "The team thinks clearly about trust, receipts, and staged autonomy."
+> "There is a real product kernel here."
+> "The repo is too big and too messy to be easy to trust on first read."
+> "The vision is better than the current packaging and codebase hygiene."
+> "I would believe the bounded software-execution wedge sooner than the larger platform story."
+
+Per Claude:
+
+> "Either a 10-person team's output from a brilliant founder who's 6 months from either shipping something unusually good or burning out maintaining their own infrastructure. The next 60 days determine which."
+
+## What changes the read
+
+Both reviewers agreed the unlock is not subtraction. It is **legibility**. Specifically:
+
+1. **Truth-surface alignment** — apply the project's own epistemic-CI doctrine to its own canonical metrics so docs cannot drift from code without a CI failure.
+2. **Identity consolidation** — one canonical packaging story, one canonical install surface, README that leads with the bounded-execution wedge.
+3. **Hotspot legibility** — split god-modules into subpackages without removing functionality. Public APIs unchanged; same code, just findable.
+4. **Wire / showcase / shelve classification** — every subsystem labeled as `(A) wire`, `(B) showcase`, or `(C) shelved-revisit` with explicit revival criteria. Nothing deleted.
+5. **Generated artifacts as build outputs** — move `docs/api/openapi*` to CI-built or `.gitattributes merge=theirs` strategy to eliminate conflict storms.
+6. **One narrow public activation of the AGT track** — even 10 published CruxSets at `aragora.ai/cruxes` converts the dormant infrastructure from "speculative" to "click-able."
+7. **One external user doing one real thing weekly** — the highest-leverage move overall, not in scope of this audit but the ultimate trust unlock.
+
+## Preservation guarantees
+
+The following must NOT be removed by any execution of this plan:
+
+- `aragora/verticals/` (legal, healthcare, financial, software domain specialists)
+- `aragora/extensions/` (gastown, moltbot — alternative product surfaces)
+- `aragora/genesis/` (fractal resolution, Argonaut ledger)
+- `aragora/modes/` (architect/coder/reviewer/etc. operational modes)
+- `aragora/marketplace/`, `aragora/skills/`, `aragora/blockchain/`
+- The Nomic loop, proof-first queue, reputation substrate, AGT-* track
+- Multi-agent debate primitives — the adversarial design is the thesis
+- Any other subsystem may be tagged "shelved" but must remain on disk with a revival-criteria pointer
+
+## What this audit does NOT recommend
+
+- **Big refactor sprint or code freeze.** Parallel one-hotspot-per-month is faster overall.
+- **Pivoting the vision.** The "agent civilization substrate" direction is correct; the problem is presentation and activation, not direction.
+- **Subtracting the AGT-* track.** The 13 PRs landed Apr 16-17 are forward-bet investment that will look obvious in retrospect once activated.
+- **Single-vertical narrowing.** The platform thesis is intact; choose one *showcase application*, not one vertical to live in.
+
+## References
+
+- [docs/plans/2026-04-17-trust-compound-plan.md](../plans/2026-04-17-trust-compound-plan.md) — the executable plan derived from this assessment
+- [docs/status/claims/canonical_metrics.yaml](../status/claims/canonical_metrics.yaml) — the executable claim manifest landing Step 1 of the plan
+- [docs/CANONICAL_GOALS.md](../CANONICAL_GOALS.md) — current canonical metrics surface
+- [docs/COMMERCIAL_OVERVIEW.md](../COMMERCIAL_OVERVIEW.md) — what is true on `main` vs long-term ambition
+- [docs/status/NEXT_STEPS_CANONICAL.md](../status/NEXT_STEPS_CANONICAL.md) — substrate-first execution gate
+- [docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md](../plans/AGENT_CIVILIZATION_SUBSTRATE.md) — the AGT track this audit assesses
+- [docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md) — the doctrine the canonical-metrics manifest dogfoods

--- a/docs/plans/2026-04-17-trust-compound-plan.md
+++ b/docs/plans/2026-04-17-trust-compound-plan.md
@@ -1,0 +1,163 @@
+# Trust-Compound Plan (TCP)
+
+> **Created:** 2026-04-17
+> **Source:** [docs/audits/2026-04-17-codex-claude-joint-assessment.md](../audits/2026-04-17-codex-claude-joint-assessment.md)
+> **Goal:** make the repo legible without subtracting any preserved subsystem
+> **Activation gate:** TCP-1..TCP-7 are planning truth, not new boss-ready scope. Codex autopilot may pick up TCP issues only when the proof-first reconciler permits it.
+
+## Sequencing rationale
+
+Each step was chosen for **leverage per week** and for compatibility with the substrate-first activation gate. Earlier steps unlock or ratify later ones; none requires a code freeze. Long-running steps run in the background while normal work continues.
+
+| Order | Code | Step | Owner | Estimated effort | Long-running execution surface |
+|-------|------|------|-------|------------------|--------------------------------|
+| 1 | TCP-1 | Canonical-metrics claim manifest + CI verifier | Codex autopilot or Claude Code | 1 day | `docs/status/claims/canonical_metrics.yaml` + `aragora.epistemic.ClaimVerifier` runs in CI on every push and on a daily schedule |
+| 2 | TCP-2 | Packaging identity consolidation | Founder, 30 min | 30 min | One-shot |
+| 3 | TCP-3 | Hotspot-file split proposals (1 file/month) | Droid deep audit | 1 month per file | Droid produces a split proposal per file; PRs land monthly |
+| 4 | TCP-4 | Wire / showcase / shelve classification | Claude Code | 1 week | Extends `docs/STRANDED_FEATURES_AUDIT.md`; verified periodically by a tagged-state check in CI |
+| 5 | TCP-5 | Generated-artifacts CI migration | Codex autopilot | 1-2 weeks | Build pipeline change; reduces conflict storms ongoing |
+| 6 | TCP-6 | README top-of-fold rewrite to lead with bounded wedge | Founder, 30 min | 30 min | One-shot |
+| 7 | TCP-7 | One narrow public AGT-* activation (e.g. `aragora.ai/cruxes`) | Claude Code session | 1 week + ongoing | Static page rebuilt nightly from the CruxSet store; the "click-able proof" output |
+
+## Step contracts
+
+### TCP-1 — Canonical-metrics executable claim manifest
+
+**Why first:** highest signal-to-noise. Mismatch between `CANONICAL_GOALS.md` (claims 42 KM adapters) and `python3 scripts/doc_stats.py` (reports 0) is exactly the failure class the project's own DIC-13 / DIC-14 epistemic-CI doctrine is designed to prevent. Dogfooding the doctrine compounds trust faster than any other single move.
+
+**Deliverables:**
+
+- `docs/status/claims/canonical_metrics.yaml` — claim manifest in the existing schema, one claim per headline number in `CANONICAL_GOALS.md`
+- `scripts/check_canonical_metrics.py` — extracts the claimed value from `CANONICAL_GOALS.md` and reconciles against the live count; prints structured JSON; exit 0 if consistent, non-zero on drift
+- `tests/integration/test_canonical_metrics_manifest.py` — verifies the manifest schema-validates, the script runs end-to-end, and at least one claim's verifier exits 0 against the current repo
+- CI workflow integration: run the script on every push to `main` and on a daily schedule
+
+**Acceptance criteria:**
+
+- All claims in the manifest schema-validate
+- The script either confirms each claim or fails clearly with which value drifted
+- The 42-vs-0 KM-adapters drift is either resolved or explicitly downgraded to a known-broken claim with a follow-up issue
+
+**Long-running execution:** the manifest and verifier are intended to run in CI indefinitely. New canonical claims (test counts, agent counts, version) are added by appending to the YAML.
+
+### TCP-2 — Packaging identity consolidation
+
+**Why second:** highest first-impression ROI. 30 minutes of founder time fixes a top-of-page trust signal.
+
+**Decisions to make (one-shot):**
+
+- Is `aragora-debate` (the pip package) a separate product or a slice of the main install? Document both shape and relationship in README.
+- Fix `pyproject.toml` git URL: currently `github.com/an0mium/aragora`, repo lives at `github.com/synaptent/aragora`
+- README install table: keep the three install surfaces if all three are intended product offerings; merge or remove if not
+
+**Acceptance criteria:**
+
+- `pyproject.toml` `[project.urls]` matches reality
+- README install table has one canonical "start here" path with the others labeled as alternatives
+- One-paragraph README section explaining the relationship between `aragora` and `aragora-debate`
+
+### TCP-3 — Hotspot-file split proposals (rolling)
+
+**Why third:** behavior-preserving legibility win. Splitting `boss_loop.py` into a subpackage doesn't remove a single line — it just makes 4.5k LOC findable in 4-5 ~1k-line files with clear module docstrings.
+
+**Order of attack:**
+
+1. `aragora/swarm/boss_loop.py` (~4.5k) — most read by external reviewers since it's the autonomy entry point
+2. `aragora/nomic/dev_coordination.py` (~5.3k) — largest absolute size
+3. `aragora/server/handlers/playground.py` (~4.2k)
+4. `aragora/pipeline/idea_to_execution.py` (~4.0k)
+5. `aragora/cli/parser.py` (~3.6k) — easiest, most mechanical (subparser registration sprawl)
+
+**Acceptance criteria for each split PR:**
+
+- Public API unchanged (top-level imports re-export everything)
+- All existing tests pass without modification
+- New file structure has one clear concern per file with docstrings
+- New subpackage has a `README.md` (or top-level docstring) explaining the layout
+
+**Long-running execution:** Droid deep-audit packet (already drafted earlier in the joint-assessment session) produces a split proposal per file. PRs land at most one per month to avoid review fatigue.
+
+### TCP-4 — Wire / showcase / shelve classification
+
+**Why:** converts visible sprawl into honest cataloguing. Nothing is deleted; the inspector reads the labels.
+
+**Deliverables:**
+
+- Extend `docs/STRANDED_FEATURES_AUDIT.md` with a three-column table for every subpackage under `aragora/`:
+  - `(A) wire` — currently on the critical path to the bounded-execution wedge or the AGT-* track
+  - `(B) showcase` — demonstrates the platform end-to-end (Inbox Trust Wedge, AGT pipeline dry-run, etc.)
+  - `(C) shelved-revisit` — preserved on disk, maintenance suspended, revival criteria specified
+- One sentence per `(C)` row stating what condition would revive maintenance
+- A claim manifest entry under TCP-1 verifying the classification is non-empty and covers all subpackages
+
+**Preservation guarantee:** the table CANNOT be a deletion plan. Anything classified `(C)` stays on disk.
+
+### TCP-5 — Generated artifacts as build outputs
+
+**Why:** OpenAPI/SDK conflict storms are a CI workflow problem, not a structural one. Two paths:
+
+- **Lazy-rebuild path:** keep the generated files committed but use `.gitattributes merge=theirs` / `merge=ours` to auto-resolve; rebuild on every push to `main`
+- **Build-output path:** move generated files to `build/` (gitignored), publish per-tag as build artifacts; consumers fetch by tag
+
+**Acceptance criteria:**
+
+- No more PRs blocked by `docs/api/openapi*.{json,yaml}` merge conflicts
+- A clear documented procedure for downstream consumers to fetch the latest schema
+
+**Long-running execution:** once the workflow lands, ongoing maintenance is zero.
+
+### TCP-6 — README top-of-fold rewrite
+
+**Why:** the README already says the right thing ("govern AI-assisted work with receipts, review, and truthful gates"). Lead harder with that. Move the agent-civilization vision to a clearly-labeled `## Roadmap` section so the bounded-execution wedge gets the first 30 seconds of attention.
+
+**Acceptance criteria:**
+
+- First two screens of the README sell the bounded wedge (current product)
+- A `## Roadmap` or `## Forward bet` section explicitly captures the AGT-* / agent-civilization direction
+- Install table has one canonical path
+
+### TCP-7 — One narrow public AGT-* activation
+
+**Why:** the unlock that flips Codex's verdict from "might be impressive in 60 days" to "clearly doing something useful today." Pick one AGT-* flag, activate narrowly, publish output.
+
+**Suggested wedge:** emit CruxSets for one debate category (e.g. "ship/hold decisions"), publish them as a static page at `aragora.ai/cruxes` rebuilt nightly from the CruxSet store. Shows the system identifying load-bearing disagreements on real questions.
+
+**Acceptance criteria:**
+
+- One AGT-* flag activated in production via env var (not just merged behind default-off)
+- Output is publicly readable at a stable URL
+- At least 10 real CruxSets published before the activation is rated successful
+
+**Long-running execution:** the page rebuilds nightly; the CruxSet count grows over time; failure modes (zero new cruxes for >7 days, signature verification failure, etc.) flag follow-up issues via DIC-17.
+
+## Cross-cutting rules
+
+- **Nothing in `aragora/` is deleted by this plan.** `verticals/`, `extensions/`, `genesis/`, `modes/`, marketplace/, etc. are all preserved (see audit doc preservation list).
+- **No code freeze.** TCP-3 (hotspot splits) runs in parallel with all other work, one file per month.
+- **Substrate-first gate is unchanged.** TCP issues do NOT carry `boss-ready` until the proof-first reconciler permits the upper-layer tranche, in line with how DIC-13..22 and AGT-01..06 are governed.
+- **TCP-1 is the keystone.** Once the canonical-metrics manifest runs in CI, every subsequent step (TCP-3 splits, TCP-4 classification) gets verified by it — drift becomes a build failure rather than a slow trust erosion.
+
+## Dispatch matrix (who does what)
+
+| Step | Best-fit dispatcher | Spec source |
+|------|---------------------|-------------|
+| TCP-1 | Codex autopilot (issue spec is well-bounded) or Claude Code | This doc + the existing `docs/status/claims/proof_first_claims.yaml` template |
+| TCP-2 | Founder, no delegation | This doc |
+| TCP-3 | Droid deep audit (`droid exec -m claude-opus-4-7 -r high --auto low`); split proposals only, no PRs | Droid dispatch packet drafted in joint-assessment session; extend with split mandate |
+| TCP-4 | Claude Code session | This doc + `docs/STRANDED_FEATURES_AUDIT.md` |
+| TCP-5 | Codex autopilot | This doc |
+| TCP-6 | Founder, no delegation | This doc |
+| TCP-7 | Claude Code (continuation of AGT-* track familiarity) | This doc + `docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md` |
+
+## Tracking
+
+- GitHub epic: see follow-up issue created from this plan
+- Per-step issues: TCP-1..TCP-7 each get one issue, all linked to the epic
+- Status: `in_progress` once a PR exists; `closed` when acceptance criteria pass
+
+## When to revisit this plan
+
+- After TCP-1 lands and runs in CI for 7 days — confirm the manifest catches at least one drift event; tighten thresholds
+- After TCP-3 ships its first hotspot split — measure subjective "could a new contributor understand this in an hour" against the pre-split baseline
+- After TCP-7 publishes 10 CruxSets — re-read the joint assessment and update the verdict
+- Otherwise: every quarter, regenerate the joint assessment from a cold-read perspective and diff against this plan

--- a/docs/status/claims/canonical_metrics.yaml
+++ b/docs/status/claims/canonical_metrics.yaml
@@ -95,3 +95,87 @@ claims:
     receipts:
       - type: canonical_metrics_check
         path: docs/status/generated/canonical_metrics/latest.json
+
+  - claim_id: security.gitleaks.dual_stage
+    statement: "gitleaks pre-commit hook runs at BOTH pre-commit AND pre-push stages so a forced --no-verify locally still gets caught before secrets reach the remote."
+    owner: security
+    scope: repo
+    confidence: high
+    evidence:
+      - path: .pre-commit-config.yaml
+      - path: benchmarks/bench_readiness/incident_2026-04-07_high-gravity.md
+    freshness_sla_hours: 24
+    verification:
+      kind: command
+      command: "python3 scripts/check_canonical_metrics.py --claim security.gitleaks.dual_stage"
+      expected_result: "exit 0 when gitleaks hook declares stages: [pre-commit, pre-push]"
+    failure:
+      severity: blocking
+      allowed_action: report_only
+      repair_note: "Restore the gitleaks dual-stage configuration. Single-stage misses --no-verify bypass attempts which is how the 2026-04-07 HIGH-GRAVITY Anthropic key leaked."
+    receipts:
+      - type: canonical_metrics_check
+        path: docs/status/generated/canonical_metrics/latest.json
+
+  - claim_id: security.model_pins.frontier_aligned
+    statement: "aragora/config/model_pins.py exists and exports OPUS_4_7, GPT_5_4, and GEMINI_3_1_PRO so consumers stop hardcoding model IDs."
+    owner: security
+    scope: repo
+    confidence: high
+    evidence:
+      - path: aragora/config/model_pins.py
+    freshness_sla_hours: 168
+    verification:
+      kind: command
+      command: "python3 scripts/check_canonical_metrics.py --claim security.model_pins.frontier_aligned"
+      expected_result: "exit 0 when the three frontier model pin constants are exported"
+    failure:
+      severity: warning
+      allowed_action: report_only
+      repair_note: "Restore aragora/config/model_pins.py with OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO constants. Drift here means new code can re-introduce hardcoded model IDs that drift from the canonical frontier."
+    receipts:
+      - type: canonical_metrics_check
+        path: docs/status/generated/canonical_metrics/latest.json
+
+  - claim_id: security.incident_log.present
+    statement: "The 2026-04-07 HIGH-GRAVITY incident write-up and 90-day key-rotation schedule remain in the repo for institutional memory."
+    owner: security
+    scope: repo
+    confidence: high
+    evidence:
+      - path: benchmarks/bench_readiness/incident_2026-04-07_high-gravity.md
+      - path: benchmarks/bench_readiness/rotation-schedule.yaml
+    freshness_sla_hours: 720
+    verification:
+      kind: command
+      command: "python3 scripts/check_canonical_metrics.py --claim security.incident_log.present"
+      expected_result: "exit 0 when both the incident log and rotation schedule files exist"
+    failure:
+      severity: warning
+      allowed_action: report_only
+      repair_note: "Do not delete the incident write-up or rotation schedule. They are the audit trail for the 2026-04-07 Anthropic key leak and the rotation cadence the team committed to."
+    receipts:
+      - type: canonical_metrics_check
+        path: docs/status/generated/canonical_metrics/latest.json
+
+  - claim_id: security.openrouter_fallback.wired
+    statement: "Anthropic, OpenAI, and Gemini API agents inherit QuotaFallbackMixin so a missing or revoked direct provider key never blocks a debate."
+    owner: security
+    scope: repo
+    confidence: high
+    evidence:
+      - path: aragora/agents/api_agents/anthropic.py
+      - path: aragora/agents/api_agents/openai.py
+      - path: aragora/agents/api_agents/gemini.py
+    freshness_sla_hours: 168
+    verification:
+      kind: command
+      command: "python3 scripts/check_canonical_metrics.py --claim security.openrouter_fallback.wired"
+      expected_result: "exit 0 when all three frontier-provider agents declare QuotaFallbackMixin in their MRO"
+    failure:
+      severity: blocking
+      allowed_action: report_only
+      repair_note: "Restore QuotaFallbackMixin on the affected provider agent. Removing it re-introduces the 'missing direct key blocks debates' failure mode the OpenRouter-first policy was put in place to prevent."
+    receipts:
+      - type: canonical_metrics_check
+        path: docs/status/generated/canonical_metrics/latest.json

--- a/docs/status/claims/canonical_metrics.yaml
+++ b/docs/status/claims/canonical_metrics.yaml
@@ -1,0 +1,97 @@
+schema_version: 1
+manifest_id: canonical_metrics
+description: >
+  Executable claims about the headline canonical metrics stated in
+  docs/CANONICAL_GOALS.md. Each claim is verified by a small repo-local
+  script that recomputes the value from the actual code/tests and compares
+  against what the doc claims. This manifest dogfoods the DIC-14 ClaimVerifier
+  doctrine on the project's own truth-surface, per TCP-1 in
+  docs/plans/2026-04-17-trust-compound-plan.md.
+
+  First-class goal: drift between a claim in docs and its actual value in code
+  is a CI failure, not a footnote discovered months later by a cold reviewer.
+claims:
+  - claim_id: canonical.km_adapters.count
+    statement: "CANONICAL_GOALS.md's stated Knowledge Mound adapter count matches the live registry."
+    owner: trust-compound-plan
+    scope: repo
+    confidence: high
+    evidence:
+      - path: docs/CANONICAL_GOALS.md
+      - path: aragora/knowledge/mound/adapters/
+      - path: scripts/doc_stats.py
+    freshness_sla_hours: 24
+    verification:
+      kind: command
+      command: "python3 scripts/check_canonical_metrics.py --claim canonical.km_adapters.count"
+      expected_result: "exit 0 with JSON {status: pass} when the doc claim matches the live count"
+    failure:
+      severity: warning
+      allowed_action: report_only
+      repair_note: "Either update CANONICAL_GOALS.md to match the live count, or fix the adapter registration path if adapters are missing."
+    receipts:
+      - type: canonical_metrics_check
+        path: docs/status/generated/canonical_metrics/latest.json
+
+  - claim_id: canonical.python_modules.count
+    statement: "CANONICAL_GOALS.md's stated Python-module count is within tolerance of the live file count under aragora/."
+    owner: trust-compound-plan
+    scope: repo
+    confidence: medium
+    evidence:
+      - path: docs/CANONICAL_GOALS.md
+      - path: aragora/
+    freshness_sla_hours: 168
+    verification:
+      kind: command
+      command: "python3 scripts/check_canonical_metrics.py --claim canonical.python_modules.count"
+      expected_result: "exit 0 when the claimed count is within the configured tolerance of the live count"
+    failure:
+      severity: info
+      allowed_action: report_only
+      repair_note: "Module count grows naturally. Refresh CANONICAL_GOALS.md when drift exceeds 10%."
+    receipts:
+      - type: canonical_metrics_check
+        path: docs/status/generated/canonical_metrics/latest.json
+
+  - claim_id: canonical.test_definitions.count
+    statement: "CANONICAL_GOALS.md's stated test-definition count is within tolerance of `grep -c 'def test_'` across tests/."
+    owner: trust-compound-plan
+    scope: repo
+    confidence: medium
+    evidence:
+      - path: docs/CANONICAL_GOALS.md
+      - path: tests/
+    freshness_sla_hours: 168
+    verification:
+      kind: command
+      command: "python3 scripts/check_canonical_metrics.py --claim canonical.test_definitions.count"
+      expected_result: "exit 0 when the claimed count is within tolerance of the live count"
+    failure:
+      severity: info
+      allowed_action: report_only
+      repair_note: "Test count grows naturally. Refresh CANONICAL_GOALS.md when drift exceeds 10%."
+    receipts:
+      - type: canonical_metrics_check
+        path: docs/status/generated/canonical_metrics/latest.json
+
+  - claim_id: canonical.version.matches_pyproject
+    statement: "CANONICAL_GOALS.md's stated version matches the version in pyproject.toml."
+    owner: trust-compound-plan
+    scope: repo
+    confidence: high
+    evidence:
+      - path: docs/CANONICAL_GOALS.md
+      - path: pyproject.toml
+    freshness_sla_hours: 24
+    verification:
+      kind: command
+      command: "python3 scripts/check_canonical_metrics.py --claim canonical.version.matches_pyproject"
+      expected_result: "exit 0 when the two strings match exactly"
+    failure:
+      severity: blocking
+      allowed_action: report_only
+      repair_note: "Version drift between docs and pyproject is a release-readiness bug. Fix immediately."
+    receipts:
+      - type: canonical_metrics_check
+        path: docs/status/generated/canonical_metrics/latest.json

--- a/docs/status/generated/canonical_metrics/latest.json
+++ b/docs/status/generated/canonical_metrics/latest.json
@@ -1,0 +1,42 @@
+{
+  "manifest_id": "canonical_metrics",
+  "results": [
+    {
+      "claim_id": "canonical.km_adapters.count",
+      "claimed": "42",
+      "message": "docs claim 42 adapters but live count is 45 \u2014 drift of 3. Update CANONICAL_GOALS.md or fix adapter registration.",
+      "observed": "45",
+      "status": "fail",
+      "tolerance": "+/-2"
+    },
+    {
+      "claim_id": "canonical.python_modules.count",
+      "claimed": "3800+",
+      "message": "docs claim 3800+ modules; live count is 3989 \u2014 within tolerance",
+      "observed": "3989",
+      "status": "pass",
+      "tolerance": "+/-20%"
+    },
+    {
+      "claim_id": "canonical.test_definitions.count",
+      "claimed": "210000+",
+      "message": "docs claim 210000+ tests; live count is 155944. Refresh CANONICAL_GOALS.md when drift exceeds 20%.",
+      "observed": "155944",
+      "status": "warn",
+      "tolerance": "+/-20%"
+    },
+    {
+      "claim_id": "canonical.version.matches_pyproject",
+      "claimed": "2.8.0",
+      "message": "docs and pyproject.toml both report version 2.8.0",
+      "observed": "2.8.0",
+      "status": "pass",
+      "tolerance": "exact"
+    }
+  ],
+  "summary": {
+    "fail": 1,
+    "pass": 2,
+    "warn": 1
+  }
+}

--- a/scripts/check_canonical_metrics.py
+++ b/scripts/check_canonical_metrics.py
@@ -45,6 +45,14 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 ADAPTERS_DIR = REPO_ROOT / "aragora" / "knowledge" / "mound" / "adapters"
 OUTPUT_PATH = REPO_ROOT / "docs" / "status" / "generated" / "canonical_metrics" / "latest.json"
 
+PRECOMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+MODEL_PINS = REPO_ROOT / "aragora" / "config" / "model_pins.py"
+INCIDENT_LOG = REPO_ROOT / "benchmarks" / "bench_readiness" / "incident_2026-04-07_high-gravity.md"
+ROTATION_SCHEDULE = REPO_ROOT / "benchmarks" / "bench_readiness" / "rotation-schedule.yaml"
+ANTHROPIC_AGENT = REPO_ROOT / "aragora" / "agents" / "api_agents" / "anthropic.py"
+OPENAI_AGENT = REPO_ROOT / "aragora" / "agents" / "api_agents" / "openai.py"
+GEMINI_AGENT = REPO_ROOT / "aragora" / "agents" / "api_agents" / "gemini.py"
+
 
 @dataclass
 class ClaimCheck:
@@ -321,11 +329,171 @@ def _check_version_matches_pyproject() -> ClaimCheck:
     )
 
 
+# ---------------------------------------------------------------------------
+# Security claim checks — added in Phase 14c, see docs/status/claims/canonical_metrics.yaml.
+# These checks are tolerant of the underlying artefacts being missing (they
+# report fail/warn rather than raising) so the manifest stays evaluable on any
+# commit; missing artefacts are themselves drift to surface, not a script bug.
+# ---------------------------------------------------------------------------
+
+
+def _check_gitleaks_dual_stage() -> ClaimCheck:
+    claim_id = "security.gitleaks.dual_stage"
+    if not PRECOMMIT_CONFIG.is_file():
+        return ClaimCheck(
+            claim_id=claim_id,
+            status="fail",
+            claimed="gitleaks at [pre-commit, pre-push]",
+            observed="<.pre-commit-config.yaml missing>",
+            tolerance="exact",
+            message=".pre-commit-config.yaml is missing — restore from PR #6194 (Droid foundation).",
+        )
+    text = PRECOMMIT_CONFIG.read_text(encoding="utf-8")
+    # Match the gitleaks block and look for both stages within ~10 lines.
+    pattern = re.compile(
+        r"(?m)^\s*-\s*id:\s*gitleaks\b[\s\S]{0,400}?stages:\s*\[\s*pre-commit\s*,\s*pre-push\s*\]",
+    )
+    if pattern.search(text):
+        return ClaimCheck(
+            claim_id=claim_id,
+            status="pass",
+            claimed="gitleaks at [pre-commit, pre-push]",
+            observed="gitleaks block declares both stages",
+            tolerance="exact",
+            message="gitleaks runs at both pre-commit and pre-push — bypass via --no-verify is caught at push time.",
+        )
+    return ClaimCheck(
+        claim_id=claim_id,
+        status="fail",
+        claimed="gitleaks at [pre-commit, pre-push]",
+        observed="gitleaks block missing one of the required stages",
+        tolerance="exact",
+        message=(
+            "gitleaks is not configured for both pre-commit AND pre-push. "
+            "This regresses the 2026-04-07 incident response — restore the dual-stage config."
+        ),
+    )
+
+
+def _check_model_pins_frontier_aligned() -> ClaimCheck:
+    claim_id = "security.model_pins.frontier_aligned"
+    if not MODEL_PINS.is_file():
+        return ClaimCheck(
+            claim_id=claim_id,
+            status="fail",
+            claimed="OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO exported",
+            observed="<aragora/config/model_pins.py missing>",
+            tolerance="exact",
+            message="aragora/config/model_pins.py is missing — likely PR #6194 has not merged yet.",
+        )
+    text = MODEL_PINS.read_text(encoding="utf-8")
+    required = ("OPUS_4_7", "GPT_5_4", "GEMINI_3_1_PRO")
+    missing = [
+        name for name in required if not re.search(rf"^\s*{name}\s*[:=]", text, re.MULTILINE)
+    ]
+    if not missing:
+        return ClaimCheck(
+            claim_id=claim_id,
+            status="pass",
+            claimed="OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO exported",
+            observed="all three frontier constants present",
+            tolerance="exact",
+            message="model_pins registry exports the three canonical frontier IDs.",
+        )
+    return ClaimCheck(
+        claim_id=claim_id,
+        status="fail",
+        claimed="OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO exported",
+        observed=f"missing: {', '.join(missing)}",
+        tolerance="exact",
+        message=(
+            f"model_pins.py is missing exports: {', '.join(missing)}. "
+            "Restore them — consumers across 66+ files import from this single registry."
+        ),
+    )
+
+
+def _check_incident_log_present() -> ClaimCheck:
+    claim_id = "security.incident_log.present"
+    missing = [p.name for p in (INCIDENT_LOG, ROTATION_SCHEDULE) if not p.is_file()]
+    if not missing:
+        return ClaimCheck(
+            claim_id=claim_id,
+            status="pass",
+            claimed="incident log + rotation schedule present",
+            observed="both files present",
+            tolerance="exact",
+            message="2026-04-07 incident write-up and 90-day rotation schedule are intact.",
+        )
+    return ClaimCheck(
+        claim_id=claim_id,
+        status="fail" if len(missing) == 2 else "warn",
+        claimed="incident log + rotation schedule present",
+        observed=f"missing: {', '.join(missing)}",
+        tolerance="exact",
+        message=(
+            f"Audit-trail file(s) missing: {', '.join(missing)}. "
+            "These document the 2026-04-07 Anthropic-key leak response and rotation cadence — do not delete."
+        ),
+    )
+
+
+def _check_openrouter_fallback_wired() -> ClaimCheck:
+    claim_id = "security.openrouter_fallback.wired"
+    targets = {"anthropic": ANTHROPIC_AGENT, "openai": OPENAI_AGENT, "gemini": GEMINI_AGENT}
+    missing_files = [name for name, path in targets.items() if not path.is_file()]
+    if missing_files:
+        return ClaimCheck(
+            claim_id=claim_id,
+            status="fail",
+            claimed="QuotaFallbackMixin on anthropic/openai/gemini agents",
+            observed=f"agent file(s) missing: {', '.join(missing_files)}",
+            tolerance="exact",
+            message=f"Provider agent file(s) missing — repo layout regression: {', '.join(missing_files)}.",
+        )
+    # Either QuotaFallbackMixin directly OR OpenAICompatibleMixin (which itself
+    # inherits from QuotaFallbackMixin) in the class declaration line counts as
+    # wired — both routes give the agent the OpenRouter quota-fallback path.
+    pattern = re.compile(
+        r"^class\s+\w+\s*\([^)]*(?:QuotaFallbackMixin|OpenAICompatibleMixin)",
+        re.MULTILINE,
+    )
+    not_wired = [
+        name
+        for name, path in targets.items()
+        if not pattern.search(path.read_text(encoding="utf-8"))
+    ]
+    if not not_wired:
+        return ClaimCheck(
+            claim_id=claim_id,
+            status="pass",
+            claimed="QuotaFallbackMixin on anthropic/openai/gemini agents",
+            observed="all three frontier-provider agents inherit QuotaFallbackMixin",
+            tolerance="exact",
+            message="OpenRouter universal fallback is wired on all three frontier providers.",
+        )
+    return ClaimCheck(
+        claim_id=claim_id,
+        status="fail",
+        claimed="QuotaFallbackMixin on anthropic/openai/gemini agents",
+        observed=f"missing on: {', '.join(not_wired)}",
+        tolerance="exact",
+        message=(
+            f"QuotaFallbackMixin not declared on: {', '.join(not_wired)}. "
+            "Removing it re-introduces the 'missing direct key blocks debates' failure mode."
+        ),
+    )
+
+
 CHECKS: dict[str, Callable[[], ClaimCheck]] = {
     "canonical.km_adapters.count": _check_km_adapters_count,
     "canonical.python_modules.count": _check_python_modules_count,
     "canonical.test_definitions.count": _check_test_definitions_count,
     "canonical.version.matches_pyproject": _check_version_matches_pyproject,
+    "security.gitleaks.dual_stage": _check_gitleaks_dual_stage,
+    "security.model_pins.frontier_aligned": _check_model_pins_frontier_aligned,
+    "security.incident_log.present": _check_incident_log_present,
+    "security.openrouter_fallback.wired": _check_openrouter_fallback_wired,
 }
 
 

--- a/scripts/check_canonical_metrics.py
+++ b/scripts/check_canonical_metrics.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Check that CANONICAL_GOALS.md's headline numbers match live repo state.
+
+Implements TCP-1 from docs/plans/2026-04-17-trust-compound-plan.md. Each
+claim in docs/status/claims/canonical_metrics.yaml delegates to this script
+via the existing DIC-14 ClaimVerifier infrastructure.
+
+Usage:
+    python3 scripts/check_canonical_metrics.py --claim <claim_id>
+    python3 scripts/check_canonical_metrics.py --all
+
+Exit codes:
+    0  all requested claims pass (or are within tolerance)
+    1  at least one claim drifted beyond tolerance
+    2  usage error / unknown claim
+
+Prints structured JSON per claim to stdout so the ClaimVerifier (or CI)
+can capture the result.
+
+Design notes:
+
+- The script is intentionally small and uses only stdlib + regex so it
+  runs on every push and on a schedule without pulling heavy deps.
+- Each check is a pure function of (doc text, live repo state); no
+  network calls, no LLM invocations, no flakiness sources.
+- Tolerances are per-claim so fast-growing counts (tests, modules) can
+  drift within a band without failing CI, while exact claims (version)
+  must match strictly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CANONICAL_GOALS = REPO_ROOT / "docs" / "CANONICAL_GOALS.md"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+ADAPTERS_DIR = REPO_ROOT / "aragora" / "knowledge" / "mound" / "adapters"
+OUTPUT_PATH = REPO_ROOT / "docs" / "status" / "generated" / "canonical_metrics" / "latest.json"
+
+
+@dataclass
+class ClaimCheck:
+    claim_id: str
+    status: str  # "pass" | "fail" | "warn"
+    claimed: str
+    observed: str
+    tolerance: str
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Observers — recompute values from live state
+# ---------------------------------------------------------------------------
+
+
+def _observe_km_adapters_count() -> int:
+    """Count KM adapter files under aragora/knowledge/mound/adapters/.
+
+    Definition: any .py file in that directory whose name ends in
+    ``_adapter.py`` OR which defines a class ending in ``Adapter`` that
+    registers via the adapter factory. We use the filename heuristic
+    because the factory import is heavy; the filename count is a
+    reasonable first-pass approximation.
+    """
+    if not ADAPTERS_DIR.is_dir():
+        return 0
+    count = 0
+    for child in ADAPTERS_DIR.iterdir():
+        if child.is_file() and child.name.endswith("_adapter.py"):
+            count += 1
+    return count
+
+
+def _observe_python_modules_count() -> int:
+    """Count non-test Python files under aragora/."""
+    aragora_dir = REPO_ROOT / "aragora"
+    if not aragora_dir.is_dir():
+        return 0
+    count = 0
+    for path in aragora_dir.rglob("*.py"):
+        # Skip obvious non-module artifacts
+        parts = path.relative_to(aragora_dir).parts
+        if any(part.startswith(".") or part == "__pycache__" for part in parts):
+            continue
+        count += 1
+    return count
+
+
+def _observe_test_definitions_count() -> int:
+    """Count `def test_` occurrences across tests/."""
+    tests_dir = REPO_ROOT / "tests"
+    if not tests_dir.is_dir():
+        return 0
+    pattern = re.compile(r"^\s*def test_", re.MULTILINE)
+    count = 0
+    for path in tests_dir.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        count += len(pattern.findall(text))
+    return count
+
+
+def _observe_pyproject_version() -> str:
+    try:
+        text = PYPROJECT.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    match = re.search(r'^\s*version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    return match.group(1) if match else ""
+
+
+# ---------------------------------------------------------------------------
+# Claim extractors — parse the value from CANONICAL_GOALS.md
+# ---------------------------------------------------------------------------
+
+_GOALS_TEXT_CACHE: str | None = None
+
+
+def _goals_text() -> str:
+    global _GOALS_TEXT_CACHE
+    if _GOALS_TEXT_CACHE is None:
+        _GOALS_TEXT_CACHE = CANONICAL_GOALS.read_text(encoding="utf-8")
+    return _GOALS_TEXT_CACHE
+
+
+def _claimed_km_adapter_count() -> int | None:
+    """Parse 'Knowledge Mound adapters | <n> registered adapter specs'."""
+    match = re.search(
+        r"Knowledge Mound adapters\s*\|\s*(\d+)",
+        _goals_text(),
+    )
+    return int(match.group(1)) if match else None
+
+
+def _claimed_python_modules_count() -> int | None:
+    """Parse 'Python modules | 3,800+' → 3800."""
+    match = re.search(
+        r"Python modules\s*\|\s*([\d,]+)\+?",
+        _goals_text(),
+    )
+    if match is None:
+        return None
+    return int(match.group(1).replace(",", ""))
+
+
+def _claimed_test_definitions_count() -> int | None:
+    """Parse 'Automated tests | 210,000+' → 210000."""
+    match = re.search(
+        r"Automated tests\s*\|\s*([\d,]+)\+?",
+        _goals_text(),
+    )
+    if match is None:
+        return None
+    return int(match.group(1).replace(",", ""))
+
+
+def _claimed_version() -> str | None:
+    match = re.search(
+        r"Version\s*\|\s*([\d.]+)",
+        _goals_text(),
+    )
+    return match.group(1) if match else None
+
+
+# ---------------------------------------------------------------------------
+# Claim checks
+# ---------------------------------------------------------------------------
+
+
+def _check_km_adapters_count() -> ClaimCheck:
+    claimed = _claimed_km_adapter_count()
+    observed = _observe_km_adapters_count()
+    if claimed is None:
+        return ClaimCheck(
+            claim_id="canonical.km_adapters.count",
+            status="fail",
+            claimed="<missing>",
+            observed=str(observed),
+            tolerance="exact",
+            message="Could not parse adapter count from CANONICAL_GOALS.md",
+        )
+    # Tolerance of +/-2 because adapter-registration naming may
+    # legitimately slip during refactors and the filename heuristic is
+    # imperfect. Anything bigger than that is real drift.
+    delta = abs(claimed - observed)
+    if delta <= 2:
+        return ClaimCheck(
+            claim_id="canonical.km_adapters.count",
+            status="pass",
+            claimed=str(claimed),
+            observed=str(observed),
+            tolerance="+/-2",
+            message=f"docs claim {claimed} adapters; live count is {observed}",
+        )
+    return ClaimCheck(
+        claim_id="canonical.km_adapters.count",
+        status="fail",
+        claimed=str(claimed),
+        observed=str(observed),
+        tolerance="+/-2",
+        message=(
+            f"docs claim {claimed} adapters but live count is {observed} — "
+            f"drift of {delta}. Update CANONICAL_GOALS.md or fix adapter registration."
+        ),
+    )
+
+
+def _check_python_modules_count() -> ClaimCheck:
+    claimed = _claimed_python_modules_count()
+    observed = _observe_python_modules_count()
+    if claimed is None:
+        return ClaimCheck(
+            claim_id="canonical.python_modules.count",
+            status="fail",
+            claimed="<missing>",
+            observed=str(observed),
+            tolerance="+/-20%",
+            message="Could not parse module count from CANONICAL_GOALS.md",
+        )
+    # Modules grow naturally; tolerate +/-20% drift before flagging.
+    # The doc uses "3,800+" notation, so observed >= claimed is fine.
+    tolerance_band = max(int(claimed * 0.2), 100)
+    if observed >= claimed - tolerance_band:
+        return ClaimCheck(
+            claim_id="canonical.python_modules.count",
+            status="pass",
+            claimed=f"{claimed}+",
+            observed=str(observed),
+            tolerance="+/-20%",
+            message=f"docs claim {claimed}+ modules; live count is {observed} — within tolerance",
+        )
+    return ClaimCheck(
+        claim_id="canonical.python_modules.count",
+        status="warn",
+        claimed=f"{claimed}+",
+        observed=str(observed),
+        tolerance="+/-20%",
+        message=(
+            f"docs claim {claimed}+ modules; live count is {observed}. "
+            f"Refresh CANONICAL_GOALS.md when drift exceeds 20%."
+        ),
+    )
+
+
+def _check_test_definitions_count() -> ClaimCheck:
+    claimed = _claimed_test_definitions_count()
+    observed = _observe_test_definitions_count()
+    if claimed is None:
+        return ClaimCheck(
+            claim_id="canonical.test_definitions.count",
+            status="fail",
+            claimed="<missing>",
+            observed=str(observed),
+            tolerance="+/-20%",
+            message="Could not parse test count from CANONICAL_GOALS.md",
+        )
+    tolerance_band = max(int(claimed * 0.2), 5000)
+    if observed >= claimed - tolerance_band:
+        return ClaimCheck(
+            claim_id="canonical.test_definitions.count",
+            status="pass",
+            claimed=f"{claimed}+",
+            observed=str(observed),
+            tolerance="+/-20%",
+            message=f"docs claim {claimed}+ tests; live count is {observed}",
+        )
+    return ClaimCheck(
+        claim_id="canonical.test_definitions.count",
+        status="warn",
+        claimed=f"{claimed}+",
+        observed=str(observed),
+        tolerance="+/-20%",
+        message=(
+            f"docs claim {claimed}+ tests; live count is {observed}. "
+            f"Refresh CANONICAL_GOALS.md when drift exceeds 20%."
+        ),
+    )
+
+
+def _check_version_matches_pyproject() -> ClaimCheck:
+    claimed = _claimed_version()
+    observed = _observe_pyproject_version()
+    if claimed is None:
+        return ClaimCheck(
+            claim_id="canonical.version.matches_pyproject",
+            status="fail",
+            claimed="<missing>",
+            observed=observed or "<missing>",
+            tolerance="exact",
+            message="Could not parse version from CANONICAL_GOALS.md",
+        )
+    if observed == claimed:
+        return ClaimCheck(
+            claim_id="canonical.version.matches_pyproject",
+            status="pass",
+            claimed=claimed,
+            observed=observed,
+            tolerance="exact",
+            message=f"docs and pyproject.toml both report version {claimed}",
+        )
+    return ClaimCheck(
+        claim_id="canonical.version.matches_pyproject",
+        status="fail",
+        claimed=claimed,
+        observed=observed or "<missing>",
+        tolerance="exact",
+        message=(
+            f"version drift: CANONICAL_GOALS.md says {claimed!r} but "
+            f"pyproject.toml says {observed!r}. Reconcile before release."
+        ),
+    )
+
+
+CHECKS: dict[str, Callable[[], ClaimCheck]] = {
+    "canonical.km_adapters.count": _check_km_adapters_count,
+    "canonical.python_modules.count": _check_python_modules_count,
+    "canonical.test_definitions.count": _check_test_definitions_count,
+    "canonical.version.matches_pyproject": _check_version_matches_pyproject,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify canonical metrics claims")
+    parser.add_argument("--claim", help="Verify a single claim by id")
+    parser.add_argument("--all", action="store_true", help="Verify every claim")
+    parser.add_argument(
+        "--write-receipt",
+        action="store_true",
+        help=("Also write a receipt file to docs/status/generated/canonical_metrics/latest.json"),
+    )
+    args = parser.parse_args()
+
+    if not args.claim and not args.all:
+        print("error: must pass --claim <id> or --all", file=sys.stderr)
+        return 2
+
+    if args.claim:
+        if args.claim not in CHECKS:
+            print(
+                f"error: unknown claim {args.claim!r}; known claims: {', '.join(sorted(CHECKS))}",
+                file=sys.stderr,
+            )
+            return 2
+        results = [CHECKS[args.claim]()]
+    else:
+        results = [check() for check in CHECKS.values()]
+
+    payload = {
+        "manifest_id": "canonical_metrics",
+        "results": [asdict(r) for r in results],
+        "summary": {
+            "pass": sum(1 for r in results if r.status == "pass"),
+            "warn": sum(1 for r in results if r.status == "warn"),
+            "fail": sum(1 for r in results if r.status == "fail"),
+        },
+    }
+    print(json.dumps(payload, sort_keys=True, indent=2))
+
+    if args.write_receipt:
+        OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        OUTPUT_PATH.write_text(
+            json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+        )
+
+    if payload["summary"]["fail"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_canonical_metrics_manifest.py
+++ b/tests/integration/test_canonical_metrics_manifest.py
@@ -142,3 +142,44 @@ class TestReceiptWriteOption:
         assert receipt_path.exists()
         content = json.loads(receipt_path.read_text(encoding="utf-8"))
         assert content["manifest_id"] == "canonical_metrics"
+
+
+class TestSecurityClaimsRegistered:
+    """The Phase-14c security.* claims must be wired into the verifier."""
+
+    SECURITY_CLAIM_IDS = (
+        "security.gitleaks.dual_stage",
+        "security.model_pins.frontier_aligned",
+        "security.incident_log.present",
+        "security.openrouter_fallback.wired",
+    )
+
+    def test_security_claims_appear_in_manifest(self) -> None:
+        import yaml
+
+        payload = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+        manifest_ids = {claim["claim_id"] for claim in payload["claims"]}
+        for claim_id in self.SECURITY_CLAIM_IDS:
+            assert claim_id in manifest_ids, f"security claim {claim_id} missing from manifest"
+
+    def test_security_claims_are_individually_runnable(self) -> None:
+        for claim_id in self.SECURITY_CLAIM_IDS:
+            rc, payload = _run_check("--claim", claim_id)
+            assert rc in {0, 1}, f"verifier crashed on {claim_id} (rc={rc})"
+            assert len(payload["results"]) == 1
+            assert payload["results"][0]["claim_id"] == claim_id
+
+    def test_openrouter_fallback_currently_passes(self) -> None:
+        """OpenRouter wiring must hold on every commit — it's a blocking claim.
+
+        Removing QuotaFallbackMixin (or OpenAICompatibleMixin, which inherits
+        from it) regresses the failure mode the OpenRouter-first policy was
+        put in place to prevent. If this test fails, the regression is in
+        aragora/agents/api_agents/, not in the verifier.
+        """
+        rc, payload = _run_check("--claim", "security.openrouter_fallback.wired")
+        result = payload["results"][0]
+        assert result["status"] == "pass", (
+            "QuotaFallbackMixin coverage regressed on a frontier provider agent. "
+            f"Details: {result['message']}"
+        )

--- a/tests/integration/test_canonical_metrics_manifest.py
+++ b/tests/integration/test_canonical_metrics_manifest.py
@@ -1,0 +1,144 @@
+"""Integration tests for the canonical-metrics executable claim manifest.
+
+These tests verify that:
+- docs/status/claims/canonical_metrics.yaml is schema-valid
+- scripts/check_canonical_metrics.py runs end-to-end without crashing
+- At least one claim currently resolves cleanly against the live repo
+  (catching the case where the whole manifest has regressed in parsing)
+
+This suite does NOT assert that every claim passes — drift is expected
+and the script reports it. The job of these tests is to prove the
+verifier itself works, not that the claims are all currently true.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "docs" / "status" / "claims" / "canonical_metrics.yaml"
+CHECK_SCRIPT = REPO_ROOT / "scripts" / "check_canonical_metrics.py"
+
+
+def _run_check(*extra_args: str) -> tuple[int, dict]:
+    """Invoke the check script and parse its stdout as JSON."""
+    result = subprocess.run(
+        [sys.executable, str(CHECK_SCRIPT), *extra_args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=REPO_ROOT,
+    )
+    payload = json.loads(result.stdout) if result.stdout.strip() else {}
+    return result.returncode, payload
+
+
+class TestManifestPresent:
+    def test_manifest_file_exists(self) -> None:
+        assert MANIFEST_PATH.exists(), f"manifest missing at {MANIFEST_PATH}"
+
+    def test_check_script_is_executable(self) -> None:
+        assert CHECK_SCRIPT.exists(), f"check script missing at {CHECK_SCRIPT}"
+
+
+class TestManifestSchema:
+    def test_manifest_is_valid_yaml(self) -> None:
+        import yaml
+
+        payload = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+        assert payload["manifest_id"] == "canonical_metrics"
+        assert payload["schema_version"] == 1
+        assert isinstance(payload["claims"], list)
+        assert len(payload["claims"]) >= 1
+
+    def test_every_claim_has_required_fields(self) -> None:
+        import yaml
+
+        payload = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+        required = {
+            "claim_id",
+            "statement",
+            "owner",
+            "scope",
+            "confidence",
+            "evidence",
+            "freshness_sla_hours",
+            "verification",
+            "failure",
+            "receipts",
+        }
+        for claim in payload["claims"]:
+            missing = required - set(claim.keys())
+            assert not missing, f"claim {claim.get('claim_id')} missing fields: {missing}"
+
+    def test_every_claim_id_appears_in_check_script(self) -> None:
+        """Regression guard: YAML claim ids must be wired in the Python script."""
+        import yaml
+
+        payload = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+        claim_ids = {claim["claim_id"] for claim in payload["claims"]}
+        script_text = CHECK_SCRIPT.read_text(encoding="utf-8")
+        for claim_id in claim_ids:
+            assert claim_id in script_text, (
+                f"claim {claim_id!r} declared in manifest but not wired into check script"
+            )
+
+
+class TestCheckScriptRunsEndToEnd:
+    def test_all_claims_produces_structured_output(self) -> None:
+        rc, payload = _run_check("--all")
+        # rc is 0 or 1 depending on current drift — both are valid
+        # (1 means "drift reported"; not a test failure)
+        assert rc in {0, 1}
+        assert payload["manifest_id"] == "canonical_metrics"
+        assert "results" in payload
+        assert "summary" in payload
+        assert len(payload["results"]) >= 1
+
+    def test_single_claim_mode_isolates_one_result(self) -> None:
+        rc, payload = _run_check("--claim", "canonical.version.matches_pyproject")
+        assert rc in {0, 1}
+        assert len(payload["results"]) == 1
+        assert payload["results"][0]["claim_id"] == "canonical.version.matches_pyproject"
+
+    def test_unknown_claim_returns_usage_error(self) -> None:
+        rc, payload = _run_check("--claim", "not_a_real_claim")
+        assert rc == 2
+
+    def test_version_claim_currently_passes(self) -> None:
+        """The version claim must pass; it's the most constrained check.
+
+        If this fails it means CANONICAL_GOALS.md and pyproject.toml have
+        drifted and a release-readiness bug is on main — not a test
+        infrastructure problem.
+        """
+        rc, payload = _run_check("--claim", "canonical.version.matches_pyproject")
+        assert payload["results"][0]["status"] == "pass", (
+            "version drift between CANONICAL_GOALS.md and pyproject.toml. "
+            f"Details: {payload['results'][0]['message']}"
+        )
+
+    def test_summary_counts_add_up(self) -> None:
+        rc, payload = _run_check("--all")
+        total = payload["summary"]["pass"] + payload["summary"]["warn"] + payload["summary"]["fail"]
+        assert total == len(payload["results"])
+
+
+class TestReceiptWriteOption:
+    def test_write_receipt_creates_file(self, tmp_path, monkeypatch) -> None:
+        """The --write-receipt flag must produce a receipt file."""
+        # Run in a temp copy of the repo structure so we don't pollute the real receipt
+        # We call the script with --write-receipt and check the output path in repo_root.
+        # For safety, we invoke and then check — if the file exists, the write path works.
+        rc, _ = _run_check("--all", "--write-receipt")
+        receipt_path = (
+            REPO_ROOT / "docs" / "status" / "generated" / "canonical_metrics" / "latest.json"
+        )
+        assert receipt_path.exists()
+        content = json.loads(receipt_path.read_text(encoding="utf-8"))
+        assert content["manifest_id"] == "canonical_metrics"


### PR DESCRIPTION
## Summary

Turns the joint Codex+Claude assessment of the repo state into **permanent, executable, long-running artifacts**. Lands TCP-1 of the trust-compound plan (canonical-metrics executable claim manifest + CI verifier) as a working example of the whole approach.

## Artifacts

| Artifact | Purpose | Execution surface |
|---|---|---|
| `docs/audits/2026-04-17-codex-claude-joint-assessment.md` | The audit itself — convergent verdict, strengths, weaknesses, explicit preservation guarantees | Referenced doc |
| `docs/plans/2026-04-17-trust-compound-plan.md` | 7 steps (TCP-1..TCP-7) with contracts, dispatch matrix, acceptance criteria | Referenced doc |
| `docs/status/claims/canonical_metrics.yaml` | Executable claim manifest in the DIC-13/14 schema | Runs under `aragora.epistemic.ClaimVerifier` or directly via CI |
| `scripts/check_canonical_metrics.py` | Stdlib-only verifier backing the manifest | Invoked on every push + scheduled daily |
| `tests/integration/test_canonical_metrics_manifest.py` | Schema + end-to-end coverage for the manifest | Standard pytest |
| `docs/status/generated/canonical_metrics/latest.json` | Seeded receipt | Updated each time the verifier runs with `--write-receipt` |

## Why this shape

Both Codex and Claude independently rated the project's own epistemic-CI doctrine as strong but **not yet applied to the project's own canonical metrics**. TCP-1 closes that gap by dogfooding the doctrine — the manifest is what the rest of the plan (TCP-3 hotspot splits, TCP-4 classification, etc.) gets verified against.

## First-run results (the manifest is already useful)

```
canonical.km_adapters.count:              FAIL  (docs 42, live 45, tolerance +/-2)
canonical.python_modules.count:           PASS  (docs 3800+, live 3989)
canonical.test_definitions.count:         WARN  (docs 210000+, live 155933)
canonical.version.matches_pyproject:      PASS  (2.8.0 matches)
```

The manifest caught **real drift on its first run** — the KM adapter count and test count both disagree with what CANONICAL_GOALS.md claims. This is the class of failure the project was designed to prevent; now the failure is visible.

## Preservation guarantees (from the audit)

The following must **NOT** be removed by any execution of this plan. The audit doc captures this explicitly so future TCP-4 classification work cannot accidentally excise preserved work:

- `aragora/verticals/`, `aragora/extensions/`, `aragora/genesis/`, `aragora/modes/`
- `aragora/marketplace/`, `aragora/skills/`, `aragora/blockchain/`
- The Nomic loop, proof-first queue, reputation substrate, AGT-* track
- Multi-agent debate primitives — the adversarial design is the thesis

## Long-running execution

- **CI**: `scripts/check_canonical_metrics.py --all --write-receipt` on every push + scheduled daily
- **Future**: the other TCP steps plug in the same way. TCP-3 hotspot splits → each split PR runs the metric check; TCP-4 classification → extends the manifest with one claim per subpackage tier; TCP-7 AGT activation → adds a CruxSet-count claim
- **Dispatch**: per the plan's dispatch matrix, each TCP step has a named owner (Codex autopilot / Droid / Claude Code / Founder); issues will be filed for TCP-2..TCP-7 once this PR merges

## Test plan

- [x] 11 integration tests pass (`tests/integration/test_canonical_metrics_manifest.py`)
- [x] Script runs end-to-end in both `--all` and `--claim <id>` modes
- [x] Unknown claim returns usage error (exit 2)
- [x] Structured JSON output to stdout; receipt file produced with `--write-receipt`
- [x] No new dependencies — stdlib only + existing PyYAML (already used across the repo)

## What this PR does NOT do

- Does NOT resolve the 42/45 adapter-count drift (leaves it for a follow-up; the manifest's job is to expose the drift, not silently fix it)
- Does NOT modify `CANONICAL_GOALS.md` numbers (would be falsifying current state)
- Does NOT file TCP-2..TCP-7 issues (follow-up after this merges; the plan doc has the specs)
- Does NOT wire the manifest into the GitHub Actions workflows yet (deferred one step to keep this PR reviewable)

## Refs

- Joint assessment: Codex (GPT-5.4) + Claude (Opus 4.7), 2026-04-17
- Existing DIC-13/14 schema: `docs/status/claims/executable_claim_manifest.schema.json`
- ClaimVerifier: `aragora/epistemic/claim_verifier.py`
- AGT-* track this assessment reviews: #6080, #6082, #6084, #6086, #6088, #6110, #6112, #6114, #6116, #6122, #6126, #6144

🤖 Generated with [Claude Code](https://claude.com/claude-code)