### PR TITLE
fix(security): treat leaked-era LLM keys as strict secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 .aragora_sessions.yaml
 .aragora_sessions.json
 .aragora_events/
+.aragora_coordination/
 
 # Worktree session lock files (created by SessionStart hook, removed on Stop)
 .claude-session-active

--- a/aragora/config/secrets.py
+++ b/aragora/config/secrets.py
@@ -136,7 +136,13 @@ MANAGED_SECRETS = frozenset(
 )
 
 # CRITICAL SECRETS - These MUST NOT fall back to environment variables in production
-# These are high-value secrets where env var fallback could indicate a security issue
+# These are high-value secrets where env var fallback could indicate a security issue.
+#
+# Hardening note (2026-04-17, HIGH-GRAVITY incident response): LLM API keys
+# were added to this set because the Anthropic key leak demonstrated that
+# local plaintext copies are a real attack surface. In strict mode, a missing
+# AWS Secrets Manager entry will now raise SecretNotFoundError instead of
+# silently consuming a stale .env value.
 CRITICAL_SECRETS = frozenset(
     {
         # Authentication - Compromise allows session forging
@@ -155,6 +161,12 @@ CRITICAL_SECRETS = frozenset(
         # Payment - Financial data access
         "STRIPE_SECRET_KEY",
         "STRIPE_WEBHOOK_SECRET",
+        # LLM API keys - Compromise allows direct spend + model abuse
+        # (added 2026-04-17 after HIGH-GRAVITY leak of an Anthropic key)
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "GEMINI_API_KEY",
     }
 )
 

--- a/aragora/config/secrets.py
+++ b/aragora/config/secrets.py
@@ -167,6 +167,11 @@ CRITICAL_SECRETS = frozenset(
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
         "GEMINI_API_KEY",
+        "XAI_API_KEY",
+        "GROK_API_KEY",
+        "MISTRAL_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "KIMI_API_KEY",
     }
 )
 

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -543,6 +543,13 @@ class TestStrictMode:
         assert is_critical_secret("STRIPE_SECRET_KEY") is True
         assert is_critical_secret("OPENAI_API_KEY") is True
         assert is_critical_secret("ANTHROPIC_API_KEY") is True
+        assert is_critical_secret("OPENROUTER_API_KEY") is True
+        assert is_critical_secret("GEMINI_API_KEY") is True
+        assert is_critical_secret("XAI_API_KEY") is True
+        assert is_critical_secret("GROK_API_KEY") is True
+        assert is_critical_secret("MISTRAL_API_KEY") is True
+        assert is_critical_secret("DEEPSEEK_API_KEY") is True
+        assert is_critical_secret("KIMI_API_KEY") is True
 
         # Non-critical secrets
         assert is_critical_secret("SENTRY_DSN") is False
@@ -566,6 +573,40 @@ class TestStrictMode:
                 manager.get("JWT_SECRET_KEY")
 
             assert "JWT_SECRET_KEY" in str(exc_info.value)
+            assert "Secrets Manager" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "provider_key",
+        [
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "OPENROUTER_API_KEY",
+            "GEMINI_API_KEY",
+            "XAI_API_KEY",
+            "GROK_API_KEY",
+            "MISTRAL_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "KIMI_API_KEY",
+        ],
+    )
+    def test_strict_mode_raises_for_provider_api_keys_not_in_aws(self, provider_key):
+        """Provider API keys must not fall back to env vars in strict mode."""
+
+        config = SecretsConfig(use_aws=True)
+        manager = SecretManager(config)
+        manager._cached_secrets = {}
+        manager._cache_timestamp = time.time()
+        manager._initialized = True
+
+        with patch.dict(
+            os.environ,
+            {"ARAGORA_ENV": "production", provider_key: "env_value"},
+            clear=True,
+        ):
+            with pytest.raises(SecretNotFoundError) as exc_info:
+                manager.get(provider_key)
+
+            assert provider_key in str(exc_info.value)
             assert "Secrets Manager" in str(exc_info.value)
 
     def test_strict_mode_allows_non_critical_env_fallback(self):

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -541,9 +541,10 @@ class TestStrictMode:
         assert is_critical_secret("JWT_SECRET_KEY") is True
         assert is_critical_secret("DATABASE_URL") is True
         assert is_critical_secret("STRIPE_SECRET_KEY") is True
+        assert is_critical_secret("OPENAI_API_KEY") is True
+        assert is_critical_secret("ANTHROPIC_API_KEY") is True
 
         # Non-critical secrets
-        assert is_critical_secret("OPENAI_API_KEY") is False
         assert is_critical_secret("SENTRY_DSN") is False
         assert is_critical_secret("RANDOM_CONFIG") is False
 


### PR DESCRIPTION
## Summary
- treat leaked-era LLM API keys as strict secrets in production/staging
- document the HIGH-GRAVITY hardening rationale in 
- update focused secrets expectations to match the stricter posture

## Validation
- ........................................................                 [100%]
56 passed in 1.20s
- preflight: checking whitespace
preflight: changed files
  - .gitignore
  - aragora/config/secrets.py
  - tests/config/test_secrets.py
preflight: ok
