### PR TITLE
test: repair stale mainline route and RLM expectations

### DIFF
--- a/tests/server/fastapi/test_runs_routes.py
+++ b/tests/server/fastapi/test_runs_routes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -70,7 +70,7 @@ def _override_auth(client: TestClient, permissions: set[str]) -> None:
 
 
 def test_list_runs_route_requires_auth(client) -> None:
-    response = client.get("/api/v2/runs")
+    response = client.get("/api/runs")
 
     assert response.status_code == 401
 
@@ -89,7 +89,7 @@ def test_list_runs_route_is_registered(client) -> None:
     )
 
     _override_auth(client, {"orchestration:read"})
-    response = client.get("/api/v2/runs")
+    response = client.get("/api/runs")
     client.app.dependency_overrides.clear()
 
     assert response.status_code == 200
@@ -102,7 +102,7 @@ def test_list_runs_route_is_registered(client) -> None:
                     {
                         "stage": BackboneStage.PLAN.value,
                         "status": "completed",
-                        "created_at": None,
+                        "created_at": ANY,
                     }
                 ],
                 "execution_id": "exec-fastapi",
@@ -115,7 +115,7 @@ def test_list_runs_route_is_registered(client) -> None:
 
 
 def test_get_run_route_requires_auth(client) -> None:
-    response = client.get("/api/v2/runs/run-fastapi-detail")
+    response = client.get("/api/runs/run-fastapi-detail")
 
     assert response.status_code == 401
 
@@ -131,7 +131,7 @@ def test_get_run_route_is_registered(client) -> None:
     )
 
     _override_auth(client, {"orchestration:read"})
-    response = client.get("/api/v2/runs/run-fastapi-detail")
+    response = client.get("/api/runs/run-fastapi-detail")
     client.app.dependency_overrides.clear()
 
     assert response.status_code == 200
@@ -143,7 +143,7 @@ def test_get_run_route_is_registered(client) -> None:
                 {
                     "stage": BackboneStage.EXECUTION.value,
                     "status": "running",
-                    "created_at": None,
+                    "created_at": ANY,
                 }
             ],
             "execution_id": None,
@@ -157,5 +157,5 @@ def test_get_run_route_is_registered(client) -> None:
 def test_runs_routes_are_exposed_in_openapi(client) -> None:
     spec = client.app.openapi()
 
-    assert "/api/v2/runs" in spec["paths"]
-    assert "/api/v2/runs/{run_id}" in spec["paths"]
+    assert "/api/runs" in spec["paths"]
+    assert "/api/runs/{run_id}" in spec["paths"]

--- a/tests/server/handlers/test_rlm.py
+++ b/tests/server/handlers/test_rlm.py
@@ -506,12 +506,16 @@ class TestRLMCompress:
     def test_compress_content_too_large(self, rlm_handler):
         """Compress with content over 10MB returns 413.
 
-        We mock read_json_body to bypass the body-level size check and test
+        We mock _read_json_object_body to bypass the body-level size check and test
         the content-level size validation directly.
         """
         large_content = "x" * (10_000_001)
         handler = make_mock_handler(method="POST", authenticated=True)
-        with patch.object(rlm_handler, "read_json_body", return_value={"content": large_content}):
+        with patch.object(
+            rlm_handler,
+            "_read_json_object_body",
+            return_value=({"content": large_content}, None),
+        ):
             result = rlm_handler.handle_compress("/api/v1/rlm/compress", {}, handler)
         assert result is not None
         assert result.status_code == 413


### PR DESCRIPTION
## Summary
- update FastAPI runs route tests to the current `/api/runs` surface
- stop pinning generated stage event timestamps in runs route assertions
- patch the RLM oversized-content test against `_read_json_object_body`, which is the live handler entrypoint

## Why
`main` was carrying two stale test expectations that were showing up as baseline-red signal while settling #6295:
- `tests/server/fastapi/test_runs_routes.py` still expected the old `/api/v2/runs` paths and fixed `created_at=None`
- `tests/server/handlers/test_rlm.py` mocked `read_json_body`, but `handle_compress()` now reads through `_read_json_object_body`

## Verification
- `pytest -q tests/server/handlers/test_rlm.py tests/server/fastapi/test_runs_routes.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`