### PR TITLE
fix(automation): raise publisher git timeout

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -30,7 +30,7 @@ DEFAULT_SINCE_HOURS = 72
 DEFAULT_PUBLISH_LIMIT = 1
 DEFAULT_MAX_OPEN_PRS = 1
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
-DEFAULT_GIT_TIMEOUT_SECONDS = 15
+DEFAULT_GIT_TIMEOUT_SECONDS = 60
 DEFAULT_SCAN_LIMIT = 12
 CODEX_BRANCH_PREFIX = "codex/"
 DEFAULT_PREFLIGHT_SCRIPT = "scripts/automation_pr_preflight.sh"
@@ -116,9 +116,20 @@ def _run(
     check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     env = github_cli_env(os.environ) if args and args[0] == "gh" else None
-    timeout = (
-        DEFAULT_COMMAND_TIMEOUT_SECONDS if args and args[0] == "gh" else DEFAULT_GIT_TIMEOUT_SECONDS
-    )
+    if args and args[0] == "gh":
+        timeout = int(
+            os.environ.get(
+                "ARAGORA_AUTOMATION_GH_TIMEOUT_SECONDS",
+                str(DEFAULT_COMMAND_TIMEOUT_SECONDS),
+            )
+        )
+    else:
+        timeout = int(
+            os.environ.get(
+                "ARAGORA_AUTOMATION_GIT_TIMEOUT_SECONDS",
+                str(DEFAULT_GIT_TIMEOUT_SECONDS),
+            )
+        )
     try:
         return subprocess.run(
             args,

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -199,6 +199,22 @@ def test_open_pr_heads_counts_only_codex_branches(monkeypatch: Any, tmp_path: Pa
     }
 
 
+def test_run_uses_env_overrides_for_git_timeout(monkeypatch: Any, tmp_path: Path) -> None:
+    recorded: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        recorded["timeout"] = kwargs["timeout"]
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setenv("ARAGORA_AUTOMATION_GIT_TIMEOUT_SECONDS", "90")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = mod._run(["git", "status"], cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert recorded["timeout"] == 90
+
+
 def test_worktree_is_dirty_ignores_untracked_files(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- raise the branch publisher git timeout from 15s to 60s
- allow git/gh timeout overrides via environment for automation tuning
- add a regression test for the git timeout override path

## Validation
- python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py
- python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
