### PR TITLE
fix(ci): verify benchmark publication draft PR handoff

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: benchmark-truth-publication
@@ -325,7 +325,10 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           cat docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Commit and publish refreshed trust-loop surfaces branch
+      - name: Commit, publish, and verify draft PR for refreshed trust-loop surfaces
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -345,12 +348,75 @@ jobs:
 
           branch="benchmark-truth-publication/${GITHUB_RUN_ID}"
           title="docs(status): refresh recurring trust-loop surfaces"
+          body_file="$RUNNER_TEMP/benchmark-truth-publication-pr.md"
+
+          find_draft_pr() {
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --head "$branch" \
+              --json url,isDraft \
+              --jq '.[] | select(.isDraft == true) | .url' | head -n 1
+          }
+
+          cat > "$body_file" <<EOF
+          ## Summary
+
+          Automated refresh of recurring trust-loop benchmark and rescue status surfaces.
+
+          - updates benchmark truth artifacts and scorecards
+          - updates rescue productization outputs
+          - refreshes the rendered status pages
+
+          Source workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
 
           git checkout -b "$branch"
           git commit -m "${title}"
           git push origin "$branch"
+
+          pr_url=""
+          for _ in 1 2 3; do
+            pr_url="$(find_draft_pr)"
+            if [[ -n "$pr_url" ]]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [[ -z "$pr_url" ]]; then
+            set +e
+            create_output="$(
+              gh pr create \
+                --repo "$GITHUB_REPOSITORY" \
+                --draft \
+                --base main \
+                --head "$branch" \
+                --title "$title" \
+                --body-file "$body_file" 2>&1
+            )"
+            create_status=$?
+            set -e
+            if [[ $create_status -ne 0 ]]; then
+              echo "$create_output"
+            fi
+          fi
+
+          for _ in 1 2 3 4 5; do
+            pr_url="$(find_draft_pr)"
+            if [[ -n "$pr_url" ]]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [[ -z "$pr_url" ]]; then
+            echo "::error::Benchmark publication branch was pushed but no draft PR exists for $branch"
+            exit 1
+          fi
+
           {
             echo "Published automation branch: \`$branch\`"
             echo ""
-            echo "Auto PR Publisher will open the draft PR if repository policy allows it."
+            echo "Draft PR: $pr_url"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check_branch_mutation_policy.py
+++ b/scripts/check_branch_mutation_policy.py
@@ -148,14 +148,21 @@ def find_mutating_workflow_violations(workflows: dict[str, str]) -> list[Violati
                         message="must not push directly to main",
                     )
                 )
-            if "gh pr create" in text:
+            if "gh pr create" not in text:
                 violations.append(
                     Violation(
                         path=f".github/workflows/{name}",
                         message=(
-                            "must delegate pull request creation to Auto PR Publisher "
-                            "instead of invoking gh pr create"
+                            "must create a draft pull request in-band for "
+                            "benchmark-truth-publication/* branches"
                         ),
+                    )
+                )
+            elif "--draft" not in text:
+                violations.append(
+                    Violation(
+                        path=f".github/workflows/{name}",
+                        message="must create the benchmark publication pull request as a draft",
                     )
                 )
     return violations

--- a/tests/cli/test_agt_commands.py
+++ b/tests/cli/test_agt_commands.py
@@ -58,7 +58,7 @@ class TestMetricsViah:
         # ``datetime.now(UTC)`` internally). Previously this test pinned
         # ``now`` to a fixed date, causing it to break after that date
         # fell outside the 24h window.
-        now = datetime.now(tz=UTC)
+        now = datetime.now(tz=UTC).replace(microsecond=0)
         _seed_ledger(
             ledger_path,
             [

--- a/tests/scripts/test_benchmark_truth_publication_workflow.py
+++ b/tests/scripts/test_benchmark_truth_publication_workflow.py
@@ -157,25 +157,34 @@ def test_runs_daily_and_manual_dispatch() -> None:
     assert schedule == [{"cron": "20 13 * * *"}]
 
 
-def test_publishes_refresh_via_branch_only_and_delegates_pr_creation() -> None:
+def test_publishes_refresh_via_branch_and_verifies_draft_pr() -> None:
     workflow = _benchmark_truth_publication_workflow()
     permissions = workflow.get("permissions")
     assert permissions == {
         "contents": "write",
         "issues": "write",
-        "pull-requests": "read",
+        "pull-requests": "write",
     }
 
     publish_run = str(_workflow_step("Publish tracked trust-loop surfaces").get("run", ""))
     run = str(
-        _workflow_step("Commit and publish refreshed trust-loop surfaces branch").get("run", "")
+        _workflow_step(
+            "Commit, publish, and verify draft PR for refreshed trust-loop surfaces"
+        ).get("run", "")
     )
     assert "--freshness-map docs/benchmarks/benchmark_corpus_freshness.json \\" in publish_run
     assert "--ensure-issues \\" in publish_run
     assert 'branch="benchmark-truth-publication/${GITHUB_RUN_ID}"' in run
+    assert 'body_file="$RUNNER_TEMP/benchmark-truth-publication-pr.md"' in run
     assert 'git checkout -b "$branch"' in run
     assert 'git push origin "$branch"' in run
     assert 'git commit -m "${title}"' in run
+    assert "gh pr list \\" in run
+    assert "--json url,isDraft \\" in run
+    assert "select(.isDraft == true)" in run
+    assert "gh pr create \\" in run
+    assert "--draft \\" in run
+    assert "Benchmark publication branch was pushed but no draft PR exists" in run
+    assert 'echo "Draft PR: $pr_url"' in run
     assert "[skip ci]" not in run
-    assert "gh pr create" not in run
     assert "git push origin HEAD:main" not in run

--- a/tests/scripts/test_check_branch_mutation_policy.py
+++ b/tests/scripts/test_check_branch_mutation_policy.py
@@ -46,7 +46,6 @@ def test_find_mutating_workflow_violations_requires_safe_benchmark_truth_publica
             "jobs:\n  x:\n    steps:\n      - run: |\n"
             '          branch="unsafe/tmp"\n'
             '          git push origin "$branch"\n'
-            '          gh pr create --base main --head "$branch"\n'
         ),
     }
     violations = find_mutating_workflow_violations(workflows)
@@ -58,8 +57,24 @@ def test_find_mutating_workflow_violations_requires_safe_benchmark_truth_publica
         "must push only to benchmark-truth-publication/* branch namespace" in v.message
         for v in violations
     )
+    assert any("must create a draft pull request in-band" in v.message for v in violations)
+
+
+def test_find_mutating_workflow_violations_requires_draft_benchmark_publication_pr() -> None:
+    workflows = {
+        "benchmark-truth-publication.yml": (
+            "on:\n  workflow_dispatch:\n"
+            "jobs:\n  x:\n    steps:\n      - run: |\n"
+            '          branch="benchmark-truth-publication/123"\n'
+            '          git push origin "$branch"\n'
+            '          gh pr create --base main --head "$branch"\n'
+        ),
+    }
+    violations = find_mutating_workflow_violations(workflows)
+    assert violations
     assert any(
-        "must delegate pull request creation to Auto PR Publisher" in v.message for v in violations
+        "must create the benchmark publication pull request as a draft" in v.message
+        for v in violations
     )
 
 


### PR DESCRIPTION
## Source
- #6059 Publish pending benchmark truth branch

## Summary
- make the benchmark publication workflow create or verify a draft PR in-band after pushing `benchmark-truth-publication/${GITHUB_RUN_ID}`
- surface the resulting draft PR URL in the workflow summary instead of relying on an unverified downstream push trigger
- update the branch-mutation policy and focused workflow-contract tests to require in-band draft PR creation

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_check_branch_mutation_policy.py tests/scripts/test_auto_pr_publisher_workflow.py -p no:rerunfailures -p no:cacheprovider` -> `20 passed in 0.79s`
- `python3 -m ruff check scripts/check_branch_mutation_policy.py tests/scripts/test_benchmark_truth_publication_workflow.py tests/scripts/test_check_branch_mutation_policy.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Skipped
- no live GitHub Actions rerun from this sandbox, so end-to-end confirmation still depends on the next benchmark publication execution

## Risks / Assumptions
- benchmark publication should now fail closed if its branch push succeeds but no draft PR exists afterward
- Auto PR Publisher remains enabled for benchmark branches, so a concurrent publisher-created draft PR is treated as success rather than failure
