### PR TITLE
feat(ci): GitHub App auto-approver for safe automation PRs (dry-run default)

### DIFF
--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -1,7 +1,28 @@
 # AI Agent Coordination
 
-**Last updated:** 2026-03-05
+**Last updated:** 2026-04-18
 **Maintainer:** Update this file when starting/finishing work
+
+---
+
+## Autonomous pipeline (2026-04-18)
+
+**Auto-approver for safe automation PRs** is deployed in **dry-run mode**:
+
+- Script: `scripts/auto_approve_safe_prs.py`
+- Design: `docs/plans/2026-04-18-auto-approver-design.md`
+- LaunchAgent: `scripts/launchd/com.aragora.auto-approver.plist` (every 5 min)
+- Uses the `aragora-automation` GitHub App (App ID `3328101`) to submit
+  `APPROVE` reviews on PRs that satisfy an 8-point conservative allowlist
+  (author, opt-in label, CI green, no protected paths, small diff, idempotent).
+- **Default: dry-run.** Live approvals require
+  `~/.aragora/auto_approver.live` (created via
+  `scripts/auto_approver_activate.sh on`).
+- Kill switch: `touch ~/.aragora/auto_approver.disabled`.
+- Audit trail: `~/.aragora/auto_approver_audit.jsonl`.
+
+Future sessions that touch automation-gated PR flow should read the design
+doc first and consult the audit log before debugging approvals.
 
 ---
 

--- a/docs/plans/2026-04-18-auto-approver-design.md
+++ b/docs/plans/2026-04-18-auto-approver-design.md
@@ -1,0 +1,106 @@
+# Auto-approver for safe automation PRs
+
+**Date:** 2026-04-18
+**Owner:** automation platform
+**Status:** dry-run (phase 1)
+**Related PR:** `feature/github-app-auto-approver`
+
+## Problem
+
+Every PR in `synaptent/aragora` requires a review approval before auto-merge
+fires. All automations (Codex autopilots, droid missions, Claude Code) author
+PRs under `an0mium` and therefore cannot self-approve. The human founder has
+been using `gh pr merge --admin` to bypass the review gate, which works but
+skips the safety net. Without an automated approver, the merge-arbiter drains
+zero PRs autonomously — review is the load-bearing bottleneck.
+
+## Solution
+
+A new cron-style script `scripts/auto_approve_safe_prs.py` uses the
+`aragora-automation` GitHub App (App ID `3328101`, installation
+`122689816`) to submit `APPROVE` reviews on PRs that satisfy **every** gate in
+a conservative allowlist. The App has `pull_requests: write` granted
+(verified at mission start via `GET /app/installations/:id`).
+
+### Approval criteria (ALL must pass)
+
+| # | Gate | Rationale |
+|---|------|-----------|
+| 1 | PR is `OPEN` and `MERGEABLE` (not conflicting, not blocked) | Don't approve PRs with conflicts or failing required checks. |
+| 2 | PR is not a draft | Drafts opt out of auto-merge. |
+| 3 | Author in allowlist (`an0mium`, `factory-droid[bot]`, `codex-bot`, ...) | Scope to automation accounts only. |
+| 4 | PR carries at least one opt-in label (`autonomous`, `codex-automation`, `droid-generated`, `auto-approve`) | Explicit consent per-PR. |
+| 5 | ALL CI checks have `conclusion: SUCCESS` | No pending, failed, cancelled runs. |
+| 6 | No protected paths touched | CLAUDE.md, `aragora/__init__.py`, `.env*`, `.github/workflows/*`, `scripts/baselines/*`, `*private-key*`, `*secrets*`, `scripts/nomic_loop.py`. |
+| 7 | Diff under LOC threshold (default **5000** additions+deletions) | Large refactors need human review. |
+| 8 | Not already approved for same head SHA by the App (idempotent) | Don't spam. Re-approves when head SHA changes. |
+
+### Self-approval protection
+
+Gate 0 (checked before all others): if the PR author is
+`aragora-automation[bot]`, we refuse — prevents any future scenario where the
+App opens its own PRs and approves them.
+
+## Safety layer
+
+| Feature | Mechanism | Operator action |
+|---------|-----------|-----------------|
+| Dry-run | Default. Requires `~/.aragora/auto_approver.live` to submit reviews. | `scripts/auto_approver_activate.sh on` to go live. |
+| Kill switch | `~/.aragora/auto_approver.disabled` (exit 0 without action). | `touch ~/.aragora/auto_approver.disabled` to pause. |
+| Rate limit | Max 10 approvals/hour via `~/.aragora/auto_approver_rate.json`. | `--rate-limit-per-hour N` to tune. |
+| Audit log | `~/.aragora/auto_approver_audit.jsonl`, one JSON line per decision. | `tail -f` to watch in real time. |
+| Idempotency | Lists prior reviews; skips when App approved current head SHA. | Re-approves automatically when head SHA changes. |
+| Allowlists | Authors, labels, and protected paths all opt-in. | `--allowed-author`, `--optin-label` to override. |
+
+## Deployment
+
+`launchd` agent at `scripts/launchd/com.aragora.auto-approver.plist`, scheduled every 5
+minutes. Logs consolidated at `~/.aragora/auto-approver-launchd.log`.
+
+```bash
+cp scripts/launchd/com.aragora.auto-approver.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.aragora.auto-approver.plist
+```
+
+On first load it runs in DRY-RUN mode. Decisions are logged but no reviews are
+submitted. Operator verifies the `auto_approver_audit.jsonl` stream for 2+
+hours and at least one full cycle of open PRs before flipping to live:
+
+```bash
+scripts/auto_approver_activate.sh on      # create ~/.aragora/auto_approver.live
+scripts/auto_approver_activate.sh status  # confirm
+```
+
+## Rollback / emergency
+
+If the approver approves something bad:
+
+1. **Immediate pause:** `touch ~/.aragora/auto_approver.disabled`. The next
+   invocation (within 5 min) exits without action.
+2. **Dismiss the review:** `gh pr review <number> -R synaptent/aragora --request-changes`
+   (or via the UI).
+3. **Revert merged change:** `gh pr revert <number>` if the merge already fired.
+4. **Audit:** `grep '"number": <number>' ~/.aragora/auto_approver_audit.jsonl` shows the
+   exact gate-pass reasoning plus the head SHA at approval time.
+5. **Tighten gates:** shrink the label allowlist, lower `--max-diff-loc`, or
+   add the offending path to `PROTECTED_PATH_PATTERNS`.
+
+## Expected velocity impact
+
+Pre-approver: zero auto-approvals. Every merge blocks on human review.
+
+Post-approver (dry-run): zero behavior change, full audit trail of
+*would-have-approved* PRs. Operator uses this window to calibrate gates.
+
+Post-approver (live): automation-labeled PRs with all-green CI and no protected
+paths auto-approve within ~5 min. Combined with the existing merge-arbiter,
+this removes the single biggest human gate on the autonomous pipeline while
+keeping allowlist-scoped risk and the kill switch as an immediate off-switch.
+
+## Known follow-ups
+
+- Shrink dry-run window after first verification cycle.
+- Consider expanding `DEFAULT_OPTIN_LABELS` once first wave proves stable.
+- Consider a SLO alert if `approvals_in_window` regularly exceeds 70% of quota.
+- Consider cross-linking to `scripts/merge_codex_automation_prs.py` so the same
+  safety signals feed both the approver and the merge-arbiter.

--- a/scripts/auto_approve_safe_prs.py
+++ b/scripts/auto_approve_safe_prs.py
@@ -1,0 +1,973 @@
+#!/usr/bin/env python3
+"""Auto-approve safe automation PRs via the ``aragora-automation`` GitHub App.
+
+This script is the receipt-gated approver that removes the single biggest human
+gate on the autonomous merge pipeline. It scans open pull requests in the
+configured repository and submits ``APPROVE`` reviews using the App installation
+token **only when every conservative guardrail passes**.
+
+Guardrails (ALL must hold):
+
+1. PR is OPEN and ``mergeable`` (not ``CONFLICTING``/``UNKNOWN``).
+2. PR is not a draft.
+3. PR author is on the automation allowlist (``an0mium``, ``factory-droid[bot]``, ...).
+4. PR carries at least one opt-in label (``autonomous``, ``codex-automation``, ...).
+5. All required CI checks have ``conclusion: SUCCESS`` (no pending, failed, cancelled).
+6. PR does not touch any protected path (CLAUDE.md, secrets, CI configs, baselines, ...).
+7. PR diff is under the configurable LOC threshold.
+8. The App has not already approved the PR's current head SHA (idempotency).
+
+Additional safety features:
+
+- ``--dry-run`` logs what WOULD be approved; default to live only when the
+  ``~/.aragora/auto_approver.live`` flag exists.
+- Kill switch: presence of ``~/.aragora/auto_approver.disabled`` exits with 0.
+- Rate limit: at most ``N`` approvals per hour (default 10); persistent counter.
+- Audit log: every invocation appends a JSON line to
+  ``~/.aragora/auto_approver_audit.jsonl`` with full decision trace.
+- Self-approval protection: refuses to approve PRs authored by the App bot itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import logging
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+# Allow importing the ``aragora`` package when running from the repo root.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.github_app_auth import get_github_app_installation_token  # noqa: E402
+
+logger = logging.getLogger("auto_approve_safe_prs")
+
+# ---------------------------------------------------------------------------
+# Defaults — kept conservative on purpose. Operators can widen via CLI flags
+# once behavior is verified in dry-run mode.
+# ---------------------------------------------------------------------------
+
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_MAX_DIFF_LOC = 5000
+DEFAULT_RATE_LIMIT_PER_HOUR = 10
+DEFAULT_PER_PAGE = 30
+
+DEFAULT_ALLOWED_AUTHORS: tuple[str, ...] = (
+    "an0mium",
+    "factory-droid[bot]",
+    "codex-bot",
+    "aragora-automation[bot]",
+    "app/aragora-automation",
+)
+
+DEFAULT_OPTIN_LABELS: tuple[str, ...] = (
+    "autonomous",
+    "codex-automation",
+    "droid-generated",
+    "auto-approve",
+)
+
+# Protected paths. Patterns accepted by :func:`fnmatch.fnmatchcase`.
+# Normalize to forward slashes at compare time.
+PROTECTED_PATH_PATTERNS: tuple[str, ...] = (
+    "CLAUDE.md",
+    "**/CLAUDE.md",
+    "aragora/__init__.py",
+    ".env",
+    ".env.*",
+    "**/.env",
+    "**/.env.*",
+    "scripts/nomic_loop.py",
+    ".github/workflows/*",
+    ".github/workflows/**",
+    "scripts/baselines/*",
+    "scripts/baselines/**",
+    "**/secrets*",
+    "**/*secrets*",
+    "**/*private-key*",
+    "**/*private_key*",
+    "**/github-app.pem",
+    "*.pem",
+    "**/*.pem",
+)
+
+# Paths under ~/.aragora used for persistent state and kill switch.
+STATE_DIR = Path.home() / ".aragora"
+KILL_SWITCH_PATH = STATE_DIR / "auto_approver.disabled"
+LIVE_FLAG_PATH = STATE_DIR / "auto_approver.live"
+RATE_LIMIT_PATH = STATE_DIR / "auto_approver_rate.json"
+AUDIT_LOG_PATH = STATE_DIR / "auto_approver_audit.jsonl"
+SCRIPT_LOG_PATH = STATE_DIR / "auto_approver.log"
+
+# Identity of the App bot, used to detect our own prior reviews / PRs.
+# ``aragora-automation`` is the slug of App ID 3328101. GitHub reports this
+# author as ``aragora-automation[bot]`` on REST responses.
+APP_BOT_LOGIN = "aragora-automation[bot]"
+
+GITHUB_API = "https://api.github.com"
+GITHUB_API_VERSION = "2022-11-28"
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CheckRun:
+    name: str
+    status: str  # e.g. "completed", "in_progress", "queued"
+    conclusion: str  # e.g. "success", "failure", "cancelled", ""
+
+
+@dataclass(frozen=True)
+class PriorReview:
+    user_login: str
+    state: str  # "APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"
+    commit_id: str
+    submitted_at: str
+
+
+@dataclass(frozen=True)
+class PRSnapshot:
+    number: int
+    title: str
+    html_url: str
+    author: str
+    head_sha: str
+    head_ref: str
+    is_draft: bool
+    mergeable: str  # GitHub REST: "MERGEABLE", "CONFLICTING", "UNKNOWN"
+    labels: tuple[str, ...]
+    changed_files: tuple[str, ...]
+    additions: int
+    deletions: int
+    checks: tuple[CheckRun, ...]
+    prior_reviews: tuple[PriorReview, ...]
+
+
+@dataclass(frozen=True)
+class ApprovalPolicy:
+    allowed_authors: tuple[str, ...] = DEFAULT_ALLOWED_AUTHORS
+    optin_labels: tuple[str, ...] = DEFAULT_OPTIN_LABELS
+    protected_paths: tuple[str, ...] = PROTECTED_PATH_PATTERNS
+    max_diff_loc: int = DEFAULT_MAX_DIFF_LOC
+    app_bot_login: str = APP_BOT_LOGIN
+
+
+@dataclass
+class ApprovalDecision:
+    number: int
+    approve: bool
+    reason: str  # single-word/phrase machine-readable reason
+    details: list[str] = field(default_factory=list)  # human-readable explanation lines
+    head_sha: str = ""
+    url: str = ""
+
+
+@dataclass
+class RateLimitState:
+    window_start_epoch: float
+    approvals_in_window: int
+
+
+# ---------------------------------------------------------------------------
+# Pure decision logic — fully testable with mocked snapshots.
+# ---------------------------------------------------------------------------
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    # Strip a leading "./" if present, but never a bare "." which would eat
+    # dotfiles like ".env".
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def path_is_protected(path: str, patterns: tuple[str, ...]) -> bool:
+    """Return True when ``path`` matches any protected pattern."""
+    normalized = _normalize_path(path)
+    lowered = normalized.lower()
+    for pattern in patterns:
+        # ``fnmatch`` handles ``*`` and ``?`` but treats ``**`` as ``*``. We
+        # additionally try a direct substring-style contains check for patterns
+        # that use ``**`` at segment boundaries.
+        if fnmatch.fnmatchcase(normalized, pattern) or fnmatch.fnmatchcase(
+            lowered, pattern.lower()
+        ):
+            return True
+        # Expand ``**/X`` to any suffix match.
+        if pattern.startswith("**/"):
+            tail = pattern[3:]
+            if fnmatch.fnmatchcase(normalized, tail):
+                return True
+            if normalized.endswith("/" + tail):
+                return True
+        # Expand ``X/**`` prefix match.
+        if pattern.endswith("/**"):
+            head = pattern[:-3]
+            if normalized == head or normalized.startswith(head + "/"):
+                return True
+    return False
+
+
+def any_protected_paths(paths: tuple[str, ...], patterns: tuple[str, ...]) -> list[str]:
+    return [p for p in paths if path_is_protected(p, patterns)]
+
+
+def _author_allowed(author: str, allowed: tuple[str, ...]) -> bool:
+    return author.lower() in {name.lower() for name in allowed}
+
+
+def _has_optin_label(labels: tuple[str, ...], optin: tuple[str, ...]) -> bool:
+    label_set = {label.lower() for label in labels}
+    return any(opt.lower() in label_set for opt in optin)
+
+
+# Check-run conclusions that are non-blocking for auto-approval.
+# Consistent with scripts/merge_codex_automation_prs.py SAFE_CHECK_CONCLUSIONS.
+_SAFE_CHECK_CONCLUSIONS = frozenset({"success", "neutral", "skipped"})
+
+
+def _checks_all_successful(checks: tuple[CheckRun, ...]) -> tuple[bool, str]:
+    if not checks:
+        return False, "no_checks_reported"
+    for run in checks:
+        status = (run.status or "").lower()
+        conclusion = (run.conclusion or "").lower()
+        if status != "completed":
+            return False, f"checks_pending:{run.name}"
+        if conclusion not in _SAFE_CHECK_CONCLUSIONS:
+            return False, f"checks_failed:{run.name}:{conclusion or 'unknown'}"
+    return True, "checks_success"
+
+
+def _already_approved_current_head(
+    prior_reviews: tuple[PriorReview, ...],
+    *,
+    app_login: str,
+    head_sha: str,
+) -> bool:
+    app_lower = app_login.lower()
+    for review in prior_reviews:
+        if review.user_login.lower() != app_lower:
+            continue
+        if review.state.upper() != "APPROVED":
+            continue
+        if review.commit_id == head_sha:
+            return True
+    return False
+
+
+def evaluate_pr(pr: PRSnapshot, policy: ApprovalPolicy) -> ApprovalDecision:
+    """Apply the 8 approval gates to ``pr`` and return a decision.
+
+    Pure function — no side effects. Suitable for unit testing.
+    """
+    decision = ApprovalDecision(
+        number=pr.number,
+        approve=False,
+        reason="",
+        head_sha=pr.head_sha,
+        url=pr.html_url,
+    )
+
+    # Gate 0: never approve our own PRs (self-approval loop guard).
+    if pr.author.lower() == policy.app_bot_login.lower():
+        decision.reason = "self_authored"
+        decision.details.append(f"author={pr.author} is the App bot itself")
+        return decision
+
+    # Gate 1: mergeability (state is known to be OPEN since we only fetch open PRs).
+    if pr.mergeable.upper() != "MERGEABLE":
+        decision.reason = "not_mergeable"
+        decision.details.append(f"mergeable={pr.mergeable}")
+        return decision
+
+    # Gate 2: not a draft.
+    if pr.is_draft:
+        decision.reason = "draft"
+        decision.details.append("PR is marked as draft")
+        return decision
+
+    # Gate 3: author allowlist.
+    if not _author_allowed(pr.author, policy.allowed_authors):
+        decision.reason = "author_not_allowlisted"
+        decision.details.append(f"author={pr.author} not in {list(policy.allowed_authors)}")
+        return decision
+
+    # Gate 4: opt-in label.
+    if not _has_optin_label(pr.labels, policy.optin_labels):
+        decision.reason = "missing_optin_label"
+        decision.details.append(
+            f"labels={list(pr.labels)} does not intersect {list(policy.optin_labels)}"
+        )
+        return decision
+
+    # Gate 5: CI checks.
+    checks_ok, check_reason = _checks_all_successful(pr.checks)
+    if not checks_ok:
+        decision.reason = check_reason
+        decision.details.append(check_reason)
+        return decision
+
+    # Gate 6: protected paths.
+    protected_hits = any_protected_paths(pr.changed_files, policy.protected_paths)
+    if protected_hits:
+        decision.reason = "protected_paths_touched"
+        decision.details.append(f"protected={protected_hits[:5]}")
+        return decision
+
+    # Gate 7: diff size.
+    net_loc = pr.additions + pr.deletions
+    if net_loc > policy.max_diff_loc:
+        decision.reason = "diff_too_large"
+        decision.details.append(f"net_loc={net_loc} > {policy.max_diff_loc}")
+        return decision
+
+    # Gate 8: idempotency — do not re-approve same head SHA.
+    if _already_approved_current_head(
+        pr.prior_reviews,
+        app_login=policy.app_bot_login,
+        head_sha=pr.head_sha,
+    ):
+        decision.reason = "already_approved"
+        decision.details.append(f"App already approved head_sha={pr.head_sha}")
+        return decision
+
+    # All gates passed.
+    decision.approve = True
+    decision.reason = "eligible"
+    decision.details.append(
+        f"author={pr.author} labels={list(pr.labels)} net_loc={net_loc} head_sha={pr.head_sha[:8]}"
+    )
+    decision.details.append("all_checks_success=" + ",".join(sorted({c.name for c in pr.checks})))
+    return decision
+
+
+# ---------------------------------------------------------------------------
+# Rate limit + kill switch + audit log
+# ---------------------------------------------------------------------------
+
+
+def kill_switch_engaged(path: Path = KILL_SWITCH_PATH) -> bool:
+    return path.exists()
+
+
+def is_live_mode(path: Path = LIVE_FLAG_PATH) -> bool:
+    return path.exists()
+
+
+def _load_rate_limit(path: Path) -> RateLimitState | None:
+    """Load persisted state, or return None when absent/corrupt."""
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8") or "{}")
+    except (OSError, json.JSONDecodeError):
+        return None
+    try:
+        return RateLimitState(
+            window_start_epoch=float(payload.get("window_start_epoch")),
+            approvals_in_window=int(payload.get("approvals_in_window") or 0),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _save_rate_limit(path: Path, state: RateLimitState) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "window_start_epoch": state.window_start_epoch,
+                "approvals_in_window": state.approvals_in_window,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def rate_limit_check_and_reserve(
+    path: Path,
+    *,
+    limit_per_hour: int,
+    now_epoch: float | None = None,
+) -> tuple[bool, RateLimitState]:
+    """Return ``(allowed, updated_state)``.
+
+    Reserves one slot on success. When ``allowed`` is False the caller must not
+    approve. The updated state is always persisted by the caller via
+    :func:`_save_rate_limit` to keep this function testable without disk I/O
+    beyond the initial load. ``now_epoch`` is injectable for testing.
+    """
+    now = time.time() if now_epoch is None else now_epoch
+    loaded = _load_rate_limit(path)
+    if loaded is None:
+        state = RateLimitState(window_start_epoch=now, approvals_in_window=0)
+    elif now - loaded.window_start_epoch >= 3600:
+        # Window rolled over.
+        state = RateLimitState(window_start_epoch=now, approvals_in_window=0)
+    else:
+        state = loaded
+    if state.approvals_in_window >= limit_per_hour:
+        return False, state
+    state = RateLimitState(
+        window_start_epoch=state.window_start_epoch,
+        approvals_in_window=state.approvals_in_window + 1,
+    )
+    return True, state
+
+
+def append_audit_record(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, sort_keys=True, default=str)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+# ---------------------------------------------------------------------------
+# GitHub REST helpers
+# ---------------------------------------------------------------------------
+
+
+class GitHubClient:
+    """Thin urllib-based wrapper around the GitHub REST API.
+
+    Uses the App installation token from :mod:`aragora.swarm.github_app_auth`.
+    Dependency-injectable for testing via the ``request`` callable.
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        *,
+        token: str,
+        request: Callable[..., Any] | None = None,
+    ) -> None:
+        self.repo = repo
+        self._token = token
+        default_request: Callable[..., Any] = self._urlopen
+        self._request: Callable[..., Any] = request if request is not None else default_request
+
+    def _headers(self, *, accept: str = "application/vnd.github+json") -> dict[str, str]:
+        return {
+            "Authorization": f"token {self._token}",
+            "Accept": accept,
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+            "User-Agent": "aragora-auto-approver/1.0",
+        }
+
+    @staticmethod
+    def _urlopen(
+        url: str,
+        *,
+        method: str = "GET",
+        headers: Mapping[str, str],
+        data: bytes | None = None,
+        timeout: float = 20.0,
+    ) -> Any:
+        req = urllib.request.Request(url, method=method, headers=dict(headers), data=data)
+        if urllib.parse.urlparse(url).netloc != "api.github.com":
+            raise RuntimeError(f"refusing non-GitHub URL: {url}")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310
+            return json.loads(resp.read().decode("utf-8") or "null")
+
+    def get(self, endpoint: str, *, accept: str = "application/vnd.github+json") -> Any:
+        url = f"{GITHUB_API}{endpoint}"
+        return self._request(url, method="GET", headers=self._headers(accept=accept))
+
+    def post(self, endpoint: str, payload: dict[str, Any]) -> Any:
+        url = f"{GITHUB_API}{endpoint}"
+        return self._request(
+            url,
+            method="POST",
+            headers=self._headers(),
+            data=json.dumps(payload).encode("utf-8"),
+        )
+
+    # ---- High level: build a PRSnapshot ------------------------------------
+
+    def list_open_prs(self, per_page: int = DEFAULT_PER_PAGE) -> list[dict[str, Any]]:
+        return list(self.get(f"/repos/{self.repo}/pulls?state=open&per_page={per_page}") or [])
+
+    def get_pr(self, number: int) -> dict[str, Any]:
+        return dict(self.get(f"/repos/{self.repo}/pulls/{number}") or {})
+
+    def get_pr_files(self, number: int) -> list[dict[str, Any]]:
+        pages: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            batch = self.get(f"/repos/{self.repo}/pulls/{number}/files?per_page=100&page={page}")
+            items = list(batch or [])
+            pages.extend(items)
+            if len(items) < 100:
+                break
+            page += 1
+            if page > 10:  # safety: PRs with >1000 files are clearly not auto-approvable
+                break
+        return pages
+
+    def get_commit_checks(self, sha: str) -> list[dict[str, Any]]:
+        # Combine check-runs (GitHub Checks API) + commit statuses.
+        runs: list[dict[str, Any]] = []
+        batch = self.get(f"/repos/{self.repo}/commits/{sha}/check-runs?per_page=100")
+        for entry in (batch or {}).get("check_runs", []) or []:
+            runs.append(
+                {
+                    "name": str(entry.get("name") or ""),
+                    "status": str(entry.get("status") or ""),
+                    "conclusion": str(entry.get("conclusion") or ""),
+                }
+            )
+        status_payload = self.get(f"/repos/{self.repo}/commits/{sha}/status")
+        for entry in (status_payload or {}).get("statuses", []) or []:
+            state = str(entry.get("state") or "").lower()
+            runs.append(
+                {
+                    "name": str(entry.get("context") or "status"),
+                    "status": "completed"
+                    if state in {"success", "failure", "error"}
+                    else "pending",
+                    "conclusion": "success" if state == "success" else state,
+                }
+            )
+        return runs
+
+    def list_reviews(self, number: int) -> list[dict[str, Any]]:
+        return list(self.get(f"/repos/{self.repo}/pulls/{number}/reviews?per_page=100") or [])
+
+    def submit_review(self, number: int, *, body: str, event: str = "APPROVE") -> dict[str, Any]:
+        return dict(
+            self.post(
+                f"/repos/{self.repo}/pulls/{number}/reviews",
+                {"body": body, "event": event},
+            )
+            or {}
+        )
+
+
+def build_snapshot(client: GitHubClient, number: int) -> PRSnapshot:
+    pr = client.get_pr(number)
+    head = pr.get("head") or {}
+    user = pr.get("user") or {}
+    labels_raw = pr.get("labels") or []
+    labels = tuple(sorted({str(item.get("name") or "") for item in labels_raw if item.get("name")}))
+    files = client.get_pr_files(number)
+    changed = tuple(str(entry.get("filename") or "") for entry in files if entry.get("filename"))
+    sha = str(head.get("sha") or "")
+    raw_mergeable_state = str(pr.get("mergeable_state") or "")
+    raw_mergeable_flag = pr.get("mergeable")
+    checks_raw = client.get_commit_checks(sha) if sha else []
+    checks = tuple(
+        CheckRun(
+            name=str(c.get("name") or ""),
+            status=str(c.get("status") or ""),
+            conclusion=str(c.get("conclusion") or ""),
+        )
+        for c in checks_raw
+    )
+    reviews_raw = client.list_reviews(number)
+    prior_reviews = tuple(
+        PriorReview(
+            user_login=str((r.get("user") or {}).get("login") or ""),
+            state=str(r.get("state") or ""),
+            commit_id=str(r.get("commit_id") or ""),
+            submitted_at=str(r.get("submitted_at") or ""),
+        )
+        for r in reviews_raw
+    )
+    return PRSnapshot(
+        number=int(pr.get("number") or number),
+        title=str(pr.get("title") or ""),
+        html_url=str(pr.get("html_url") or ""),
+        author=str(user.get("login") or ""),
+        head_sha=sha,
+        head_ref=str(head.get("ref") or ""),
+        is_draft=bool(pr.get("draft") or False),
+        mergeable=_mergeability_from_state(raw_mergeable_state, raw_mergeable_flag),
+        labels=labels,
+        changed_files=changed,
+        additions=int(pr.get("additions") or 0),
+        deletions=int(pr.get("deletions") or 0),
+        checks=checks,
+        prior_reviews=prior_reviews,
+    )
+
+
+def _mergeability_from_state(mergeable_state: str, mergeable: bool | None) -> str:
+    """Map GitHub's detailed ``mergeable_state`` to our 3-value enum.
+
+    GitHub returns detailed states: ``clean``, ``unstable``, ``has_hooks``,
+    ``blocked``, ``dirty``, ``behind``, ``unknown``. We map these to
+    MERGEABLE / CONFLICTING / UNKNOWN with the following rationale:
+
+    - ``clean``/``unstable``/``has_hooks`` → MERGEABLE. The CI-check gate
+      independently verifies all checks are SUCCESS.
+    - ``blocked`` → MERGEABLE. "blocked" typically means "missing required
+      approval" (the exact state we want to approve). If it's blocked on a
+      failing required check, the independent check gate will still reject.
+    - ``dirty`` (conflicts) / ``behind`` (needs rebase) → CONFLICTING.
+    - ``unknown`` (still computing) → UNKNOWN. Caller falls through to the
+      ``mergeable`` boolean when available.
+    """
+    state = (mergeable_state or "").lower()
+    if state in {"clean", "has_hooks", "unstable", "blocked"}:
+        return "MERGEABLE"
+    if state in {"dirty", "behind"}:
+        return "CONFLICTING"
+    if mergeable is True:
+        return "MERGEABLE"
+    if mergeable is False:
+        return "CONFLICTING"
+    return "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Main orchestration
+# ---------------------------------------------------------------------------
+
+
+APPROVAL_BODY_TEMPLATE = """\
+✅ **Auto-approved by aragora-automation[bot]**
+
+This PR satisfied every conservative auto-approval gate:
+
+- Author on allowlist: `{author}`
+- Opt-in label(s) present: `{labels}`
+- All CI checks `SUCCESS` ({check_count} runs)
+- No protected paths touched ({file_count} files, {loc} LOC net)
+- Head SHA: `{sha}`
+
+Audit trail: see `~/.aragora/auto_approver_audit.jsonl`.
+Kill switch: `touch ~/.aragora/auto_approver.disabled`.
+
+This is an automated review — any human reviewer may override or dismiss it.
+"""
+
+
+def build_approval_body(pr: PRSnapshot) -> str:
+    return APPROVAL_BODY_TEMPLATE.format(
+        author=pr.author,
+        labels=", ".join(pr.labels),
+        check_count=len(pr.checks),
+        file_count=len(pr.changed_files),
+        loc=pr.additions + pr.deletions,
+        sha=pr.head_sha[:12],
+    )
+
+
+def configure_logging(log_path: Path) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(log_path, encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    # Also echo to stderr for launchd / interactive runs.
+    stream = logging.StreamHandler()
+    stream.setFormatter(logging.Formatter("%(asctime)s %(levelname)s: %(message)s"))
+    logger.addHandler(stream)
+
+
+def run(
+    repo: str,
+    *,
+    policy: ApprovalPolicy,
+    dry_run: bool,
+    rate_limit_per_hour: int,
+    rate_limit_path: Path = RATE_LIMIT_PATH,
+    audit_log_path: Path = AUDIT_LOG_PATH,
+    kill_switch_path: Path = KILL_SWITCH_PATH,
+    live_flag_path: Path = LIVE_FLAG_PATH,
+    client_factory: Callable[[str, str], GitHubClient] | None = None,
+    per_page: int = DEFAULT_PER_PAGE,
+    now_epoch: float | None = None,
+) -> dict[str, Any]:
+    """Run a single pass. Returns a summary dict suitable for JSON output."""
+    now_iso = datetime.now(tz=UTC).isoformat()
+    summary: dict[str, Any] = {
+        "repo": repo,
+        "timestamp": now_iso,
+        "mode": "dry-run" if dry_run else "live",
+        "decisions": [],
+        "approvals": [],
+        "skips": [],
+        "kill_switch": False,
+        "rate_limited": False,
+    }
+
+    if kill_switch_engaged(kill_switch_path):
+        summary["kill_switch"] = True
+        logger.warning("Kill switch engaged at %s; exiting without work.", kill_switch_path)
+        append_audit_record(
+            audit_log_path,
+            {
+                "timestamp": now_iso,
+                "repo": repo,
+                "event": "kill_switch_engaged",
+                "path": str(kill_switch_path),
+            },
+        )
+        return summary
+
+    # Effective mode: caller can force dry_run=True, but live requires the flag.
+    effective_dry_run = dry_run or not is_live_mode(live_flag_path)
+    summary["mode"] = "dry-run" if effective_dry_run else "live"
+
+    token = get_github_app_installation_token()
+    if not token:
+        summary["error"] = "no_installation_token"
+        logger.error("Could not mint GitHub App installation token; aborting.")
+        append_audit_record(
+            audit_log_path,
+            {"timestamp": now_iso, "repo": repo, "event": "token_mint_failed"},
+        )
+        return summary
+
+    factory = client_factory or (lambda r, t: GitHubClient(r, token=t))
+    client = factory(repo, token)
+
+    try:
+        open_prs = client.list_open_prs(per_page=per_page)
+    except urllib.error.HTTPError as exc:
+        summary["error"] = f"list_prs_failed:{exc.code}"
+        logger.error("Failed to list open PRs: %s", exc)
+        return summary
+
+    logger.info("Inspecting %d open PR(s) in %s (mode=%s).", len(open_prs), repo, summary["mode"])
+
+    for pr_summary in open_prs:
+        number = int(pr_summary.get("number") or 0)
+        if not number:
+            continue
+        try:
+            snapshot = build_snapshot(client, number)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("Failed to build snapshot for #%d: %s", number, exc)
+            summary["skips"].append(
+                {"number": number, "reason": "snapshot_failed", "error": str(exc)}
+            )
+            continue
+
+        decision = evaluate_pr(snapshot, policy)
+        summary["decisions"].append(asdict(decision))
+
+        logger.info(
+            "PR #%d: approve=%s reason=%s head_sha=%s",
+            decision.number,
+            decision.approve,
+            decision.reason,
+            decision.head_sha[:8] if decision.head_sha else "?",
+        )
+
+        audit_record = {
+            "timestamp": now_iso,
+            "repo": repo,
+            "number": decision.number,
+            "head_sha": decision.head_sha,
+            "author": snapshot.author,
+            "labels": list(snapshot.labels),
+            "approve": decision.approve,
+            "reason": decision.reason,
+            "details": decision.details,
+            "mode": summary["mode"],
+            "url": decision.url,
+        }
+
+        if not decision.approve:
+            summary["skips"].append(
+                {"number": decision.number, "reason": decision.reason, "url": decision.url}
+            )
+            audit_record["event"] = "skip"
+            append_audit_record(audit_log_path, audit_record)
+            continue
+
+        # Rate limit — reserve a slot before network call.
+        allowed, new_state = rate_limit_check_and_reserve(
+            rate_limit_path,
+            limit_per_hour=rate_limit_per_hour,
+            now_epoch=now_epoch,
+        )
+        if not allowed:
+            summary["rate_limited"] = True
+            summary["skips"].append(
+                {
+                    "number": decision.number,
+                    "reason": "rate_limited",
+                    "url": decision.url,
+                }
+            )
+            audit_record["event"] = "rate_limited"
+            append_audit_record(audit_log_path, audit_record)
+            logger.warning(
+                "Rate limit reached (%d/hr); PR #%d deferred.",
+                rate_limit_per_hour,
+                decision.number,
+            )
+            # Do not persist the reservation since we didn't actually approve.
+            break
+
+        body = build_approval_body(snapshot)
+
+        if effective_dry_run:
+            audit_record["event"] = "dry_run_approve"
+            audit_record["body"] = body
+            append_audit_record(audit_log_path, audit_record)
+            summary["approvals"].append(
+                {
+                    "number": decision.number,
+                    "head_sha": decision.head_sha,
+                    "url": decision.url,
+                    "mode": "dry-run",
+                }
+            )
+            logger.info(
+                "[dry-run] Would approve PR #%d (head=%s).",
+                decision.number,
+                decision.head_sha[:8],
+            )
+            continue
+
+        # Live approval.
+        try:
+            response = client.submit_review(decision.number, body=body, event="APPROVE")
+        except Exception as exc:  # pragma: no cover - network errors
+            audit_record["event"] = "approve_failed"
+            audit_record["error"] = str(exc)
+            append_audit_record(audit_log_path, audit_record)
+            logger.error("Failed to approve PR #%d: %s", decision.number, exc)
+            summary["skips"].append(
+                {
+                    "number": decision.number,
+                    "reason": "approve_failed",
+                    "error": str(exc),
+                    "url": decision.url,
+                }
+            )
+            continue
+
+        # Persist the rate-limit reservation only after a successful live approval.
+        _save_rate_limit(rate_limit_path, new_state)
+        audit_record["event"] = "approved"
+        audit_record["review_id"] = response.get("id")
+        append_audit_record(audit_log_path, audit_record)
+        summary["approvals"].append(
+            {
+                "number": decision.number,
+                "head_sha": decision.head_sha,
+                "url": decision.url,
+                "mode": "live",
+                "review_id": response.get("id"),
+            }
+        )
+        logger.info(
+            "Approved PR #%d (review_id=%s head=%s).",
+            decision.number,
+            response.get("id"),
+            decision.head_sha[:8],
+        )
+
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Auto-approve safe automation PRs via the aragora-automation GitHub App."
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="OWNER/NAME (default: %(default)s)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log would-approve decisions without submitting reviews.",
+    )
+    parser.add_argument(
+        "--max-diff-loc",
+        type=int,
+        default=DEFAULT_MAX_DIFF_LOC,
+        help="Maximum additions+deletions for auto-approval (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--rate-limit-per-hour",
+        type=int,
+        default=DEFAULT_RATE_LIMIT_PER_HOUR,
+        help="Maximum auto-approvals per rolling hour (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--allowed-author",
+        action="append",
+        default=None,
+        help="Override allowed authors. Repeatable; replaces defaults when provided.",
+    )
+    parser.add_argument(
+        "--optin-label",
+        action="append",
+        default=None,
+        help="Override opt-in labels. Repeatable; replaces defaults when provided.",
+    )
+    parser.add_argument(
+        "--per-page",
+        type=int,
+        default=DEFAULT_PER_PAGE,
+        help="PRs per page to fetch (default: %(default)s).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable summary.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    configure_logging(SCRIPT_LOG_PATH)
+
+    policy = ApprovalPolicy(
+        allowed_authors=tuple(args.allowed_author)
+        if args.allowed_author
+        else DEFAULT_ALLOWED_AUTHORS,
+        optin_labels=tuple(args.optin_label) if args.optin_label else DEFAULT_OPTIN_LABELS,
+        protected_paths=PROTECTED_PATH_PATTERNS,
+        max_diff_loc=args.max_diff_loc,
+    )
+
+    summary = run(
+        args.repo,
+        policy=policy,
+        dry_run=args.dry_run,
+        rate_limit_per_hour=args.rate_limit_per_hour,
+        per_page=args.per_page,
+    )
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True, default=str))
+    else:
+        approvals = summary.get("approvals") or []
+        skips = summary.get("skips") or []
+        print(f"mode={summary['mode']} repo={summary['repo']}")
+        print(f"approvals: {len(approvals)}")
+        for item in approvals:
+            print(f"  APPROVE #{item['number']} {item.get('url', '')}")
+        print(f"skips: {len(skips)}")
+        for item in skips:
+            print(f"  skip #{item['number']} reason={item.get('reason', '?')}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - CLI guard
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/auto_approver_activate.sh
+++ b/scripts/auto_approver_activate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Toggle the auto-approver between dry-run and live mode.
+#
+# Usage:
+#   scripts/auto_approver_activate.sh on    # enable live approvals
+#   scripts/auto_approver_activate.sh off   # return to dry-run mode
+#   scripts/auto_approver_activate.sh status
+#
+# The auto-approver script refuses to submit reviews unless
+# ~/.aragora/auto_approver.live exists, so this toggle is the operator's
+# explicit opt-in into production mode.
+
+set -euo pipefail
+
+STATE_DIR="${HOME}/.aragora"
+LIVE_FLAG="${STATE_DIR}/auto_approver.live"
+DISABLED_FLAG="${STATE_DIR}/auto_approver.disabled"
+
+mkdir -p "${STATE_DIR}"
+
+case "${1:-status}" in
+  on|enable|live)
+    touch "${LIVE_FLAG}"
+    if [[ -e "${DISABLED_FLAG}" ]]; then
+      echo "WARNING: kill switch ${DISABLED_FLAG} is still present; remove it to unblock approvals." >&2
+    fi
+    echo "auto-approver: LIVE (flag: ${LIVE_FLAG})"
+    ;;
+  off|disable|dryrun|dry-run)
+    rm -f "${LIVE_FLAG}"
+    echo "auto-approver: DRY-RUN (flag removed: ${LIVE_FLAG})"
+    ;;
+  kill|pause)
+    touch "${DISABLED_FLAG}"
+    echo "auto-approver: KILL SWITCH engaged (${DISABLED_FLAG})."
+    echo "Remove the file to resume: rm ${DISABLED_FLAG}"
+    ;;
+  resume|unkill)
+    rm -f "${DISABLED_FLAG}"
+    echo "auto-approver: KILL SWITCH cleared. Mode is $( [[ -e "${LIVE_FLAG}" ]] && echo LIVE || echo DRY-RUN )."
+    ;;
+  status|*)
+    mode="DRY-RUN"
+    if [[ -e "${LIVE_FLAG}" ]]; then mode="LIVE"; fi
+    kill_state="no"
+    if [[ -e "${DISABLED_FLAG}" ]]; then kill_state="YES (paused)"; fi
+    echo "auto-approver: mode=${mode} kill_switch=${kill_state}"
+    echo "  live flag:     ${LIVE_FLAG}"
+    echo "  disable flag:  ${DISABLED_FLAG}"
+    ;;
+esac

--- a/scripts/launchd/com.aragora.auto-approver.plist
+++ b/scripts/launchd/com.aragora.auto-approver.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent: aragora auto-approver for safe automation PRs.
+
+  On first deployment, the script runs in DRY-RUN mode because
+  ~/.aragora/auto_approver.live does not exist. Behavior is fully logged
+  under ~/.aragora/auto_approver_audit.jsonl and
+  ~/.aragora/auto-approver-launchd.log.
+
+  To transition from dry-run to live, run:
+      scripts/auto_approver_activate.sh on
+
+  To pause immediately (no approvals until cleared):
+      touch ~/.aragora/auto_approver.disabled
+
+  Installation:
+      cp scripts/launchd/com.aragora.auto-approver.plist ~/Library/LaunchAgents/
+      launchctl load ~/Library/LaunchAgents/com.aragora.auto-approver.plist
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.aragora.auto-approver</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>cd /Users/armand/Development/aragora &amp;&amp; /usr/bin/python3 scripts/auto_approve_safe_prs.py --json</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/armand/Development/aragora</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>ARAGORA_AUTOMATION_ENV_FILE</key>
+    <string>/Users/armand/.aragora/.env.automation</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <!-- Every 5 minutes. The script itself is rate-limited and idempotent. -->
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>StandardOutPath</key>
+  <string>/Users/armand/.aragora/auto-approver-launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/armand/.aragora/auto-approver-launchd.log</string>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>Nice</key>
+  <integer>5</integer>
+</dict>
+</plist>

--- a/tests/scripts/test_auto_approve_safe_prs.py
+++ b/tests/scripts/test_auto_approve_safe_prs.py
@@ -1,0 +1,617 @@
+"""Unit tests for ``scripts/auto_approve_safe_prs.py``.
+
+These tests exercise the pure decision logic, safety features, and mocked
+GitHub API integration without ever hitting the network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.auto_approve_safe_prs import (
+    DEFAULT_ALLOWED_AUTHORS,
+    DEFAULT_OPTIN_LABELS,
+    PROTECTED_PATH_PATTERNS,
+    ApprovalPolicy,
+    CheckRun,
+    GitHubClient,
+    PRSnapshot,
+    PriorReview,
+    RateLimitState,
+    _load_rate_limit,
+    _save_rate_limit,
+    any_protected_paths,
+    append_audit_record,
+    build_approval_body,
+    build_snapshot,
+    evaluate_pr,
+    is_live_mode,
+    kill_switch_engaged,
+    path_is_protected,
+    rate_limit_check_and_reserve,
+    run,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _pr(
+    number: int = 1,
+    *,
+    author: str = "an0mium",
+    labels: tuple[str, ...] = ("autonomous",),
+    changed_files: tuple[str, ...] = ("aragora/server/handlers/new.py",),
+    is_draft: bool = False,
+    mergeable: str = "MERGEABLE",
+    checks: tuple[CheckRun, ...] | None = None,
+    prior_reviews: tuple[PriorReview, ...] = (),
+    head_sha: str = "abcd" * 10,
+    additions: int = 50,
+    deletions: int = 10,
+) -> PRSnapshot:
+    if checks is None:
+        checks = (
+            CheckRun(name="tests", status="completed", conclusion="success"),
+            CheckRun(name="lint", status="completed", conclusion="success"),
+        )
+    return PRSnapshot(
+        number=number,
+        title=f"PR #{number}",
+        html_url=f"https://github.com/synaptent/aragora/pull/{number}",
+        author=author,
+        head_sha=head_sha,
+        head_ref=f"feature/pr-{number}",
+        is_draft=is_draft,
+        mergeable=mergeable,
+        labels=labels,
+        changed_files=changed_files,
+        additions=additions,
+        deletions=deletions,
+        checks=checks,
+        prior_reviews=prior_reviews,
+    )
+
+
+def _policy(**overrides: Any) -> ApprovalPolicy:
+    defaults: dict[str, Any] = {
+        "allowed_authors": DEFAULT_ALLOWED_AUTHORS,
+        "optin_labels": DEFAULT_OPTIN_LABELS,
+        "protected_paths": PROTECTED_PATH_PATTERNS,
+        "max_diff_loc": 5000,
+    }
+    defaults.update(overrides)
+    return ApprovalPolicy(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Path protection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "CLAUDE.md",
+        "aragora/CLAUDE.md",
+        "aragora/tests/CLAUDE.md",
+        "scripts/CLAUDE.md",
+        ".env",
+        ".env.production",
+        "aragora/.env",
+        "scripts/nomic_loop.py",
+        "aragora/__init__.py",
+        ".github/workflows/ci.yml",
+        "scripts/baselines/check_sdk_parity.json",
+        "some/dir/github-app.pem",
+        "aragora/secrets.py",
+        "aragora/config/secrets_manager.py",
+        "vendor/aws-private-key.pem",
+        "priv/server-private-key.txt",
+    ],
+)
+def test_path_is_protected_positive(path: str) -> None:
+    assert path_is_protected(path, PROTECTED_PATH_PATTERNS), path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "aragora/server/handlers/new.py",
+        "docs/guide.md",
+        "tests/test_foo.py",
+        "sdk/python/aragora_sdk/namespaces/costs.py",
+        "README.md",
+        "scripts/auto_approve_safe_prs.py",
+    ],
+)
+def test_path_is_protected_negative(path: str) -> None:
+    assert not path_is_protected(path, PROTECTED_PATH_PATTERNS), path
+
+
+def test_any_protected_paths_returns_subset() -> None:
+    paths = ("ok.py", "CLAUDE.md", "other.py", ".env")
+    hits = any_protected_paths(paths, PROTECTED_PATH_PATTERNS)
+    assert hits == ["CLAUDE.md", ".env"]
+
+
+# ---------------------------------------------------------------------------
+# evaluate_pr gates
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_pr_approves_when_all_gates_pass() -> None:
+    decision = evaluate_pr(_pr(), _policy())
+    assert decision.approve is True
+    assert decision.reason == "eligible"
+
+
+def test_evaluate_pr_rejects_self_authored() -> None:
+    decision = evaluate_pr(_pr(author="aragora-automation[bot]"), _policy())
+    assert decision.approve is False
+    assert decision.reason == "self_authored"
+
+
+def test_evaluate_pr_rejects_draft() -> None:
+    decision = evaluate_pr(_pr(is_draft=True), _policy())
+    assert decision.approve is False
+    assert decision.reason == "draft"
+
+
+def test_evaluate_pr_rejects_not_mergeable() -> None:
+    decision = evaluate_pr(_pr(mergeable="CONFLICTING"), _policy())
+    assert decision.approve is False
+    assert decision.reason == "not_mergeable"
+
+
+def test_evaluate_pr_rejects_non_allowlisted_author() -> None:
+    decision = evaluate_pr(_pr(author="random-human"), _policy())
+    assert decision.approve is False
+    assert decision.reason == "author_not_allowlisted"
+
+
+def test_evaluate_pr_rejects_missing_optin_label() -> None:
+    decision = evaluate_pr(_pr(labels=("bug",)), _policy())
+    assert decision.approve is False
+    assert decision.reason == "missing_optin_label"
+
+
+def test_evaluate_pr_accepts_any_optin_label() -> None:
+    for label in DEFAULT_OPTIN_LABELS:
+        decision = evaluate_pr(_pr(labels=(label,)), _policy())
+        assert decision.approve is True, f"should accept {label}"
+
+
+def test_evaluate_pr_rejects_pending_checks() -> None:
+    pending = (CheckRun(name="tests", status="in_progress", conclusion=""),)
+    decision = evaluate_pr(_pr(checks=pending), _policy())
+    assert decision.approve is False
+    assert decision.reason.startswith("checks_pending")
+
+
+def test_evaluate_pr_rejects_failed_checks() -> None:
+    failed = (
+        CheckRun(name="tests", status="completed", conclusion="success"),
+        CheckRun(name="lint", status="completed", conclusion="failure"),
+    )
+    decision = evaluate_pr(_pr(checks=failed), _policy())
+    assert decision.approve is False
+    assert decision.reason.startswith("checks_failed")
+
+
+def test_evaluate_pr_rejects_cancelled_checks() -> None:
+    cancelled = (CheckRun(name="smoke", status="completed", conclusion="cancelled"),)
+    decision = evaluate_pr(_pr(checks=cancelled), _policy())
+    assert decision.approve is False
+    assert "cancelled" in decision.reason
+
+
+def test_evaluate_pr_accepts_neutral_and_skipped_checks() -> None:
+    runs = (
+        CheckRun(name="tests", status="completed", conclusion="success"),
+        CheckRun(name="optional", status="completed", conclusion="neutral"),
+        CheckRun(name="docs-only", status="completed", conclusion="skipped"),
+    )
+    decision = evaluate_pr(_pr(checks=runs), _policy())
+    assert decision.approve is True
+
+
+def test_evaluate_pr_rejects_no_checks_reported() -> None:
+    decision = evaluate_pr(_pr(checks=()), _policy())
+    assert decision.approve is False
+    assert decision.reason == "no_checks_reported"
+
+
+def test_evaluate_pr_rejects_protected_paths() -> None:
+    decision = evaluate_pr(
+        _pr(changed_files=("aragora/server/handlers/ok.py", "CLAUDE.md")),
+        _policy(),
+    )
+    assert decision.approve is False
+    assert decision.reason == "protected_paths_touched"
+
+
+def test_evaluate_pr_rejects_large_diff() -> None:
+    decision = evaluate_pr(_pr(additions=4000, deletions=2000), _policy(max_diff_loc=5000))
+    assert decision.approve is False
+    assert decision.reason == "diff_too_large"
+
+
+def test_evaluate_pr_idempotent_when_already_approved_same_head() -> None:
+    sha = "deadbeef" * 5
+    prior = (
+        PriorReview(
+            user_login="aragora-automation[bot]",
+            state="APPROVED",
+            commit_id=sha,
+            submitted_at="2026-04-18T00:00:00Z",
+        ),
+    )
+    decision = evaluate_pr(_pr(head_sha=sha, prior_reviews=prior), _policy())
+    assert decision.approve is False
+    assert decision.reason == "already_approved"
+
+
+def test_evaluate_pr_re_approves_when_head_changed() -> None:
+    old_sha = "deadbeef" * 5
+    new_sha = "cafebabe" * 5
+    prior = (
+        PriorReview(
+            user_login="aragora-automation[bot]",
+            state="APPROVED",
+            commit_id=old_sha,
+            submitted_at="2026-04-18T00:00:00Z",
+        ),
+    )
+    decision = evaluate_pr(_pr(head_sha=new_sha, prior_reviews=prior), _policy())
+    assert decision.approve is True
+    assert decision.reason == "eligible"
+
+
+def test_evaluate_pr_ignores_non_app_prior_reviews() -> None:
+    sha = "feedbeef" * 5
+    prior = (
+        PriorReview(
+            user_login="some-human",
+            state="APPROVED",
+            commit_id=sha,
+            submitted_at="2026-04-18T00:00:00Z",
+        ),
+    )
+    decision = evaluate_pr(_pr(head_sha=sha, prior_reviews=prior), _policy())
+    assert decision.approve is True
+
+
+# ---------------------------------------------------------------------------
+# Rate limit + kill switch + live flag
+# ---------------------------------------------------------------------------
+
+
+def test_kill_switch_detects_file(tmp_path: Path) -> None:
+    flag = tmp_path / "auto_approver.disabled"
+    assert not kill_switch_engaged(flag)
+    flag.touch()
+    assert kill_switch_engaged(flag)
+
+
+def test_is_live_mode_requires_flag(tmp_path: Path) -> None:
+    flag = tmp_path / "auto_approver.live"
+    assert not is_live_mode(flag)
+    flag.touch()
+    assert is_live_mode(flag)
+
+
+def test_rate_limit_allows_up_to_quota(tmp_path: Path) -> None:
+    path = tmp_path / "rate.json"
+    now = 1_000_000.0
+    for i in range(3):
+        allowed, state = rate_limit_check_and_reserve(path, limit_per_hour=3, now_epoch=now + i)
+        assert allowed is True, f"iteration {i}"
+        _save_rate_limit(path, state)
+    # 4th in same window — denied.
+    allowed, _ = rate_limit_check_and_reserve(path, limit_per_hour=3, now_epoch=now + 10)
+    assert allowed is False
+
+
+def test_rate_limit_rolls_over_after_hour(tmp_path: Path) -> None:
+    path = tmp_path / "rate.json"
+    now = 1_000_000.0
+    for i in range(3):
+        allowed, state = rate_limit_check_and_reserve(path, limit_per_hour=3, now_epoch=now + i)
+        assert allowed is True
+        _save_rate_limit(path, state)
+    # After the window rolls over, quota resets.
+    allowed, state = rate_limit_check_and_reserve(path, limit_per_hour=3, now_epoch=now + 3600 + 5)
+    assert allowed is True
+    _save_rate_limit(path, state)
+    assert state.approvals_in_window == 1
+
+
+def test_rate_limit_round_trips_through_disk(tmp_path: Path) -> None:
+    path = tmp_path / "rate.json"
+    assert _load_rate_limit(path) is None
+    state = RateLimitState(window_start_epoch=123.0, approvals_in_window=4)
+    _save_rate_limit(path, state)
+    loaded = _load_rate_limit(path)
+    assert loaded is not None
+    assert loaded.window_start_epoch == 123.0
+    assert loaded.approvals_in_window == 4
+
+
+def test_append_audit_record_writes_jsonl(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    append_audit_record(path, {"n": 1, "reason": "eligible"})
+    append_audit_record(path, {"n": 2, "reason": "draft"})
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["n"] == 1
+    assert json.loads(lines[1])["reason"] == "draft"
+
+
+# ---------------------------------------------------------------------------
+# build_approval_body
+# ---------------------------------------------------------------------------
+
+
+def test_build_approval_body_includes_audit_trail() -> None:
+    body = build_approval_body(_pr(number=42))
+    assert "Auto-approved" in body
+    assert "an0mium" in body
+    assert "autonomous" in body
+    assert "kill switch" in body.lower() or "auto_approver.disabled" in body
+
+
+# ---------------------------------------------------------------------------
+# Mocked GitHubClient / run() integration
+# ---------------------------------------------------------------------------
+
+
+class FakeGitHub:
+    """In-memory stand-in for GitHubClient, mimicking just the shape we need."""
+
+    def __init__(self, prs: list[dict[str, Any]]) -> None:
+        self.prs = prs
+        self.submitted_reviews: list[dict[str, Any]] = []
+
+    # Emulate the client's public surface used by ``run``/``build_snapshot``.
+    def list_open_prs(self, per_page: int = 30) -> list[dict[str, Any]]:
+        return [{"number": pr["number"]} for pr in self.prs]
+
+    def _find(self, number: int) -> dict[str, Any]:
+        for pr in self.prs:
+            if pr["number"] == number:
+                return pr
+        raise KeyError(number)
+
+    def get_pr(self, number: int) -> dict[str, Any]:
+        pr = self._find(number)
+        return {
+            "number": pr["number"],
+            "title": pr.get("title", f"PR {number}"),
+            "html_url": f"https://github.com/synaptent/aragora/pull/{number}",
+            "draft": pr.get("draft", False),
+            "mergeable_state": pr.get("mergeable_state", "clean"),
+            "mergeable": pr.get("mergeable", True),
+            "additions": pr.get("additions", 10),
+            "deletions": pr.get("deletions", 5),
+            "head": {"sha": pr.get("sha", "a" * 40), "ref": pr.get("ref", "feature/x")},
+            "user": {"login": pr.get("author", "an0mium")},
+            "labels": [{"name": n} for n in pr.get("labels", ["autonomous"])],
+        }
+
+    def get_pr_files(self, number: int) -> list[dict[str, Any]]:
+        pr = self._find(number)
+        return [{"filename": f} for f in pr.get("files", ["aragora/ok.py"])]
+
+    def get_commit_checks(self, sha: str) -> list[dict[str, Any]]:
+        # Single "tests" success by default; per-PR override via ``checks``.
+        for pr in self.prs:
+            if pr.get("sha") == sha:
+                return pr.get(
+                    "checks",
+                    [{"name": "tests", "status": "completed", "conclusion": "success"}],
+                )
+        return [{"name": "tests", "status": "completed", "conclusion": "success"}]
+
+    def list_reviews(self, number: int) -> list[dict[str, Any]]:
+        return self._find(number).get("reviews", [])
+
+    def submit_review(self, number: int, *, body: str, event: str = "APPROVE") -> dict[str, Any]:
+        self.submitted_reviews.append({"number": number, "body": body, "event": event})
+        return {"id": 9000 + number, "state": event}
+
+
+@pytest.fixture
+def _state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    # Point the script's default state paths into a tmp dir.
+    import scripts.auto_approve_safe_prs as module
+
+    monkeypatch.setattr(module, "KILL_SWITCH_PATH", tmp_path / "auto_approver.disabled")
+    monkeypatch.setattr(module, "LIVE_FLAG_PATH", tmp_path / "auto_approver.live")
+    monkeypatch.setattr(module, "RATE_LIMIT_PATH", tmp_path / "rate.json")
+    monkeypatch.setattr(module, "AUDIT_LOG_PATH", tmp_path / "audit.jsonl")
+    monkeypatch.setattr(module, "SCRIPT_LOG_PATH", tmp_path / "script.log")
+    return tmp_path
+
+
+def _install_fake_token(monkeypatch: pytest.MonkeyPatch, token: str = "fake-token") -> None:
+    import scripts.auto_approve_safe_prs as module
+
+    monkeypatch.setattr(module, "get_github_app_installation_token", lambda: token)
+
+
+def test_run_dry_run_does_not_submit(_state_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_token(monkeypatch)
+    fake = FakeGitHub([{"number": 1, "sha": "a" * 40}])
+    summary = run(
+        "synaptent/aragora",
+        policy=_policy(),
+        dry_run=True,
+        rate_limit_per_hour=10,
+        rate_limit_path=_state_dir / "rate.json",
+        audit_log_path=_state_dir / "audit.jsonl",
+        kill_switch_path=_state_dir / "auto_approver.disabled",
+        live_flag_path=_state_dir / "auto_approver.live",
+        client_factory=lambda repo, token: fake,  # type: ignore[arg-type,return-value]
+    )
+    assert summary["mode"] == "dry-run"
+    assert len(summary["approvals"]) == 1
+    assert summary["approvals"][0]["mode"] == "dry-run"
+    assert fake.submitted_reviews == []
+
+
+def test_run_live_mode_requires_flag_file(
+    _state_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_token(monkeypatch)
+    fake = FakeGitHub([{"number": 1, "sha": "a" * 40}])
+    # dry_run=False but no live flag → still dry-run.
+    summary = run(
+        "synaptent/aragora",
+        policy=_policy(),
+        dry_run=False,
+        rate_limit_per_hour=10,
+        rate_limit_path=_state_dir / "rate.json",
+        audit_log_path=_state_dir / "audit.jsonl",
+        kill_switch_path=_state_dir / "auto_approver.disabled",
+        live_flag_path=_state_dir / "auto_approver.live",
+        client_factory=lambda repo, token: fake,  # type: ignore[arg-type,return-value]
+    )
+    assert summary["mode"] == "dry-run"
+    assert fake.submitted_reviews == []
+
+
+def test_run_live_mode_submits_when_flag_exists(
+    _state_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_token(monkeypatch)
+    (_state_dir / "auto_approver.live").touch()
+    fake = FakeGitHub([{"number": 42, "sha": "b" * 40}])
+    summary = run(
+        "synaptent/aragora",
+        policy=_policy(),
+        dry_run=False,
+        rate_limit_per_hour=10,
+        rate_limit_path=_state_dir / "rate.json",
+        audit_log_path=_state_dir / "audit.jsonl",
+        kill_switch_path=_state_dir / "auto_approver.disabled",
+        live_flag_path=_state_dir / "auto_approver.live",
+        client_factory=lambda repo, token: fake,  # type: ignore[arg-type,return-value]
+    )
+    assert summary["mode"] == "live"
+    assert len(fake.submitted_reviews) == 1
+    assert fake.submitted_reviews[0]["number"] == 42
+    assert fake.submitted_reviews[0]["event"] == "APPROVE"
+
+
+def test_run_kill_switch_short_circuits(_state_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_token(monkeypatch)
+    (_state_dir / "auto_approver.disabled").touch()
+    fake = FakeGitHub([{"number": 1, "sha": "a" * 40}])
+    summary = run(
+        "synaptent/aragora",
+        policy=_policy(),
+        dry_run=False,
+        rate_limit_per_hour=10,
+        rate_limit_path=_state_dir / "rate.json",
+        audit_log_path=_state_dir / "audit.jsonl",
+        kill_switch_path=_state_dir / "auto_approver.disabled",
+        live_flag_path=_state_dir / "auto_approver.live",
+        client_factory=lambda repo, token: fake,  # type: ignore[arg-type,return-value]
+    )
+    assert summary["kill_switch"] is True
+    assert summary["approvals"] == []
+    assert fake.submitted_reviews == []
+
+
+def test_run_rate_limit_blocks_second_approval(
+    _state_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_token(monkeypatch)
+    (_state_dir / "auto_approver.live").touch()
+    fake = FakeGitHub(
+        [
+            {"number": 1, "sha": "a" * 40},
+            {"number": 2, "sha": "b" * 40},
+        ]
+    )
+    summary = run(
+        "synaptent/aragora",
+        policy=_policy(),
+        dry_run=False,
+        rate_limit_per_hour=1,
+        rate_limit_path=_state_dir / "rate.json",
+        audit_log_path=_state_dir / "audit.jsonl",
+        kill_switch_path=_state_dir / "auto_approver.disabled",
+        live_flag_path=_state_dir / "auto_approver.live",
+        client_factory=lambda repo, token: fake,  # type: ignore[arg-type,return-value]
+    )
+    assert summary["rate_limited"] is True
+    assert len(fake.submitted_reviews) == 1  # only the first
+    reasons = [s["reason"] for s in summary["skips"]]
+    assert "rate_limited" in reasons
+
+
+def test_run_skips_protected_path_in_live_mode(
+    _state_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_token(monkeypatch)
+    (_state_dir / "auto_approver.live").touch()
+    fake = FakeGitHub([{"number": 1, "sha": "a" * 40, "files": ["CLAUDE.md"]}])
+    summary = run(
+        "synaptent/aragora",
+        policy=_policy(),
+        dry_run=False,
+        rate_limit_per_hour=10,
+        rate_limit_path=_state_dir / "rate.json",
+        audit_log_path=_state_dir / "audit.jsonl",
+        kill_switch_path=_state_dir / "auto_approver.disabled",
+        live_flag_path=_state_dir / "auto_approver.live",
+        client_factory=lambda repo, token: fake,  # type: ignore[arg-type,return-value]
+    )
+    assert fake.submitted_reviews == []
+    assert summary["skips"][0]["reason"] == "protected_paths_touched"
+
+
+def test_build_snapshot_maps_github_payload() -> None:
+    fake = FakeGitHub(
+        [
+            {
+                "number": 7,
+                "sha": "c" * 40,
+                "files": ["aragora/foo.py"],
+                "labels": ["autonomous", "docs"],
+                "reviews": [
+                    {
+                        "user": {"login": "some-human"},
+                        "state": "COMMENTED",
+                        "commit_id": "c" * 40,
+                        "submitted_at": "2026-04-17T12:00:00Z",
+                    }
+                ],
+            }
+        ]
+    )
+    snapshot = build_snapshot(fake, 7)  # type: ignore[arg-type]
+    assert snapshot.number == 7
+    assert snapshot.head_sha == "c" * 40
+    assert "autonomous" in snapshot.labels
+    assert snapshot.changed_files == ("aragora/foo.py",)
+    assert snapshot.prior_reviews[0].state == "COMMENTED"
+    assert snapshot.checks[0].conclusion == "success"
+
+
+def test_githubclient_urlopen_rejects_non_github_host() -> None:
+    client = GitHubClient("synaptent/aragora", token="fake")
+    with pytest.raises(RuntimeError, match="non-GitHub URL"):
+        GitHubClient._urlopen(
+            "https://evil.example.com/api",
+            method="GET",
+            headers={},
+        )


### PR DESCRIPTION
## Summary

Adds an auto-approver that removes the single biggest human gate on the autonomous merge pipeline. A new script \`scripts/auto_approve_safe_prs.py\` scans open PRs in \`synaptent/aragora\` and uses the \`aragora-automation\` GitHub App installation token to submit \`APPROVE\` reviews — **only** when every conservative gate in an 8-point allowlist passes.

**Ships in DRY-RUN mode by default. No live approvals until the operator explicitly opts in.**

## Phase 1 finding

Verified at design time that the App has the \`pull_requests: write\` permission via \`GET /app/installations/122689816\`. Account: \`an0mium\`. Repo selection: \`all\`. No settings changes required.

## 8 approval gates (ALL must pass)

| # | Gate | Rejection reason on failure |
|---|------|------------------------------|
| 0 | Not our own PR | \`self_authored\` |
| 1 | MERGEABLE (not dirty/behind) | \`not_mergeable\` |
| 2 | Not a draft | \`draft\` |
| 3 | Author allowlisted (\`an0mium\`, \`factory-droid[bot]\`, \`codex-bot\`, \`aragora-automation[bot]\`) | \`author_not_allowlisted\` |
| 4 | Opt-in label (\`autonomous\`, \`codex-automation\`, \`droid-generated\`, \`auto-approve\`) | \`missing_optin_label\` |
| 5 | All CI checks \`SUCCESS\`/\`neutral\`/\`skipped\` | \`checks_pending\` / \`checks_failed\` |
| 6 | No protected paths touched (CLAUDE.md, .env*, secrets*, *private-key*, scripts/nomic_loop.py, .github/workflows/*, scripts/baselines/*) | \`protected_paths_touched\` |
| 7 | Diff ≤ 5000 LOC net | \`diff_too_large\` |
| 8 | Not already approved for current head SHA | \`already_approved\` |

Head SHA changes → re-approves automatically.

## Safety layer

- **DRY-RUN is default.** Live approvals require \`~/.aragora/auto_approver.live\` (created via \`scripts/auto_approver_activate.sh on\`).
- **Kill switch:** \`touch ~/.aragora/auto_approver.disabled\` → script exits 0 immediately.
- **Rate limit:** ≤10 approvals/hour, persistent counter at \`~/.aragora/auto_approver_rate.json\`.
- **Audit log:** every invocation appends a JSON line to \`~/.aragora/auto_approver_audit.jsonl\` with full decision trace.
- **Self-approval guard:** refuses to approve any PR authored by \`aragora-automation[bot]\`.

## Deployment

- LaunchAgent: \`scripts/launchd/com.aragora.auto-approver.plist\` (runs every 5 min).
- Activation toggle: \`scripts/auto_approver_activate.sh {on|off|kill|resume|status}\`.
- Install with \`cp scripts/launchd/com.aragora.auto-approver.plist ~/Library/LaunchAgents/ && launchctl load …\`.
- First 2h post-install: dry-run. Operator reviews \`~/.aragora/auto_approver_audit.jsonl\`, then \`scripts/auto_approver_activate.sh on\`.

## Tests

55 unit tests in \`tests/scripts/test_auto_approve_safe_prs.py\`:
- Protected-path pattern matching (dotfiles, nested CLAUDE.md, .pem globs, secrets)
- All 8 gates with positive + negative cases
- Rate-limit rollover across the 1-hour window
- Kill-switch short-circuit
- Live-flag requirement for real submission
- Idempotency against mocked prior App reviews
- Re-approval when head SHA changes
- Fake-GitHub client for end-to-end dry-run vs live

\`\`\`
python3 -m pytest tests/scripts/test_auto_approve_safe_prs.py -q
… 55 passed in 1.91s
\`\`\`

Dry-run smoke-test against live GitHub produced 13 skips (6 missing label, 2 not mergeable, 2 failed Quality Gates, 2 drafts, 1 checks failed) and 0 approvals — expected since no current PR carries an opt-in label.

## Rollback / emergency

If something bad slips through:
1. \`touch ~/.aragora/auto_approver.disabled\` (pauses within 5 min)
2. Dismiss the review via GitHub UI or \`gh pr review\`
3. \`grep '\"number\": <n>' ~/.aragora/auto_approver_audit.jsonl\` shows the exact gate-pass reasoning
4. Tighten gates: shrink label allowlist, lower \`--max-diff-loc\`, or add the path to \`PROTECTED_PATH_PATTERNS\`

## Design doc

\`docs/plans/2026-04-18-auto-approver-design.md\` — full rationale, criteria, rollback procedure, expected velocity impact, known follow-ups.

## Validation

- 55/55 unit tests passing
- \`mypy scripts/auto_approve_safe_prs.py\` clean
- \`scripts/automation_pr_preflight.sh origin/main HEAD\` passes
- Pre-push hooks all green (ruff, gitleaks, mypy-baseline)
- Live dry-run invocation against \`synaptent/aragora\` confirmed correct gate behavior

## Known follow-ups

- Shrink dry-run window after verification cycle
- Consider SLO alert if \`approvals_in_window\` regularly >70% of quota
- Consider cross-linking to \`scripts/merge_codex_automation_prs.py\` so the same safety signals feed both

---

🤖 This is draft-only. No live approvals until the operator flips the flag.