### PR TITLE
fix(receipts): decode anchor-status receipt ids

### DIFF
--- a/aragora/server/handlers/gauntlet/handler.py
+++ b/aragora/server/handlers/gauntlet/handler.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, unquote
 
 from aragora.observability.metrics import track_handler
 from aragora.server.validation.entities import validate_gauntlet_id
@@ -138,7 +138,7 @@ class GauntletHandler(
             parts = path.rstrip("/").split("/")
             # /api/receipts/{receipt_id}/anchor-status => ['', 'api', 'receipts', '{id}', 'anchor-status']
             if len(parts) >= 5:
-                receipt_id = parts[3]
+                receipt_id = unquote(parts[3])
                 return self._get_receipt_anchor_status(receipt_id, query_params)
 
         # POST /api/gauntlet/{id}/receipt/verify

--- a/tests/handlers/gauntlet/test_handler.py
+++ b/tests/handlers/gauntlet/test_handler.py
@@ -428,6 +428,17 @@ class TestHandleParameterizedRoute:
         assert _status(result) == 400
 
     @pytest.mark.asyncio
+    async def test_get_receipt_anchor_status_decodes_receipt_id(self, handler):
+        """Routes percent-encoded receipt IDs to anchor lookup with the decoded value."""
+        handler._get_receipt_anchor_status = MagicMock(
+            return_value=HandlerResult(status_code=200, content_type="application/json", body=b"{}")
+        )
+        path = "/api/receipts/r%2F123/anchor-status"
+        result = await handler._handle_parameterized_route(path, "GET", {}, None)
+        assert result is not None
+        handler._get_receipt_anchor_status.assert_called_once_with("r/123", {})
+
+    @pytest.mark.asyncio
     async def test_get_receipt(self, handler):
         """Routes GET /receipt to _get_receipt."""
         handler._get_receipt = AsyncMock(


### PR DESCRIPTION
## Summary
- decode percent-encoded receipt IDs before routing `/api/v1/receipts/{receipt_id}/anchor-status`
- add a focused gauntlet handler regression test for slash-bearing receipt IDs

## Repro
- on `origin/main`, `GauntletHandler._handle_parameterized_route('/api/receipts/r%2F123/anchor-status', 'GET', {}, None)` forwards `r%2F123` into `store.get(...)` and returns `404`
- after this patch, the same route looks up `r/123` and returns the anchor result

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/handlers/gauntlet/test_handler.py sdk/python/tests/test_receipts.py -p no:rerunfailures -p no:cacheprovider`
- `python3 -m ruff check aragora/server/handlers/gauntlet/handler.py tests/handlers/gauntlet/test_handler.py`
- `PYTHONDONTWRITEBYTECODE=1 bash scripts/automation_pr_preflight.sh origin/main HEAD`
