### PR TITLE
fix(ci): cancel test-fast only on synchronize events (unblocks #6295, #6297)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ on:
 
 concurrency:
   group: tests-${{ github.event.pull_request.number || github.ref }}${{ startsWith(github.ref, 'refs/heads/dev/') && format('-{0}', github.sha) || '' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   # ============================================================


### PR DESCRIPTION
## Problem

Test-fast shards on #6295 and #6297 show sustained CANCELLED state (not FAILURE) across multiple runs. They never complete, so merge is blocked by "no green signal on current head" even though no test actually fails.

## Root cause

`.github/workflows/test.yml` concurrency config:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

This cancels in-progress runs on ANY `pull_request` event — including non-code events like:
- `ready_for_review` (draft toggle)
- `labeled` / `unlabeled`
- `reopened`
- merge-arbiter rebases, review submissions, etc.

With 4+ active Codex automation lanes causing frequent PR event churn, the cancellation window is small enough that test-fast shards (~5min) rarely finish.

## Fix

Narrow cancellation to `synchronize` events only (new commits). Non-code events let in-progress runs complete naturally.

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
```

## Blast radius

- Same SHA with non-synchronize events: new run queues, doesn't cancel in-progress — wasteful re-run possible but safe
- Same PR new commit: cancellation works as before
- Scheduled runs / workflow_dispatch: unchanged (cancel-in-progress remains false for those)
- 20 other workflows use the identical pattern; this PR only touches test.yml to verify the approach. Follow-up if the fix works.

## Verification after merge

On the next `synchronize` event to #6295 or #6297, test-fast shards should complete. If CANCELLED persists, there's a different cause and follow-up diagnosis is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)