### PR TITLE
Report observer checkout health in proof-first status surfaces

### DIFF
--- a/aragora/cli/commands/shift_status.py
+++ b/aragora/cli/commands/shift_status.py
@@ -60,6 +60,19 @@ def render_shift_status(payload: dict[str, Any]) -> str:
                 reason=failure_policy.get("reason") or "-",
             )
         )
+    observer_bits: list[str] = []
+    if payload.get("observer_branch"):
+        observer_bits.append(f"branch={payload.get('observer_branch')}")
+    if payload.get("observer_has_uncommitted_changes") is not None:
+        observer_bits.append(f"dirty={payload.get('observer_has_uncommitted_changes')}")
+    if payload.get("observer_behind_origin_main") is not None:
+        observer_bits.append(f"behind_origin_main={payload.get('observer_behind_origin_main')}")
+    if payload.get("observer_ahead_of_origin_main") is not None:
+        observer_bits.append(f"ahead_of_origin_main={payload.get('observer_ahead_of_origin_main')}")
+    if observer_bits:
+        lines.append("observer=" + " ".join(observer_bits))
+    if payload.get("observer_warning"):
+        lines.append(f"observer_warning={payload.get('observer_warning')}")
     return "\n".join(lines)
 
 

--- a/aragora/swarm/live_shift_status.py
+++ b/aragora/swarm/live_shift_status.py
@@ -20,16 +20,24 @@ def _has_repo_metadata(repo_root: Path) -> bool:
     return (repo_root / ".git").exists()
 
 
-def _infer_repo_name(repo_root: Path) -> str | None:
+def _run_git_command(
+    repo_root: Path, *args: str, timeout: int = 5
+) -> subprocess.CompletedProcess[str] | None:
     try:
-        proc = subprocess.run(
-            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+        return subprocess.run(
+            ["git", "-C", str(repo_root), *args],
             text=True,
             capture_output=True,
-            timeout=5,
+            timeout=timeout,
             check=False,
         )
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def _infer_repo_name(repo_root: Path) -> str | None:
+    proc = _run_git_command(repo_root, "remote", "get-url", "origin")
+    if proc is None:
         return None
     remote = (proc.stdout or "").strip()
     if remote.startswith("git@github.com:"):
@@ -135,6 +143,69 @@ def _count_live_open_prs(repo_root: Path, *, repo_name: str | None) -> int | Non
     return len(payload) if isinstance(payload, list) else None
 
 
+def _detect_observer_state(repo_root: Path) -> dict[str, Any]:
+    if not _has_repo_metadata(repo_root):
+        return {}
+    payload: dict[str, Any] = {}
+    branch_proc = _run_git_command(repo_root, "rev-parse", "--abbrev-ref", "HEAD")
+    head_proc = _run_git_command(repo_root, "rev-parse", "HEAD")
+    origin_main_proc = _run_git_command(repo_root, "rev-parse", "origin/main")
+    rev_list_proc = _run_git_command(
+        repo_root, "rev-list", "--left-right", "--count", "origin/main...HEAD"
+    )
+    status_proc = _run_git_command(repo_root, "status", "--short")
+
+    branch = (
+        (branch_proc.stdout or "").strip() if branch_proc and branch_proc.returncode == 0 else ""
+    )
+    if branch:
+        payload["observer_branch"] = branch
+
+    head = (head_proc.stdout or "").strip() if head_proc and head_proc.returncode == 0 else ""
+    if head:
+        payload["observer_head"] = head
+
+    origin_main = (
+        (origin_main_proc.stdout or "").strip()
+        if origin_main_proc and origin_main_proc.returncode == 0
+        else ""
+    )
+    if origin_main:
+        payload["observer_origin_main_head"] = origin_main
+
+    if rev_list_proc and rev_list_proc.returncode == 0:
+        counts = (rev_list_proc.stdout or "").strip().split()
+        if len(counts) == 2:
+            behind_count: int | None
+            ahead_count: int | None
+            try:
+                behind_count = int(counts[0])
+                ahead_count = int(counts[1])
+            except ValueError:
+                behind_count = ahead_count = None
+            else:
+                payload["observer_behind_origin_main"] = behind_count
+                payload["observer_ahead_of_origin_main"] = ahead_count
+
+    has_uncommitted_changes = bool((status_proc.stdout or "").strip()) if status_proc else None
+    if has_uncommitted_changes is not None:
+        payload["observer_has_uncommitted_changes"] = has_uncommitted_changes
+
+    warning_parts: list[str] = []
+    if payload.get("observer_has_uncommitted_changes"):
+        warning_parts.append("dirty checkout")
+    payload_behind = payload.get("observer_behind_origin_main")
+    if isinstance(payload_behind, int) and payload_behind > 0:
+        warning_parts.append(f"{payload_behind} behind origin/main")
+    payload_ahead = payload.get("observer_ahead_of_origin_main")
+    if isinstance(payload_ahead, int) and payload_ahead > 0:
+        warning_parts.append(f"{payload_ahead} ahead of origin/main")
+    if warning_parts:
+        payload["observer_warning"] = "observer checkout is " + ", ".join(warning_parts)
+
+    return payload
+
+
 def _load_live_shift_truth(repo_root: Path) -> dict[str, Any]:
     if not _has_repo_metadata(repo_root):
         return {}
@@ -152,6 +223,7 @@ def _load_live_shift_truth(repo_root: Path) -> dict[str, Any]:
     open_prs = _count_live_open_prs(repo_root, repo_name=repo_name)
     if open_prs is not None:
         live_truth["current_open_prs"] = open_prs
+    live_truth.update(_detect_observer_state(repo_root))
     return live_truth
 
 

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -54,6 +54,15 @@ If a roadmap item does not strengthen one or more of those layers, it is probabl
 
 **Current focus:** move from early `Teammate` behavior to reliable `Foreman` behavior without losing the broader thesis.
 
+## 60-Day Operating Focus
+
+The full eight-pillar thesis stays canonical. The active operating focus for the next 60 days is intentionally narrower:
+
+1. **Reliable Autonomous Execution** must become boringly trustworthy on bounded backlogs.
+2. **Cryptographic Receipts and Auditability** must make the operator proof surfaces, benchmark publication, and runtime truth legible enough that external claims can be kept narrower than measured proof.
+
+All other pillars remain planning truth unless a change directly improves one of those two active focus areas. This is a sequencing rule, not a retreat from the broader roadmap.
+
 ## Eight Foundational Pillars
 
 ### 1. Adversarial Heterogeneous Consensus

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-04-16
+Last updated: 2026-04-18
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -11,6 +11,8 @@ This is the single source of truth for short-horizon execution priorities.
 ## Current Gate
 
 The immediate gate is keeping recurring benchmark truth publication complete, fresh, and trustworthy on current `main`, then keeping `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
+
+Operator commands only count as proof when they are run from a clean, current `origin/main` observer. A dirty or diverged founder checkout is planning context, not runtime truth.
 
 What is already true:
 
@@ -43,6 +45,7 @@ What is already true:
 
 What is still missing:
 
+- proof that operator status surfaces remain truthful when observed from a clean current-`main` checkout instead of a dirty founder checkout
 - proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
 - proof that recurring benchmark publication stays complete and fresh on `main` without operator babysitting
 - broader repair-loop coverage on top of the existing audit trail
@@ -56,6 +59,12 @@ Queue rule for this tranche:
 
 - only roadmap codes in the **Do now** set may carry or be auto-created with `boss-ready`
 - delayed-track issues may stay open for planning truth, but restock and auto-decomposition should strip them from the live dispatch queue
+
+Observer rule for this tranche:
+
+- run `swarm shift-status`, `swarm status`, benchmark publication, and operator proofs from a clean worktree reconciled to current `origin/main`
+- treat a dirty or diverged root checkout as non-authoritative for runtime truth, even when it is useful for local founder notes or in-flight security work
+- if the observer reports itself as dirty, ahead, or behind, fix the observer before widening roadmap scope or restocking the live queue
 
 ## 30-Day Success Metric
 
@@ -123,12 +132,15 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 | Order | Code | Why it matters to the wedge | Acceptance criteria | Proof metric | Layer | GitHub coverage |
 |---|---|---|---|---|---|---|
 | 1 | `CS-01..03` | The wedge fails commercially if external claims outrun measured proof. | Roadmap, status, and positioning docs keep the wedge-first story and gate claims on measured proof. | External-facing docs stay narrower than current truth metrics and current gate status. | trust | Epics #804 and #806 are closed; enforcement is now via proof-first queue governance and recurring publication surfaces. |
+| 2 | Observer truth | Runtime truth is not credible if it is read from a dirty or stale checkout. | `swarm shift-status` and sibling operator surfaces report whether the observer itself is dirty, ahead, or behind `origin/main`. | Operators can distinguish product regressions from bad observer state without shell forensics. | trust | Implement on live status surfaces before widening proof-first queue scope. |
 
 ## Do Now / Delay / Avoid
 
 ### Do now
 
 - `CS-01..03`
+- observer truth on current `main`
+- benchmark publication freshness and completeness
 
 ### Delay
 
@@ -154,6 +166,7 @@ This is the executable backlog for the next 30 days. Keep it to one bounded lane
 - There is no dedicated open boss-ready trust-loop issue right now.
 - Keep the live queue empty unless the recurring `TW-01/TW-02/TW-03` publication surfaces expose a fresh repeated rescue class or a concrete regression.
 - Keep `CS-01..03` enforced through the docs/status surfaces while the live queue remains empty.
+- Do not restock queue work to compensate for stale or dirty observer surfaces; fix the observer and the publication path first.
 
 `TW-01` ([#5539](https://github.com/synaptent/aragora/issues/5539)), `TW-02` ([#5540](https://github.com/synaptent/aragora/issues/5540)), and `TW-03` ([#5330](https://github.com/synaptent/aragora/issues/5330)) now publish through repo-tracked recurring status surfaces at `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`. `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; do not recycle them as active blockers unless new evidence shows a concrete regression.
 

--- a/tests/cli/test_shift_status.py
+++ b/tests/cli/test_shift_status.py
@@ -89,6 +89,16 @@ def test_load_shift_status_reconciles_live_truth_when_repo_available(tmp_path: P
             "aragora.swarm.live_shift_status._count_live_open_prs",
             return_value=9,
         ),
+        patch(
+            "aragora.swarm.live_shift_status._detect_observer_state",
+            return_value={
+                "observer_branch": "main",
+                "observer_has_uncommitted_changes": True,
+                "observer_behind_origin_main": 54,
+                "observer_ahead_of_origin_main": 1,
+                "observer_warning": "observer checkout is dirty checkout, 54 behind origin/main, 1 ahead of origin/main",
+            },
+        ),
     ):
         payload = load_shift_status(tmp_path, max_age_hours=48.0)
 
@@ -96,6 +106,11 @@ def test_load_shift_status_reconciles_live_truth_when_repo_available(tmp_path: P
     assert payload["current_open_prs"] == 9
     assert payload["current_boss_running"] is True
     assert payload["current_merge_running"] is False
+    assert payload["observer_branch"] == "main"
+    assert payload["observer_has_uncommitted_changes"] is True
+    assert payload["observer_behind_origin_main"] == 54
+    assert payload["observer_ahead_of_origin_main"] == 1
+    assert "observer checkout is dirty checkout" in payload["observer_warning"]
     assert payload["prs_merged"] == 1
 
 
@@ -178,6 +193,15 @@ def test_load_shift_status_reports_missing_ledger_without_creating_it(tmp_path: 
 def test_render_shift_status_includes_operator_summary(tmp_path: Path) -> None:
     _seed_shift_ledger(tmp_path)
     payload = load_shift_status(tmp_path, max_age_hours=48.0)
+    payload.update(
+        {
+            "observer_branch": "codex/observer-truth-governance",
+            "observer_has_uncommitted_changes": True,
+            "observer_behind_origin_main": 54,
+            "observer_ahead_of_origin_main": 1,
+            "observer_warning": "observer checkout is dirty checkout, 54 behind origin/main, 1 ahead of origin/main",
+        }
+    )
 
     text = render_shift_status(payload)
 
@@ -189,6 +213,14 @@ def test_render_shift_status_includes_operator_summary(tmp_path: Path) -> None:
     assert "benchmark_fresh=True" in text
     assert "merged_prs=1" in text
     assert "last_stop=completed" in text
+    assert (
+        "observer=branch=codex/observer-truth-governance dirty=True behind_origin_main=54 ahead_of_origin_main=1"
+        in text
+    )
+    assert (
+        "observer_warning=observer checkout is dirty checkout, 54 behind origin/main, 1 ahead of origin/main"
+        in text
+    )
 
 
 def test_cmd_shift_status_json_prints_ledger_summary(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add observer checkout health metadata to the shared proof-first status loader
- render observer dirty/ahead/behind warnings in `swarm shift-status`
- tighten canonical docs around clean observers and the narrower proof-first operating focus

## Testing
- python3 -m pytest tests/cli/test_shift_status.py -q
- python3 -m ruff check aragora/swarm/live_shift_status.py aragora/cli/commands/shift_status.py tests/cli/test_shift_status.py
- python3 scripts/check_docs_consistency.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 -m aragora.cli.main swarm shift-status --json