### PR TITLE
fix(automation): tune publisher throughput and launchd tooling

### DIFF
--- a/scripts/install_codex_automation_publisher_launchd.sh
+++ b/scripts/install_codex_automation_publisher_launchd.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 LABEL="com.aragora.codex-automation-publisher"
+LAUNCHD_DOMAIN="gui/$(id -u)"
 INTERVAL_SECONDS=300
 LOG_PATH="${REPO_ROOT}/.aragora/overnight/codex-automation-publisher.log"
 
@@ -77,10 +78,13 @@ cat >"${PLIST_PATH}" <<EOF
 </plist>
 EOF
 
-launchctl unload "${PLIST_PATH}" >/dev/null 2>&1 || true
-launchctl load "${PLIST_PATH}"
+launchctl bootout "${LAUNCHD_DOMAIN}" "${PLIST_PATH}" >/dev/null 2>&1 || true
+launchctl bootstrap "${LAUNCHD_DOMAIN}" "${PLIST_PATH}"
+launchctl kickstart -k "${LAUNCHD_DOMAIN}/${LABEL}" >/dev/null 2>&1 || true
 
 echo "Installed launchd job: ${LABEL}"
 echo "Plist: ${PLIST_PATH}"
 echo "Interval: ${INTERVAL_SECONDS}s"
 echo "Log: ${LOG_PATH}"
+echo "--- launchctl ---"
+launchctl print "${LAUNCHD_DOMAIN}/${LABEL}" | sed -n '1,20p'

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -5,6 +5,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOCK_DIR="${TMPDIR:-/tmp}/com.aragora.codex-automation-publisher.lock"
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+HANDOFF_LIMIT="${ARAGORA_AUTOMATION_HANDOFF_LIMIT:-2}"
+MAX_OPEN_ISSUES="${ARAGORA_AUTOMATION_MAX_OPEN_ISSUES:-16}"
+BRANCH_LIMIT="${ARAGORA_AUTOMATION_BRANCH_PUBLISH_LIMIT:-2}"
+MAX_OPEN_PRS="${ARAGORA_AUTOMATION_MAX_OPEN_PRS:-16}"
+BRANCH_SCAN_LIMIT="${ARAGORA_AUTOMATION_BRANCH_SCAN_LIMIT:-40}"
 STAMP() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
@@ -47,7 +52,11 @@ if ! git fetch --no-write-fetch-head --prune origin '+refs/heads/*:refs/remotes/
 fi
 
 echo "$(STAMP) [codex-automation-publisher] starting handoff publish pass"
-if python3 scripts/publish_automation_handoffs.py --apply --limit 1 --max-open-issues 12 --json; then
+if python3 scripts/publish_automation_handoffs.py \
+  --apply \
+  --limit "${HANDOFF_LIMIT}" \
+  --max-open-issues "${MAX_OPEN_ISSUES}" \
+  --json; then
   echo "$(STAMP) [codex-automation-publisher] handoff publish pass complete"
 else
   echo "$(STAMP) [codex-automation-publisher] handoff publish pass failed; continuing"
@@ -57,8 +66,9 @@ echo "$(STAMP) [codex-automation-publisher] starting branch publish pass"
 if python3 scripts/publish_codex_automation_branches.py \
   --base origin/main \
   --apply \
-  --limit 1 \
-  --max-open-prs 1 \
+  --limit "${BRANCH_LIMIT}" \
+  --max-open-prs "${MAX_OPEN_PRS}" \
+  --scan-limit "${BRANCH_SCAN_LIMIT}" \
   --json; then
   echo "$(STAMP) [codex-automation-publisher] branch publish pass complete"
 else

--- a/scripts/status_codex_automation_publisher_launchd.sh
+++ b/scripts/status_codex_automation_publisher_launchd.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 LABEL="com.aragora.codex-automation-publisher"
+LAUNCHD_DOMAIN="gui/$(id -u)"
 PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
 
 if [[ -f "${PLIST_PATH}" ]]; then
@@ -13,4 +14,4 @@ else
 fi
 
 echo "--- launchctl ---"
-launchctl list | grep "${LABEL}" || echo "job not loaded"
+launchctl print "${LAUNCHD_DOMAIN}/${LABEL}" 2>/dev/null | sed -n '1,20p' || echo "job not loaded"

--- a/scripts/uninstall_codex_automation_publisher_launchd.sh
+++ b/scripts/uninstall_codex_automation_publisher_launchd.sh
@@ -4,9 +4,10 @@
 set -euo pipefail
 
 LABEL="com.aragora.codex-automation-publisher"
+LAUNCHD_DOMAIN="gui/$(id -u)"
 PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
 
-launchctl unload "${PLIST_PATH}" >/dev/null 2>&1 || true
+launchctl bootout "${LAUNCHD_DOMAIN}" "${PLIST_PATH}" >/dev/null 2>&1 || true
 rm -f "${PLIST_PATH}"
 
 echo "Removed launchd job: ${LABEL}"


### PR DESCRIPTION
## Summary
- switch the launchd installer/status/uninstaller to the `launchctl bootstrap/bootout/print` flow that matches modern macOS behavior
- make the status script report the actual `gui/$UID` job state instead of the misleading `launchctl list | grep` result
- raise the automation publisher caps moderately and make them env-overridable
  - handoff limit `1 -> 2`
  - max open issues `12 -> 16`
  - branch publish limit `1 -> 2`
  - max open PRs `1 -> 16`
  - branch scan limit `12 -> 40`

## Why
Over the last 8 hours, the main throughput choke point was the publisher bridge, not lack of candidate work. The bridge was repeatedly showing `open_pr_count` well above the hardcoded `max_open_prs=1`, so it stayed permanently throttled. At the same time, the existing status script was incorrectly reporting `job not loaded` even when `launchctl print gui/$UID/...` showed the job running, which made diagnosis noisy.

## Validation
- `bash -n scripts/install_codex_automation_publisher_launchd.sh scripts/status_codex_automation_publisher_launchd.sh scripts/uninstall_codex_automation_publisher_launchd.sh scripts/run_codex_automation_publisher.sh`
- `bash scripts/status_codex_automation_publisher_launchd.sh`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Live operational context
Outside this PR, I also reloaded the live LaunchAgent from a normal shell and verified the job is running again via `launchctl print gui/501/com.aragora.codex-automation-publisher`. I updated the live automation configs so the writer/scout/steward lanes now suppress repeated unchanged-state reports and use slightly higher scout/writer suppression thresholds.
