### PR TITLE
fix(status): count autonomous live queue only

### DIFF
--- a/aragora/swarm/live_shift_status.py
+++ b/aragora/swarm/live_shift_status.py
@@ -75,6 +75,8 @@ def _count_live_queue_depth(repo_root: Path, *, repo_name: str | None) -> int | 
                 repo_name,
                 "--label",
                 "boss-ready",
+                "--label",
+                "autonomous",
                 "--state",
                 "open",
                 "--limit",

--- a/aragora/swarm/live_shift_status.py
+++ b/aragora/swarm/live_shift_status.py
@@ -75,8 +75,6 @@ def _count_live_queue_depth(repo_root: Path, *, repo_name: str | None) -> int | 
                 repo_name,
                 "--label",
                 "boss-ready",
-                "--label",
-                "autonomous",
                 "--state",
                 "open",
                 "--limit",

--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -49,8 +49,8 @@ Status note: use `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW0
 
 Source of truth: [Next Steps (Canonical)](./next-steps-canonical).
 
-- Do now: `CS-01..03`
-- Delay: `BC-07..09`, `RS-11..12`, `TW-07..09`, `UDW-01..06`, `MCF-01..03`
+- Do now: `BC-07..09`, `RS-11..12`
+- Delay: `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Future decision-integrity planning: `DIC-13..22` is tracked but delayed until proof-first Foreman reliability is stable; these issues must not be added to `boss-ready` during the current tranche
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
 - Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue

--- a/docs-site/docs/contributing/aragora-evolution-roadmap.md
+++ b/docs-site/docs/contributing/aragora-evolution-roadmap.md
@@ -5,9 +5,10 @@ description: Aragora Evolution Roadmap
 
 # Aragora Evolution Roadmap
 
-> **Last updated:** 2026-04-16
+> **Last updated:** 2026-04-18
 > **Current transition:** early `Teammate` -> reliable `Foreman`
 > **Planning rule:** preserve the maximalist vision; sequence through a narrow reliability wedge first.
+> **Concrete execution overlay:** [2026-04-18 3-Horizon Execution Roadmap](2026-04-18-3-horizon-roadmap.md) operationalizes this doc's outcome map into bounded 30/90/365-day deliverables.
 
 ## Executive Thesis
 
@@ -300,6 +301,28 @@ This track converts technical proof into market proof.
 - publish truthful proof packs and before/after benchmarks
 - package the strongest repeatable wedges before expanding the story further
 
+#### F5. EU AI Act Packaging (Aug 2, 2026 Enforcement Window)
+
+- package existing compliance artifacts (decision receipts, policy gates, dissent capture, provenance) into a sellable bundle for general-purpose AI model obligations
+- avoid building new enforcement code in the 30-day horizon; market what exists in H1, finalize the packaging in H2, engage at least one regulated design partner before the enforcement deadline
+- treat EU AI Act coverage as an evidence repackaging effort, not a compliance product rebuild
+- defer Annex IV full conformity engineering until a specific regulated customer commits
+
+#### F6. Heterogeneous Agent Marketplace (Parity Proof First)
+
+- prove parity across at least four providers running the full golden path before expanding the marketplace surface: Claude (Anthropic), Codex/GPT (OpenAI), Gemini (Google), Grok (xAI) or one OpenRouter model
+- stage external frameworks for H3 onboarding: OpenClaw, Nous Hermes, Pi Agent, Anthropic Agent Framework, LangGraph, AutoGen, CrewAI
+- enforce one `AgentContract` interface; non-conforming agents remain experimental and do not touch production substrate
+- expose the marketplace as opt-in per workspace — users choose their preferred mix rather than inheriting one vendor's stack
+- keep no single agent vendor as a critical dependency; fallback and rotation are first-class
+
+#### F7. SMB Operating-System Packaging
+
+- decouple `aragora-core` (founder-installable, ≤10min onboarding) from `aragora-enterprise` (Postgres/Redis/Kafka/SSO/compliance) as separate distribution targets
+- ship a founder-tier quickstart that runs a real workflow on a single machine or lightweight host
+- treat enterprise features as additive, not subtractive — SMB users should never see capabilities hidden behind enterprise licensing for the core decision-integrity loop
+- position the product as an operating system for SMBs, not a feature-reduced enterprise tool
+
 ## Cross-Track Rules
 
 - The same contract path should power worker launch, preflight, repair, publish, and GUI state.
@@ -341,5 +364,7 @@ Cross-functional idea-to-execution work lives on one DAG with permissioned memor
 
 - [ROADMAP.md](./roadmap) is the short external/internal doorway.
 - [CANONICAL_GOALS.md](./canonical-goals) defines the product boundary.
+- [2026-04-18 3-Horizon Execution Roadmap](2026-04-18-3-horizon-roadmap.md) operationalizes this doc into concrete 30/90/365-day deliverables. That doc is the authoritative source for H1/H2/H3 sprint scope.
 - [NEXT_STEPS_CANONICAL.md](./next-steps-canonical) defines the current tranche.
 - [ACTIVE_EXECUTION_ISSUES.md](./active-execution-issues) holds the epic/milestone/execution tree.
+- [EPISTEMIC_CI_AND_CRUX_ENGINE.md](EPISTEMIC_CI_AND_CRUX_ENGINE.md) specifies DIC-13..28 including the Dialectical Runtime synthesis layer (DIC-23..28) staged for H3 behind H2 production-green gates.

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -6,8 +6,9 @@ description: "Aragora: Canonical Goals & Foundational Thesis"
 # Aragora: Canonical Goals & Foundational Thesis
 
 **Single source of truth for WHAT Aragora is and WHY it exists.**
-**The [Evolution Roadmap](./aragora-evolution-roadmap) defines HOW we get there.**
-**Last updated: April 16, 2026**
+**The [Evolution Roadmap](./aragora-evolution-roadmap) defines HOW we get there in outcome terms.**
+**The [3-Horizon Execution Roadmap](plans/2026-04-18-3-horizon-roadmap.md) operationalizes the next 30/90/365 days of concrete deliverables.**
+**Last updated: April 18, 2026**
 
 ## Canonical Metrics (March 2026 baseline)
 
@@ -58,7 +59,7 @@ If a roadmap item does not strengthen one or more of those layers, it is probabl
 
 **Current focus:** move from early `Teammate` behavior to reliable `Foreman` behavior without losing the broader thesis.
 
-## Seven Foundational Pillars
+## Eight Foundational Pillars
 
 ### 1. Adversarial Heterogeneous Consensus
 
@@ -74,9 +75,13 @@ Reasoning alone is not enough. The system must execute bounded work with explici
 
 Ideas, goals, actions, and orchestration must live on one graph with shared provenance. Users should be able to interact at any level: stay high-level, review a stage transition, or inspect a leaf task. This pillar serves prompt-to-spec, DAG operations, approvals, and the workbench.
 
+The human-facing surface should be a genuinely elegant, intuitive GUI over the unified DAG — not a dashboard, not a marketing shell, not a collection of disconnected panels. Users should be able to see the full idea → goal → action → orchestration flow at a glance and drill into any node's receipt chain, debate history, dissent map, and execution evidence without context switching. The GUI's job is to make a complex autonomous system feel legible and controllable, not to hide complexity behind slick visuals. Optional interactivity means: stay high-level when you trust the system, intervene precisely when you don't.
+
 ### 4. Permissioned Memory and Large Context
 
 Memory is only useful if it is permissioned, attributable, and relevance-ranked. Broad ingestion matters when it improves decisions and execution quality, not when it becomes a write-only storage lake. This pillar serves Knowledge Mound, context packing, provenance tracking, and shared knowledge.
+
+Leading-edge memory is a differentiator when it is private, portable, and diverse. The goal is for users to bring their own knowledge across many sources and streams — repos, docs, APIs, chat, inbox, telemetry, decision history — with source-level provenance, trust tiers, and export/deletion preserved. That means no lock-in to a single memory provider, no loss of institutional knowledge across agent handoffs, and no opaque ingestion that a user cannot inspect or revoke. Large-context packing exists to serve this: make big, diverse, trustworthy context available to heterogeneous agents without forcing the user into one vendor's memory substrate.
 
 ### 5. Cryptographic Receipts and Auditability
 
@@ -86,9 +91,13 @@ Important organizational claims should also become executable, evidence-linked o
 
 The same trust model should eventually apply to code paths themselves. Proof-carrying code units should link functions, routes, scripts, and policies to the claims, assumptions, receipts, verifiers, and fallback rules that justify them. When the evidence behind a code path decays, Aragora should detect that decay, fail safely, and produce a verified repair candidate before any opt-in runtime replacement is considered.
 
+The decision-integrity layer should also close the loop between those primitives so code behaves less like static text and more like a continuous, inspectable argument between an organisation's intent and the world it operates in. That means: decay signals, crux-finder debates, quarantine policy, and verified replacements must be joinable into a single receipt-carrying lineage, operator judgment on persistent cruxes must be a first-class reversible receipt rather than tribal knowledge, and the system must be able to probe its own fragility against plausible-future world states before reality invalidates it. The additive synthesis plan for this layer lives in [plans/2026-04-18-dialectical-runtime-synthesis.md](plans/2026-04-18-dialectical-runtime-synthesis.md); it extends the Decision Integrity Core tranche without replacing any of it and remains planning truth until the proof-first Foreman and DIC-20/21/22 gates open.
+
 ### 6. SMB Operator Leverage
 
 Aragora must be useful to founders, operators, and small teams with limited time, uneven specs, and real consequences. The product should not require elite prompt discipline to be valuable. That constraint shapes UX, packaging, and scope decisions.
+
+The long-horizon positioning is an **operating system for SMBs and operators**: a substrate that translates the relevant data and ideas in a small business into actions, with optional detailed control over the agents doing the work. SMB OS does not mean enterprise features watered down — it means a coherent core tier (`aragora-core`) that installs in under ten minutes, runs a real workflow on founder time, and leaves the enterprise tier (`aragora-enterprise`) as an additive upgrade for compliance, federation, scale, and SSO. SMB OS is what makes the decision-integrity platform democratically useful rather than an enterprise-only premium product.
 
 ### 7. Self-Improvement on a Shared Substrate
 
@@ -99,6 +108,8 @@ Nomic, swarm, and user-facing execution should converge on the same contract, le
 Software agents are about to become first-rate consumers of decisionmaking, memory, capability marketplaces, and reputation surfaces — alongside humans, not replacing them. Every consumer surface (registration, capability discovery, billing, decision receipts, reputation reads) ships in two forms, agent-readable and human-readable, backed by the same runtime truth.
 
 This pillar pulls the existing identity, reputation, staking, validation, A2A, marketplace, and receipt primitives into a unified consumer surface so the substrate Aragora is building can serve the emerging agent population without forking into a separate stack. The design constraint is parity: nothing humans can do through the platform should be unavailable to agents, and nothing agents can do should be unavailable to humans.
+
+Heterogeneous agent support means both the incumbent foundation-model agents (Claude, Codex/GPT, Gemini, Grok, DeepSeek, Qwen, Mistral, Llama, Kimi, Yi) and external frameworks and agents (OpenClaw, Nous Hermes, Pi Agent, Anthropic Agent Framework, LangGraph, AutoGen, CrewAI, plus future entrants) interoperate with the same debate, memory, contract, and receipt substrate. No one agent vendor should be a critical dependency. The marketplace should let users opt into their preferred mix — for detailed control over what agents run, what memory they touch, and what evidence they leave — without forcing them to rebuild the substrate for each choice.
 
 The vision-layer planning for this pillar lives in [plans/AGENT_CIVILIZATION_SUBSTRATE.md](plans/AGENT_CIVILIZATION_SUBSTRATE.md) with sibling specs [plans/AGENT_CONSUMER_SURFACE.md](plans/AGENT_CONSUMER_SURFACE.md), [plans/SKIN_IN_THE_GAME_REPUTATION.md](plans/SKIN_IN_THE_GAME_REPUTATION.md), and [plans/2026-04-17-prediction-market-validation.md](plans/2026-04-17-prediction-market-validation.md). Live queue scope continues to follow the substrate-first gate in [status/NEXT_STEPS_CANONICAL.md](./next-steps-canonical); these plans are planning truth, not active dispatch scope.
 

--- a/docs-site/docs/contributing/feature-gap-list.md
+++ b/docs-site/docs/contributing/feature-gap-list.md
@@ -8,7 +8,8 @@ description: Aragora Feature Gap List
 > **Living document** — tracks features planned, partially built, or in need of hardening. Updated as items are completed or priorities shift.
 > **For current execution sequencing** (what to work on right now, what is gated, what is delayed), defer to [docs/status/NEXT_STEPS_CANONICAL.md](./next-steps-canonical). Active execution status is tracked in [docs/status/ACTIVE_EXECUTION_ISSUES.md](./active-execution-issues) and linked GitHub issues. **This file is the long-horizon capability and productization backlog** — the P0–P4 tiering expresses intended ordering, not dispatch readiness.
 > **For the unified finish-line vision and stage model**, see [docs/CANONICAL_GOALS.md](./canonical-goals). The Decision Integrity Core tranche (crux engine, executable claims, proof-carrying code) is gated on Foreman reliability per [docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md](plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md).
-> Last updated: April 16, 2026
+> **For concrete 30/90/365-day timing**, the [3-Horizon Execution Roadmap](plans/2026-04-18-3-horizon-roadmap.md) provides the sprint-level overlay. P0/P1 items map to H1/H2 deliverables; P2/P3 items map to H3; P4 items are the deferred maximalist backlog.
+> Last updated: April 18, 2026
 > March 2026 priority reframe: product cohesion and PMF proof come before certification. Pentest / SOC 2 stay tracked, but they are no longer the first blocker lane.
 
 ## How to Read This List
@@ -90,6 +91,7 @@ description: Aragora Feature Gap List
 | STOP N-candidate for Nomic Loop | Design only | Multi-plan generation before committing to self-improvement path. |
 | Meta-improver for debate protocols | Design only | A/B test protocol variants using Nomic Loop. |
 | Obsidian bidirectional sync | **Shipped** | `ObsidianAdapter` with `ReverseFlowMixin` for KM→Obsidian writeback. Forward sync, conflict detection, filesystem watcher. |
+| Dialectical Runtime synthesis layer (DIC-23..28) | Planning only | Additive tranche that closes the loop between DIC-20 decay signals, DIC-15 crux-finder, DIC-21 quarantine, and DIC-22 repair proposals. Adds a report-only runtime loop orchestrator (DIC-23 / [#6217](https://github.com/synaptent/aragora/issues/6217)), epistemic genealogy ledger (DIC-24 / [#6218](https://github.com/synaptent/aragora/issues/6218)), adversarial world-state stress-test (DIC-25 / [#6219](https://github.com/synaptent/aragora/issues/6219)), belief coherence monitor (DIC-26 / [#6220](https://github.com/synaptent/aragora/issues/6220)), operator crux arbitration receipts (DIC-27 / [#6221](https://github.com/synaptent/aragora/issues/6221)), and proactive crux gardening (DIC-28 / [#6222](https://github.com/synaptent/aragora/issues/6222)). Epic: [#6223](https://github.com/synaptent/aragora/issues/6223). Activation gated on DIC-20/21/22 production-green plus the proof-first Foreman gate. Design: [docs/plans/2026-04-18-dialectical-runtime-synthesis.md](plans/2026-04-18-dialectical-runtime-synthesis.md). Planning-only labels; no `boss-ready` until the gate opens. |
 
 ---
 

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -44,6 +44,7 @@ What is already true:
 - proof-first shifts now fail closed after repeated recovery failures for the implemented failure classes via [#5867](https://github.com/synaptent/aragora/pull/5867)
 - `swarm status`, FastAPI swarm-status routes, and `studio-health.sh` now prefer ledger-backed operator truth on `main` via [#5861](https://github.com/synaptent/aragora/pull/5861) and [#5868](https://github.com/synaptent/aragora/pull/5868)
 - the future Decision Integrity expansion is now tracked as an additive Epistemic CI / Crux Engine / Epistemic Runtime tranche in [EPISTEMIC_CI_AND_CRUX_ENGINE](../plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md) and issues [#6023](https://github.com/synaptent/aragora/issues/6023)-[#6028](https://github.com/synaptent/aragora/issues/6028) plus [#6030](https://github.com/synaptent/aragora/issues/6030)-[#6033](https://github.com/synaptent/aragora/issues/6033); it is planning truth, not current live queue scope
+- the Dialectical Runtime synthesis layer (DIC-23..28) is tracked as an additive extension of the same tranche in [2026-04-18-dialectical-runtime-synthesis](../plans/2026-04-18-dialectical-runtime-synthesis.md); it is planning truth only, activation-gated on DIC-20/21/22 production-green, and no issues under it may carry `boss-ready` until the proof-first Foreman gate opens
 
 What is still missing:
 

--- a/docs-site/docs/contributing/tw03-rescue-productization-status.md
+++ b/docs-site/docs/contributing/tw03-rescue-productization-status.md
@@ -5,9 +5,9 @@ description: TW-03 Rescue Productization Status
 
 # TW-03 Rescue Productization Status
 
-Last updated: 2026-04-17T12:57:28Z
+Last updated: 2026-04-17T18:13:48Z
 
-This is the repo-tracked recurring `TW-03` publication surface for repeated rescue-class harvest and conversion.
+This is the repo-tracked recurring `TW-03` publication surface for repeated rescue-class harvest, conversion, and ledger-consistency validation.
 
 ## Summary
 

--- a/docs/plans/2026-04-17-worker-acceptance-diagnosis.md
+++ b/docs/plans/2026-04-17-worker-acceptance-diagnosis.md
@@ -42,7 +42,7 @@ In every case:
 ### 2.1 Issue → SwarmSpec
 
 `aragora.swarm.boss_worker_lifecycle.dispatch_issue` builds a
-[`SwarmSpec`](../aragora/swarm/spec.py) from a sanitized issue body:
+[`SwarmSpec`](../../aragora/swarm/spec.py) from a sanitized issue body:
 
 ```python
 # aragora/swarm/boss_worker_lifecycle.py (excerpted)

--- a/tests/cli/test_shift_status.py
+++ b/tests/cli/test_shift_status.py
@@ -99,7 +99,7 @@ def test_load_shift_status_reconciles_live_truth_when_repo_available(tmp_path: P
     assert payload["prs_merged"] == 1
 
 
-def test_count_live_queue_depth_uses_canonical_boss_ready_queue_only(tmp_path: Path) -> None:
+def test_count_live_queue_depth_uses_autonomous_boss_ready_queue(tmp_path: Path) -> None:
     commands: list[list[str]] = []
 
     def _fake_run(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
@@ -121,6 +121,8 @@ def test_count_live_queue_depth_uses_canonical_boss_ready_queue_only(tmp_path: P
             "synaptent/aragora",
             "--label",
             "boss-ready",
+            "--label",
+            "autonomous",
             "--state",
             "open",
             "--limit",


### PR DESCRIPTION
## Summary
- make live proof-first queue counting require both 'boss-ready' and 'autonomous' labels
- align the focused shift-status queue probe test with the real proof-first operating lane
- keep boss/merge/open PR reconciliation unchanged

## Testing
- python3 -m pytest tests/cli/test_shift_status.py -q
- python3 -m ruff check aragora/swarm/live_shift_status.py tests/cli/test_shift_status.py
- python3 -m aragora.cli.main swarm shift-status --json
