### PR TITLE
fix(mypy): Tier A config — restore pre-push parity with CI typecheck

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ connectors = [
 experimental = [
     "playwright>=1.40,<2.0",
 ]
+dev = [
+    "mypy>=1.19.0,<2.0",
+    "types-PyYAML>=6.0,<7.0",
+    "types-croniter>=2.0,<6.0",
+]
 all = [
     "fastapi>=0.135.3,<1.0",
     "uvicorn>=0.30,<1.0",
@@ -146,3 +151,44 @@ ignore = ["E402", "E501", "E731", "E741", "E712", "C401", "C405", "C408", "C416"
 "aragora/knowledge/mound/checkpoint.py" = ["BLE001", "G004"]
 "aragora/knowledge/mound/ops/*.py" = ["BLE001", "G004"]
 "aragora/knowledge/pipeline.py" = ["BLE001", "G004"]
+
+# -----------------------------------------------------------------------------
+# mypy configuration — Tier A (config-only) remediation.
+#
+# Restores parity between the pre-push mypy hook and CI's changed-file gate.
+# Both layers intend "report errors for the file under check; do not leak
+# transitive errors from the whole import closure". CI already uses
+# `--follow-imports=skip`; this section encodes the equivalent intent at the
+# config level so the pre-push hook stops flagging ~1,400 transitive errors
+# that CI never had to look at. Sources are unchanged; Tier B (real type-bug
+# fixes) is scoped to separate PRs per the triage at
+# .aragora_coordination/mypy_triage_2026-04-17.md.
+# -----------------------------------------------------------------------------
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+# Match CI intent: type-check the target file(s), silence transitive noise.
+follow_imports = "silent"
+# Avoid turning untyped function bodies into noise-only notes.
+check_untyped_defs = false
+# Keep narrowing and Optional handling strict (mypy's default, made explicit).
+strict_optional = true
+disable_error_code = [
+    "annotation-unchecked",  # pure informational notes, not failures
+    "truthy-function",       # ~45 legacy optional-import idioms
+    "import-untyped",        # defense in depth; stubs installed via [dev] extras
+]
+
+# Optional-import fallback modules. These deliberately rebind a symbol to
+# ``None`` when the optional dependency is unavailable, e.g.
+#   try:  from x import Y
+#   except ImportError:  Y = None  # type: ignore[assignment]
+# mypy >= 1.16 flags this pattern as [misc] "Cannot assign to a type". The
+# pattern is intentional and reviewed; silence [misc] for these modules only.
+[[tool.mypy.overrides]]
+module = [
+    "aragora.cli.commands.swarm",
+    "aragora.cli.commands.worktree",
+    "aragora.connectors.chat.*",
+]
+disable_error_code = ["misc"]


### PR DESCRIPTION
## Summary

Config-only fix that restores the pre-push mypy hook to CI parity by adding the missing `[tool.mypy]` section to `pyproject.toml`. The section has been absent from `main` since commit `eaa30815d` (pre-2026-02-24), and without it mypy has been running on `follow_imports=normal`, dragging ~2,400 transitive errors into every single-file pre-push invocation. CI's changed-file gate in `lint.yml` uses `--follow-imports=skip`, so CI has stayed green while developers were forced to push with `--no-verify`.

**This unblocks PR #6194 and PR #6198 from needing `--no-verify` on push.**

## Source of truth

Triage report (authored ~30 min before this PR, lives in the session's coordination dir, not committed):

`.aragora_coordination/mypy_triage_2026-04-17.md`

Tier B (the real type-bug fixes — ~568 errors across 10 hotspot files) and Tier C (the long tail, dispatchable to droids) are scoped to follow-up PRs per the triage plan. Tier A is deliberately config-only and independent of both foundation PRs.

## Changes (pyproject.toml only)

1. **New `[tool.mypy]` block**:
   - `python_version = "3.11"`
   - `follow_imports = "silent"` — matches CI intent; suppresses transitive noise while still type-checking imports for inference.
   - `check_untyped_defs = false` — eliminates 168 `[annotation-unchecked]` informational notes.
   - `strict_optional = true` — explicit (default); keeps Optional narrowing honest.
   - `ignore_missing_imports = true` — moved from CLI flag into config.
   - `disable_error_code = ["annotation-unchecked", "truthy-function", "import-untyped"]` — 168 + 45 + 28 cohorts.

2. **New `[[tool.mypy.overrides]]` block** — suppresses `[misc]` only in the three optional-import modules that deliberately rebind imports to `None` on `ImportError` (`aragora.cli.commands.swarm`, `aragora.cli.commands.worktree`, `aragora.connectors.chat.*`). This is an intentional, reviewed pattern that mypy ≥1.16 flags as `"Cannot assign to a type"`.

3. **New `[project.optional-dependencies].dev` group** carrying `mypy>=1.19`, `types-PyYAML`, `types-croniter`. These are dev-only; runtime dependencies are untouched. Install with `pip install -e .[dev]`.

## Validation

All runs against origin/main tip `df645d835` with cache cleared.

### Whole-tree (scripts/test_tiers.sh typecheck scenario)

| | Before Tier A | After Tier A | Delta |
|---|---:|---:|---:|
| Errors | 3,109 | 3,015 | −94 |
| Files with errors | 713 | 674 | −39 |
| `[annotation-unchecked]` notes | 168 | 0 | −168 |

### Pre-push single-file (the scenario the hook actually runs)

Using `aragora/debate/phases/consensus_phase.py` as a representative staged file:

| | Before Tier A | After Tier A | Delta |
|---|---:|---:|---:|
| Errors | **2,485** | **86** | **−2,399** |
| Files touched | 567 | 1 | −566 |

The −2,399 on the pre-push path comfortably exceeds the triage's conservative ~1,400 prediction. Whole-tree sees a smaller drop because `follow_imports=silent` does nothing when every file is a target — exactly as the triage called out.

### Pre-commit / pre-push hooks

```
$ .venv/bin/pre-commit run --files pyproject.toml
trim trailing whitespace.................Passed
fix end of files.........................Passed
check for added large files..............Passed
check for merge conflicts................Passed
detect private key.......................Passed
Detect secrets with gitleaks.............Passed
```

Push itself succeeded with all pre-push hooks green (gitleaks, mypy skipped since no `aragora/**` files changed).

## Scope guarantees

- **No source files modified** — only `pyproject.toml`.
- **No runtime dependencies changed** — stubs live in a new `[dev]` extra.
- **No touching of PR #6194 or PR #6198** — this PR branches from `origin/main` (`df645d835`), independent of both.
- **No `# type: ignore` additions.**
- **Fully reversible** — revert the single commit and the old behavior returns.

## Follow-ups (out of scope for this PR)

From the triage plan:

1. `fix(auth): require_user decorator removes 180+ mypy errors across handlers`
2. `fix(debate): invariant on ctx.result after consensus phase runs (~130 errors)`
3. `fix(cli): restructure swarm DevCoordinationStore optional-import (~141 errors)`
4. `fix(knowledge): narrow mound Connection/Redis handles (~72 errors)`
5. Tier C long-tail droid dispatch (25–40 PRs, ratcheted CI gate).

Co-Authored-By: Droid (Factory.ai) <noreply@factory.ai>