### PR TITLE
fix(automation): harden GitHub publisher bridge

### DIFF
--- a/docs/briefs/automation-merge-contract.md
+++ b/docs/briefs/automation-merge-contract.md
@@ -59,9 +59,19 @@ If any gate fails, the next useful action is a repair attempt with the failure o
 
 The bridge intentionally does not use browser fallback. Browser profiles can be locked by other tools, and interactive safety prompts make browser-based GitHub publishing unreliable for unattended automations. If `gh` is unavailable, automations should keep the handoff in memory/inbox and let the next bridge pass retry.
 
+The publisher bridge now has an explicit GitHub health probe at `scripts/github_cli_health.py`. Sandboxed coding automations should treat a failed probe as a hard boundary and switch into handoff-only mode immediately instead of retrying `gh issue create`, `gh pr create`, `gh workflow run`, or merge-watch commands from inside the sandbox.
+
+For steady local operation, install the publisher bridge as a LaunchAgent from a normal user shell:
+
+```bash
+bash scripts/install_codex_automation_publisher_launchd.sh
+```
+
+Use `bash scripts/status_codex_automation_publisher_launchd.sh` to inspect the job and `bash scripts/uninstall_codex_automation_publisher_launchd.sh` to remove it.
+
 ## Prompt Snippet For Codex App Automations
 
-Use this repo's automation merge contract at `docs/briefs/automation-merge-contract.md`. Work on one bounded issue or maintenance task. Make the smallest credible change, run the targeted validation, and before publishing run `bash scripts/automation_pr_preflight.sh origin/main HEAD`. If validation or publishing fails, leave an exact handoff with branch, failing command, blocker, and next action instead of opening a misleading PR. Do not use browser fallback for GitHub publishing; leave structured memory/inbox evidence for `scripts/run_codex_automation_publisher.sh`.
+Use this repo's automation merge contract at `docs/briefs/automation-merge-contract.md`. Work on one bounded issue or maintenance task. Make the smallest credible change, run the targeted validation, and before publishing run `bash scripts/automation_pr_preflight.sh origin/main HEAD`. If GitHub health is degraded or publishing fails, switch to handoff-only mode: leave the exact branch, failing command, blocker, and next action in structured memory/inbox evidence for `scripts/run_codex_automation_publisher.sh` instead of opening a misleading PR. Do not use browser fallback for GitHub publishing.
 
 ## Prompt Snippet For Boss-Loop Operators
 

--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Bounded GitHub CLI health probe for automation publisher flows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+DEFAULT_TIMEOUT_SECONDS = 20
+CONNECTIVITY_ERROR_TOKENS = (
+    "error connecting to api.github.com",
+    "could not resolve host: api.github.com",
+    "could not resolve host: github.com",
+    "failed to connect to github.com",
+    "failed to connect to api.github.com",
+    "network is unreachable",
+    "connection timed out",
+    "connection refused",
+    "temporary failure in name resolution",
+    "no route to host",
+)
+
+
+@dataclass(frozen=True)
+class GitHubCLIHealth:
+    ready: bool
+    auth_ok: bool
+    api_ok: bool
+    mode: str
+    error: str
+    repo: str
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def is_github_connectivity_error(message: str) -> bool:
+    lowered = str(message or "").strip().lower()
+    return any(token in lowered for token in CONNECTIVITY_ERROR_TOKENS)
+
+
+def _run(args: list[str], *, cwd: Path, timeout_seconds: int) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        message = stderr or f"command timed out after {timeout_seconds}s: {' '.join(args)}"
+        return subprocess.CompletedProcess(args=args, returncode=124, stdout=stdout, stderr=message)
+
+
+def check_github_cli_health(
+    repo_root: Path,
+    *,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> GitHubCLIHealth:
+    repo_root = repo_root.resolve()
+    repo_label = str(repo_root)
+    if shutil.which("gh") is None:
+        return GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="gh_missing",
+            error="gh CLI not found on PATH",
+            repo=repo_label,
+        )
+
+    auth_proc = _run(["gh", "auth", "status"], cwd=repo_root, timeout_seconds=timeout_seconds)
+    if auth_proc.returncode != 0:
+        error = auth_proc.stderr.strip() or auth_proc.stdout.strip() or "gh auth status failed"
+        mode = "connectivity_failed" if is_github_connectivity_error(error) else "auth_failed"
+        return GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode=mode,
+            error=error,
+            repo=repo_label,
+        )
+
+    api_proc = _run(["gh", "api", "rate_limit"], cwd=repo_root, timeout_seconds=timeout_seconds)
+    if api_proc.returncode != 0:
+        error = api_proc.stderr.strip() or api_proc.stdout.strip() or "gh api rate_limit failed"
+        mode = "connectivity_failed" if is_github_connectivity_error(error) else "api_failed"
+        return GitHubCLIHealth(
+            ready=False,
+            auth_ok=True,
+            api_ok=False,
+            mode=mode,
+            error=error,
+            repo=repo_label,
+        )
+
+    return GitHubCLIHealth(
+        ready=True,
+        auth_ok=True,
+        api_ok=True,
+        mode="ready",
+        error="",
+        repo=repo_label,
+    )
+
+
+def ensure_github_cli_ready(
+    repo_root: Path,
+    *,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> GitHubCLIHealth:
+    health = check_github_cli_health(repo_root, timeout_seconds=timeout_seconds)
+    if not health.ready:
+        raise RuntimeError(health.error or health.mode)
+    return health
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check whether gh can reach GitHub from here.")
+    parser.add_argument("--repo", default=".", help="Path inside the target repository")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"Timeout for each gh probe (default: {DEFAULT_TIMEOUT_SECONDS})",
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable output")
+    parser.add_argument("--quiet", action="store_true", help="Suppress normal output")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    health = check_github_cli_health(
+        Path(args.repo),
+        timeout_seconds=int(args.timeout_seconds),
+    )
+
+    if args.json:
+        print(json.dumps(health.to_dict(), indent=2))
+    elif not args.quiet:
+        if health.ready:
+            print(f"gh ready for GitHub automation in {health.repo}")
+        else:
+            print(f"gh unavailable in {health.repo}: [{health.mode}] {health.error}".strip())
+    return 0 if health.ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_codex_automation_publisher_launchd.sh
+++ b/scripts/install_codex_automation_publisher_launchd.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Install a launchd job that runs the codex automation publisher bridge on an interval.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LABEL="com.aragora.codex-automation-publisher"
+INTERVAL_SECONDS=300
+LOG_PATH="${REPO_ROOT}/.aragora/overnight/codex-automation-publisher.log"
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/install_codex_automation_publisher_launchd.sh [options]
+
+Options:
+  --interval-seconds <n>        launchd StartInterval (default: 300)
+  --log-path <file>             Log file path (default: .aragora/overnight/codex-automation-publisher.log)
+  --help                        Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --interval-seconds)
+            INTERVAL_SECONDS="${2:-300}"
+            shift 2
+            ;;
+        --log-path)
+            LOG_PATH="${2:-}"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if ! [[ "${INTERVAL_SECONDS}" =~ ^[0-9]+$ ]]; then
+    echo "interval must be numeric" >&2
+    exit 2
+fi
+
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+mkdir -p "$(dirname "${PLIST_PATH}")"
+mkdir -p "$(dirname "${LOG_PATH}")"
+
+cat >"${PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>cd "${REPO_ROOT}" &amp;&amp; ./scripts/run_codex_automation_publisher.sh</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>${INTERVAL_SECONDS}</integer>
+  <key>WorkingDirectory</key>
+  <string>${REPO_ROOT}</string>
+  <key>StandardOutPath</key>
+  <string>${LOG_PATH}</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_PATH}</string>
+</dict>
+</plist>
+EOF
+
+launchctl unload "${PLIST_PATH}" >/dev/null 2>&1 || true
+launchctl load "${PLIST_PATH}"
+
+echo "Installed launchd job: ${LABEL}"
+echo "Plist: ${PLIST_PATH}"
+echo "Interval: ${INTERVAL_SECONDS}s"
+echo "Log: ${LOG_PATH}"

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -14,10 +14,16 @@ import json
 import os
 import re
 import subprocess
+import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.github_cli_health import check_github_cli_health
 
 UTC = timezone.utc
 DEFAULT_CODEX_HOME = Path("/Users/armand/.codex")
@@ -297,9 +303,9 @@ def load_handoffs(
 
 
 def _ensure_gh_auth(repo_root: Path) -> None:
-    proc = _run(["gh", "auth", "status"], cwd=repo_root)
-    if proc.returncode != 0:
-        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh auth failed")
+    health = check_github_cli_health(repo_root)
+    if not health.ready:
+        raise RuntimeError(health.error or health.mode)
 
 
 def _title_tokens(title: str) -> set[str]:
@@ -630,9 +636,35 @@ def main(argv: list[str] | None = None) -> int:
     codex_home = _codex_home(args.codex_home)
     labels = list(dict.fromkeys(args.labels))
     automation_ids = set(args.automation_ids or DEFAULT_AUTOMATION_IDS)
-
-    _ensure_gh_auth(repo_root)
     handoffs = load_handoffs(codex_home, automation_ids=automation_ids)
+    github_health = check_github_cli_health(repo_root)
+    if not github_health.ready:
+        payload = {
+            "repo": str(repo_root),
+            "codex_home": str(codex_home),
+            "github_repo": args.github_repo,
+            "labels": labels,
+            "automation_ids": sorted(automation_ids),
+            "handoff_count": len(handoffs),
+            "github_health": github_health.to_dict(),
+            "decisions": [
+                asdict(
+                    PublishDecision(
+                        task_title=handoff.task_title,
+                        source_file=handoff.source_file,
+                        eligible=False,
+                        reason="github_unavailable",
+                    )
+                )
+                for handoff in handoffs
+            ],
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(f"github_unavailable: {github_health.mode} {github_health.error}".strip())
+        return 1
+
     decisions = decide_handoffs(
         handoffs,
         repo_root=repo_root,
@@ -660,6 +692,7 @@ def main(argv: list[str] | None = None) -> int:
         "labels": labels,
         "automation_ids": sorted(automation_ids),
         "handoff_count": len(handoffs),
+        "github_health": github_health.to_dict(),
         "decisions": [asdict(item) for item in results],
     }
     if args.json:

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -776,7 +776,7 @@ def main(argv: list[str] | None = None) -> int:
 
     github_health = check_github_cli_health(repo_root)
     if not github_health.ready:
-        payload: dict[str, Any] = {
+        unavailable_payload: dict[str, Any] = {
             "repo": str(repo_root),
             "base": args.base,
             "cutoff": cutoff.isoformat(),
@@ -786,7 +786,7 @@ def main(argv: list[str] | None = None) -> int:
             "decisions": [],
         }
         if args.json:
-            print(json.dumps(payload, indent=2))
+            print(json.dumps(unavailable_payload, indent=2))
         else:
             print(f"github_unavailable: {github_health.mode} {github_health.error}".strip())
         return 1

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -20,6 +20,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.github_cli_health import check_github_cli_health
+
 UTC = timezone.utc
 DEFAULT_SINCE_HOURS = 72
 DEFAULT_PUBLISH_LIMIT = 1
@@ -485,9 +490,9 @@ def select_publishable_branches(
 
 
 def _ensure_gh_auth(repo_root: Path) -> None:
-    proc = _run(["gh", "auth", "status"], cwd=repo_root)
-    if proc.returncode != 0:
-        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh auth failed")
+    health = check_github_cli_health(repo_root)
+    if not health.ready:
+        raise RuntimeError(health.error or health.mode)
 
 
 def _github_base_ref(base: str) -> str:
@@ -769,6 +774,23 @@ def main(argv: list[str] | None = None) -> int:
         for branch in branches
     ]
 
+    github_health = check_github_cli_health(repo_root)
+    if not github_health.ready:
+        payload: dict[str, Any] = {
+            "repo": str(repo_root),
+            "base": args.base,
+            "cutoff": cutoff.isoformat(),
+            "open_pr_count": 0,
+            "max_open_prs": args.max_open_prs,
+            "github_health": github_health.to_dict(),
+            "decisions": [],
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(f"github_unavailable: {github_health.mode} {github_health.error}".strip())
+        return 1
+
     open_pr_heads = _open_pr_heads(repo_root, args.github_repo)
     historical_pr_branches = _branches_with_pr_history(
         repo_root,
@@ -798,6 +820,7 @@ def main(argv: list[str] | None = None) -> int:
         "cutoff": cutoff.isoformat(),
         "open_pr_count": len(open_pr_heads),
         "max_open_prs": args.max_open_prs,
+        "github_health": github_health.to_dict(),
         "decisions": [asdict(decision) for decision in decisions],
     }
 

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOCK_DIR="${TMPDIR:-/tmp}/com.aragora.codex-automation-publisher.lock"
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
 STAMP() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
@@ -23,6 +24,22 @@ cd "$REPO_ROOT"
 if ! command -v gh >/dev/null 2>&1; then
   echo "$(STAMP) [codex-automation-publisher] gh CLI not found"
   exit 1
+fi
+
+echo "$(STAMP) [codex-automation-publisher] checking GitHub CLI health"
+HEALTH_JSON="$(python3 scripts/github_cli_health.py --repo "${REPO_ROOT}" --json 2>/dev/null || true)"
+HEALTH_READY="$(
+  printf '%s' "${HEALTH_JSON}" \
+    | python3 -c 'import json,sys; print("true" if json.load(sys.stdin).get("ready") else "false")' \
+      2>/dev/null \
+    || echo "false"
+)"
+if [[ "${HEALTH_READY}" != "true" ]]; then
+  echo "$(STAMP) [codex-automation-publisher] GitHub unavailable; leaving automations in handoff-only mode"
+  if [[ -n "${HEALTH_JSON}" ]]; then
+    printf '%s\n' "${HEALTH_JSON}"
+  fi
+  exit 0
 fi
 
 if ! git fetch --no-write-fetch-head --prune origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1; then

--- a/scripts/status_codex_automation_publisher_launchd.sh
+++ b/scripts/status_codex_automation_publisher_launchd.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Show status of the codex automation publisher launchd job.
+
+set -euo pipefail
+
+LABEL="com.aragora.codex-automation-publisher"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+if [[ -f "${PLIST_PATH}" ]]; then
+    echo "plist: present (${PLIST_PATH})"
+else
+    echo "plist: missing (${PLIST_PATH})"
+fi
+
+echo "--- launchctl ---"
+launchctl list | grep "${LABEL}" || echo "job not loaded"

--- a/scripts/uninstall_codex_automation_publisher_launchd.sh
+++ b/scripts/uninstall_codex_automation_publisher_launchd.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Uninstall the codex automation publisher launchd job.
+
+set -euo pipefail
+
+LABEL="com.aragora.codex-automation-publisher"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+launchctl unload "${PLIST_PATH}" >/dev/null 2>&1 || true
+rm -f "${PLIST_PATH}"
+
+echo "Removed launchd job: ${LABEL}"
+echo "Plist removed: ${PLIST_PATH}"

--- a/tests/scripts/test_github_cli_health.py
+++ b/tests/scripts/test_github_cli_health.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import scripts.github_cli_health as mod
+
+
+def test_check_github_cli_health_ready(monkeypatch) -> None:
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
+
+    def fake_run(
+        args: list[str], *, cwd: Path, timeout_seconds: int
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    health = mod.check_github_cli_health(Path("."))
+
+    assert health.ready is True
+    assert health.mode == "ready"
+    assert health.auth_ok is True
+    assert health.api_ok is True
+
+
+def test_check_github_cli_health_detects_connectivity_failure(monkeypatch) -> None:
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
+
+    def fake_run(
+        args: list[str], *, cwd: Path, timeout_seconds: int
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "auth", "status"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="ok", stderr="")
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=1,
+            stdout="",
+            stderr="error connecting to api.github.com",
+        )
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    health = mod.check_github_cli_health(Path("."))
+
+    assert health.ready is False
+    assert health.mode == "connectivity_failed"
+    assert health.auth_ok is True
+    assert health.api_ok is False
+    assert mod.is_github_connectivity_error(health.error) is True
+
+
+def test_check_github_cli_health_detects_auth_failure(monkeypatch) -> None:
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
+
+    def fake_run(
+        args: list[str], *, cwd: Path, timeout_seconds: int
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=1,
+            stdout="",
+            stderr="You are not logged into any GitHub hosts. Run gh auth login.",
+        )
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    health = mod.check_github_cli_health(Path("."))
+
+    assert health.ready is False
+    assert health.mode == "auth_failed"
+    assert health.auth_ok is False
+    assert health.api_ok is False
+
+
+def test_main_json_reports_unavailable_state(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root, timeout_seconds=mod.DEFAULT_TIMEOUT_SECONDS: mod.GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="error connecting to api.github.com",
+            repo=str(Path(repo_root).resolve()),
+        ),
+    )
+
+    exit_code = mod.main(["--json"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert '"mode": "connectivity_failed"' in out
+    assert '"ready": false' in out

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from scripts.github_cli_health import GitHubCLIHealth
 import scripts.publish_automation_handoffs as mod
 from scripts.publish_automation_handoffs import Handoff, PublishDecision
 
@@ -292,6 +293,40 @@ def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: 
         "--add-label",
         "boss-ready,autonomous",
     ]
+
+
+def test_main_reports_github_health_when_unavailable(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / "memory.md"),
+        task_title="Fix tmux readiness detection for named Claude lanes",
+        priority="MEDIUM",
+        body="body",
+        labels={},
+        expires_at=None,
+    )
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: [handoff])
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=True,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="error connecting to api.github.com",
+            repo=str(tmp_path),
+        ),
+    )
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--codex-home", str(tmp_path), "--json"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert '"mode": "connectivity_failed"' in out
+    assert '"reason": "github_unavailable"' in out
 
 
 def test_create_issue_truncates_oversized_body(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import scripts.publish_codex_automation_branches as mod
+from scripts.github_cli_health import GitHubCLIHealth
 from scripts.publish_codex_automation_branches import (
     BranchSnapshot,
     WorktreeSnapshot,
@@ -269,6 +270,33 @@ branch refs/heads/codex/b
 
     assert [snapshot.branch for snapshot in snapshots] == ["codex/b"]
     assert dirty_checked == [str(Path("/tmp/codex-b").resolve())]
+
+
+def test_main_reports_github_health_when_unavailable(
+    monkeypatch: Any, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "_local_codex_branches", lambda repo_root: [])
+    monkeypatch.setattr(mod, "_list_worktrees", lambda repo_root, branch_filter=None: [])
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=True,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="error connecting to api.github.com",
+            repo=str(tmp_path),
+        ),
+    )
+
+    exit_code = mod.main(["--repo", str(tmp_path), "--json"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert '"mode": "connectivity_failed"' in out
+    assert '"decisions": []' in out
 
 
 def test_publish_decisions_respects_open_pr_cap(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a shared `scripts/github_cli_health.py` probe so automation publishers can distinguish auth/network failure from a healthy GitHub shell
- harden the handoff and branch publisher scripts plus the publisher bridge script to fail fast into handoff-only mode when GitHub is unreachable
- add launchd install/status/uninstall helpers for the codex automation publisher and document the intended publisher-bridge operating pattern

## Why
Codex desktop automations repeatedly succeed at local repo work while failing on `gh` / DNS access from restricted automation sandboxes. This change makes that boundary explicit and gives the repo a first-class non-sandboxed publisher lane instead of forcing every automation to rediscover the same failure mode.

## Validation
- `python3 -m pytest -q tests/scripts/test_github_cli_health.py tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_publish_automation_handoffs.py`
- `python3 -m ruff check scripts/github_cli_health.py scripts/publish_codex_automation_branches.py scripts/publish_automation_handoffs.py tests/scripts/test_github_cli_health.py tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_publish_automation_handoffs.py`
- `python3 scripts/github_cli_health.py --json`
- `python3 scripts/publish_automation_handoffs.py --json --limit 1`
- `python3 scripts/publish_codex_automation_branches.py --json --limit 1 --scan-limit 3`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
