### PR TITLE
fix(automation): skip repo-wide mypy on publish

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -34,6 +34,7 @@ DEFAULT_GIT_TIMEOUT_SECONDS = 60
 DEFAULT_SCAN_LIMIT = 12
 CODEX_BRANCH_PREFIX = "codex/"
 DEFAULT_PREFLIGHT_SCRIPT = "scripts/automation_pr_preflight.sh"
+DEFAULT_PRE_PUSH_SKIP_HOOKS = "mypy-baseline"
 STOPWORDS = {
     "and",
     "are",
@@ -114,8 +115,12 @@ def _run(
     *,
     cwd: Path,
     check: bool = False,
+    env_overrides: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = github_cli_env(os.environ) if args and args[0] == "gh" else None
+    if env_overrides:
+        env = dict(os.environ if env is None else env)
+        env.update(env_overrides)
     if args and args[0] == "gh":
         timeout = int(
             os.environ.get(
@@ -510,13 +515,29 @@ def _github_base_ref(base: str) -> str:
     return base.removeprefix("origin/")
 
 
+def _merge_skip_hooks(existing: str | None, additions: str) -> str:
+    merged: list[str] = []
+    for raw in (existing or "").split(",") + additions.split(","):
+        hook_id = raw.strip()
+        if hook_id and hook_id not in merged:
+            merged.append(hook_id)
+    return ",".join(merged)
+
+
 def _push_branch(repo_root: Path, branch: str, upstream: str | None) -> None:
     args = ["git", "push"]
     if upstream:
         args.extend(["origin", branch])
     else:
         args.extend(["-u", "origin", branch])
-    proc = _run(args, cwd=repo_root)
+    pre_push_skip = os.environ.get(
+        "ARAGORA_AUTOMATION_PRE_PUSH_SKIP",
+        DEFAULT_PRE_PUSH_SKIP_HOOKS,
+    ).strip()
+    env_overrides = None
+    if pre_push_skip:
+        env_overrides = {"SKIP": _merge_skip_hooks(os.environ.get("SKIP"), pre_push_skip)}
+    proc = _run(args, cwd=repo_root, env_overrides=env_overrides)
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or f"failed to push {branch}")
 

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -215,6 +215,30 @@ def test_run_uses_env_overrides_for_git_timeout(monkeypatch: Any, tmp_path: Path
     assert recorded["timeout"] == 90
 
 
+def test_push_branch_skips_only_configured_pre_push_hooks(monkeypatch: Any, tmp_path: Path) -> None:
+    recorded: dict[str, Any] = {}
+
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        check: bool = False,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        recorded["args"] = args
+        recorded["env_overrides"] = env_overrides
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setenv("SKIP", "gitleaks")
+    monkeypatch.setenv("ARAGORA_AUTOMATION_PRE_PUSH_SKIP", "mypy-baseline")
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    mod._push_branch(tmp_path, "codex/test-branch", "origin/main")
+
+    assert recorded["args"] == ["git", "push", "origin", "codex/test-branch"]
+    assert recorded["env_overrides"] == {"SKIP": "gitleaks,mypy-baseline"}
+
+
 def test_worktree_is_dirty_ignores_untracked_files(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- skip only the repo-wide pre-push mypy hook during automation branch publication
- preserve any existing SKIP hooks instead of overwriting them
- add regression coverage for the targeted SKIP env passed to git push

## Validation
- python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py
- python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
