### PR TITLE
feat: autonomous follow-ups v1 — stage-gate auto-remediation, queue autofill, TW-01 filter (all flagged off)

### DIFF
--- a/aragora/stage_gate/__init__.py
+++ b/aragora/stage_gate/__init__.py
@@ -1,0 +1,29 @@
+"""Stage-Gate Conductor support modules.
+
+The Stage-Gate Conductor runs as a scheduled trigger that watches roadmap
+tiers, proof surfaces, and queue labels for drift.  When it detects drift it
+creates a ``stage-gate-drift`` labeled GitHub issue.
+
+This sub-package contains post-detection helpers that operate on those drift
+issues.  ``auto_remediation`` dispatches a small, conservative repair for
+recognised drift patterns so a human does not have to pick up every drift
+ticket by hand.
+"""
+
+from __future__ import annotations
+
+from aragora.stage_gate.auto_remediation import (
+    AUTO_REMEDIATION_FLAG_ENV,
+    RemediationAction,
+    RemediationResult,
+    auto_remediation_enabled,
+    remediate_drift,
+)
+
+__all__ = [
+    "AUTO_REMEDIATION_FLAG_ENV",
+    "RemediationAction",
+    "RemediationResult",
+    "auto_remediation_enabled",
+    "remediate_drift",
+]

--- a/aragora/stage_gate/auto_remediation.py
+++ b/aragora/stage_gate/auto_remediation.py
@@ -1,0 +1,478 @@
+"""Autonomous remediation for Stage-Gate Conductor drift issues.
+
+The Stage-Gate Conductor writes a ``stage-gate-drift`` labeled issue when it
+detects a known drift pattern (boss-ready applied to a deferred track,
+duplicated epics, or stale benchmark truth).  Today a human has to pick up
+that issue and decide what to do.
+
+This module extends the flow by offering a small, deterministic dispatcher:
+if the drift pattern matches one of the recognised remediations, a targeted
+repair is attempted.  Everything else no-ops, leaving the human-owned issue
+untouched.
+
+Design goals
+------------
+* **Conservative by default** — if the drift type is unknown, the evidence is
+  thin, or the feature flag is disabled, the dispatcher logs and returns a
+  ``noop`` result.
+* **Flag gated** — the behaviour is off unless
+  :data:`AUTO_REMEDIATION_FLAG_ENV` (``ARAGORA_STAGE_GATE_AUTO_REMEDIATION``)
+  is set to a truthy value in the environment.
+* **Dependency injected** — the remediation functions do not talk to GitHub
+  directly; callers provide a small action interface so tests can exercise
+  each pattern without network I/O.
+* **Auditable** — every invocation returns a :class:`RemediationResult` with
+  the pattern name, actions taken, and a human-readable reason.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+AUTO_REMEDIATION_FLAG_ENV = "ARAGORA_STAGE_GATE_AUTO_REMEDIATION"
+
+_TRUTHY_VALUES = frozenset({"1", "true", "t", "yes", "y", "on"})
+
+KNOWN_DRIFT_TYPES: frozenset[str] = frozenset(
+    {
+        "boss_ready_on_deferred_track",
+        "duplicate_epic",
+        "doc_staleness",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Result / action data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RemediationAction:
+    """One concrete action recorded during a remediation attempt."""
+
+    kind: str
+    target: str
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind, "target": self.target, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class RemediationResult:
+    """Outcome of a remediation dispatch."""
+
+    applied: bool
+    drift_type: str
+    pattern: str
+    reason: str
+    actions: tuple[RemediationAction, ...] = ()
+    evidence_keys: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "applied": self.applied,
+            "drift_type": self.drift_type,
+            "pattern": self.pattern,
+            "reason": self.reason,
+            "actions": [action.to_dict() for action in self.actions],
+            "evidence_keys": list(self.evidence_keys),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Action protocol
+# ---------------------------------------------------------------------------
+
+
+class RemediationActions(Protocol):
+    """Thin interface around GitHub / CI side-effects.
+
+    The concrete implementation is provided by the Conductor's GitHub app
+    adapter.  Tests pass a stub that records calls.  Every method returns a
+    boolean that the dispatcher surfaces via the audit log; a method returning
+    ``False`` is treated as a skip, not a hard error.
+    """
+
+    def remove_label(self, issue_number: int, label: str) -> bool: ...
+
+    def post_comment(self, issue_number: int, body: str) -> bool: ...
+
+    def trigger_workflow(self, workflow: str, *, ref: str | None = None) -> bool: ...
+
+
+# ---------------------------------------------------------------------------
+# Feature flag helper
+# ---------------------------------------------------------------------------
+
+
+def auto_remediation_enabled(
+    env: dict[str, str] | None = None,
+    *,
+    flag: str = AUTO_REMEDIATION_FLAG_ENV,
+) -> bool:
+    """Return ``True`` when the feature flag is truthy."""
+    source = env if env is not None else os.environ
+    value = str(source.get(flag, "")).strip().lower()
+    return value in _TRUTHY_VALUES
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+def remediate_drift(
+    drift_type: str,
+    evidence: dict[str, Any],
+    *,
+    actions: RemediationActions | None = None,
+    env: dict[str, str] | None = None,
+) -> RemediationResult:
+    """Dispatch a remediation for ``drift_type`` if the pattern is recognised.
+
+    Parameters
+    ----------
+    drift_type:
+        Canonical drift label emitted by the Stage-Gate Conductor.  See
+        :data:`KNOWN_DRIFT_TYPES` for the recognised values.
+    evidence:
+        Structured payload describing the drift.  The required keys depend on
+        the remediation; missing keys trigger a ``noop`` result.
+    actions:
+        Concrete action interface.  When ``None`` the dispatcher returns a
+        ``noop`` result — useful when the caller only wants to know whether a
+        remediation *would* be attempted.
+    env:
+        Optional environment override used for the feature flag check.  When
+        ``None`` the process environment is consulted.
+    """
+    normalized = str(drift_type or "").strip().lower()
+    if not normalized:
+        return _noop(drift_type, "missing_drift_type", "no drift_type provided")
+
+    if not auto_remediation_enabled(env):
+        return _noop(
+            drift_type,
+            "flag_disabled",
+            f"auto-remediation disabled (set {AUTO_REMEDIATION_FLAG_ENV}=1 to enable)",
+            evidence=evidence,
+        )
+
+    if normalized not in KNOWN_DRIFT_TYPES:
+        return _noop(
+            drift_type,
+            "unrecognised_drift",
+            f"no remediation registered for drift_type={drift_type!r}",
+            evidence=evidence,
+        )
+
+    if actions is None:
+        return _noop(
+            drift_type,
+            "no_actions_adapter",
+            "remediation recognised but no actions adapter was provided",
+            evidence=evidence,
+        )
+
+    if normalized == "boss_ready_on_deferred_track":
+        return _remediate_boss_ready_deferred(evidence, actions)
+    if normalized == "duplicate_epic":
+        return _remediate_duplicate_epic(evidence, actions)
+    if normalized == "doc_staleness":
+        return _remediate_doc_staleness(evidence, actions)
+
+    # Defensive fall-through; should not happen because of the KNOWN_DRIFT_TYPES check.
+    return _noop(drift_type, "unhandled_pattern", "pattern matched but no handler ran")
+
+
+# ---------------------------------------------------------------------------
+# Individual remediations
+# ---------------------------------------------------------------------------
+
+
+def _remediate_boss_ready_deferred(
+    evidence: dict[str, Any],
+    actions: RemediationActions,
+) -> RemediationResult:
+    """Strip ``boss-ready`` from an issue carrying a deferred-track label.
+
+    Required evidence
+    -----------------
+    ``issue_number``:
+        Integer number of the drift-bearing issue.
+    ``track``:
+        Name of the deferred track (for the comment text).
+    ``deferred_label`` *(optional)*:
+        The specific deferred-track label detected; used in the comment.
+    """
+    issue_number = _coerce_int(evidence.get("issue_number"))
+    track = _coerce_text(evidence.get("track") or evidence.get("deferred_label"))
+    if issue_number is None or not track:
+        return _noop(
+            "boss_ready_on_deferred_track",
+            "thin_evidence",
+            "expected issue_number and track in evidence",
+            evidence=evidence,
+        )
+
+    applied_actions: list[RemediationAction] = []
+    comment = (
+        f"Stage-Gate auto-remediation: removed `boss-ready` because this issue is "
+        f"tracked on the deferred `{track}` lane. The substrate gate for that lane "
+        "has not opened yet. Re-add `boss-ready` only after the gate opens."
+    )
+
+    removed = _safely(lambda: actions.remove_label(issue_number, "boss-ready"))
+    if removed:
+        applied_actions.append(
+            RemediationAction(
+                kind="remove_label",
+                target=f"issue#{issue_number}",
+                detail="boss-ready",
+            )
+        )
+
+    commented = _safely(lambda: actions.post_comment(issue_number, comment))
+    if commented:
+        applied_actions.append(
+            RemediationAction(
+                kind="post_comment",
+                target=f"issue#{issue_number}",
+                detail=f"deferred_track={track}",
+            )
+        )
+
+    if not applied_actions:
+        return _noop(
+            "boss_ready_on_deferred_track",
+            "no_actions_taken",
+            "actions adapter rejected all calls",
+            evidence=evidence,
+        )
+
+    return RemediationResult(
+        applied=True,
+        drift_type="boss_ready_on_deferred_track",
+        pattern="strip_boss_ready_and_comment",
+        reason=f"stripped boss-ready from deferred track {track}",
+        actions=tuple(applied_actions),
+        evidence_keys=_evidence_keys(evidence),
+    )
+
+
+def _remediate_duplicate_epic(
+    evidence: dict[str, Any],
+    actions: RemediationActions,
+) -> RemediationResult:
+    """Comment on both epics linking each other; flag for human merge decision.
+
+    Required evidence
+    -----------------
+    ``epic_numbers``:
+        Iterable of exactly two integer issue numbers that are duplicates of
+        each other.  Anything other than a pair is treated as thin evidence.
+    """
+    raw = evidence.get("epic_numbers") or evidence.get("issue_numbers")
+    numbers = _coerce_int_sequence(raw, length=2)
+    if numbers is None:
+        return _noop(
+            "duplicate_epic",
+            "thin_evidence",
+            "expected epic_numbers to be a pair of issue numbers",
+            evidence=evidence,
+        )
+
+    first, second = numbers
+    applied_actions: list[RemediationAction] = []
+
+    for issue_number, sibling in ((first, second), (second, first)):
+        body = (
+            f"Stage-Gate auto-remediation: potential duplicate of #{sibling}. "
+            "Both epics appear to track the same goal. A human must decide which "
+            "to keep and which to close — not auto-merging."
+        )
+
+        def _post(n: int = issue_number, b: str = body) -> bool:
+            return actions.post_comment(n, b)
+
+        if _safely(_post):
+            applied_actions.append(
+                RemediationAction(
+                    kind="post_comment",
+                    target=f"issue#{issue_number}",
+                    detail=f"links=#{sibling}",
+                )
+            )
+
+    if not applied_actions:
+        return _noop(
+            "duplicate_epic",
+            "no_actions_taken",
+            "actions adapter rejected all comment calls",
+            evidence=evidence,
+        )
+
+    return RemediationResult(
+        applied=True,
+        drift_type="duplicate_epic",
+        pattern="cross_link_and_flag",
+        reason=f"cross-linked duplicate epics #{first} and #{second} for human review",
+        actions=tuple(applied_actions),
+        evidence_keys=_evidence_keys(evidence),
+    )
+
+
+def _remediate_doc_staleness(
+    evidence: dict[str, Any],
+    actions: RemediationActions,
+) -> RemediationResult:
+    """Rerun the benchmark/doc publication workflow to refresh truth surfaces.
+
+    Required evidence
+    -----------------
+    ``workflow`` *(optional)*:
+        Workflow identifier (name or path).  Defaults to
+        ``benchmark-publication``.
+    ``ref`` *(optional)*:
+        Git ref to run against.  Passed through to the workflow trigger;
+        defaults to ``None`` so the underlying adapter can pick the sensible
+        default (typically ``main``).
+    ``issue_number`` *(optional)*:
+        When provided, a comment is posted on the drift issue recording the
+        workflow trigger so humans can audit it.
+    """
+    workflow = _coerce_text(evidence.get("workflow")) or "benchmark-publication"
+    ref = _coerce_text(evidence.get("ref")) or None
+    issue_number = _coerce_int(evidence.get("issue_number"))
+
+    applied_actions: list[RemediationAction] = []
+    triggered = _safely(lambda: actions.trigger_workflow(workflow, ref=ref))
+    if triggered:
+        applied_actions.append(
+            RemediationAction(
+                kind="trigger_workflow",
+                target=workflow,
+                detail=f"ref={ref or 'default'}",
+            )
+        )
+
+    if issue_number is not None:
+        body = (
+            "Stage-Gate auto-remediation: re-triggered the "
+            f"`{workflow}` workflow to refresh stale benchmark truth "
+            f"(ref={ref or 'default'})."
+        )
+        if _safely(lambda: actions.post_comment(issue_number, body)):
+            applied_actions.append(
+                RemediationAction(
+                    kind="post_comment",
+                    target=f"issue#{issue_number}",
+                    detail=f"workflow={workflow}",
+                )
+            )
+
+    if not applied_actions:
+        return _noop(
+            "doc_staleness",
+            "no_actions_taken",
+            "workflow trigger failed and no comment was posted",
+            evidence=evidence,
+        )
+
+    return RemediationResult(
+        applied=True,
+        drift_type="doc_staleness",
+        pattern="rerun_publication_workflow",
+        reason=f"triggered workflow {workflow!r} to refresh benchmark truth",
+        actions=tuple(applied_actions),
+        evidence_keys=_evidence_keys(evidence),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _safely(call: Callable[[], bool]) -> bool:
+    """Swallow adapter exceptions so one broken call does not crash the run."""
+    try:
+        return bool(call())
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        logger.warning("stage_gate auto-remediation action raised: %s", exc)
+        return False
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
+def _coerce_text(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _coerce_int_sequence(value: Any, *, length: int) -> tuple[int, ...] | None:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Iterable):
+        return None
+    numbers: list[int] = []
+    for item in value:
+        coerced = _coerce_int(item)
+        if coerced is None:
+            return None
+        numbers.append(coerced)
+    if len(numbers) != length:
+        return None
+    return tuple(numbers)
+
+
+def _evidence_keys(evidence: dict[str, Any]) -> tuple[str, ...]:
+    return tuple(sorted(str(key) for key in evidence or {}))
+
+
+def _noop(
+    drift_type: str,
+    pattern: str,
+    reason: str,
+    *,
+    evidence: dict[str, Any] | None = None,
+) -> RemediationResult:
+    logger.info(
+        "stage_gate auto-remediation noop: drift=%s pattern=%s reason=%s",
+        drift_type,
+        pattern,
+        reason,
+    )
+    return RemediationResult(
+        applied=False,
+        drift_type=str(drift_type or ""),
+        pattern=pattern,
+        reason=reason,
+        actions=(),
+        evidence_keys=_evidence_keys(evidence or {}),
+    )
+
+
+__all__: Sequence[str] = (
+    "AUTO_REMEDIATION_FLAG_ENV",
+    "KNOWN_DRIFT_TYPES",
+    "RemediationAction",
+    "RemediationActions",
+    "RemediationResult",
+    "auto_remediation_enabled",
+    "remediate_drift",
+)

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -641,6 +641,7 @@ class BossLoop:
         self._failed_issues: list[dict[str, Any]] = []
         self._iteration_statuses: list[BossIterationStatus] = []
         self._consecutive_failures = 0
+        self._consecutive_empty_iterations = 0
         self._issue_attempt_counts: dict[int | str, int] = {}
         self._pending_handoff_prompts: dict[int, tuple[str, str | None]] = {}
         self._stop_reason: str | None = None
@@ -1135,6 +1136,47 @@ class BossLoop:
             self._last_sanitation_summary = sanitation
         else:
             self._last_sanitation_summary = []
+
+    def _maybe_autofill_queue(
+        self,
+        *,
+        candidate_issues: list[GitHubIssue],
+    ) -> dict[str, Any] | None:
+        """Optionally restock the queue when it stays empty for N consecutive ticks.
+
+        Default-off behaviour: unless ``ARAGORA_QUEUE_AUTOFILL`` is truthy in
+        the environment the call is a no-op.  On success we bump the empty-tick
+        counter back to zero so we don't immediately re-enter autofill on the
+        next idle tick.
+        """
+        self._consecutive_empty_iterations += 1
+        try:
+            from aragora.swarm.queue_autofill import (
+                maybe_autofill_queue,
+                queue_autofill_enabled,
+            )
+        except Exception:  # pragma: no cover - defensive import guard
+            logger.debug("Queue autofill module unavailable", exc_info=True)
+            return None
+
+        if not queue_autofill_enabled(self._env):
+            return None
+
+        try:
+            result = maybe_autofill_queue(
+                repo_root=Path.cwd(),
+                consecutive_empty_ticks=self._consecutive_empty_iterations,
+                existing_candidates=candidate_issues,
+                env=self._env,
+            )
+        except Exception:  # pragma: no cover - defensive guard
+            logger.warning("Queue autofill attempt raised", exc_info=True)
+            return None
+
+        payload = result.to_dict()
+        if payload.get("attempted") and payload.get("reason") in {"created", "created_dry_run"}:
+            self._consecutive_empty_iterations = 0
+        return payload
 
     def _no_suitable_issue_guidance(
         self,
@@ -3722,6 +3764,15 @@ class BossLoop:
                     already_maxed=already_maxed,
                     report=eligibility_report,
                 )
+            autofill_payload = self._maybe_autofill_queue(
+                candidate_issues=candidate_issues,
+            )
+            if autofill_payload and autofill_payload.get("attempted"):
+                autofill_reason = autofill_payload.get("reason")
+                created_count = autofill_payload.get("created_count") or 0
+                next_actions.append(
+                    f"Queue autofill: reason={autofill_reason} created={created_count}"
+                )
             return BossIterationStatus(
                 iteration=iteration,
                 run_id=self.run_id,
@@ -3734,6 +3785,10 @@ class BossLoop:
                 next_actions=next_actions,
                 elapsed_seconds=time.monotonic() - iter_start,
             )
+
+        # An eligible issue was found — reset the empty-tick counter so the
+        # autofill does not fire on the next idle round.
+        self._consecutive_empty_iterations = 0
 
         # Step 3: Check runner freshness only when there is eligible work to dispatch
         # Circuit breaker: skip decomposed issues if budget exhausted or fast-fail detected
@@ -3972,6 +4027,15 @@ class BossLoop:
                     already_maxed=already_maxed,
                     report=eligibility_report,
                 )
+            autofill_payload = self._maybe_autofill_queue(
+                candidate_issues=candidate_issues,
+            )
+            if autofill_payload and autofill_payload.get("attempted"):
+                autofill_reason = autofill_payload.get("reason")
+                created_count = autofill_payload.get("created_count") or 0
+                next_actions.append(
+                    f"Queue autofill: reason={autofill_reason} created={created_count}"
+                )
             return [
                 BossIterationStatus(
                     iteration=iteration,
@@ -3986,6 +4050,9 @@ class BossLoop:
                     elapsed_seconds=time.monotonic() - iter_start,
                 )
             ]
+
+        # Eligible issues were found — reset the empty-tick counter.
+        self._consecutive_empty_iterations = 0
 
         freshness = self._freshness_checker(
             freshness_ttl_seconds=self.config.freshness_ttl_seconds,

--- a/aragora/swarm/proof_first_queue.py
+++ b/aragora/swarm/proof_first_queue.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
@@ -15,6 +17,17 @@ from aragora.swarm.roadmap_priority import (
 
 if TYPE_CHECKING:
     from aragora.swarm.boss_feed import GitHubIssue
+
+
+TW01_ALLOW_FLAG_ENV = "ARAGORA_PROOF_FIRST_ALLOW_TW01"
+_TRUTHY_VALUES = frozenset({"1", "true", "t", "yes", "y", "on"})
+_TW01_TITLE_PREFIX = "[tw-01]"
+_TW01_FILES_HEADING_RE = re.compile(r"^#+\s*files\b", re.IGNORECASE | re.MULTILINE)
+_TW01_VALIDATION_HEADING_RE = re.compile(r"^#+\s*validation\b", re.IGNORECASE | re.MULTILINE)
+_TW01_PYTEST_RE = re.compile(r"\bpytest\b", re.IGNORECASE)
+_TW01_FILE_PATH_RE = re.compile(r"`([^`\n]+?\.[A-Za-z0-9]+)`")
+# Accept a broader set of file path hints (bullet lists, bare lines).
+_TW01_BARE_FILE_PATH_RE = re.compile(r"(?:^|\s)([A-Za-z0-9_./\-]+\.[A-Za-z0-9]+)", re.MULTILINE)
 
 _BENCHMARK_TERMS = (
     "benchmark",
@@ -91,6 +104,156 @@ def _load_policy(
     return load_roadmap_priority_policy(Path(repo_root))
 
 
+def _tw01_allow_enabled(env: dict[str, str] | None = None) -> bool:
+    source = env if env is not None else os.environ
+    value = str(source.get(TW01_ALLOW_FLAG_ENV, "")).strip().lower()
+    return value in _TRUTHY_VALUES
+
+
+def _extract_section_body(body: str, heading_re: re.Pattern[str]) -> tuple[str, bool]:
+    """Return ``(section_text, present)`` for the first matching markdown heading.
+
+    ``section_text`` contains the lines following the heading up to the next
+    markdown heading.  ``present`` is ``True`` iff the heading was matched.
+    """
+    match = heading_re.search(body)
+    if match is None:
+        return "", False
+    remainder = body[match.end() :]
+    next_heading = re.search(r"^#+\s+\S", remainder, re.MULTILINE)
+    if next_heading is not None:
+        section = remainder[: next_heading.start()]
+    else:
+        section = remainder
+    return section.strip(), True
+
+
+def _tw01_parse_target_files(files_section: str) -> tuple[str, ...]:
+    """Extract candidate file paths from the ``## Files`` section."""
+    paths: list[str] = []
+    for match in _TW01_FILE_PATH_RE.findall(files_section):
+        cleaned = match.strip()
+        if cleaned:
+            paths.append(cleaned)
+    if paths:
+        # Preserve declaration order but deduplicate.
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for path in paths:
+            if path in seen:
+                continue
+            seen.add(path)
+            deduped.append(path)
+        return tuple(deduped)
+
+    # Fall back to bare-token path detection when no backticks were used.
+    bare_matches = _TW01_BARE_FILE_PATH_RE.findall(files_section)
+    seen = set()
+    deduped = []
+    for raw in bare_matches:
+        cleaned = raw.strip(" \t-*")
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        deduped.append(cleaned)
+    return tuple(deduped)
+
+
+def _tw01_any_target_exists(
+    paths: tuple[str, ...], repo_root: Path | str | None
+) -> tuple[bool, tuple[str, ...]]:
+    """Return ``(exists, present_paths)`` for the provided target paths."""
+    if not paths:
+        return False, ()
+    if repo_root is None:
+        # Without a repo root we cannot verify the file exists.  Err on the
+        # side of caution and reject.
+        return False, ()
+    base = Path(repo_root)
+    present: list[str] = []
+    for path in paths:
+        resolved = base / path
+        try:
+            if resolved.exists():
+                present.append(path)
+        except OSError:
+            continue
+    return bool(present), tuple(present)
+
+
+def _evaluate_tw01_candidate(
+    title: str,
+    body: str,
+    *,
+    repo_root: Path | str | None,
+    roadmap_codes: tuple[str, ...],
+) -> ProofFirstQueueDecision:
+    """Apply the TW-01 strict acceptance gate."""
+    files_section, files_present = _extract_section_body(body, _TW01_FILES_HEADING_RE)
+    if not files_present:
+        return ProofFirstQueueDecision(
+            allowed=False,
+            lane="tw01_rejected",
+            reason="TW-01 body missing `## Files` section",
+            matched_terms=("tw-01",),
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
+
+    target_files = _tw01_parse_target_files(files_section)
+    if not target_files:
+        return ProofFirstQueueDecision(
+            allowed=False,
+            lane="tw01_rejected",
+            reason="TW-01 `## Files` section lists no target files",
+            matched_terms=("tw-01",),
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
+
+    validation_section, validation_present = _extract_section_body(
+        body, _TW01_VALIDATION_HEADING_RE
+    )
+    if not validation_present:
+        return ProofFirstQueueDecision(
+            allowed=False,
+            lane="tw01_rejected",
+            reason="TW-01 body missing `## Validation` section",
+            matched_terms=("tw-01",),
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
+    if not _TW01_PYTEST_RE.search(validation_section):
+        return ProofFirstQueueDecision(
+            allowed=False,
+            lane="tw01_rejected",
+            reason="TW-01 `## Validation` section must include a pytest command",
+            matched_terms=("tw-01",),
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
+
+    exists, present_paths = _tw01_any_target_exists(target_files, repo_root)
+    if not exists:
+        return ProofFirstQueueDecision(
+            allowed=False,
+            lane="tw01_rejected",
+            reason=("TW-01 target files do not exist in repo: " + ", ".join(target_files[:5])),
+            matched_terms=("tw-01",),
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
+
+    return ProofFirstQueueDecision(
+        allowed=True,
+        lane="test_authoring",
+        reason="TW-01 test-authoring issue with valid Files and Validation sections",
+        matched_terms=("tw-01",) + present_paths,
+        roadmap_codes=roadmap_codes,
+        blocked_codes=(),
+    )
+
+
 def classify_proof_first_queue_issue(
     title: str,
     body: str = "",
@@ -98,8 +261,16 @@ def classify_proof_first_queue_issue(
     labels: list[str] | tuple[str, ...] | set[str] = (),
     repo_root: Path | str | None = None,
     roadmap_policy: RoadmapPriorityPolicy | None = None,
+    env: dict[str, str] | None = None,
 ) -> ProofFirstQueueDecision:
-    """Return whether an issue belongs in the canonical proof-first queue."""
+    """Return whether an issue belongs in the canonical proof-first queue.
+
+    The ``env`` argument is consulted for opt-in feature flags, notably
+    :data:`TW01_ALLOW_FLAG_ENV` (``ARAGORA_PROOF_FIRST_ALLOW_TW01``).  When
+    the flag is truthy, titles starting with ``[TW-01]`` are routed through
+    the dedicated :func:`_evaluate_tw01_candidate` acceptance gate.  With the
+    flag off the classifier behaves exactly as before.
+    """
 
     normalized_text = _normalize_text(title, body, " ".join(str(label) for label in labels))
     policy = _load_policy(repo_root=repo_root, roadmap_policy=roadmap_policy)
@@ -125,6 +296,18 @@ def classify_proof_first_queue_issue(
                 roadmap_codes=priority.codes,
                 blocked_codes=priority.blocked_codes,
             )
+
+    normalized_title = str(title or "").strip().lower()
+    if normalized_title.startswith(_TW01_TITLE_PREFIX):
+        if _tw01_allow_enabled(env):
+            return _evaluate_tw01_candidate(
+                title,
+                body,
+                repo_root=repo_root,
+                roadmap_codes=roadmap_codes,
+            )
+        # With the flag off, TW-01 items continue to fall through to the
+        # pre-existing lanes (typically non_canonical).
 
     benchmark_matches = _matched_terms(normalized_text, _BENCHMARK_TERMS)
     if "[tw-02]" in normalized_text or (
@@ -233,6 +416,7 @@ def filter_noncanonical_boss_ready_issues(
 
 __all__ = [
     "ProofFirstQueueDecision",
+    "TW01_ALLOW_FLAG_ENV",
     "classify_proof_first_queue_issue",
     "filter_noncanonical_boss_ready_issues",
 ]

--- a/aragora/swarm/queue_autofill.py
+++ b/aragora/swarm/queue_autofill.py
@@ -1,0 +1,537 @@
+"""Automatic restock of the boss-loop queue when it goes empty.
+
+When the boss loop picks up no eligible issue for ``N`` consecutive ticks
+(default 3) we call back into the issue scanner to mint a small batch of
+well-proven candidates.  This keeps the autonomous loop from idling while
+waiting for a human to re-label work.
+
+Design constraints (from the mission brief)
+-------------------------------------------
+* **Default off** — the feature is gated on
+  :data:`QUEUE_AUTOFILL_FLAG_ENV` (``ARAGORA_QUEUE_AUTOFILL``).  When the
+  flag is falsy the loop calls :func:`maybe_autofill_queue` but it returns a
+  ``skipped`` result without touching GitHub.
+* **Well-proven categories only** — we only scan ``test_coverage`` and
+  ``broad_exception`` (high historical success).  Anything else is ignored.
+* **Small batches** — never create more than ``max_issues`` (default 3) in
+  one invocation.
+* **Filter-aligned** — every candidate is routed through
+  :func:`classify_proof_first_queue_issue` with the current roadmap policy
+  *before* it is created.  If the filter would reject it, we drop it.
+* **Rate limited** — at most one autofill per ``min_interval_seconds``
+  (default 3600).  The last-run timestamp is persisted in a small JSON
+  sentinel inside ``.aragora/overnight/`` so it survives process restarts.
+* **Auditable** — every invocation writes a single ``event: queue_autofill``
+  row to the boss metrics JSONL so operators can see exactly what happened.
+
+The module is intentionally thin: it composes pieces that already live in
+the codebase (``issue_scanner.scan_all``, ``classify_proof_first_queue_issue``,
+``boss_validation.assess_issue_body_sanitation``) and contributes only the
+policy wrapper.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+QUEUE_AUTOFILL_FLAG_ENV = "ARAGORA_QUEUE_AUTOFILL"
+
+_TRUTHY_VALUES = frozenset({"1", "true", "t", "yes", "y", "on"})
+
+DEFAULT_EMPTY_TICK_THRESHOLD = 3
+DEFAULT_MAX_ISSUES = 3
+DEFAULT_MIN_INTERVAL_SECONDS = 3600.0
+DEFAULT_SENTINEL_PATH = Path(".aragora/overnight/queue_autofill.json")
+DEFAULT_METRICS_PATH = Path(".aragora/overnight/boss_metrics.jsonl")
+
+# Only well-proven scanner categories are eligible for autofill.
+ALLOWED_CATEGORIES: frozenset[str] = frozenset({"test_coverage", "broad_exception"})
+
+
+@dataclass(frozen=True)
+class AutofillCandidate:
+    """Lightweight summary of a candidate that passed the autofill filters."""
+
+    title: str
+    category: str
+    fingerprint: str
+    file_scope: tuple[str, ...]
+    lane: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "category": self.category,
+            "fingerprint": self.fingerprint,
+            "file_scope": list(self.file_scope),
+            "lane": self.lane,
+        }
+
+
+@dataclass(frozen=True)
+class AutofillResult:
+    """Outcome of one autofill invocation."""
+
+    attempted: bool
+    reason: str
+    consecutive_empty_ticks: int
+    threshold: int
+    rate_limited: bool = False
+    seconds_since_last: float | None = None
+    scanned_count: int = 0
+    eligible_count: int = 0
+    filtered_out: int = 0
+    duplicate_count: int = 0
+    created: tuple[AutofillCandidate, ...] = ()
+    errors: tuple[str, ...] = ()
+
+    @property
+    def created_count(self) -> int:
+        return len(self.created)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event": "queue_autofill",
+            "attempted": self.attempted,
+            "reason": self.reason,
+            "consecutive_empty_ticks": self.consecutive_empty_ticks,
+            "threshold": self.threshold,
+            "rate_limited": self.rate_limited,
+            "seconds_since_last": self.seconds_since_last,
+            "scanned_count": self.scanned_count,
+            "eligible_count": self.eligible_count,
+            "filtered_out": self.filtered_out,
+            "duplicate_count": self.duplicate_count,
+            "created_count": self.created_count,
+            "created": [candidate.to_dict() for candidate in self.created],
+            "errors": list(self.errors),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Feature-flag helper
+# ---------------------------------------------------------------------------
+
+
+def queue_autofill_enabled(
+    env: dict[str, str] | None = None,
+    *,
+    flag: str = QUEUE_AUTOFILL_FLAG_ENV,
+) -> bool:
+    """Return ``True`` when the autofill feature flag is truthy."""
+    source = env if env is not None else os.environ
+    value = str(source.get(flag, "")).strip().lower()
+    return value in _TRUTHY_VALUES
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit sentinel helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_last_run(sentinel_path: Path) -> float | None:
+    try:
+        payload = json.loads(sentinel_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    value = payload.get("last_run_ts") if isinstance(payload, dict) else None
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _write_last_run(sentinel_path: Path, timestamp: float) -> None:
+    try:
+        sentinel_path.parent.mkdir(parents=True, exist_ok=True)
+        sentinel_path.write_text(
+            json.dumps({"last_run_ts": float(timestamp)}, sort_keys=True),
+            encoding="utf-8",
+        )
+    except OSError as exc:  # pragma: no cover - best effort
+        logger.warning("queue_autofill: failed to persist sentinel at %s: %s", sentinel_path, exc)
+
+
+# ---------------------------------------------------------------------------
+# Core decision function
+# ---------------------------------------------------------------------------
+
+
+def maybe_autofill_queue(
+    *,
+    repo_root: Path,
+    consecutive_empty_ticks: int,
+    existing_candidates: Iterable[Any] = (),
+    create_issue: Callable[[AutofillCandidate], bool] | None = None,
+    env: dict[str, str] | None = None,
+    now: float | None = None,
+    threshold: int = DEFAULT_EMPTY_TICK_THRESHOLD,
+    max_issues: int = DEFAULT_MAX_ISSUES,
+    min_interval_seconds: float = DEFAULT_MIN_INTERVAL_SECONDS,
+    categories: Sequence[str] = ("test_coverage", "broad_exception"),
+    sentinel_path: Path | None = None,
+    metrics_jsonl_path: Path | None = None,
+    scan_fn: Callable[..., list[Any]] | None = None,
+    classify_fn: Callable[..., Any] | None = None,
+    validate_body_fn: Callable[[str], tuple[bool, str]] | None = None,
+    format_body_fn: Callable[[Any], str] | None = None,
+) -> AutofillResult:
+    """Decide whether to restock the queue and, if so, create small bounded issues.
+
+    ``existing_candidates`` is the list of boss-loop-visible candidates the
+    caller already rejected (because they didn't meet the filter).  We use
+    that list only to decide whether restocking is justified — if any of the
+    existing candidates *would* pass the canonical filter today we skip the
+    autofill entirely to avoid duplicating tracked work.
+
+    ``create_issue`` is a thin callback provided by the caller (typically a
+    wrapper around ``gh issue create``).  We call it once per candidate that
+    survives every gate.  Returning ``False`` is treated as a failed create
+    and is surfaced via :attr:`AutofillResult.errors`.
+    """
+    threshold = max(1, int(threshold))
+    max_issues = max(0, int(max_issues))
+    min_interval_seconds = max(0.0, float(min_interval_seconds))
+    timestamp = float(now) if now is not None else time.time()
+    repo_root = Path(repo_root).resolve()
+    sentinel_path = (sentinel_path or (repo_root / DEFAULT_SENTINEL_PATH)).resolve()
+    metrics_jsonl_path = (
+        metrics_jsonl_path.resolve()
+        if metrics_jsonl_path is not None
+        else (repo_root / DEFAULT_METRICS_PATH).resolve()
+    )
+
+    if not queue_autofill_enabled(env):
+        return _finalize(
+            AutofillResult(
+                attempted=False,
+                reason="flag_disabled",
+                consecutive_empty_ticks=consecutive_empty_ticks,
+                threshold=threshold,
+            ),
+            metrics_jsonl_path,
+        )
+
+    if consecutive_empty_ticks < threshold:
+        return _finalize(
+            AutofillResult(
+                attempted=False,
+                reason="below_threshold",
+                consecutive_empty_ticks=consecutive_empty_ticks,
+                threshold=threshold,
+            ),
+            metrics_jsonl_path,
+        )
+
+    if max_issues <= 0:
+        return _finalize(
+            AutofillResult(
+                attempted=False,
+                reason="max_issues_zero",
+                consecutive_empty_ticks=consecutive_empty_ticks,
+                threshold=threshold,
+            ),
+            metrics_jsonl_path,
+        )
+
+    # Rate limit: one run per min_interval_seconds.
+    last_run_ts = _read_last_run(sentinel_path)
+    seconds_since_last = (timestamp - last_run_ts) if last_run_ts is not None else None
+    if (
+        last_run_ts is not None
+        and seconds_since_last is not None
+        and seconds_since_last < min_interval_seconds
+    ):
+        return _finalize(
+            AutofillResult(
+                attempted=False,
+                reason="rate_limited",
+                consecutive_empty_ticks=consecutive_empty_ticks,
+                threshold=threshold,
+                rate_limited=True,
+                seconds_since_last=seconds_since_last,
+            ),
+            metrics_jsonl_path,
+        )
+
+    # If any already-known candidate would pass the canonical filter, there
+    # is already suitable work — don't duplicate.
+    classify_fn = classify_fn or _default_classify
+    pre_existing_passes = sum(
+        1
+        for candidate in existing_candidates
+        if _candidate_would_pass_filter(candidate, classify_fn, repo_root)
+    )
+    if pre_existing_passes > 0:
+        return _finalize(
+            AutofillResult(
+                attempted=False,
+                reason="existing_queue_has_work",
+                consecutive_empty_ticks=consecutive_empty_ticks,
+                threshold=threshold,
+                seconds_since_last=seconds_since_last,
+                duplicate_count=pre_existing_passes,
+            ),
+            metrics_jsonl_path,
+        )
+
+    scan_fn = scan_fn or _default_scan
+    validate_body_fn = validate_body_fn or _default_validate_body
+    format_body_fn = format_body_fn or _default_format_body
+
+    allowed_cats = tuple(cat for cat in categories if cat in ALLOWED_CATEGORIES)
+    if not allowed_cats:
+        return _finalize(
+            AutofillResult(
+                attempted=False,
+                reason="no_allowed_categories",
+                consecutive_empty_ticks=consecutive_empty_ticks,
+                threshold=threshold,
+            ),
+            metrics_jsonl_path,
+        )
+
+    errors: list[str] = []
+    try:
+        scanned = list(scan_fn(repo_root, categories=list(allowed_cats)))
+    except Exception as exc:
+        logger.warning("queue_autofill: scanner raised: %s", exc)
+        return _finalize(
+            AutofillResult(
+                attempted=True,
+                reason="scan_failed",
+                consecutive_empty_ticks=consecutive_empty_ticks,
+                threshold=threshold,
+                seconds_since_last=seconds_since_last,
+                errors=(str(exc),),
+            ),
+            metrics_jsonl_path,
+        )
+
+    eligible: list[tuple[Any, str, str]] = []
+    filtered_out = 0
+    for candidate in scanned:
+        category = getattr(candidate, "category", "")
+        if category not in ALLOWED_CATEGORIES:
+            filtered_out += 1
+            continue
+        body = format_body_fn(candidate)
+        ok, reason = validate_body_fn(body)
+        if not ok:
+            filtered_out += 1
+            logger.debug(
+                "queue_autofill: validation rejected candidate %r: %s",
+                getattr(candidate, "title", ""),
+                reason,
+            )
+            continue
+        decision = classify_fn(
+            getattr(candidate, "title", ""),
+            body,
+            labels=("boss-ready",),
+            repo_root=repo_root,
+        )
+        if not getattr(decision, "allowed", False):
+            filtered_out += 1
+            continue
+        lane = getattr(decision, "lane", "")
+        eligible.append((candidate, body, lane))
+
+    if not eligible:
+        result = AutofillResult(
+            attempted=True,
+            reason="no_eligible_candidates",
+            consecutive_empty_ticks=consecutive_empty_ticks,
+            threshold=threshold,
+            seconds_since_last=seconds_since_last,
+            scanned_count=len(scanned),
+            eligible_count=0,
+            filtered_out=filtered_out,
+        )
+        _write_last_run(sentinel_path, timestamp)
+        return _finalize(result, metrics_jsonl_path)
+
+    trimmed = eligible[:max_issues]
+    created: list[AutofillCandidate] = []
+
+    if create_issue is None:
+        # Dry-run style: report what *would* be created but don't call GitHub.
+        for candidate, _body, lane in trimmed:
+            created.append(_as_autofill_candidate(candidate, lane))
+        result = AutofillResult(
+            attempted=True,
+            reason="created_dry_run",
+            consecutive_empty_ticks=consecutive_empty_ticks,
+            threshold=threshold,
+            seconds_since_last=seconds_since_last,
+            scanned_count=len(scanned),
+            eligible_count=len(eligible),
+            filtered_out=filtered_out,
+            created=tuple(created),
+        )
+        _write_last_run(sentinel_path, timestamp)
+        return _finalize(result, metrics_jsonl_path)
+
+    for candidate, _body, lane in trimmed:
+        autofill = _as_autofill_candidate(candidate, lane)
+        try:
+            ok = bool(create_issue(autofill))
+        except Exception as exc:
+            errors.append(f"{autofill.title}: {exc}")
+            continue
+        if ok:
+            created.append(autofill)
+        else:
+            errors.append(f"{autofill.title}: create_issue returned False")
+
+    result = AutofillResult(
+        attempted=True,
+        reason=("created" if created else "create_failed"),
+        consecutive_empty_ticks=consecutive_empty_ticks,
+        threshold=threshold,
+        seconds_since_last=seconds_since_last,
+        scanned_count=len(scanned),
+        eligible_count=len(eligible),
+        filtered_out=filtered_out,
+        created=tuple(created),
+        errors=tuple(errors),
+    )
+    _write_last_run(sentinel_path, timestamp)
+    return _finalize(result, metrics_jsonl_path)
+
+
+# ---------------------------------------------------------------------------
+# Defaults that lazily pull the real implementations
+# ---------------------------------------------------------------------------
+
+
+def _default_scan(repo_root: Path, *, categories: list[str]) -> list[Any]:
+    from aragora.swarm.issue_scanner import scan_all
+
+    return scan_all(repo_root, categories=categories)
+
+
+def _default_classify(
+    title: str,
+    body: str,
+    *,
+    labels: Iterable[str] = (),
+    repo_root: Path | None = None,
+) -> Any:
+    from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue
+
+    return classify_proof_first_queue_issue(
+        title,
+        body,
+        labels=tuple(labels),
+        repo_root=repo_root,
+    )
+
+
+def _default_validate_body(body: str) -> tuple[bool, str]:
+    try:
+        from aragora.swarm.boss_validation import assess_issue_body_sanitation
+
+        ok, reason = assess_issue_body_sanitation(body)
+        return ok, reason or ""
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("queue_autofill: validation fallback triggered: %s", exc)
+        if "## Task" not in body or len(body.strip()) < 50:
+            return False, "fallback_validation_failed"
+        return True, ""
+
+
+def _default_format_body(candidate: Any) -> str:
+    """Minimal boss-ready body used when the caller did not supply a formatter.
+
+    The real generator script builds a richer body via the issue upgrader.
+    For the autofill guardrails we only need enough structure to let the
+    sanitizer recognise the shape of a proper boss issue.
+    """
+    title = getattr(candidate, "title", "autofill candidate")
+    description = getattr(candidate, "description", title)
+    file_scope = list(getattr(candidate, "file_scope", []) or [])
+    new_files = list(getattr(candidate, "new_files", []) or [])
+    validation = getattr(candidate, "validation_command", "")
+    criteria = list(getattr(candidate, "acceptance_criteria", []) or [])
+    fingerprint = getattr(candidate, "fingerprint", "")
+
+    parts: list[str] = [f"## Task\n\n{description}"]
+    scope_lines: list[str] = [f"- `{path}`" for path in file_scope]
+    scope_lines.extend(f"- `{path}` (create)" for path in new_files)
+    if scope_lines:
+        parts.append("### File Scope\n" + "\n".join(scope_lines))
+    if validation:
+        parts.append(f"### Validation\n```bash\n{validation}\n```")
+    if criteria:
+        parts.append("### Acceptance Criteria\n" + "\n".join(f"- {item}" for item in criteria))
+    if fingerprint:
+        parts.append(f"<!-- fingerprint:{fingerprint} -->")
+    return "\n\n".join(parts)
+
+
+def _as_autofill_candidate(candidate: Any, lane: str) -> AutofillCandidate:
+    file_scope = tuple(getattr(candidate, "file_scope", ()) or ())
+    return AutofillCandidate(
+        title=str(getattr(candidate, "title", "")),
+        category=str(getattr(candidate, "category", "")),
+        fingerprint=str(getattr(candidate, "fingerprint", "")),
+        file_scope=file_scope,
+        lane=str(lane or ""),
+    )
+
+
+def _candidate_would_pass_filter(
+    candidate: Any,
+    classify_fn: Callable[..., Any],
+    repo_root: Path,
+) -> bool:
+    title = getattr(candidate, "title", "")
+    body = getattr(candidate, "body", "") or ""
+    labels = getattr(candidate, "labels", ()) or ()
+    try:
+        decision = classify_fn(title, body, labels=tuple(labels), repo_root=repo_root)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("queue_autofill: classify probe failed: %s", exc)
+        return False
+    return bool(getattr(decision, "allowed", False))
+
+
+def _finalize(result: AutofillResult, metrics_jsonl_path: Path) -> AutofillResult:
+    _emit_metrics(result, metrics_jsonl_path)
+    return result
+
+
+def _emit_metrics(result: AutofillResult, metrics_jsonl_path: Path) -> None:
+    try:
+        metrics_jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = result.to_dict()
+        payload["timestamp"] = time.time()
+        with metrics_jsonl_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True))
+            handle.write("\n")
+    except OSError as exc:  # pragma: no cover - best effort
+        logger.debug("queue_autofill: metrics emit skipped: %s", exc)
+
+
+__all__ = [
+    "ALLOWED_CATEGORIES",
+    "AutofillCandidate",
+    "AutofillResult",
+    "DEFAULT_EMPTY_TICK_THRESHOLD",
+    "DEFAULT_MAX_ISSUES",
+    "DEFAULT_MIN_INTERVAL_SECONDS",
+    "QUEUE_AUTOFILL_FLAG_ENV",
+    "maybe_autofill_queue",
+    "queue_autofill_enabled",
+]

--- a/tests/stage_gate/test_auto_remediation.py
+++ b/tests/stage_gate/test_auto_remediation.py
@@ -1,0 +1,311 @@
+"""Tests for :mod:`aragora.stage_gate.auto_remediation`.
+
+The dispatcher is intentionally conservative: it should only attempt a
+repair when (a) the feature flag is on, (b) the drift pattern is
+recognised, and (c) the evidence contains the expected keys.  These tests
+exercise both the happy paths and every guard rail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from aragora.stage_gate.auto_remediation import (
+    AUTO_REMEDIATION_FLAG_ENV,
+    RemediationResult,
+    auto_remediation_enabled,
+    remediate_drift,
+)
+
+
+# ---------------------------------------------------------------------------
+# Recording stub for the RemediationActions protocol
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RecordingActions:
+    """Collects every action call for assertions, returns configurable results."""
+
+    remove_label_result: bool = True
+    post_comment_result: bool = True
+    trigger_workflow_result: bool = True
+    calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = field(default_factory=list)
+
+    def remove_label(self, issue_number: int, label: str) -> bool:
+        self.calls.append(("remove_label", (issue_number, label), {}))
+        return self.remove_label_result
+
+    def post_comment(self, issue_number: int, body: str) -> bool:
+        self.calls.append(("post_comment", (issue_number, body), {}))
+        return self.post_comment_result
+
+    def trigger_workflow(self, workflow: str, *, ref: str | None = None) -> bool:
+        self.calls.append(("trigger_workflow", (workflow,), {"ref": ref}))
+        return self.trigger_workflow_result
+
+
+FLAG_ENV = {AUTO_REMEDIATION_FLAG_ENV: "1"}
+
+
+# ---------------------------------------------------------------------------
+# Feature-flag guard
+# ---------------------------------------------------------------------------
+
+
+def test_auto_remediation_enabled_respects_truthy_values() -> None:
+    assert auto_remediation_enabled({AUTO_REMEDIATION_FLAG_ENV: "1"}) is True
+    assert auto_remediation_enabled({AUTO_REMEDIATION_FLAG_ENV: "true"}) is True
+    assert auto_remediation_enabled({AUTO_REMEDIATION_FLAG_ENV: "YES"}) is True
+
+
+def test_auto_remediation_enabled_defaults_off() -> None:
+    assert auto_remediation_enabled({}) is False
+    assert auto_remediation_enabled({AUTO_REMEDIATION_FLAG_ENV: "0"}) is False
+    assert auto_remediation_enabled({AUTO_REMEDIATION_FLAG_ENV: "false"}) is False
+    assert auto_remediation_enabled({AUTO_REMEDIATION_FLAG_ENV: "  "}) is False
+
+
+def test_flag_disabled_short_circuits_dispatcher() -> None:
+    actions = RecordingActions()
+    result = remediate_drift(
+        "boss_ready_on_deferred_track",
+        {"issue_number": 42, "track": "deferred-cleanup"},
+        actions=actions,
+        env={},  # flag missing ⇒ disabled
+    )
+
+    assert isinstance(result, RemediationResult)
+    assert result.applied is False
+    assert result.pattern == "flag_disabled"
+    assert actions.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Recognised pattern: boss-ready on deferred track
+# ---------------------------------------------------------------------------
+
+
+def test_boss_ready_on_deferred_track_strips_label_and_comments() -> None:
+    actions = RecordingActions()
+    evidence = {
+        "issue_number": 501,
+        "track": "AGT-deferred",
+        "deferred_label": "track:agt-deferred",
+    }
+
+    result = remediate_drift(
+        "boss_ready_on_deferred_track",
+        evidence,
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is True
+    assert result.drift_type == "boss_ready_on_deferred_track"
+    assert result.pattern == "strip_boss_ready_and_comment"
+    action_kinds = [action.kind for action in result.actions]
+    assert action_kinds == ["remove_label", "post_comment"]
+    assert ("remove_label", (501, "boss-ready"), {}) in actions.calls
+    comment_calls = [call for call in actions.calls if call[0] == "post_comment"]
+    assert comment_calls
+    assert "AGT-deferred" in comment_calls[0][1][1]
+    assert "boss-ready" in comment_calls[0][1][1]
+
+
+def test_boss_ready_on_deferred_track_thin_evidence_is_noop() -> None:
+    actions = RecordingActions()
+    result = remediate_drift(
+        "boss_ready_on_deferred_track",
+        {"issue_number": 501},  # track missing
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is False
+    assert result.pattern == "thin_evidence"
+    assert actions.calls == []
+
+
+def test_boss_ready_on_deferred_track_adapter_rejection_is_noop() -> None:
+    actions = RecordingActions(remove_label_result=False, post_comment_result=False)
+    result = remediate_drift(
+        "boss_ready_on_deferred_track",
+        {"issue_number": 501, "track": "deferred"},
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is False
+    assert result.pattern == "no_actions_taken"
+    # Both calls were attempted but returned False
+    kinds = [call[0] for call in actions.calls]
+    assert kinds == ["remove_label", "post_comment"]
+
+
+# ---------------------------------------------------------------------------
+# Recognised pattern: duplicate epic
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_epic_cross_links_both_sides() -> None:
+    actions = RecordingActions()
+    result = remediate_drift(
+        "duplicate_epic",
+        {"epic_numbers": (700, 701)},
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is True
+    assert result.pattern == "cross_link_and_flag"
+    post_calls = [call for call in actions.calls if call[0] == "post_comment"]
+    assert len(post_calls) == 2
+    targets = {call[1][0] for call in post_calls}
+    assert targets == {700, 701}
+    # Each comment must reference the sibling epic
+    assert "#701" in post_calls[0][1][1] or "#701" in post_calls[1][1][1]
+    assert "#700" in post_calls[0][1][1] or "#700" in post_calls[1][1][1]
+
+
+def test_duplicate_epic_requires_pair() -> None:
+    actions = RecordingActions()
+    result = remediate_drift(
+        "duplicate_epic",
+        {"epic_numbers": (700,)},  # only one number
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is False
+    assert result.pattern == "thin_evidence"
+    assert actions.calls == []
+
+
+def test_duplicate_epic_rejects_non_iterable_evidence() -> None:
+    actions = RecordingActions()
+    result = remediate_drift(
+        "duplicate_epic",
+        {"epic_numbers": "700,701"},
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is False
+    assert result.pattern == "thin_evidence"
+
+
+# ---------------------------------------------------------------------------
+# Recognised pattern: doc staleness
+# ---------------------------------------------------------------------------
+
+
+def test_doc_staleness_triggers_workflow_with_default_ref() -> None:
+    actions = RecordingActions()
+    result = remediate_drift(
+        "doc_staleness",
+        {"issue_number": 42},
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is True
+    assert result.pattern == "rerun_publication_workflow"
+    trigger_calls = [call for call in actions.calls if call[0] == "trigger_workflow"]
+    assert len(trigger_calls) == 1
+    assert trigger_calls[0][1] == ("benchmark-publication",)
+    assert trigger_calls[0][2] == {"ref": None}
+    # Audit comment posted on the referenced issue
+    comment_calls = [call for call in actions.calls if call[0] == "post_comment"]
+    assert comment_calls
+    assert comment_calls[0][1][0] == 42
+
+
+def test_doc_staleness_uses_custom_workflow_and_ref() -> None:
+    actions = RecordingActions()
+    result = remediate_drift(
+        "doc_staleness",
+        {"workflow": "corpus-publish", "ref": "release/april"},
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is True
+    trigger_calls = [call for call in actions.calls if call[0] == "trigger_workflow"]
+    assert trigger_calls[0][1] == ("corpus-publish",)
+    assert trigger_calls[0][2] == {"ref": "release/april"}
+
+
+def test_doc_staleness_noop_when_workflow_refuses() -> None:
+    actions = RecordingActions(trigger_workflow_result=False)
+    result = remediate_drift(
+        "doc_staleness",
+        {},  # no issue number, so comment is skipped
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is False
+    assert result.pattern == "no_actions_taken"
+
+
+# ---------------------------------------------------------------------------
+# Unknown / malformed drift input
+# ---------------------------------------------------------------------------
+
+
+def test_unrecognised_drift_is_noop() -> None:
+    actions = RecordingActions()
+    result = remediate_drift(
+        "mystery_drift",
+        {"any": "thing"},
+        actions=actions,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is False
+    assert result.pattern == "unrecognised_drift"
+    assert actions.calls == []
+
+
+@pytest.mark.parametrize("bad", ["", None, "   "])
+def test_empty_drift_type_is_noop(bad: Any) -> None:
+    actions = RecordingActions()
+    result = remediate_drift(bad, {}, actions=actions, env=FLAG_ENV)
+
+    assert result.applied is False
+    assert result.pattern == "missing_drift_type"
+    assert actions.calls == []
+
+
+def test_missing_actions_adapter_is_noop_even_when_flag_is_on() -> None:
+    result = remediate_drift(
+        "boss_ready_on_deferred_track",
+        {"issue_number": 1, "track": "deferred"},
+        actions=None,
+        env=FLAG_ENV,
+    )
+
+    assert result.applied is False
+    assert result.pattern == "no_actions_adapter"
+
+
+def test_result_serialisation_round_trips_to_dict() -> None:
+    actions = RecordingActions()
+    result = remediate_drift(
+        "boss_ready_on_deferred_track",
+        {"issue_number": 1, "track": "deferred"},
+        actions=actions,
+        env=FLAG_ENV,
+    )
+    payload = result.to_dict()
+
+    assert payload["applied"] is True
+    assert payload["drift_type"] == "boss_ready_on_deferred_track"
+    assert payload["pattern"] == "strip_boss_ready_and_comment"
+    assert payload["evidence_keys"] == ["issue_number", "track"]
+    for action in payload["actions"]:
+        assert set(action.keys()) == {"kind", "target", "detail"}

--- a/tests/swarm/test_proof_first_queue.py
+++ b/tests/swarm/test_proof_first_queue.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue
+from pathlib import Path
+
+from aragora.swarm.proof_first_queue import (
+    TW01_ALLOW_FLAG_ENV,
+    classify_proof_first_queue_issue,
+)
 from aragora.swarm.roadmap_priority import RoadmapPriorityPolicy
 
 
@@ -47,3 +52,180 @@ def test_classify_proof_first_queue_issue_blocks_generic_cleanup() -> None:
 
     assert decision.allowed is False
     assert decision.lane == "non_canonical"
+
+
+# ---------------------------------------------------------------------------
+# TW-01 test-authoring expansion (flagged, default off)
+# ---------------------------------------------------------------------------
+
+
+FLAG_ON = {TW01_ALLOW_FLAG_ENV: "1"}
+FLAG_OFF: dict[str, str] = {}
+
+
+def _tw01_body(
+    *,
+    files: list[str] | None = None,
+    validation: str = "pytest tests/foo/test_bar.py -q",
+    extra_sections: str = "",
+) -> str:
+    files = files if files is not None else ["aragora/swarm/proof_first_queue.py"]
+    file_lines = "\n".join(f"- `{path}`" for path in files)
+    body = "## Task\n\nAuthor a new test module.\n\n"
+    if files:
+        body += f"## Files\n\n{file_lines}\n\n"
+    body += f"## Validation\n\n```bash\n{validation}\n```\n"
+    if extra_sections:
+        body += "\n" + extra_sections
+    return body
+
+
+def test_tw01_flag_off_falls_through_to_non_canonical(tmp_path: Path) -> None:
+    decision = classify_proof_first_queue_issue(
+        "[TW-01] Author regression tests for foo",
+        _tw01_body(),
+        repo_root=tmp_path,
+        env=FLAG_OFF,
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "non_canonical"
+
+
+def test_tw01_flag_on_accepts_well_formed_issue(tmp_path: Path) -> None:
+    target = tmp_path / "aragora" / "foo.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("# module\n", encoding="utf-8")
+
+    decision = classify_proof_first_queue_issue(
+        "[TW-01] Author regression tests for foo.py",
+        _tw01_body(files=["aragora/foo.py"]),
+        repo_root=tmp_path,
+        env=FLAG_ON,
+    )
+
+    assert decision.allowed is True
+    assert decision.lane == "test_authoring"
+    assert "tw-01" in decision.matched_terms
+    assert "aragora/foo.py" in decision.matched_terms
+
+
+def test_tw01_flag_on_rejects_issue_missing_files_section(tmp_path: Path) -> None:
+    body = (
+        "## Task\n\nAuthor a new test module.\n\n"
+        "## Validation\n\n```bash\npytest tests/foo/test_bar.py -q\n```\n"
+    )
+    decision = classify_proof_first_queue_issue(
+        "[TW-01] Author regression tests",
+        body,
+        repo_root=tmp_path,
+        env=FLAG_ON,
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "tw01_rejected"
+    assert "missing `## Files`" in decision.reason
+
+
+def test_tw01_flag_on_rejects_issue_with_no_files_listed(tmp_path: Path) -> None:
+    body = (
+        "## Task\n\nAuthor a new test module.\n\n"
+        "## Files\n\n(To be filled in later.)\n\n"
+        "## Validation\n\n```bash\npytest -q\n```\n"
+    )
+    decision = classify_proof_first_queue_issue(
+        "[TW-01] Author regression tests",
+        body,
+        repo_root=tmp_path,
+        env=FLAG_ON,
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "tw01_rejected"
+    assert "no target files" in decision.reason
+
+
+def test_tw01_flag_on_rejects_issue_missing_validation(tmp_path: Path) -> None:
+    target = tmp_path / "aragora" / "foo.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("# module\n", encoding="utf-8")
+
+    body = "## Task\n\nAuthor a new test module.\n\n## Files\n\n- `aragora/foo.py`\n"
+    decision = classify_proof_first_queue_issue(
+        "[TW-01] Author regression tests for foo",
+        body,
+        repo_root=tmp_path,
+        env=FLAG_ON,
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "tw01_rejected"
+    assert "missing `## Validation`" in decision.reason
+
+
+def test_tw01_flag_on_rejects_issue_without_pytest_command(tmp_path: Path) -> None:
+    target = tmp_path / "aragora" / "foo.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("# module\n", encoding="utf-8")
+
+    body = _tw01_body(
+        files=["aragora/foo.py"],
+        validation="make test-foo",
+    )
+    decision = classify_proof_first_queue_issue(
+        "[TW-01] Author regression tests for foo",
+        body,
+        repo_root=tmp_path,
+        env=FLAG_ON,
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "tw01_rejected"
+    assert "pytest" in decision.reason
+
+
+def test_tw01_flag_on_rejects_issue_pointing_at_nonexistent_file(tmp_path: Path) -> None:
+    decision = classify_proof_first_queue_issue(
+        "[TW-01] Author regression tests for missing",
+        _tw01_body(files=["aragora/does_not_exist.py"]),
+        repo_root=tmp_path,
+        env=FLAG_ON,
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "tw01_rejected"
+    assert "do not exist" in decision.reason
+
+
+def test_tw01_flag_on_accepts_when_any_listed_file_exists(tmp_path: Path) -> None:
+    target = tmp_path / "aragora" / "real.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("# module\n", encoding="utf-8")
+
+    decision = classify_proof_first_queue_issue(
+        "[TW-01] Author regression tests",
+        _tw01_body(files=["aragora/missing.py", "aragora/real.py"]),
+        repo_root=tmp_path,
+        env=FLAG_ON,
+    )
+
+    assert decision.allowed is True
+    assert decision.lane == "test_authoring"
+    assert "aragora/real.py" in decision.matched_terms
+
+
+def test_tw02_behaviour_unchanged_by_flag(tmp_path: Path) -> None:
+    # Regression test: TW-02 continues to classify as benchmark_regression
+    # whether the TW-01 flag is on or off.
+    for env in (FLAG_OFF, FLAG_ON):
+        decision = classify_proof_first_queue_issue(
+            "[TW-02] Restock stale issues in tw-01-bounded-execution-v1 rev-1",
+            (
+                "Refresh benchmark corpus freshness after stale closed issues "
+                "were detected in the truth artifact."
+            ),
+            repo_root=tmp_path,
+            env=env,
+        )
+        assert decision.allowed is True, f"flag={env} broke TW-02 acceptance"
+        assert decision.lane == "benchmark_regression"

--- a/tests/swarm/test_queue_autofill.py
+++ b/tests/swarm/test_queue_autofill.py
@@ -1,0 +1,512 @@
+"""Tests for :mod:`aragora.swarm.queue_autofill`.
+
+These exercise the policy surface of ``maybe_autofill_queue`` without
+touching the real scanner, classifier, or GitHub.  Every dependency is
+injected via keyword arguments to the function under test.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora.swarm.queue_autofill import (
+    ALLOWED_CATEGORIES,
+    AutofillCandidate,
+    AutofillResult,
+    DEFAULT_EMPTY_TICK_THRESHOLD,
+    QUEUE_AUTOFILL_FLAG_ENV,
+    maybe_autofill_queue,
+    queue_autofill_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCandidate:
+    category: str
+    title: str
+    description: str = ""
+    file_scope: list[str] = field(default_factory=list)
+    new_files: list[str] = field(default_factory=list)
+    validation_command: str = "pytest -q"
+    acceptance_criteria: list[str] = field(default_factory=list)
+    fingerprint: str = "fp-test"
+
+
+@dataclass
+class _FakeDecision:
+    allowed: bool
+    lane: str = "test_coverage_autofill"
+
+
+def _make_scan(
+    results: list[_FakeCandidate] | None = None,
+    *,
+    raise_exc: Exception | None = None,
+) -> Any:
+    results = results or []
+
+    def scan(repo_root: Path, *, categories: list[str]) -> list[_FakeCandidate]:
+        if raise_exc is not None:
+            raise raise_exc
+        return [candidate for candidate in results if candidate.category in categories]
+
+    return scan
+
+
+def _make_classify(allowed: bool = True, lane: str = "test_coverage_autofill") -> Any:
+    def classify(title: str, body: str, *, labels: Any = (), repo_root: Path | None = None) -> Any:
+        return _FakeDecision(allowed=allowed, lane=lane)
+
+    return classify
+
+
+def _make_validate(ok: bool = True, reason: str = "") -> Any:
+    def validate(body: str) -> tuple[bool, str]:
+        return ok, reason
+
+    return validate
+
+
+FLAG_ENV = {QUEUE_AUTOFILL_FLAG_ENV: "1"}
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+
+def test_queue_autofill_enabled_defaults_off() -> None:
+    assert queue_autofill_enabled({}) is False
+    assert queue_autofill_enabled({QUEUE_AUTOFILL_FLAG_ENV: "0"}) is False
+
+
+def test_queue_autofill_enabled_truthy() -> None:
+    assert queue_autofill_enabled({QUEUE_AUTOFILL_FLAG_ENV: "1"}) is True
+    assert queue_autofill_enabled({QUEUE_AUTOFILL_FLAG_ENV: "YES"}) is True
+
+
+def test_flag_disabled_returns_skipped_and_does_not_scan(tmp_path: Path) -> None:
+    def boom(*_args: Any, **_kwargs: Any) -> list[Any]:  # pragma: no cover
+        raise AssertionError("scan must not run when flag is off")
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env={},  # flag off
+        scan_fn=boom,
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    assert isinstance(result, AutofillResult)
+    assert result.attempted is False
+    assert result.reason == "flag_disabled"
+
+
+# ---------------------------------------------------------------------------
+# Threshold gate
+# ---------------------------------------------------------------------------
+
+
+def test_below_threshold_skips(tmp_path: Path) -> None:
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=DEFAULT_EMPTY_TICK_THRESHOLD - 1,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+    assert result.attempted is False
+    assert result.reason == "below_threshold"
+
+
+# ---------------------------------------------------------------------------
+# Existing work still matches filter → skip
+# ---------------------------------------------------------------------------
+
+
+class _ExistingCandidate:
+    def __init__(self, title: str, body: str = "", labels: tuple[str, ...] = ("boss-ready",)):
+        self.title = title
+        self.body = body
+        self.labels = labels
+
+
+def test_skips_when_existing_candidate_would_pass_filter(tmp_path: Path) -> None:
+    existing = [_ExistingCandidate("[TW-02] refresh benchmark truth artifact")]
+
+    def classify(title: str, body: str, *, labels: Any = (), repo_root: Path | None = None) -> Any:
+        # Existing candidate passes the filter.
+        return _FakeDecision(allowed=True, lane="benchmark_regression")
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        existing_candidates=existing,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([_FakeCandidate(category="test_coverage", title="Add tests")]),
+        classify_fn=classify,
+        validate_body_fn=_make_validate(),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    assert result.attempted is False
+    assert result.reason == "existing_queue_has_work"
+    assert result.duplicate_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Category filtering
+# ---------------------------------------------------------------------------
+
+
+def test_ignores_candidates_outside_allowed_categories(tmp_path: Path) -> None:
+    candidates = [
+        _FakeCandidate(category="silent_exception", title="drop silent excepts"),
+        _FakeCandidate(category="type_annotation", title="add return types"),
+    ]
+    created: list[AutofillCandidate] = []
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=_make_scan(candidates),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        create_issue=lambda candidate: (created.append(candidate) or True),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    # scan_fn filters by the explicit categories list we pass, so nothing
+    # should even surface in the scanner output, and no issues get created.
+    assert result.attempted is True
+    assert result.reason == "no_eligible_candidates"
+    assert created == []
+    assert "silent_exception" not in ALLOWED_CATEGORIES
+
+
+def test_disallows_categories_even_if_scan_returns_them(tmp_path: Path) -> None:
+    """Defence-in-depth: reject non-allowed categories even if scan leaks them."""
+
+    def leaky_scan(repo_root: Path, *, categories: list[str]) -> list[_FakeCandidate]:
+        return [_FakeCandidate(category="silent_exception", title="sneaky")]
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=leaky_scan,
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    assert result.attempted is True
+    assert result.reason == "no_eligible_candidates"
+    assert result.filtered_out == 1
+
+
+# ---------------------------------------------------------------------------
+# Rate limit
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limited_within_interval(tmp_path: Path) -> None:
+    sentinel = tmp_path / "sentinel.json"
+    sentinel.write_text(json.dumps({"last_run_ts": 1000.0}), encoding="utf-8")
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        now=1500.0,  # 500s since last_run, default interval is 3600
+        scan_fn=_make_scan([]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        sentinel_path=sentinel,
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+    assert result.attempted is False
+    assert result.reason == "rate_limited"
+    assert result.rate_limited is True
+    assert result.seconds_since_last == pytest.approx(500.0)
+
+
+def test_passes_rate_limit_when_interval_elapsed(tmp_path: Path) -> None:
+    sentinel = tmp_path / "sentinel.json"
+    sentinel.write_text(json.dumps({"last_run_ts": 1000.0}), encoding="utf-8")
+    candidate = _FakeCandidate(
+        category="test_coverage",
+        title="Add unit tests for module X",
+        description="Add unit tests.",
+        file_scope=["aragora/foo.py"],
+    )
+    created: list[AutofillCandidate] = []
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        now=5000.0,  # 4000s > 3600s
+        scan_fn=_make_scan([candidate]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        create_issue=lambda item: (created.append(item) or True),
+        sentinel_path=sentinel,
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+    assert result.attempted is True
+    assert result.reason == "created"
+    assert len(created) == 1
+    # Sentinel bumped forward to now=5000.0
+    payload = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert payload == {"last_run_ts": 5000.0}
+
+
+# ---------------------------------------------------------------------------
+# Happy path + max_issues clamp
+# ---------------------------------------------------------------------------
+
+
+def test_creates_up_to_max_issues(tmp_path: Path) -> None:
+    candidates = [
+        _FakeCandidate(
+            category="test_coverage",
+            title=f"Add unit tests for module {i}",
+            description="Description",
+            file_scope=[f"aragora/module_{i}.py"],
+        )
+        for i in range(5)
+    ]
+    created: list[AutofillCandidate] = []
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=10,
+        env=FLAG_ENV,
+        max_issues=2,
+        scan_fn=_make_scan(candidates),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        create_issue=lambda item: (created.append(item) or True),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    assert result.attempted is True
+    assert result.reason == "created"
+    assert result.created_count == 2
+    assert len(created) == 2
+
+
+def test_classifier_rejection_is_filtered_out(tmp_path: Path) -> None:
+    candidate = _FakeCandidate(
+        category="test_coverage",
+        title="Add tests",
+        description="Boring",
+        file_scope=["aragora/foo.py"],
+    )
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([candidate]),
+        classify_fn=_make_classify(allowed=False),
+        validate_body_fn=_make_validate(),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    assert result.attempted is True
+    assert result.reason == "no_eligible_candidates"
+    assert result.filtered_out == 1
+
+
+def test_sanitation_rejection_is_filtered_out(tmp_path: Path) -> None:
+    candidate = _FakeCandidate(category="test_coverage", title="Add tests")
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([candidate]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(ok=False, reason="too_short"),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    assert result.attempted is True
+    assert result.reason == "no_eligible_candidates"
+    assert result.filtered_out == 1
+
+
+# ---------------------------------------------------------------------------
+# Metrics emission
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_row_records_event_queue_autofill(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.jsonl"
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=metrics,
+    )
+    assert result.attempted is True
+
+    rows = [json.loads(line) for line in metrics.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["event"] == "queue_autofill"
+    assert rows[0]["reason"] == "no_eligible_candidates"
+    assert "timestamp" in rows[0]
+
+
+def test_metrics_row_includes_created_titles(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.jsonl"
+    candidate = _FakeCandidate(
+        category="broad_exception",
+        title="Narrow broad except in foo.py",
+        description="Some description",
+        file_scope=["aragora/foo.py"],
+    )
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([candidate]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        create_issue=lambda _c: True,
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=metrics,
+    )
+    assert result.attempted is True
+    assert result.reason == "created"
+    assert result.created_count == 1
+
+    rows = [json.loads(line) for line in metrics.read_text(encoding="utf-8").splitlines()]
+    payload = rows[0]
+    assert payload["event"] == "queue_autofill"
+    assert payload["created_count"] == 1
+    assert payload["created"][0]["title"] == "Narrow broad except in foo.py"
+    assert payload["created"][0]["category"] == "broad_exception"
+
+
+# ---------------------------------------------------------------------------
+# Failure accounting
+# ---------------------------------------------------------------------------
+
+
+def test_scan_failure_reports_error(tmp_path: Path) -> None:
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([], raise_exc=RuntimeError("boom")),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+    assert result.attempted is True
+    assert result.reason == "scan_failed"
+    assert result.errors and "boom" in result.errors[0]
+
+
+def test_create_issue_failure_surfaces_in_errors(tmp_path: Path) -> None:
+    candidate = _FakeCandidate(
+        category="test_coverage",
+        title="Add unit tests",
+        file_scope=["aragora/foo.py"],
+    )
+
+    def flaky_create(_: AutofillCandidate) -> bool:
+        return False
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([candidate]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        create_issue=flaky_create,
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    assert result.attempted is True
+    assert result.reason == "create_failed"
+    assert result.created_count == 0
+    assert result.errors
+
+
+# ---------------------------------------------------------------------------
+# Dry-run (no create callback)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_create_callback_yields_dry_run(tmp_path: Path) -> None:
+    candidate = _FakeCandidate(
+        category="test_coverage",
+        title="Add unit tests for bar.py",
+        description="Cover bar.py",
+        file_scope=["aragora/bar.py"],
+    )
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([candidate]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        create_issue=None,
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    assert result.attempted is True
+    assert result.reason == "created_dry_run"
+    assert result.created_count == 1
+    assert result.created[0].title == "Add unit tests for bar.py"
+
+
+def test_max_issues_zero_short_circuits(tmp_path: Path) -> None:
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        max_issues=0,
+        scan_fn=_make_scan([_FakeCandidate(category="test_coverage", title="x")]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+    assert result.attempted is False
+    assert result.reason == "max_issues_zero"


### PR DESCRIPTION
## Summary

Three tightly-bounded autonomous follow-ups that extend the existing swarm after Mission #1 (auto-approver) unblocks PRs to land without human review. Each task ships behind its own feature flag — every behaviour is default OFF until an operator flips the flag, so this PR is safe to merge without any live runtime change.

## Tasks

### Task 1 — Stage-Gate Conductor autonomous drift response
- New module `aragora/stage_gate/auto_remediation.py` with `remediate_drift(drift_type, evidence)` dispatcher
- Three recognised remediations (each conservative, each returns an auditable `RemediationResult`):
  - `boss_ready_on_deferred_track` → strip `boss-ready` + post explanatory comment
  - `duplicate_epic` → cross-link both epics, flag for human merge decision
  - `doc_staleness` → re-trigger the publication workflow (default `benchmark-publication`)
- Unknown patterns, thin evidence, disabled flag, or missing adapter all produce a no-op result — never a raise.

### Task 2 — Queue self-restocking when empty
- New module `aragora/swarm/queue_autofill.py` with `maybe_autofill_queue(...)`
- Wired into `boss_loop.py` on both `no_suitable_issue` paths (single-issue and parallel)
- Policy defaults (overridable via kwargs):
  - Fires after 3 consecutive empty ticks
  - Only scans `test_coverage` + `broad_exception` (well-proven categories)
  - Max 3 issues per invocation
  - Skips entirely if any existing candidate would already pass the canonical filter
  - Rate limited: 1 run per hour via `.aragora/overnight/queue_autofill.json` sentinel
  - Every call writes one `event: queue_autofill` row to `boss_metrics.jsonl`

### Task 3 — Canonical filter TW-01 expansion
- Extends `classify_proof_first_queue_issue` with a strict TW-01 acceptance gate:
  - Title must start with `[TW-01]`
  - Body must contain a `## Files` section listing target files
  - Body must contain a `## Validation` section referencing `pytest`
  - At least one listed target file must exist in the repo
- TW-02, TW-03, docs-proof-drift, and roadmap-DO_NOW lanes are unchanged; explicit regression test for TW-02.

## Feature flags

| Flag | Default | Enables |
|------|---------|---------|
| `ARAGORA_STAGE_GATE_AUTO_REMEDIATION` | off | Task 1 drift auto-remediation dispatcher |
| `ARAGORA_QUEUE_AUTOFILL` | off | Task 2 queue self-restocking in the boss loop |
| `ARAGORA_PROOF_FIRST_ALLOW_TW01` | off | Task 3 TW-01 test-authoring lane |

Each flag is read via a small helper (`auto_remediation_enabled`, `queue_autofill_enabled`, `_tw01_allow_enabled`). None of the tasks have cross-dependencies — disabling one does not affect the others.

## Activation procedure

1. **Task 1** — `export ARAGORA_STAGE_GATE_AUTO_REMEDIATION=1` on the environment that wraps the Stage-Gate Conductor dispatcher. A GitHub adapter implementing `RemediationActions` (three methods: `remove_label`, `post_comment`, `trigger_workflow`) must be injected before the dispatcher is useful; an unset adapter still yields a no-op.
2. **Task 2** — `export ARAGORA_QUEUE_AUTOFILL=1` on the boss-loop host. Sentinel file (`.aragora/overnight/queue_autofill.json`) is auto-created on first run.
3. **Task 3** — `export ARAGORA_PROOF_FIRST_ALLOW_TW01=1` on any process that calls `classify_proof_first_queue_issue` (boss loop, issue-scanner generator, `filter_noncanonical_boss_ready_issues`).

## Validation

- `pytest tests/stage_gate/ tests/swarm/test_queue_autofill.py tests/swarm/test_proof_first_queue.py tests/swarm/test_proof_first_queue_classification.py -q` → **61 passed**
- `ruff check aragora/stage_gate/ aragora/swarm/queue_autofill.py aragora/swarm/proof_first_queue.py aragora/swarm/boss_loop.py tests/stage_gate/ tests/swarm/test_queue_autofill.py tests/swarm/test_proof_first_queue.py` → **All checks passed**
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → **ok**
- `mypy --baseline-filter aragora/stage_gate/ aragora/swarm/queue_autofill.py` → **no new errors**

## Commits

- `feat(stage-gate): autonomous drift remediation dispatcher (flagged off)`
- `feat(swarm): queue self-restocking when boss loop stays idle (flagged off)`
- `feat(proof-first): allow TW-01 test-authoring lane under strict gate (flagged off)`
