### PR TITLE
[DIC-26] Belief Coherence Monitor skeleton

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -8,6 +8,8 @@ Exposes:
   :func:`propose_followup_for_failed_claim`)
 - DIC-20: epistemic decay monitor (:class:`DecaySignal`,
   :class:`DecayReason`, :func:`evaluate_unit`)
+- DIC-26: belief coherence monitor (:class:`BeliefEntry`,
+  :class:`CoherenceReport`, :func:`scan_coherence`)
 
 See ``docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md`` for the full
 DIC-13..22 sequence and ``docs/status/NEXT_STEPS_CANONICAL.md`` for
@@ -19,6 +21,15 @@ from __future__ import annotations
 import os
 
 from .claim_verifier import ClaimResult, ClaimStatus, ClaimVerifier
+from .coherence import (
+    BeliefEntry,
+    CoherenceIssue,
+    CoherenceReport,
+    IncoherenceKind,
+    coherence_monitor_enabled,
+    from_belief_node,
+    scan_coherence,
+)
 from .decay_monitor import DecayReason, DecaySignal, evaluate_unit
 from .followup import (
     DEFAULT_CRUX_LOAD_BEARING_THRESHOLD,
@@ -30,20 +41,27 @@ from .followup import (
 )
 
 __all__ = [
+    "BeliefEntry",
     "ClaimResult",
     "ClaimStatus",
     "ClaimVerifier",
+    "CoherenceIssue",
+    "CoherenceReport",
     "DEFAULT_CRUX_LOAD_BEARING_THRESHOLD",
     "DEFAULT_DELTA_LOSS_THRESHOLD",
     "DecayReason",
     "DecaySignal",
     "FollowupProposal",
+    "IncoherenceKind",
+    "coherence_monitor_enabled",
     "enable_epistemic_followup",
     "epistemic_followup_enabled",
     "evaluate_unit",
+    "from_belief_node",
     "propose_followup_for_crux",
     "propose_followup_for_cruxset",
     "propose_followup_for_failed_claim",
+    "scan_coherence",
 ]
 
 

--- a/aragora/epistemic/coherence.py
+++ b/aragora/epistemic/coherence.py
@@ -1,0 +1,210 @@
+"""Belief Coherence Monitor (DIC-26 / #6220).
+
+Scans a belief ledger for systemic incoherence — contradictions, evidence
+conflicts, and confidence rot — without triggering repair or queue writes.
+
+Default: **OFF**. Set ``ARAGORA_COHERENCE_MONITOR_ENABLED=1`` to enable.
+Pure function — no queue mutation, no issue creation, no dispatch changes.
+Activation gate: same proof-first Foreman gate as DIC-23..28.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_PASSING = frozenset({"pass", "unsupported"})
+_FAILING = frozenset({"fail", "stale", "error", "contested"})
+_DEFAULT_CONTRADICTION_GAP: float = 0.5
+_DEFAULT_MIN_CONFIDENCE: float = 0.3
+
+
+class IncoherenceKind(str, Enum):
+    CONTRADICTION = "contradiction"
+    EVIDENCE_CONFLICT = "evidence_conflict"
+    CONFIDENCE_ROT = "confidence_rot"
+
+
+@dataclass(frozen=True)
+class BeliefEntry:
+    """Flattened belief record for coherence scanning."""
+
+    belief_id: str
+    subject: str
+    confidence: float
+    status: str = "unknown"
+    evidence_paths: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(f"confidence must be in [0, 1], got {self.confidence}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "belief_id": self.belief_id,
+            "subject": self.subject,
+            "confidence": self.confidence,
+            "status": self.status,
+            "evidence_paths": list(self.evidence_paths),
+        }
+
+
+@dataclass(frozen=True)
+class CoherenceIssue:
+    kind: IncoherenceKind
+    belief_ids: tuple[str, ...]
+    detail: str
+    severity: str = "warning"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "belief_ids": list(self.belief_ids),
+            "detail": self.detail,
+            "severity": self.severity,
+        }
+
+
+@dataclass
+class CoherenceReport:
+    scanned: int
+    issues: list[CoherenceIssue] = field(default_factory=list)
+    enabled: bool = True
+
+    @property
+    def coherent(self) -> bool:
+        return not self.issues
+
+    @property
+    def contradiction_count(self) -> int:
+        return sum(1 for i in self.issues if i.kind == IncoherenceKind.CONTRADICTION)
+
+    @property
+    def evidence_conflict_count(self) -> int:
+        return sum(1 for i in self.issues if i.kind == IncoherenceKind.EVIDENCE_CONFLICT)
+
+    @property
+    def confidence_rot_count(self) -> int:
+        return sum(1 for i in self.issues if i.kind == IncoherenceKind.CONFIDENCE_ROT)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scanned": self.scanned,
+            "coherent": self.coherent,
+            "issue_count": len(self.issues),
+            "contradiction_count": self.contradiction_count,
+            "evidence_conflict_count": self.evidence_conflict_count,
+            "confidence_rot_count": self.confidence_rot_count,
+            "issues": [i.to_dict() for i in self.issues],
+            "enabled": self.enabled,
+        }
+
+
+def coherence_monitor_enabled() -> bool:
+    """Return True when ``ARAGORA_COHERENCE_MONITOR_ENABLED`` is truthy."""
+    raw = str(os.environ.get("ARAGORA_COHERENCE_MONITOR_ENABLED") or "").strip().lower()
+    return raw in _TRUTHY
+
+
+def _detect_contradictions(entries: list[BeliefEntry], gap: float) -> list[CoherenceIssue]:
+    by_subject: dict[str, list[BeliefEntry]] = {}
+    for e in entries:
+        by_subject.setdefault(e.subject, []).append(e)
+    issues: list[CoherenceIssue] = []
+    for subject, group in by_subject.items():
+        if len(group) < 2:
+            continue
+        high = [e for e in group if e.confidence >= 1.0 - gap]
+        low = [e for e in group if e.confidence <= gap]
+        if not (high and low):
+            continue
+        ids = tuple(e.belief_id for e in high + low)
+        hi_s = ", ".join(f"{e.belief_id}({e.confidence:.2f})" for e in high)
+        lo_s = ", ".join(f"{e.belief_id}({e.confidence:.2f})" for e in low)
+        issues.append(CoherenceIssue(
+            kind=IncoherenceKind.CONTRADICTION,
+            belief_ids=ids,
+            detail=f"Subject {subject!r}: high [{hi_s}] contradicts low [{lo_s}].",
+            severity="error",
+        ))
+    return issues
+
+
+def _detect_evidence_conflicts(entries: list[BeliefEntry]) -> list[CoherenceIssue]:
+    path_map: dict[str, list[BeliefEntry]] = {}
+    for e in entries:
+        for path in e.evidence_paths:
+            path_map.setdefault(path, []).append(e)
+    issues: list[CoherenceIssue] = []
+    for path, group in path_map.items():
+        if len(group) < 2:
+            continue
+        statuses = {e.status for e in group}
+        if statuses & _PASSING and statuses & _FAILING:
+            ids = tuple(e.belief_id for e in group)
+            issues.append(CoherenceIssue(
+                kind=IncoherenceKind.EVIDENCE_CONFLICT,
+                belief_ids=ids,
+                detail=(
+                    f"Evidence {path!r} cited by {len(ids)} beliefs with "
+                    f"conflicting outcomes: {sorted(statuses)}."
+                ),
+                severity="warning",
+            ))
+    return issues
+
+
+def _detect_confidence_rot(
+    entries: list[BeliefEntry], min_confidence: float
+) -> list[CoherenceIssue]:
+    issues: list[CoherenceIssue] = []
+    for e in entries:
+        if e.confidence < min_confidence:
+            severity = "error" if e.confidence < min_confidence / 2 else "warning"
+            issues.append(CoherenceIssue(
+                kind=IncoherenceKind.CONFIDENCE_ROT,
+                belief_ids=(e.belief_id,),
+                detail=(
+                    f"Belief {e.belief_id!r} confidence {e.confidence:.2f} "
+                    f"below minimum {min_confidence:.2f}."
+                ),
+                severity=severity,
+            ))
+    return issues
+
+
+def scan_coherence(
+    entries: list[BeliefEntry],
+    *,
+    contradiction_gap: float = _DEFAULT_CONTRADICTION_GAP,
+    min_confidence: float = _DEFAULT_MIN_CONFIDENCE,
+    enabled: bool | None = None,
+) -> CoherenceReport:
+    """Scan a belief ledger for contradiction, evidence conflict, and rot."""
+    if enabled is None:
+        enabled = coherence_monitor_enabled()
+    if not enabled:
+        return CoherenceReport(scanned=len(entries), issues=[], enabled=False)
+    issues: list[CoherenceIssue] = []
+    issues.extend(_detect_contradictions(entries, contradiction_gap))
+    issues.extend(_detect_evidence_conflicts(entries))
+    issues.extend(_detect_confidence_rot(entries, min_confidence))
+    return CoherenceReport(scanned=len(entries), issues=issues, enabled=True)
+
+
+def from_belief_node(node: Any) -> BeliefEntry:
+    """Extract a :class:`BeliefEntry` from a ``BeliefNode`` (duck-typed)."""
+    status = getattr(getattr(node, "status", None), "value", "unknown")
+    posterior = getattr(node, "posterior", None)
+    confidence = float(getattr(posterior, "p_true", 0.5))
+    evidence_paths = tuple(str(p) for p in getattr(node, "evidence_paths", []))
+    return BeliefEntry(
+        belief_id=str(getattr(node, "belief_id", "")),
+        subject=str(getattr(node, "claim_id", "")),
+        confidence=confidence,
+        status=status,
+        evidence_paths=evidence_paths,
+    )

--- a/aragora/epistemic/coherence.py
+++ b/aragora/epistemic/coherence.py
@@ -124,12 +124,14 @@ def _detect_contradictions(entries: list[BeliefEntry], gap: float) -> list[Coher
         ids = tuple(e.belief_id for e in high + low)
         hi_s = ", ".join(f"{e.belief_id}({e.confidence:.2f})" for e in high)
         lo_s = ", ".join(f"{e.belief_id}({e.confidence:.2f})" for e in low)
-        issues.append(CoherenceIssue(
-            kind=IncoherenceKind.CONTRADICTION,
-            belief_ids=ids,
-            detail=f"Subject {subject!r}: high [{hi_s}] contradicts low [{lo_s}].",
-            severity="error",
-        ))
+        issues.append(
+            CoherenceIssue(
+                kind=IncoherenceKind.CONTRADICTION,
+                belief_ids=ids,
+                detail=f"Subject {subject!r}: high [{hi_s}] contradicts low [{lo_s}].",
+                severity="error",
+            )
+        )
     return issues
 
 
@@ -145,15 +147,17 @@ def _detect_evidence_conflicts(entries: list[BeliefEntry]) -> list[CoherenceIssu
         statuses = {e.status for e in group}
         if statuses & _PASSING and statuses & _FAILING:
             ids = tuple(e.belief_id for e in group)
-            issues.append(CoherenceIssue(
-                kind=IncoherenceKind.EVIDENCE_CONFLICT,
-                belief_ids=ids,
-                detail=(
-                    f"Evidence {path!r} cited by {len(ids)} beliefs with "
-                    f"conflicting outcomes: {sorted(statuses)}."
-                ),
-                severity="warning",
-            ))
+            issues.append(
+                CoherenceIssue(
+                    kind=IncoherenceKind.EVIDENCE_CONFLICT,
+                    belief_ids=ids,
+                    detail=(
+                        f"Evidence {path!r} cited by {len(ids)} beliefs with "
+                        f"conflicting outcomes: {sorted(statuses)}."
+                    ),
+                    severity="warning",
+                )
+            )
     return issues
 
 
@@ -164,15 +168,17 @@ def _detect_confidence_rot(
     for e in entries:
         if e.confidence < min_confidence:
             severity = "error" if e.confidence < min_confidence / 2 else "warning"
-            issues.append(CoherenceIssue(
-                kind=IncoherenceKind.CONFIDENCE_ROT,
-                belief_ids=(e.belief_id,),
-                detail=(
-                    f"Belief {e.belief_id!r} confidence {e.confidence:.2f} "
-                    f"below minimum {min_confidence:.2f}."
-                ),
-                severity=severity,
-            ))
+            issues.append(
+                CoherenceIssue(
+                    kind=IncoherenceKind.CONFIDENCE_ROT,
+                    belief_ids=(e.belief_id,),
+                    detail=(
+                        f"Belief {e.belief_id!r} confidence {e.confidence:.2f} "
+                        f"below minimum {min_confidence:.2f}."
+                    ),
+                    severity=severity,
+                )
+            )
     return issues
 
 

--- a/tests/epistemic/test_coherence.py
+++ b/tests/epistemic/test_coherence.py
@@ -1,0 +1,163 @@
+"""Unit tests for DIC-26 coherence monitor (aragora.epistemic.coherence)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.coherence import (
+    BeliefEntry,
+    CoherenceIssue,
+    CoherenceReport,
+    IncoherenceKind,
+    coherence_monitor_enabled,
+    from_belief_node,
+    scan_coherence,
+)
+
+
+def _e(
+    bid: str,
+    subject: str = "claim.default",
+    confidence: float = 0.8,
+    status: str = "pass",
+    evidence_paths: tuple[str, ...] = (),
+) -> BeliefEntry:
+    return BeliefEntry(bid, subject, confidence, status, evidence_paths)
+
+
+# --- flag gate ---
+
+
+def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ARAGORA_COHERENCE_MONITOR_ENABLED", raising=False)
+    assert not coherence_monitor_enabled()
+
+
+def test_enabled_by_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    for val in ("1", "true", "yes", "on"):
+        monkeypatch.setenv("ARAGORA_COHERENCE_MONITOR_ENABLED", val)
+        assert coherence_monitor_enabled()
+
+
+def test_disabled_returns_empty_report() -> None:
+    report = scan_coherence([_e("b1")], enabled=False)
+    assert report.enabled is False and report.scanned == 1 and report.coherent
+
+
+def test_enabled_kwarg_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ARAGORA_COHERENCE_MONITOR_ENABLED", raising=False)
+    assert scan_coherence([], enabled=True).enabled is True
+
+
+# --- empty / single ---
+
+
+def test_empty_ledger_is_coherent() -> None:
+    report = scan_coherence([], enabled=True)
+    assert report.coherent and report.scanned == 0 and report.to_dict()["issue_count"] == 0
+
+
+def test_single_entry_no_issues() -> None:
+    assert scan_coherence([_e("b1")], enabled=True).coherent
+
+
+# --- contradiction ---
+
+
+def test_contradiction_opposing_confidence() -> None:
+    hi = _e("b-hi", subject="claim.x", confidence=0.95)
+    lo = _e("b-lo", subject="claim.x", confidence=0.05)
+    report = scan_coherence([hi, lo], enabled=True)
+    assert report.contradiction_count == 1
+    issue = next(i for i in report.issues if i.kind == IncoherenceKind.CONTRADICTION)
+    assert "b-hi" in issue.belief_ids and "b-lo" in issue.belief_ids
+    assert issue.severity == "error"
+
+
+def test_no_contradiction_consistent_or_different_subjects() -> None:
+    # same subject, both high confidence → no contradiction
+    a = _e("b-a", subject="claim.y", confidence=0.8)
+    b = _e("b-b", subject="claim.y", confidence=0.75)
+    assert scan_coherence([a, b], enabled=True).contradiction_count == 0
+    # different subjects, one high one low → no contradiction
+    hi = _e("b1", subject="alpha", confidence=0.95)
+    lo = _e("b2", subject="beta", confidence=0.05)
+    assert scan_coherence([hi, lo], enabled=True).contradiction_count == 0
+
+
+# --- evidence conflict ---
+
+
+def test_evidence_conflict_mixed_outcomes() -> None:
+    passing = _e("b-pass", status="pass", evidence_paths=("docs/status/foo.md",))
+    failing = _e("b-fail", status="fail", evidence_paths=("docs/status/foo.md",))
+    report = scan_coherence([passing, failing], enabled=True)
+    assert report.evidence_conflict_count >= 1
+    issue = next(i for i in report.issues if i.kind == IncoherenceKind.EVIDENCE_CONFLICT)
+    assert "b-pass" in issue.belief_ids and "b-fail" in issue.belief_ids
+
+
+def test_no_conflict_consistent_evidence() -> None:
+    a = _e("b-a", status="pass", evidence_paths=("docs/status/bar.md",))
+    b = _e("b-b", status="pass", evidence_paths=("docs/status/bar.md",))
+    assert scan_coherence([a, b], enabled=True).evidence_conflict_count == 0
+
+
+# --- confidence rot ---
+
+
+def test_confidence_rot_below_threshold() -> None:
+    low = _e("b-low", confidence=0.1)
+    report = scan_coherence([low], min_confidence=0.3, enabled=True)
+    rot = [i for i in report.issues if i.kind == IncoherenceKind.CONFIDENCE_ROT]
+    assert len(rot) == 1 and rot[0].belief_ids == ("b-low",)
+
+
+def test_no_rot_above_threshold_and_error_severity_below_half() -> None:
+    ok = _e("b-ok", confidence=0.8)
+    assert scan_coherence([ok], min_confidence=0.3, enabled=True).confidence_rot_count == 0
+    very_low = _e("b-vl", confidence=0.05)
+    report = scan_coherence([very_low], min_confidence=0.3, enabled=True)
+    rot = next(i for i in report.issues if i.kind == IncoherenceKind.CONFIDENCE_ROT)
+    assert rot.severity == "error"
+
+
+# --- aggregate + serialisation ---
+
+
+def test_report_not_coherent_with_issues() -> None:
+    hi = _e("b-hi", subject="s", confidence=0.95)
+    lo = _e("b-lo", subject="s", confidence=0.05)
+    report = scan_coherence([hi, lo], enabled=True)
+    assert not report.coherent and report.contradiction_count >= 1
+
+
+def test_coherence_issue_to_dict() -> None:
+    issue = CoherenceIssue(IncoherenceKind.CONTRADICTION, ("a", "b"), "test", "error")
+    d = issue.to_dict()
+    assert d["kind"] == "contradiction" and d["belief_ids"] == ["a", "b"] and d["severity"] == "error"
+
+
+def test_belief_entry_invalid_confidence() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        BeliefEntry("b", "s", confidence=1.5)
+
+
+def test_from_belief_node_duck_type() -> None:
+    class _P:
+        p_true = 0.72
+
+    class _S:
+        value = "updated"
+
+    class _N:
+        belief_id = "node-001"
+        claim_id = "claim.abc"
+        status = _S()
+        posterior = _P()
+        evidence_paths = ["docs/status/abc.md"]
+
+    entry = from_belief_node(_N())
+    assert entry.belief_id == "node-001"
+    assert abs(entry.confidence - 0.72) < 1e-6
+    assert entry.evidence_paths == ("docs/status/abc.md",)

--- a/tests/epistemic/test_coherence.py
+++ b/tests/epistemic/test_coherence.py
@@ -135,7 +135,9 @@ def test_report_not_coherent_with_issues() -> None:
 def test_coherence_issue_to_dict() -> None:
     issue = CoherenceIssue(IncoherenceKind.CONTRADICTION, ("a", "b"), "test", "error")
     d = issue.to_dict()
-    assert d["kind"] == "contradiction" and d["belief_ids"] == ["a", "b"] and d["severity"] == "error"
+    assert (
+        d["kind"] == "contradiction" and d["belief_ids"] == ["a", "b"] and d["severity"] == "error"
+    )
 
 
 def test_belief_entry_invalid_confidence() -> None:


### PR DESCRIPTION
## Slice

Adds `aragora/epistemic/coherence.py` — a pure, flag-gated scanner that detects three classes of systemic incoherence across a belief ledger (contradiction, evidence conflict, confidence rot) without touching any live queue path. Exports wired into `aragora/epistemic/__init__.py`.

## Gating

- Default: **OFF** (flag: `ARAGORA_COHERENCE_MONITOR_ENABLED`; pass `enabled=True` in tests)
- Live queue effect: **none** — `scan_coherence` is a pure function; no issue creation, no queue mutation, no dispatch changes
- Advances issue: #6220 (DIC-26 Belief Coherence Monitor)
- Activation gate: same proof-first Foreman gate as DIC-23..28 dialectical-runtime-synthesis layer; blocked until DIC-20/21/22 are production-green

## Tests

`tests/epistemic/test_coherence.py` — 16 cases covering:
- **Flag gate**: disabled by default; env-var truthy values (`1`/`true`/`yes`/`on`); `enabled=` kwarg override; disabled report is empty and coherent
- **Empty / single entry**: empty ledger is coherent; single entry has no issues
- **Contradiction**: same-subject opposing-confidence pair flagged as `error`; consistent confidence and different subjects produce no contradiction
- **Evidence conflict**: shared evidence path with mixed pass/fail outcomes flagged; consistent outcomes are clean
- **Confidence rot**: confidence below threshold flagged; above threshold is clean; severity `error` when below half-threshold
- **Aggregate + serialisation**: `coherent` property, `CoherenceIssue.to_dict()`, invalid confidence raises `ValueError`, `from_belief_node` duck-typed bridge

## Validation

- `python3 -c "..."` — 16 inline behavioral assertions **PASSED**
- `ruff check aragora/epistemic/coherence.py tests/epistemic/test_coherence.py aragora/epistemic/__init__.py` — **clean**
- `mypy aragora/epistemic/coherence.py aragora/epistemic/__init__.py --ignore-missing-imports` — **clean**
- Net diff: **305 LOC** (176 module + 111 tests + 18 `__init__.py` additions)

## Out of scope

- Wiring `scan_coherence` into the DIC-23 dialectical runtime loop — depends on DIC-23 orchestrator landing first
- `BeliefNetwork` live integration (the `from_belief_node` bridge covers duck-typed extraction; full KM adapter is a follow-on)
- DIC-27 (Operator Crux Arbitration) — human resolution of persistent cruxes; deferred to next vision-incubator run
- `ARAGORA_COHERENCE_MONITOR_ENABLED=true` being set anywhere in production config — callers must opt in explicitly