### PR TITLE
test(idea-canvas): exercise update store error path

### DIFF
--- a/tests/handlers/test_idea_canvas.py
+++ b/tests/handlers/test_idea_canvas.py
@@ -624,7 +624,7 @@ class TestUpdateCanvas:
         store.update_canvas.side_effect = TypeError("bad type")
         mock_get_store.return_value = store
 
-        result = handler._update_canvas(_ctx(), "ic-1", {}, "u1")
+        result = handler._update_canvas(_ctx(), "ic-1", {"name": "Updated"}, "u1")
         assert _status(result) == 500
 
 


### PR DESCRIPTION
## Summary
- update the stale store-error test to send one valid field so it reaches `store.update_canvas`
- keep the assertion focused on the 500 error path instead of the empty-body validator

## Validation
- `python3 -m pytest -q tests/handlers/test_idea_canvas.py::TestUpdateCanvas::test_update_store_error`
- `python3 -m pytest -q tests/handlers/test_idea_canvas.py -k 'TestUpdateCanvas'`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`