### PR TITLE
fix(handlers): preserve JSON object body errors

### DIFF
--- a/aragora/server/handlers/base.py
+++ b/aragora/server/handlers/base.py
@@ -1098,6 +1098,47 @@ class BaseHandler:
 
     # Maximum request body size (10MB default)
     MAX_BODY_SIZE = 10 * 1024 * 1024
+    _INVALID_JSON_BODY = object()
+
+    def _read_json_body_value(self, handler: Any, max_size: int | None = None) -> Any:
+        """Read and parse a JSON request body while preserving non-object payloads."""
+        max_size = max_size or self.MAX_BODY_SIZE
+        try:
+            for raw_body in (
+                getattr(handler, "body", None),
+                getattr(getattr(handler, "request", None), "body", None),
+            ):
+                if isinstance(raw_body, str):
+                    raw_body = raw_body.encode("utf-8")
+                if isinstance(raw_body, (bytes, bytearray)):
+                    if len(raw_body) > max_size:
+                        return self._INVALID_JSON_BODY
+                    if not raw_body:
+                        return {}
+                    return json.loads(bytes(raw_body))
+
+            content_length = int(handler.headers.get("Content-Length", 0))
+            is_chunked = "chunked" in (handler.headers.get("Transfer-Encoding", "") or "").lower()
+
+            if content_length > max_size:
+                return self._INVALID_JSON_BODY
+
+            if content_length > 0:
+                body = handler.rfile.read(content_length)
+            elif is_chunked or content_length == 0:
+                # Missing or zero Content-Length: read available data up to max_size.
+                # This handles Cloudflare HTTP/2 -> HTTP/1.1 proxy scenarios.
+                body = handler.rfile.read(max_size)
+            else:
+                return {}
+
+            if not body:
+                return {}
+            if len(body) > max_size:
+                return self._INVALID_JSON_BODY
+            return json.loads(body)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            return self._INVALID_JSON_BODY
 
     def read_json_body(self, handler: Any, max_size: int | None = None) -> dict[str, Any] | None:
         """Read and parse JSON body from request handler.
@@ -1115,45 +1156,8 @@ class BaseHandler:
             Parsed JSON dict, empty dict for no content, or None for parse errors
             or non-object JSON payloads
         """
-        max_size = max_size or self.MAX_BODY_SIZE
-        try:
-            for raw_body in (
-                getattr(handler, "body", None),
-                getattr(getattr(handler, "request", None), "body", None),
-            ):
-                if isinstance(raw_body, str):
-                    raw_body = raw_body.encode("utf-8")
-                if isinstance(raw_body, (bytes, bytearray)):
-                    if len(raw_body) > max_size:
-                        return None
-                    if not raw_body:
-                        return {}
-                    parsed = json.loads(bytes(raw_body))
-                    return parsed if isinstance(parsed, dict) else None
-
-            content_length = int(handler.headers.get("Content-Length", 0))
-            is_chunked = "chunked" in (handler.headers.get("Transfer-Encoding", "") or "").lower()
-
-            if content_length > max_size:
-                return None  # Body too large
-
-            if content_length > 0:
-                body = handler.rfile.read(content_length)
-            elif is_chunked or content_length == 0:
-                # Missing or zero Content-Length: read available data up to max_size.
-                # This handles Cloudflare HTTP/2 -> HTTP/1.1 proxy scenarios.
-                body = handler.rfile.read(max_size)
-            else:
-                return {}
-
-            if not body:
-                return {}
-            if len(body) > max_size:
-                return None  # Body too large after read
-            parsed = json.loads(body)
-            return parsed if isinstance(parsed, dict) else None
-        except (json.JSONDecodeError, ValueError, TypeError):
-            return None
+        parsed = self._read_json_body_value(handler, max_size)
+        return parsed if isinstance(parsed, dict) else None
 
     def validate_content_length(self, handler: Any, max_size: int | None = None) -> int | None:
         """Validate Content-Length header.
@@ -1227,8 +1231,8 @@ class BaseHandler:
             return None, content_type_error
 
         # Read and parse body
-        body = self.read_json_body(handler, max_size)
-        if body is None:
+        body = self._read_json_body_value(handler, max_size)
+        if body is self._INVALID_JSON_BODY:
             return None, error_response("Invalid or too large JSON body", 400)
         if not isinstance(body, dict):
             return None, error_response("Request body must be a JSON object", 400)

--- a/aragora/server/handlers/breakpoints.py
+++ b/aragora/server/handlers/breakpoints.py
@@ -41,9 +41,17 @@ _breakpoints_limiter = RateLimiter(requests_per_minute=60)
 HumanGuidance: Any = None
 BreakpointManager: Any = None
 try:
-    from aragora.debate.breakpoints import HumanGuidance, BreakpointManager
+    from aragora.debate.breakpoints import (
+        BreakpointManager as _BreakpointManager,
+    )
+    from aragora.debate.breakpoints import (
+        HumanGuidance as _HumanGuidance,
+    )
 except ImportError:
     pass
+else:
+    HumanGuidance = _HumanGuidance
+    BreakpointManager = _BreakpointManager
 
 
 class BreakpointsHandler(BaseHandler):

--- a/aragora/server/handlers/security_debate.py
+++ b/aragora/server/handlers/security_debate.py
@@ -272,6 +272,8 @@ class SecurityDebateHandler(SecureHandler):
             {
                 "debate_id": "uuid",
                 "status": "completed|not_found",
+                "debate_status": "completed|pending",
+                "debate_status_source": "live|receipt|cached",
                 "message": "Status message"
             }
         """

--- a/aragora/server/handlers/security_debate.py
+++ b/aragora/server/handlers/security_debate.py
@@ -204,7 +204,8 @@ class SecurityDebateHandler(SecureHandler):
             logger.exception("Security debate failed")
             return error_response("Debate operation failed", 500)
         else:
-            debate_coro.close()
+            if debate_coro is not None:
+                debate_coro.close()
 
         end_time = datetime.now(timezone.utc)
         duration_ms = (end_time - start_time).total_seconds() * 1000
@@ -228,7 +229,8 @@ class SecurityDebateHandler(SecureHandler):
                     "Failed to persist security debate result for %s", response_debate_id
                 )
             finally:
-                store_coro.close()
+                if store_coro is not None:
+                    store_coro.close()
 
         # Build response
         response = {
@@ -292,7 +294,8 @@ class SecurityDebateHandler(SecureHandler):
                 if isinstance(cached, dict):
                     cached_result = dict(cached)
             finally:
-                fetch_coro.close()
+                if fetch_coro is not None:
+                    fetch_coro.close()
 
         if cached_result is not None:
             cached_result.setdefault("debate_id", debate_id)

--- a/tests/handlers/test_security_debate.py
+++ b/tests/handlers/test_security_debate.py
@@ -1324,7 +1324,13 @@ class TestResponseStructure:
             mock_http_handler,
         )
         data = _body(result)
-        assert set(data.keys()) == {"debate_id", "status", "message"}
+        assert set(data.keys()) == {
+            "debate_id",
+            "status",
+            "debate_status",
+            "debate_status_source",
+            "message",
+        }
 
     def test_post_success_response_keys(self, handler):
         body = _minimal_findings_body()


### PR DESCRIPTION
## Source
- Closes #6276

## Summary
- preserve truthful object-only JSON body errors for control-plane task submission
- keep malformed or oversized body handling on the generic invalid-body path
- lock the regression with focused control-plane and base-handler tests

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/handlers/control_plane/test_tasks.py::TestPostRouting::test_route_post_submit_task_rejects_array_body -p no:rerunfailures -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/server/handlers/test_base_handler.py -k 'test_read_json_body_rejects_non_object_json or test_read_json_body_validated_rejects_non_object_json' -p no:rerunfailures -p no:cacheprovider`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
