### PR TITLE
docs(inbox): add trust wedge activation artifacts

### DIFF
--- a/docs/examples/inbox-trust-wedge-activation-prompt-pack.yaml
+++ b/docs/examples/inbox-trust-wedge-activation-prompt-pack.yaml
@@ -1,0 +1,266 @@
+bundle_id: inbox-trust-wedge-activation-2026-04-17
+objective: >-
+  Convert the repo's inbox trust wedge from "structurally implemented" into a
+  repeatable internal proof surface with receipts, operator transferability,
+  proof-pack artifacts, and bounded design-partner readiness.
+repo:
+  name: synaptent/aragora
+  root: /Users/armand/Development/aragora
+  base_ref: origin/main
+shared_constraints:
+  report_requirements:
+    - exact commands run
+    - URLs for issues, PRs, or docs touched
+    - residual risk
+    - truthful stop reason if blocked
+  execution_rules:
+    - keep issues out of boss-ready until the canonical queue gate changes
+    - keep reply, send, and forward actions out of scope
+    - treat live inbox actioning as approval-gated until activation criteria are met
+references:
+  source_refs:
+    activation_plan:
+      kind: doc
+      url: https://github.com/synaptent/aragora/blob/main/docs/plans/INBOX_TRUST_WEDGE_ACTIVATION_PLAN.md
+      meaning: canonical activation strategy and stop conditions
+    pmf_plan:
+      kind: doc
+      url: https://github.com/synaptent/aragora/blob/main/docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md
+      meaning: PMF-critical founder and inbox dogfood plan
+    proof_ladder:
+      kind: doc
+      url: https://github.com/synaptent/aragora/blob/main/docs/strategy/PROOF_AND_EVIDENCE.md
+      meaning: evidence ladder and internal dogfood unlock bar
+    active_tree:
+      kind: doc
+      url: https://github.com/synaptent/aragora/blob/main/docs/status/ACTIVE_EXECUTION_ISSUES.md
+      meaning: canonical roadmap code mapping
+    tw04_issue:
+      kind: issue
+      url: https://github.com/synaptent/aragora/issues/6159
+      state: open
+      meaning: receipt-before-action inbox guarantee
+    tw05_issue:
+      kind: issue
+      url: https://github.com/synaptent/aragora/issues/6160
+      state: open
+      meaning: contracts, memory, and approval-policy reuse
+    tw06_issue:
+      kind: issue
+      url: https://github.com/synaptent/aragora/issues/6161
+      state: open
+      meaning: receipt-linked operator feedback and calibration
+    tw10_issue:
+      kind: issue
+      url: https://github.com/synaptent/aragora/issues/6162
+      state: open
+      meaning: internal and partner-facing inbox operating cadence
+    tw11_issue:
+      kind: issue
+      url: https://github.com/synaptent/aragora/issues/6163
+      state: open
+      meaning: truthful proof-pack publication
+    tw12_issue:
+      kind: issue
+      url: https://github.com/synaptent/aragora/issues/6164
+      state: open
+      meaning: wedge graduation decision
+lanes:
+  - lane_id: tw04_receipt_truth
+    owner_role: inbox_safety_engineer
+    title: Preserve receipt-before-action truth for inbox workflows
+    prompt: >-
+      Harden the inbox trust wedge so every executed inbox action is provably
+      tied to a persisted reviewable receipt and every failure stops truthfully.
+      Prefer narrow fixes on the wedge path over generalized platform work.
+    source_refs:
+      - https://github.com/synaptent/aragora/issues/6159
+      - https://github.com/synaptent/aragora/blob/main/docs/plans/INBOX_TRUST_WEDGE_ACTIVATION_PLAN.md
+    target_agent: codex
+    review_model: claude
+    allowed_write_scope:
+      - aragora/inbox/**
+      - aragora/cli/commands/triage.py
+      - aragora/cli/commands/inbox_wedge.py
+      - aragora/server/fastapi/routes/inbox.py
+      - tests/inbox/**
+      - tests/cli/test_triage_command.py
+      - tests/cli/test_inbox_wedge_command.py
+      - docs/plans/**
+    acceptance_criteria:
+      - No inbox action executes without a persisted valid receipt.
+      - Truthful terminal states survive dry-run, review, and execute paths.
+      - Focused validation commands are recorded in the final report.
+    constraints:
+      - Do not widen into reply/send/forward automation.
+      - Do not generalize the fix into unrelated queue or DAG work.
+    verification_commands:
+      - python3 -m pytest tests/cli/test_triage_command.py tests/cli/test_inbox_wedge_command.py tests/inbox/test_trust_wedge.py tests/inbox/test_receipt_gated_executor.py -q
+      - python3 -m ruff check aragora/cli/commands/triage.py aragora/cli/commands/inbox_wedge.py aragora/inbox tests/cli/test_triage_command.py tests/cli/test_inbox_wedge_command.py tests/inbox/test_trust_wedge.py tests/inbox/test_receipt_gated_executor.py
+    stop_conditions:
+      - Live proof requires credentials or policy inputs unavailable to the lane.
+      - The smallest credible fix lives outside the allowed wedge path.
+    expected_receipts_artifacts:
+      - issue URL
+      - PR URL or doc URL
+      - validation command transcript
+
+  - lane_id: tw05_non_code_policy_reuse
+    owner_role: non_code_policy_engineer
+    title: Reuse contracts and approval policies across non-code inbox actions
+    prompt: >-
+      Reuse the proof-first contract, memory, and approval-policy primitives on
+      the inbox wedge without broadening into generic substrate work. Keep the
+      action surface narrow and make the reuse explicit and testable.
+    source_refs:
+      - https://github.com/synaptent/aragora/issues/6160
+      - https://github.com/synaptent/aragora/blob/main/docs/plans/INBOX_TRUST_WEDGE_ACTIVATION_PLAN.md
+    target_agent: codex
+    review_model: claude
+    allowed_write_scope:
+      - aragora/inbox/**
+      - aragora/swarm/**
+      - aragora/cli/commands/triage.py
+      - tests/inbox/**
+      - tests/cli/test_triage_command.py
+      - docs/plans/**
+    verification_commands:
+      - python3 -m pytest tests/inbox/test_triage_runner.py tests/inbox/test_auto_approval.py tests/inbox/test_triage_instrumentation.py tests/cli/test_triage_command.py -q
+      - python3 -m ruff check aragora/inbox aragora/swarm aragora/cli/commands/triage.py tests/inbox/test_triage_runner.py tests/inbox/test_auto_approval.py tests/inbox/test_triage_instrumentation.py tests/cli/test_triage_command.py
+    stop_conditions:
+      - The change would require broad queue-governance or host-state rewrites.
+    expected_receipts_artifacts:
+      - issue URL
+      - changed paths
+      - residual risk
+
+  - lane_id: tw06_feedback_calibration
+    owner_role: feedback_calibration_engineer
+    title: Tie operator feedback and calibration to receipts
+    prompt: >-
+      Make operator feedback on inbox actions durable, receipt-linked, and
+      visible through existing queue, digest, audit, and calibration surfaces.
+      Prefer additive telemetry and reviewability over net-new dashboards.
+    source_refs:
+      - https://github.com/synaptent/aragora/issues/6161
+      - https://github.com/synaptent/aragora/blob/main/docs/templates/INBOX_TRUST_WEDGE_PROOF_PACK_TEMPLATE.md
+    target_agent: codex
+    review_model: claude
+    allowed_write_scope:
+      - aragora/inbox/**
+      - aragora/cli/commands/triage.py
+      - tests/inbox/**
+      - tests/cli/test_triage_command.py
+      - docs/templates/**
+      - docs/plans/**
+    verification_commands:
+      - python3 -m pytest tests/inbox/test_triage_instrumentation.py tests/inbox/test_cli_review.py tests/cli/test_triage_command.py -q
+      - python3 -m ruff check aragora/inbox/triage_instrumentation.py aragora/cli/commands/triage.py tests/inbox/test_triage_instrumentation.py tests/inbox/test_cli_review.py tests/cli/test_triage_command.py
+    stop_conditions:
+      - The lane starts inventing a parallel analytics system instead of using wedge telemetry.
+    expected_receipts_artifacts:
+      - issue URL
+      - changed paths
+      - sample calibration output
+
+  - lane_id: tw10_internal_cadence
+    owner_role: trust_wedge_operator
+    title: Establish weekly internal inbox operating cadence
+    prompt: >-
+      Produce or refine the operator-ready runbook, cadence, and acceptance
+      worksheet for repeated internal inbox trust wedge runs. Optimize for
+      transferability to two non-builder operators and leave exact commands.
+    source_refs:
+      - https://github.com/synaptent/aragora/issues/6162
+      - https://github.com/synaptent/aragora/blob/main/docs/plans/INBOX_TRUST_WEDGE_ACTIVATION_PLAN.md
+      - https://github.com/synaptent/aragora/blob/main/docs/strategy/PROOF_AND_EVIDENCE.md
+    target_agent: codex
+    review_model: claude
+    allowed_write_scope:
+      - docs/plans/**
+      - docs/status/**
+      - docs/templates/**
+      - docs/examples/**
+    verification_commands:
+      - python3 -m aragora.cli.main triage --help
+      - python3 -m aragora.cli.main inbox-wedge --help
+      - python3 -m aragora.cli.main swarm tranche plan --from-prompts docs/examples/inbox-trust-wedge-activation-prompt-pack.yaml --output /tmp/inbox-trust-wedge-tranche.yaml --json
+    stop_conditions:
+      - The lane assumes live credentials or real inbox access that it cannot verify.
+      - The deliverable drifts into a sales narrative instead of an operator path.
+    expected_receipts_artifacts:
+      - runbook path
+      - acceptance worksheet
+      - residual risk
+
+  - lane_id: tw11_proof_pack
+    owner_role: proof_pack_editor
+    title: Publish truthful proof-pack and before-after evidence surfaces
+    prompt: >-
+      Define and, where appropriate, automate the truthful proof-pack surface
+      for the inbox trust wedge. Keep proof assets compact, receipt-backed, and
+      narrow enough to support a bounded design-partner conversation.
+    source_refs:
+      - https://github.com/synaptent/aragora/issues/6163
+      - https://github.com/synaptent/aragora/blob/main/docs/templates/INBOX_TRUST_WEDGE_PROOF_PACK_TEMPLATE.md
+      - https://github.com/synaptent/aragora/blob/main/docs/strategy/PROOF_AND_EVIDENCE.md
+    target_agent: codex
+    review_model: claude
+    allowed_write_scope:
+      - docs/plans/**
+      - docs/status/**
+      - docs/templates/**
+      - docs/examples/**
+      - scripts/**
+      - tests/scripts/**
+    verification_commands:
+      - python3 -m aragora.cli.main inbox-wedge --help
+      - python3 -m aragora.cli.main triage calibrate --json
+      - python3 -m aragora.cli.main inbox-wedge report --json --limit 10
+    stop_conditions:
+      - The lane starts publishing claims broader than current internal proof.
+    expected_receipts_artifacts:
+      - proof-pack template or generator path
+      - sample artifact path
+      - residual risk
+
+  - lane_id: tw12_wedge_graduation
+    owner_role: wedge_packaging_editor
+    title: Decide if the inbox wedge graduates to packaged offering
+    prompt: >-
+      Define the bounded decision framework for whether the inbox trust wedge
+      stays internal, enters partner dry-run mode, or graduates to a packaged
+      offering. Keep the decision tied to measured proof, not narrative.
+    source_refs:
+      - https://github.com/synaptent/aragora/issues/6164
+      - https://github.com/synaptent/aragora/blob/main/docs/plans/INBOX_TRUST_WEDGE_ACTIVATION_PLAN.md
+      - https://github.com/synaptent/aragora/blob/main/docs/status/DESIGN_PARTNER_PROGRAM.md
+    target_agent: codex
+    review_model: claude
+    allowed_write_scope:
+      - docs/plans/**
+      - docs/status/**
+      - docs/outreach/**
+      - docs/COMMERCIAL_OVERVIEW.md
+    verification_commands:
+      - git diff --stat -- docs/plans docs/status docs/outreach docs/COMMERCIAL_OVERVIEW.md
+    stop_conditions:
+      - The lane attempts pricing or packaging certainty unsupported by wedge proof.
+    expected_receipts_artifacts:
+      - graduation memo
+      - decision rubric
+      - residual risk
+terminal_outcomes:
+  success:
+    definition: >-
+      The inbox trust wedge has a bounded execution map, issue map, proof-pack
+      shape, and operator path that are narrow enough to execute without
+      widening the live queue prematurely.
+  needs_human:
+    definition: >-
+      A lane requires live credentials, operator policy, or design-partner
+      input that cannot be truthfully simulated.
+  stop_and_replan:
+    definition: >-
+      The wedge objective drifts into generic platform expansion or conflicts
+      with the canonical short-horizon queue gate.

--- a/docs/examples/inbox-trust-wedge-activation-sources.yaml
+++ b/docs/examples/inbox-trust-wedge-activation-sources.yaml
@@ -1,0 +1,121 @@
+manifest_version: 1
+queue_id: inbox-trust-wedge-activation-2026-04-17
+
+sources:
+  - id: tw04-receipt-truth
+    kind: issue
+    code: TW-04
+    url: https://github.com/synaptent/aragora/issues/6159
+    mode: execute
+    priority: 10
+    merge_class: manual
+    max_lanes: 1
+    autonomy_mode: checkpoint
+    objective: >-
+      Preserve receipt-before-action guarantees for inbox workflows and fail
+      closed truthfully whenever that guarantee cannot be preserved.
+    allowed_write_scope:
+      - aragora/inbox/**
+      - aragora/cli/commands/triage.py
+      - aragora/cli/commands/inbox_wedge.py
+      - aragora/server/fastapi/routes/inbox.py
+      - tests/inbox/**
+      - tests/cli/test_triage_command.py
+      - tests/cli/test_inbox_wedge_command.py
+      - docs/plans/**
+
+  - id: tw05-non-code-policy-reuse
+    kind: issue
+    code: TW-05
+    url: https://github.com/synaptent/aragora/issues/6160
+    mode: execute
+    priority: 20
+    merge_class: manual
+    max_lanes: 1
+    autonomy_mode: checkpoint
+    objective: >-
+      Reuse contracts, memory, and approval policies across non-code inbox
+      actions without widening into generic autonomy substrate work.
+    allowed_write_scope:
+      - aragora/inbox/**
+      - aragora/swarm/**
+      - aragora/cli/commands/triage.py
+      - tests/inbox/**
+      - tests/cli/test_triage_command.py
+      - docs/plans/**
+
+  - id: tw06-feedback-calibration
+    kind: issue
+    code: TW-06
+    url: https://github.com/synaptent/aragora/issues/6161
+    mode: execute
+    priority: 30
+    merge_class: manual
+    max_lanes: 1
+    autonomy_mode: checkpoint
+    objective: >-
+      Capture operator feedback tied to receipts and expose the signal through
+      queue, digest, audit, and calibration surfaces.
+    allowed_write_scope:
+      - aragora/inbox/**
+      - aragora/cli/commands/triage.py
+      - tests/inbox/**
+      - tests/cli/test_triage_command.py
+      - docs/templates/**
+      - docs/plans/**
+
+  - id: tw10-internal-cadence
+    kind: issue
+    code: TW-10
+    url: https://github.com/synaptent/aragora/issues/6162
+    mode: execute
+    priority: 40
+    merge_class: manual
+    max_lanes: 1
+    autonomy_mode: checkpoint
+    objective: >-
+      Establish the weekly internal operating cadence for repeated inbox trust
+      wedge runs on real workloads with two non-builder operators.
+    allowed_write_scope:
+      - docs/plans/**
+      - docs/status/**
+      - docs/templates/**
+      - docs/examples/**
+
+  - id: tw11-proof-pack
+    kind: issue
+    code: TW-11
+    url: https://github.com/synaptent/aragora/issues/6163
+    mode: execute
+    priority: 50
+    merge_class: manual
+    max_lanes: 1
+    autonomy_mode: checkpoint
+    objective: >-
+      Publish truthful proof packs and before-after evidence assets for the
+      inbox trust wedge without widening the claim beyond measured proof.
+    allowed_write_scope:
+      - docs/plans/**
+      - docs/status/**
+      - docs/templates/**
+      - docs/examples/**
+      - scripts/**
+      - tests/scripts/**
+
+  - id: tw12-graduation-decision
+    kind: issue
+    code: TW-12
+    url: https://github.com/synaptent/aragora/issues/6164
+    mode: execute
+    priority: 60
+    merge_class: manual
+    max_lanes: 1
+    autonomy_mode: checkpoint
+    objective: >-
+      Decide whether the inbox trust wedge stays internal, enters design-partner
+      dry-run mode, or graduates to a packaged offering based on proof.
+    allowed_write_scope:
+      - docs/plans/**
+      - docs/status/**
+      - docs/outreach/**
+      - docs/COMMERCIAL_OVERVIEW.md

--- a/docs/plans/INBOX_TRUST_WEDGE_ACTIVATION_PLAN.md
+++ b/docs/plans/INBOX_TRUST_WEDGE_ACTIVATION_PLAN.md
@@ -1,0 +1,277 @@
+# Inbox Trust Wedge Activation Plan
+
+Last updated: 2026-04-17
+Status: planning-truth artifact; not a live `boss-ready` lane under the current queue gate
+
+Related:
+- `docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md`
+- `docs/strategy/PROOF_AND_EVIDENCE.md`
+- `docs/status/NEXT_STEPS_CANONICAL.md`
+- `docs/status/ACTIVE_EXECUTION_ISSUES.md`
+- `docs/status/DESIGN_PARTNER_PROGRAM.md`
+- `docs/examples/inbox-trust-wedge-activation-prompt-pack.yaml`
+- `docs/examples/inbox-trust-wedge-activation-sources.yaml`
+- `docs/templates/INBOX_TRUST_WEDGE_PROOF_PACK_TEMPLATE.md`
+- `aragora/cli/commands/triage.py`
+- `aragora/cli/commands/inbox_wedge.py`
+
+## Purpose
+
+Turn the repo's existing inbox trust wedge thesis into durable execution truth:
+
+- one stable operator plan
+- one automation-ready prompt pack
+- one machine-readable source manifest
+- one proof-pack template
+- one bounded GitHub issue set mapped to the canonical roadmap codes
+
+This plan exists because Aragora already has a real kernel, but the repo is too
+broad and too internally complex to justify widening the story without repeated
+workflow proof. The right move is not more substrate breadth. The right move is
+making one consequential inbox workflow repeatable, auditable, and easy for a
+non-builder to run.
+
+## Queue Posture
+
+This document does **not** change the live queue rule in
+`docs/status/NEXT_STEPS_CANONICAL.md`.
+
+Current canonical posture:
+
+- `CS-01..03` remains the only short-horizon **Do now** set
+- trust-wedge inbox work may exist as planning truth and bounded backlog
+- no `TW-*` inbox activation issue created from this plan should carry
+  `boss-ready` until the canonical queue gate is deliberately changed
+
+Use this plan to preserve execution truth and prepare bounded follow-on work,
+not to silently widen the live queue.
+
+## Why This Wedge
+
+The repo already commits to this wedge in multiple places:
+
+- `docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md` says the founder loop is proven and
+  the current objective is the inbox trust wedge plus design-partner readiness
+- `docs/strategy/PROOF_AND_EVIDENCE.md` defines internal dogfood success around
+  repeated inbox runs, operator transferability, truthful stopping, and proof
+  packs
+- `aragora/cli/commands/triage.py` already exposes the founder-facing command
+  surface: `auth`, `run`, `status`, `queue`, `label`, `digest`, `audit`, and
+  `calibrate`
+- `aragora/cli/commands/inbox_wedge.py` already exposes the receipt loop:
+  `create`, `review`, `show`, `list`, `execute`, `report`, and `export`
+
+This is the fastest route from "there is real machinery here" to
+"someone else can trust and use one workflow repeatedly."
+
+## Current Product Truth
+
+What is already true on current `main`:
+
+- the inbox trust wedge is structurally implemented
+- receipt-before-action is part of the intended execution contract
+- Gmail auth, dry-run, and approval-gated execution surfaces exist
+- operator telemetry surfaces already exist for queue, digest, audit, and
+  calibration
+- the proof ladder already defines the exact unlock bar for internal dogfood
+
+What is not yet proven:
+
+- 10 consecutive live runs over at least 5 business days on a real internal
+  inbox
+- <=10 minute time-to-first-useful-result for 2 non-builder operators
+- >=70% accepted-action rate over a 2-week window
+- zero false-success incidents across that window
+- one compact proof pack that a design partner can inspect
+
+## Activation Criteria
+
+Treat the inbox trust wedge as activated for internal dogfood only when all of
+the following are true:
+
+1. 10 consecutive live runs complete over at least 5 business days on a real
+   internal inbox.
+2. 2 internal operators other than the primary builder can authenticate, run
+   the workflow, and reach first useful result in 10 minutes or less from the
+   written runbook.
+3. Over a 2-week window, at least 70% of runs end in an accepted action, and
+   every remaining run stops truthfully with a blocker class and next action.
+4. Zero false-success incidents occur.
+5. Every executed action has a persisted receipt and reviewable state.
+
+These are the only criteria that unlock the next rung. Connector breadth,
+additional docs, and generic platform polish do not.
+
+## Non-Goals
+
+Do not use this plan to justify:
+
+- `AGT-*` activation
+- broad provider or connector expansion
+- reply, send, or forward automation
+- generalized org substrate claims
+- dashboard-first polish detached from the live inbox path
+- enterprise assurance sprawl before wedge proof
+- broad cleanup work not tied to inbox proof or proof-pack generation
+
+## 30-Day Execution Order
+
+### Week 1: Internal baseline and first truthful runs
+
+- run `aragora triage status`
+- complete `aragora triage auth`
+- run the wedge in `--dry-run` mode on a real internal inbox slice
+- switch to approval-gated live mode only after receipt creation and review are
+  visible and correct
+- fix only blockers that prevent repeated real runs
+
+### Week 2: Operator transferability
+
+- put 2 non-builder operators through the written path
+- measure setup-to-first-useful-result time
+- tighten auth, runbook, and blocker messages until the path is usable without
+  founder repo spelunking
+- keep the allowed action surface narrow: `ARCHIVE`, `STAR`, `LABEL`, `IGNORE`
+
+### Week 3: Proof-pack assembly
+
+- finish the 10-run / 5-business-day internal proof bar
+- export representative receipts and blocker examples
+- compile the accepted-action rate, truthful-stop rate, latency, and override
+  evidence into one proof pack
+- keep claims narrow: "receipt-gated inbox triage works repeatably on internal
+  consequential workflows"
+
+### Week 4: Design-partner prep
+
+- freeze one repeatable runbook and one proof pack
+- run one bounded external dry-run or approval-gated design-partner rehearsal
+- decide whether the wedge is ready for recurring partner use, still internal
+  only, or not yet fit
+
+## Exact Operator Surfaces
+
+Readiness and auth:
+
+```bash
+python3 -m aragora.cli.main triage status
+python3 -m aragora.cli.main triage auth
+```
+
+Dry-run and live founder/operator use:
+
+```bash
+python3 -m aragora.cli.main triage run --batch 5 --dry-run
+python3 -m aragora.cli.main triage run --batch 5
+python3 -m aragora.cli.main triage run --batch 5 --auto-approve
+```
+
+Receipt review and inspection:
+
+```bash
+python3 -m aragora.cli.main inbox-wedge list --limit 20
+python3 -m aragora.cli.main inbox-wedge show <receipt_id>
+python3 -m aragora.cli.main inbox-wedge review <receipt_id> --choice approve
+python3 -m aragora.cli.main inbox-wedge execute <receipt_id>
+```
+
+Telemetry and evidence export:
+
+```bash
+python3 -m aragora.cli.main triage queue --limit 20
+python3 -m aragora.cli.main triage digest --hours 24
+python3 -m aragora.cli.main triage audit --batch 20
+python3 -m aragora.cli.main triage calibrate --json
+python3 -m aragora.cli.main inbox-wedge report --limit 200
+python3 -m aragora.cli.main inbox-wedge export /tmp/inbox-wedge.jsonl --limit 200
+```
+
+## Automation-Ready Artifacts
+
+Use these machine-readable artifacts for bounded long-running execution:
+
+- prompt pack: `docs/examples/inbox-trust-wedge-activation-prompt-pack.yaml`
+- source manifest: `docs/examples/inbox-trust-wedge-activation-sources.yaml`
+
+Suggested tranche workflow:
+
+```bash
+python3 -m aragora.cli.main swarm tranche plan \
+  --from-prompts docs/examples/inbox-trust-wedge-activation-prompt-pack.yaml \
+  --output .aragora/tranches/inbox-trust-wedge-activation/tranche.yaml \
+  --json
+
+python3 -m aragora.cli.main swarm tranche inspect \
+  --manifest .aragora/tranches/inbox-trust-wedge-activation/tranche.yaml \
+  --json
+
+python3 -m aragora.cli.main swarm tranche design-review \
+  --manifest .aragora/tranches/inbox-trust-wedge-activation/tranche.yaml \
+  --json
+```
+
+Operational rule:
+
+- use tranche automation for bounded code/doc/status lanes
+- keep actual inbox actioning human-gated until the activation criteria are met
+- stop rather than bluff when the lane needs live credentials, operator policy,
+  or external partner input
+
+## Proof-Pack Contract
+
+Every inbox activation cycle should leave behind:
+
+- exact commands run
+- run window and operator identity
+- receipt bundle paths or IDs
+- accepted-action counts and truthful-stop counts
+- latency, cost, override, and time-to-first-result metrics
+- representative blocker examples with next actions
+- one explicit gate decision:
+  - `internal_ready`
+  - `partner_dry_run_ready`
+  - `not_ready`
+
+Use `docs/templates/INBOX_TRUST_WEDGE_PROOF_PACK_TEMPLATE.md` as the canonical
+shape.
+
+## Mapping To Canonical Roadmap Codes
+
+This plan maps directly to the existing trust-wedge backlog:
+
+- `TW-04` Preserve receipt-before-action guarantees for inbox workflows
+  ([#6159](https://github.com/synaptent/aragora/issues/6159))
+- `TW-05` Reuse contracts, memory, and approval policies across non-code actions
+  ([#6160](https://github.com/synaptent/aragora/issues/6160))
+- `TW-06` Capture operator feedback tied to receipts
+  ([#6161](https://github.com/synaptent/aragora/issues/6161))
+- `TW-10` Establish weekly design-partner operating cadence on real workloads
+  ([#6162](https://github.com/synaptent/aragora/issues/6162))
+- `TW-11` Publish truthful proof packs and before/after benchmarks
+  ([#6163](https://github.com/synaptent/aragora/issues/6163))
+- `TW-12` Decide which wedges graduate to packaged offerings
+  ([#6164](https://github.com/synaptent/aragora/issues/6164))
+
+Issue creation from this plan should preserve those codes verbatim and keep the
+issues out of the live `boss-ready` queue until the short-horizon queue gate is
+updated explicitly.
+
+## Stop Conditions
+
+Stop and re-plan if any of the following happen:
+
+- a run executes an action without a persisted valid receipt
+- the workflow claims success while the operator would classify it as a blocker
+- the queue or plan widens into broad substrate or connector work
+- operator transferability stalls because the path still requires repo
+  spelunking
+- the proof pack cannot be assembled from durable receipts and visible outputs
+
+## Success Definition
+
+This plan succeeds when Aragora can truthfully say:
+
+> The inbox trust wedge is repeatable on internal consequential work, every
+> action is receipt-gated, operators can reach first useful result quickly from
+> a written path, and the resulting proof pack is strong enough to support a
+> bounded design-partner dry run.

--- a/docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md
+++ b/docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md
@@ -12,6 +12,13 @@ The founder loop is proven repeatable: 5/5 consecutive live runs, 35-62s range, 
 
 The current objective is to **dogfood the second workflow** (inbox trust wedge) and **prepare for design partner outreach**.
 
+Related execution artifacts:
+
+- `docs/plans/INBOX_TRUST_WEDGE_ACTIVATION_PLAN.md`
+- `docs/examples/inbox-trust-wedge-activation-prompt-pack.yaml`
+- `docs/examples/inbox-trust-wedge-activation-sources.yaml`
+- `docs/templates/INBOX_TRUST_WEDGE_PROOF_PACK_TEMPLATE.md`
+
 ## Founder Metrics Tree
 
 The founder scorecard should answer one question in decision order:

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -23,6 +23,7 @@ The strict status reconciler requires this canonical map to link the live execut
 - Enterprise assurance carryover: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), [#509](https://github.com/synaptent/aragora/issues/509)
 - Execution epics (closed): [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), [#806](https://github.com/synaptent/aragora/issues/806) — all closed as of April 2026; current obligation is operationalizing the proof-first loop
 - Current execution lanes: [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
+- Inbox/design-partner trust-wedge planning: [#6159](https://github.com/synaptent/aragora/issues/6159), [#6160](https://github.com/synaptent/aragora/issues/6160), [#6161](https://github.com/synaptent/aragora/issues/6161), [#6162](https://github.com/synaptent/aragora/issues/6162), [#6163](https://github.com/synaptent/aragora/issues/6163), [#6164](https://github.com/synaptent/aragora/issues/6164) — planning truth only; keep out of `boss-ready` until the canonical queue gate changes
 - Future decision-integrity tranche: [#6023](https://github.com/synaptent/aragora/issues/6023), [#6024](https://github.com/synaptent/aragora/issues/6024), [#6025](https://github.com/synaptent/aragora/issues/6025), [#6026](https://github.com/synaptent/aragora/issues/6026), [#6027](https://github.com/synaptent/aragora/issues/6027), [#6028](https://github.com/synaptent/aragora/issues/6028), [#6030](https://github.com/synaptent/aragora/issues/6030), [#6031](https://github.com/synaptent/aragora/issues/6031), [#6032](https://github.com/synaptent/aragora/issues/6032), [#6033](https://github.com/synaptent/aragora/issues/6033) — Epistemic CI, Crux Engine, and Epistemic Runtime planning; not live `boss-ready` work
 
 ## Reverse-Staged Rocket Bootstrap
@@ -119,9 +120,9 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 ### Milestone 3.2 — Inbox / Operator Action Loops `[30-90d]`
 
-- [ ] **TW-04** Preserve receipt-before-action guarantees for inbox workflows
-- [ ] **TW-05** Reuse contracts, memory, and approval policies across non-code actions
-- [ ] **TW-06** Capture operator feedback tied to receipts
+- [ ] **TW-04** Preserve receipt-before-action guarantees for inbox workflows ([#6159](https://github.com/synaptent/aragora/issues/6159))
+- [ ] **TW-05** Reuse contracts, memory, and approval policies across non-code actions ([#6160](https://github.com/synaptent/aragora/issues/6160))
+- [ ] **TW-06** Capture operator feedback tied to receipts ([#6161](https://github.com/synaptent/aragora/issues/6161))
 
 ### Milestone 3.3 — Prompt-to-Spec Handoff `[30-90d]`
 
@@ -131,9 +132,9 @@ Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
 ### Milestone 3.4 — Design-Partner Recurrence `[90-365d]`
 
-- [ ] **TW-10** Establish weekly design-partner operating cadence on real workloads
-- [ ] **TW-11** Publish truthful proof packs and before/after benchmarks
-- [ ] **TW-12** Decide which wedges graduate to packaged offerings
+- [ ] **TW-10** Establish weekly design-partner operating cadence on real workloads ([#6162](https://github.com/synaptent/aragora/issues/6162))
+- [ ] **TW-11** Publish truthful proof packs and before/after benchmarks ([#6163](https://github.com/synaptent/aragora/issues/6163))
+- [ ] **TW-12** Decide which wedges graduate to packaged offerings ([#6164](https://github.com/synaptent/aragora/issues/6164))
 
 ## Epic 4 — Unified DAG Workbench
 

--- a/docs/templates/INBOX_TRUST_WEDGE_PROOF_PACK_TEMPLATE.md
+++ b/docs/templates/INBOX_TRUST_WEDGE_PROOF_PACK_TEMPLATE.md
@@ -1,0 +1,128 @@
+# Inbox Trust Wedge Proof Pack
+
+Use this template for the compact artifact that closes the internal-dogfood
+gate and supports a bounded design-partner conversation.
+
+## 1. Run Window
+
+- Window start:
+- Window end:
+- Operators:
+- Inbox/account scope:
+- Workflow version / branch / commit:
+- Related issue or tranche IDs:
+
+## 2. Workflow Statement
+
+Describe the exact workflow that was proven in one sentence:
+
+`real inbox -> debate-backed triage -> persisted receipt -> approval/review -> provider action`
+
+Allowed actions during this window:
+
+- `ARCHIVE`
+- `STAR`
+- `LABEL`
+- `IGNORE`
+
+Explicitly excluded actions:
+
+- reply
+- send
+- forward
+
+## 3. Activation Scoreboard
+
+| Gate | Target | Actual | Pass/Fail | Evidence |
+|---|---|---|---|---|
+| Consecutive live runs | `10` over at least `5` business days |  |  |  |
+| Non-builder operators | `2` operators |  |  |  |
+| Time to first useful result | `<=10m` |  |  |  |
+| Accepted action rate | `>=70%` over `2` weeks |  |  |  |
+| Truthful-stop coverage | `100%` of non-accepted runs |  |  |  |
+| False-success incidents | `0` |  |  |  |
+| Receipt-before-action | `100%` |  |  |  |
+
+## 4. Exact Commands
+
+List the exact commands used during the proof window.
+
+```bash
+python3 -m aragora.cli.main triage status
+python3 -m aragora.cli.main triage auth
+python3 -m aragora.cli.main triage run --batch 5 --dry-run
+python3 -m aragora.cli.main triage run --batch 5
+python3 -m aragora.cli.main inbox-wedge list --limit 20
+python3 -m aragora.cli.main inbox-wedge report --limit 200
+python3 -m aragora.cli.main triage calibrate --json
+```
+
+## 5. Receipt Bundle
+
+List representative receipts and why they matter.
+
+| Receipt ID / path | Outcome | Why included |
+|---|---|---|
+|  | accepted action |  |
+|  | truthful stop |  |
+|  | override/review example |  |
+
+## 6. Outcome Summary
+
+| Metric | Value | Notes |
+|---|---|---|
+| Total runs |  |  |
+| Total emails processed |  |  |
+| Accepted actions |  |  |
+| Truthful stops |  |  |
+| Overrides |  |  |
+| Important-email misses |  |  |
+| Average latency per email |  |  |
+| Average cost per email |  |  |
+
+## 7. Truthful Stops
+
+For every non-accepted run, record the blocker and next action.
+
+| Run / receipt | Blocker class | Next action | Was it truthful? |
+|---|---|---|---|
+|  |  |  |  |
+
+## 8. Operator Transferability
+
+Summarize the non-builder operator results.
+
+| Operator | Time to auth | Time to first useful result | Blockers hit | Outcome |
+|---|---|---|---|---|
+|  |  |  |  |  |
+|  |  |  |  |  |
+
+## 9. Before / After Evidence
+
+Capture the smallest honest delta versus the incumbent path.
+
+- What was slower, riskier, or less reviewable before:
+- What is better now:
+- What still requires human attention:
+
+## 10. Remaining Risks
+
+- Risk 1:
+- Risk 2:
+- Risk 3:
+
+## 11. Gate Decision
+
+Choose exactly one:
+
+- `internal_ready`
+- `partner_dry_run_ready`
+- `not_ready`
+
+Decision rationale:
+
+## 12. Next Bounded Actions
+
+- Action 1:
+- Action 2:
+- Action 3:


### PR DESCRIPTION
## Summary
- add a stable inbox trust wedge activation plan grounded in the current PMF/proof docs and queue rules
- add automation-ready prompt-pack and source-manifest artifacts that Aragora can compile into a tranche manifest
- add a proof-pack template and create/link the canonical TW-04/05/06 and TW-10/11/12 GitHub issues

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `python3 -m aragora.cli.main swarm tranche plan --from-prompts docs/examples/inbox-trust-wedge-activation-prompt-pack.yaml --output /tmp/inbox-trust-wedge-activation-tranche.yaml --json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
- keeps the new inbox/design-partner issue set out of `boss-ready` and records that explicitly in the docs
- turns the strategic recommendation into durable repo artifacts plus linked backlog, rather than a one-off chat assessment
