### PR TITLE
fix(automation): route PR-targeted handoffs out of boss queue

### DIFF
--- a/docs/briefs/automation-merge-contract.md
+++ b/docs/briefs/automation-merge-contract.md
@@ -20,6 +20,8 @@ For local Codex app automation branches, `scripts/publish_codex_automation_branc
 
 For local Codex app automation handoffs, `scripts/publish_automation_handoffs.py --apply` reads structured memory blocks, deduplicates them against existing GitHub issues and PRs, and creates missing `boss-ready` issues from a normal shell with working `gh` access. Scout automations should leave structured handoffs in memory/inbox when GitHub writes fail instead of using browser fallback for issue or PR creation.
 
+If a handoff explicitly targets an already-open pull request (for example `PR #6288` in the task title or evidence block), the handoff publisher should treat it as PR follow-up work instead of minting a new `boss-ready` issue. PR-targeted follow-ups must not consume boss-ready issue capacity.
+
 For Aragora boss-loop workers, run the same script against the worker branch before merge arbitration:
 
 ```bash

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -56,6 +56,7 @@ BLOCK_POSITION_KEY = "__block_position"
 BLOCK_TIMESTAMP_PATTERN = re.compile(
     r"(?m)(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)"
 )
+PR_REFERENCE_PATTERN = re.compile(r"(?i)\b(?:PR|pull request)\s*#(\d+)\b")
 STOPWORDS = {
     "a",
     "an",
@@ -399,6 +400,52 @@ def _existing_pr(repo_root: Path, repo: str, title: str) -> dict[str, Any] | Non
     return None
 
 
+def _referenced_pr_numbers(handoff: Handoff) -> list[int]:
+    seen: set[int] = set()
+    numbers: list[int] = []
+    for match in PR_REFERENCE_PATTERN.finditer(f"{handoff.task_title}\n{handoff.body}"):
+        try:
+            number = int(match.group(1))
+        except (TypeError, ValueError):
+            continue
+        if number in seen:
+            continue
+        seen.add(number)
+        numbers.append(number)
+    return numbers
+
+
+def _pr_by_number(repo_root: Path, repo: str, number: int) -> dict[str, Any] | None:
+    proc = _run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,url,state",
+        ],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        stderr = (proc.stderr or proc.stdout or "").lower()
+        if "could not resolve to a pull request" in stderr or "not found" in stderr:
+            return None
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "failed to view PR")
+    payload = json.loads(proc.stdout or "{}")
+    return payload if isinstance(payload, dict) else None
+
+
+def _target_open_pr(repo_root: Path, repo: str, handoff: Handoff) -> dict[str, Any] | None:
+    for number in _referenced_pr_numbers(handoff):
+        pr = _pr_by_number(repo_root, repo, number)
+        if isinstance(pr, dict) and str(pr.get("state") or "").upper() == "OPEN":
+            return pr
+    return None
+
+
 def _open_boss_ready_count(repo_root: Path, repo: str, labels: list[str]) -> int:
     args = [
         "gh",
@@ -502,6 +549,18 @@ def decide_handoffs(
                     eligible=False,
                     reason="existing_issue",
                     existing_issue_url=str(existing.get("url") or ""),
+                )
+            )
+            continue
+        target_pr = _target_open_pr(repo_root, repo, handoff)
+        if target_pr:
+            decisions.append(
+                PublishDecision(
+                    task_title=handoff.task_title,
+                    source_file=handoff.source_file,
+                    eligible=False,
+                    reason="target_open_pr",
+                    existing_pr_url=str(target_pr.get("url") or ""),
                 )
             )
             continue

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -214,6 +214,63 @@ def test_decide_handoffs_marks_duplicate_pr(monkeypatch: Any, tmp_path: Path) ->
     ]
 
 
+def test_decide_handoffs_routes_explicit_pr_followup_before_issue_cap(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / "memory.md"),
+        task_title="Prevent draft approval packets in PR #6288",
+        priority="HIGH",
+        body=(
+            "Why Now: PR #6288 already carries the active review-queue implementation.\n"
+            "Repo Evidence:\n- gh pr view 6288 --json number,title,headRefName,url,isDraft\n"
+        ),
+        labels={},
+        expires_at=None,
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, json.dumps([{"number": 1}]), "")
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 6288,
+                        "title": "feat(review): add read-only queue packet builder",
+                        "url": "https://github.com/synaptent/aragora/pull/6288",
+                        "state": "OPEN",
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=1,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="target_open_pr",
+            existing_pr_url="https://github.com/synaptent/aragora/pull/6288",
+        )
+    ]
+
+
 def test_decide_handoffs_respects_open_issue_cap(monkeypatch: Any, tmp_path: Path) -> None:
     handoff = Handoff(
         source_file=str(tmp_path / "memory.md"),
@@ -241,6 +298,19 @@ def test_decide_handoffs_respects_open_issue_cap(monkeypatch: Any, tmp_path: Pat
 
     assert decisions[0].eligible is False
     assert decisions[0].reason == "open_issue_cap"
+
+
+def test_referenced_pr_numbers_deduplicates_multiple_mentions(tmp_path: Path) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / "memory.md"),
+        task_title="Amend PR #6288 packet recommendation logic",
+        priority="HIGH",
+        body="Repo Evidence:\n- pull request #6288 still marks drafts as approve_candidate.\n",
+        labels={},
+        expires_at=None,
+    )
+
+    assert mod._referenced_pr_numbers(handoff) == [6288]
 
 
 def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- detect explicit `PR #...` / `pull request #...` references in structured automation handoffs
- classify open PR-targeted handoffs as `target_open_pr` before boss-ready issue dedupe/cap logic
- document that PR-targeted follow-ups do not consume `boss-ready` issue capacity

## Why
The publisher was correctly enforcing the open `boss-ready` issue cap, but it was applying that cap to handoffs that were actually asking to amend an already-open PR, such as the live `PR #6288` follow-up. Those should be routed as PR follow-up work, not blocked as queue churn.

## Validation
- `python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py`
- `python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py`
- `python3 scripts/publish_automation_handoffs.py --json --limit 5`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Live proof
Current dry-run publisher output on this branch now classifies the active handoff `Prevent draft/parked approval packets in PR #6288` as:
- `reason: target_open_pr`
- `existing_pr_url: https://github.com/synaptent/aragora/pull/6288`

instead of dropping it behind `open_issue_cap`.
