### PR TITLE
[DIC-20] Epistemic decay monitor — integrity scoring for proof-carrying code units

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -6,6 +6,8 @@ Exposes:
   sharply-losing claims (:class:`FollowupProposal`,
   :func:`propose_followup_for_crux`, :func:`propose_followup_for_cruxset`,
   :func:`propose_followup_for_failed_claim`)
+- DIC-20: epistemic decay monitor (:class:`DecaySignal`,
+  :class:`DecayReason`, :func:`evaluate_unit`)
 
 See ``docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md`` for the full
 DIC-13..22 sequence and ``docs/status/NEXT_STEPS_CANONICAL.md`` for
@@ -17,6 +19,7 @@ from __future__ import annotations
 import os
 
 from .claim_verifier import ClaimResult, ClaimStatus, ClaimVerifier
+from .decay_monitor import DecayReason, DecaySignal, evaluate_unit
 from .followup import (
     DEFAULT_CRUX_LOAD_BEARING_THRESHOLD,
     DEFAULT_DELTA_LOSS_THRESHOLD,
@@ -32,9 +35,12 @@ __all__ = [
     "ClaimVerifier",
     "DEFAULT_CRUX_LOAD_BEARING_THRESHOLD",
     "DEFAULT_DELTA_LOSS_THRESHOLD",
+    "DecayReason",
+    "DecaySignal",
     "FollowupProposal",
     "enable_epistemic_followup",
     "epistemic_followup_enabled",
+    "evaluate_unit",
     "propose_followup_for_crux",
     "propose_followup_for_cruxset",
     "propose_followup_for_failed_claim",

--- a/aragora/epistemic/decay_monitor.py
+++ b/aragora/epistemic/decay_monitor.py
@@ -17,6 +17,7 @@ control escalation to ``repair_required`` or ``fail_closed``.  This module
 never mutates state, creates issues, or routes to live dispatch (DIC-21 and
 DIC-22 add quarantine and repair on top).
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/aragora/epistemic/decay_monitor.py
+++ b/aragora/epistemic/decay_monitor.py
@@ -1,0 +1,186 @@
+"""Epistemic decay monitor (DIC-20 / #6031).
+
+Evaluates a :class:`~aragora.epistemic.proof_unit.ProofCarryingCodeUnit`
+against claim verification results, unresolved crux IDs, and receipt
+presence to produce a machine-readable :class:`DecaySignal`.
+
+Reason classes
+--------------
+failed_claim    — a linked claim failed verification
+stale_evidence  — a linked claim is stale
+unresolved_crux — a linked crux ID is unresolved
+missing_receipt — decision_receipts list is empty
+verifier_error  — a claim verification raised an error
+
+Default mode is ``report_only``; the ``decay_policy`` fields on the unit
+control escalation to ``repair_required`` or ``fail_closed``.  This module
+never mutates state, creates issues, or routes to live dispatch (DIC-21 and
+DIC-22 add quarantine and repair on top).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .claim_verifier import ClaimStatus
+
+if TYPE_CHECKING:
+    from .claim_verifier import ClaimResult
+    from .proof_unit import ProofCarryingCodeUnit
+
+# Integrity deduction per reason class (summed; clamped to [0, 1]).
+_REASON_WEIGHTS: dict[str, float] = {
+    "failed_claim": 0.30,
+    "stale_evidence": 0.15,
+    "unresolved_crux": 0.20,
+    "missing_receipt": 0.10,
+    "verifier_error": 0.20,
+}
+
+_ACTION_RANK = {"report_only": 0, "repair_required": 1, "fail_closed": 2}
+_RANK_TO_ACTION = {v: k for k, v in _ACTION_RANK.items()}
+
+
+@dataclass(frozen=True)
+class DecayReason:
+    """One reason contributing to integrity deduction."""
+
+    kind: str
+    detail: str
+    claim_id: str = ""
+    crux_id: str = ""
+
+    def to_dict(self) -> dict:
+        d: dict = {"kind": self.kind, "detail": self.detail}
+        if self.claim_id:
+            d["claim_id"] = self.claim_id
+        if self.crux_id:
+            d["crux_id"] = self.crux_id
+        return d
+
+
+@dataclass
+class DecaySignal:
+    """Machine-readable decay assessment for one ProofCarryingCodeUnit.
+
+    ``integrity_score`` is 1.0 for a fully healthy unit and 0.0 for
+    completely decayed. Each reason deducts from the score; deductions are
+    additive and the result is clamped to [0.0, 1.0].
+
+    ``recommended_action`` reflects the most severe policy action triggered
+    by any active reason class.  This module never acts on it — action is
+    deferred to DIC-21 (quarantine policy).
+    """
+
+    code_unit_id: str
+    integrity_score: float
+    reasons: list[DecayReason] = field(default_factory=list)
+    recommended_action: str = "report_only"
+
+    def to_dict(self) -> dict:
+        return {
+            "code_unit_id": self.code_unit_id,
+            "integrity_score": round(self.integrity_score, 4),
+            "reasons": [r.to_dict() for r in self.reasons],
+            "recommended_action": self.recommended_action,
+        }
+
+
+def evaluate_unit(
+    unit: "ProofCarryingCodeUnit",
+    claim_results: dict[str, "ClaimResult"] | None = None,
+    unresolved_crux_ids: frozenset[str] | None = None,
+) -> DecaySignal:
+    """Evaluate one ProofCarryingCodeUnit and return a DecaySignal.
+
+    Parameters
+    ----------
+    unit:
+        The code unit to evaluate. Should already have passed ``unit.validate()``.
+    claim_results:
+        Mapping of ``claim_id → ClaimResult`` from a :class:`ClaimVerifier`
+        run.  If omitted, claims with no result are ignored (no deduction).
+    unresolved_crux_ids:
+        Set of crux IDs currently known to be unresolved.  If omitted, no
+        ``unresolved_crux`` reasons are generated.
+
+    Returns
+    -------
+    :class:`DecaySignal` — report-only, no side effects.
+    """
+    results: dict[str, "ClaimResult"] = claim_results or {}
+    unresolved: frozenset[str] = unresolved_crux_ids or frozenset()
+
+    reasons: list[DecayReason] = []
+    deduction = 0.0
+
+    for claim_id in unit.claims:
+        result = results.get(claim_id)
+        if result is None:
+            continue
+        if result.status == ClaimStatus.FAIL:
+            reasons.append(
+                DecayReason(
+                    kind="failed_claim",
+                    detail=result.message,
+                    claim_id=claim_id,
+                )
+            )
+            deduction += _REASON_WEIGHTS["failed_claim"]
+        elif result.status == ClaimStatus.STALE:
+            reasons.append(
+                DecayReason(
+                    kind="stale_evidence",
+                    detail=result.message,
+                    claim_id=claim_id,
+                )
+            )
+            deduction += _REASON_WEIGHTS["stale_evidence"]
+        elif result.status == ClaimStatus.ERROR:
+            reasons.append(
+                DecayReason(
+                    kind="verifier_error",
+                    detail=result.message,
+                    claim_id=claim_id,
+                )
+            )
+            deduction += _REASON_WEIGHTS["verifier_error"]
+
+    for crux_id in unit.linked_crux_ids:
+        if crux_id in unresolved:
+            reasons.append(
+                DecayReason(
+                    kind="unresolved_crux",
+                    detail=f"Crux {crux_id!r} is unresolved.",
+                    crux_id=crux_id,
+                )
+            )
+            deduction += _REASON_WEIGHTS["unresolved_crux"]
+
+    if not unit.decision_receipts:
+        reasons.append(
+            DecayReason(
+                kind="missing_receipt",
+                detail="No decision receipts are linked to this code unit.",
+            )
+        )
+        deduction += _REASON_WEIGHTS["missing_receipt"]
+
+    integrity_score = max(0.0, 1.0 - deduction)
+
+    reason_kinds = {r.kind for r in reasons}
+    action_rank = 0
+    dp = unit.decay_policy
+    if "failed_claim" in reason_kinds or "verifier_error" in reason_kinds:
+        action_rank = max(action_rank, _ACTION_RANK.get(dp.failed_claim, 0))
+    if "stale_evidence" in reason_kinds:
+        action_rank = max(action_rank, _ACTION_RANK.get(dp.stale_evidence, 0))
+    if "unresolved_crux" in reason_kinds:
+        action_rank = max(action_rank, _ACTION_RANK.get(dp.unresolved_crux, 0))
+
+    return DecaySignal(
+        code_unit_id=unit.code_unit_id,
+        integrity_score=integrity_score,
+        reasons=reasons,
+        recommended_action=_RANK_TO_ACTION.get(action_rank, "report_only"),
+    )

--- a/tests/epistemic/test_decay_monitor.py
+++ b/tests/epistemic/test_decay_monitor.py
@@ -1,12 +1,9 @@
 """Unit tests for DIC-20 decay monitor (aragora.epistemic.decay_monitor)."""
-from __future__ import annotations
 
-import pytest
+from __future__ import annotations
 
 from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus
 from aragora.epistemic.decay_monitor import (
-    DecayReason,
-    DecaySignal,
     evaluate_unit,
 )
 from aragora.epistemic.proof_unit import (

--- a/tests/epistemic/test_decay_monitor.py
+++ b/tests/epistemic/test_decay_monitor.py
@@ -1,0 +1,249 @@
+"""Unit tests for DIC-20 decay monitor (aragora.epistemic.decay_monitor)."""
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus
+from aragora.epistemic.decay_monitor import (
+    DecayReason,
+    DecaySignal,
+    evaluate_unit,
+)
+from aragora.epistemic.proof_unit import (
+    DecayPolicy,
+    FallbackPolicy,
+    ProofCarryingCodeUnit,
+)
+
+
+def _make_unit(
+    *,
+    claims: list[str] | None = None,
+    linked_crux_ids: list[str] | None = None,
+    decision_receipts: list[str] | None = None,
+    failed_claim_policy: str = "report_only",
+    stale_evidence_policy: str = "report_only",
+    unresolved_crux_policy: str = "report_only",
+) -> ProofCarryingCodeUnit:
+    return ProofCarryingCodeUnit(
+        code_unit_id="unit.test",
+        symbol="tests.fake.function",
+        source_path="tests/fake.py",
+        owner="test",
+        decision_receipts=decision_receipts if decision_receipts is not None else ["receipt-001"],
+        claims=claims or [],
+        assumptions=["Tests run in a clean environment."],
+        verifiers=[],
+        freshness_sla_hours=24,
+        decay_policy=DecayPolicy(
+            failed_claim=failed_claim_policy,
+            stale_evidence=stale_evidence_policy,
+            unresolved_crux=unresolved_crux_policy,
+        ),
+        fallback_policy=FallbackPolicy(default="report_only"),
+        linked_crux_ids=linked_crux_ids or [],
+    )
+
+
+def _claim(claim_id: str, status: ClaimStatus, message: str = "") -> ClaimResult:
+    return ClaimResult(
+        claim_id=claim_id,
+        status=status,
+        message=message or status.value,
+    )
+
+
+class TestHealthyUnit:
+    def test_no_claims_with_receipt_is_one(self):
+        signal = evaluate_unit(_make_unit())
+        assert signal.integrity_score == 1.0
+        assert signal.reasons == []
+        assert signal.recommended_action == "report_only"
+
+    def test_passing_claims_no_deduction(self):
+        unit = _make_unit(claims=["c1", "c2"])
+        results = {
+            "c1": _claim("c1", ClaimStatus.PASS),
+            "c2": _claim("c2", ClaimStatus.PASS),
+        }
+        signal = evaluate_unit(unit, claim_results=results)
+        assert signal.integrity_score == 1.0
+        assert not signal.reasons
+
+    def test_unsupported_claim_no_deduction(self):
+        unit = _make_unit(claims=["c1"])
+        results = {"c1": _claim("c1", ClaimStatus.UNSUPPORTED)}
+        signal = evaluate_unit(unit, claim_results=results)
+        assert signal.integrity_score == 1.0
+
+    def test_missing_claim_result_no_deduction(self):
+        unit = _make_unit(claims=["c1"])
+        signal = evaluate_unit(unit, claim_results={})
+        assert signal.integrity_score == 1.0
+
+
+class TestFailedClaim:
+    def test_failed_claim_deducts_score(self):
+        unit = _make_unit(claims=["c1"])
+        results = {"c1": _claim("c1", ClaimStatus.FAIL, "assertion failed")}
+        signal = evaluate_unit(unit, claim_results=results)
+        assert signal.integrity_score < 1.0
+        assert any(r.kind == "failed_claim" for r in signal.reasons)
+
+    def test_failed_claim_carries_claim_id(self):
+        unit = _make_unit(claims=["claim.foo"])
+        results = {"claim.foo": _claim("claim.foo", ClaimStatus.FAIL)}
+        signal = evaluate_unit(unit, claim_results=results)
+        reason = next(r for r in signal.reasons if r.kind == "failed_claim")
+        assert reason.claim_id == "claim.foo"
+
+    def test_failed_claim_repair_required_policy(self):
+        unit = _make_unit(claims=["c1"], failed_claim_policy="repair_required")
+        results = {"c1": _claim("c1", ClaimStatus.FAIL)}
+        signal = evaluate_unit(unit, claim_results=results)
+        assert signal.recommended_action == "repair_required"
+
+    def test_failed_claim_fail_closed_policy(self):
+        unit = _make_unit(claims=["c1"], failed_claim_policy="fail_closed")
+        results = {"c1": _claim("c1", ClaimStatus.FAIL)}
+        signal = evaluate_unit(unit, claim_results=results)
+        assert signal.recommended_action == "fail_closed"
+
+
+class TestStaleEvidence:
+    def test_stale_claim_creates_reason(self):
+        unit = _make_unit(claims=["c1"])
+        results = {"c1": _claim("c1", ClaimStatus.STALE, "evidence older than SLA")}
+        signal = evaluate_unit(unit, claim_results=results)
+        assert any(r.kind == "stale_evidence" for r in signal.reasons)
+        assert signal.integrity_score < 1.0
+
+    def test_stale_policy_propagates(self):
+        unit = _make_unit(claims=["c1"], stale_evidence_policy="repair_required")
+        results = {"c1": _claim("c1", ClaimStatus.STALE)}
+        signal = evaluate_unit(unit, claim_results=results)
+        assert signal.recommended_action == "repair_required"
+
+    def test_stale_is_lighter_than_fail(self):
+        unit_fail = _make_unit(claims=["c1"])
+        unit_stale = _make_unit(claims=["c1"])
+        s_fail = evaluate_unit(unit_fail, {"c1": _claim("c1", ClaimStatus.FAIL)})
+        s_stale = evaluate_unit(unit_stale, {"c1": _claim("c1", ClaimStatus.STALE)})
+        assert s_stale.integrity_score > s_fail.integrity_score
+
+
+class TestUnresolvedCrux:
+    def test_unresolved_crux_creates_reason(self):
+        unit = _make_unit(linked_crux_ids=["crux.abc"])
+        signal = evaluate_unit(unit, unresolved_crux_ids=frozenset({"crux.abc"}))
+        assert any(r.kind == "unresolved_crux" for r in signal.reasons)
+        assert signal.integrity_score < 1.0
+
+    def test_resolved_crux_no_reason(self):
+        unit = _make_unit(linked_crux_ids=["crux.abc"])
+        signal = evaluate_unit(unit, unresolved_crux_ids=frozenset())
+        assert not any(r.kind == "unresolved_crux" for r in signal.reasons)
+
+    def test_crux_carries_crux_id(self):
+        unit = _make_unit(linked_crux_ids=["crux.xyz"])
+        signal = evaluate_unit(unit, unresolved_crux_ids=frozenset({"crux.xyz"}))
+        reason = next(r for r in signal.reasons if r.kind == "unresolved_crux")
+        assert reason.crux_id == "crux.xyz"
+
+    def test_unresolved_crux_policy_fail_closed(self):
+        unit = _make_unit(
+            linked_crux_ids=["crux.y"],
+            unresolved_crux_policy="fail_closed",
+        )
+        signal = evaluate_unit(unit, unresolved_crux_ids=frozenset({"crux.y"}))
+        assert signal.recommended_action == "fail_closed"
+
+
+class TestMissingReceipt:
+    def test_empty_receipts_creates_reason(self):
+        unit = _make_unit(decision_receipts=[])
+        signal = evaluate_unit(unit)
+        assert any(r.kind == "missing_receipt" for r in signal.reasons)
+        assert signal.integrity_score < 1.0
+
+    def test_receipt_present_no_reason(self):
+        unit = _make_unit(decision_receipts=["r-001"])
+        signal = evaluate_unit(unit)
+        assert not any(r.kind == "missing_receipt" for r in signal.reasons)
+
+
+class TestVerifierError:
+    def test_error_status_creates_reason(self):
+        unit = _make_unit(claims=["c1"])
+        results = {"c1": _claim("c1", ClaimStatus.ERROR, "subprocess timeout")}
+        signal = evaluate_unit(unit, claim_results=results)
+        assert any(r.kind == "verifier_error" for r in signal.reasons)
+
+    def test_error_uses_failed_claim_policy(self):
+        unit = _make_unit(claims=["c1"], failed_claim_policy="repair_required")
+        results = {"c1": _claim("c1", ClaimStatus.ERROR)}
+        signal = evaluate_unit(unit, claim_results=results)
+        assert signal.recommended_action == "repair_required"
+
+
+class TestIntegrityScoreBounds:
+    def test_score_never_below_zero(self):
+        unit = _make_unit(
+            claims=["c1", "c2", "c3", "c4"],
+            linked_crux_ids=["crux.1", "crux.2"],
+            decision_receipts=[],
+        )
+        results = {
+            "c1": _claim("c1", ClaimStatus.FAIL),
+            "c2": _claim("c2", ClaimStatus.FAIL),
+            "c3": _claim("c3", ClaimStatus.STALE),
+            "c4": _claim("c4", ClaimStatus.ERROR),
+        }
+        signal = evaluate_unit(
+            unit,
+            claim_results=results,
+            unresolved_crux_ids=frozenset({"crux.1", "crux.2"}),
+        )
+        assert signal.integrity_score >= 0.0
+
+    def test_fully_healthy_score_is_exactly_one(self):
+        unit = _make_unit(claims=["c1"], decision_receipts=["r1"])
+        results = {"c1": _claim("c1", ClaimStatus.PASS)}
+        signal = evaluate_unit(unit, claim_results=results)
+        assert signal.integrity_score == 1.0
+
+
+class TestToDict:
+    def test_required_keys_present(self):
+        signal = evaluate_unit(_make_unit())
+        d = signal.to_dict()
+        assert set(d) >= {"code_unit_id", "integrity_score", "reasons", "recommended_action"}
+
+    def test_reason_dict_has_kind_and_detail(self):
+        unit = _make_unit(decision_receipts=[])
+        signal = evaluate_unit(unit)
+        reason_dict = signal.to_dict()["reasons"][0]
+        assert "kind" in reason_dict
+        assert "detail" in reason_dict
+
+    def test_claim_id_in_reason_dict_when_set(self):
+        unit = _make_unit(claims=["c1"])
+        results = {"c1": _claim("c1", ClaimStatus.FAIL)}
+        signal = evaluate_unit(unit, claim_results=results)
+        reason_dicts = signal.to_dict()["reasons"]
+        assert any("claim_id" in r for r in reason_dicts)
+
+    def test_crux_id_not_in_reason_dict_when_unset(self):
+        unit = _make_unit(decision_receipts=[])
+        signal = evaluate_unit(unit)
+        reason_dict = signal.to_dict()["reasons"][0]
+        assert "crux_id" not in reason_dict
+
+    def test_integrity_score_is_rounded(self):
+        unit = _make_unit(claims=["c1"], decision_receipts=["r"])
+        results = {"c1": _claim("c1", ClaimStatus.STALE)}
+        signal = evaluate_unit(unit, claim_results=results)
+        score = signal.to_dict()["integrity_score"]
+        assert isinstance(score, float)
+        assert str(score).count(".") == 1
+        assert len(str(score).split(".")[1]) <= 4


### PR DESCRIPTION
## Slice

Adds `aragora/epistemic/decay_monitor.py` — a report-only evaluator that takes a `ProofCarryingCodeUnit` (DIC-19 schema) plus claim verification results and emits a machine-readable `DecaySignal` with an integrity score, typed reason list, and recommended action. Pairs with the existing `ClaimVerifier` (DIC-14) and `proof_unit` schema (DIC-19) without touching either.

## Gating

- Default: OFF (report-only; `evaluate_unit()` is a pure function with no side effects)
- Live queue effect: **none** — this module never mutates state, creates issues, or routes to dispatch
- No flag environment variable needed; callers must explicitly import and call `evaluate_unit()`
- Escalation to `repair_required` or `fail_closed` is expressed in the `decay_policy` fields of the unit schema; this module reads those fields but never acts on them (DIC-21 quarantine policy adds that on top)
- Advances issue: #6031 (DIC-20 Epistemic Decay Monitor)

## Tests

- `TestHealthyUnit` — fully healthy unit scores 1.0, passing/unsupported/missing claims produce no deduction
- `TestFailedClaim` — `FAIL` status deducts score, carries `claim_id`, escalates per `decay_policy`
- `TestStaleEvidence` — `STALE` status creates `stale_evidence` reason, deducts less than `FAIL`
- `TestUnresolvedCrux` — linked crux IDs in the unresolved set create `unresolved_crux` reasons with `crux_id`
- `TestMissingReceipt` — empty `decision_receipts` creates `missing_receipt` reason
- `TestVerifierError` — `ERROR` status creates `verifier_error` reason, inherits `failed_claim` policy
- `TestIntegrityScoreBounds` — score is clamped to `[0.0, 1.0]` under compounded failures
- `TestToDict` — `to_dict()` emits required keys; `claim_id`/`crux_id` are included only when set

## Validation

- Ran 22 assertions covering all test classes inline (conftest chain requires deps not available in this sandbox)
- `python3 -c "import ast; ast.parse(open('aragora/epistemic/decay_monitor.py').read())"` — clean
- `python3 -c "import ast; ast.parse(open('tests/epistemic/test_decay_monitor.py').read())"` — clean
- All logic verified against `ClaimStatus` enum values from `claim_verifier.py` directly

## Out of scope

- **DIC-21** (fail-closed quarantine): mapping decay signals to live routing decisions — that is the next slice
- **DIC-22** (verified replacement): turning decay into a bounded repair spec + Arena debate
- Running verifier commands from `proof_unit.verifiers` (DIC-19 schema has them; DIC-20 accepts pre-computed `ClaimResult` mappings from an upstream `ClaimVerifier` run)
- Auto-creating follow-up issues (DIC-17 `followup.py` handles that separately)