### PR TITLE
fix(automation): use user auth for GitHub writes

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -76,7 +76,7 @@ STOPWORDS = {
 }
 
 try:
-    from aragora.swarm.github_app_auth import github_cli_env
+    from aragora.swarm.github_app_auth import gh_subprocess_run, github_cli_env
 except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
 
     def github_cli_env(
@@ -85,6 +85,25 @@ except Exception:  # pragma: no cover - fallback for partially bootstrapped scri
         prefer_app: bool = True,
     ) -> dict[str, str]:
         return dict(os.environ if base_env is None else base_env)
+
+    def gh_subprocess_run(
+        args: list[str],
+        *,
+        timeout: float = 30.0,
+        prefer_app: bool = True,
+        write_op: bool = False,
+        env: dict[str, str] | None = None,
+        max_retries: int = 0,
+    ) -> subprocess.CompletedProcess[str]:
+        del prefer_app, write_op, max_retries
+        return subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=dict(os.environ if env is None else env),
+            check=False,
+        )
 
 
 @dataclass(frozen=True)
@@ -108,8 +127,25 @@ class PublishDecision:
     created_issue_url: str | None = None
 
 
+def _gh_write_op(args: list[str]) -> bool:
+    return len(args) >= 2 and (args[0], args[1]) in {
+        ("issue", "create"),
+        ("issue", "edit"),
+        ("issue", "comment"),
+    }
+
+
 def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
     env = github_cli_env(os.environ) if args and args[0] == "gh" else None
+    if args and args[0] == "gh":
+        return gh_subprocess_run(
+            args[1:],
+            timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+            prefer_app=True,
+            write_op=_gh_write_op(args[1:]),
+            env=dict(os.environ if env is None else env),
+            max_retries=0,
+        )
     try:
         return subprocess.run(
             args,

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -67,7 +67,7 @@ ACTIVE_SESSION_FILES = (
 )
 
 try:
-    from aragora.swarm.github_app_auth import github_cli_env
+    from aragora.swarm.github_app_auth import gh_subprocess_run, github_cli_env
 except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
 
     def github_cli_env(
@@ -76,6 +76,25 @@ except Exception:  # pragma: no cover - fallback for partially bootstrapped scri
         prefer_app: bool = True,
     ) -> dict[str, str]:
         return dict(os.environ if base_env is None else base_env)
+
+    def gh_subprocess_run(
+        args: list[str],
+        *,
+        timeout: float = 30.0,
+        prefer_app: bool = True,
+        write_op: bool = False,
+        env: dict[str, str] | None = None,
+        max_retries: int = 0,
+    ) -> subprocess.CompletedProcess[str]:
+        del prefer_app, write_op, max_retries
+        return subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=dict(os.environ if env is None else env),
+            check=False,
+        )
 
 
 @dataclass(frozen=True)
@@ -110,6 +129,13 @@ class PublishDecision:
     worktree_paths: list[str]
 
 
+def _gh_write_op(args: list[str]) -> bool:
+    return len(args) >= 2 and (args[0], args[1]) in {
+        ("pr", "create"),
+        ("pr", "edit"),
+    }
+
+
 def _run(
     args: list[str],
     *,
@@ -127,6 +153,14 @@ def _run(
                 "ARAGORA_AUTOMATION_GH_TIMEOUT_SECONDS",
                 str(DEFAULT_COMMAND_TIMEOUT_SECONDS),
             )
+        )
+        return gh_subprocess_run(
+            args[1:],
+            timeout=timeout,
+            prefer_app=True,
+            write_op=_gh_write_op(args[1:]),
+            env=dict(os.environ if env is None else env),
+            max_retries=0,
         )
     else:
         timeout = int(

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -166,6 +166,36 @@ def test_decide_handoffs_marks_duplicate_issue(monkeypatch: Any, tmp_path: Path)
     ]
 
 
+def test_run_uses_user_auth_for_issue_create(monkeypatch: Any, tmp_path: Path) -> None:
+    recorded: dict[str, Any] = {}
+
+    def fake_gh_run(
+        args: list[str],
+        *,
+        timeout: float,
+        prefer_app: bool,
+        write_op: bool,
+        env: dict[str, str],
+        max_retries: int,
+    ) -> subprocess.CompletedProcess[str]:
+        recorded["args"] = args
+        recorded["prefer_app"] = prefer_app
+        recorded["write_op"] = write_op
+        recorded["env"] = env
+        recorded["max_retries"] = max_retries
+        return subprocess.CompletedProcess(args=["gh", *args], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod, "gh_subprocess_run", fake_gh_run)
+
+    result = mod._run(["gh", "issue", "create", "--title", "Example"], cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert recorded["args"][:2] == ["issue", "create"]
+    assert recorded["prefer_app"] is True
+    assert recorded["write_op"] is True
+    assert recorded["max_retries"] == 0
+
+
 def test_decide_handoffs_marks_duplicate_pr(monkeypatch: Any, tmp_path: Path) -> None:
     handoff = Handoff(
         source_file=str(tmp_path / "memory.md"),

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -239,6 +239,36 @@ def test_push_branch_skips_only_configured_pre_push_hooks(monkeypatch: Any, tmp_
     assert recorded["env_overrides"] == {"SKIP": "gitleaks,mypy-baseline"}
 
 
+def test_run_uses_user_auth_for_gh_write_ops(monkeypatch: Any, tmp_path: Path) -> None:
+    recorded: dict[str, Any] = {}
+
+    def fake_gh_run(
+        args: list[str],
+        *,
+        timeout: float,
+        prefer_app: bool,
+        write_op: bool,
+        env: dict[str, str],
+        max_retries: int,
+    ) -> subprocess.CompletedProcess[str]:
+        recorded["args"] = args
+        recorded["prefer_app"] = prefer_app
+        recorded["write_op"] = write_op
+        recorded["env"] = env
+        recorded["max_retries"] = max_retries
+        return subprocess.CompletedProcess(args=["gh", *args], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod, "gh_subprocess_run", fake_gh_run)
+
+    result = mod._run(["gh", "pr", "create", "--base", "main"], cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert recorded["args"][:2] == ["pr", "create"]
+    assert recorded["prefer_app"] is True
+    assert recorded["write_op"] is True
+    assert recorded["max_retries"] == 0
+
+
 def test_worktree_is_dirty_ignores_untracked_files(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- route automation publisher GitHub writes through the user PAT path instead of the app token
- keep app-token preference for GitHub reads
- add coverage for write-op auth routing in both publisher scripts

## Validation
- python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_publish_automation_handoffs.py
- python3 -m ruff check scripts/publish_codex_automation_branches.py scripts/publish_automation_handoffs.py tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_publish_automation_handoffs.py
