### PR TITLE
fix(swarm): create queue autofill issues from boss loop

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1174,6 +1174,7 @@ class BossLoop:
                 repo_root=Path.cwd(),
                 consecutive_empty_ticks=self._consecutive_empty_iterations,
                 existing_candidates=candidate_issues,
+                create_issue=self._create_queue_autofill_issue,
                 env=self._env,
             )
         except Exception:  # pragma: no cover - defensive guard
@@ -1184,6 +1185,33 @@ class BossLoop:
         if payload.get("attempted") and payload.get("reason") in {"created", "created_dry_run"}:
             self._consecutive_empty_iterations = 0
         return payload
+
+    def _create_queue_autofill_issue(self, candidate: Any, body: str) -> bool:
+        repo = str(self.config.repo or "").strip()
+        if not repo:
+            raise RuntimeError("missing_repo_slug")
+
+        from aragora.swarm.github_app_auth import gh_subprocess_run
+
+        cmd = [
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            str(getattr(candidate, "title", "") or "").strip(),
+            "--body",
+            body,
+            "--label",
+            "boss-ready",
+            "--label",
+            "autonomous",
+        ]
+        proc = gh_subprocess_run(cmd, timeout=30, write_op=True)
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip()
+            raise RuntimeError(detail or "gh issue create failed")
+        return True
 
     def _no_suitable_issue_guidance(
         self,

--- a/aragora/swarm/queue_autofill.py
+++ b/aragora/swarm/queue_autofill.py
@@ -172,7 +172,7 @@ def maybe_autofill_queue(
     repo_root: Path,
     consecutive_empty_ticks: int,
     existing_candidates: Iterable[Any] = (),
-    create_issue: Callable[[AutofillCandidate], bool] | None = None,
+    create_issue: Callable[[AutofillCandidate, str], bool] | None = None,
     env: dict[str, str] | None = None,
     now: float | None = None,
     threshold: int = DEFAULT_EMPTY_TICK_THRESHOLD,
@@ -196,8 +196,9 @@ def maybe_autofill_queue(
 
     ``create_issue`` is a thin callback provided by the caller (typically a
     wrapper around ``gh issue create``).  We call it once per candidate that
-    survives every gate.  Returning ``False`` is treated as a failed create
-    and is surfaced via :attr:`AutofillResult.errors`.
+    survives every gate, passing both the candidate summary and the formatted
+    issue body. Returning ``False`` is treated as a failed create and is
+    surfaced via :attr:`AutofillResult.errors`.
     """
     threshold = max(1, int(threshold))
     max_issues = max(0, int(max_issues))
@@ -382,10 +383,10 @@ def maybe_autofill_queue(
         _write_last_run(sentinel_path, timestamp)
         return _finalize(result, metrics_jsonl_path)
 
-    for candidate, _body, lane in trimmed:
+    for candidate, body, lane in trimmed:
         autofill = _as_autofill_candidate(candidate, lane)
         try:
-            ok = bool(create_issue(autofill))
+            ok = bool(create_issue(autofill, body))
         except Exception as exc:
             errors.append(f"{autofill.title}: {exc}")
             continue

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -54,6 +54,7 @@ from aragora.swarm.boss_loop import (
     sanitize_issue_body_for_dispatch,
     select_eligible_issue,
 )
+from aragora.swarm.queue_autofill import AutofillCandidate, AutofillResult, QUEUE_AUTOFILL_FLAG_ENV
 from aragora.swarm.roadmap_priority import RoadmapPriorityPolicy
 from aragora.swarm.session_state import SessionStateStore
 from aragora.swarm.task_sanitizer import SanitizationOutcome
@@ -142,6 +143,86 @@ def _preflight_receipt(
         expires_at="2026-04-14T01:19:05Z",
         artifacts={"target_ref": "main"},
     )
+
+
+# ---------------------------------------------------------------------------
+# Queue autofill wiring
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_autofill_queue_creates_live_issue_with_expected_labels() -> None:
+    loop = BossLoop(
+        config=_boss_config(repo="synaptent/aragora"),
+        env={QUEUE_AUTOFILL_FLAG_ENV: "1"},
+    )
+    commands: list[tuple[list[str], dict[str, Any]]] = []
+
+    def fake_maybe_autofill_queue(**kwargs: Any) -> AutofillResult:
+        create_issue = kwargs["create_issue"]
+        candidate = AutofillCandidate(
+            title="Add unit tests for foo.py",
+            category="test_coverage",
+            fingerprint="fp-foo",
+            file_scope=("aragora/foo.py",),
+            lane="test_coverage_autofill",
+        )
+        ok = create_issue(candidate, "## Task\n\nCover foo.py")
+        return AutofillResult(
+            attempted=True,
+            reason="created" if ok else "create_failed",
+            consecutive_empty_ticks=kwargs["consecutive_empty_ticks"],
+            threshold=3,
+            created=(candidate,) if ok else (),
+        )
+
+    def fake_gh(args: list[str], **kwargs: Any) -> Any:
+        commands.append((list(args), dict(kwargs)))
+        return SimpleNamespace(
+            returncode=0,
+            stdout="https://github.com/synaptent/aragora/issues/999\n",
+            stderr="",
+        )
+
+    with (
+        patch(
+            "aragora.swarm.queue_autofill.maybe_autofill_queue",
+            side_effect=fake_maybe_autofill_queue,
+        ),
+        patch("aragora.swarm.github_app_auth.gh_subprocess_run", side_effect=fake_gh),
+    ):
+        payload = loop._maybe_autofill_queue(candidate_issues=[])
+
+    assert payload is not None
+    assert payload["reason"] == "created"
+    assert payload["created_count"] == 1
+    assert loop._consecutive_empty_iterations == 0
+    assert len(commands) == 1
+    cmd, kwargs = commands[0]
+    assert cmd[:3] == ["issue", "create", "--repo"]
+    assert cmd[3] == "synaptent/aragora"
+    assert cmd[cmd.index("--title") + 1] == "Add unit tests for foo.py"
+    assert cmd[cmd.index("--body") + 1] == "## Task\n\nCover foo.py"
+    label_flags = [cmd[i + 1] for i, token in enumerate(cmd) if token == "--label"]
+    assert label_flags == ["boss-ready", "autonomous"]
+    assert kwargs["write_op"] is True
+
+
+def test_create_queue_autofill_issue_surfaces_gh_failure_detail() -> None:
+    loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
+    candidate = AutofillCandidate(
+        title="Add unit tests for foo.py",
+        category="test_coverage",
+        fingerprint="fp-foo",
+        file_scope=("aragora/foo.py",),
+        lane="test_coverage_autofill",
+    )
+
+    with patch(
+        "aragora.swarm.github_app_auth.gh_subprocess_run",
+        return_value=SimpleNamespace(returncode=1, stdout="", stderr="forbidden"),
+    ):
+        with pytest.raises(RuntimeError, match="forbidden"):
+            loop._create_queue_autofill_issue(candidate, "## Task\n\nCover foo.py")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_queue_autofill.py
+++ b/tests/swarm/test_queue_autofill.py
@@ -190,7 +190,7 @@ def test_ignores_candidates_outside_allowed_categories(tmp_path: Path) -> None:
         scan_fn=_make_scan(candidates),
         classify_fn=_make_classify(),
         validate_body_fn=_make_validate(),
-        create_issue=lambda candidate: (created.append(candidate) or True),
+        create_issue=lambda candidate, _body: (created.append(candidate) or True),
         sentinel_path=tmp_path / "sentinel.json",
         metrics_jsonl_path=tmp_path / "metrics.jsonl",
     )
@@ -270,7 +270,7 @@ def test_passes_rate_limit_when_interval_elapsed(tmp_path: Path) -> None:
         scan_fn=_make_scan([candidate]),
         classify_fn=_make_classify(),
         validate_body_fn=_make_validate(),
-        create_issue=lambda item: (created.append(item) or True),
+        create_issue=lambda item, _body: (created.append(item) or True),
         sentinel_path=sentinel,
         metrics_jsonl_path=tmp_path / "metrics.jsonl",
     )
@@ -280,6 +280,44 @@ def test_passes_rate_limit_when_interval_elapsed(tmp_path: Path) -> None:
     # Sentinel bumped forward to now=5000.0
     payload = json.loads(sentinel.read_text(encoding="utf-8"))
     assert payload == {"last_run_ts": 5000.0}
+
+
+def test_create_issue_callback_receives_formatted_body(tmp_path: Path) -> None:
+    candidate = _FakeCandidate(
+        category="test_coverage",
+        title="Add unit tests for baz.py",
+        description="Cover baz.py",
+        file_scope=["aragora/baz.py"],
+        validation_command="pytest -q tests/test_baz.py",
+        acceptance_criteria=["Add focused regression coverage."],
+        fingerprint="fp-baz",
+    )
+    seen: dict[str, Any] = {}
+
+    def create_issue(item: AutofillCandidate, body: str) -> bool:
+        seen["candidate"] = item
+        seen["body"] = body
+        return True
+
+    result = maybe_autofill_queue(
+        repo_root=tmp_path,
+        consecutive_empty_ticks=5,
+        env=FLAG_ENV,
+        scan_fn=_make_scan([candidate]),
+        classify_fn=_make_classify(),
+        validate_body_fn=_make_validate(),
+        create_issue=create_issue,
+        sentinel_path=tmp_path / "sentinel.json",
+        metrics_jsonl_path=tmp_path / "metrics.jsonl",
+    )
+
+    assert result.reason == "created"
+    assert seen["candidate"].title == "Add unit tests for baz.py"
+    body = str(seen["body"])
+    assert "## Task" in body
+    assert "Cover baz.py" in body
+    assert "pytest -q tests/test_baz.py" in body
+    assert "<!-- fingerprint:fp-baz -->" in body
 
 
 # ---------------------------------------------------------------------------
@@ -307,7 +345,7 @@ def test_creates_up_to_max_issues(tmp_path: Path) -> None:
         scan_fn=_make_scan(candidates),
         classify_fn=_make_classify(),
         validate_body_fn=_make_validate(),
-        create_issue=lambda item: (created.append(item) or True),
+        create_issue=lambda item, _body: (created.append(item) or True),
         sentinel_path=tmp_path / "sentinel.json",
         metrics_jsonl_path=tmp_path / "metrics.jsonl",
     )
@@ -401,7 +439,7 @@ def test_metrics_row_includes_created_titles(tmp_path: Path) -> None:
         scan_fn=_make_scan([candidate]),
         classify_fn=_make_classify(),
         validate_body_fn=_make_validate(),
-        create_issue=lambda _c: True,
+        create_issue=lambda _c, _body: True,
         sentinel_path=tmp_path / "sentinel.json",
         metrics_jsonl_path=metrics,
     )
@@ -445,7 +483,7 @@ def test_create_issue_failure_surfaces_in_errors(tmp_path: Path) -> None:
         file_scope=["aragora/foo.py"],
     )
 
-    def flaky_create(_: AutofillCandidate) -> bool:
+    def flaky_create(_: AutofillCandidate, _body: str) -> bool:
         return False
 
     result = maybe_autofill_queue(


### PR DESCRIPTION
## Summary
- pass a real issue-creation callback from boss loop into queue autofill
- create live autofill issues with canonical labels and surface GitHub failures truthfully
- lock the callback contract with focused boss-loop and queue-autofill tests

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/swarm/test_queue_autofill.py -p no:rerunfailures -p no:cacheprovider
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/swarm/test_boss_loop.py -k 'autofill_queue_creates_live_issue_with_expected_labels or create_queue_autofill_issue_surfaces_gh_failure_detail' -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check aragora/swarm/boss_loop.py aragora/swarm/queue_autofill.py tests/swarm/test_boss_loop.py tests/swarm/test_queue_autofill.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD