### PR TITLE
fix(benchmarks): resolve shared corpus metrics

### DIFF
--- a/aragora/utils/__init__.py
+++ b/aragora/utils/__init__.py
@@ -10,6 +10,7 @@ from aragora.utils.datetime_helpers import (
     to_iso_timestamp,
     utc_now,
 )
+from aragora.utils.git_paths import git_common_repo_root, resolve_repo_fallback_path
 from aragora.utils.json_helpers import safe_json_loads
 from aragora.utils.optional_imports import LazyImport, try_import, try_import_class
 from aragora.utils.paths import PathTraversalError, is_safe_path, safe_path, validate_path_component
@@ -25,6 +26,9 @@ __all__ = [
     "parse_timestamp",
     "timestamp_ms",
     "timestamp_s",
+    # Git/worktree helpers
+    "git_common_repo_root",
+    "resolve_repo_fallback_path",
     # JSON helpers
     "safe_json_loads",
     # Import helpers

--- a/aragora/utils/git_paths.py
+++ b/aragora/utils/git_paths.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def git_common_repo_root(repo_root: Path) -> Path | None:
+    """Return the canonical repo root behind git's common dir, if any."""
+
+    proc = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        return None
+    common_dir = Path(proc.stdout.strip())
+    if common_dir.name != ".git":
+        return None
+    return common_dir.parent.resolve()
+
+
+def resolve_repo_fallback_path(
+    candidate: Path,
+    *,
+    repo_root: Path,
+    common_root: Path | None = None,
+) -> Path:
+    """Resolve a repo-local path, falling back through git-common-dir.
+
+    Managed worktrees often keep shared runtime artifacts under the canonical
+    repo root instead of each linked checkout. If ``candidate`` is missing from
+    the current worktree but exists at the same relative path under the shared
+    repo root, return that shared path instead.
+    """
+
+    repo_root = repo_root.resolve()
+    if candidate.exists():
+        return candidate.resolve()
+
+    if candidate.is_absolute():
+        try:
+            relative = candidate.relative_to(repo_root)
+        except ValueError:
+            return candidate
+    else:
+        repo_relative = repo_root / candidate
+        if repo_relative.exists():
+            return repo_relative.resolve()
+        relative = candidate
+
+    shared_root = common_root if common_root is not None else git_common_repo_root(repo_root)
+    if shared_root is not None:
+        shared_candidate = (shared_root / relative).resolve()
+        if shared_candidate.exists():
+            return shared_candidate
+
+    return candidate if candidate.is_absolute() else (repo_root / candidate).resolve()

--- a/scripts/reconcile_b0_pr_truth.py
+++ b/scripts/reconcile_b0_pr_truth.py
@@ -38,6 +38,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from aragora.swarm.terminal_truth import TerminalClass, classify_from_metrics  # noqa: E402
+from aragora.utils.git_paths import git_common_repo_root, resolve_repo_fallback_path  # noqa: E402
 
 DEFAULT_METRICS_PATH = REPO_ROOT / ".aragora" / "overnight" / "boss_metrics.jsonl"
 B0_TAG = "b0-cohort"
@@ -57,38 +58,15 @@ GH_NETWORK_RETRY_ATTEMPTS = 3
 
 
 def _git_common_repo_root() -> Path | None:
-    proc = subprocess.run(
-        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=REPO_ROOT,
-    )
-    if proc.returncode != 0:
-        return None
-    common_dir = Path(proc.stdout.strip())
-    if common_dir.name != ".git":
-        return None
-    return common_dir.parent.resolve()
+    return git_common_repo_root(REPO_ROOT)
 
 
 def resolve_metrics_path(candidate: Path) -> Path:
-    if candidate.exists():
-        return candidate.resolve()
-    if candidate.is_absolute():
-        return candidate
-
-    repo_relative = (REPO_ROOT / candidate).resolve()
-    if repo_relative.exists():
-        return repo_relative
-
-    common_root = _git_common_repo_root()
-    if common_root is not None:
-        common_relative = (common_root / candidate).resolve()
-        if common_relative.exists():
-            return common_relative
-
-    return candidate.resolve()
+    return resolve_repo_fallback_path(
+        candidate,
+        repo_root=REPO_ROOT,
+        common_root=_git_common_repo_root(),
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/benchmarks/test_corpus_freshness.py
+++ b/tests/benchmarks/test_corpus_freshness.py
@@ -25,6 +25,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from aragora.utils import git_paths
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CORPUS_PATH = REPO_ROOT / "docs/benchmarks/corpus.json"
 LATEST_TRUTH_PATH = (
@@ -96,6 +98,12 @@ def load_metrics_rows(path: Path) -> list[dict[str, Any]]:
             if isinstance(payload, dict):
                 rows.append(payload)
     return rows
+
+
+def resolve_boss_metrics_path(path: Path = BOSS_METRICS_PATH) -> Path:
+    """Resolve boss metrics through the shared git-common-dir repo root."""
+
+    return git_paths.resolve_repo_fallback_path(path, repo_root=REPO_ROOT)
 
 
 def validate_corpus_freshness(
@@ -233,7 +241,7 @@ def validate_corpus_freshness(
 def test_current_benchmark_corpus_has_fresh_verifiable_truth() -> None:
     corpus = _read_json(CORPUS_PATH)
     truth = _read_json(LATEST_TRUTH_PATH)
-    dispatch_outcomes = load_dispatch_outcomes(load_metrics_rows(BOSS_METRICS_PATH))
+    dispatch_outcomes = load_dispatch_outcomes(load_metrics_rows(resolve_boss_metrics_path()))
 
     failures = validate_corpus_freshness(
         corpus=corpus,
@@ -467,3 +475,22 @@ def test_dispatch_outcomes_ignores_rows_without_worker_outcome() -> None:
     outcomes = load_dispatch_outcomes(rows)
 
     assert outcomes == {5903: ["blocked", "pr_adopted"]}
+
+
+def test_resolve_boss_metrics_path_falls_back_to_git_common_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    worktree_root = tmp_path / "worktree-root"
+    shared_root = tmp_path / "shared-root"
+    metrics_file = shared_root / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    metrics_file.parent.mkdir(parents=True)
+    metrics_file.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr("tests.benchmarks.test_corpus_freshness.REPO_ROOT", worktree_root)
+    monkeypatch.setattr(git_paths, "git_common_repo_root", lambda _repo_root: shared_root)
+
+    resolved = resolve_boss_metrics_path(
+        worktree_root / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    )
+
+    assert resolved == metrics_file.resolve()


### PR DESCRIPTION
Resolve benchmark corpus freshness metrics through the shared git-common-dir repo root when managed worktrees do not have a local .aragora/overnight/boss_metrics.jsonl, reuse the same fallback in reconcile_b0_pr_truth, and add a regression test for the managed-worktree/shared-root layout.\n\nValidation:\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/benchmarks/test_corpus_freshness.py tests/scripts/test_reconcile_b0_pr_truth.py -p no:rerunfailures -p no:cacheprovider\n- python3 -m ruff check aragora/utils/git_paths.py aragora/utils/__init__.py scripts/reconcile_b0_pr_truth.py tests/benchmarks/test_corpus_freshness.py\n- direct proof: resolve_boss_metrics_path() now resolves the shared metrics file and validate_corpus_freshness(...) returns failure_count 0\n\nCloses #6187