### PR TITLE
feat(review): require explicit human settlement before automation merge

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -122,6 +122,13 @@ def add_review_pr_parser(subparsers) -> None:
         action="store_true",
         help="Print the final run summary as JSON",
     )
+    parser.add_argument(
+        "--no-publish-review",
+        dest="publish_review",
+        action="store_false",
+        help="Persist artifacts without posting any GitHub review output.",
+    )
+    parser.set_defaults(publish_review=True)
     parser.set_defaults(func=cmd_review_pr)
 
 
@@ -139,6 +146,7 @@ def cmd_review_pr(args: argparse.Namespace) -> int:
             if getattr(args, "artifact_dir", None)
             else None,
             keep_worktree=bool(getattr(args, "keep_worktree", False)),
+            publish_review=bool(getattr(args, "publish_review", True)),
         )
     )
     if getattr(args, "json_output", False):
@@ -164,6 +172,7 @@ async def run_review_pr_loop(
     artifact_root: Path | None = None,
     keep_worktree: bool = False,
     advisory_only: bool = True,
+    publish_review: bool = True,
 ) -> dict[str, Any]:
     target = _fetch_pr_target(pr_ref, repo_override=repo_override, repo_root=repo_root)
     run_dir = _artifact_run_dir(repo_root, target.number, artifact_root=artifact_root)
@@ -225,14 +234,24 @@ async def run_review_pr_loop(
         "review_runs": review_runs,
         "fix_run": fix_run,
         "final_status": final_status,
+        "publish_review": publish_review,
     }
-    payload["github_review"] = await _publish_review_outcome(
-        target=target,
-        review_runs=review_runs,
-        fix_run=fix_run,
-        final_status=final_status,
-        advisory_only=advisory_only,
-    )
+    if publish_review:
+        payload["github_review"] = await _publish_review_outcome(
+            target=target,
+            review_runs=review_runs,
+            fix_run=fix_run,
+            final_status=final_status,
+            advisory_only=advisory_only,
+        )
+    else:
+        payload["github_review"] = {
+            "posted": False,
+            "event": None,
+            "mode": "advisory" if advisory_only else "status",
+            "url": None,
+            "error": None,
+        }
     _write_json(run_dir / "run.json", payload)
     return payload
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1356,6 +1356,13 @@ def _add_review_pr_parser(subparsers) -> None:
         action="store_true",
         help="Print the final run summary as JSON",
     )
+    parser.add_argument(
+        "--no-publish-review",
+        dest="publish_review",
+        action="store_false",
+        help="Persist artifacts without posting any GitHub review output.",
+    )
+    parser.set_defaults(publish_review=True)
     parser.set_defaults(func=_lazy("aragora.cli.commands.review_pr", "cmd_review_pr"))
 
     # Audit command (compliance audit logs)

--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -19,6 +19,7 @@ import subprocess
 import time
 from dataclasses import dataclass, field
 from functools import lru_cache
+from pathlib import Path
 
 from aragora.swarm.github_app_auth import gh_subprocess_run
 
@@ -47,6 +48,14 @@ REDUCED_LANE_ONLY_CHECKS = frozenset(
         "publish-draft-pr",
         "review",
         "changes",
+    }
+)
+AUTOMATION_REVIEWER_LOGINS = frozenset(
+    {
+        "an0mium",
+        "github-actions[bot]",
+        "dependabot[bot]",
+        "aragora-automation[bot]",
     }
 )
 
@@ -234,7 +243,7 @@ def _list_candidate_prs(config: MergeArbiterConfig) -> list[dict]:
             "--state",
             "open",
             "--json",
-            "number,headRefName,headRefOid,isDraft",
+            "number,headRefName,headRefOid,isDraft,reviewDecision",
             "--limit",
             "100",
         ]
@@ -281,6 +290,73 @@ def _get_check_status(pr_number: int, repo: str) -> dict[str, str]:
     return {c["name"]: c.get("state", "").upper() for c in checks if "name" in c}
 
 
+def _list_pr_reviews(pr_number: int, repo: str) -> list[dict]:
+    """Return PR review events as raw GitHub API payloads."""
+    result = _run_gh(
+        [
+            "api",
+            f"repos/{repo}/pulls/{pr_number}/reviews",
+            "--paginate",
+        ]
+    )
+    if result.returncode != 0:
+        logger.debug("gh api pulls/%d/reviews failed: %s", pr_number, result.stderr.strip())
+        return []
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _review_counts_as_human_approval(review: dict, head_sha: str | None) -> bool:
+    """Return True when a review is an approval tied to the current head and not automation."""
+    if str(review.get("state", "")).upper() != "APPROVED":
+        return False
+    if head_sha and str(review.get("commit_id", "")).strip() != str(head_sha).strip():
+        return False
+    user = review.get("user") or {}
+    if not isinstance(user, dict):
+        return False
+    login = str(user.get("login", "")).strip()
+    user_type = str(user.get("type", "")).strip().lower()
+    if not login:
+        return False
+    if login in AUTOMATION_REVIEWER_LOGINS or login.endswith("[bot]") or user_type == "bot":
+        return False
+    return True
+
+
+def _has_matching_human_approval(pr_number: int, repo: str, head_sha: str | None) -> bool:
+    """Require an explicit human approval on the current PR head SHA."""
+    for review in reversed(_list_pr_reviews(pr_number, repo)):
+        if _review_counts_as_human_approval(review, head_sha):
+            return True
+    return False
+
+
+def _has_local_settlement_receipt(
+    pr_number: int, head_sha: str | None, repo_root: Path | None = None
+) -> bool:
+    """Accept a local review-queue approval receipt as an explicit settlement signal."""
+    if not head_sha:
+        return False
+    root = (repo_root or Path.cwd()) / ".aragora" / "review-queue" / "settlements"
+    receipt = root / f"pr-{pr_number}-{str(head_sha)[:12]}-approve.json"
+    if not receipt.exists():
+        return False
+    try:
+        payload = json.loads(receipt.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return (
+        str(payload.get("action", "")).strip() == "approve"
+        and str(payload.get("head_sha", "")).strip() == str(head_sha).strip()
+    )
+
+
 def _promote_draft(pr_number: int, repo: str) -> bool:
     """Mark a draft PR as ready for review."""
     result = _run_gh(
@@ -322,6 +398,7 @@ def _evaluate_pr(pr: dict, config: MergeArbiterConfig) -> MergeResult:
     branch: str = pr.get("headRefName", "")
     head_sha = pr.get("headRefOid")
     is_draft: bool = pr.get("isDraft", False)
+    review_decision = str(pr.get("reviewDecision", "")).strip().upper()
     required_checks = _get_required_checks(config.repo)
 
     if is_draft:
@@ -402,6 +479,18 @@ def _evaluate_pr(pr: dict, config: MergeArbiterConfig) -> MergeResult:
             branch,
             False,
             f"failing full-suite checks: {', '.join(failing_ready)}",
+        )
+
+    has_settlement = _has_local_settlement_receipt(pr_number, head_sha) or (
+        review_decision == "APPROVED"
+        and _has_matching_human_approval(pr_number, config.repo, head_sha)
+    )
+    if not has_settlement:
+        return MergeResult(
+            pr_number,
+            branch,
+            False,
+            "waiting for explicit human settlement on the current head SHA",
         )
 
     if config.dry_run:

--- a/tests/cli/commands/test_review_pr.py
+++ b/tests/cli/commands/test_review_pr.py
@@ -48,6 +48,19 @@ def test_review_pr_parser_accepts_fix_loop_flags() -> None:
     assert args.json_output is True
 
 
+def test_review_pr_parser_accepts_no_publish_flag() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "review-pr",
+            "1137",
+            "--no-publish-review",
+        ]
+    )
+    assert args.command == "review-pr"
+    assert args.publish_review is False
+
+
 @pytest.mark.asyncio
 async def test_run_review_pr_loop_review_only_writes_artifact(
     tmp_path: Path,
@@ -107,6 +120,55 @@ async def test_run_review_pr_loop_review_only_writes_artifact(
     assert persisted["pr"]["number"] == 1137
     assert persisted["github_review"]["posted"] is True
     assert persisted["github_review_mode"] == "advisory"
+    assert persisted["publish_review"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_review_pr_loop_skips_github_review_when_publish_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    sample_target: review_pr.PullRequestTarget,
+) -> None:
+    monkeypatch.setattr(review_pr, "_fetch_pr_target", lambda *_, **__: sample_target)
+    monkeypatch.setattr(review_pr, "_fetch_pr_diff", lambda *_: "diff --git a/foo b/foo\n+ok\n")
+
+    async def _fake_review(**_: object) -> review_pr.ReviewPass:
+        return review_pr.ReviewPass(
+            reviewer="claude",
+            reviewed_at="2026-03-21T10:00:00+00:00",
+            status="passed",
+            summary="Looks good",
+            findings=[],
+            candidate={"label": "claude:max-01"},
+            attempts=[],
+            raw_response="{}",
+        )
+
+    monkeypatch.setattr(review_pr, "_run_review_pass", _fake_review)
+
+    async def _should_not_publish(**_: object) -> dict[str, object]:
+        raise AssertionError("_publish_review_outcome should not be called")
+
+    monkeypatch.setattr(review_pr, "_publish_review_outcome", _should_not_publish)
+
+    result = await review_pr.run_review_pr_loop(
+        pr_ref="1137",
+        repo_root=tmp_path,
+        reviewer="claude",
+        artifact_root=tmp_path / "artifacts",
+        publish_review=False,
+    )
+
+    assert result["final_status"] == "passed"
+    assert result["github_review"] == {
+        "posted": False,
+        "event": None,
+        "mode": "advisory",
+        "url": None,
+        "error": None,
+    }
+    persisted = json.loads((Path(result["artifact_dir"]) / "run.json").read_text())
+    assert persisted["publish_review"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from aragora.swarm.merge_arbiter import (
+    AUTOMATION_REVIEWER_LOGINS,
     REQUIRED_CHECKS,
     ArbiterSummary,
     MergeArbiter,
@@ -17,7 +18,10 @@ from aragora.swarm.merge_arbiter import (
     _classify_required_checks,
     _evaluate_pr,
     _get_check_status,
+    _has_local_settlement_receipt,
+    _has_matching_human_approval,
     _list_candidate_prs,
+    _review_counts_as_human_approval,
     _merge_pr,
     _promote_draft,
 )
@@ -47,12 +51,14 @@ def _pr(
     number: int = 1,
     branch: str = "aragora/boss-harvest/fix-1",
     draft: bool = False,
+    review_decision: str = "",
 ) -> dict:
     return {
         "number": number,
         "headRefName": branch,
         "headRefOid": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
         "isDraft": draft,
+        "reviewDecision": review_decision,
     }
 
 
@@ -122,6 +128,57 @@ class TestGetCheckStatus:
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
             mock_gh.return_value = _make_gh_result(returncode=1)
             assert _get_check_status(1, "owner/repo") == {}
+
+
+class TestHumanSettlement:
+    def test_review_counts_as_human_approval(self):
+        review = {
+            "state": "APPROVED",
+            "commit_id": "deadbeef",
+            "user": {"login": "armand", "type": "User"},
+        }
+        assert _review_counts_as_human_approval(review, "deadbeef") is True
+
+    def test_review_rejects_automation_logins_and_stale_heads(self):
+        bot_login = next(iter(AUTOMATION_REVIEWER_LOGINS))
+        bot_review = {
+            "state": "APPROVED",
+            "commit_id": "deadbeef",
+            "user": {"login": bot_login, "type": "User"},
+        }
+        stale_review = {
+            "state": "APPROVED",
+            "commit_id": "cafebabe",
+            "user": {"login": "armand", "type": "User"},
+        }
+        assert _review_counts_as_human_approval(bot_review, "deadbeef") is False
+        assert _review_counts_as_human_approval(stale_review, "deadbeef") is False
+
+    def test_has_matching_human_approval_scans_reviews(self):
+        reviews = [
+            {
+                "state": "COMMENTED",
+                "commit_id": "deadbeef",
+                "user": {"login": "armand", "type": "User"},
+            },
+            {
+                "state": "APPROVED",
+                "commit_id": "deadbeef",
+                "user": {"login": "armand", "type": "User"},
+            },
+        ]
+        with patch("aragora.swarm.merge_arbiter._list_pr_reviews", return_value=reviews):
+            assert _has_matching_human_approval(12, "owner/repo", "deadbeef") is True
+
+    def test_has_local_settlement_receipt_matches_head_sha(self, tmp_path):
+        root = tmp_path / ".aragora" / "review-queue" / "settlements"
+        root.mkdir(parents=True)
+        receipt = root / "pr-12-deadbeefdead-approve.json"
+        receipt.write_text(
+            json.dumps({"action": "approve", "head_sha": "deadbeefdead1111"}),
+            encoding="utf-8",
+        )
+        assert _has_local_settlement_receipt(12, "deadbeefdead1111", repo_root=tmp_path) is True
 
 
 class TestClassifyRequiredChecks:
@@ -211,13 +268,17 @@ class TestEvaluatePrAllPassing:
     def test_merges_ready_pr_when_required_and_full_suite_checks_pass(self):
         config = MergeArbiterConfig()
         checks = _all_passing_ready_checks("Status Doc Reconciliation")
-        pr = _pr(42, "codex/ok")
+        pr = _pr(42, "codex/ok", review_decision="APPROVED")
         with (
             patch(
                 "aragora.swarm.merge_arbiter._get_required_checks",
                 return_value=list(REQUIRED_CHECKS),
             ),
             patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks,
+            patch(
+                "aragora.swarm.merge_arbiter._has_matching_human_approval",
+                return_value=True,
+            ),
             patch("aragora.swarm.merge_arbiter._merge_pr") as mock_merge,
         ):
             mock_checks.return_value = checks
@@ -296,6 +357,28 @@ class TestEvaluatePrFailingCheck:
         assert "failing full-suite checks" in result.reason
         assert "Quality Gates=FAILURE" in result.reason
 
+    def test_ready_pr_waits_for_explicit_human_settlement(self):
+        config = MergeArbiterConfig()
+        status = _all_passing_ready_checks("Status Doc Reconciliation")
+        with (
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
+            patch("aragora.swarm.merge_arbiter._get_check_status", return_value=status),
+            patch(
+                "aragora.swarm.merge_arbiter._has_local_settlement_receipt",
+                return_value=False,
+            ),
+            patch(
+                "aragora.swarm.merge_arbiter._has_matching_human_approval",
+                return_value=False,
+            ),
+        ):
+            result = _evaluate_pr(_pr(14, "codex/waiting"), config)
+        assert result.success is False
+        assert "explicit human settlement" in result.reason
+
 
 # ---------------------------------------------------------------------------
 # _evaluate_pr — dry-run mode
@@ -312,10 +395,14 @@ class TestEvaluatePrDryRun:
                 return_value=list(REQUIRED_CHECKS),
             ),
             patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks,
+            patch(
+                "aragora.swarm.merge_arbiter._has_matching_human_approval",
+                return_value=True,
+            ),
             patch("aragora.swarm.merge_arbiter._merge_pr") as mock_merge,
         ):
             mock_checks.return_value = checks
-            result = _evaluate_pr(_pr(99, "codex/dry"), config)
+            result = _evaluate_pr(_pr(99, "codex/dry", review_decision="APPROVED"), config)
         assert result.success is True
         assert "dry-run" in result.reason
         mock_merge.assert_not_called()
@@ -436,7 +523,7 @@ class TestFullRun:
         )
         arbiter = MergeArbiter(config=config)
 
-        pr = _pr(7, "codex/good")
+        pr = _pr(7, "codex/good", review_decision="APPROVED")
         checks = _all_passing_ready_checks("Status Doc Reconciliation")
 
         with (
@@ -446,6 +533,10 @@ class TestFullRun:
                 return_value=list(REQUIRED_CHECKS),
             ),
             patch("aragora.swarm.merge_arbiter._get_check_status", return_value=checks),
+            patch(
+                "aragora.swarm.merge_arbiter._has_matching_human_approval",
+                return_value=True,
+            ),
             patch("aragora.swarm.merge_arbiter._merge_pr", return_value=(True, "merged")),
         ):
             summary = await arbiter.run()


### PR DESCRIPTION
## Summary
- add a `review-pr` no-publish path so packet generation can persist artifacts without posting GitHub review output
- require a matching human `APPROVED` review on the current head SHA before `merge_arbiter` will merge an automation PR
- keep the scope aligned with post-`#6288` main instead of reviving the older full `review-queue run` rewrite

## Validation
- `python3 -m pytest tests/cli/commands/test_review_pr.py tests/cli/test_parser_lazy_review_pr.py tests/swarm/test_merge_arbiter.py -q`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
