### PR TITLE
feat(review): add founder settlement loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,800+ Python modules | 210,000+ tests | 5,000+ test files | 210+ debate modules | 3,100+ API operations across 2,900+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 3,800+ Python modules | 210,000+ tests | 5,000+ test files | 210+ debate modules | 3,100+ API operations across 2,800+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
 
 ## Architecture
 

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1,16 +1,19 @@
-"""Read-only PR review queue + advisory packets (Phase 2a of #6279).
+"""PR review queue, advisory packets, and human settlement (Phases 2a/2b).
 
-Phase 2a is **strictly read-only**: builds a prioritized queue of open PRs and
-generates advisory packets for individual PRs. The packet is explicitly
-advisory — it does not approve, block, or otherwise settle a PR. Settlement
-remains a human action via GitHub UI or ``gh`` directly.
+This command keeps machine review advisory-only while making the human
+settlement step fast and receipt-backed:
 
-Out of scope for Phase 2a (intentionally not implemented):
+- ``build`` prioritizes open PRs for founder review
+- ``packet`` builds the advisory packet for one live PR head
+- ``run`` walks a human through approve/request-changes/defer in one loop
+- ``act`` performs one explicit human settlement action with freshness checks
 
-- ``review-queue run`` (interactive review session)
-- ``review-queue act --approve|--request-changes|--defer`` (settlement actions)
+Out of scope (intentionally still not implemented):
+
 - ``review-queue digest`` (rolled-up activity report)
-- Any GitHub write API call
+- ``merge_arbiter`` enforcement of settlement receipts
+- Bot-only merge on green CI
+- Any hidden merge path that bypasses explicit human action
 
 See docs/plans/2026-04-19-batched-pr-review-triage.md for the full design.
 """
@@ -18,12 +21,17 @@ See docs/plans/2026-04-19-batched-pr-review-triage.md for the full design.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import subprocess
 import sys
+import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+from aragora.worktree.fleet import resolve_repo_root
 
 UTC = timezone.utc
 
@@ -54,6 +62,13 @@ LANE_ORDER: dict[str, int] = {
 
 ADVISORY_NOTE = (
     "This packet is advisory only. It does not approve or block merge. Human settlement required."
+)
+REVIEW_QUEUE_ARTIFACT_DIR = ".aragora/review-queue"
+REQUEST_CHANGES_REASON_REQUIRED = (
+    "request-changes requires a one-line human reason so the repair loop stays bounded."
+)
+DEFER_REASON_REQUIRED = (
+    "defer requires a one-line human reason so the PR does not disappear silently."
 )
 
 
@@ -89,20 +104,48 @@ class ReviewPacket:
     title: str
     url: str
     head_sha: str
+    base_sha: str
     author: str
     is_draft: bool
     additions: int
     deletions: int
     changed_files: int
+    queue_bucket: str
     touched_subsystems: list[str]
     high_risk_paths_touched: list[str]
+    validation: list[str]
     checks_summary: str
     risk_flags: list[str]
     machine_recommendation: str
     machine_recommendation_reason: str
+    packet_sha: str
     generated_at: str
     advisory_only: bool = True
     settlement_note: str = ADVISORY_NOTE
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class SettlementReceipt:
+    """Persisted human settlement receipt for one PR/head/packet tuple."""
+
+    session_id: str
+    reviewed_at: str
+    actor: str
+    action: str
+    reason: str
+    pr_number: int
+    pr_url: str
+    head_sha: str
+    base_sha: str
+    packet_sha: str
+    queue_bucket: str
+    machine_recommendation: str
+    github_event: str
+    elapsed_seconds: float | None = None
+    receipt_path: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -112,15 +155,16 @@ class ReviewPacket:
 
 
 def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
-    """Register 'review-queue' with read-only build/packet sub-actions."""
+    """Register review-queue build/packet/run/act sub-actions."""
     parser = subparsers.add_parser(
         "review-queue",
-        help="Read-only PR review queue + advisory packets (Phase 2a)",
+        help="PR review queue + advisory packets + human settlement",
         description=(
             "Build a prioritized queue of open PRs ready for human review, or\n"
-            "generate an advisory packet for one PR.\n\n"
-            "Phase 2a is strictly read-only: no approve/request-changes/defer\n"
-            "actions, no GitHub writes. See\n"
+            "generate an advisory packet for one PR, or settle one PR with an\n"
+            "explicit human action.\n\n"
+            "Machine review remains advisory only. Settlement writes are human\n"
+            "GitHub reviews/comments plus local founder-review receipts. See\n"
             "docs/plans/2026-04-19-batched-pr-review-triage.md for the design."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -150,6 +194,46 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     packet_p.add_argument("--json", action="store_true", help="Output as JSON")
 
+    run_p = sub.add_parser("run", help="Interactively settle a prioritized PR queue")
+    run_p.add_argument("--limit", type=int, default=30, help="Max PRs to walk (default: 30)")
+    run_p.add_argument(
+        "--ready-only",
+        action="store_true",
+        help="Restrict the session to ready_now items",
+    )
+    run_p.add_argument(
+        "--include-parked",
+        action="store_true",
+        help="Include parked items in the session",
+    )
+    run_p.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+
+    act_p = sub.add_parser("act", help="Settle one PR with a human action")
+    act_p.add_argument("pr", help="PR number")
+    act_p.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    act_group = act_p.add_mutually_exclusive_group(required=True)
+    act_group.add_argument("--approve", action="store_true", help="Post a human APPROVE review")
+    act_group.add_argument(
+        "--request-changes",
+        action="store_true",
+        help="Post a human REQUEST_CHANGES review",
+    )
+    act_group.add_argument("--defer", action="store_true", help="Leave a human defer comment")
+    act_p.add_argument(
+        "--reason",
+        default="",
+        help="One-line human reason (required for --request-changes and --defer)",
+    )
+    act_p.add_argument("--json", action="store_true", help="Output settlement receipt as JSON")
+
     parser.set_defaults(func=cmd_review_queue)
 
 
@@ -160,9 +244,13 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
         return _cmd_build(args)
     if command == "packet":
         return _cmd_packet(args)
+    if command == "run":
+        return _cmd_run(args)
+    if command == "act":
+        return _cmd_act(args)
     print(
-        "Usage: aragora review-queue {build,packet} [...]\n"
-        "Phase 2a is read-only. Run 'aragora review-queue build --help' for options.",
+        "Usage: aragora review-queue {build,packet,run,act} [...]\n"
+        "Run 'aragora review-queue run --help' for the human settlement loop.",
         file=sys.stderr,
     )
     return 2
@@ -172,6 +260,7 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
 
 
 def _cmd_build(args: argparse.Namespace) -> int:
+    json_output = bool(getattr(args, "json", False) or getattr(args, "json_output", False))
     try:
         items = _build_queue(limit=args.limit)
     except _GhError as exc:
@@ -182,7 +271,7 @@ def _cmd_build(args: argparse.Namespace) -> int:
         ready_only=bool(getattr(args, "ready_only", False)),
         include_parked=bool(getattr(args, "include_parked", False)),
     )
-    if getattr(args, "json", False):
+    if json_output:
         print(json.dumps([item.to_dict() for item in items], indent=2))
     else:
         _render_table(items)
@@ -190,15 +279,148 @@ def _cmd_build(args: argparse.Namespace) -> int:
 
 
 def _cmd_packet(args: argparse.Namespace) -> int:
+    json_output = bool(getattr(args, "json", False) or getattr(args, "json_output", False))
     try:
         packet = _build_packet(args.pr, repo_override=args.repo)
     except _GhError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    if getattr(args, "json", False):
+    if json_output:
         print(json.dumps(packet.to_dict(), indent=2))
     else:
         _render_packet(packet)
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    repo_root = resolve_repo_root(Path.cwd())
+    try:
+        _require_clean_worktree(repo_root)
+        items = _build_queue(limit=args.limit)
+    except _GhError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    items = _filter_lanes(
+        items,
+        ready_only=bool(getattr(args, "ready_only", False)),
+        include_parked=bool(getattr(args, "include_parked", False)),
+    )
+    if not items:
+        print("(no PRs in scope)")
+        return 0
+
+    session_id = _session_id()
+    started_at = datetime.now(UTC).isoformat()
+    session_receipt: dict[str, Any] = {
+        "session_id": session_id,
+        "started_at": started_at,
+        "completed_at": None,
+        "reviewed_prs": [],
+        "queue_size": len(items),
+        "ready_only": bool(getattr(args, "ready_only", False)),
+        "include_parked": bool(getattr(args, "include_parked", False)),
+    }
+    session_path = _session_receipt_path(repo_root, session_id)
+    _write_json(session_path, session_receipt)
+
+    for index, item in enumerate(items, start=1):
+        try:
+            packet = _build_packet(str(item.number), repo_override=getattr(args, "repo", None))
+        except _GhError as exc:
+            print(f"\n! skipped PR #{item.number}: {exc}", file=sys.stderr)
+            continue
+        _render_session_packet(packet, item=item, index=index, total=len(items))
+        decision_started = time.monotonic()
+
+        while True:
+            choice = input(
+                "[a]pprove [r]equest-changes [d]efer [o]pen-files [p]acket-json [q]uit: "
+            )
+            normalized = choice.strip().lower()
+            if normalized == "o":
+                _render_changed_files(packet.pr_number, repo_override=getattr(args, "repo", None))
+                continue
+            if normalized == "p":
+                print(json.dumps(packet.to_dict(), indent=2))
+                continue
+            if normalized == "q":
+                session_receipt["completed_at"] = datetime.now(UTC).isoformat()
+                _write_json(session_path, session_receipt)
+                print(f"Session saved: {session_path}")
+                return 0
+            if normalized not in {"a", "r", "d"}:
+                print("Choose one of: a, r, d, o, p, q")
+                continue
+
+            action = {
+                "a": "approve",
+                "r": "request_changes",
+                "d": "defer",
+            }[normalized]
+            reason = ""
+            if action == "approve":
+                reason = input("approve note (optional): ").strip()
+            else:
+                while not reason:
+                    prompt = "reason (required): "
+                    reason = input(prompt).strip()
+            try:
+                receipt = _settle_packet(
+                    packet=packet,
+                    action=action,
+                    reason=reason,
+                    repo_root=repo_root,
+                    repo_override=getattr(args, "repo", None),
+                    session_id=session_id,
+                    elapsed_seconds=round(time.monotonic() - decision_started, 3),
+                )
+            except _GhError as exc:
+                print(f"! could not settle PR #{packet.pr_number}: {exc}", file=sys.stderr)
+                continue
+            session_receipt["reviewed_prs"].append(receipt.to_dict())
+            _write_json(session_path, session_receipt)
+            print(
+                f"{action} recorded for PR #{packet.pr_number} "
+                f"(packet {packet.packet_sha}, head {packet.head_sha})"
+            )
+            break
+
+    session_receipt["completed_at"] = datetime.now(UTC).isoformat()
+    _write_json(session_path, session_receipt)
+    print(f"Session complete: {session_path}")
+    return 0
+
+
+def _cmd_act(args: argparse.Namespace) -> int:
+    json_output = bool(getattr(args, "json", False) or getattr(args, "json_output", False))
+    action = _requested_action(args)
+    reason = str(getattr(args, "reason", "") or "").strip()
+    if action == "request_changes" and not reason:
+        print(f"error: {REQUEST_CHANGES_REASON_REQUIRED}", file=sys.stderr)
+        return 2
+    if action == "defer" and not reason:
+        print(f"error: {DEFER_REASON_REQUIRED}", file=sys.stderr)
+        return 2
+
+    repo_root = resolve_repo_root(Path.cwd())
+    try:
+        _require_clean_worktree(repo_root)
+        packet = _build_packet(args.pr, repo_override=getattr(args, "repo", None))
+        receipt = _settle_packet(
+            packet=packet,
+            action=action,
+            reason=reason,
+            repo_root=repo_root,
+            repo_override=getattr(args, "repo", None),
+            session_id=_session_id(),
+        )
+    except _GhError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if json_output:
+        print(json.dumps(receipt.to_dict(), indent=2))
+    else:
+        _render_settlement_receipt(receipt)
     return 0
 
 
@@ -207,6 +429,20 @@ def _cmd_packet(args: argparse.Namespace) -> int:
 
 class _GhError(RuntimeError):
     """Raised when a 'gh' invocation fails or returns malformed JSON."""
+
+
+def _gh_text(args: list[str]) -> str:
+    """Run a 'gh' command and return plain stdout."""
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "no stderr"
+        raise _GhError(f"gh {' '.join(args)} failed: {stderr}")
+    return proc.stdout.strip()
 
 
 def _gh_json(args: list[str]) -> Any:
@@ -378,8 +614,8 @@ def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
             "number",
             "title",
             "url",
-            "headRefName",
             "headRefOid",
+            "baseRefOid",
             "isDraft",
             "mergeable",
             "reviewDecision",
@@ -390,6 +626,7 @@ def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
             "changedFiles",
             "statusCheckRollup",
             "files",
+            "body",
         ]
     )
     args = ["pr", "view", str(number), "--json", fields]
@@ -418,6 +655,8 @@ def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
     deletions = int(pr.get("deletions", 0) or 0)
     is_draft = bool(pr.get("isDraft", False))
     mergeable = str(pr.get("mergeable", "")).strip().upper()
+    queue_item = _classify_pr(pr)
+    validation = _extract_validation_commands(str(pr.get("body", "") or ""))
 
     risk_flags: list[str] = []
     if is_draft:
@@ -461,24 +700,30 @@ def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
     if isinstance(author_payload, dict):
         author = str(author_payload.get("login", "")).strip()
 
-    return ReviewPacket(
+    packet = ReviewPacket(
         pr_number=number,
         title=str(pr.get("title", "")).strip(),
         url=str(pr.get("url", "")).strip(),
         head_sha=str(pr.get("headRefOid", "")).strip(),
+        base_sha=str(pr.get("baseRefOid", "")).strip(),
         author=author,
         is_draft=is_draft,
         additions=additions,
         deletions=deletions,
         changed_files=int(pr.get("changedFiles", 0) or 0),
+        queue_bucket=queue_item.lane,
         touched_subsystems=touched,
         high_risk_paths_touched=high_risk,
+        validation=validation,
         checks_summary=checks_summary,
         risk_flags=risk_flags,
         machine_recommendation=recommendation,
         machine_recommendation_reason=recommendation_reason,
+        packet_sha="",
         generated_at=datetime.now(UTC).isoformat(),
     )
+    packet.packet_sha = _packet_sha(packet)
+    return packet
 
 
 def _subsystem_for(path: str) -> str:
@@ -512,6 +757,210 @@ def _parse_pr_number(pr_ref: str) -> int:
         raise _GhError(f"invalid PR ref: {pr_ref!r}") from exc
 
 
+def _extract_validation_commands(body: str) -> list[str]:
+    """Parse bullet lines from a conventional PR `## Validation` section."""
+    lines: list[str] = []
+    in_validation = False
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        lower = line.lower()
+        if lower.startswith("## "):
+            in_validation = lower == "## validation"
+            continue
+        if not in_validation:
+            continue
+        if line.startswith("### "):
+            break
+        if line.startswith("- ") or line.startswith("* "):
+            lines.append(line[2:].strip())
+    return lines
+
+
+def _requested_action(args: argparse.Namespace) -> str:
+    if bool(getattr(args, "approve", False)):
+        return "approve"
+    if bool(getattr(args, "request_changes", False)):
+        return "request_changes"
+    if bool(getattr(args, "defer", False)):
+        return "defer"
+    raise _GhError("no settlement action selected")
+
+
+def _packet_sha(packet: ReviewPacket) -> str:
+    payload = packet.to_dict()
+    payload.pop("packet_sha", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _session_id() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _review_queue_root(repo_root: Path) -> Path:
+    return repo_root / REVIEW_QUEUE_ARTIFACT_DIR
+
+
+def _session_receipt_path(repo_root: Path, session_id: str) -> Path:
+    return _review_queue_root(repo_root) / "sessions" / f"{session_id}.json"
+
+
+def _settlement_receipt_path(
+    repo_root: Path,
+    *,
+    session_id: str,
+    pr_number: int,
+    action: str,
+) -> Path:
+    filename = f"pr-{pr_number}-{session_id}-{action}.json"
+    return _review_queue_root(repo_root) / "receipts" / filename
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _require_clean_worktree(repo_root: Path) -> None:
+    proc = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "no stderr"
+        raise _GhError(f"git status failed in {repo_root}: {stderr}")
+    if proc.stdout.strip():
+        raise _GhError(
+            "review-queue settlement requires a clean worktree so receipts match the reviewed truth"
+        )
+
+
+def _current_head_sha(pr_number: int, *, repo_override: str | None) -> str:
+    args = ["pr", "view", str(pr_number), "--json", "headRefOid"]
+    if repo_override:
+        args.extend(["--repo", repo_override])
+    payload = _gh_json(args)
+    if not isinstance(payload, dict):
+        raise _GhError(f"PR #{pr_number} not found while verifying packet freshness")
+    return str(payload.get("headRefOid", "")).strip()
+
+
+def _github_actor() -> str:
+    try:
+        payload = _gh_json(["api", "user"])
+    except _GhError:
+        return "unknown"
+    if not isinstance(payload, dict):
+        return "unknown"
+    return str(payload.get("login", "unknown") or "unknown").strip()
+
+
+def _github_settlement_event(action: str) -> str:
+    if action == "approve":
+        return "APPROVE"
+    if action == "request_changes":
+        return "REQUEST_CHANGES"
+    return "COMMENT"
+
+
+def _settlement_body(packet: ReviewPacket, *, action: str, reason: str) -> str:
+    lines = [
+        "Human settlement via `aragora review-queue`.",
+        "",
+        f"- Action: `{action}`",
+        f"- Packet SHA: `{packet.packet_sha}`",
+        f"- Head SHA: `{packet.head_sha}`",
+        f"- Base SHA: `{packet.base_sha}`",
+        f"- Queue bucket: `{packet.queue_bucket}`",
+        f"- Machine recommendation: `{packet.machine_recommendation}`",
+    ]
+    if reason:
+        lines.append(f"- Reason: {reason}")
+    lines.extend(
+        [
+            "",
+            ADVISORY_NOTE,
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _settle_packet(
+    *,
+    packet: ReviewPacket,
+    action: str,
+    reason: str,
+    repo_root: Path,
+    repo_override: str | None,
+    session_id: str,
+    elapsed_seconds: float | None = None,
+) -> SettlementReceipt:
+    current_head_sha = _current_head_sha(packet.pr_number, repo_override=repo_override)
+    if current_head_sha != packet.head_sha:
+        raise _GhError(
+            f"PR #{packet.pr_number} head changed from {packet.head_sha} to {current_head_sha}; "
+            "refresh the packet before settlement"
+        )
+
+    body = _settlement_body(packet, action=action, reason=reason)
+    if action == "approve":
+        gh_args = ["pr", "review", str(packet.pr_number), "--approve", "--body", body]
+    elif action == "request_changes":
+        gh_args = ["pr", "review", str(packet.pr_number), "--request-changes", "--body", body]
+    else:
+        gh_args = ["pr", "comment", str(packet.pr_number), "--body", body]
+    if repo_override:
+        gh_args.extend(["--repo", repo_override])
+    _gh_text(gh_args)
+
+    reviewed_at = datetime.now(UTC).isoformat()
+    receipt = SettlementReceipt(
+        session_id=session_id,
+        reviewed_at=reviewed_at,
+        actor=_github_actor(),
+        action=action,
+        reason=reason,
+        pr_number=packet.pr_number,
+        pr_url=packet.url,
+        head_sha=packet.head_sha,
+        base_sha=packet.base_sha,
+        packet_sha=packet.packet_sha,
+        queue_bucket=packet.queue_bucket,
+        machine_recommendation=packet.machine_recommendation,
+        github_event=_github_settlement_event(action),
+        elapsed_seconds=elapsed_seconds,
+    )
+    receipt_path = _settlement_receipt_path(
+        repo_root,
+        session_id=session_id,
+        pr_number=packet.pr_number,
+        action=action,
+    )
+    receipt.receipt_path = str(receipt_path)
+    _write_json(receipt_path, receipt.to_dict())
+    return receipt
+
+
+def _render_changed_files(pr_number: int, *, repo_override: str | None) -> None:
+    args = ["pr", "view", str(pr_number), "--json", "files"]
+    if repo_override:
+        args.extend(["--repo", repo_override])
+    payload = _gh_json(args)
+    files = []
+    if isinstance(payload, dict):
+        for item in payload.get("files") or []:
+            if isinstance(item, dict) and item.get("path"):
+                files.append(str(item["path"]).strip())
+    print("changed files:")
+    for path in files:
+        print(f"  - {path}")
+    if not files:
+        print("  (no changed files reported)")
+
+
 # --- Rendering -------------------------------------------------------------
 
 
@@ -538,8 +987,8 @@ def _render_table(items: list[QueueItem]) -> None:
         print(f"        {item.url}  [{item.lane_reason}]")
     print()
     print(
-        "Note: this queue is advisory only. Settlement (approve/request-changes/defer) "
-        "requires human action via GitHub UI or `gh pr review` / `gh pr merge`."
+        "Note: machine review remains advisory only. Settlement writes are explicit "
+        "human `gh pr review` / `gh pr comment` actions with local receipts."
     )
 
 
@@ -549,8 +998,11 @@ def _render_packet(packet: ReviewPacket) -> None:
     print(f"# {packet.url}")
     print()
     print(f"head SHA:        {packet.head_sha}")
+    print(f"base SHA:        {packet.base_sha}")
+    print(f"packet SHA:      {packet.packet_sha}")
     print(f"author:          {packet.author}")
     print(f"draft:           {packet.is_draft}")
+    print(f"queue bucket:    {packet.queue_bucket}")
     print(
         f"diff:            +{packet.additions}/-{packet.deletions} "
         f"across {packet.changed_files} files"
@@ -567,6 +1019,11 @@ def _render_packet(packet: ReviewPacket) -> None:
         for path in packet.high_risk_paths_touched:
             print(f"  - {path}")
         print()
+    if packet.validation:
+        print("validation:")
+        for line in packet.validation:
+            print(f"  - {line}")
+        print()
     if packet.risk_flags:
         print("risk flags:")
         for flag in packet.risk_flags:
@@ -578,3 +1035,30 @@ def _render_packet(packet: ReviewPacket) -> None:
     print(f"generated at: {packet.generated_at}")
     print()
     print(f"-- {packet.settlement_note}")
+
+
+def _render_session_packet(
+    packet: ReviewPacket,
+    *,
+    item: QueueItem,
+    index: int,
+    total: int,
+) -> None:
+    print()
+    print(f"[{index}/{total}] lane={item.lane}  reason={item.lane_reason}")
+    _render_packet(packet)
+
+
+def _render_settlement_receipt(receipt: SettlementReceipt) -> None:
+    print(f"Recorded {receipt.action} for PR #{receipt.pr_number}")
+    print(f"  actor:        {receipt.actor}")
+    print(f"  reviewed at:  {receipt.reviewed_at}")
+    print(f"  head SHA:     {receipt.head_sha}")
+    print(f"  packet SHA:   {receipt.packet_sha}")
+    print(f"  queue bucket: {receipt.queue_bucket}")
+    print(f"  event:        {receipt.github_event}")
+    if receipt.reason:
+        print(f"  reason:       {receipt.reason}")
+    if receipt.elapsed_seconds is not None:
+        print(f"  elapsed:      {receipt.elapsed_seconds:.3f}s")
+    print(f"  receipt:      {receipt.receipt_path}")

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1377,10 +1377,106 @@ def _add_review_pr_parser(subparsers) -> None:
 
 
 def _add_review_queue_parser(subparsers) -> None:
-    """Register read-only review-queue (Phase 2a of #6279)."""
-    from aragora.cli.commands.review_queue import add_review_queue_parser
+    """Register review-queue lazily so unrelated CLI paths stay lightweight."""
+    parser = subparsers.add_parser(
+        "review-queue",
+        help="PR review queue + advisory packets + human settlement",
+        description=(
+            "Build a prioritized queue of open PRs, generate an advisory packet, "
+            "or record an explicit human settlement action."
+        ),
+    )
+    queue_subparsers = parser.add_subparsers(dest="review_queue_command")
 
-    add_review_queue_parser(subparsers)
+    build_parser = queue_subparsers.add_parser(
+        "build",
+        help="Build prioritized review queue from open PRs",
+    )
+    build_parser.add_argument("--limit", type=int, default=100, help="Max PRs to fetch")
+    build_parser.add_argument(
+        "--ready-only",
+        action="store_true",
+        help="Show only ready_now lane",
+    )
+    build_parser.add_argument(
+        "--include-parked",
+        action="store_true",
+        help="Include parked lane",
+    )
+    build_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output as JSON",
+    )
+    build_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
+
+    packet_parser = queue_subparsers.add_parser(
+        "packet",
+        help="Generate advisory review packet for one PR",
+    )
+    packet_parser.add_argument("pr", help="PR number")
+    packet_parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    packet_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output as JSON",
+    )
+    packet_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
+
+    run_parser = queue_subparsers.add_parser(
+        "run",
+        help="Interactively settle a prioritized PR queue",
+    )
+    run_parser.add_argument("--limit", type=int, default=30, help="Max PRs to walk")
+    run_parser.add_argument(
+        "--ready-only",
+        action="store_true",
+        help="Restrict the session to ready_now items",
+    )
+    run_parser.add_argument(
+        "--include-parked",
+        action="store_true",
+        help="Include parked items in the session",
+    )
+    run_parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    run_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
+
+    act_parser = queue_subparsers.add_parser(
+        "act",
+        help="Settle one PR with a human action",
+    )
+    act_parser.add_argument("pr", help="PR number")
+    act_parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    action_group = act_parser.add_mutually_exclusive_group(required=True)
+    action_group.add_argument("--approve", action="store_true", help="Post a human APPROVE review")
+    action_group.add_argument(
+        "--request-changes",
+        action="store_true",
+        help="Post a human REQUEST_CHANGES review",
+    )
+    action_group.add_argument("--defer", action="store_true", help="Leave a human defer comment")
+    act_parser.add_argument("--reason", default="", help="One-line human reason")
+    act_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output settlement receipt as JSON",
+    )
+    act_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
 
 
 def _add_codebase_audit_parser(subparsers) -> None:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Generated Aragora CLI command catalog from live parser
+description: Aragora CLI Reference
 ---
 
 # Aragora CLI Reference

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference
@@ -109,7 +109,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | Read-only PR review queue + advisory packets (Phase 2a) | `build`, `packet` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `build`, `packet`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -189,7 +189,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,800+ Python modules | 210,000+ tests | 5,000+ test files | 210+ debate modules | 3,100+ API operations across 2,900+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 3,800+ Python modules | 210,000+ tests | 5,000+ test files | 210+ debate modules | 3,100+ API operations across 2,800+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
 
 ## Architecture
 

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -40,7 +40,7 @@ Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / s
 
 ### 3. Extensible and Modular
 
-Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,100+ API operations across 2,900+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
+Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,100+ API operations across 2,800+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
 
 ### 4. Multi-Agent Robustness
 
@@ -686,7 +686,7 @@ aragora serve --api-port 8080 --ws-port 8765
 
 ## API Endpoints
 
-The server exposes 3,100+ API operations across 2,900+ paths. Key categories:
+The server exposes 3,100+ API operations across 2,800+ paths. Key categories:
 
 | Category | Description |
 |----------|-------------|

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -35,7 +35,7 @@ Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / s
 
 ### 3. Extensible and Modular
 
-Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,100+ API operations across 2,900+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
+Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,100+ API operations across 2,800+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
 
 ### 4. Multi-Agent Robustness
 
@@ -681,7 +681,7 @@ aragora serve --api-port 8080 --ws-port 8765
 
 ## API Endpoints
 
-The server exposes 3,100+ API operations across 2,900+ paths. Key categories:
+The server exposes 3,100+ API operations across 2,800+ paths. Key categories:
 
 | Category | Description |
 |----------|-------------|

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -104,7 +104,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | Read-only PR review queue + advisory packets (Phase 2a) | `build`, `packet` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `build`, `packet`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1,4 +1,4 @@
-"""Tests for aragora review-queue (Phase 2a, read-only)."""
+"""Tests for aragora review-queue packet + settlement flows."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import argparse
 import io
 import json
 from contextlib import redirect_stdout
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -20,10 +21,13 @@ from aragora.cli.commands.review_queue import (
     _build_packet,
     _build_queue,
     _classify_pr,
+    _extract_validation_commands,
     _filter_lanes,
     _GhError,
     _is_high_risk_path,
     _parse_pr_number,
+    _requested_action,
+    _settle_packet,
     _subsystem_for,
     _summarize_checks,
     add_review_queue_parser,
@@ -48,6 +52,7 @@ def _make_pr(
     checks: list[dict[str, Any]] | None = None,
     files: list[str] | None = None,
     author: str = "an0mium",
+    body: str = "",
 ) -> dict[str, Any]:
     """Build a synthetic gh-pr-list-style payload."""
     return {
@@ -56,6 +61,7 @@ def _make_pr(
         "url": f"https://github.com/synaptent/aragora/pull/{number}",
         "headRefName": f"branch-{number}",
         "headRefOid": f"sha{number:08d}",
+        "baseRefOid": "basesha0001",
         "isDraft": is_draft,
         "mergeable": mergeable,
         "reviewDecision": review_decision,
@@ -67,6 +73,7 @@ def _make_pr(
         "statusCheckRollup": checks
         or [{"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"}],
         "files": [{"path": p} for p in (files or [])],
+        "body": body,
     }
 
 
@@ -302,6 +309,25 @@ class TestParsePRNumber:
             _parse_pr_number("not a number")
 
 
+class TestValidationExtraction:
+    def test_extracts_validation_bullets(self) -> None:
+        body = """
+## Summary
+- one
+
+## Validation
+- `python3 -m pytest tests/cli/commands/test_review_queue.py -q`
+- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
+
+## Notes
+- later
+"""
+        assert _extract_validation_commands(body) == [
+            "`python3 -m pytest tests/cli/commands/test_review_queue.py -q`",
+            "`bash scripts/automation_pr_preflight.sh origin/main HEAD`",
+        ]
+
+
 # --- _build_queue + _build_packet (with mocked gh) -------------------------
 
 
@@ -336,6 +362,11 @@ class TestBuildQueueAndPacket:
         pr_payload = _make_pr(
             number=6280,
             files=["aragora/cli/commands/review_pr.py", "tests/cli/commands/test_review_pr.py"],
+            body=(
+                "## Validation\n"
+                "- `python3 -m pytest tests/cli/commands/test_review_pr.py -q`\n"
+                "- `bash scripts/automation_pr_preflight.sh origin/main HEAD`\n"
+            ),
         )
         monkeypatch.setattr(
             "aragora.cli.commands.review_queue._gh_json",
@@ -346,9 +377,16 @@ class TestBuildQueueAndPacket:
         assert packet.advisory_only is True
         assert packet.settlement_note == ADVISORY_NOTE
         assert packet.machine_recommendation == "approve_candidate"
+        assert packet.queue_bucket == "ready_now"
+        assert packet.base_sha == "basesha0001"
+        assert packet.packet_sha.startswith("sha256:")
         assert "aragora/cli" in packet.touched_subsystems
         assert "tests/cli" in packet.touched_subsystems
         assert packet.high_risk_paths_touched == []
+        assert packet.validation == [
+            "`python3 -m pytest tests/cli/commands/test_review_pr.py -q`",
+            "`bash scripts/automation_pr_preflight.sh origin/main HEAD`",
+        ]
 
     def test_build_packet_flags_high_risk_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
         pr_payload = _make_pr(
@@ -460,17 +498,21 @@ class TestJsonOutput:
             "title",
             "url",
             "head_sha",
+            "base_sha",
             "author",
             "is_draft",
             "additions",
             "deletions",
             "changed_files",
+            "queue_bucket",
             "touched_subsystems",
             "high_risk_paths_touched",
+            "validation",
             "checks_summary",
             "risk_flags",
             "machine_recommendation",
             "machine_recommendation_reason",
+            "packet_sha",
             "generated_at",
             "advisory_only",
             "settlement_note",
@@ -494,7 +536,7 @@ class TestJsonOutput:
 
 
 class TestCommandDispatch:
-    def test_parser_registers_build_and_packet(self) -> None:
+    def test_parser_registers_build_packet_run_and_act(self) -> None:
         root = argparse.ArgumentParser()
         sub = root.add_subparsers()
         add_review_queue_parser(sub)
@@ -507,11 +549,134 @@ class TestCommandDispatch:
         ns_packet = root.parse_args(["review-queue", "packet", "6280", "--json"])
         assert ns_packet.review_queue_command == "packet"
         assert ns_packet.pr == "6280"
+        # run invocation parses
+        ns_run = root.parse_args(["review-queue", "run", "--limit", "3", "--ready-only"])
+        assert ns_run.review_queue_command == "run"
+        assert ns_run.limit == 3
+        assert ns_run.ready_only is True
+        # act invocation parses
+        ns_act = root.parse_args(
+            ["review-queue", "act", "6280", "--request-changes", "--reason", "needs a test"]
+        )
+        assert ns_act.review_queue_command == "act"
+        assert ns_act.pr == "6280"
+        assert ns_act.request_changes is True
+        assert ns_act.reason == "needs a test"
 
     def test_cmd_review_queue_with_no_subcommand_returns_2(self) -> None:
         ns = argparse.Namespace(review_queue_command=None)
         rc = cmd_review_queue(ns)
         assert rc == 2
+
+
+class TestSettlementHelpers:
+    def test_requested_action(self) -> None:
+        assert (
+            _requested_action(argparse.Namespace(approve=True, request_changes=False, defer=False))
+            == "approve"
+        )
+        assert (
+            _requested_action(argparse.Namespace(approve=False, request_changes=True, defer=False))
+            == "request_changes"
+        )
+        assert (
+            _requested_action(argparse.Namespace(approve=False, request_changes=False, defer=True))
+            == "defer"
+        )
+
+    def test_settle_packet_writes_receipt(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        recorded: list[list[str]] = []
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._current_head_sha",
+            lambda pr_number, repo_override=None: "headsha123",
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_text",
+            lambda args: recorded.append(args) or "",
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._github_actor",
+            lambda: "an0mium",
+        )
+        packet = ReviewPacket(
+            pr_number=6294,
+            title="route PR-targeted handoffs out of boss queue",
+            url="https://github.com/synaptent/aragora/pull/6294",
+            head_sha="headsha123",
+            base_sha="basesha123",
+            author="codex",
+            is_draft=False,
+            additions=10,
+            deletions=2,
+            changed_files=1,
+            queue_bucket="ready_now",
+            touched_subsystems=["scripts"],
+            high_risk_paths_touched=[],
+            validation=["`python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py`"],
+            checks_summary="5/5 green",
+            risk_flags=[],
+            machine_recommendation="approve_candidate",
+            machine_recommendation_reason="all green, bounded diff, no high-risk paths",
+            packet_sha="sha256:testpacket",
+            generated_at="2026-04-19T05:00:00+00:00",
+        )
+        receipt = _settle_packet(
+            packet=packet,
+            action="approve",
+            reason="looks bounded",
+            repo_root=tmp_path,
+            repo_override=None,
+            session_id="session-1",
+            elapsed_seconds=1.25,
+        )
+        assert recorded and "--approve" in recorded[0]
+        assert receipt.actor == "an0mium"
+        assert receipt.github_event == "APPROVE"
+        assert receipt.receipt_path.endswith("pr-6294-session-1-approve.json")
+        saved = json.loads(Path(receipt.receipt_path).read_text())
+        assert saved["packet_sha"] == "sha256:testpacket"
+        assert saved["reason"] == "looks bounded"
+
+    def test_settle_packet_rejects_stale_head(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._current_head_sha",
+            lambda pr_number, repo_override=None: "new-head",
+        )
+        packet = ReviewPacket(
+            pr_number=1,
+            title="stale",
+            url="https://github.com/synaptent/aragora/pull/1",
+            head_sha="old-head",
+            base_sha="basesha123",
+            author="codex",
+            is_draft=False,
+            additions=1,
+            deletions=1,
+            changed_files=1,
+            queue_bucket="ready_now",
+            touched_subsystems=["aragora/cli"],
+            high_risk_paths_touched=[],
+            validation=[],
+            checks_summary="1/1 green",
+            risk_flags=[],
+            machine_recommendation="approve_candidate",
+            machine_recommendation_reason="clean",
+            packet_sha="sha256:testpacket",
+            generated_at="2026-04-19T05:00:00+00:00",
+        )
+        with pytest.raises(_GhError, match="refresh the packet"):
+            _settle_packet(
+                packet=packet,
+                action="approve",
+                reason="",
+                repo_root=tmp_path,
+                repo_override=None,
+                session_id="session-2",
+            )
 
     def test_build_command_renders_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
@@ -572,3 +737,17 @@ class TestCommandDispatch:
         assert payload["pr_number"] == 42
         assert payload["advisory_only"] is True
         assert payload["settlement_note"] == ADVISORY_NOTE
+
+    def test_act_command_requires_reason_for_request_changes(self) -> None:
+        ns = argparse.Namespace(
+            review_queue_command="act",
+            pr="42",
+            repo=None,
+            approve=False,
+            request_changes=True,
+            defer=False,
+            reason="",
+            json=False,
+        )
+        rc = cmd_review_queue(ns)
+        assert rc == 2

--- a/tests/cli/test_parser_lazy_review_pr.py
+++ b/tests/cli/test_parser_lazy_review_pr.py
@@ -68,3 +68,38 @@ def test_build_parser_keeps_triage_status_free_of_heavy_review_imports(monkeypat
     assert imported == []
     assert args.command == "triage"
     assert args.triage_command == "status"
+
+
+def test_build_parser_keeps_review_queue_runtime_lazy(monkeypatch):
+    sys.modules.pop("aragora.cli.commands.review_queue", None)
+    imported: list[str] = []
+    real_import = builtins.__import__
+
+    def tracking_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "aragora.cli.commands.review_queue":
+            imported.append(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", tracking_import)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "review-queue",
+            "act",
+            "6280",
+            "--request-changes",
+            "--reason",
+            "needs a test",
+            "--json",
+        ]
+    )
+
+    assert imported == []
+    assert args.command == "review-queue"
+    assert args.review_queue_command == "act"
+    assert args.pr == "6280"
+    assert args.request_changes is True
+    assert args.reason == "needs a test"
+    assert args.json_output is True
+    assert args.func.__name__ == "cmd_review_queue"


### PR DESCRIPTION
## Summary
- add `aragora review-queue run` and `aragora review-queue act` for explicit human approve/request-changes/defer actions
- persist founder-review receipts keyed to packet SHA and head SHA, with a freshness gate before any GitHub write
- keep the queue path lazy in the main CLI parser and leave `merge_arbiter` enforcement out of this slice

## Validation
- `python3 -m pytest -q tests/cli/commands/test_review_queue.py tests/cli/test_parser_lazy_review_pr.py`
- `python3 -m ruff check aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/cli/commands/test_review_queue.py tests/cli/test_parser_lazy_review_pr.py`
- `python3 -m aragora.cli.main review-queue build --limit 3 --json`
- `python3 -m aragora.cli.main review-queue packet 6293 --json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Scope notes
- no `merge_arbiter` changes
- no auto-merge path
- no queue autofill / broader autonomy work
- intended successor to the too-broad `#6286` control-path lane
