### PR TITLE
fix(automation): probe GitHub health with app auth

### DIFF
--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -57,6 +57,10 @@ def is_github_connectivity_error(message: str) -> bool:
     return any(token in lowered for token in CONNECTIVITY_ERROR_TOKENS)
 
 
+def _command_error(proc: subprocess.CompletedProcess[str], fallback: str) -> str:
+    return proc.stderr.strip() or proc.stdout.strip() or fallback
+
+
 def _run(args: list[str], *, cwd: Path, timeout_seconds: int) -> subprocess.CompletedProcess[str]:
     env = github_cli_env(os.environ) if args and args[0] == "gh" else None
     try:
@@ -93,10 +97,23 @@ def check_github_cli_health(
             repo=repo_label,
         )
 
+    api_proc = _run(["gh", "api", "rate_limit"], cwd=repo_root, timeout_seconds=timeout_seconds)
+    if api_proc.returncode == 0:
+        return GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=repo_label,
+        )
+
+    api_error = _command_error(api_proc, "gh api rate_limit failed")
     auth_proc = _run(["gh", "auth", "status"], cwd=repo_root, timeout_seconds=timeout_seconds)
     if auth_proc.returncode != 0:
-        error = auth_proc.stderr.strip() or auth_proc.stdout.strip() or "gh auth status failed"
-        mode = "connectivity_failed" if is_github_connectivity_error(error) else "auth_failed"
+        auth_error = _command_error(auth_proc, "gh auth status failed")
+        mode = "connectivity_failed" if is_github_connectivity_error(api_error) else "auth_failed"
+        error = api_error if mode == "connectivity_failed" else auth_error
         return GitHubCLIHealth(
             ready=False,
             auth_ok=False,
@@ -106,25 +123,13 @@ def check_github_cli_health(
             repo=repo_label,
         )
 
-    api_proc = _run(["gh", "api", "rate_limit"], cwd=repo_root, timeout_seconds=timeout_seconds)
-    if api_proc.returncode != 0:
-        error = api_proc.stderr.strip() or api_proc.stdout.strip() or "gh api rate_limit failed"
-        mode = "connectivity_failed" if is_github_connectivity_error(error) else "api_failed"
-        return GitHubCLIHealth(
-            ready=False,
-            auth_ok=True,
-            api_ok=False,
-            mode=mode,
-            error=error,
-            repo=repo_label,
-        )
-
+    mode = "connectivity_failed" if is_github_connectivity_error(api_error) else "api_failed"
     return GitHubCLIHealth(
-        ready=True,
+        ready=False,
         auth_ok=True,
-        api_ok=True,
-        mode="ready",
-        error="",
+        api_ok=False,
+        mode=mode,
+        error=api_error,
         repo=repo_label,
     )
 

--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -5,11 +5,24 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
+
+try:
+    from aragora.swarm.github_app_auth import github_cli_env
+except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
+
+    def github_cli_env(
+        base_env: dict[str, str] | None = None,
+        *,
+        prefer_app: bool = True,
+    ) -> dict[str, str]:
+        return dict(os.environ if base_env is None else base_env)
+
 
 DEFAULT_TIMEOUT_SECONDS = 20
 CONNECTIVITY_ERROR_TOKENS = (
@@ -45,6 +58,7 @@ def is_github_connectivity_error(message: str) -> bool:
 
 
 def _run(args: list[str], *, cwd: Path, timeout_seconds: int) -> subprocess.CompletedProcess[str]:
+    env = github_cli_env(os.environ) if args and args[0] == "gh" else None
     try:
         return subprocess.run(
             args,
@@ -53,6 +67,7 @@ def _run(args: list[str], *, cwd: Path, timeout_seconds: int) -> subprocess.Comp
             capture_output=True,
             check=False,
             timeout=timeout_seconds,
+            env=env,
         )
     except subprocess.TimeoutExpired as exc:
         stdout = exc.stdout if isinstance(exc.stdout, str) else ""

--- a/tests/scripts/test_github_cli_health.py
+++ b/tests/scripts/test_github_cli_health.py
@@ -6,6 +6,24 @@ from pathlib import Path
 import scripts.github_cli_health as mod
 
 
+def test_run_uses_github_cli_env_for_gh(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "github_cli_env", lambda env: {"GH_TOKEN": "app-token"})
+
+    captured: dict[str, object] = {}
+
+    def fake_subprocess_run(*args, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(
+            args=kwargs.get("args", args[0]), returncode=0, stdout="", stderr=""
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+
+    mod._run(["gh", "auth", "status"], cwd=Path("."), timeout_seconds=5)
+
+    assert captured["env"] == {"GH_TOKEN": "app-token"}
+
+
 def test_check_github_cli_health_ready(monkeypatch) -> None:
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 

--- a/tests/scripts/test_github_cli_health.py
+++ b/tests/scripts/test_github_cli_health.py
@@ -42,20 +42,53 @@ def test_check_github_cli_health_ready(monkeypatch) -> None:
     assert health.api_ok is True
 
 
+def test_check_github_cli_health_ready_with_app_env_auth_even_if_auth_status_is_stale(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
+
+    calls: list[list[str]] = []
+
+    def fake_run(
+        args: list[str], *, cwd: Path, timeout_seconds: int
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args[:3] == ["gh", "api", "rate_limit"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="ok", stderr="")
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=1,
+            stdout="",
+            stderr="the token in default is invalid",
+        )
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    health = mod.check_github_cli_health(Path("."))
+
+    assert health.ready is True
+    assert health.mode == "ready"
+    assert health.auth_ok is True
+    assert health.api_ok is True
+    assert calls == [["gh", "api", "rate_limit"]]
+
+
 def test_check_github_cli_health_detects_connectivity_failure(monkeypatch) -> None:
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 
     def fake_run(
         args: list[str], *, cwd: Path, timeout_seconds: int
     ) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "api", "rate_limit"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="error connecting to api.github.com",
+            )
         if args[:3] == ["gh", "auth", "status"]:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout="ok", stderr="")
-        return subprocess.CompletedProcess(
-            args=args,
-            returncode=1,
-            stdout="",
-            stderr="error connecting to api.github.com",
-        )
+        raise AssertionError(f"unexpected args: {args}")
 
     monkeypatch.setattr(mod, "_run", fake_run)
 
@@ -68,17 +101,66 @@ def test_check_github_cli_health_detects_connectivity_failure(monkeypatch) -> No
     assert mod.is_github_connectivity_error(health.error) is True
 
 
+def test_check_github_cli_health_prefers_connectivity_error_when_auth_status_is_stale(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
+
+    def fake_run(
+        args: list[str], *, cwd: Path, timeout_seconds: int
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "api", "rate_limit"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="error connecting to api.github.com",
+            )
+        if args[:3] == ["gh", "auth", "status"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="the token in default is invalid",
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    health = mod.check_github_cli_health(Path("."))
+
+    assert health.ready is False
+    assert health.mode == "connectivity_failed"
+    assert health.auth_ok is False
+    assert health.api_ok is False
+    assert health.error == "error connecting to api.github.com"
+
+
 def test_check_github_cli_health_detects_auth_failure(monkeypatch) -> None:
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 
     def fake_run(
         args: list[str], *, cwd: Path, timeout_seconds: int
     ) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "api", "rate_limit"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="HTTP 401: Requires authentication",
+            )
+        if args[:3] == ["gh", "auth", "status"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="You are not logged into any GitHub hosts. Run gh auth login.",
+            )
         return subprocess.CompletedProcess(
             args=args,
             returncode=1,
             stdout="",
-            stderr="You are not logged into any GitHub hosts. Run gh auth login.",
+            stderr="unexpected args",
         )
 
     monkeypatch.setattr(mod, "_run", fake_run)


### PR DESCRIPTION
## Summary
- make `scripts/github_cli_health.py` run `gh` with the repo's GitHub app auth helper when available
- prefer the live `gh api rate_limit` probe over stale `gh auth status` output, so automations treat real API reachability as authoritative
- keep the existing CLI contract and fallback behavior for partially bootstrapped contexts
- add regression tests for helper-provided auth env and the API-first ready path

## Why
Several automations were reporting `auth_failed` or `error connecting to api.github.com` from their own runtime while the installed publisher bridge and normal shells could still reach GitHub. The shared health probe was using raw `gh`, while the publisher scripts already use `github_cli_env(...)`. It also trusted `gh auth status` too early, which can report a stale invalid default token even when the actual API call succeeds under the app-auth environment. Aligning the health probe with the publisher auth path and preferring the live API probe removes two false-negative sources in automation-context health checks.

## Validation
- `python3 -m pytest -q tests/scripts/test_github_cli_health.py`
- `python3 -m ruff check scripts/github_cli_health.py tests/scripts/test_github_cli_health.py`
- `python3 scripts/github_cli_health.py --json`
- `cd /Users/armand/.codex/worktrees/37b3/aragora && python3 scripts/github_cli_health.py --json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
The live observer/shepherd automation configs were also updated outside the repo so they now run from `local` instead of `worktree` where appropriate, dual-probe the current cwd and canonical repo root, and distinguish `split-brain auth/context` and publisher `throttled` states from real GitHub degradation. Those runtime config changes are intentionally not part of this repo PR.
