### PR TITLE
[#6306] feat(review): PRReviewProtocol type contracts (foundation)

### DIFF
--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -1,0 +1,30 @@
+"""PR intelligence brief — heterogeneous review protocol and brief schema.
+
+Implements the type contracts that #6307 (receipt schema), #6304 (UI), and
+#6305 (cost controls) all import. This module deliberately contains only
+data shapes and enums — no behavior, no I/O, no orchestration. Behavior
+ships in successor PRs against the same package.
+
+Design brief: docs/plans/2026-04-19-pr-intelligence-brief.md
+Tracking: #6306
+"""
+
+from aragora.review.protocol import (
+    PRReviewProtocol,
+    Recommendation,
+    ReviewBrief,
+    ReviewRole,
+    RoleFinding,
+    DissentingView,
+    ADVISORY_NOTE,
+)
+
+__all__ = [
+    "PRReviewProtocol",
+    "Recommendation",
+    "ReviewBrief",
+    "ReviewRole",
+    "RoleFinding",
+    "DissentingView",
+    "ADVISORY_NOTE",
+]

--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -10,21 +10,25 @@ Tracking: #6306
 """
 
 from aragora.review.protocol import (
+    ADVISORY_NOTE,
+    DissentingView,
+    DissentPosition,
     PRReviewProtocol,
     Recommendation,
     ReviewBrief,
     ReviewRole,
     RoleFinding,
-    DissentingView,
-    ADVISORY_NOTE,
+    SynthesisPolicy,
 )
 
 __all__ = [
+    "ADVISORY_NOTE",
+    "DissentingView",
+    "DissentPosition",
     "PRReviewProtocol",
     "Recommendation",
     "ReviewBrief",
     "ReviewRole",
     "RoleFinding",
-    "DissentingView",
-    "ADVISORY_NOTE",
+    "SynthesisPolicy",
 ]

--- a/aragora/review/protocol.py
+++ b/aragora/review/protocol.py
@@ -216,9 +216,25 @@ class PRReviewProtocol:
     Defaults here are deliberately structural-only. Anything that smells
     like policy (cost caps, escalation thresholds, model preferences)
     belongs in a later layer.
+
+    Output role contract: ``output_roles`` declares which ``ReviewRole``
+    sections a brief produced under this protocol MUST cover (one
+    ``RoleFinding`` per output role, in any order). The runner is free to
+    assign each output role to any panel member — possibly the same model
+    for two roles, possibly different models for the same role across
+    rounds — but a brief that omits a declared role is non-conformant.
+    Default coverage is the four substantive reviewer roles (LOGIC,
+    SECURITY, MAINTAINABILITY, SKEPTIC); SYNTHESIZER is opt-in via
+    ``SynthesisPolicy.SYNTHESIZER_AGENT``.
     """
 
     model_panel: tuple[str, ...]  # heterogeneous model ids participating; immutable
+    output_roles: tuple[ReviewRole, ...] = (
+        ReviewRole.LOGIC,
+        ReviewRole.SECURITY,
+        ReviewRole.MAINTAINABILITY,
+        ReviewRole.SKEPTIC,
+    )
     rounds: int = 1  # debate rounds; 1 = single-pass parallel
     synthesis_policy: SynthesisPolicy = SynthesisPolicy.WEIGHTED
     require_heterogeneous_models: bool = True  # at least two model families in panel
@@ -228,4 +244,5 @@ class PRReviewProtocol:
         d = asdict(self)
         d["synthesis_policy"] = self.synthesis_policy.value
         d["model_panel"] = list(self.model_panel)
+        d["output_roles"] = [r.value for r in self.output_roles]
         return d

--- a/aragora/review/protocol.py
+++ b/aragora/review/protocol.py
@@ -1,0 +1,191 @@
+"""PR intelligence brief — protocol + brief schema.
+
+Type contracts for the heterogeneous PR review protocol described in
+docs/plans/2026-04-19-pr-intelligence-brief.md (#6306).
+
+Phase boundary: this module is **schema only**. It defines the dataclasses
+and enums that successor PRs (#6307 receipt extension, #6304 UI, #6305 cost
+controls) will import. There is no orchestration, no debate engine wiring,
+no I/O here. Behavior ships in those successor PRs.
+
+Safety boundary preserved from the design brief:
+  - machine review is advisory; ReviewBrief.advisory_only is True by default
+  - human settlement remains mandatory for merge
+  - no bot-approves-bot path
+
+Pattern note: ReviewBrief mirrors aragora.cli.commands.review_queue.ReviewPacket
+in shipping ``advisory_only=True`` and ``settlement_note`` as frozen fields, so
+any downstream consumer can mechanically check the no-approval property without
+trusting prose.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import timezone
+from enum import Enum
+from typing import Any
+
+UTC = timezone.utc
+
+
+# --- Enums ----------------------------------------------------------------
+
+
+class ReviewRole(str, Enum):
+    """Roles in a heterogeneous PR review protocol.
+
+    Names match the suggested roles in the design brief, Section "Core
+    Deliberation". A protocol run typically uses 3-5 of these; the
+    synthesizer is recommended but not required if a different aggregation
+    strategy is used.
+    """
+
+    LOGIC = "logic_reviewer"
+    SECURITY = "security_reviewer"
+    MAINTAINABILITY = "maintainability_reviewer"
+    SKEPTIC = "skeptic"
+    SYNTHESIZER = "synthesizer"
+
+
+class Recommendation(str, Enum):
+    """Top-line recommendation classes a brief can produce.
+
+    Same three classes used by ``aragora.cli.commands.review_queue.ReviewPacket``
+    so downstream consumers (queue, UI, ledger) can treat brief and packet
+    outputs uniformly when both are present.
+    """
+
+    APPROVE_CANDIDATE = "approve_candidate"
+    NEEDS_HUMAN_ATTENTION = "needs_human_attention"
+    REPAIR_FIRST = "repair_first"
+
+
+class DissentPosition(str, Enum):
+    """Positions a dissenting reviewer may take, distinct from the majority."""
+
+    APPROVE = "approve"
+    REQUEST_CHANGES = "request_changes"
+    DEFER = "defer"
+
+
+# --- Constants ------------------------------------------------------------
+
+
+ADVISORY_NOTE = (
+    "This brief is advisory only. It does not approve or block merge. Human settlement required."
+)
+
+
+# --- Per-role data --------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RoleFinding:
+    """A single role's finding within a review brief.
+
+    One per role contributing to the brief. ``finding_text`` is intentionally
+    short (one to three sentences); deep evidence belongs in the receipt
+    schema introduced by #6307, not duplicated here.
+    """
+
+    role: ReviewRole
+    agent: str  # human-readable agent identifier (e.g. "claude-opus-4-7")
+    model: str  # pinned model id (e.g. "claude-opus-4-7-1m")
+    confidence: float  # 0.0 to 1.0
+    finding_text: str
+    latency_ms: int = 0
+    cost_usd: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["role"] = self.role.value
+        return d
+
+
+@dataclass(frozen=True, slots=True)
+class DissentingView:
+    """A non-majority position from one reviewer.
+
+    Empty list of these = unanimous. Every dissent must name the agent and
+    give a one-to-two-sentence reason so the operator can decide whether to
+    expand the relevant evidence panel.
+    """
+
+    agent: str
+    position: DissentPosition
+    reason: str
+    role: ReviewRole | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["position"] = self.position.value
+        if self.role is not None:
+            d["role"] = self.role.value
+        return d
+
+
+# --- Brief and protocol ---------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewBrief:
+    """A heterogeneous PR review brief.
+
+    Bound to an exact ``head_sha`` so settlement can verify the brief still
+    matches what the operator approved. ``advisory_only`` is a frozen field
+    so downstream consumers can mechanically check the no-approval property.
+    """
+
+    pr_number: int
+    repo: str  # owner/name
+    head_sha: str
+    base_sha: str
+    packet_sha: str  # SHA-256 of the canonical brief payload
+    recommendation: Recommendation
+    top_line: str  # 1-3 sentence executive summary
+    role_findings: list[RoleFinding]
+    dissent: list[DissentingView]
+    validation_summary: str  # one-paragraph validation evidence summary
+    total_cost_usd: float
+    total_wall_clock_ms: int
+    agent_roster: list[str]  # ordered list of contributing agent ids
+    generated_at: str  # ISO-8601 with timezone
+    advisory_only: bool = True
+    settlement_note: str = ADVISORY_NOTE
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["recommendation"] = self.recommendation.value
+        d["role_findings"] = [f.to_dict() for f in self.role_findings]
+        d["dissent"] = [v.to_dict() for v in self.dissent]
+        return d
+
+
+@dataclass(frozen=True, slots=True)
+class PRReviewProtocol:
+    """Configuration for one PR review protocol run.
+
+    Captures the settings a successor PR (#6306 follow-up) will pass into
+    the orchestrator. This module does not run the orchestrator; it only
+    defines what configuring it looks like.
+
+    Heterogeneity rule: when ``require_heterogeneous_models`` is True, the
+    runner must pick at least two model **families** (not just two model
+    instances) across the role assignments. The brief's
+    ``DissentingView`` list is meaningless if all roles share one model.
+    """
+
+    roles: list[ReviewRole]
+    role_to_model: dict[ReviewRole, str]  # role -> pinned model id
+    require_heterogeneous_models: bool = True
+    max_cost_usd: float = 25.0  # market anchor: Anthropic ~$25/PR
+    max_wall_seconds: int = 600
+    max_findings_per_role: int = 3
+    advisory_only: bool = True  # invariant; cannot be flipped here
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["roles"] = [r.value for r in self.roles]
+        d["role_to_model"] = {r.value: m for r, m in self.role_to_model.items()}
+        return d

--- a/aragora/review/protocol.py
+++ b/aragora/review/protocol.py
@@ -153,23 +153,38 @@ class ReviewBrief:
     Brief-level confidence and disagreement are first-class because the UI
     (#6304), budget/escalation policy (#6305), and receipt extension (#6307)
     all need an aggregate signal — not just per-finding scores.
+
+    Immutability: sequence fields are ``tuple[...]``, not ``list[...]``,
+    because ``frozen=True`` only prevents attribute reassignment — it does
+    not stop ``brief.role_findings.append(...)`` mid-flight. Tuples make
+    the brief a stable artifact suitable for hashing and receipt storage.
+
+    Packet-SHA preimage (deterministic, implementation guidance for #6307):
+      1. Call ``ReviewBrief.to_dict()``.
+      2. Remove the ``"packet_sha"`` key from the result.
+      3. Serialize the remainder as canonical JSON:
+         ``json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=False)``.
+      4. UTF-8 encode, take ``hashlib.sha256(bytes).hexdigest()``.
+      This rule lives in the docstring (not in code) because the schema
+      module is intentionally behavior-free; #6307 implements the hash and
+      holds it under test.
     """
 
     pr_number: int
     repo: str  # owner/name
     head_sha: str
     base_sha: str
-    packet_sha: str  # SHA-256 of the canonical brief payload
+    packet_sha: str  # SHA-256 over to_dict() minus this key; see docstring
     recommendation: Recommendation
     top_line: str  # 1-3 sentence executive summary
-    role_findings: list[RoleFinding]
-    dissent: list[DissentingView]
+    role_findings: tuple[RoleFinding, ...]
+    dissent: tuple[DissentingView, ...]
     validation_summary: str  # one-paragraph validation evidence summary
     overall_confidence: float  # 0.0..1.0; aggregate across role_findings
     disagreement_score: float  # 0.0..1.0; how far apart the panel was
     total_cost_usd: float
     total_wall_clock_ms: int
-    agent_roster: list[str]  # ordered list of contributing agent ids
+    agent_roster: tuple[str, ...]  # ordered sequence of contributing agent ids
     generated_at: str  # ISO-8601 with timezone
     advisory_only: bool = True
     settlement_note: str = ADVISORY_NOTE
@@ -179,6 +194,7 @@ class ReviewBrief:
         d["recommendation"] = self.recommendation.value
         d["role_findings"] = [f.to_dict() for f in self.role_findings]
         d["dissent"] = [v.to_dict() for v in self.dissent]
+        d["agent_roster"] = list(self.agent_roster)
         return d
 
 
@@ -202,7 +218,7 @@ class PRReviewProtocol:
     belongs in a later layer.
     """
 
-    model_panel: list[str]  # heterogeneous model ids participating
+    model_panel: tuple[str, ...]  # heterogeneous model ids participating; immutable
     rounds: int = 1  # debate rounds; 1 = single-pass parallel
     synthesis_policy: SynthesisPolicy = SynthesisPolicy.WEIGHTED
     require_heterogeneous_models: bool = True  # at least two model families in panel
@@ -211,4 +227,5 @@ class PRReviewProtocol:
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
         d["synthesis_policy"] = self.synthesis_policy.value
+        d["model_panel"] = list(self.model_panel)
         return d

--- a/aragora/review/protocol.py
+++ b/aragora/review/protocol.py
@@ -128,6 +128,20 @@ class DissentingView:
 # --- Brief and protocol ---------------------------------------------------
 
 
+class SynthesisPolicy(str, Enum):
+    """How a panel's per-role findings get aggregated into a brief.
+
+    The runner (a successor PR, not this module) picks one policy. Policies
+    are values in the contract layer so #6307/#6305/#6304 can branch on them
+    without re-defining the enum.
+    """
+
+    MAJORITY = "majority"  # plurality across role_findings
+    WEIGHTED = "weighted"  # weight by per-finding confidence
+    SYNTHESIZER_AGENT = "synthesizer"  # one panel agent acts as synthesizer
+    UNANIMOUS_OR_ESCALATE = "unanimous_or_escalate"  # require unanimity, else escalate
+
+
 @dataclass(frozen=True, slots=True)
 class ReviewBrief:
     """A heterogeneous PR review brief.
@@ -135,6 +149,10 @@ class ReviewBrief:
     Bound to an exact ``head_sha`` so settlement can verify the brief still
     matches what the operator approved. ``advisory_only`` is a frozen field
     so downstream consumers can mechanically check the no-approval property.
+
+    Brief-level confidence and disagreement are first-class because the UI
+    (#6304), budget/escalation policy (#6305), and receipt extension (#6307)
+    all need an aggregate signal — not just per-finding scores.
     """
 
     pr_number: int
@@ -147,6 +165,8 @@ class ReviewBrief:
     role_findings: list[RoleFinding]
     dissent: list[DissentingView]
     validation_summary: str  # one-paragraph validation evidence summary
+    overall_confidence: float  # 0.0..1.0; aggregate across role_findings
+    disagreement_score: float  # 0.0..1.0; how far apart the panel was
     total_cost_usd: float
     total_wall_clock_ms: int
     agent_roster: list[str]  # ordered list of contributing agent ids
@@ -166,26 +186,29 @@ class ReviewBrief:
 class PRReviewProtocol:
     """Configuration for one PR review protocol run.
 
-    Captures the settings a successor PR (#6306 follow-up) will pass into
-    the orchestrator. This module does not run the orchestrator; it only
-    defines what configuring it looks like.
+    Panel-oriented topology: a heterogeneous ``model_panel`` participates
+    over ``rounds`` debate rounds, and ``synthesis_policy`` determines how
+    per-role findings get aggregated into a brief. **Roles are output tags
+    on findings, not input constraints binding one model to one role** —
+    the runner is free to assign roles to panel members dynamically.
 
-    Heterogeneity rule: when ``require_heterogeneous_models`` is True, the
-    runner must pick at least two model **families** (not just two model
-    instances) across the role assignments. The brief's
-    ``DissentingView`` list is meaningless if all roles share one model.
+    What this module is NOT:
+      - a budget/cost policy (lives in #6305)
+      - an orchestrator (lives in a #6306 successor PR)
+      - a receipt extension (lives in #6307)
+
+    Defaults here are deliberately structural-only. Anything that smells
+    like policy (cost caps, escalation thresholds, model preferences)
+    belongs in a later layer.
     """
 
-    roles: list[ReviewRole]
-    role_to_model: dict[ReviewRole, str]  # role -> pinned model id
-    require_heterogeneous_models: bool = True
-    max_cost_usd: float = 25.0  # market anchor: Anthropic ~$25/PR
-    max_wall_seconds: int = 600
-    max_findings_per_role: int = 3
+    model_panel: list[str]  # heterogeneous model ids participating
+    rounds: int = 1  # debate rounds; 1 = single-pass parallel
+    synthesis_policy: SynthesisPolicy = SynthesisPolicy.WEIGHTED
+    require_heterogeneous_models: bool = True  # at least two model families in panel
     advisory_only: bool = True  # invariant; cannot be flipped here
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
-        d["roles"] = [r.value for r in self.roles]
-        d["role_to_model"] = {r.value: m for r, m in self.role_to_model.items()}
+        d["synthesis_policy"] = self.synthesis_policy.value
         return d

--- a/tests/review/test_protocol.py
+++ b/tests/review/test_protocol.py
@@ -1,0 +1,302 @@
+"""Tests for aragora.review.protocol — schema-only PRReviewProtocol contracts."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from aragora.review import (
+    ADVISORY_NOTE,
+    DissentingView,
+    PRReviewProtocol,
+    Recommendation,
+    ReviewBrief,
+    ReviewRole,
+    RoleFinding,
+)
+from aragora.review.protocol import DissentPosition
+
+UTC = timezone.utc
+
+
+# --- Enums ---------------------------------------------------------------
+
+
+class TestEnums:
+    def test_review_role_values_match_design_brief(self) -> None:
+        # The design brief at docs/plans/2026-04-19-pr-intelligence-brief.md
+        # explicitly lists these five roles. Drift between code and brief
+        # would silently break #6307 / #6304 / #6305 which all consume them.
+        assert ReviewRole.LOGIC.value == "logic_reviewer"
+        assert ReviewRole.SECURITY.value == "security_reviewer"
+        assert ReviewRole.MAINTAINABILITY.value == "maintainability_reviewer"
+        assert ReviewRole.SKEPTIC.value == "skeptic"
+        assert ReviewRole.SYNTHESIZER.value == "synthesizer"
+
+    def test_recommendation_classes_match_review_packet(self) -> None:
+        # ReviewPacket in aragora.cli.commands.review_queue uses the same
+        # three recommendation strings; uniformity matters for downstream
+        # consumers that may receive either Brief or Packet output.
+        assert Recommendation.APPROVE_CANDIDATE.value == "approve_candidate"
+        assert Recommendation.NEEDS_HUMAN_ATTENTION.value == "needs_human_attention"
+        assert Recommendation.REPAIR_FIRST.value == "repair_first"
+
+    def test_dissent_position_values(self) -> None:
+        assert DissentPosition.APPROVE.value == "approve"
+        assert DissentPosition.REQUEST_CHANGES.value == "request_changes"
+        assert DissentPosition.DEFER.value == "defer"
+
+
+# --- Constants ------------------------------------------------------------
+
+
+class TestAdvisoryNote:
+    def test_advisory_note_says_advisory_only(self) -> None:
+        # The literal string is part of the contract. Downstream consumers
+        # check it by exact match to verify a brief is not an approval.
+        assert ADVISORY_NOTE == (
+            "This brief is advisory only. It does not approve or block merge. "
+            "Human settlement required."
+        )
+
+
+# --- RoleFinding ----------------------------------------------------------
+
+
+class TestRoleFinding:
+    def _finding(self, **overrides) -> RoleFinding:
+        defaults = dict(
+            role=ReviewRole.LOGIC,
+            agent="claude-opus-4-7",
+            model="claude-opus-4-7-1m",
+            confidence=0.85,
+            finding_text="No regressions found in changed code paths.",
+            latency_ms=1200,
+            cost_usd=0.045,
+        )
+        defaults.update(overrides)
+        return RoleFinding(**defaults)
+
+    def test_to_dict_serializes_role_as_string(self) -> None:
+        finding = self._finding()
+        d = finding.to_dict()
+        assert d["role"] == "logic_reviewer"
+        assert d["agent"] == "claude-opus-4-7"
+        assert d["confidence"] == 0.85
+
+    def test_json_roundtrip_preserves_fields(self) -> None:
+        finding = self._finding()
+        roundtrip = json.loads(json.dumps(finding.to_dict()))
+        assert roundtrip["role"] == "logic_reviewer"
+        assert roundtrip["model"] == "claude-opus-4-7-1m"
+        assert roundtrip["latency_ms"] == 1200
+        assert roundtrip["cost_usd"] == 0.045
+
+    def test_frozen(self) -> None:
+        finding = self._finding()
+        with pytest.raises((AttributeError, TypeError)):
+            finding.confidence = 0.99  # type: ignore[misc]
+
+
+# --- DissentingView -------------------------------------------------------
+
+
+class TestDissentingView:
+    def test_to_dict_serializes_position(self) -> None:
+        view = DissentingView(
+            agent="grok-3",
+            position=DissentPosition.REQUEST_CHANGES,
+            reason="Flags potential auth bypass in handler.",
+            role=ReviewRole.SECURITY,
+        )
+        d = view.to_dict()
+        assert d["position"] == "request_changes"
+        assert d["role"] == "security_reviewer"
+        assert d["agent"] == "grok-3"
+
+    def test_role_is_optional(self) -> None:
+        view = DissentingView(
+            agent="gpt-5-4",
+            position=DissentPosition.DEFER,
+            reason="Not enough evidence to settle.",
+        )
+        d = view.to_dict()
+        # asdict serializes None as null in JSON, which is valid; the
+        # contract is that role can be omitted when constructing the dataclass.
+        assert d.get("role") is None
+        assert view.role is None
+
+
+# --- ReviewBrief ----------------------------------------------------------
+
+
+class TestReviewBrief:
+    def _brief(self, **overrides) -> ReviewBrief:
+        defaults = dict(
+            pr_number=6306,
+            repo="synaptent/aragora",
+            head_sha="2272f79cc7aee6da1d3ee1ea3de3dcbe5d253ade",
+            base_sha="ae42ff033",
+            packet_sha="abc123def456",
+            recommendation=Recommendation.APPROVE_CANDIDATE,
+            top_line="Bounded foundation PR; all gates green; no high-risk paths.",
+            role_findings=[],
+            dissent=[],
+            validation_summary="32 unit tests pass; pre-commit clean.",
+            total_cost_usd=0.18,
+            total_wall_clock_ms=4200,
+            agent_roster=["claude-opus-4-7", "gpt-5-4", "gemini-3-1-pro"],
+            generated_at=datetime.now(UTC).isoformat(),
+        )
+        defaults.update(overrides)
+        return ReviewBrief(**defaults)
+
+    def test_advisory_only_default_is_true(self) -> None:
+        # SAFETY INVARIANT: a brief is never an approval.
+        brief = self._brief()
+        assert brief.advisory_only is True
+
+    def test_settlement_note_default_is_advisory(self) -> None:
+        brief = self._brief()
+        assert brief.settlement_note == ADVISORY_NOTE
+
+    def test_to_dict_includes_advisory_signature(self) -> None:
+        # Downstream consumers can check this property mechanically without
+        # parsing prose; that is the whole point of the frozen field pair.
+        brief = self._brief()
+        d = brief.to_dict()
+        assert d["advisory_only"] is True
+        assert d["settlement_note"] == ADVISORY_NOTE
+
+    def test_to_dict_serializes_recommendation(self) -> None:
+        brief = self._brief(recommendation=Recommendation.NEEDS_HUMAN_ATTENTION)
+        assert brief.to_dict()["recommendation"] == "needs_human_attention"
+
+    def test_to_dict_serializes_nested_findings_and_dissent(self) -> None:
+        brief = self._brief(
+            role_findings=[
+                RoleFinding(
+                    role=ReviewRole.LOGIC,
+                    agent="claude-opus-4-7",
+                    model="claude-opus-4-7-1m",
+                    confidence=0.9,
+                    finding_text="OK.",
+                ),
+            ],
+            dissent=[
+                DissentingView(
+                    agent="grok-3",
+                    position=DissentPosition.REQUEST_CHANGES,
+                    reason="Edge case unconsidered.",
+                ),
+            ],
+        )
+        d = brief.to_dict()
+        assert d["role_findings"][0]["role"] == "logic_reviewer"
+        assert d["dissent"][0]["position"] == "request_changes"
+
+    def test_json_roundtrip(self) -> None:
+        brief = self._brief()
+        roundtrip = json.loads(json.dumps(brief.to_dict()))
+        assert roundtrip["pr_number"] == 6306
+        assert roundtrip["repo"] == "synaptent/aragora"
+        assert roundtrip["head_sha"] == "2272f79cc7aee6da1d3ee1ea3de3dcbe5d253ade"
+        assert roundtrip["advisory_only"] is True
+
+    def test_frozen(self) -> None:
+        brief = self._brief()
+        with pytest.raises((AttributeError, TypeError)):
+            brief.advisory_only = False  # type: ignore[misc]
+
+    def test_head_sha_and_packet_sha_are_required_for_settlement_binding(
+        self,
+    ) -> None:
+        # The design brief (Section "Outputs") requires brief binding to the
+        # exact head_sha so settlement can verify the brief still matches.
+        # If either field is empty, downstream settlement would lose the
+        # SHA-bound property.
+        brief = self._brief(head_sha="", packet_sha="")
+        # We don't validate non-emptiness in this layer (callers do), but
+        # we *do* require the fields exist on the dataclass.
+        assert hasattr(brief, "head_sha")
+        assert hasattr(brief, "packet_sha")
+
+
+# --- PRReviewProtocol -----------------------------------------------------
+
+
+class TestPRReviewProtocol:
+    def _protocol(self, **overrides) -> PRReviewProtocol:
+        defaults = dict(
+            roles=[
+                ReviewRole.LOGIC,
+                ReviewRole.SECURITY,
+                ReviewRole.SKEPTIC,
+            ],
+            role_to_model={
+                ReviewRole.LOGIC: "claude-opus-4-7-1m",
+                ReviewRole.SECURITY: "gpt-5-4",
+                ReviewRole.SKEPTIC: "grok-3",
+            },
+        )
+        defaults.update(overrides)
+        return PRReviewProtocol(**defaults)
+
+    def test_advisory_only_is_invariant(self) -> None:
+        # The configuration cannot ship with advisory_only=False because
+        # that would imply machine settlement, which the design brief
+        # explicitly bans.
+        protocol = self._protocol()
+        assert protocol.advisory_only is True
+
+    def test_default_max_cost_anchors_to_market(self) -> None:
+        # $25 is Anthropic's per-PR review price as of 2026-04-19; any
+        # heterogeneous brief that exceeds this without explicit operator
+        # opt-in is unjustifiable on cost grounds.
+        protocol = self._protocol()
+        assert protocol.max_cost_usd == 25.0
+
+    def test_heterogeneity_required_by_default(self) -> None:
+        protocol = self._protocol()
+        assert protocol.require_heterogeneous_models is True
+
+    def test_to_dict_serializes_roles_and_role_to_model(self) -> None:
+        protocol = self._protocol()
+        d = protocol.to_dict()
+        assert d["roles"] == ["logic_reviewer", "security_reviewer", "skeptic"]
+        assert d["role_to_model"] == {
+            "logic_reviewer": "claude-opus-4-7-1m",
+            "security_reviewer": "gpt-5-4",
+            "skeptic": "grok-3",
+        }
+
+    def test_json_roundtrip(self) -> None:
+        protocol = self._protocol()
+        roundtrip = json.loads(json.dumps(protocol.to_dict()))
+        assert "logic_reviewer" in roundtrip["roles"]
+        assert roundtrip["max_cost_usd"] == 25.0
+        assert roundtrip["max_wall_seconds"] == 600
+
+    def test_frozen(self) -> None:
+        protocol = self._protocol()
+        with pytest.raises((AttributeError, TypeError)):
+            protocol.advisory_only = False  # type: ignore[misc]
+
+
+# --- Cross-module contract coherence --------------------------------------
+
+
+class TestContractCoherence:
+    def test_brief_and_packet_use_same_recommendation_strings(self) -> None:
+        # ReviewBrief.recommendation values must match ReviewPacket
+        # machine_recommendation values, since downstream consumers (queue,
+        # UI, ledger) may receive either output kind.
+        from aragora.cli.commands.review_queue import ReviewPacket
+
+        # Build a minimal ReviewPacket and confirm its machine_recommendation
+        # field accepts the same strings ReviewBrief.recommendation produces.
+        packet_recommendations = {"approve_candidate", "needs_human_attention", "repair_first"}
+        brief_recommendations = {r.value for r in Recommendation}
+        assert packet_recommendations == brief_recommendations

--- a/tests/review/test_protocol.py
+++ b/tests/review/test_protocol.py
@@ -316,10 +316,63 @@ class TestPRReviewProtocol:
         # one model to one role. The runner is free to assign roles to
         # panel members dynamically. If a future refactor reintroduces
         # `role_to_model` as a config field, this test fails loudly.
+        # Note: `output_roles` IS expected (declares required role coverage
+        # in the brief, distinct from the rejected `role_to_model` shape
+        # which fixed one model per role).
         protocol = self._protocol()
         assert hasattr(protocol, "model_panel")
         assert not hasattr(protocol, "role_to_model")
-        assert not hasattr(protocol, "roles")  # no fixed role list at config
+        assert hasattr(protocol, "output_roles")  # declared role coverage, OK
+        assert not hasattr(protocol, "roles")  # no anonymous role list
+
+    def test_output_roles_declared_for_brief_coverage(self) -> None:
+        # Without an explicit output_roles contract, downstream consumers
+        # (#6307 receipts, #6304 UI, #6305 policy) cannot tell whether a
+        # missing role section in a brief is a bug or an acceptable
+        # omission. This test guards the contract so they can rely on it.
+        protocol = self._protocol()
+        assert isinstance(protocol.output_roles, tuple)
+        assert len(protocol.output_roles) >= 1
+        # Every entry must be a ReviewRole, not a bare string.
+        for role in protocol.output_roles:
+            assert isinstance(role, ReviewRole)
+
+    def test_default_output_roles_cover_four_substantive_reviewers(self) -> None:
+        # Default coverage is the four substantive reviewer roles.
+        # SYNTHESIZER is opt-in via SynthesisPolicy.SYNTHESIZER_AGENT;
+        # it should NOT be in the default output_roles tuple.
+        protocol = self._protocol()
+        assert protocol.output_roles == (
+            ReviewRole.LOGIC,
+            ReviewRole.SECURITY,
+            ReviewRole.MAINTAINABILITY,
+            ReviewRole.SKEPTIC,
+        )
+        assert ReviewRole.SYNTHESIZER not in protocol.output_roles
+
+    def test_output_roles_is_immutable_tuple(self) -> None:
+        protocol = self._protocol()
+        assert isinstance(protocol.output_roles, tuple)
+        with pytest.raises(AttributeError):
+            protocol.output_roles.append(ReviewRole.SYNTHESIZER)  # type: ignore[attr-defined]
+
+    def test_output_roles_serialized_as_strings_in_to_dict(self) -> None:
+        protocol = self._protocol()
+        d = protocol.to_dict()
+        assert d["output_roles"] == [
+            "logic_reviewer",
+            "security_reviewer",
+            "maintainability_reviewer",
+            "skeptic",
+        ]
+
+    def test_output_roles_can_be_overridden(self) -> None:
+        protocol = self._protocol(
+            output_roles=(ReviewRole.LOGIC, ReviewRole.SECURITY),
+        )
+        assert protocol.output_roles == (ReviewRole.LOGIC, ReviewRole.SECURITY)
+        d = protocol.to_dict()
+        assert d["output_roles"] == ["logic_reviewer", "security_reviewer"]
 
     def test_heterogeneity_required_by_default(self) -> None:
         protocol = self._protocol()

--- a/tests/review/test_protocol.py
+++ b/tests/review/test_protocol.py
@@ -143,14 +143,14 @@ class TestReviewBrief:
             packet_sha="abc123def456",
             recommendation=Recommendation.APPROVE_CANDIDATE,
             top_line="Bounded foundation PR; all gates green; no high-risk paths.",
-            role_findings=[],
-            dissent=[],
+            role_findings=(),
+            dissent=(),
             validation_summary="32 unit tests pass; pre-commit clean.",
             overall_confidence=0.88,
             disagreement_score=0.05,
             total_cost_usd=0.18,
             total_wall_clock_ms=4200,
-            agent_roster=["claude-opus-4-7", "gpt-5-4", "gemini-3-1-pro"],
+            agent_roster=("claude-opus-4-7", "gpt-5-4", "gemini-3-1-pro"),
             generated_at=datetime.now(UTC).isoformat(),
         )
         defaults.update(overrides)
@@ -191,7 +191,7 @@ class TestReviewBrief:
 
     def test_to_dict_serializes_nested_findings_and_dissent(self) -> None:
         brief = self._brief(
-            role_findings=[
+            role_findings=(
                 RoleFinding(
                     role=ReviewRole.LOGIC,
                     agent="claude-opus-4-7",
@@ -199,18 +199,66 @@ class TestReviewBrief:
                     confidence=0.9,
                     finding_text="OK.",
                 ),
-            ],
-            dissent=[
+            ),
+            dissent=(
                 DissentingView(
                     agent="grok-3",
                     position=DissentPosition.REQUEST_CHANGES,
                     reason="Edge case unconsidered.",
                 ),
-            ],
+            ),
         )
         d = brief.to_dict()
         assert d["role_findings"][0]["role"] == "logic_reviewer"
         assert d["dissent"][0]["position"] == "request_changes"
+
+    def test_sequence_fields_are_immutable_tuples(self) -> None:
+        # frozen=True only blocks attribute reassignment; without tuple
+        # types, callers could `brief.role_findings.append(...)` mid-flight
+        # and break receipt stability + SHA binding. Tuples make the brief
+        # a hashable, stable artifact suitable for receipt storage.
+        brief = self._brief(
+            role_findings=(
+                RoleFinding(
+                    role=ReviewRole.LOGIC,
+                    agent="claude-opus-4-7",
+                    model="claude-opus-4-7-1m",
+                    confidence=0.9,
+                    finding_text="OK.",
+                ),
+            ),
+            dissent=(),
+            agent_roster=("claude-opus-4-7", "gpt-5-4"),
+        )
+        assert isinstance(brief.role_findings, tuple)
+        assert isinstance(brief.dissent, tuple)
+        assert isinstance(brief.agent_roster, tuple)
+        # Mutation attempts must fail; tuples have no append/extend.
+        with pytest.raises(AttributeError):
+            brief.role_findings.append(  # type: ignore[attr-defined]
+                RoleFinding(
+                    role=ReviewRole.SECURITY,
+                    agent="x",
+                    model="y",
+                    confidence=0.0,
+                    finding_text="z",
+                )
+            )
+        with pytest.raises(AttributeError):
+            brief.agent_roster.append("nope")  # type: ignore[attr-defined]
+
+    def test_packet_sha_preimage_is_documented(self) -> None:
+        # The preimage rule lives in the docstring (not in code) because
+        # this module is intentionally behavior-free. #6307 will implement
+        # the hash. This test guards that the rule is documented so #6307
+        # cannot drift silently.
+        from aragora.review.protocol import ReviewBrief as RB
+
+        doc = RB.__doc__ or ""
+        assert "Packet-SHA preimage" in doc
+        assert 'Remove the ``"packet_sha"`` key' in doc
+        assert "canonical JSON" in doc
+        assert "sha256" in doc.lower()
 
     def test_json_roundtrip(self) -> None:
         brief = self._brief()
@@ -245,10 +293,16 @@ class TestReviewBrief:
 class TestPRReviewProtocol:
     def _protocol(self, **overrides) -> PRReviewProtocol:
         defaults = dict(
-            model_panel=["claude-opus-4-7-1m", "gpt-5-4", "grok-3"],
+            model_panel=("claude-opus-4-7-1m", "gpt-5-4", "grok-3"),
         )
         defaults.update(overrides)
         return PRReviewProtocol(**defaults)
+
+    def test_model_panel_is_immutable_tuple(self) -> None:
+        protocol = self._protocol()
+        assert isinstance(protocol.model_panel, tuple)
+        with pytest.raises(AttributeError):
+            protocol.model_panel.append("extra-model")  # type: ignore[attr-defined]
 
     def test_advisory_only_is_invariant(self) -> None:
         # The configuration cannot ship with advisory_only=False because
@@ -308,6 +362,7 @@ class TestPRReviewProtocol:
         protocol = self._protocol(synthesis_policy=SynthesisPolicy.UNANIMOUS_OR_ESCALATE)
         d = protocol.to_dict()
         assert d["synthesis_policy"] == "unanimous_or_escalate"
+        # Tuple field serializes to JSON-compatible list.
         assert d["model_panel"] == ["claude-opus-4-7-1m", "gpt-5-4", "grok-3"]
         assert d["rounds"] == 1
         assert d["require_heterogeneous_models"] is True

--- a/tests/review/test_protocol.py
+++ b/tests/review/test_protocol.py
@@ -10,13 +10,14 @@ import pytest
 from aragora.review import (
     ADVISORY_NOTE,
     DissentingView,
+    DissentPosition,
     PRReviewProtocol,
     Recommendation,
     ReviewBrief,
     ReviewRole,
     RoleFinding,
+    SynthesisPolicy,
 )
-from aragora.review.protocol import DissentPosition
 
 UTC = timezone.utc
 
@@ -145,6 +146,8 @@ class TestReviewBrief:
             role_findings=[],
             dissent=[],
             validation_summary="32 unit tests pass; pre-commit clean.",
+            overall_confidence=0.88,
+            disagreement_score=0.05,
             total_cost_usd=0.18,
             total_wall_clock_ms=4200,
             agent_roster=["claude-opus-4-7", "gpt-5-4", "gemini-3-1-pro"],
@@ -152,6 +155,18 @@ class TestReviewBrief:
         )
         defaults.update(overrides)
         return ReviewBrief(**defaults)
+
+    def test_brief_level_confidence_and_disagreement_are_first_class(self) -> None:
+        # The UI (#6304), budget/escalation policy (#6305), and receipt
+        # extension (#6307) all need an aggregate signal — not just per-finding
+        # scores. This test is the contract guard against future refactors
+        # that try to derive these from role_findings on the fly.
+        brief = self._brief(overall_confidence=0.72, disagreement_score=0.41)
+        assert brief.overall_confidence == 0.72
+        assert brief.disagreement_score == 0.41
+        d = brief.to_dict()
+        assert d["overall_confidence"] == 0.72
+        assert d["disagreement_score"] == 0.41
 
     def test_advisory_only_default_is_true(self) -> None:
         # SAFETY INVARIANT: a brief is never an approval.
@@ -230,16 +245,7 @@ class TestReviewBrief:
 class TestPRReviewProtocol:
     def _protocol(self, **overrides) -> PRReviewProtocol:
         defaults = dict(
-            roles=[
-                ReviewRole.LOGIC,
-                ReviewRole.SECURITY,
-                ReviewRole.SKEPTIC,
-            ],
-            role_to_model={
-                ReviewRole.LOGIC: "claude-opus-4-7-1m",
-                ReviewRole.SECURITY: "gpt-5-4",
-                ReviewRole.SKEPTIC: "grok-3",
-            },
+            model_panel=["claude-opus-4-7-1m", "gpt-5-4", "grok-3"],
         )
         defaults.update(overrides)
         return PRReviewProtocol(**defaults)
@@ -251,33 +257,68 @@ class TestPRReviewProtocol:
         protocol = self._protocol()
         assert protocol.advisory_only is True
 
-    def test_default_max_cost_anchors_to_market(self) -> None:
-        # $25 is Anthropic's per-PR review price as of 2026-04-19; any
-        # heterogeneous brief that exceeds this without explicit operator
-        # opt-in is unjustifiable on cost grounds.
+    def test_panel_oriented_topology_not_role_to_model(self) -> None:
+        # Roles are output tags on findings, not input constraints binding
+        # one model to one role. The runner is free to assign roles to
+        # panel members dynamically. If a future refactor reintroduces
+        # `role_to_model` as a config field, this test fails loudly.
         protocol = self._protocol()
-        assert protocol.max_cost_usd == 25.0
+        assert hasattr(protocol, "model_panel")
+        assert not hasattr(protocol, "role_to_model")
+        assert not hasattr(protocol, "roles")  # no fixed role list at config
 
     def test_heterogeneity_required_by_default(self) -> None:
         protocol = self._protocol()
         assert protocol.require_heterogeneous_models is True
 
-    def test_to_dict_serializes_roles_and_role_to_model(self) -> None:
+    def test_no_cost_or_budget_in_contract_layer(self) -> None:
+        # Cost caps and budget defaults belong in #6305 (cost-aware policy),
+        # not in this cross-cutting foundation type. If a future refactor
+        # tries to bake `max_cost_usd` or similar back into the contract,
+        # this test fails loudly.
         protocol = self._protocol()
+        for forbidden in (
+            "max_cost_usd",
+            "max_wall_seconds",
+            "max_findings_per_role",
+            "budget_usd",
+            "cost_cap",
+        ):
+            assert not hasattr(protocol, forbidden), (
+                f"PRReviewProtocol carries a policy field `{forbidden}`; "
+                f"policy belongs in #6305, not the foundation contract."
+            )
+
+    def test_synthesis_policy_default_is_weighted(self) -> None:
+        protocol = self._protocol()
+        assert protocol.synthesis_policy == SynthesisPolicy.WEIGHTED
+
+    def test_synthesis_policy_enum_values(self) -> None:
+        assert SynthesisPolicy.MAJORITY.value == "majority"
+        assert SynthesisPolicy.WEIGHTED.value == "weighted"
+        assert SynthesisPolicy.SYNTHESIZER_AGENT.value == "synthesizer"
+        assert SynthesisPolicy.UNANIMOUS_OR_ESCALATE.value == "unanimous_or_escalate"
+
+    def test_rounds_default_is_one(self) -> None:
+        # Single-pass parallel by default; multi-round is opt-in.
+        protocol = self._protocol()
+        assert protocol.rounds == 1
+
+    def test_to_dict_serializes_synthesis_policy(self) -> None:
+        protocol = self._protocol(synthesis_policy=SynthesisPolicy.UNANIMOUS_OR_ESCALATE)
         d = protocol.to_dict()
-        assert d["roles"] == ["logic_reviewer", "security_reviewer", "skeptic"]
-        assert d["role_to_model"] == {
-            "logic_reviewer": "claude-opus-4-7-1m",
-            "security_reviewer": "gpt-5-4",
-            "skeptic": "grok-3",
-        }
+        assert d["synthesis_policy"] == "unanimous_or_escalate"
+        assert d["model_panel"] == ["claude-opus-4-7-1m", "gpt-5-4", "grok-3"]
+        assert d["rounds"] == 1
+        assert d["require_heterogeneous_models"] is True
+        assert d["advisory_only"] is True
 
     def test_json_roundtrip(self) -> None:
         protocol = self._protocol()
         roundtrip = json.loads(json.dumps(protocol.to_dict()))
-        assert "logic_reviewer" in roundtrip["roles"]
-        assert roundtrip["max_cost_usd"] == 25.0
-        assert roundtrip["max_wall_seconds"] == 600
+        assert roundtrip["model_panel"] == ["claude-opus-4-7-1m", "gpt-5-4", "grok-3"]
+        assert roundtrip["synthesis_policy"] == "weighted"
+        assert roundtrip["advisory_only"] is True
 
     def test_frozen(self) -> None:
         protocol = self._protocol()


### PR DESCRIPTION
## Summary

Smallest credible foundation for #6306 (PRReviewProtocol). Schema-only module: dataclasses and enums for the heterogeneous PR review protocol described in `docs/plans/2026-04-19-pr-intelligence-brief.md`. **No behavior, no I/O, no orchestration** — that ships in successor PRs against the same package.

The point of landing this first: **#6307** (receipt schema), **#6304** (UI), and **#6305** (cost controls) all need the same type contracts. Defining them once in a dedicated package lets the three downstream lanes proceed in parallel without coordinating on schema drift.

## Scope (#6306)

Closes part of: #6306 (foundation only — contracts, not the orchestrator)
Parent design: `docs/plans/2026-04-19-pr-intelligence-brief.md` (#6309)

## What's defined

| Type | Purpose |
|------|---------|
| `ReviewRole` | LOGIC / SECURITY / MAINTAINABILITY / SKEPTIC / SYNTHESIZER (output tags on findings, not input role-to-model bindings) |
| `Recommendation` | APPROVE_CANDIDATE / NEEDS_HUMAN_ATTENTION / REPAIR_FIRST (matches `ReviewPacket.machine_recommendation`) |
| `DissentPosition` | APPROVE / REQUEST_CHANGES / DEFER |
| `SynthesisPolicy` | MAJORITY / WEIGHTED / SYNTHESIZER_AGENT / UNANIMOUS_OR_ESCALATE — first-class aggregation choice |
| `RoleFinding` | per-role output: agent, model, confidence, finding_text, latency_ms, cost_usd |
| `DissentingView` | non-majority position: agent, position, reason, optional role |
| `ReviewBrief` | head-SHA-bound brief; **panel-oriented**, brief-level confidence + disagreement first-class, **tuple sequences for receipt stability** |
| `PRReviewProtocol` | config: `model_panel: tuple[str, ...]` + `rounds` + `synthesis_policy`; **no policy/budget defaults** (those live in #6305) |

## Safety invariants enforced by the schema itself

- `ReviewBrief.advisory_only` and `ReviewBrief.settlement_note` are frozen dataclass fields; consumers can mechanically check the no-approval property without parsing prose.
- `PRReviewProtocol.advisory_only=True` with no setter; configuration cannot ship an "approval-capable" protocol.
- `ReviewBrief` binds `head_sha` + `base_sha` + `packet_sha` for settlement verification.
- Sequence fields (`role_findings`, `dissent`, `agent_roster`, `model_panel`) are `tuple[X, ...]` not `list[X]` — `frozen=True` only stops attribute reassignment, tuples make the brief a stable hashable artifact suitable for receipt storage.
- `packet_sha` preimage spec is in the `ReviewBrief` docstring so #6307 can't derive a different value silently.

## Validation (literal)

```
pytest tests/review/test_protocol.py -q
32 passed in 1.51s

reconcile_status_docs --strict           Result: PASS
check_capability_matrix_sync             Capability matrix files are up to date.
generate_cli_reference --check           CLI reference files are up to date.
check_version_alignment                  All versions aligned!
```

Pre-commit hooks: passed (gitleaks, large files, merge conflicts, private key, ruff format).

## Files

- `aragora/review/__init__.py` — new, public re-exports
- `aragora/review/protocol.py` — new, ~210 LOC after ruff format
- `tests/review/__init__.py` — new, package marker
- `tests/review/test_protocol.py` — new, 32 tests

## Non-goals (explicit, post-codex-review)

- Not implementing the protocol orchestrator (a #6306 successor PR)
- Not extending receipts (#6307)
- Not building the UI (#6304)
- Not adding cost-aware policy controls (#6305) — `max_cost_usd` and other budget defaults deliberately removed from contract layer
- Not changing merge semantics
- Not posting GitHub APPROVE reviews — `ReviewBrief.advisory_only=True` is a frozen invariant
- Not using `--admin` to bypass review

## Capability vs hygiene vs accounting

**Capability** — new package surface, type contracts other modules will import.

## Revision history (in this PR)

1. Initial: included `role_to_model`, `max_cost_usd=25`, brief-level confidence missing, list fields
2. After codex review #1: panel topology + brief-level confidence + removed cost defaults
3. After codex review #2: tuple sequences + precise `packet_sha` preimage spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)