### PR TITLE
feat(benchmarks): salvage tier1 benchmark harness

### DIFF
--- a/benchmarks/bench_readiness/tier1/cli.py
+++ b/benchmarks/bench_readiness/tier1/cli.py
@@ -1,0 +1,117 @@
+"""CLI entry point for the Tier-1 benchmark.
+
+Usage::
+
+    # Full pilot (N=10 per domain, all 4 domains, ~40 items)
+    python -m benchmarks.bench_readiness.tier1.cli
+
+    # Smoke test (N=1 per domain, 4 items)
+    python -m benchmarks.bench_readiness.tier1.cli --limit 1
+
+    # One domain only
+    python -m benchmarks.bench_readiness.tier1.cli --domains legal --limit 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sys
+
+ALL_DOMAINS = ("legal", "aragora_custom", "mmlu_pro", "swebench_lite")
+DEFAULT_OUT = pathlib.Path("benchmarks/bench_readiness/tier1/results")
+
+
+def _resolve_api_key() -> str:
+    """Fetch the Anthropic key. Prefers AWS-first path per the hardening posture.
+
+    If ``ARAGORA_USE_SECRETS_MANAGER=true`` and AWS is reachable, we pull
+    from the ``aragora/production`` bundle. Otherwise fall back to the env
+    var. Strict mode callers should set the env before invocation.
+    """
+    try:
+        from aragora.config.secrets import get_secret
+
+        v = get_secret("ANTHROPIC_API_KEY")
+        if v:
+            return v
+    except Exception:  # noqa: BLE001 - any secrets backend failure should fall back to env
+        pass
+
+    v = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not v:
+        sys.stderr.write(
+            "ERROR: ANTHROPIC_API_KEY not available via AWS Secrets Manager "
+            "or environment. Set ARAGORA_USE_SECRETS_MANAGER=true with AWS "
+            "credentials, or export ANTHROPIC_API_KEY directly.\n",
+        )
+        sys.exit(2)
+    return v
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Tier-1 benchmark: solo Opus 4.7 vs aragora-debate (3x Opus 4.7)."
+    )
+    parser.add_argument(
+        "--domains",
+        nargs="+",
+        choices=ALL_DOMAINS,
+        default=list(ALL_DOMAINS),
+        help="Task domains to include. Defaults to all four.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Max items per domain. Use 1 for a smoke test.",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="RNG seed.")
+    parser.add_argument(
+        "--out",
+        type=pathlib.Path,
+        default=DEFAULT_OUT,
+        help="Output directory for CSV + summary.",
+    )
+    parser.add_argument(
+        "--debate-rounds",
+        type=int,
+        default=2,
+        help="Number of debate rounds (default 2).",
+    )
+    parser.add_argument(
+        "--model",
+        default="claude-opus-4-7",
+        help="Model ID for both solo and debate agents.",
+    )
+    args = parser.parse_args()
+
+    api_key = _resolve_api_key()
+
+    from benchmarks.bench_readiness.tier1.runner import run
+
+    manifest = run(
+        api_key=api_key,
+        domains=list(args.domains),
+        limit=args.limit,
+        seed=args.seed,
+        out_dir=args.out,
+        debate_rounds=args.debate_rounds,
+        model=args.model,
+    )
+
+    sys.stdout.write(
+        "\n"
+        + "=" * 60
+        + "\n"
+        + f"Items : {manifest['items']}\n"
+        + f"CSV   : {manifest['csv']}\n"
+        + f"Sum   : {manifest['summary']}\n"
+        + "=" * 60
+        + "\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_readiness/tier1/judge.py
+++ b/benchmarks/bench_readiness/tier1/judge.py
@@ -1,0 +1,249 @@
+"""LLM-judge — Claude Opus 4.7 grades two blinded answers side-by-side.
+
+For ``exact_match`` tasks, the judge is bypassed and we just check the
+ground truth. For ``llm_judge`` and ``test_based`` (fallback) tasks we
+randomize A/B assignment, ask Opus to score four dimensions, and extract
+a winner.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+from dataclasses import dataclass
+
+from benchmarks.bench_readiness.tier1.systems.base import SystemOutput
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+JUDGE_MODEL = "claude-opus-4-7"
+JUDGE_SYSTEM = (
+    "You are an impartial expert judge evaluating two anonymous answers to "
+    "the same question. Score each answer independently, then pick a winner. "
+    "You must output ONLY valid JSON matching the schema; no preamble, no "
+    "markdown fences, no trailing text."
+)
+
+JUDGE_SCHEMA_HINT = """{
+  "answer_a": {
+    "correctness": 0-10,
+    "completeness": 0-10,
+    "reasoning_quality": 0-10,
+    "usefulness": 0-10
+  },
+  "answer_b": {
+    "correctness": 0-10,
+    "completeness": 0-10,
+    "reasoning_quality": 0-10,
+    "usefulness": 0-10
+  },
+  "winner": "A" | "B" | "TIE",
+  "rationale": "one paragraph explaining the winner"
+}"""
+
+
+@dataclass
+class JudgeVerdict:
+    """One judge's scoring of two answers for a single task."""
+
+    task_id: str
+    a_system: str
+    b_system: str
+    scores_a: dict[str, int]
+    scores_b: dict[str, int]
+    winner_system: str  # canonical system name (not "A"/"B")
+    rationale: str
+    exact_match_used: bool = False
+    error: str = ""
+
+
+def _extract_final_letter(answer: str) -> str | None:
+    """For MMLU-Pro: pull the final 'Answer: X' letter out of free text."""
+    if not answer:
+        return None
+    match = re.search(
+        r"(?:final\s+)?answer\s*[:\-]\s*\(?([A-J])\)?",
+        answer,
+        re.IGNORECASE,
+    )
+    if match:
+        return match.group(1).upper()
+
+    # Fallback: last isolated capital letter in the last 100 chars
+    tail = answer.strip()[-120:]
+    letters = re.findall(r"\b([A-J])\b", tail)
+    if letters:
+        return letters[-1].upper()
+    return None
+
+
+def _judge_exact_match(task: TaskItem, solo: SystemOutput, debate: SystemOutput) -> JudgeVerdict:
+    """Score MMLU-Pro style items using ground-truth letter match."""
+    ref = (task.reference_answer or "").strip().upper()
+
+    solo_letter = _extract_final_letter(solo.answer) or ""
+    debate_letter = _extract_final_letter(debate.answer) or ""
+
+    solo_correct = solo_letter == ref
+    debate_correct = debate_letter == ref
+
+    # Translate to 0-10 scale
+    def _score(correct: bool) -> dict[str, int]:
+        return {
+            "correctness": 10 if correct else 0,
+            "completeness": 10 if correct else 5,
+            "reasoning_quality": 5,  # not scored without LLM-judge
+            "usefulness": 10 if correct else 5,
+        }
+
+    if solo_correct and not debate_correct:
+        winner = solo.system
+    elif debate_correct and not solo_correct:
+        winner = debate.system
+    else:
+        winner = "TIE"
+
+    return JudgeVerdict(
+        task_id=task.task_id,
+        a_system=solo.system,
+        b_system=debate.system,
+        scores_a=_score(solo_correct),
+        scores_b=_score(debate_correct),
+        winner_system=winner,
+        rationale=(
+            f"Reference: {ref}. Solo extracted: {solo_letter or '(none)'}, "
+            f"Debate extracted: {debate_letter or '(none)'}."
+        ),
+        exact_match_used=True,
+    )
+
+
+def _judge_llm(
+    task: TaskItem,
+    solo: SystemOutput,
+    debate: SystemOutput,
+    *,
+    api_key: str,
+    seed: int,
+) -> JudgeVerdict:
+    """Score a pair of answers using Opus 4.7 as the judge.
+
+    A/B assignment is randomized (with seed) to prevent position bias.
+    """
+    import anthropic
+
+    rng = random.Random(seed)
+    a_is_solo = rng.random() < 0.5
+    if a_is_solo:
+        a_system, a_answer = solo.system, solo.answer
+        b_system, b_answer = debate.system, debate.answer
+    else:
+        a_system, a_answer = debate.system, debate.answer
+        b_system, b_answer = solo.system, solo.answer
+
+    rubric_block = ""
+    if task.reference_answer:
+        rubric_block = f"\n\nRubric (not visible to the answerers):\n{task.reference_answer}\n"
+
+    user_prompt = (
+        f"Question:\n{task.prompt}\n"
+        f"{('Context:' + chr(10) + task.context + chr(10) + chr(10)) if task.context else ''}"
+        f"{rubric_block}\n"
+        f"Answer A:\n{a_answer or '(no answer)'}\n\n"
+        f"Answer B:\n{b_answer or '(no answer)'}\n\n"
+        f"Output JSON matching this schema exactly:\n{JUDGE_SCHEMA_HINT}"
+    )
+
+    client = anthropic.Anthropic(api_key=api_key)
+    try:
+        msg = client.messages.create(
+            model=JUDGE_MODEL,
+            max_tokens=1024,
+            system=JUDGE_SYSTEM,
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+        raw_text = ""
+        for block in msg.content:
+            if getattr(block, "type", None) == "text":
+                raw_text += block.text
+
+        # Tolerate stray fences or whitespace around the JSON
+        cleaned = raw_text.strip()
+        if cleaned.startswith("```"):
+            cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+            cleaned = re.sub(r"\s*```$", "", cleaned)
+        parsed = json.loads(cleaned)
+
+        scores_a = {
+            k: int(parsed["answer_a"].get(k, 0))
+            for k in ("correctness", "completeness", "reasoning_quality", "usefulness")
+        }
+        scores_b = {
+            k: int(parsed["answer_b"].get(k, 0))
+            for k in ("correctness", "completeness", "reasoning_quality", "usefulness")
+        }
+        winner_letter = (parsed.get("winner") or "TIE").strip().upper()
+        rationale = str(parsed.get("rationale", ""))[:2000]
+    except Exception as e:  # noqa: BLE001 - provider SDKs can raise heterogeneous errors
+        return JudgeVerdict(
+            task_id=task.task_id,
+            a_system=a_system,
+            b_system=b_system,
+            scores_a={},
+            scores_b={},
+            winner_system="",
+            rationale="",
+            error=f"judge_error: {type(e).__name__}: {e}",
+        )
+
+    if winner_letter == "A":
+        winner_system = a_system
+    elif winner_letter == "B":
+        winner_system = b_system
+    else:
+        winner_system = "TIE"
+
+    # Re-map scores back to solo vs debate (not A vs B) for CSV clarity
+    solo_scores = scores_a if a_is_solo else scores_b
+    debate_scores = scores_b if a_is_solo else scores_a
+
+    return JudgeVerdict(
+        task_id=task.task_id,
+        a_system=solo.system,
+        b_system=debate.system,
+        scores_a=solo_scores,
+        scores_b=debate_scores,
+        winner_system=winner_system,
+        rationale=rationale,
+    )
+
+
+def judge(
+    task: TaskItem,
+    solo: SystemOutput,
+    debate: SystemOutput,
+    *,
+    api_key: str,
+    seed: int = 0,
+) -> JudgeVerdict:
+    """Score a single (task, solo_output, debate_output) triple.
+
+    Uses exact-match for ``eval_strategy="exact_match"`` tasks, otherwise
+    routes to the LLM judge.
+    """
+    if solo.error or debate.error:
+        return JudgeVerdict(
+            task_id=task.task_id,
+            a_system=solo.system,
+            b_system=debate.system,
+            scores_a={},
+            scores_b={},
+            winner_system="",
+            rationale="",
+            error=f"system_errors: solo={solo.error!r} debate={debate.error!r}",
+        )
+
+    if task.eval_strategy == "exact_match":
+        return _judge_exact_match(task, solo, debate)
+
+    return _judge_llm(task, solo, debate, api_key=api_key, seed=seed)

--- a/benchmarks/bench_readiness/tier1/runner.py
+++ b/benchmarks/bench_readiness/tier1/runner.py
@@ -1,0 +1,202 @@
+"""Tier-1 benchmark runner — iterates tasks, runs both systems, judges, writes CSV."""
+
+from __future__ import annotations
+
+import csv
+import json
+import pathlib
+import time
+from collections.abc import Iterable, Iterator
+
+from benchmarks.bench_readiness.tier1.judge import JudgeVerdict, judge
+from benchmarks.bench_readiness.tier1.systems import (
+    SystemOutput,
+    run_aragora_debate,
+    run_solo_opus,
+)
+from benchmarks.bench_readiness.tier1.tasks import legal as legal_loader
+from benchmarks.bench_readiness.tier1.tasks import aragora_custom as custom_loader
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+CSV_FIELDS = [
+    "task_id",
+    "domain",
+    "eval_strategy",
+    "solo_system",
+    "debate_system",
+    "solo_latency_sec",
+    "debate_latency_sec",
+    "solo_tokens_in",
+    "solo_tokens_out",
+    "solo_cost_usd",
+    "debate_tokens_in",
+    "debate_tokens_out",
+    "solo_error",
+    "debate_error",
+    "solo_correctness",
+    "solo_completeness",
+    "solo_reasoning_quality",
+    "solo_usefulness",
+    "debate_correctness",
+    "debate_completeness",
+    "debate_reasoning_quality",
+    "debate_usefulness",
+    "winner_system",
+    "exact_match_used",
+    "judge_error",
+    "judge_rationale",
+    "metadata_json",
+    "solo_answer",
+    "debate_answer",
+]
+
+
+def _load_tasks(domains: Iterable[str], limit: int, seed: int) -> Iterator[TaskItem]:
+    """Yield up to ``limit`` items per domain, lazily."""
+    for d in domains:
+        if d == "legal":
+            yield from legal_loader.load(limit, seed)
+        elif d == "aragora_custom":
+            yield from custom_loader.load(limit, seed)
+        elif d == "mmlu_pro":
+            # Import lazily so harness still works if datasets is absent
+            from benchmarks.bench_readiness.tier1.tasks import mmlu_pro
+
+            yield from mmlu_pro.load(limit, seed)
+        elif d == "swebench_lite":
+            from benchmarks.bench_readiness.tier1.tasks import swebench
+
+            yield from swebench.load(limit, seed)
+        else:
+            raise ValueError(f"unknown domain: {d}")
+
+
+def _row(
+    task: TaskItem,
+    solo: SystemOutput,
+    dbt: SystemOutput,
+    verdict: JudgeVerdict,
+) -> dict[str, object]:
+    return {
+        "task_id": task.task_id,
+        "domain": task.domain,
+        "eval_strategy": task.eval_strategy,
+        "solo_system": solo.system,
+        "debate_system": dbt.system,
+        "solo_latency_sec": round(solo.latency_sec, 3),
+        "debate_latency_sec": round(dbt.latency_sec, 3),
+        "solo_tokens_in": solo.tokens_in,
+        "solo_tokens_out": solo.tokens_out,
+        "solo_cost_usd": round(solo.cost_usd, 4),
+        "debate_tokens_in": dbt.tokens_in,
+        "debate_tokens_out": dbt.tokens_out,
+        "solo_error": solo.error,
+        "debate_error": dbt.error,
+        "solo_correctness": verdict.scores_a.get("correctness", ""),
+        "solo_completeness": verdict.scores_a.get("completeness", ""),
+        "solo_reasoning_quality": verdict.scores_a.get("reasoning_quality", ""),
+        "solo_usefulness": verdict.scores_a.get("usefulness", ""),
+        "debate_correctness": verdict.scores_b.get("correctness", ""),
+        "debate_completeness": verdict.scores_b.get("completeness", ""),
+        "debate_reasoning_quality": verdict.scores_b.get("reasoning_quality", ""),
+        "debate_usefulness": verdict.scores_b.get("usefulness", ""),
+        "winner_system": verdict.winner_system,
+        "exact_match_used": verdict.exact_match_used,
+        "judge_error": verdict.error,
+        "judge_rationale": verdict.rationale[:1500],
+        "metadata_json": json.dumps(task.metadata, separators=(",", ":")),
+        "solo_answer": solo.answer[:4000],
+        "debate_answer": dbt.answer[:4000],
+    }
+
+
+def _summarize(rows: list[dict[str, object]]) -> str:
+    """Produce a human-readable Markdown summary of the run."""
+    by_domain: dict[str, list[dict[str, object]]] = {}
+    for r in rows:
+        by_domain.setdefault(str(r["domain"]), []).append(r)
+
+    lines = ["# Tier-1 Benchmark Summary", ""]
+    lines.append(f"Total items: **{len(rows)}**  ")
+    lines.append(f"Run at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append("")
+
+    for domain, drs in sorted(by_domain.items()):
+        lines.append(f"## {domain}  (n={len(drs)})")
+        if not drs:
+            lines.append("")
+            continue
+
+        solo_sys = drs[0]["solo_system"]
+        dbt_sys = drs[0]["debate_system"]
+        solo_wins = sum(1 for r in drs if r["winner_system"] == solo_sys)
+        dbt_wins = sum(1 for r in drs if r["winner_system"] == dbt_sys)
+        ties = sum(1 for r in drs if r["winner_system"] == "TIE")
+        errors = sum(1 for r in drs if r["judge_error"] or r["solo_error"] or r["debate_error"])
+
+        lines.append(f"- Solo ({solo_sys}) wins: **{solo_wins}**")
+        lines.append(f"- Debate ({dbt_sys}) wins: **{dbt_wins}**")
+        lines.append(f"- Ties: **{ties}**")
+        lines.append(f"- Errors / skipped: **{errors}**")
+
+        # Average latency
+        solo_avg = sum(float(r["solo_latency_sec"]) for r in drs) / len(drs)
+        dbt_avg = sum(float(r["debate_latency_sec"]) for r in drs) / len(drs)
+        lines.append(f"- Avg latency — solo: {solo_avg:.1f}s | debate: {dbt_avg:.1f}s")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def run(
+    *,
+    api_key: str,
+    domains: list[str],
+    limit: int,
+    seed: int,
+    out_dir: pathlib.Path,
+    debate_rounds: int = 2,
+    model: str = "claude-opus-4-7",
+    log=print,  # noqa: A002
+) -> dict[str, object]:
+    """Execute the benchmark end-to-end.
+
+    Returns a manifest dict with CSV path, summary path, and counts.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    csv_path = out_dir / f"tier1_results_{ts}.csv"
+    summary_path = out_dir / f"tier1_summary_{ts}.md"
+
+    rows: list[dict[str, object]] = []
+
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_FIELDS, quoting=csv.QUOTE_MINIMAL)
+        writer.writeheader()
+
+        for i, task in enumerate(_load_tasks(domains, limit, seed), start=1):
+            log(f"[{i}] {task.task_id}  ({task.domain})")
+
+            solo = run_solo_opus(task, api_key=api_key, model=model)
+            log(f"    solo   : {solo.latency_sec:.1f}s  err={solo.error!r}")
+
+            dbt = run_aragora_debate(task, api_key=api_key, model=model, rounds=debate_rounds)
+            log(f"    debate : {dbt.latency_sec:.1f}s  err={dbt.error!r}")
+
+            verdict = judge(task, solo, dbt, api_key=api_key, seed=seed + i)
+            log(f"    judge  : winner={verdict.winner_system!r}  err={verdict.error!r}")
+
+            row = _row(task, solo, dbt, verdict)
+            writer.writerow(row)
+            f.flush()
+            rows.append(row)
+
+    summary_md = _summarize(rows)
+    summary_path.write_text(summary_md, encoding="utf-8")
+
+    return {
+        "csv": str(csv_path),
+        "summary": str(summary_path),
+        "items": len(rows),
+        "domains": domains,
+    }

--- a/benchmarks/bench_readiness/tier1/systems/__init__.py
+++ b/benchmarks/bench_readiness/tier1/systems/__init__.py
@@ -1,0 +1,24 @@
+"""Systems under test.
+
+Keep provider-specific imports lazy so the harness can be imported and tested
+without requiring every runtime dependency to be installed.
+"""
+
+from benchmarks.bench_readiness.tier1.systems.base import SystemOutput
+
+
+def run_solo_opus(*args, **kwargs):
+    from benchmarks.bench_readiness.tier1.systems.solo_opus import run_solo_opus as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def run_aragora_debate(*args, **kwargs):
+    from benchmarks.bench_readiness.tier1.systems.aragora_debate import (
+        run_aragora_debate as _impl,
+    )
+
+    return _impl(*args, **kwargs)
+
+
+__all__ = ["SystemOutput", "run_solo_opus", "run_aragora_debate"]

--- a/benchmarks/bench_readiness/tier1/systems/aragora_debate.py
+++ b/benchmarks/bench_readiness/tier1/systems/aragora_debate.py
@@ -1,0 +1,130 @@
+"""Aragora-debate system — 3 x Opus 4.7 agents with affirmative/negative/neutral stances.
+
+Uses the standalone ``aragora_debate`` package (MIT, zero required deps)
+rather than the full ``aragora.Arena`` because Phase B established that
+the full Arena pulls in pipeline stages, research, and network hooks even
+with demo flags. For a clean A/B, we want the debate engine proper —
+nothing else.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from benchmarks.bench_readiness.tier1.systems.base import SystemOutput
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+_STANCES = ("affirmative", "negative", "neutral")
+
+SYSTEM_PROMPT_TEMPLATE = (
+    "You are a careful expert analyst participating in an adversarial debate. "
+    "Your assigned stance for this debate is '{stance}'. Take that stance "
+    "seriously but adjust your view if the counter-argument is stronger. "
+    "Be specific, defensible, and concise."
+)
+
+
+def _synthesize_answer(result) -> str:
+    """Produce a single text answer from the debate result.
+
+    The standalone package's DebateResult carries a receipt (with final
+    consensus) plus per-agent proposals. We return the consensus verdict
+    text if present, otherwise the final-round proposals concatenated.
+    """
+    receipt = getattr(result, "receipt", None)
+    if receipt is not None:
+        verdict = getattr(receipt, "verdict", None)
+        if verdict is not None:
+            text = getattr(verdict, "text", "") or getattr(verdict, "summary", "")
+            if text:
+                return text.strip()
+
+    # Fallback: concatenate final proposals
+    proposals = getattr(result, "final_proposals", None) or []
+    if proposals:
+        parts = []
+        for p in proposals:
+            who = getattr(p, "author", "agent")
+            txt = getattr(p, "text", "") or getattr(p, "content", "")
+            if txt:
+                parts.append(f"[{who}]\n{txt}")
+        if parts:
+            return "\n\n---\n\n".join(parts)
+
+    # Last-ditch: stringify the result
+    return str(result)
+
+
+async def _run(task: TaskItem, api_key: str, model: str, rounds: int) -> SystemOutput:
+    from aragora_debate import Debate, create_agent
+
+    topic = task.prompt
+    context = task.context
+
+    debate = Debate(
+        topic=topic,
+        context=context,
+        rounds=rounds,
+        consensus="majority",
+        early_stopping=True,
+        enable_trickster=False,
+        enable_convergence=True,
+        convergence_threshold=0.85,
+    )
+
+    for stance in _STANCES:
+        agent = create_agent(
+            "anthropic",
+            name=f"opus-{stance}",
+            model=model,
+            api_key=api_key,
+            system_prompt=SYSTEM_PROMPT_TEMPLATE.format(stance=stance),
+            stance=stance,
+        )
+        debate.add_agent(agent)
+
+    t0 = time.perf_counter()
+    try:
+        result = await debate.run()
+        latency = time.perf_counter() - t0
+        answer = _synthesize_answer(result)
+
+        # Token counting across agents is best-effort; the standalone package
+        # does not aggregate it by default. We approximate by counting what's
+        # in the final answer and the topic/context.
+        tokens_in_approx = (len(topic) + len(context)) // 4  # 1 tok ~ 4 chars
+        tokens_out_approx = len(answer) // 4
+
+        return SystemOutput(
+            system=f"aragora_debate_3x_{model}",
+            answer=answer,
+            latency_sec=latency,
+            tokens_in=tokens_in_approx,
+            tokens_out=tokens_out_approx,
+            cost_usd=0.0,  # per-agent billing not exposed; tracked via raw
+            raw={
+                "rounds": rounds,
+                "stances": list(_STANCES),
+                "convergence_reached": getattr(result, "converged", None),
+            },
+        )
+    except Exception as e:  # noqa: BLE001 - debate providers raise non-uniform runtime errors
+        latency = time.perf_counter() - t0
+        return SystemOutput(
+            system=f"aragora_debate_3x_{model}",
+            answer="",
+            latency_sec=latency,
+            error=f"{type(e).__name__}: {e}",
+        )
+
+
+def run_aragora_debate(
+    task: TaskItem,
+    *,
+    api_key: str,
+    model: str = "claude-opus-4-7",
+    rounds: int = 2,
+) -> SystemOutput:
+    """Synchronous wrapper around the async :class:`Debate`."""
+    return asyncio.run(_run(task, api_key, model, rounds))

--- a/benchmarks/bench_readiness/tier1/systems/base.py
+++ b/benchmarks/bench_readiness/tier1/systems/base.py
@@ -1,0 +1,40 @@
+"""Common dataclass for system-under-test outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SystemOutput:
+    """Canonical output from a system run on a single task.
+
+    Attributes
+    ----------
+    system:
+        Display name of the system, e.g. ``solo_opus_4_7`` or
+        ``aragora_debate_3x_opus``.
+    answer:
+        The final textual answer handed to the judge.
+    latency_sec:
+        Wall-clock seconds from run start to answer return.
+    tokens_in / tokens_out:
+        Best-effort token counts. May be 0 for systems that don't surface them.
+    cost_usd:
+        Best-effort dollar cost. May be 0 if not tracked.
+    error:
+        Non-empty if the run failed. Callers should skip judging failed runs.
+    raw:
+        Free-form per-system internals (number of rounds, consensus method,
+        raw model responses, etc.) — not persisted to CSV.
+    """
+
+    system: str
+    answer: str
+    latency_sec: float
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float = 0.0
+    error: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)

--- a/benchmarks/bench_readiness/tier1/systems/solo_opus.py
+++ b/benchmarks/bench_readiness/tier1/systems/solo_opus.py
@@ -1,0 +1,77 @@
+"""Solo Opus 4.7 baseline — single model call, no tools, no agent loop."""
+
+from __future__ import annotations
+
+import time
+
+from benchmarks.bench_readiness.tier1.systems.base import SystemOutput
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+SYSTEM_PROMPT = (
+    "You are a careful expert analyst. Think step-by-step. When the question "
+    "has a clear correct answer, give it. When the question is open-ended, "
+    "take a defensible position and justify it concisely."
+)
+
+
+def run_solo_opus(
+    task: TaskItem,
+    *,
+    api_key: str,
+    model: str = "claude-opus-4-7",
+    max_tokens: int = 2048,
+) -> SystemOutput:
+    """Run a single Opus 4.7 completion for the given task.
+
+    Returns a :class:`SystemOutput` whose ``answer`` is the model's raw text.
+    On any exception, ``error`` is populated and ``answer`` is empty.
+    """
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    user_content = task.prompt
+    if task.context:
+        user_content = f"Context:\n{task.context}\n\nQuestion:\n{task.prompt}"
+
+    t0 = time.perf_counter()
+    try:
+        msg = client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_content}],
+        )
+        latency = time.perf_counter() - t0
+
+        # Best-effort text extraction
+        parts = []
+        for block in msg.content:
+            if getattr(block, "type", None) == "text":
+                parts.append(block.text)
+        answer = "\n".join(parts).strip()
+
+        usage = getattr(msg, "usage", None)
+        tokens_in = getattr(usage, "input_tokens", 0) or 0
+        tokens_out = getattr(usage, "output_tokens", 0) or 0
+
+        # Opus 4.7 pricing (as of 2026-04): $15/M input, $75/M output
+        cost = (tokens_in * 15 + tokens_out * 75) / 1_000_000
+
+        return SystemOutput(
+            system=f"solo_opus_{model}",
+            answer=answer,
+            latency_sec=latency,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=cost,
+            raw={"stop_reason": getattr(msg, "stop_reason", "")},
+        )
+    except Exception as e:  # noqa: BLE001 - provider SDKs can fail in many ways at runtime
+        latency = time.perf_counter() - t0
+        return SystemOutput(
+            system=f"solo_opus_{model}",
+            answer="",
+            latency_sec=latency,
+            error=f"{type(e).__name__}: {e}",
+        )

--- a/benchmarks/bench_readiness/tier1/tasks/__init__.py
+++ b/benchmarks/bench_readiness/tier1/tasks/__init__.py
@@ -1,0 +1,5 @@
+"""Task loaders for the Tier-1 benchmark."""
+
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+__all__ = ["TaskItem"]

--- a/benchmarks/bench_readiness/tier1/tasks/aragora_custom.py
+++ b/benchmarks/bench_readiness/tier1/tasks/aragora_custom.py
@@ -1,0 +1,215 @@
+"""Aragora custom decision tasks — the domain the product is actually built for.
+
+10 real decisions that a small-to-medium team would plausibly send through
+an aragora debate: architecture choices, vendor tradeoffs, hiring/sequencing
+calls, and compliance/risk judgments. No ground-truth answer because these
+are genuinely debatable; scoring is rubric-based via the LLM-judge.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+_ITEMS: list[tuple[str, str, str, str]] = [
+    (
+        "monorepo-vs-polyrepo",
+        "A Series-A SaaS with 12 engineers, 3 product surfaces (web app, iOS, "
+        "a CLI), and a shared TypeScript SDK is deciding whether to consolidate "
+        "into a monorepo (Turborepo/Nx) or stay with three separate repos.",
+        "Should they adopt a monorepo? Give a defensible recommendation with "
+        "the 2-3 strongest arguments on each side, the specific team signal "
+        "that would flip the decision, and concrete first steps if adopted.",
+        "Strong answer: (1) takes a position rather than hedging; (2) identifies "
+        "concrete tradeoffs — atomic cross-package changes, shared tooling, and "
+        "refactor ergonomics on the pro side vs CI complexity, tooling maturity "
+        "gaps, and onboarding/partial-checkout friction on the con side; "
+        "(3) provides a decision-flip signal (e.g., 'if CI costs exceed $X/mo "
+        "or > N mobile-only engineers'); (4) gives 2-4 concrete first steps.",
+    ),
+    (
+        "gdpr-fine-risk-us-expansion",
+        "A U.S. B2B SaaS startup is considering expanding to EU customers. They "
+        "have moderate privacy practices (SSO, encryption-at-rest) but no DPO, "
+        "no DPA template, no SCC template, and no EU representative.",
+        "Go/no-go on EU expansion right now, with what mitigations? Quantify "
+        "the risk where possible.",
+        "Strong answer: (1) takes an explicit go/no-go stance; (2) names the "
+        "three hard blockers — Art. 27 EU representative, Art. 28 DPA, Art. 46 "
+        "SCCs for cross-border transfer — and calls out they are cheap/fast to "
+        "fix; (3) quantifies fine exposure appropriately (Art. 83: up to 4% "
+        "annual worldwide turnover or €20M, whichever is greater; but for a "
+        "pre-Series-B startup enforcement is more likely via customer DPIA "
+        "rejections than regulator fines); (4) provides a sequenced 4-6 week "
+        "mitigation plan.",
+    ),
+    (
+        "llm-provider-diversification",
+        "A fintech customer-support automation platform built on Anthropic's "
+        "Claude has a 3-hour incident when Anthropic's API is down. They are "
+        "debating whether to add OpenAI GPT as an active failover, keep a "
+        "warm standby, or accept the risk with credits.",
+        "What's the right incident-response posture for this team given the "
+        "cost/complexity tradeoff? Give a specific recommendation with a "
+        "concrete implementation outline.",
+        "Strong answer: (1) picks ONE of active failover / warm standby / "
+        "accept-risk with explicit reasoning; (2) addresses the correctness "
+        "gap — different models behave differently under the same prompt, so "
+        "failover has an output-quality cost; (3) recommends prompt/eval parity "
+        "(run both models through same eval set) before trusting failover; "
+        "(4) concrete outline: circuit breaker on Claude, degraded-mode "
+        "playbook (shorter/simpler responses), provider-agnostic prompt "
+        "abstraction layer; (5) quantifies cost of 3hr outage × frequency vs "
+        "dual-vendor fixed+variable cost.",
+    ),
+    (
+        "oss-license-for-core-product",
+        "A profitable open-core startup ($8M ARR, 4 years in) has been shipping "
+        "MIT-licensed code. A well-funded competitor has forked the core, "
+        "added enterprise features, and is now selling a competing product. "
+        "Leadership is debating: relicense to AGPL going forward, relicense to "
+        "SSPL/BSL, stay MIT and compete on service, or split the repo "
+        "(BSL for core, MIT for SDK).",
+        "What's the right move? Acknowledge the community backlash risk explicitly.",
+        "Strong answer: (1) takes an explicit position with a defensible rationale; "
+        "(2) distinguishes between AGPL (still OSI-approved, forces network-use "
+        "source disclosure), SSPL (effectively prevents cloud hosting without "
+        "commercial license, not OSI-approved), and BSL (time-delayed release); "
+        "(3) acknowledges the reputational / community-trust cost of relicensing "
+        "— contrast ElasticSearch/HashiCorp backlash vs MongoDB which retained "
+        "most users; (4) recommends action on the CLA/contribution model, not "
+        "just the license; (5) provides a rollout plan: grandfathering, "
+        "communication, pricing signals.",
+    ),
+    (
+        "ai-feature-hallucination-shipping",
+        "A customer-facing product is two days from launching an AI summary "
+        "feature. QA found a 3% hallucination rate on internal test data. "
+        "The team is split between shipping with a disclaimer, delaying a "
+        "sprint to add grounding/citation, or shipping behind a feature flag "
+        "to 5% of users.",
+        "Ship, delay, or gradual rollout? What specific guardrails or metrics justify each choice?",
+        "Strong answer: (1) takes a concrete position; (2) distinguishes "
+        "disclaimer (visibility only, no real mitigation) vs grounding (reduces "
+        "rate but not to zero) vs gradual rollout (limits blast radius, gives "
+        "observation signal); (3) names the specific metric that would flip "
+        "the decision — e.g., 'if CSAT impact of hallucinations is < 2% in the "
+        "5% rollout, proceed; if > 5%, roll back'; (4) acknowledges the "
+        "brand-trust asymmetry — hallucinations in a first launch cost more "
+        "than hallucinations in a mature feature; (5) provides a rollback trigger.",
+    ),
+    (
+        "vertical-focus-commercial",
+        "A general-purpose multi-agent deliberation platform (like aragora "
+        "itself — 43 agent types, 5 verticals, multiple channels) is deciding "
+        "between: (a) stay horizontal and sell to anyone, (b) pick one vertical "
+        "and own it (legal / healthcare / accounting / software engineering), "
+        "or (c) pick two verticals as a 'core + adjacent' strategy.",
+        "Which strategy wins, why, and what's the concrete 12-month plan to execute on it?",
+        "Strong answer: (1) takes a clear position, with preference for ONE "
+        "vertical over multi-vertical; (2) applies standard reasoning about "
+        "vertical SaaS motion — concentrated sales motion, targeted marketing, "
+        "defensible pricing, more predictable buyer persona; (3) names which "
+        "vertical with specific reasoning — legal is the strongest fit for "
+        "audit-trail / decision-receipt products because law firms bill for "
+        "defensibility and have regulated documentation requirements; "
+        "healthcare has HIPAA overhead but also Tier-1 willingness-to-pay; "
+        "accounting has SOX; software engineering has most competitors; "
+        "(4) gives a concrete 12-month plan: 3 months design partner acquisition "
+        "in the chosen vertical, 3 months product focus with partners, 6 months "
+        "GTM motion.",
+    ),
+    (
+        "on-call-rotation-small-team",
+        "A 6-person backend team has an on-call rotation that runs 1-week "
+        "shifts, 24/7, follow-the-sun handoff not possible (all US-based). "
+        "Two engineers are threatening to leave citing burnout. Options: "
+        "shorten shifts to 3.5 days, hire a dedicated SRE, outsource to a "
+        "managed on-call service, invest in runbook automation to reduce "
+        "page volume.",
+        "What's the right move to reduce burnout without cratering on-call "
+        "coverage? What metric proves it worked 90 days later?",
+        "Strong answer: (1) takes a concrete position; (2) rejects the single-"
+        "lever framing — proposes a multi-intervention plan; (3) correctly "
+        "identifies the actual leverage point: reducing PAGE VOLUME is higher-"
+        "leverage than splitting a fixed page load across shorter shifts or "
+        "more people (the latter just spreads misery); (4) specific "
+        "implementations — alert quality review (suppress noise), runbook "
+        "automation for top-3 pager causes, SLO-gated releases; (5) success "
+        "metric — e.g., pages/week and 'would recommend on-call to a friend' "
+        "NPS-style score 90 days in.",
+    ),
+    (
+        "postgres-to-datalake-reporting",
+        "A mid-market B2B SaaS (100 customers, 40TB of operational Postgres, "
+        "complex reporting dashboards) has been building reports directly from "
+        "Postgres read replicas. Queries are slow (30s+ for month-end rollups) "
+        "and block customer-facing APIs. Options: add a separate analytics "
+        "Postgres, move to ClickHouse, move to Snowflake/BigQuery with CDC, "
+        "build an in-memory OLAP layer in the app.",
+        "Pick the right architecture for the next 3 years of scale and "
+        "explain why the others are wrong FOR THIS TEAM.",
+        "Strong answer: (1) picks ONE; (2) distinguishes operational vs analytical "
+        "workloads clearly; (3) explicit reasoning about why the others are wrong "
+        "for THIS team (team size, skills, cost profile, customer data-residency "
+        "implications); (4) addresses CDC latency tradeoffs, cost trajectory at "
+        "100→500 customers, and what happens to the choice at 10x scale; "
+        "(5) includes a migration sequencing plan that doesn't break existing "
+        "dashboards during cutover.",
+    ),
+    (
+        "acquire-vs-build-compliance-tool",
+        "A fintech has regulatory reporting obligations in three jurisdictions "
+        "(US SEC, UK FCA, EU ESMA). They're debating building their own "
+        "compliance-reporting tool ($600K / 8 months / 2 eng + 1 compliance "
+        "lead) vs buying one of two enterprise SaaS tools ($180K/yr, 80% "
+        "fit) vs buying a startup tool ($40K/yr, 50% fit, but growing fast).",
+        "Buy one of the three, or build? Decision must include a threshold "
+        "for WHEN to revisit the decision.",
+        "Strong answer: (1) takes a position; (2) applies cost comparison over "
+        "3 years including ongoing build-vs-buy maintenance — build has $600K "
+        "one-time + ~$200K/yr ongoing vs enterprise SaaS $540K/3yr all-in; "
+        "(3) weighs integration risk, regulator-audit burden of in-house "
+        "systems, and feature velocity; (4) names the flip trigger — e.g., "
+        "'revisit if fit drops below 60% due to vendor roadmap divergence, or "
+        "if headcount growth absorbs the maintenance cost'; (5) if recommending "
+        "startup tool, flags the vendor-risk mitigation (escrow, exit clause).",
+    ),
+    (
+        "incident-postmortem-blame",
+        "A production outage caused by a junior engineer pushing an unreviewed "
+        "migration to main resulted in 4 hours of downtime and $120K in SLA "
+        "credits. Leadership is debating: terminate the engineer (public signal), "
+        "formal write-up in file, quiet 1:1 coaching with continued tenure, "
+        "or blameless postmortem with no individual consequence.",
+        "What's the right response organizationally? Address both the "
+        "individual AND the systemic signal.",
+        "Strong answer: (1) takes an explicit position favoring blameless or "
+        "near-blameless approach; (2) distinguishes INDIVIDUAL accountability "
+        "(coaching, pairing, re-review process) from SYSTEMIC root cause "
+        "(why was the migration pushable to main unreviewed? why was there no "
+        "CI/CD gate? why was there no peer review workflow?); (3) correctly "
+        "identifies that terminating the engineer punishes the symptom and "
+        "teaches the rest of the team to hide mistakes; (4) concrete remediation "
+        "— branch protection, review-required gates, migration-specific approvers, "
+        "staged rollouts; (5) acknowledges the ONE exception — deliberate or "
+        "grossly-negligent action requires individual consequence.",
+    ),
+]
+
+
+def load(limit: int, seed: int = 42) -> Iterable[TaskItem]:
+    """Yield up to ``limit`` aragora-custom items in file order."""
+    for i, (slug, context, prompt, rubric) in enumerate(_ITEMS):
+        if i >= limit:
+            break
+        yield TaskItem(
+            task_id=f"aragora-{slug}",
+            domain="aragora_custom",
+            prompt=prompt,
+            context=context,
+            reference_answer=rubric,
+            eval_strategy="llm_judge",
+            metadata={"decision_type": slug},
+        )

--- a/benchmarks/bench_readiness/tier1/tasks/base.py
+++ b/benchmarks/bench_readiness/tier1/tasks/base.py
@@ -1,0 +1,47 @@
+"""TaskItem — the uniform interface across all four benchmark domains.
+
+A TaskItem carries everything a system-under-test needs to answer a question
+plus everything a judge needs to score the answer. Keep this surface small
+so new domains only have to implement a loader that yields TaskItems.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TaskItem:
+    """A single benchmarked item.
+
+    Attributes
+    ----------
+    task_id:
+        Stable identifier for this item. Used as the CSV row key.
+    domain:
+        One of ``mmlu_pro``, ``swebench_lite``, ``legal``, ``aragora_custom``.
+    prompt:
+        The question handed verbatim to both the solo and debate systems.
+    context:
+        Optional background text. Legal contracts go here; reasoning tasks
+        typically leave it empty.
+    reference_answer:
+        The ground-truth answer when one exists (MMLU-Pro, SWE-bench). Empty
+        string when the task is subjective (legal, custom).
+    eval_strategy:
+        ``exact_match`` | ``test_based`` | ``llm_judge``. Determines whether
+        primary scoring uses the reference answer, runs tests, or defers to
+        the LLM judge.
+    metadata:
+        Free-form per-domain metadata (e.g. category for MMLU, repo/issue for
+        SWE-bench). Persisted to CSV under a single ``metadata_json`` column.
+    """
+
+    task_id: str
+    domain: str
+    prompt: str
+    context: str = ""
+    reference_answer: str = ""
+    eval_strategy: str = "llm_judge"
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/benchmarks/bench_readiness/tier1/tasks/legal.py
+++ b/benchmarks/bench_readiness/tier1/tasks/legal.py
@@ -1,0 +1,224 @@
+"""Legal contract review — 10 curated tasks.
+
+CUAD and similar public legal datasets have restrictive licenses for
+benchmarking. Curated synthetic clauses + ground-truth rubrics give us
+a clean signal without licensing complications.
+
+Each task is: (a) a short contract excerpt, (b) a specific review question
+that would plausibly be asked by a lawyer or paralegal, (c) a rubric of
+points the correct answer must make. The LLM-judge scores against the
+rubric.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+_ITEMS: list[tuple[str, str, str, str]] = [
+    (
+        "liability-cap-carveouts",
+        (
+            "Except with respect to (a) a party's indemnification obligations, "
+            "(b) breach of confidentiality, (c) gross negligence or willful "
+            "misconduct, or (d) infringement of intellectual property rights, "
+            "neither party's aggregate liability shall exceed the fees paid by "
+            "Customer in the twelve months preceding the claim."
+        ),
+        "Review this limitation-of-liability clause from the Customer's perspective. "
+        "What are the carve-outs (if any), are they customary, and what is the "
+        "single biggest risk this clause poses to the Customer?",
+        "Must identify: (1) the four specific carve-outs (indemnity, confidentiality, "
+        "gross negligence/willful misconduct, IP infringement); (2) confirm all four "
+        "are customary; (3) flag the primary risk — 12-month fee cap is a narrow "
+        "fees-paid cap (not fees-payable), so early terminations before 12 months "
+        "or low-fee pilots leave the Customer exposed.",
+    ),
+    (
+        "data-processing-addendum",
+        (
+            "Processor shall process Personal Data only on documented instructions "
+            "from Controller, including transfers to a third country, unless "
+            "required by Union or Member State law; Processor shall inform "
+            "Controller of any such legal requirement before processing, unless "
+            "that law prohibits such information on important grounds of public "
+            "interest."
+        ),
+        "Does this clause satisfy GDPR Art. 28(3)(a)? What's missing for a fully "
+        "compliant Data Processing Addendum?",
+        "Must note: (1) clause covers the Art. 28(3)(a) 'documented instructions' "
+        "requirement including the cross-border carve-out; (2) flag what's missing "
+        "for full Art. 28(3): (b) confidentiality obligations on processor staff, "
+        "(c) Art. 32 security measures reference, (d) sub-processor rules, "
+        "(e) data subject rights assistance, (f) breach notification timelines, "
+        "(g) DPIA assistance, (h) end-of-engagement deletion/return, (i) audit rights.",
+    ),
+    (
+        "non-compete-scope",
+        (
+            "Executive agrees that for a period of 24 months following "
+            "termination of employment for any reason, Executive shall not, "
+            "directly or indirectly, engage in any business that competes with "
+            "the Company anywhere in the world."
+        ),
+        "Analyze the enforceability of this non-compete in California and in "
+        "New York. Is there a meaningful difference in outcomes?",
+        "Must state: (1) California generally refuses to enforce non-competes under "
+        "Bus. & Prof. Code § 16600 except narrow sale-of-business / dissolution "
+        "carve-outs — this clause would be void as to a CA-based executive; "
+        "(2) New York enforces non-competes under a reasonableness test — 24 months "
+        "is on the long end, worldwide geographic scope is almost certainly "
+        "unreasonable and would likely be blue-penciled or voided; (3) material "
+        "difference in outcome exists (CA void, NY likely modified).",
+    ),
+    (
+        "ip-assignment-moral-rights",
+        (
+            "Contractor hereby assigns to Company all right, title, and interest "
+            "in and to the Work Product, including all intellectual property "
+            "rights therein, and waives any moral rights to the extent "
+            "permitted by applicable law."
+        ),
+        "Is this IP assignment effective in France and in the United States?",
+        "Must note: (1) US — effective; 'work-for-hire' doctrine and broad IP "
+        "assignments are routinely enforced; moral-rights waiver is meaningful "
+        "only under VARA for visual art. (2) France — moral rights (droit moral) "
+        "are INALIENABLE under Art. L. 121-1 CPI; a waiver is legally ineffective "
+        "regardless of what the contract says. The 'to the extent permitted' "
+        "savings clause does not rescue it for moral rights in France. Company "
+        "cannot rely on this waiver for French-authored content.",
+    ),
+    (
+        "payment-terms-offset",
+        (
+            "Customer shall pay all undisputed fees within 30 days of invoice. "
+            "Customer may not withhold, offset, or deduct any amount from "
+            "payments owed hereunder, notwithstanding any dispute."
+        ),
+        "From the Customer's side, what is the practical problem with this "
+        "no-offset clause and what should the Customer negotiate?",
+        "Must identify: (1) problem — Customer loses its strongest negotiating "
+        "lever (payment freeze) when Vendor breaches; forces Customer into "
+        "litigation/arbitration to claim anything back; (2) Customer should "
+        "negotiate: right to withhold disputed portion only, notice-and-cure "
+        "window before offset prohibition applies, or setoff right for judgments "
+        "and undisputed amounts due from Vendor.",
+    ),
+    (
+        "auto-renewal-notice",
+        (
+            "This Agreement shall automatically renew for successive 12-month "
+            "periods unless either party provides written notice of "
+            "non-renewal at least 90 days prior to the end of the then-current "
+            "term. Fees for the renewal term will be the Vendor's then-current "
+            "list pricing."
+        ),
+        "Flag every customer-unfriendly element of this auto-renewal clause.",
+        "Must flag: (1) 90-day notice window is long — customer must diarize; "
+        "(2) 'then-current list pricing' allows unilateral price increases without "
+        "cap; (3) missing — no obligation on Vendor to notify Customer of upcoming "
+        "auto-renewal or price change; (4) missing — no customer-favorable cap "
+        "(e.g., CPI or 5%) on renewal price. Customer should negotiate: shorter "
+        "window, Vendor notification duty, and a price-cap formula.",
+    ),
+    (
+        "sla-credits-sole-remedy",
+        (
+            "If Vendor fails to meet the Service Level commitments, Customer's "
+            "sole and exclusive remedy shall be service credits equal to 5% of "
+            "the monthly fees for each full hour of unavailability, not to "
+            "exceed 30% of the monthly fees for that month."
+        ),
+        "Evaluate this SLA remedy from the Customer's perspective.",
+        "Must address: (1) service credits as 'sole and exclusive remedy' is "
+        "standard but restrictive — blocks damages recovery; (2) 5%/hr with 30% "
+        "monthly cap = max 6 hours of outage fully credited — worse than "
+        "typical enterprise SLAs (99.9% = ~43 min/month, so 6 hours implies "
+        "99.17% which is a weak SLA); (3) Customer should negotiate: (a) "
+        "termination right after N consecutive months of SLA misses, (b) carve-out "
+        "from 'sole remedy' for persistent or severe outages, (c) higher credit "
+        "percentages or uncapped credits.",
+    ),
+    (
+        "indemnity-ip-scope",
+        (
+            "Vendor shall defend, indemnify, and hold harmless Customer from "
+            "and against any third-party claims alleging that the Services, "
+            "as delivered by Vendor and used in accordance with this "
+            "Agreement, infringe any U.S. patent, copyright, or trademark. "
+            "This indemnity shall not apply to (i) modifications made by "
+            "Customer or (ii) use of the Services in combination with any "
+            "third-party products."
+        ),
+        "What's wrong with this IP indemnity from the Customer's perspective?",
+        "Must identify: (1) geographic scope — only U.S. patents/copyrights/"
+        "trademarks; international customers or products are unprotected; "
+        "(2) missing trade secret coverage; (3) combination carve-out is broad — "
+        "almost any enterprise use involves third-party integrations; (4) "
+        "'as delivered by Vendor and used in accordance with this Agreement' "
+        "is a strict condition; (5) no remedies specified (e.g., replace/"
+        "modify/refund on injunction). Customer should negotiate: worldwide "
+        "scope (or at least major jurisdictions), trade secret inclusion, "
+        "narrower combination carve-out, and specified remedies.",
+    ),
+    (
+        "termination-for-convenience",
+        (
+            "Customer may terminate this Agreement for convenience upon 180 "
+            "days' prior written notice to Vendor, provided that Customer "
+            "shall pay a termination fee equal to 50% of the remaining fees "
+            "that would have been due through the end of the then-current term."
+        ),
+        "Is this 'termination for convenience' genuinely for convenience, "
+        "or functionally not? What's a reasonable counter-proposal?",
+        "Must say: (1) not genuinely for convenience — the 50% remainder-of-term "
+        "payment is economically equivalent to no termination right for most of "
+        "a term; (2) if customer is 11 months into a 12-month term, cost is 0.5 "
+        "months of fees (fine) — if 2 months into a 36-month term, cost is 17 "
+        "months of fees (prohibitive); (3) reasonable counter: shorter notice "
+        "(60-90 days), a capped termination fee (e.g., 3-6 months), and/or "
+        "termination-for-convenience limited to specified causes or a recurring "
+        "annual window.",
+    ),
+    (
+        "ai-model-training-rights",
+        (
+            "Vendor may use Customer Data (including all inputs and outputs) "
+            "to train, fine-tune, and improve Vendor's AI models and services, "
+            "on a non-exclusive, perpetual, worldwide, royalty-free basis. "
+            "Customer may opt out by written notice to the Vendor."
+        ),
+        "From an enterprise Customer's perspective, list every red flag.",
+        "Must flag: (1) opt-out not opt-in — default consent is contrary to GDPR "
+        "Art. 6/7 and many enterprise procurement policies; (2) 'all inputs and "
+        "outputs' — sweeps in confidential data, trade secrets, PII, regulated "
+        "data; (3) perpetual — survives termination; (4) worldwide — ignores "
+        "data-residency commitments to end users; (5) royalty-free — customer "
+        "provides training data at zero compensation; (6) no indemnity carve-out "
+        "if the trained model emits Customer Data to other customers; (7) no "
+        "distinction between user prompts and system outputs. Customer must "
+        "negotiate: opt-in default, exclusion of confidential/PII/regulated data, "
+        "term-limited license, and explicit confidentiality+indemnity flowdown.",
+    ),
+]
+
+
+def load(limit: int, seed: int = 42) -> Iterable[TaskItem]:
+    """Yield up to ``limit`` legal review items in file order.
+
+    ``seed`` is accepted for interface consistency but unused — items are
+    curated rather than sampled.
+    """
+    for i, (slug, context, prompt, rubric) in enumerate(_ITEMS):
+        if i >= limit:
+            break
+        yield TaskItem(
+            task_id=f"legal-{slug}",
+            domain="legal",
+            prompt=prompt,
+            context=context,
+            reference_answer=rubric,
+            eval_strategy="llm_judge",
+            metadata={"clause_type": slug},
+        )

--- a/benchmarks/bench_readiness/tier1/tasks/mmlu_pro.py
+++ b/benchmarks/bench_readiness/tier1/tasks/mmlu_pro.py
@@ -1,0 +1,57 @@
+"""MMLU-Pro hard subset loader.
+
+Uses the public TIGER-Lab/MMLU-Pro HuggingFace dataset. Samples only from
+the harder categories where frontier models still disagree (law,
+formal_logic, math, physics, economics). Exact-match primary + LLM-judge
+secondary for reasoning quality.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+_HARD_CATEGORIES = ("law", "math", "physics", "economics", "philosophy")
+
+
+def load(limit: int, seed: int = 42) -> Iterable[TaskItem]:
+    """Yield up to ``limit`` MMLU-Pro items from hard categories.
+
+    The dataset is streamed, filtered, shuffled deterministically, then
+    truncated to ``limit``.
+    """
+    from datasets import load_dataset
+
+    ds = load_dataset("TIGER-Lab/MMLU-Pro", split="test")
+    ds = ds.filter(lambda r: r["category"] in _HARD_CATEGORIES)
+    ds = ds.shuffle(seed=seed)
+
+    for i, row in enumerate(ds):
+        if i >= limit:
+            break
+
+        options = row["options"]
+        lettered = "\n".join(f"({chr(ord('A') + j)}) {opt}" for j, opt in enumerate(options))
+        prompt = (
+            f"{row['question']}\n\n"
+            f"Options:\n{lettered}\n\n"
+            "Think step-by-step, then give your final answer on its own line "
+            "as 'Answer: X' where X is a single letter."
+        )
+
+        answer_letter = chr(ord("A") + int(row["answer_index"]))
+
+        yield TaskItem(
+            task_id=f"mmlu_pro-{row['question_id']}",
+            domain="mmlu_pro",
+            prompt=prompt,
+            context="",
+            reference_answer=answer_letter,
+            eval_strategy="exact_match",
+            metadata={
+                "category": row["category"],
+                "src": row.get("src", ""),
+                "option_count": len(options),
+            },
+        )

--- a/benchmarks/bench_readiness/tier1/tasks/swebench.py
+++ b/benchmarks/bench_readiness/tier1/tasks/swebench.py
@@ -1,0 +1,50 @@
+"""SWE-bench Lite loader (problem-statement only).
+
+Tier-1 does NOT execute patches — that requires Docker image builds per
+repo. Instead we present the problem statement and let each system propose
+a patch as text. The LLM-judge then compares the proposed patch to the
+reference patch for semantic equivalence. This is a weaker signal than
+actual test execution but viable for a first-pass benchmark.
+
+A follow-up Tier-2 run should swap this for the full SWE-bench harness.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+
+def load(limit: int, seed: int = 42) -> Iterable[TaskItem]:
+    """Yield up to ``limit`` SWE-bench Lite problems."""
+    from datasets import load_dataset
+
+    ds = load_dataset("princeton-nlp/SWE-bench_Lite", split="test")
+    ds = ds.shuffle(seed=seed)
+
+    for i, row in enumerate(ds):
+        if i >= limit:
+            break
+
+        prompt = (
+            f"Repository: {row['repo']}\n"
+            f"Issue:\n{row['problem_statement']}\n\n"
+            "Propose a minimal patch in unified diff format that would "
+            "resolve this issue. Explain your reasoning briefly before the "
+            "diff."
+        )
+
+        yield TaskItem(
+            task_id=f"swebench-{row['instance_id']}",
+            domain="swebench_lite",
+            prompt=prompt,
+            context="",
+            reference_answer=row["patch"],
+            eval_strategy="llm_judge",
+            metadata={
+                "repo": row["repo"],
+                "instance_id": row["instance_id"],
+                "base_commit": row.get("base_commit", ""),
+            },
+        )

--- a/tests/benchmarks/test_tier1_harness.py
+++ b/tests/benchmarks/test_tier1_harness.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import builtins
+import sys
+import types
+
+from benchmarks.bench_readiness.tier1 import judge, runner
+from benchmarks.bench_readiness.tier1.systems import SystemOutput
+from benchmarks.bench_readiness.tier1.tasks import aragora_custom, legal, mmlu_pro, swebench
+from benchmarks.bench_readiness.tier1.tasks.base import TaskItem
+
+
+def test_legal_loader_respects_limit() -> None:
+    items = list(legal.load(limit=2))
+
+    assert len(items) == 2
+    assert all(item.domain == "legal" for item in items)
+    assert items[0].task_id.startswith("legal-")
+
+
+def test_aragora_custom_loader_respects_limit() -> None:
+    items = list(aragora_custom.load(limit=3))
+
+    assert len(items) == 3
+    assert all(item.domain == "aragora_custom" for item in items)
+    assert items[0].task_id.startswith("aragora-")
+
+
+def test_extract_final_letter_and_exact_match() -> None:
+    task = TaskItem(
+        task_id="mmlu-1",
+        domain="mmlu_pro",
+        prompt="Question",
+        reference_answer="B",
+        eval_strategy="exact_match",
+    )
+    solo = SystemOutput(system="solo", answer="Reasoning\nAnswer: B", latency_sec=1.0)
+    debate = SystemOutput(system="debate", answer="Reasoning\nAnswer: C", latency_sec=1.0)
+
+    verdict = judge.judge(task, solo, debate, api_key="unused", seed=0)
+
+    assert verdict.exact_match_used is True
+    assert verdict.winner_system == "solo"
+    assert verdict.scores_a["correctness"] == 10
+    assert verdict.scores_b["correctness"] == 0
+
+
+def test_runner_summarize_groups_rows_by_domain() -> None:
+    summary = runner._summarize(
+        [
+            {
+                "domain": "legal",
+                "solo_system": "solo",
+                "debate_system": "debate",
+                "winner_system": "solo",
+                "judge_error": "",
+                "solo_error": "",
+                "debate_error": "",
+                "solo_latency_sec": 1.0,
+                "debate_latency_sec": 2.0,
+            },
+            {
+                "domain": "legal",
+                "solo_system": "solo",
+                "debate_system": "debate",
+                "winner_system": "TIE",
+                "judge_error": "",
+                "solo_error": "",
+                "debate_error": "",
+                "solo_latency_sec": 1.5,
+                "debate_latency_sec": 2.5,
+            },
+        ]
+    )
+
+    assert "# Tier-1 Benchmark Summary" in summary
+    assert "## legal  (n=2)" in summary
+    assert "Solo (solo) wins: **1**" in summary
+    assert "Ties: **1**" in summary
+
+
+def test_systems_module_keeps_provider_imports_lazy(monkeypatch) -> None:
+    for name in (
+        "benchmarks.bench_readiness.tier1.systems",
+        "benchmarks.bench_readiness.tier1.systems.solo_opus",
+        "benchmarks.bench_readiness.tier1.systems.aragora_debate",
+    ):
+        sys.modules.pop(name, None)
+
+    imported: list[str] = []
+    real_import = builtins.__import__
+
+    def tracking_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {
+            "benchmarks.bench_readiness.tier1.systems.solo_opus",
+            "benchmarks.bench_readiness.tier1.systems.aragora_debate",
+        }:
+            imported.append(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", tracking_import)
+
+    import benchmarks.bench_readiness.tier1.systems as systems
+
+    assert imported == []
+    assert hasattr(systems, "run_solo_opus")
+    assert hasattr(systems, "run_aragora_debate")
+
+
+def test_mmlu_loader_uses_dataset_rows(monkeypatch) -> None:
+    class FakeDataset:
+        def __init__(self, rows):
+            self._rows = list(rows)
+
+        def filter(self, predicate):
+            return FakeDataset([row for row in self._rows if predicate(row)])
+
+        def shuffle(self, seed):
+            assert seed == 7
+            return self
+
+        def __iter__(self):
+            return iter(self._rows)
+
+    fake_module = types.SimpleNamespace(
+        load_dataset=lambda *args, **kwargs: FakeDataset(
+            [
+                {
+                    "question_id": "q1",
+                    "category": "law",
+                    "question": "What is law?",
+                    "options": ["A1", "B1", "C1"],
+                    "answer_index": 1,
+                    "src": "test",
+                }
+            ]
+        )
+    )
+    monkeypatch.setitem(sys.modules, "datasets", fake_module)
+
+    items = list(mmlu_pro.load(limit=1, seed=7))
+
+    assert len(items) == 1
+    assert items[0].domain == "mmlu_pro"
+    assert items[0].reference_answer == "B"
+
+
+def test_swebench_loader_uses_dataset_rows(monkeypatch) -> None:
+    class FakeDataset:
+        def __init__(self, rows):
+            self._rows = list(rows)
+
+        def shuffle(self, seed):
+            assert seed == 11
+            return self
+
+        def __iter__(self):
+            return iter(self._rows)
+
+    fake_module = types.SimpleNamespace(
+        load_dataset=lambda *args, **kwargs: FakeDataset(
+            [
+                {
+                    "instance_id": "inst1",
+                    "repo": "owner/repo",
+                    "problem_statement": "Bug details",
+                    "patch": "diff --git a/x b/x",
+                    "base_commit": "abc123",
+                }
+            ]
+        )
+    )
+    monkeypatch.setitem(sys.modules, "datasets", fake_module)
+
+    items = list(swebench.load(limit=1, seed=11))
+
+    assert len(items) == 1
+    assert items[0].domain == "swebench_lite"
+    assert items[0].metadata["repo"] == "owner/repo"


### PR DESCRIPTION
## Summary
- salvage the additive tier-1 benchmark harness from the parked root snapshot into a clean branch
- keep provider imports lazy so the harness can be imported and tested without requiring every runtime dependency at import time
- add focused benchmark-harness tests for loaders, exact-match judging, summaries, and lazy provider import behavior

## Validation
- `python3 -m pytest tests/benchmarks/test_tier1_harness.py -q`
- `python3 -m ruff check benchmarks/bench_readiness/tier1 tests/benchmarks/test_tier1_harness.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
