### PR TITLE
feat(swarm): persist boss loop session retry state

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -27,6 +27,11 @@ from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
 from aragora.swarm.dispatch_contract_gate import dispatch_contract_gate
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.session_state import (
+    SessionState,
+    SessionStateStore,
+    summarize_session_blocker,
+)
 from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
 from aragora.swarm.terminal_truth import (
     TerminalClass,
@@ -588,6 +593,7 @@ class BossLoop:
         freshness_checker: Any | None = None,
         env: dict[str, str] | None = None,
         exec_argv: list[str] | None = None,
+        session_state_store: SessionStateStore | None = None,
     ) -> None:
         self.config = config or BossLoopConfig()
         self.run_id = f"boss-{uuid.uuid4().hex[:12]}"
@@ -603,6 +609,7 @@ class BossLoop:
         self._freshness_checker = freshness_checker or check_runner_freshness
         self._env = env
         self._exec_argv = exec_argv
+        self._session_state_store = session_state_store or SessionStateStore()
         self._attempted_issues: list[dict[str, Any]] = []
         self._completed_issues: list[dict[str, Any]] = []
         self._failed_issues: list[dict[str, Any]] = []
@@ -1264,6 +1271,8 @@ class BossLoop:
             sanitation_summary = "Skipped by sanitation: " + "; ".join(sanitation)
             needs_human_reasons.append(sanitation_summary)
             next_actions.append(sanitation_summary)
+        for blocker_summary in self._session_blocker_summaries(already_maxed):
+            needs_human_reasons.append(blocker_summary)
         return needs_human_reasons, next_actions
 
     def _emit_terminal_receipt(self, result: BossLoopResult) -> None:
@@ -1351,6 +1360,194 @@ class BossLoop:
                 if isinstance(paths, list):
                     files.extend(str(p) for p in paths if str(p).strip())
         return files
+
+    @staticmethod
+    def _extract_worker_exit_code(worker_result: dict[str, Any]) -> int | None:
+        run = worker_result.get("run")
+        if not isinstance(run, dict):
+            return None
+        exit_codes: list[int] = []
+        for work_order in run.get("work_orders", []) or []:
+            if not isinstance(work_order, dict):
+                continue
+            raw_exit_code = work_order.get("exit_code")
+            if isinstance(raw_exit_code, bool):
+                continue
+            if isinstance(raw_exit_code, int):
+                exit_codes.append(raw_exit_code)
+                continue
+            text = str(raw_exit_code or "").strip()
+            if not text:
+                continue
+            try:
+                exit_codes.append(int(text))
+            except ValueError:
+                continue
+        if not exit_codes:
+            return None
+        for exit_code in exit_codes:
+            if exit_code != 0:
+                return exit_code
+        return exit_codes[0]
+
+    @staticmethod
+    def _first_work_order_text(worker_result: dict[str, Any], *keys: str) -> str | None:
+        run = worker_result.get("run")
+        if not isinstance(run, dict):
+            return None
+        for work_order in run.get("work_orders", []) or []:
+            if not isinstance(work_order, dict):
+                continue
+            for key in keys:
+                value = str(work_order.get(key, "")).strip()
+                if value:
+                    return value
+        return None
+
+    @staticmethod
+    def _extract_worker_failing_verification(
+        worker_result: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        run = worker_result.get("run")
+        if not isinstance(run, dict):
+            return None
+        for work_order in run.get("work_orders", []) or []:
+            if not isinstance(work_order, dict):
+                continue
+            verification_results = work_order.get("verification_results", [])
+            if not isinstance(verification_results, list):
+                continue
+            for entry in verification_results:
+                if not isinstance(entry, dict) or entry.get("passed") is True:
+                    continue
+                result: dict[str, Any] = {}
+                command = str(entry.get("command", "")).strip()
+                if command:
+                    result["command"] = command
+                exit_code = entry.get("exit_code")
+                if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+                    result["exit_code"] = exit_code
+                stderr_tail = str(entry.get("stderr_tail", "")).strip()
+                if stderr_tail:
+                    result["stderr_tail"] = stderr_tail
+                stdout_tail = str(entry.get("stdout_tail", "")).strip()
+                if stdout_tail:
+                    result["stdout_tail"] = stdout_tail
+                if result:
+                    return result
+        return None
+
+    def _session_state_for_issue(self, issue_number: int) -> SessionState | None:
+        try:
+            return self._session_state_store.latest_for_issue(issue_number)
+        except Exception:
+            logger.debug(
+                "Boss loop session-state lookup failed for issue #%s",
+                issue_number,
+                exc_info=True,
+            )
+            return None
+
+    def _session_blocker_summaries(self, issue_numbers: set[int]) -> list[str]:
+        summaries: list[str] = []
+        for issue_number in sorted(issue_numbers):
+            try:
+                summary = summarize_session_blocker(self._session_state_for_issue(issue_number))
+            except Exception:
+                logger.debug(
+                    "Boss loop session-state blocker classification failed for issue #%s",
+                    issue_number,
+                    exc_info=True,
+                )
+                continue
+            if summary:
+                summaries.append(summary)
+        return summaries
+
+    def _record_session_attempt(
+        self,
+        issue: GitHubIssue,
+        worker_result: dict[str, Any],
+        *,
+        selected_runner: dict[str, Any] | None = None,
+        requested_target_agent: str | None = None,
+    ) -> None:
+        receipt_metadata = worker_result.get("receipt_metadata")
+        if not isinstance(receipt_metadata, dict):
+            receipt_metadata = {}
+        reasons = [
+            str(item).strip()
+            for item in worker_result.get("reasons", []) or []
+            if str(item).strip()
+        ]
+        deliverable = worker_result.get("deliverable")
+        branch_name = self._first_work_order_text(worker_result, "branch", "branch_name")
+        if not branch_name and isinstance(deliverable, dict):
+            branch_name = str(deliverable.get("branch", "")).strip() or None
+        pr_url = self._published_pr_url(worker_result)
+        target_agent = (
+            str(
+                receipt_metadata.get("actual_target_agent")
+                or requested_target_agent
+                or receipt_metadata.get("requested_target_agent")
+                or ""
+            ).strip()
+            or None
+        )
+        runner_type = (
+            str(
+                receipt_metadata.get("runner_type")
+                or (selected_runner or {}).get("runner_type")
+                or ""
+            ).strip()
+            or None
+        )
+        metadata: dict[str, Any] = {}
+        run_id = str(worker_result.get("run_id", "")).strip()
+        if run_id:
+            metadata["run_id"] = run_id
+        receipt_id = str(worker_result.get("receipt_id", "")).strip()
+        if receipt_id:
+            metadata["receipt_id"] = receipt_id
+        if reasons:
+            metadata["failure_reason"] = reasons[0]
+        failing_verification = self._extract_worker_failing_verification(worker_result)
+        if failing_verification:
+            metadata["failing_verification"] = failing_verification
+        stderr_tail = self._first_work_order_text(worker_result, "stderr_tail")
+        if stderr_tail:
+            metadata["stderr_tail"] = stderr_tail
+        stdout_tail = self._first_work_order_text(worker_result, "stdout_tail")
+        if stdout_tail:
+            metadata["stdout_tail"] = stdout_tail
+        if branch_name:
+            metadata["branch_name"] = branch_name
+        if pr_url:
+            metadata["pr_url"] = pr_url
+
+        try:
+            self._session_state_store.record_attempt(
+                issue_number=issue.number,
+                status=str(worker_result.get("status", "")).strip() or "unknown",
+                outcome=str(worker_result.get("outcome", "")).strip()
+                or str(worker_result.get("status", "")).strip()
+                or "unknown",
+                exit_code=self._extract_worker_exit_code(worker_result),
+                changed_files=self._extract_worker_files_changed(worker_result),
+                target_agent=target_agent,
+                runner_type=runner_type,
+                worktree_path=self._first_work_order_text(worker_result, "worktree_path"),
+                branch_name=branch_name,
+                pr_url=pr_url,
+                resume_hint=reasons[0] if reasons else None,
+                metadata=metadata,
+            )
+        except Exception:
+            logger.debug(
+                "Boss loop session-state attempt record failed for issue #%s",
+                issue.number,
+                exc_info=True,
+            )
 
     def _repo_slug_for_issue(self, issue: GitHubIssue) -> str | None:
         configured_repo = str(self.config.repo or "").strip()
@@ -4977,7 +5174,8 @@ class BossLoop:
                 }
             )
 
-        self._attach_issue_handoff_metadata(spec, issue)
+        prior_session_state = self._session_state_for_issue(issue.number)
+        self._attach_issue_handoff_metadata(spec, issue, session_state=prior_session_state)
 
         gate = await check_pre_dispatch_gate(
             sanitized_issue_body,
@@ -5166,17 +5364,30 @@ class BossLoop:
                 )
             except Exception:
                 pass  # Never block autonomous dispatch
+        self._record_session_attempt(
+            issue,
+            result,
+            selected_runner=selected_runner,
+            requested_target_agent=requested_target_agent,
+        )
         if result.get("status") == "failed":
             error = str(result.get("error", "")).strip()
             if error:
                 logger.warning("Boss dispatch failed for issue #%d: %s", issue.number, error)
         return result
 
-    def _attach_issue_handoff_metadata(self, spec: Any, issue: GitHubIssue) -> None:
+    def _attach_issue_handoff_metadata(
+        self,
+        spec: Any,
+        issue: GitHubIssue,
+        *,
+        session_state: SessionState | None = None,
+    ) -> None:
         repo_slug = self._repo_slug_for_issue(issue) or ""
         work_orders = getattr(spec, "work_orders", None)
         if not isinstance(work_orders, list):
             return
+        resume_context = session_state.resume_payload() if session_state is not None else {}
         for index, work_order in enumerate(work_orders, start=1):
             if not isinstance(work_order, dict):
                 continue
@@ -5191,6 +5402,18 @@ class BossLoop:
                 "handoff_key",
                 f"github-issue:{repo_part}:{issue.number}:{work_order_id}",
             )
+            if resume_context:
+                metadata["resume_context"] = dict(resume_context)
+                repair_journal = resume_context.get("repair_journal")
+                if (
+                    isinstance(repair_journal, list)
+                    and repair_journal
+                    and not metadata.get("repair_journal")
+                ):
+                    metadata["repair_journal"] = [dict(item) for item in repair_journal]
+                resume_hint = str(resume_context.get("resume_hint", "")).strip()
+                if resume_hint:
+                    metadata.setdefault("resume_hint", resume_hint)
             work_order["metadata"] = metadata
 
     def _receipt_metadata_for_result(

--- a/aragora/swarm/session_state.py
+++ b/aragora/swarm/session_state.py
@@ -81,6 +81,108 @@ def _coerce_path_list(value: Any) -> list[str]:
     return [str(item).strip() for item in value if str(item).strip()]
 
 
+def _coerce_exit_code(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    text = _optional_text(value)
+    if text is None:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _text_list(value: Any, *, limit: int = 25) -> list[str]:
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    items: list[str] = []
+    seen: set[str] = set()
+    for raw in value:
+        text = str(raw or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        items.append(text)
+        if len(items) >= limit:
+            break
+    return items
+
+
+def _coerce_failing_verification(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    command = _optional_text(value.get("command"))
+    exit_code = _coerce_exit_code(value.get("exit_code"))
+    stderr_tail = _optional_text(value.get("stderr_tail"))
+    stdout_tail = _optional_text(value.get("stdout_tail"))
+    result: dict[str, Any] = {}
+    if command is not None:
+        result["command"] = command
+    if exit_code is not None:
+        result["exit_code"] = exit_code
+    if stderr_tail is not None:
+        result["stderr_tail"] = stderr_tail
+    if stdout_tail is not None:
+        result["stdout_tail"] = stdout_tail
+    return result or None
+
+
+def _coerce_attempt_entry(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    entry: dict[str, Any] = {}
+    at = _optional_text(value.get("at"))
+    if at is not None:
+        entry["at"] = at
+    status = _optional_text(value.get("status"))
+    if status is not None:
+        entry["status"] = status
+    worker_outcome = _optional_text(value.get("worker_outcome"))
+    if worker_outcome is not None:
+        entry["worker_outcome"] = worker_outcome
+    failure_reason = _optional_text(value.get("failure_reason"))
+    if failure_reason is not None:
+        entry["failure_reason"] = failure_reason
+    exit_code = _coerce_exit_code(value.get("exit_code"))
+    if exit_code is not None:
+        entry["exit_code"] = exit_code
+    changed_paths = _text_list(value.get("changed_paths"))
+    if not changed_paths:
+        changed_paths = _coerce_path_list(value.get("changed_files"))
+    if changed_paths:
+        entry["changed_paths"] = list(changed_paths)
+        entry["changed_files"] = list(changed_paths)
+    test_output = _optional_text(value.get("test_output"))
+    if test_output is not None:
+        entry["test_output"] = test_output
+    stderr_tail = _optional_text(value.get("stderr_tail"))
+    if stderr_tail is not None:
+        entry["stderr_tail"] = stderr_tail
+    stdout_tail = _optional_text(value.get("stdout_tail"))
+    if stdout_tail is not None:
+        entry["stdout_tail"] = stdout_tail
+    branch_name = _optional_text(value.get("branch_name"))
+    if branch_name is not None:
+        entry["branch_name"] = branch_name
+    pr_url = _optional_text(value.get("pr_url"))
+    if pr_url is not None:
+        entry["pr_url"] = pr_url
+    failing_verification = _coerce_failing_verification(value.get("failing_verification"))
+    if failing_verification is not None:
+        entry["failing_verification"] = failing_verification
+    return entry or None
+
+
+def _attempt_changed_paths(attempt: Mapping[str, Any]) -> list[str]:
+    paths = _text_list(attempt.get("changed_paths"))
+    if paths:
+        return paths
+    return _coerce_path_list(attempt.get("changed_files"))
+
+
 @dataclass(slots=True)
 class SessionState:
     """Durable local session metadata for future retry/repair orchestration."""
@@ -116,7 +218,11 @@ class SessionState:
         self.resume_hint = _optional_text(self.resume_hint)
         self.blocker_evidence = _optional_text(self.blocker_evidence)
         self.retry_count = max(0, int(self.retry_count or 0))
-        self.attempts = _coerce_dict_list(self.attempts)
+        self.attempts = [
+            entry
+            for entry in (_coerce_attempt_entry(item) for item in self.attempts)
+            if entry is not None
+        ]
         self.repair_journal = _coerce_dict_list(self.repair_journal)
         self.created_at = _coerce_datetime(self.created_at)
         self.updated_at = _coerce_datetime(self.updated_at)
@@ -162,7 +268,7 @@ class SessionState:
             resume_hint=data.get("resume_hint"),
             blocker_evidence=data.get("blocker_evidence"),
             retry_count=data.get("retry_count", 0),
-            attempts=_coerce_dict_list(data.get("attempts")),
+            attempts=list(data.get("attempts") or []),
             repair_journal=_coerce_dict_list(data.get("repair_journal")),
             metadata=dict(data.get("metadata") or {}),
             created_at=_coerce_datetime(data.get("created_at")),
@@ -171,20 +277,107 @@ class SessionState:
 
     def record_attempt(
         self,
-        exit_code: int | None,
-        changed_files: list[str] | tuple[str, ...] | set[str] | None,
-        test_output: str | None,
-        worker_outcome: str | None,
+        exit_code: int | None = None,
+        changed_files: list[str] | tuple[str, ...] | set[str] | None = None,
+        test_output: str | None = None,
+        worker_outcome: str | None = None,
+        *,
+        status: str | None = None,
+        outcome: str | None = None,
+        target_agent: str | None = None,
+        runner_type: str | None = None,
+        worktree_path: str | None = None,
+        branch_name: str | None = None,
+        pr_url: str | None = None,
+        resume_hint: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
+        advanced_mode = any(
+            value is not None
+            for value in (
+                status,
+                outcome,
+                target_agent,
+                runner_type,
+                worktree_path,
+                branch_name,
+                pr_url,
+                resume_hint,
+                metadata,
+            )
+        )
+        changed_paths = _text_list(changed_files or ())
+
+        if advanced_mode:
+            self.status = str(status or self.status or "created").strip() or "created"
+            self.target_agent = _optional_text(target_agent) or self.target_agent
+            self.runner_type = _optional_text(runner_type) or self.runner_type
+            self.worktree_path = _optional_text(worktree_path) or self.worktree_path
+            self.branch_name = _optional_text(branch_name) or self.branch_name
+            self.pr_url = _optional_text(pr_url) or self.pr_url
+            resolved_resume_hint = _optional_text(resume_hint)
+            if resolved_resume_hint is not None:
+                self.resume_hint = resolved_resume_hint
+
+            payload = dict(metadata or {})
+            failure_reason = _optional_text(payload.get("failure_reason")) or resolved_resume_hint
+            attempt: dict[str, Any] = {
+                "at": _utcnow().isoformat(),
+                "status": self.status,
+            }
+            outcome_text = _optional_text(outcome) or _optional_text(worker_outcome)
+            if outcome_text is not None:
+                attempt["worker_outcome"] = outcome_text
+            normalized_exit_code = _coerce_exit_code(exit_code)
+            if normalized_exit_code is not None:
+                attempt["exit_code"] = normalized_exit_code
+            if changed_paths:
+                attempt["changed_paths"] = list(changed_paths)
+                attempt["changed_files"] = list(changed_paths)
+            output_text = _optional_text(test_output)
+            if output_text is not None:
+                attempt["test_output"] = output_text
+            if failure_reason is not None:
+                attempt["failure_reason"] = failure_reason
+
+            resolved_branch = _optional_text(payload.get("branch_name")) or _optional_text(
+                branch_name
+            )
+            if resolved_branch is not None:
+                attempt["branch_name"] = resolved_branch
+            resolved_pr_url = _optional_text(payload.get("pr_url")) or _optional_text(pr_url)
+            if resolved_pr_url is not None:
+                attempt["pr_url"] = resolved_pr_url
+            for key in ("stderr_tail", "stdout_tail"):
+                text = _optional_text(payload.get(key))
+                if text is not None:
+                    attempt[key] = text
+            failing_verification = _coerce_failing_verification(payload.get("failing_verification"))
+            if failing_verification is not None:
+                attempt["failing_verification"] = failing_verification
+
+            self.attempts.append(attempt)
+            self.retry_count = max(self.retry_count + 1, len(self.attempts))
+            payload.pop("failure_reason", None)
+            payload.pop("stderr_tail", None)
+            payload.pop("stdout_tail", None)
+            payload.pop("branch_name", None)
+            payload.pop("pr_url", None)
+            payload.pop("failing_verification", None)
+            self.metadata.update(payload)
+            self.touch()
+            return dict(attempt)
+
         attempt = {
             "at": _utcnow().isoformat(),
-            "exit_code": int(exit_code) if exit_code is not None else None,
-            "changed_files": _coerce_path_list(changed_files),
+            "exit_code": _coerce_exit_code(exit_code),
+            "changed_files": list(changed_paths),
+            "changed_paths": list(changed_paths),
             "test_output": _optional_text(test_output),
             "worker_outcome": _optional_text(worker_outcome),
         }
         self.attempts.append(attempt)
-        self.retry_count = max(self.retry_count, len(self.attempts))
+        self.retry_count = max(self.retry_count + 1, len(self.attempts))
         self.touch()
         return dict(attempt)
 
@@ -196,15 +389,19 @@ class SessionState:
     def should_resume(self) -> bool:
         last = self.last_attempt()
         if last is not None:
-            if last.get("changed_files"):
+            if _attempt_changed_paths(last):
                 return True
             if _optional_text(last.get("test_output")):
+                return True
+            if _optional_text(last.get("failure_reason")):
+                return True
+            if _coerce_failing_verification(last.get("failing_verification")) is not None:
                 return True
             if _optional_text(last.get("worker_outcome")) not in {None, "completed"}:
                 return True
         return bool(self.repair_journal) or self.phase not in {"explore", "plan"}
 
-    def resume_context(self) -> str:
+    def resume_context(self, *, max_attempts: int = 3) -> str:
         if not self.should_resume():
             return ""
 
@@ -212,22 +409,44 @@ class SessionState:
         if self.resume_hint:
             lines.append(f"Resume hint: {self.resume_hint}")
 
-        if self.attempts:
+        recent_attempts = self.attempts[-max(1, int(max_attempts or 1)) :]
+        if recent_attempts:
             lines.append("Prior attempts:")
-            for index, attempt in enumerate(
-                self.attempts[-3:], start=max(1, len(self.attempts) - 2)
-            ):
+            start_index = len(self.attempts) - len(recent_attempts) + 1
+            for index, attempt in enumerate(recent_attempts, start=start_index):
                 summary: list[str] = []
-                exit_code = attempt.get("exit_code")
+                exit_code = _coerce_exit_code(attempt.get("exit_code"))
                 if exit_code is not None:
                     summary.append(f"exit={exit_code}")
                 worker_outcome = _optional_text(attempt.get("worker_outcome"))
                 if worker_outcome:
                     summary.append(worker_outcome)
-                changed = _coerce_path_list(attempt.get("changed_files"))
-                if changed:
-                    summary.append(f"changed={', '.join(changed[:5])}")
+                failure_reason = _optional_text(attempt.get("failure_reason"))
+                if failure_reason:
+                    summary.append(failure_reason)
+                changed_paths = _attempt_changed_paths(attempt)
+                if changed_paths:
+                    summary.append(f"changed={', '.join(changed_paths[:5])}")
                 lines.append(f"- Attempt {index}: {', '.join(summary) if summary else 'recorded'}")
+
+                failing_verification = _coerce_failing_verification(
+                    attempt.get("failing_verification")
+                )
+                if failing_verification is not None:
+                    command = _optional_text(failing_verification.get("command"))
+                    if command:
+                        exit_suffix = ""
+                        verification_exit = _coerce_exit_code(failing_verification.get("exit_code"))
+                        if verification_exit is not None:
+                            exit_suffix = f" (exit {verification_exit})"
+                        lines.append(f"  Failing verification: {command}{exit_suffix}")
+                    stderr_tail = _optional_text(failing_verification.get("stderr_tail"))
+                    if stderr_tail:
+                        lines.append(f"  Stderr: {stderr_tail[-240:]}")
+                    stdout_tail = _optional_text(failing_verification.get("stdout_tail"))
+                    if stdout_tail:
+                        lines.append(f"  Stdout: {stdout_tail[-240:]}")
+
                 test_output = _optional_text(attempt.get("test_output"))
                 if test_output:
                     lines.append(f"  Test output: {test_output[-240:]}")
@@ -236,6 +455,29 @@ class SessionState:
             lines.append(f"Repair journal entries available: {len(self.repair_journal)}")
 
         return "\n".join(lines).strip()
+
+    def resume_payload(self, *, max_attempts: int = 3) -> dict[str, Any]:
+        recent_attempts = [dict(item) for item in self.attempts[-max(1, int(max_attempts or 1)) :]]
+        repair_journal = recent_attempts or [
+            dict(item) for item in self.repair_journal[-max(1, int(max_attempts or 1)) :]
+        ]
+        context = {
+            "session_id": self.session_id,
+            "issue_number": self.issue_number,
+            "phase": self.phase,
+            "status": self.status,
+            "retry_count": self.retry_count,
+            "resume_hint": self.resume_hint,
+            "target_agent": self.target_agent,
+            "runner_type": self.runner_type,
+            "worktree_path": self.worktree_path,
+            "branch_name": self.branch_name,
+            "pr_url": self.pr_url,
+            "repair_journal": repair_journal,
+        }
+        if recent_attempts:
+            context["last_attempt"] = dict(recent_attempts[-1])
+        return {key: value for key, value in context.items() if value not in (None, [], {})}
 
     def set_blocker(self, evidence: str) -> None:
         self.blocker_evidence = _optional_text(evidence)
@@ -302,6 +544,56 @@ class SessionStateStore:
         )
         return items
 
+    def latest_for_issue(self, issue_number: int) -> SessionState | None:
+        sessions = self.list_sessions(issue_number=issue_number)
+        return sessions[0] if sessions else None
+
+    def record_attempt(
+        self,
+        *,
+        issue_number: int,
+        status: str,
+        outcome: str | None = None,
+        exit_code: int | None = None,
+        changed_files: list[str] | None = None,
+        target_agent: str | None = None,
+        runner_type: str | None = None,
+        worktree_path: str | None = None,
+        branch_name: str | None = None,
+        pr_url: str | None = None,
+        resume_hint: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        session_id: str | None = None,
+    ) -> SessionState:
+        issue_value = _coerce_issue_number(issue_number)
+        if issue_value is None:
+            raise ValueError("issue_number must be a positive integer")
+        state = (
+            self.load(session_id) if session_id is not None else None
+        ) or self.latest_for_issue(issue_value)
+        if state is None:
+            state = SessionState(
+                session_id=session_id or f"issue-{issue_value}",
+                issue_number=issue_value,
+                status="created",
+            )
+        state.issue_number = issue_value
+        state.record_attempt(
+            status=status,
+            outcome=outcome,
+            exit_code=exit_code,
+            changed_files=changed_files,
+            target_agent=target_agent,
+            runner_type=runner_type,
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            pr_url=pr_url,
+            resume_hint=resume_hint,
+            metadata=metadata,
+        )
+        self.save(state)
+        return state
+
     def cleanup_old(
         self,
         *,
@@ -331,8 +623,18 @@ def _attempt_evidence(state: SessionState) -> list[tuple[dict[str, Any], str]]:
     for attempt in reversed(state.attempts):
         text_parts = [
             str(attempt.get("worker_outcome") or "").strip(),
+            str(attempt.get("failure_reason") or "").strip(),
             str(attempt.get("test_output") or "").strip(),
         ]
+        failing_verification = _coerce_failing_verification(attempt.get("failing_verification"))
+        if failing_verification is not None:
+            text_parts.extend(
+                [
+                    str(failing_verification.get("command") or "").strip(),
+                    str(failing_verification.get("stderr_tail") or "").strip(),
+                    str(failing_verification.get("stdout_tail") or "").strip(),
+                ]
+            )
         combined = "\n".join(part for part in text_parts if part).strip()
         evidence.append((attempt, combined))
     if state.blocker_evidence:
@@ -355,7 +657,7 @@ def classify_session_blocker(state: SessionState) -> dict[str, str]:
     evidence_rows = _attempt_evidence(state)
     for attempt, text in evidence_rows:
         normalized = text.strip()
-        exit_code = attempt.get("exit_code")
+        exit_code = _coerce_exit_code(attempt.get("exit_code"))
         if exit_code in {-1, 124, 137} or _TIMEOUT_RE.search(normalized):
             blocker_type = "timeout"
         elif _IMPORT_ERROR_RE.search(normalized):
@@ -380,3 +682,47 @@ def classify_session_blocker(state: SessionState) -> dict[str, str]:
         "evidence": fallback,
         "suggested_action": _suggested_action("test_failure"),
     }
+
+
+def summarize_session_blocker(state: SessionState | None) -> str | None:
+    if state is None or state.issue_number is None:
+        return None
+    if not state.attempts:
+        return f"Issue #{state.issue_number} exhausted retries, but no persisted attempt journal is available."
+
+    last_attempt = state.attempts[-1]
+    failing_verification = _coerce_failing_verification(last_attempt.get("failing_verification"))
+    failure_reason = _optional_text(last_attempt.get("failure_reason")) or state.resume_hint
+    changed_paths = _attempt_changed_paths(last_attempt)
+    exit_code = _coerce_exit_code(last_attempt.get("exit_code"))
+    pr_url = _optional_text(last_attempt.get("pr_url")) or state.pr_url
+    worker_outcome = _optional_text(last_attempt.get("worker_outcome")) or state.status
+
+    if failing_verification is not None:
+        command = _optional_text(failing_verification.get("command")) or "verification command"
+        verification_exit = _coerce_exit_code(failing_verification.get("exit_code"))
+        suffix = f" (exit {verification_exit})" if verification_exit is not None else ""
+        return (
+            f"Issue #{state.issue_number} exhausted retries; last blocker was failing verification "
+            f"`{command}`{suffix}."
+        )
+    if pr_url is not None:
+        return (
+            f"Issue #{state.issue_number} exhausted retries; last attempt produced reviewable output "
+            f"at {pr_url} but still needs human follow-up."
+        )
+    if changed_paths and exit_code not in (None, 0):
+        return (
+            f"Issue #{state.issue_number} exhausted retries; last attempt changed "
+            f"{len(changed_paths)} file(s) but exited {exit_code}: "
+            f"{failure_reason or worker_outcome or 'worker failed'}."
+        )
+    if not changed_paths:
+        return (
+            f"Issue #{state.issue_number} exhausted retries; last attempt made no committed file changes"
+            + (f": {failure_reason}." if failure_reason else ".")
+        )
+    return (
+        f"Issue #{state.issue_number} exhausted retries; last recorded outcome was "
+        f"{worker_outcome or 'unknown'}" + (f": {failure_reason}." if failure_reason else ".")
+    )

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -50,6 +50,7 @@ from aragora.swarm.boss_loop import (
     sanitize_issue_body_for_dispatch,
     select_eligible_issue,
 )
+from aragora.swarm.session_state import SessionStateStore
 from aragora.swarm.task_sanitizer import SanitizationOutcome
 
 UTC = timezone.utc
@@ -3655,6 +3656,218 @@ async def test_dispatch_issue_preserves_issue_header_with_refined_prompt() -> No
     spec = mock_commander_cls.return_value.run_supervised_from_spec.await_args.args[0]
     assert spec.raw_goal.startswith("[Issue #1641] Wire prompt refiner env")
     assert "Use the refined goal only." in spec.raw_goal
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_injects_session_resume_context_into_work_order_metadata(
+    tmp_path: Path,
+) -> None:
+    issue = _make_issue(
+        1734,
+        "Reuse prior repair context",
+        body=(
+            "Summary:\n"
+            "- Retry the bounded boss-loop fix with the prior failure context.\n\n"
+            "Acceptance Criteria:\n"
+            "- pytest -q tests/swarm/test_boss_loop.py\n\n"
+            "Scope hints:\n"
+            "- aragora/swarm/boss_loop.py\n"
+        ),
+    )
+    store = SessionStateStore(state_dir=tmp_path)
+    store.record_attempt(
+        issue_number=1734,
+        status="needs_human",
+        outcome="blocked",
+        exit_code=1,
+        changed_files=["aragora/swarm/boss_loop.py"],
+        target_agent="codex",
+        runner_type="codex",
+        resume_hint="pytest -q tests/swarm/test_boss_loop.py failed",
+        metadata={
+            "failure_reason": "pytest -q tests/swarm/test_boss_loop.py failed",
+            "failing_verification": {
+                "command": "pytest -q tests/swarm/test_boss_loop.py",
+                "exit_code": 1,
+            },
+        },
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1), session_state_store=store)
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    fake_run = MagicMock()
+    fake_run.to_dict.return_value = {
+        "status": "completed",
+        "run_id": "run-1734",
+        "work_orders": [
+            {
+                "status": "completed",
+                "branch": "codex/reuse-prior-context",
+                "commit_shas": ["abc123"],
+            }
+        ],
+    }
+    micro_orders = [
+        {
+            "work_order_id": "work-1",
+            "title": "Retry the bounded boss-loop fix",
+            "description": "Use the prior verification failure as repair context.",
+            "file_scope": ["aragora/swarm/boss_loop.py"],
+            "expected_tests": ["pytest -q tests/swarm/test_boss_loop.py"],
+        }
+    ]
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(
+                return_value={
+                    "refined_prompt": "",
+                    "files_to_change": [],
+                    "test_patterns": [],
+                    "constraints": [],
+                    "context_gathered": False,
+                }
+            ),
+        ),
+        patch(
+            "aragora.swarm.micro_decomposer.build_micro_work_orders",
+            return_value=micro_orders,
+        ),
+        patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls,
+    ):
+        mock_commander_cls.return_value.run_supervised_from_spec = AsyncMock(return_value=fake_run)
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    spec = mock_commander_cls.return_value.run_supervised_from_spec.await_args.args[0]
+    metadata = spec.work_orders[0]["metadata"]
+
+    assert result["status"] == "completed"
+    assert metadata["resume_context"]["issue_number"] == 1734
+    assert metadata["resume_context"]["retry_count"] == 1
+    assert metadata["repair_journal"][0]["failing_verification"]["command"] == (
+        "pytest -q tests/swarm/test_boss_loop.py"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_records_session_state_after_dispatch(tmp_path: Path) -> None:
+    issue = _make_issue(
+        1735,
+        "Persist retry attempt",
+        body=(
+            "Summary:\n"
+            "- Persist the retry attempt after dispatch.\n\n"
+            "Acceptance Criteria:\n"
+            "- pytest -q tests/swarm/test_boss_loop.py\n\n"
+            "Scope hints:\n"
+            "- aragora/swarm/boss_loop.py\n"
+        ),
+    )
+    store = SessionStateStore(state_dir=tmp_path)
+    loop = BossLoop(config=_boss_config(max_iterations=1), session_state_store=store)
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (
+        {"runner_id": "codex-runner-1", "runner_type": "codex"},
+        "codex-runner-1",
+    )
+    loop._release_runner_claim = lambda runner_id: None
+
+    fake_result = {
+        "status": "needs_human",
+        "outcome": "blocked",
+        "reasons": ["Verification failed during pytest run."],
+        "run_id": "run-1735",
+        "receipt_id": "receipt-1735",
+        "run": {
+            "work_orders": [
+                {
+                    "status": "failed",
+                    "target_agent": "codex",
+                    "worktree_path": "/tmp/aragora-1735",
+                    "branch": "codex/issue-1735",
+                    "exit_code": 1,
+                    "changed_paths": ["aragora/swarm/boss_loop.py"],
+                    "verification_results": [
+                        {
+                            "command": "pytest -q tests/swarm/test_boss_loop.py",
+                            "exit_code": 1,
+                            "passed": False,
+                            "stderr_tail": "assert False",
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value=fake_result),
+        ),
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    state = store.latest_for_issue(issue.number)
+
+    assert result["status"] == "needs_human"
+    assert state is not None
+    assert state.retry_count == 1
+    assert state.target_agent == "codex"
+    assert state.branch_name == "codex/issue-1735"
+    assert state.attempts[-1]["exit_code"] == 1
+    assert state.attempts[-1]["changed_paths"] == ["aragora/swarm/boss_loop.py"]
+
+
+def test_maxed_issue_needs_human_includes_session_blocker_summary(tmp_path: Path) -> None:
+    issue = _make_issue(1736, "Exhausted repair loop")
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = [issue]
+    store = SessionStateStore(state_dir=tmp_path)
+    store.record_attempt(
+        issue_number=1736,
+        status="needs_human",
+        outcome="blocked",
+        exit_code=1,
+        changed_files=["aragora/swarm/boss_loop.py"],
+        resume_hint="Verification failed during pytest run.",
+        metadata={
+            "failure_reason": "Verification failed during pytest run.",
+            "failing_verification": {
+                "command": "pytest -q tests/swarm/test_boss_loop.py",
+                "exit_code": 1,
+            },
+        },
+    )
+
+    loop = BossLoop(
+        config=_boss_config(max_iterations=1, max_retries_per_issue=1),
+        issue_feed=feed,
+        freshness_checker=lambda **kw: (_ for _ in ()).throw(
+            AssertionError("freshness should not be checked for maxed issues")
+        ),
+        session_state_store=store,
+    )
+    loop._issue_attempt_counts[1736] = 1
+
+    result = asyncio.run(loop.run())
+
+    assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+    assert any(
+        "Issue #1736 exhausted retries; last blocker was failing verification" in reason
+        for reason in result.needs_human_reasons
+    )
+    assert any(
+        "pytest -q tests/swarm/test_boss_loop.py" in reason for reason in result.needs_human_reasons
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/swarm/test_session_state.py
+++ b/tests/swarm/test_session_state.py
@@ -8,6 +8,7 @@ from aragora.swarm.session_state import (
     SessionState,
     SessionStateStore,
     classify_session_blocker,
+    summarize_session_blocker,
 )
 
 
@@ -276,3 +277,143 @@ def test_classify_session_blocker_defaults_to_test_failure() -> None:
 
     assert result["blocker_type"] == "test_failure"
     assert "AssertionError" in result["evidence"]
+
+
+def test_session_state_record_attempt_builds_resume_payload() -> None:
+    state = SessionState(session_id="issue-8101", issue_number=8101)
+
+    state.record_attempt(
+        status="needs_human",
+        outcome="blocked",
+        exit_code=1,
+        changed_files=[
+            "aragora/swarm/boss_loop.py",
+            "aragora/swarm/boss_loop.py",
+            "tests/swarm/test_boss_loop.py",
+        ],
+        target_agent="codex",
+        runner_type="codex",
+        branch_name="codex/session2-boss-loop-state",
+        resume_hint="pytest -q tests/swarm/test_boss_loop.py failed",
+        metadata={
+            "failure_reason": "pytest -q tests/swarm/test_boss_loop.py failed",
+            "failing_verification": {
+                "command": "pytest -q tests/swarm/test_boss_loop.py",
+                "exit_code": 1,
+                "stderr_tail": "assert False",
+            },
+        },
+    )
+
+    context = state.resume_payload()
+
+    assert state.retry_count == 1
+    assert state.status == "needs_human"
+    assert context["resume_hint"] == "pytest -q tests/swarm/test_boss_loop.py failed"
+    assert context["target_agent"] == "codex"
+    assert context["repair_journal"][0]["changed_paths"] == [
+        "aragora/swarm/boss_loop.py",
+        "tests/swarm/test_boss_loop.py",
+    ]
+    assert context["last_attempt"]["failing_verification"]["command"] == (
+        "pytest -q tests/swarm/test_boss_loop.py"
+    )
+
+
+def test_session_state_store_latest_for_issue_returns_newest(tmp_path: Path) -> None:
+    store = SessionStateStore(state_dir=tmp_path)
+    older = SessionState(
+        session_id="older-issue",
+        issue_number=8102,
+        updated_at=_dt("2026-04-13T08:00:00+00:00"),
+    )
+    newer = SessionState(
+        session_id="newer-issue",
+        issue_number=8102,
+        updated_at=_dt("2026-04-13T09:00:00+00:00"),
+    )
+
+    store.save(older)
+    store.save(newer)
+
+    latest = store.latest_for_issue(8102)
+
+    assert latest is not None
+    assert latest.session_id == "newer-issue"
+
+
+def test_session_state_store_record_attempt_reuses_latest_issue_session(tmp_path: Path) -> None:
+    store = SessionStateStore(state_dir=tmp_path)
+    existing = SessionState(session_id="issue-8103", issue_number=8103, retry_count=1)
+    store.save(existing)
+
+    updated = store.record_attempt(
+        issue_number=8103,
+        status="needs_human",
+        outcome="blocked",
+        exit_code=1,
+        changed_files=["aragora/swarm/boss_loop.py"],
+        target_agent="codex",
+        runner_type="codex",
+        resume_hint="verification failed",
+        metadata={"failure_reason": "verification failed"},
+    )
+    reloaded = store.load("issue-8103")
+
+    assert updated.session_id == "issue-8103"
+    assert reloaded is not None
+    assert reloaded.retry_count == 2
+    assert reloaded.attempts[-1]["exit_code"] == 1
+    assert reloaded.attempts[-1]["changed_paths"] == ["aragora/swarm/boss_loop.py"]
+
+
+def test_summarize_session_blocker_prefers_failing_verification_summary() -> None:
+    state = SessionState(
+        session_id="issue-8104",
+        issue_number=8104,
+        retry_count=2,
+        attempts=[
+            {
+                "at": "2026-04-13T10:00:00+00:00",
+                "worker_outcome": "blocked",
+                "exit_code": 1,
+                "failure_reason": "pytest failed",
+                "failing_verification": {
+                    "command": "pytest -q tests/swarm/test_boss_loop.py",
+                    "exit_code": 1,
+                },
+            }
+        ],
+    )
+
+    summary = summarize_session_blocker(state)
+
+    assert summary == (
+        "Issue #8104 exhausted retries; last blocker was failing verification "
+        "`pytest -q tests/swarm/test_boss_loop.py` (exit 1)."
+    )
+
+
+def test_summarize_session_blocker_reports_no_committed_changes() -> None:
+    state = SessionState(
+        session_id="issue-8105",
+        issue_number=8105,
+        retry_count=2,
+        resume_hint="Worker exited cleanly with no deliverable",
+        attempts=[
+            {
+                "at": "2026-04-13T10:30:00+00:00",
+                "worker_outcome": "clean_exit_no_deliverable",
+                "exit_code": 0,
+                "failure_reason": "Worker exited cleanly with no deliverable",
+                "changed_paths": [],
+            }
+        ],
+    )
+
+    summary = summarize_session_blocker(state)
+
+    assert summary == (
+        "Issue #8105 exhausted retries; last attempt made no committed file changes: "
+        "Worker exited cleanly with no deliverable."
+    )


### PR DESCRIPTION
## Summary
- persist boss-loop session retry state across restarts
- extend session state storage and boss loop handling to reuse durable retry metadata
- add focused coverage for boss loop retry behavior and session state persistence

## Testing
- python3 -m pytest tests/swarm/test_boss_loop.py tests/swarm/test_session_state.py -q
- bash scripts/automation_pr_preflight.sh origin/main HEAD
