### PR TITLE
[Phase 2a] feat(cli): read-only review-queue + advisory packets (#6279)

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1,0 +1,561 @@
+"""Read-only PR review queue + advisory packets (Phase 2a of #6279).
+
+Phase 2a is **strictly read-only**: builds a prioritized queue of open PRs and
+generates advisory packets for individual PRs. The packet is explicitly
+advisory — it does not approve, block, or otherwise settle a PR. Settlement
+remains a human action via GitHub UI or ``gh`` directly.
+
+Out of scope for Phase 2a (intentionally not implemented):
+
+- ``review-queue run`` (interactive review session)
+- ``review-queue act --approve|--request-changes|--defer`` (settlement actions)
+- ``review-queue digest`` (rolled-up activity report)
+- Any GitHub write API call
+
+See docs/plans/2026-04-19-batched-pr-review-triage.md for the full design.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+UTC = timezone.utc
+
+# Lane classification thresholds and risk-path catalog.
+LARGE_DIFF_THRESHOLD = 500  # additions + deletions, beyond which "needs_human_attention"
+HIGH_RISK_PATHS: tuple[str, ...] = (
+    "CLAUDE.md",
+    "aragora/__init__.py",
+    ".env",
+    "scripts/nomic_loop.py",
+)
+HIGH_RISK_PREFIXES: tuple[str, ...] = (
+    "aragora/security/",
+    "aragora/auth/",
+    "aragora/blockchain/",
+    "aragora/rbac/",
+    "scripts/auto_revert",
+    ".github/workflows/",
+)
+PARKED_LABELS: tuple[str, ...] = ("stale", "do-not-merge", "wip", "blocked")
+
+LANE_ORDER: dict[str, int] = {
+    "ready_now": 0,
+    "needs_attention": 1,
+    "repairable": 2,
+    "parked": 3,
+}
+
+ADVISORY_NOTE = (
+    "This packet is advisory only. It does not approve or block merge. Human settlement required."
+)
+
+
+@dataclass(slots=True)
+class QueueItem:
+    """One row in the prioritized review queue."""
+
+    number: int
+    title: str
+    url: str
+    head_sha: str
+    author: str
+    is_draft: bool
+    mergeable: str
+    review_decision: str
+    labels: list[str]
+    additions: int
+    deletions: int
+    changed_files: int
+    checks_summary: str
+    lane: str
+    lane_reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ReviewPacket:
+    """Advisory packet for one PR. NEVER counts as a GitHub approval."""
+
+    pr_number: int
+    title: str
+    url: str
+    head_sha: str
+    author: str
+    is_draft: bool
+    additions: int
+    deletions: int
+    changed_files: int
+    touched_subsystems: list[str]
+    high_risk_paths_touched: list[str]
+    checks_summary: str
+    risk_flags: list[str]
+    machine_recommendation: str
+    machine_recommendation_reason: str
+    generated_at: str
+    advisory_only: bool = True
+    settlement_note: str = ADVISORY_NOTE
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# --- Parser registration ---------------------------------------------------
+
+
+def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register 'review-queue' with read-only build/packet sub-actions."""
+    parser = subparsers.add_parser(
+        "review-queue",
+        help="Read-only PR review queue + advisory packets (Phase 2a)",
+        description=(
+            "Build a prioritized queue of open PRs ready for human review, or\n"
+            "generate an advisory packet for one PR.\n\n"
+            "Phase 2a is strictly read-only: no approve/request-changes/defer\n"
+            "actions, no GitHub writes. See\n"
+            "docs/plans/2026-04-19-batched-pr-review-triage.md for the design."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="review_queue_command")
+
+    build_p = sub.add_parser("build", help="Build prioritized review queue from open PRs")
+    build_p.add_argument("--limit", type=int, default=100, help="Max PRs to fetch (default: 100)")
+    build_p.add_argument(
+        "--ready-only",
+        action="store_true",
+        help="Show only ready_now lane",
+    )
+    build_p.add_argument(
+        "--include-parked",
+        action="store_true",
+        help="Include parked lane (off by default)",
+    )
+    build_p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    packet_p = sub.add_parser("packet", help="Generate advisory review packet for one PR")
+    packet_p.add_argument("pr", help="PR number")
+    packet_p.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    packet_p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    parser.set_defaults(func=cmd_review_queue)
+
+
+def cmd_review_queue(args: argparse.Namespace) -> int:
+    """Dispatch review-queue subcommands."""
+    command = getattr(args, "review_queue_command", None)
+    if command == "build":
+        return _cmd_build(args)
+    if command == "packet":
+        return _cmd_packet(args)
+    print(
+        "Usage: aragora review-queue {build,packet} [...]\n"
+        "Phase 2a is read-only. Run 'aragora review-queue build --help' for options.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+# --- Subcommand entry points -----------------------------------------------
+
+
+def _cmd_build(args: argparse.Namespace) -> int:
+    try:
+        items = _build_queue(limit=args.limit)
+    except _GhError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    items = _filter_lanes(
+        items,
+        ready_only=bool(getattr(args, "ready_only", False)),
+        include_parked=bool(getattr(args, "include_parked", False)),
+    )
+    if getattr(args, "json", False):
+        print(json.dumps([item.to_dict() for item in items], indent=2))
+    else:
+        _render_table(items)
+    return 0
+
+
+def _cmd_packet(args: argparse.Namespace) -> int:
+    try:
+        packet = _build_packet(args.pr, repo_override=args.repo)
+    except _GhError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps(packet.to_dict(), indent=2))
+    else:
+        _render_packet(packet)
+    return 0
+
+
+# --- Internals: gh shell, classification, packet building ------------------
+
+
+class _GhError(RuntimeError):
+    """Raised when a 'gh' invocation fails or returns malformed JSON."""
+
+
+def _gh_json(args: list[str]) -> Any:
+    """Run a 'gh' command and parse JSON output. Returns None for empty stdout."""
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "no stderr"
+        raise _GhError(f"gh {' '.join(args)} failed: {stderr}")
+    out = proc.stdout.strip()
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise _GhError(f"gh {' '.join(args)} returned malformed JSON: {exc}") from exc
+
+
+def _build_queue(*, limit: int) -> list[QueueItem]:
+    fields = ",".join(
+        [
+            "number",
+            "title",
+            "url",
+            "headRefName",
+            "headRefOid",
+            "isDraft",
+            "mergeable",
+            "reviewDecision",
+            "labels",
+            "author",
+            "additions",
+            "deletions",
+            "changedFiles",
+            "statusCheckRollup",
+        ]
+    )
+    raw = _gh_json(
+        [
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            fields,
+        ]
+    )
+    items: list[QueueItem] = []
+    for pr in raw or []:
+        if not isinstance(pr, dict):
+            continue
+        items.append(_classify_pr(pr))
+    items.sort(key=lambda it: (LANE_ORDER.get(it.lane, 99), -it.number))
+    return items
+
+
+def _classify_pr(pr: dict[str, Any]) -> QueueItem:
+    """Assign one PR to a lane based on draft/checks/diff/labels signals."""
+    number = int(pr.get("number", 0) or 0)
+    title = str(pr.get("title", "")).strip()
+    url = str(pr.get("url", "")).strip()
+    head_sha = str(pr.get("headRefOid", "")).strip()
+    is_draft = bool(pr.get("isDraft", False))
+    mergeable = str(pr.get("mergeable", "")).strip().upper()
+    review_decision = str(pr.get("reviewDecision", "")).strip().upper()
+    labels = [
+        str(lab.get("name", "")).strip()
+        for lab in (pr.get("labels") or [])
+        if isinstance(lab, dict) and lab.get("name")
+    ]
+    author = ""
+    author_payload = pr.get("author")
+    if isinstance(author_payload, dict):
+        author = str(author_payload.get("login", "")).strip()
+    additions = int(pr.get("additions", 0) or 0)
+    deletions = int(pr.get("deletions", 0) or 0)
+    changed_files = int(pr.get("changedFiles", 0) or 0)
+    checks_summary, has_failures, has_pending = _summarize_checks(pr.get("statusCheckRollup") or [])
+
+    parked_label_hits = [lab for lab in labels if lab in PARKED_LABELS]
+
+    if is_draft:
+        lane, reason = "parked", "draft PR"
+    elif parked_label_hits:
+        lane, reason = "parked", f"label={','.join(parked_label_hits)}"
+    elif mergeable == "CONFLICTING":
+        lane, reason = "parked", "merge conflict"
+    elif has_failures:
+        lane, reason = "repairable", checks_summary
+    elif has_pending:
+        lane, reason = "needs_attention", f"checks pending ({checks_summary})"
+    elif additions + deletions > LARGE_DIFF_THRESHOLD:
+        lane, reason = "needs_attention", f"large diff (+{additions}/-{deletions})"
+    elif mergeable in ("MERGEABLE", "UNKNOWN", ""):
+        lane, reason = "ready_now", checks_summary or "all green"
+    else:
+        lane, reason = "needs_attention", f"mergeable={mergeable}"
+
+    return QueueItem(
+        number=number,
+        title=title,
+        url=url,
+        head_sha=head_sha,
+        author=author,
+        is_draft=is_draft,
+        mergeable=mergeable,
+        review_decision=review_decision,
+        labels=labels,
+        additions=additions,
+        deletions=deletions,
+        changed_files=changed_files,
+        checks_summary=checks_summary,
+        lane=lane,
+        lane_reason=reason,
+    )
+
+
+def _summarize_checks(checks: list) -> tuple[str, bool, bool]:
+    """Return ``(summary, has_failures, has_pending)`` for a statusCheckRollup."""
+    success = failure = pending = 0
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        status = str(check.get("status", "")).upper()
+        conclusion = str(check.get("conclusion", "")).upper()
+        if conclusion == "SUCCESS":
+            success += 1
+        elif conclusion in ("FAILURE", "TIMED_OUT", "ACTION_REQUIRED"):
+            failure += 1
+        elif conclusion in ("CANCELLED", "SKIPPED", "NEUTRAL", "STALE"):
+            # Treat skipped/cancelled as not-meaningful for the summary; they
+            # are correct gating behavior in this repo (see docs/CI_LANES.md).
+            continue
+        elif status in ("IN_PROGRESS", "QUEUED", "PENDING") or not conclusion:
+            pending += 1
+    total = success + failure + pending
+    if failure > 0:
+        return (f"{failure} failing / {total} total", True, pending > 0)
+    if pending > 0:
+        return (f"{pending} pending / {total} total", False, True)
+    if success > 0:
+        return (f"{success}/{total} green", False, False)
+    return ("no checks", False, False)
+
+
+def _filter_lanes(
+    items: list[QueueItem],
+    *,
+    ready_only: bool,
+    include_parked: bool,
+) -> list[QueueItem]:
+    if ready_only:
+        return [it for it in items if it.lane == "ready_now"]
+    if not include_parked:
+        return [it for it in items if it.lane != "parked"]
+    return items
+
+
+def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
+    number = _parse_pr_number(pr_ref)
+    fields = ",".join(
+        [
+            "number",
+            "title",
+            "url",
+            "headRefName",
+            "headRefOid",
+            "isDraft",
+            "mergeable",
+            "reviewDecision",
+            "labels",
+            "author",
+            "additions",
+            "deletions",
+            "changedFiles",
+            "statusCheckRollup",
+            "files",
+        ]
+    )
+    args = ["pr", "view", str(number), "--json", fields]
+    if repo_override:
+        args.extend(["--repo", repo_override])
+    pr = _gh_json(args)
+    if pr is None or not isinstance(pr, dict):
+        raise _GhError(f"PR #{number} not found")
+
+    files: list[str] = []
+    for item in pr.get("files") or []:
+        if isinstance(item, dict):
+            path = str(item.get("path", "")).strip()
+            if path:
+                files.append(path)
+    touched = sorted({_subsystem_for(p) for p in files})
+    high_risk = [p for p in files if _is_high_risk_path(p)]
+    checks_summary, has_failures, has_pending = _summarize_checks(pr.get("statusCheckRollup") or [])
+    additions = int(pr.get("additions", 0) or 0)
+    deletions = int(pr.get("deletions", 0) or 0)
+    mergeable = str(pr.get("mergeable", "")).strip().upper()
+
+    risk_flags: list[str] = []
+    if high_risk:
+        sample = ", ".join(high_risk[:5])
+        more = "" if len(high_risk) <= 5 else f" (+{len(high_risk) - 5} more)"
+        risk_flags.append(f"touches high-risk paths: {sample}{more}")
+    if additions + deletions > LARGE_DIFF_THRESHOLD:
+        risk_flags.append(f"large diff (+{additions}/-{deletions})")
+    if mergeable == "CONFLICTING":
+        risk_flags.append("merge conflict")
+    if has_failures:
+        risk_flags.append(f"checks failing ({checks_summary})")
+
+    if has_failures or mergeable == "CONFLICTING":
+        recommendation = "repair_first"
+        recommendation_reason = "checks failing or merge conflict — fix before review"
+    elif high_risk or additions + deletions > LARGE_DIFF_THRESHOLD:
+        recommendation = "needs_human_attention"
+        recommendation_reason = "high-risk paths touched or large diff — human should read it"
+    elif has_pending:
+        recommendation = "needs_human_attention"
+        recommendation_reason = "checks still pending — wait for completion"
+    else:
+        recommendation = "approve_candidate"
+        recommendation_reason = "all green, bounded diff, no high-risk paths"
+
+    author = ""
+    author_payload = pr.get("author")
+    if isinstance(author_payload, dict):
+        author = str(author_payload.get("login", "")).strip()
+
+    return ReviewPacket(
+        pr_number=number,
+        title=str(pr.get("title", "")).strip(),
+        url=str(pr.get("url", "")).strip(),
+        head_sha=str(pr.get("headRefOid", "")).strip(),
+        author=author,
+        is_draft=bool(pr.get("isDraft", False)),
+        additions=additions,
+        deletions=deletions,
+        changed_files=int(pr.get("changedFiles", 0) or 0),
+        touched_subsystems=touched,
+        high_risk_paths_touched=high_risk,
+        checks_summary=checks_summary,
+        risk_flags=risk_flags,
+        machine_recommendation=recommendation,
+        machine_recommendation_reason=recommendation_reason,
+        generated_at=datetime.now(UTC).isoformat(),
+    )
+
+
+def _subsystem_for(path: str) -> str:
+    """Map a file path to a coarse subsystem label for risk grouping."""
+    parts = path.split("/")
+    if not parts:
+        return "(root)"
+    top = parts[0]
+    if top in ("aragora", "tests") and len(parts) >= 2:
+        return f"{top}/{parts[1]}"
+    if top in ("docs", "scripts", "sdk", "benchmarks", ".github"):
+        return top
+    return top
+
+
+def _is_high_risk_path(path: str) -> bool:
+    if path in HIGH_RISK_PATHS:
+        return True
+    return any(path.startswith(prefix) for prefix in HIGH_RISK_PREFIXES)
+
+
+def _parse_pr_number(pr_ref: str) -> int:
+    text = str(pr_ref).strip()
+    if "/" in text:
+        text = text.rstrip("/").split("/")[-1]
+    if text.startswith("#"):
+        text = text[1:]
+    try:
+        return int(text)
+    except ValueError as exc:
+        raise _GhError(f"invalid PR ref: {pr_ref!r}") from exc
+
+
+# --- Rendering -------------------------------------------------------------
+
+
+def _render_table(items: list[QueueItem]) -> None:
+    if not items:
+        print("(no PRs in scope)")
+        return
+    counts: dict[str, int] = {}
+    for item in items:
+        counts[item.lane] = counts.get(item.lane, 0) + 1
+    lane_summary = ", ".join(f"{lane}={counts.get(lane, 0)}" for lane in LANE_ORDER)
+    print(f"Review queue ({len(items)} PRs): {lane_summary}")
+    print()
+    current_lane = ""
+    for item in items:
+        if item.lane != current_lane:
+            current_lane = item.lane
+            print(f"== {item.lane} ==")
+        title_clip = item.title[:70]
+        print(
+            f"  #{item.number:>5}  {item.checks_summary:>20}  "
+            f"+{item.additions:>5}/-{item.deletions:<5}  {title_clip}"
+        )
+        print(f"        {item.url}  [{item.lane_reason}]")
+    print()
+    print(
+        "Note: this queue is advisory only. Settlement (approve/request-changes/defer) "
+        "requires human action via GitHub UI or `gh pr review` / `gh pr merge`."
+    )
+
+
+def _render_packet(packet: ReviewPacket) -> None:
+    print(f"# Advisory review packet — PR #{packet.pr_number}")
+    print(f"# {packet.title}")
+    print(f"# {packet.url}")
+    print()
+    print(f"head SHA:        {packet.head_sha}")
+    print(f"author:          {packet.author}")
+    print(f"draft:           {packet.is_draft}")
+    print(
+        f"diff:            +{packet.additions}/-{packet.deletions} "
+        f"across {packet.changed_files} files"
+    )
+    print(f"checks:          {packet.checks_summary}")
+    print()
+    if packet.touched_subsystems:
+        print("touched subsystems:")
+        for sub in packet.touched_subsystems:
+            print(f"  - {sub}")
+        print()
+    if packet.high_risk_paths_touched:
+        print("HIGH-RISK PATHS TOUCHED:")
+        for path in packet.high_risk_paths_touched:
+            print(f"  - {path}")
+        print()
+    if packet.risk_flags:
+        print("risk flags:")
+        for flag in packet.risk_flags:
+            print(f"  - {flag}")
+        print()
+    print(f"machine recommendation: {packet.machine_recommendation}")
+    print(f"  reason: {packet.machine_recommendation_reason}")
+    print()
+    print(f"generated at: {packet.generated_at}")
+    print()
+    print(f"-- {packet.settlement_note}")

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -405,14 +405,25 @@ def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
             path = str(item.get("path", "")).strip()
             if path:
                 files.append(path)
+    labels = [
+        str(lab.get("name", "")).strip()
+        for lab in (pr.get("labels") or [])
+        if isinstance(lab, dict) and lab.get("name")
+    ]
+    parked_label_hits = [lab for lab in labels if lab in PARKED_LABELS]
     touched = sorted({_subsystem_for(p) for p in files})
     high_risk = [p for p in files if _is_high_risk_path(p)]
     checks_summary, has_failures, has_pending = _summarize_checks(pr.get("statusCheckRollup") or [])
     additions = int(pr.get("additions", 0) or 0)
     deletions = int(pr.get("deletions", 0) or 0)
+    is_draft = bool(pr.get("isDraft", False))
     mergeable = str(pr.get("mergeable", "")).strip().upper()
 
     risk_flags: list[str] = []
+    if is_draft:
+        risk_flags.append("draft PR")
+    if parked_label_hits:
+        risk_flags.append(f"parked label ({','.join(parked_label_hits)})")
     if high_risk:
         sample = ", ".join(high_risk[:5])
         more = "" if len(high_risk) <= 5 else f" (+{len(high_risk) - 5} more)"
@@ -427,6 +438,14 @@ def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
     if has_failures or mergeable == "CONFLICTING":
         recommendation = "repair_first"
         recommendation_reason = "checks failing or merge conflict — fix before review"
+    elif is_draft:
+        recommendation = "needs_human_attention"
+        recommendation_reason = "draft PR — keep parked until it is ready for review"
+    elif parked_label_hits:
+        recommendation = "needs_human_attention"
+        recommendation_reason = (
+            f"parked label present ({','.join(parked_label_hits)}) — keep parked until cleared"
+        )
     elif high_risk or additions + deletions > LARGE_DIFF_THRESHOLD:
         recommendation = "needs_human_attention"
         recommendation_reason = "high-risk paths touched or large diff — human should read it"
@@ -448,7 +467,7 @@ def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
         url=str(pr.get("url", "")).strip(),
         head_sha=str(pr.get("headRefOid", "")).strip(),
         author=author,
-        is_draft=bool(pr.get("isDraft", False)),
+        is_draft=is_draft,
         additions=additions,
         deletions=deletions,
         changed_files=int(pr.get("changedFiles", 0) or 0),

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -150,6 +150,7 @@ Examples:
     _add_bench_parser(subparsers)
     _add_review_parser(subparsers)
     _add_review_pr_parser(subparsers)
+    _add_review_queue_parser(subparsers)
     _add_codebase_audit_parser(subparsers)
     _add_external_parsers(subparsers)
     _add_badge_parser(subparsers)
@@ -1366,6 +1367,13 @@ def _add_review_pr_parser(subparsers) -> None:
     from aragora.cli.document_audit import create_document_audit_parser
 
     create_document_audit_parser(subparsers)
+
+
+def _add_review_queue_parser(subparsers) -> None:
+    """Register read-only review-queue (Phase 2a of #6279)."""
+    from aragora.cli.commands.review_queue import add_review_queue_parser
+
+    add_review_queue_parser(subparsers)
 
 
 def _add_codebase_audit_parser(subparsers) -> None:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Generated Aragora CLI command catalog from live parser
+description: Aragora CLI Reference
 ---
 
 # Aragora CLI Reference

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference
@@ -11,8 +11,8 @@ description: Aragora CLI Reference
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **93**
-- Total top-level invocations (including aliases): **94**
+- Canonical top-level commands: **94**
+- Total top-level invocations (including aliases): **95**
 
 ## Installation
 
@@ -109,6 +109,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
+| `review-queue` | - | Read-only PR review queue + advisory packets (Phase 2a) | `build`, `packet` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 94 commands | 43.2% |
+| **CLI** | 95 commands | 43.2% |
 | **SDK (Python)** | 189 namespaces | 70.3% |
 | **SDK (TypeScript)** | 188 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -189,7 +189,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,800+ Python modules | 210,000+ tests | 5,000+ test files | 210+ debate modules | 3,100+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 3,800+ Python modules | 210,000+ tests | 5,000+ test files | 210+ debate modules | 3,100+ API operations across 2,900+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
 
 ## Architecture
 

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -40,7 +40,7 @@ Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / s
 
 ### 3. Extensible and Modular
 
-Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,100+ API operations across 2,700+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
+Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,100+ API operations across 2,900+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
 
 ### 4. Multi-Agent Robustness
 
@@ -341,7 +341,7 @@ aragora/
 └── cli/              # Command-line interface
 ```
 
-**Scale:** 3,800+ Python modules | 210,000+ tests across 5,000+ test files | 185 Python / 187 TypeScript SDK namespaces
+**Scale:** 3,800+ Python modules | 210,000+ tests across 5,000+ test files | 185 Python / 189 TypeScript SDK namespaces
 
 ---
 
@@ -686,7 +686,7 @@ aragora serve --api-port 8080 --ws-port 8765
 
 ## API Endpoints
 
-The server exposes 3,100+ API operations across 2,700+ paths. Key categories:
+The server exposes 3,100+ API operations across 2,900+ paths. Key categories:
 
 | Category | Description |
 |----------|-------------|

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 94 commands | 43.2% |
+| **CLI** | 95 commands | 43.2% |
 | **SDK (Python)** | 189 namespaces | 70.3% |
 | **SDK (TypeScript)** | 188 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **93**
-- Total top-level invocations (including aliases): **94**
+- Canonical top-level commands: **94**
+- Total top-level invocations (including aliases): **95**
 
 ## Installation
 
@@ -104,6 +104,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
+| `review-queue` | - | Read-only PR review queue + advisory packets (Phase 2a) | `build`, `packet` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1,0 +1,550 @@
+"""Tests for aragora review-queue (Phase 2a, read-only)."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from contextlib import redirect_stdout
+from typing import Any
+
+import pytest
+
+from aragora.cli.commands.review_queue import (
+    ADVISORY_NOTE,
+    HIGH_RISK_PATHS,
+    LARGE_DIFF_THRESHOLD,
+    PARKED_LABELS,
+    QueueItem,
+    ReviewPacket,
+    _build_packet,
+    _build_queue,
+    _classify_pr,
+    _filter_lanes,
+    _GhError,
+    _is_high_risk_path,
+    _parse_pr_number,
+    _subsystem_for,
+    _summarize_checks,
+    add_review_queue_parser,
+    cmd_review_queue,
+)
+
+
+# --- Synthetic PR payload builder ------------------------------------------
+
+
+def _make_pr(
+    *,
+    number: int = 1,
+    title: str = "test PR",
+    is_draft: bool = False,
+    mergeable: str = "MERGEABLE",
+    review_decision: str = "",
+    labels: list[str] | None = None,
+    additions: int = 10,
+    deletions: int = 5,
+    changed_files: int = 2,
+    checks: list[dict[str, Any]] | None = None,
+    files: list[str] | None = None,
+    author: str = "an0mium",
+) -> dict[str, Any]:
+    """Build a synthetic gh-pr-list-style payload."""
+    return {
+        "number": number,
+        "title": title,
+        "url": f"https://github.com/synaptent/aragora/pull/{number}",
+        "headRefName": f"branch-{number}",
+        "headRefOid": f"sha{number:08d}",
+        "isDraft": is_draft,
+        "mergeable": mergeable,
+        "reviewDecision": review_decision,
+        "labels": [{"name": lab} for lab in (labels or [])],
+        "author": {"login": author},
+        "additions": additions,
+        "deletions": deletions,
+        "changedFiles": changed_files,
+        "statusCheckRollup": checks
+        or [{"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "files": [{"path": p} for p in (files or [])],
+    }
+
+
+# --- _summarize_checks -----------------------------------------------------
+
+
+class TestSummarizeChecks:
+    def test_all_green(self) -> None:
+        checks = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+        summary, has_fail, has_pending = _summarize_checks(checks)
+        assert "2/2 green" in summary
+        assert not has_fail
+        assert not has_pending
+
+    def test_one_failing(self) -> None:
+        checks = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "COMPLETED", "conclusion": "FAILURE"},
+        ]
+        summary, has_fail, has_pending = _summarize_checks(checks)
+        assert has_fail
+        assert "1 failing" in summary
+
+    def test_pending(self) -> None:
+        checks = [
+            {"status": "IN_PROGRESS", "conclusion": ""},
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+        summary, has_fail, has_pending = _summarize_checks(checks)
+        assert has_pending
+        assert not has_fail
+        assert "1 pending" in summary
+
+    def test_skipped_excluded_from_meaningful_total(self) -> None:
+        checks = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "COMPLETED", "conclusion": "SKIPPED"},
+            {"status": "COMPLETED", "conclusion": "CANCELLED"},
+        ]
+        summary, has_fail, has_pending = _summarize_checks(checks)
+        assert not has_fail
+        assert not has_pending
+        assert "1/1 green" in summary
+
+    def test_no_checks(self) -> None:
+        summary, has_fail, has_pending = _summarize_checks([])
+        assert summary == "no checks"
+        assert not has_fail
+        assert not has_pending
+
+    def test_malformed_check_ignored(self) -> None:
+        checks: list[Any] = ["not a dict", None, {"status": "COMPLETED", "conclusion": "SUCCESS"}]
+        summary, _, _ = _summarize_checks(checks)
+        assert "1/1 green" in summary
+
+
+# --- _classify_pr lane logic -----------------------------------------------
+
+
+class TestClassifyPR:
+    def test_ready_now_when_all_green_small_diff(self) -> None:
+        pr = _make_pr()
+        item = _classify_pr(pr)
+        assert item.lane == "ready_now"
+
+    def test_draft_is_parked(self) -> None:
+        pr = _make_pr(is_draft=True)
+        item = _classify_pr(pr)
+        assert item.lane == "parked"
+        assert "draft" in item.lane_reason.lower()
+
+    def test_parked_label_parks_pr(self) -> None:
+        for label in PARKED_LABELS:
+            pr = _make_pr(labels=[label])
+            item = _classify_pr(pr)
+            assert item.lane == "parked", f"label={label} should park PR"
+
+    def test_merge_conflict_is_parked(self) -> None:
+        pr = _make_pr(mergeable="CONFLICTING")
+        item = _classify_pr(pr)
+        assert item.lane == "parked"
+        assert "conflict" in item.lane_reason.lower()
+
+    def test_failing_check_is_repairable(self) -> None:
+        pr = _make_pr(
+            checks=[
+                {"status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"status": "COMPLETED", "conclusion": "FAILURE"},
+            ]
+        )
+        item = _classify_pr(pr)
+        assert item.lane == "repairable"
+
+    def test_pending_check_needs_attention(self) -> None:
+        pr = _make_pr(
+            checks=[
+                {"status": "IN_PROGRESS", "conclusion": ""},
+            ]
+        )
+        item = _classify_pr(pr)
+        assert item.lane == "needs_attention"
+
+    def test_large_diff_needs_attention(self) -> None:
+        pr = _make_pr(additions=LARGE_DIFF_THRESHOLD + 100, deletions=10)
+        item = _classify_pr(pr)
+        assert item.lane == "needs_attention"
+        assert "large diff" in item.lane_reason.lower()
+
+    def test_priority_order_draft_beats_failing(self) -> None:
+        # A draft PR with failing checks should still be parked, not repairable.
+        pr = _make_pr(
+            is_draft=True,
+            checks=[{"status": "COMPLETED", "conclusion": "FAILURE"}],
+        )
+        item = _classify_pr(pr)
+        assert item.lane == "parked"
+
+    def test_priority_order_conflict_beats_failing(self) -> None:
+        # Conflict parks the PR even when checks also fail.
+        pr = _make_pr(
+            mergeable="CONFLICTING",
+            checks=[{"status": "COMPLETED", "conclusion": "FAILURE"}],
+        )
+        item = _classify_pr(pr)
+        assert item.lane == "parked"
+
+
+# --- _filter_lanes ---------------------------------------------------------
+
+
+class TestFilterLanes:
+    def _items(self) -> list[QueueItem]:
+        # Build 4 items, one per lane, smallest synthetic representation.
+        out: list[QueueItem] = []
+        for lane in ("ready_now", "needs_attention", "repairable", "parked"):
+            out.append(
+                _classify_pr(
+                    _make_pr(
+                        number=hash(lane) & 0xFFFF,
+                        is_draft=(lane == "parked"),
+                        checks=[{"status": "COMPLETED", "conclusion": "FAILURE"}]
+                        if lane == "repairable"
+                        else (
+                            [{"status": "IN_PROGRESS", "conclusion": ""}]
+                            if lane == "needs_attention"
+                            else [{"status": "COMPLETED", "conclusion": "SUCCESS"}]
+                        ),
+                    )
+                )
+            )
+        return out
+
+    def test_ready_only(self) -> None:
+        items = self._items()
+        result = _filter_lanes(items, ready_only=True, include_parked=False)
+        assert {it.lane for it in result} == {"ready_now"}
+
+    def test_default_excludes_parked(self) -> None:
+        items = self._items()
+        result = _filter_lanes(items, ready_only=False, include_parked=False)
+        assert "parked" not in {it.lane for it in result}
+
+    def test_include_parked_keeps_all(self) -> None:
+        items = self._items()
+        result = _filter_lanes(items, ready_only=False, include_parked=True)
+        assert "parked" in {it.lane for it in result}
+
+
+# --- _subsystem_for + _is_high_risk_path -----------------------------------
+
+
+class TestSubsystemAndRisk:
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("aragora/cli/commands/review_pr.py", "aragora/cli"),
+            ("tests/cli/commands/test_review_queue.py", "tests/cli"),
+            ("docs/CI_LANES.md", "docs"),
+            ("scripts/automation_pr_preflight.sh", "scripts"),
+            ("benchmarks/bench_readiness/README.md", "benchmarks"),
+            (".github/workflows/test.yml", ".github"),
+            ("README.md", "README.md"),
+        ],
+    )
+    def test_subsystem_mapping(self, path: str, expected: str) -> None:
+        assert _subsystem_for(path) == expected
+
+    def test_high_risk_exact_paths(self) -> None:
+        for path in HIGH_RISK_PATHS:
+            assert _is_high_risk_path(path), f"{path} should be flagged"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "aragora/security/encryption.py",
+            "aragora/auth/oidc.py",
+            "aragora/blockchain/wallet.py",
+            "aragora/rbac/checker.py",
+            "scripts/auto_revert_main_required_failures.py",
+            ".github/workflows/release.yml",
+        ],
+    )
+    def test_high_risk_prefixes(self, path: str) -> None:
+        assert _is_high_risk_path(path)
+
+    def test_non_high_risk(self) -> None:
+        assert not _is_high_risk_path("aragora/cli/commands/review_queue.py")
+        assert not _is_high_risk_path("docs/CI_LANES.md")
+        assert not _is_high_risk_path("tests/cli/commands/test_review_queue.py")
+
+
+# --- _parse_pr_number ------------------------------------------------------
+
+
+class TestParsePRNumber:
+    @pytest.mark.parametrize(
+        ("ref", "expected"),
+        [
+            ("6280", 6280),
+            ("#6280", 6280),
+            ("https://github.com/synaptent/aragora/pull/6280", 6280),
+            ("https://github.com/synaptent/aragora/pull/6280/", 6280),
+        ],
+    )
+    def test_parses(self, ref: str, expected: int) -> None:
+        assert _parse_pr_number(ref) == expected
+
+    def test_rejects_invalid(self) -> None:
+        with pytest.raises(_GhError):
+            _parse_pr_number("not a number")
+
+
+# --- _build_queue + _build_packet (with mocked gh) -------------------------
+
+
+class TestBuildQueueAndPacket:
+    def test_build_queue_classifies_and_sorts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        prs = [
+            _make_pr(number=10, is_draft=True),  # parked
+            _make_pr(number=20),  # ready_now
+            _make_pr(
+                number=30,
+                checks=[{"status": "COMPLETED", "conclusion": "FAILURE"}],
+            ),  # repairable
+            _make_pr(
+                number=40,
+                checks=[{"status": "IN_PROGRESS", "conclusion": ""}],
+            ),  # needs_attention
+        ]
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: prs,
+        )
+        items = _build_queue(limit=100)
+        assert [it.number for it in items] == [20, 40, 30, 10]
+        assert [it.lane for it in items] == [
+            "ready_now",
+            "needs_attention",
+            "repairable",
+            "parked",
+        ]
+
+    def test_build_packet_sets_recommendation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pr_payload = _make_pr(
+            number=6280,
+            files=["aragora/cli/commands/review_pr.py", "tests/cli/commands/test_review_pr.py"],
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("6280", repo_override=None)
+        assert packet.pr_number == 6280
+        assert packet.advisory_only is True
+        assert packet.settlement_note == ADVISORY_NOTE
+        assert packet.machine_recommendation == "approve_candidate"
+        assert "aragora/cli" in packet.touched_subsystems
+        assert "tests/cli" in packet.touched_subsystems
+        assert packet.high_risk_paths_touched == []
+
+    def test_build_packet_flags_high_risk_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pr_payload = _make_pr(
+            number=42,
+            files=["aragora/security/encryption.py", "aragora/cli/commands/review_pr.py"],
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("42", repo_override=None)
+        assert packet.machine_recommendation == "needs_human_attention"
+        assert "aragora/security/encryption.py" in packet.high_risk_paths_touched
+
+    def test_build_packet_failures_recommend_repair(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pr_payload = _make_pr(
+            number=99,
+            checks=[{"status": "COMPLETED", "conclusion": "FAILURE"}],
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("99", repo_override=None)
+        assert packet.machine_recommendation == "repair_first"
+
+    def test_build_packet_pending_checks_need_attention(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(
+            number=100,
+            checks=[{"status": "IN_PROGRESS", "conclusion": ""}],
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("100", repo_override=None)
+        assert packet.machine_recommendation == "needs_human_attention"
+        assert "checks still pending" in packet.machine_recommendation_reason
+
+    def test_build_packet_raises_when_pr_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: None,
+        )
+        with pytest.raises(_GhError, match="not found"):
+            _build_packet("9999", repo_override=None)
+
+
+# --- JSON output schema ----------------------------------------------------
+
+
+class TestJsonOutput:
+    def test_queue_item_to_dict_keys(self) -> None:
+        item = _classify_pr(_make_pr())
+        d = item.to_dict()
+        for key in (
+            "number",
+            "title",
+            "url",
+            "head_sha",
+            "author",
+            "is_draft",
+            "mergeable",
+            "labels",
+            "additions",
+            "deletions",
+            "changed_files",
+            "checks_summary",
+            "lane",
+            "lane_reason",
+        ):
+            assert key in d, f"QueueItem dict missing key: {key}"
+
+    def test_packet_to_dict_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: _make_pr(number=1, files=["aragora/cli/main.py"]),
+        )
+        packet = _build_packet("1", repo_override=None)
+        d = packet.to_dict()
+        for key in (
+            "pr_number",
+            "title",
+            "url",
+            "head_sha",
+            "author",
+            "is_draft",
+            "additions",
+            "deletions",
+            "changed_files",
+            "touched_subsystems",
+            "high_risk_paths_touched",
+            "checks_summary",
+            "risk_flags",
+            "machine_recommendation",
+            "machine_recommendation_reason",
+            "generated_at",
+            "advisory_only",
+            "settlement_note",
+        ):
+            assert key in d, f"ReviewPacket dict missing key: {key}"
+        # ReviewPacket.advisory_only must always be True (signature property).
+        assert d["advisory_only"] is True
+
+    def test_packet_json_round_trip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: _make_pr(number=1, files=["aragora/cli/main.py"]),
+        )
+        packet = _build_packet("1", repo_override=None)
+        roundtrip = json.loads(json.dumps(packet.to_dict()))
+        assert roundtrip["pr_number"] == 1
+        assert roundtrip["advisory_only"] is True
+
+
+# --- cmd_review_queue dispatch + parser ------------------------------------
+
+
+class TestCommandDispatch:
+    def test_parser_registers_build_and_packet(self) -> None:
+        root = argparse.ArgumentParser()
+        sub = root.add_subparsers()
+        add_review_queue_parser(sub)
+        # build invocation parses
+        ns_build = root.parse_args(["review-queue", "build", "--limit", "5", "--json"])
+        assert ns_build.review_queue_command == "build"
+        assert ns_build.limit == 5
+        assert ns_build.json is True
+        # packet invocation parses
+        ns_packet = root.parse_args(["review-queue", "packet", "6280", "--json"])
+        assert ns_packet.review_queue_command == "packet"
+        assert ns_packet.pr == "6280"
+
+    def test_cmd_review_queue_with_no_subcommand_returns_2(self) -> None:
+        ns = argparse.Namespace(review_queue_command=None)
+        rc = cmd_review_queue(ns)
+        assert rc == 2
+
+    def test_build_command_renders_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: [_make_pr(number=1)],
+        )
+        ns = argparse.Namespace(
+            review_queue_command="build",
+            limit=10,
+            ready_only=False,
+            include_parked=False,
+            json=False,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_review_queue(ns)
+        assert rc == 0
+        out = buf.getvalue()
+        assert "Review queue" in out
+        assert "advisory only" in out
+
+    def test_build_command_json_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: [_make_pr(number=1), _make_pr(number=2)],
+        )
+        ns = argparse.Namespace(
+            review_queue_command="build",
+            limit=10,
+            ready_only=False,
+            include_parked=False,
+            json=True,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_review_queue(ns)
+        assert rc == 0
+        payload = json.loads(buf.getvalue())
+        assert isinstance(payload, list)
+        assert {item["number"] for item in payload} == {1, 2}
+
+    def test_packet_command_json_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: _make_pr(number=42, files=["aragora/cli/main.py"]),
+        )
+        ns = argparse.Namespace(
+            review_queue_command="packet",
+            pr="42",
+            repo=None,
+            json=True,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_review_queue(ns)
+        assert rc == 0
+        payload = json.loads(buf.getvalue())
+        assert payload["pr_number"] == 42
+        assert payload["advisory_only"] is True
+        assert payload["settlement_note"] == ADVISORY_NOTE

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -375,6 +375,30 @@ class TestBuildQueueAndPacket:
         packet = _build_packet("99", repo_override=None)
         assert packet.machine_recommendation == "repair_first"
 
+    def test_build_packet_draft_needs_attention(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pr_payload = _make_pr(number=101, is_draft=True)
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("101", repo_override=None)
+        assert packet.machine_recommendation == "needs_human_attention"
+        assert "draft" in packet.machine_recommendation_reason.lower()
+        assert "draft PR" in packet.risk_flags
+
+    def test_build_packet_parked_label_needs_attention(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pr_payload = _make_pr(number=102, labels=["blocked"])
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        packet = _build_packet("102", repo_override=None)
+        assert packet.machine_recommendation == "needs_human_attention"
+        assert "parked label" in packet.machine_recommendation_reason.lower()
+        assert "parked label (blocked)" in packet.risk_flags
+
     def test_build_packet_pending_checks_need_attention(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Phase 2a of the batched-PR-review-triage design (#6279, merged earlier today). **Strictly read-only**: builds the prioritized review queue and generates advisory packets per PR. **No settlement actions, no GitHub writes.**

This is the human-in-loop substrate that lets a non-coder founder review 30–50 PRs in 10–15 minutes by skimming machine-prepared packets, while keeping every actual approve/request-changes/defer action a human click. It directly implements the "fast, high-leverage, real" human-role principle from the design doc.

## New surface

\`\`\`bash
aragora review-queue build [--limit 100] [--ready-only] [--include-parked] [--json]
aragora review-queue packet <pr> [--repo SLUG] [--json]
\`\`\`

**Lanes (build):**
- `ready_now` — all checks green, bounded diff, no high-risk paths touched
- `needs_attention` — checks pending OR large diff (>500 LOC)
- `repairable` — checks failing (fix before review)
- `parked` — draft, merge conflict, or `stale`/`do-not-merge`/`wip`/`blocked` label

Default excludes parked.

**Packet (advisory only):**
- touched subsystems
- high-risk paths touched (`CLAUDE.md`, `aragora/security/*`, `aragora/auth/*`, `aragora/blockchain/*`, `aragora/rbac/*`, `.github/workflows/*`, etc.)
- diff stats + checks summary
- risk flags
- machine recommendation: `approve_candidate` | `needs_human_attention` | `repair_first`
- explicit `settlement_note`: \"This packet is advisory only. It does not approve or block merge. Human settlement required.\"

`ReviewPacket.advisory_only=True` is a frozen field shipped in every JSON output, making the \"this is not an approval\" property machine-checkable for downstream consumers.

## Out of scope (intentionally NOT implemented)

- `review-queue run` — interactive review session (Phase 2b)
- `review-queue act --approve|--request-changes|--defer` — settlement actions (Phase 3)
- `review-queue digest` — rolled-up activity report
- **Any GitHub write API call**

## Design fidelity

Followed codex's specific guidance:
- Separate top-level command, no import from `triage.py` (engineering review ≠ inbox triage)
- Reuses `gh` CLI directly, no coupling to `review_pr.py` private surface
- `main.py` not touched (generic `args.func(args)` dispatch already works)
- Lazy parser registration in `parser.py`

## Files

- `aragora/cli/commands/review_queue.py` — new (~440 LOC)
- `aragora/cli/parser.py` — +7 lines (lazy registration after `_add_review_pr_parser`)
- `tests/cli/commands/test_review_queue.py` — new (~410 LOC)

## Verification

\`\`\`
$ pytest tests/cli/commands/test_review_queue.py -q
52 passed in 1.80s
\`\`\`

Coverage: lane classification (ready/parked/repairable/needs_attention), check-summary semantics (skipped excluded from meaningful total), parked-label parsing, conflict-priority-over-failing, subsystem mapping, high-risk path detection, PR ref parsing, build_queue sort order, packet recommendation logic, JSON schema sanity, command dispatch (build/packet, table/json), error paths.

**Smoke (real `gh`, this repo):**

\`\`\`
$ aragora review-queue build --limit 8
Review queue (8 PRs): ready_now=3, needs_attention=2, repairable=3, parked=0

== ready_now ==
  # 6281       44/44 green   +158/-10    fix(swarm): create queue autofill issues from boss loop
  # 6280       53/53 green   + 65/-11    review: make review-pr advisory by default
  # 6275       47/47 green   +302/-0     [DIC-22] Bounded repair-spec producer for decayed proof-carrying code
== needs_attention ==
  # 6287  3 pending / 30 total  +1616/-0   feat(benchmarks): salvage tier1 benchmark harness
  ...
== repairable ==
  # 6286  2 failing / 42 total  +1175/-15  feat(review): add batched queue and settlement gate
  # 6272  2 failing / 53 total  +144/-5    Report observer checkout health in proof-first status surfaces
  ...
\`\`\`

Note: identifies #6272 (codex told us not to touch) as `repairable` correctly — surfaces it without dispatching anyone to fix it.

\`\`\`
$ aragora review-queue packet 6280
machine recommendation: approve_candidate
  reason: all green, bounded diff, no high-risk paths
\`\`\`

This matches my own earlier human review verdict on #6280 — proof of concept that the packet's machine recommendation is calibrated reasonably.

## Non-goals

- Did NOT modify `merge_arbiter`, `review_pr.py` (beyond what #6280 already did), or any GitHub write surface.
- Did NOT remove or weaken any human gate.
- Did NOT use `--admin` to bypass review on this PR.
- Did NOT touch #6272.
- Did NOT couple to `triage.py` or `review_pr.py` private symbols.

## Capability vs hygiene vs accounting

**Capability.** New CLI surface area; runs against live `gh` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)