### PR TITLE
[#6307] feat(review): BriefReceipt + SettlementLinkage schemas (foundation)

### DIFF
--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -20,15 +20,25 @@ from aragora.review.protocol import (
     RoleFinding,
     SynthesisPolicy,
 )
+from aragora.review.receipt import (
+    BriefReceipt,
+    EvidenceRef,
+    SettlementLinkage,
+    ValidationRef,
+)
 
 __all__ = [
     "ADVISORY_NOTE",
+    "BriefReceipt",
     "DissentingView",
     "DissentPosition",
+    "EvidenceRef",
     "PRReviewProtocol",
     "Recommendation",
     "ReviewBrief",
     "ReviewRole",
     "RoleFinding",
+    "SettlementLinkage",
     "SynthesisPolicy",
+    "ValidationRef",
 ]

--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -22,9 +22,13 @@ from aragora.review.protocol import (
 )
 from aragora.review.receipt import (
     BriefReceipt,
+    EvidenceKind,
     EvidenceRef,
+    SettlementAction,
     SettlementLinkage,
+    ValidationKind,
     ValidationRef,
+    ValidationResult,
 )
 
 __all__ = [
@@ -32,13 +36,17 @@ __all__ = [
     "BriefReceipt",
     "DissentingView",
     "DissentPosition",
+    "EvidenceKind",
     "EvidenceRef",
     "PRReviewProtocol",
     "Recommendation",
     "ReviewBrief",
     "ReviewRole",
     "RoleFinding",
+    "SettlementAction",
     "SettlementLinkage",
     "SynthesisPolicy",
+    "ValidationKind",
     "ValidationRef",
+    "ValidationResult",
 ]

--- a/aragora/review/receipt.py
+++ b/aragora/review/receipt.py
@@ -27,9 +27,66 @@ Acceptance-criteria linkage (from #6307 body):
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from enum import Enum
 from typing import Any
 
 from aragora.review.protocol import ReviewBrief
+
+
+# --- Discriminator enums (strict typing across orchestrator / UI / export) ---
+
+
+class EvidenceKind(str, Enum):
+    """What kind of thing an ``EvidenceRef`` points to.
+
+    Enum values are the canonical serialized strings consumers must use;
+    downstream code branches on these so drift silently breaks exports.
+    """
+
+    FILE = "file"
+    TEST = "test"
+    COMMIT = "commit"
+    ARTIFACT = "artifact"
+    ISSUE = "issue"
+    PR = "pr"
+    EXTERNAL = "external"
+
+
+class ValidationKind(str, Enum):
+    """What kind of automated check a ``ValidationRef`` points to."""
+
+    CI_CHECK = "ci_check"
+    TEST_SUITE = "test_suite"
+    RECEIPT = "receipt"
+    BENCHMARK = "benchmark"
+    MANUAL_REVIEW = "manual_review"
+
+
+class ValidationResult(str, Enum):
+    """Pass/fail outcome for a ``ValidationRef``.
+
+    Values mirror the GitHub Actions conclusion vocabulary plus explicit
+    ``PENDING`` for not-yet-resolved runs.
+    """
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    SKIPPED = "skipped"
+    CANCELLED = "cancelled"
+    PENDING = "pending"
+
+
+class SettlementAction(str, Enum):
+    """The human action recorded by a settlement.
+
+    Same three actions the existing review-queue ``act`` CLI already
+    accepts; locking them into the contract layer prevents the UI and
+    export from inventing new strings.
+    """
+
+    APPROVE = "approve"
+    REQUEST_CHANGES = "request_changes"
+    DEFER = "defer"
 
 
 # --- Evidence and validation references -----------------------------------
@@ -44,7 +101,7 @@ class EvidenceRef:
     location so the operator (or UI) can expand on demand.
     """
 
-    kind: str  # "file" | "test" | "commit" | "artifact" | "issue" | "pr" | "external"
+    kind: EvidenceKind
     path: str  # for file/test: repo-relative path; for commit/pr/issue: canonical ref; for external: URL
     sha: str = ""  # git SHA or artifact hash where applicable
     line_range: tuple[int, int] | None = None
@@ -52,6 +109,7 @@ class EvidenceRef:
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
+        d["kind"] = self.kind.value
         if self.line_range is not None:
             d["line_range"] = list(self.line_range)
         return d
@@ -65,13 +123,16 @@ class ValidationRef:
     pass/fail outcome and link to a live run (not a static artifact).
     """
 
-    kind: str  # "ci_check" | "test_suite" | "receipt" | "benchmark" | "manual_review"
+    kind: ValidationKind
     name: str  # human-readable check name (e.g. "Version Alignment", "test-fast (server)")
-    result: str  # "success" | "failure" | "skipped" | "cancelled" | "pending"
+    result: ValidationResult
     url: str = ""  # link to the live run or artifact
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        d = asdict(self)
+        d["kind"] = self.kind.value
+        d["result"] = self.result.value
+        return d
 
 
 # --- Brief receipt --------------------------------------------------------
@@ -137,25 +198,42 @@ class SettlementLinkage:
     brief (e.g. legacy PR settled via the pre-#6306 review-queue loop)
     does not force consumers to synthesize a fake brief receipt.
 
-    Storage handoff: the existing SettlementReceipt on disk is referenced
-    by path (``settlement_receipt_path``), not by re-embedding its
-    fields. That keeps backwards compatibility with settlement receipts
-    already on disk from the pre-#6307 review-queue loop. Consumers that
-    need the full settlement payload read the file at that path.
+    Storage handoff: two-address-space design for portability.
+
+    Stable IDs (``settlement_receipt_id``, ``repair_receipt_ids``) are
+    the portable linkage keys — an exported payload can dereference
+    them on a different machine via a content-addressable lookup
+    (typically SHA-256 of the canonical receipt payload, with the
+    exact preimage rule living on whoever produces the settlement
+    receipt — the review-queue ``act`` command today, a successor PR
+    tomorrow). Consumers doing external export MUST use the IDs.
+
+    Filesystem paths (``settlement_receipt_path``, ``repair_receipt_paths``)
+    are kept alongside for backwards compatibility with existing
+    settlement receipts on disk from the pre-#6307 review-queue loop.
+    Local consumers doing a one-machine read MAY use the paths.
+
+    Neither field alone is sufficient: a linkage with only a path is
+    not exportable; a linkage with only an ID loses the local-read
+    fast-path while existing tools are still migrating.
     """
 
     brief_receipt_id: str  # BriefReceipt.receipt_id; empty if no prior brief
-    settlement_receipt_path: str  # filesystem path to existing SettlementReceipt JSON
+    settlement_receipt_id: str  # portable ID for the settlement receipt; see docstring
+    settlement_receipt_path: str  # filesystem path (backwards-compat); see docstring
     head_sha: str  # duplicated from settlement for fast-lookup / cross-validation
     packet_sha: str  # duplicated from brief for fast-lookup / cross-validation
     pr_number: int
     repo: str  # owner/name
-    action: str  # "approve" | "request_changes" | "defer"
+    action: SettlementAction
     settled_at: str  # ISO-8601 with timezone
-    repair_receipt_paths: tuple[str, ...] = ()  # filesystem paths to repair receipts, growing
+    repair_receipt_ids: tuple[str, ...] = ()  # portable IDs for repair receipts, growing
+    repair_receipt_paths: tuple[str, ...] = ()  # filesystem paths (backwards-compat), growing
     advisory_only: bool = False  # settlement is a human action; not advisory
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
+        d["action"] = self.action.value
+        d["repair_receipt_ids"] = list(self.repair_receipt_ids)
         d["repair_receipt_paths"] = list(self.repair_receipt_paths)
         return d

--- a/aragora/review/receipt.py
+++ b/aragora/review/receipt.py
@@ -202,11 +202,8 @@ class SettlementLinkage:
 
     Stable IDs (``settlement_receipt_id``, ``repair_receipt_ids``) are
     the portable linkage keys — an exported payload can dereference
-    them on a different machine via a content-addressable lookup
-    (typically SHA-256 of the canonical receipt payload, with the
-    exact preimage rule living on whoever produces the settlement
-    receipt — the review-queue ``act`` command today, a successor PR
-    tomorrow). Consumers doing external export MUST use the IDs.
+    them on a different machine via content-addressable lookup.
+    Consumers doing external export MUST use the IDs.
 
     Filesystem paths (``settlement_receipt_path``, ``repair_receipt_paths``)
     are kept alongside for backwards compatibility with existing
@@ -216,6 +213,28 @@ class SettlementLinkage:
     Neither field alone is sufficient: a linkage with only a path is
     not exportable; a linkage with only an ID loses the local-read
     fast-path while existing tools are still migrating.
+
+    Settlement-receipt-ID preimage (deterministic, implementation
+    guidance for the review-queue ``act`` writer in
+    ``aragora/cli/commands/review_queue.py`` and any successor):
+      1. Take the ``SettlementReceipt`` payload from ``to_dict()``.
+      2. Remove the ``"receipt_path"`` key (filesystem-dependent,
+         not portable).
+      3. Remove the ``"receipt_id"`` key if present (would be
+         self-referential; parallel to the packet_sha rule).
+      4. Serialize the remainder as canonical JSON:
+         ``json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=False)``.
+      5. UTF-8 encode, take ``hashlib.sha256(bytes).hexdigest()``.
+      ``settlement_receipt_id`` is exactly this hex digest.
+
+    Repair-receipt-ID preimage: same rule applied to whatever payload
+    the repair lane emits (the repair lane is a future successor PR
+    and will produce a dataclass with its own ``to_dict()``; the rule
+    above applies verbatim once that payload exists).
+
+    Both preimage rules live in this docstring (not in code) because
+    the schema module is intentionally behavior-free; the review-queue
+    ``act`` writer implements them and holds them under test.
     """
 
     brief_receipt_id: str  # BriefReceipt.receipt_id; empty if no prior brief

--- a/aragora/review/receipt.py
+++ b/aragora/review/receipt.py
@@ -1,0 +1,161 @@
+"""PR intelligence brief — receipt + settlement linkage schema.
+
+Type contracts for the receipt extension described in
+docs/plans/2026-04-19-pr-intelligence-brief.md (#6307).
+
+This module is **schema only**. No I/O, no hashing, no orchestration.
+Behavior — brief-receipt writing, repair-receipt linking, export —
+ships in successor PRs (the #6306 orchestrator, #6304 UI, #6305
+policy). This module just defines the shapes those PRs agree on.
+
+Composes, but does not redefine:
+  - aragora.review.protocol.ReviewBrief — wrapped by ``BriefReceipt``
+  - aragora.cli.commands.review_queue.SettlementReceipt — referenced by
+    path in ``SettlementLinkage`` (keeps backwards compatibility with
+    existing settlement receipts already on disk)
+
+Acceptance-criteria linkage (from #6307 body):
+  - "A settled PR can be traced back to the exact brief packet and
+    head SHA"  →  BriefReceipt.brief.packet_sha + SettlementLinkage.head_sha
+  - "Dissent survives in receipts instead of being collapsed into one
+    summary line"  →  BriefReceipt.brief.dissent (tuple of DissentingView)
+  - "Receipt payload is stable enough for operator UI and external
+    export"  →  frozen dataclasses + tuple sequences + deterministic
+    receipt_id preimage (documented on BriefReceipt)
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from aragora.review.protocol import ReviewBrief
+
+
+# --- Evidence and validation references -----------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRef:
+    """A pointer to a piece of supporting evidence cited by the brief.
+
+    Deliberately short: ``quote`` is 1-2 lines, not a full paragraph.
+    Deep evidence lives where the ref points; the brief just names the
+    location so the operator (or UI) can expand on demand.
+    """
+
+    kind: str  # "file" | "test" | "commit" | "artifact" | "issue" | "pr" | "external"
+    path: str  # for file/test: repo-relative path; for commit/pr/issue: canonical ref; for external: URL
+    sha: str = ""  # git SHA or artifact hash where applicable
+    line_range: tuple[int, int] | None = None
+    quote: str = ""  # short excerpt (≤2 lines recommended)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        if self.line_range is not None:
+            d["line_range"] = list(self.line_range)
+        return d
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationRef:
+    """A pointer to an automated check whose result backs the brief.
+
+    Different from ``EvidenceRef`` because validation refs have a
+    pass/fail outcome and link to a live run (not a static artifact).
+    """
+
+    kind: str  # "ci_check" | "test_suite" | "receipt" | "benchmark" | "manual_review"
+    name: str  # human-readable check name (e.g. "Version Alignment", "test-fast (server)")
+    result: str  # "success" | "failure" | "skipped" | "cancelled" | "pending"
+    url: str = ""  # link to the live run or artifact
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# --- Brief receipt --------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class BriefReceipt:
+    """Persisted, SHA-bound form of a ReviewBrief.
+
+    Wraps a ``ReviewBrief`` (which already carries agent_roster, dissent,
+    per-finding cost, overall_confidence, disagreement_score, and a
+    ``packet_sha`` preimage spec) and adds the evidence + validation
+    references that the raw brief does not yet carry.
+
+    Dissent survival: because ``ReviewBrief.dissent`` is already a
+    ``tuple[DissentingView, ...]`` with a frozen shape, the dissent array
+    is preserved verbatim in this receipt. There is no summarization step
+    that would collapse multi-agent disagreement into one line.
+
+    Receipt-ID preimage (deterministic, #6305/#6304 can rely on this):
+      1. Call ``BriefReceipt.to_dict()``.
+      2. Remove the ``"receipt_id"`` key from the result.
+      3. Serialize the remainder as canonical JSON:
+         ``json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=False)``.
+      4. UTF-8 encode, take ``hashlib.sha256(bytes).hexdigest()``.
+      Rule lives in the docstring (not in code) because the schema module
+      is intentionally behavior-free; the orchestrator (#6306 successor)
+      implements the hash and holds it under test.
+    """
+
+    brief: ReviewBrief
+    evidence_refs: tuple[EvidenceRef, ...]
+    validation_refs: tuple[ValidationRef, ...]
+    receipt_id: str  # SHA-256 over to_dict() minus this key; see docstring
+    created_at: str  # ISO-8601 with timezone
+    advisory_only: bool = True
+    settlement_note: str = (
+        "This receipt records an advisory brief. It does not approve or block merge. "
+        "Human settlement required."
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["brief"] = self.brief.to_dict()
+        d["evidence_refs"] = [e.to_dict() for e in self.evidence_refs]
+        d["validation_refs"] = [v.to_dict() for v in self.validation_refs]
+        return d
+
+
+# --- Settlement linkage ---------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementLinkage:
+    """Binds one brief receipt to its settlement and any later repair attempts.
+
+    Preserves the full audit trail required by #6307 acceptance:
+      brief (advisory machine output)
+        → settlement (human action, keyed by head_sha + packet_sha)
+          → repair attempts (if settlement was request_changes)
+
+    Kept as a separate dataclass so a settlement without a pre-existing
+    brief (e.g. legacy PR settled via the pre-#6306 review-queue loop)
+    does not force consumers to synthesize a fake brief receipt.
+
+    Storage handoff: the existing SettlementReceipt on disk is referenced
+    by path (``settlement_receipt_path``), not by re-embedding its
+    fields. That keeps backwards compatibility with settlement receipts
+    already on disk from the pre-#6307 review-queue loop. Consumers that
+    need the full settlement payload read the file at that path.
+    """
+
+    brief_receipt_id: str  # BriefReceipt.receipt_id; empty if no prior brief
+    settlement_receipt_path: str  # filesystem path to existing SettlementReceipt JSON
+    head_sha: str  # duplicated from settlement for fast-lookup / cross-validation
+    packet_sha: str  # duplicated from brief for fast-lookup / cross-validation
+    pr_number: int
+    repo: str  # owner/name
+    action: str  # "approve" | "request_changes" | "defer"
+    settled_at: str  # ISO-8601 with timezone
+    repair_receipt_paths: tuple[str, ...] = ()  # filesystem paths to repair receipts, growing
+    advisory_only: bool = False  # settlement is a human action; not advisory
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["repair_receipt_paths"] = list(self.repair_receipt_paths)
+        return d

--- a/tests/review/test_receipt.py
+++ b/tests/review/test_receipt.py
@@ -11,13 +11,17 @@ from aragora.review import (
     BriefReceipt,
     DissentingView,
     DissentPosition,
+    EvidenceKind,
     EvidenceRef,
     Recommendation,
     ReviewBrief,
     ReviewRole,
     RoleFinding,
+    SettlementAction,
     SettlementLinkage,
+    ValidationKind,
     ValidationRef,
+    ValidationResult,
 )
 
 UTC = timezone.utc
@@ -66,13 +70,13 @@ def _minimal_receipt(**overrides) -> BriefReceipt:
 
 class TestEvidenceRef:
     def test_frozen(self) -> None:
-        ref = EvidenceRef(kind="file", path="aragora/review/receipt.py")
+        ref = EvidenceRef(kind=EvidenceKind.FILE, path="aragora/review/receipt.py")
         with pytest.raises((AttributeError, TypeError)):
             ref.path = "elsewhere"  # type: ignore[misc]
 
     def test_line_range_serializes_as_list(self) -> None:
         ref = EvidenceRef(
-            kind="file",
+            kind=EvidenceKind.FILE,
             path="aragora/review/receipt.py",
             line_range=(42, 58),
             quote="def to_dict(self) -> dict[str, Any]:",
@@ -83,13 +87,28 @@ class TestEvidenceRef:
         assert d["path"] == "aragora/review/receipt.py"
 
     def test_line_range_omitted_when_none(self) -> None:
-        ref = EvidenceRef(kind="commit", path="main@f1a640ee2", sha="f1a640ee2")
+        ref = EvidenceRef(kind=EvidenceKind.COMMIT, path="main@f1a640ee2", sha="f1a640ee2")
         d = ref.to_dict()
         assert d["line_range"] is None
 
+    def test_kind_enum_values_match_canonical_strings(self) -> None:
+        # These are the canonical serialized strings consumers branch on.
+        # Drift breaks the orchestrator / UI / export contract silently.
+        assert EvidenceKind.FILE.value == "file"
+        assert EvidenceKind.TEST.value == "test"
+        assert EvidenceKind.COMMIT.value == "commit"
+        assert EvidenceKind.ARTIFACT.value == "artifact"
+        assert EvidenceKind.ISSUE.value == "issue"
+        assert EvidenceKind.PR.value == "pr"
+        assert EvidenceKind.EXTERNAL.value == "external"
+
+    def test_kind_serialized_as_string(self) -> None:
+        ref = EvidenceRef(kind=EvidenceKind.FILE, path="x.py")
+        assert ref.to_dict()["kind"] == "file"
+
     def test_json_roundtrip(self) -> None:
         ref = EvidenceRef(
-            kind="file",
+            kind=EvidenceKind.FILE,
             path="aragora/cli/commands/review_queue.py",
             line_range=(130, 151),
             quote="class SettlementReceipt: ...",
@@ -104,15 +123,43 @@ class TestEvidenceRef:
 
 class TestValidationRef:
     def test_frozen(self) -> None:
-        ref = ValidationRef(kind="ci_check", name="lint", result="success")
+        ref = ValidationRef(
+            kind=ValidationKind.CI_CHECK, name="lint", result=ValidationResult.SUCCESS
+        )
         with pytest.raises((AttributeError, TypeError)):
-            ref.result = "failure"  # type: ignore[misc]
+            ref.result = ValidationResult.FAILURE  # type: ignore[misc]
+
+    def test_kind_enum_values(self) -> None:
+        assert ValidationKind.CI_CHECK.value == "ci_check"
+        assert ValidationKind.TEST_SUITE.value == "test_suite"
+        assert ValidationKind.RECEIPT.value == "receipt"
+        assert ValidationKind.BENCHMARK.value == "benchmark"
+        assert ValidationKind.MANUAL_REVIEW.value == "manual_review"
+
+    def test_result_enum_values(self) -> None:
+        # Mirror the GitHub Actions conclusion vocabulary; this is the
+        # contract the orchestrator / UI / export share.
+        assert ValidationResult.SUCCESS.value == "success"
+        assert ValidationResult.FAILURE.value == "failure"
+        assert ValidationResult.SKIPPED.value == "skipped"
+        assert ValidationResult.CANCELLED.value == "cancelled"
+        assert ValidationResult.PENDING.value == "pending"
+
+    def test_enum_fields_serialize_as_strings(self) -> None:
+        ref = ValidationRef(
+            kind=ValidationKind.CI_CHECK,
+            name="Version Alignment",
+            result=ValidationResult.SUCCESS,
+        )
+        d = ref.to_dict()
+        assert d["kind"] == "ci_check"
+        assert d["result"] == "success"
 
     def test_to_dict_roundtrip(self) -> None:
         ref = ValidationRef(
-            kind="ci_check",
+            kind=ValidationKind.CI_CHECK,
             name="Version Alignment",
-            result="success",
+            result=ValidationResult.SUCCESS,
             url="https://github.com/synaptent/aragora/actions/runs/12345",
         )
         roundtrip = json.loads(json.dumps(ref.to_dict()))
@@ -138,8 +185,12 @@ class TestBriefReceipt:
 
     def test_to_dict_nests_brief_and_refs(self) -> None:
         receipt = _minimal_receipt(
-            evidence_refs=(EvidenceRef(kind="file", path="aragora/review/protocol.py"),),
-            validation_refs=(ValidationRef(kind="ci_check", name="lint", result="success"),),
+            evidence_refs=(EvidenceRef(kind=EvidenceKind.FILE, path="aragora/review/protocol.py"),),
+            validation_refs=(
+                ValidationRef(
+                    kind=ValidationKind.CI_CHECK, name="lint", result=ValidationResult.SUCCESS
+                ),
+            ),
         )
         d = receipt.to_dict()
         assert d["brief"]["pr_number"] == 6307
@@ -157,16 +208,22 @@ class TestBriefReceipt:
         # blocked, but without tuple types `receipt.evidence_refs.append(...)`
         # would still be possible mid-flight and break receipt_id binding.
         receipt = _minimal_receipt(
-            evidence_refs=(EvidenceRef(kind="file", path="x.py"),),
-            validation_refs=(ValidationRef(kind="ci_check", name="lint", result="success"),),
+            evidence_refs=(EvidenceRef(kind=EvidenceKind.FILE, path="x.py"),),
+            validation_refs=(
+                ValidationRef(
+                    kind=ValidationKind.CI_CHECK, name="lint", result=ValidationResult.SUCCESS
+                ),
+            ),
         )
         assert isinstance(receipt.evidence_refs, tuple)
         assert isinstance(receipt.validation_refs, tuple)
         with pytest.raises(AttributeError):
-            receipt.evidence_refs.append(EvidenceRef(kind="file", path="y.py"))  # type: ignore[attr-defined]
+            receipt.evidence_refs.append(EvidenceRef(kind=EvidenceKind.FILE, path="y.py"))  # type: ignore[attr-defined]
         with pytest.raises(AttributeError):
             receipt.validation_refs.append(  # type: ignore[attr-defined]
-                ValidationRef(kind="ci_check", name="x", result="success")
+                ValidationRef(
+                    kind=ValidationKind.CI_CHECK, name="x", result=ValidationResult.SUCCESS
+                )
             )
 
     def test_dissent_survives_in_receipt(self) -> None:
@@ -235,12 +292,13 @@ class TestSettlementLinkage:
     def _minimal_linkage(self, **overrides) -> SettlementLinkage:
         defaults = dict(
             brief_receipt_id="receipt-sha-xyz",
+            settlement_receipt_id="settlement-sha-abc",
             settlement_receipt_path=".aragora/review-queue/settlements/pr-6307-f1a640ee2def-approve.json",
             head_sha="f1a640ee2deadbeef",
             packet_sha="packet-sha-locked",
             pr_number=6307,
             repo="synaptent/aragora",
-            action="approve",
+            action=SettlementAction.APPROVE,
             settled_at=datetime.now(UTC).isoformat(),
         )
         defaults.update(overrides)
@@ -253,10 +311,27 @@ class TestSettlementLinkage:
         linkage = self._minimal_linkage()
         assert linkage.advisory_only is False
 
+    def test_action_enum_values(self) -> None:
+        # These three are the only valid settlement actions; they match
+        # the review-queue `act` CLI so locking them in the contract
+        # prevents UI/export from inventing new strings.
+        assert SettlementAction.APPROVE.value == "approve"
+        assert SettlementAction.REQUEST_CHANGES.value == "request_changes"
+        assert SettlementAction.DEFER.value == "defer"
+
+    def test_action_is_an_enum_not_string(self) -> None:
+        # P1 regression guard: `action` must be typed, not raw str.
+        linkage = self._minimal_linkage()
+        assert isinstance(linkage.action, SettlementAction)
+
+    def test_action_serialized_as_string(self) -> None:
+        linkage = self._minimal_linkage(action=SettlementAction.REQUEST_CHANGES)
+        assert linkage.to_dict()["action"] == "request_changes"
+
     def test_frozen(self) -> None:
         linkage = self._minimal_linkage()
         with pytest.raises((AttributeError, TypeError)):
-            linkage.action = "request_changes"  # type: ignore[misc]
+            linkage.action = SettlementAction.REQUEST_CHANGES  # type: ignore[misc]
 
     def test_repair_receipt_paths_is_immutable_tuple(self) -> None:
         linkage = self._minimal_linkage(
@@ -268,14 +343,46 @@ class TestSettlementLinkage:
                 ".aragora/repair/pr-6307-attempt-2.json"
             )
 
-    def test_to_dict_serializes_repair_paths_as_list(self) -> None:
+    def test_repair_receipt_ids_is_immutable_tuple(self) -> None:
         linkage = self._minimal_linkage(
+            repair_receipt_ids=("repair-sha-001",),
+        )
+        assert isinstance(linkage.repair_receipt_ids, tuple)
+        with pytest.raises(AttributeError):
+            linkage.repair_receipt_ids.append("repair-sha-002")  # type: ignore[attr-defined]
+
+    def test_portable_ids_alongside_paths(self) -> None:
+        # P2 regression guard: export-portable IDs must exist alongside
+        # local-only paths. An exported payload dereferences by ID on
+        # another machine; a local consumer may fast-path via the path.
+        linkage = self._minimal_linkage(
+            settlement_receipt_id="settlement-content-sha-01",
+            settlement_receipt_path=".aragora/review-queue/settlements/pr-6307-approve.json",
+            repair_receipt_ids=("repair-content-sha-01", "repair-content-sha-02"),
+            repair_receipt_paths=(
+                ".aragora/repair/pr-6307-attempt-1.json",
+                ".aragora/repair/pr-6307-attempt-2.json",
+            ),
+        )
+        assert linkage.settlement_receipt_id == "settlement-content-sha-01"
+        assert len(linkage.repair_receipt_ids) == 2
+        assert len(linkage.repair_receipt_paths) == 2
+        # Both fields survive the JSON trip so external consumers can pick
+        # the one appropriate to their address space.
+        d = linkage.to_dict()
+        assert d["settlement_receipt_id"] == "settlement-content-sha-01"
+        assert d["repair_receipt_ids"] == ["repair-content-sha-01", "repair-content-sha-02"]
+
+    def test_to_dict_serializes_both_id_and_path_lists(self) -> None:
+        linkage = self._minimal_linkage(
+            repair_receipt_ids=("repair-sha-01", "repair-sha-02"),
             repair_receipt_paths=(
                 ".aragora/repair/pr-6307-attempt-1.json",
                 ".aragora/repair/pr-6307-attempt-2.json",
             ),
         )
         d = linkage.to_dict()
+        assert d["repair_receipt_ids"] == ["repair-sha-01", "repair-sha-02"]
         assert d["repair_receipt_paths"] == [
             ".aragora/repair/pr-6307-attempt-1.json",
             ".aragora/repair/pr-6307-attempt-2.json",
@@ -292,17 +399,22 @@ class TestSettlementLinkage:
         # settlement, and later repair receipts."
         linkage = self._minimal_linkage(
             brief_receipt_id="brief-001",
+            settlement_receipt_id="settlement-001",
             settlement_receipt_path=".aragora/review-queue/settlements/pr-6307-request_changes.json",
-            action="request_changes",
+            action=SettlementAction.REQUEST_CHANGES,
+            repair_receipt_ids=("repair-001", "repair-002"),
             repair_receipt_paths=(
                 ".aragora/repair/pr-6307-attempt-1.json",
                 ".aragora/repair/pr-6307-attempt-2.json",
             ),
         )
         d = linkage.to_dict()
-        # All three audit-trail elements are present and connected.
+        # All three audit-trail elements are present and connected,
+        # both by portable ID and local path.
         assert d["brief_receipt_id"] == "brief-001"
+        assert d["settlement_receipt_id"] == "settlement-001"
         assert "settlements/" in d["settlement_receipt_path"]
+        assert d["repair_receipt_ids"] == ["repair-001", "repair-002"]
         assert len(d["repair_receipt_paths"]) == 2
 
     def test_json_roundtrip(self) -> None:
@@ -311,6 +423,7 @@ class TestSettlementLinkage:
         assert roundtrip["pr_number"] == 6307
         assert roundtrip["action"] == "approve"
         assert roundtrip["advisory_only"] is False
+        assert roundtrip["settlement_receipt_id"] == "settlement-sha-abc"
 
 
 # --- Cross-module contract coherence --------------------------------------

--- a/tests/review/test_receipt.py
+++ b/tests/review/test_receipt.py
@@ -425,6 +425,29 @@ class TestSettlementLinkage:
         assert roundtrip["advisory_only"] is False
         assert roundtrip["settlement_receipt_id"] == "settlement-sha-abc"
 
+    def test_settlement_receipt_id_preimage_is_documented(self) -> None:
+        # Introducing portable IDs without a derivation contract would
+        # mean different producers generate different IDs for the same
+        # receipt. This test locks the preimage rule in the docstring
+        # parallel to ReviewBrief.packet_sha and BriefReceipt.receipt_id.
+        from aragora.review.receipt import SettlementLinkage as SL
+
+        doc = SL.__doc__ or ""
+        assert "Settlement-receipt-ID preimage" in doc
+        assert 'Remove the ``"receipt_path"`` key' in doc
+        assert "canonical JSON" in doc
+        assert "sha256" in doc.lower()
+
+    def test_repair_receipt_id_preimage_is_documented(self) -> None:
+        # Repair receipts use the same rule; guard that the docstring
+        # says so explicitly so the future repair lane can't pick a
+        # different derivation strategy silently.
+        from aragora.review.receipt import SettlementLinkage as SL
+
+        doc = SL.__doc__ or ""
+        assert "Repair-receipt-ID preimage" in doc
+        assert "same rule" in doc.lower()
+
 
 # --- Cross-module contract coherence --------------------------------------
 

--- a/tests/review/test_receipt.py
+++ b/tests/review/test_receipt.py
@@ -1,0 +1,328 @@
+"""Tests for aragora.review.receipt — schema-only BriefReceipt + linkage contracts."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from aragora.review import (
+    BriefReceipt,
+    DissentingView,
+    DissentPosition,
+    EvidenceRef,
+    Recommendation,
+    ReviewBrief,
+    ReviewRole,
+    RoleFinding,
+    SettlementLinkage,
+    ValidationRef,
+)
+
+UTC = timezone.utc
+
+
+# --- Helpers -------------------------------------------------------------
+
+
+def _minimal_brief(**overrides) -> ReviewBrief:
+    defaults = dict(
+        pr_number=6307,
+        repo="synaptent/aragora",
+        head_sha="f1a640ee2",
+        base_sha="eeef02721",
+        packet_sha="abc123",
+        recommendation=Recommendation.APPROVE_CANDIDATE,
+        top_line="Bounded schema extension; no behavior.",
+        role_findings=(),
+        dissent=(),
+        validation_summary="pre-commit clean.",
+        overall_confidence=0.9,
+        disagreement_score=0.05,
+        total_cost_usd=0.12,
+        total_wall_clock_ms=3500,
+        agent_roster=("claude-opus-4-7", "gpt-5-4"),
+        generated_at=datetime.now(UTC).isoformat(),
+    )
+    defaults.update(overrides)
+    return ReviewBrief(**defaults)
+
+
+def _minimal_receipt(**overrides) -> BriefReceipt:
+    defaults = dict(
+        brief=_minimal_brief(),
+        evidence_refs=(),
+        validation_refs=(),
+        receipt_id="receipt-sha-xyz",
+        created_at=datetime.now(UTC).isoformat(),
+    )
+    defaults.update(overrides)
+    return BriefReceipt(**defaults)
+
+
+# --- EvidenceRef --------------------------------------------------------
+
+
+class TestEvidenceRef:
+    def test_frozen(self) -> None:
+        ref = EvidenceRef(kind="file", path="aragora/review/receipt.py")
+        with pytest.raises((AttributeError, TypeError)):
+            ref.path = "elsewhere"  # type: ignore[misc]
+
+    def test_line_range_serializes_as_list(self) -> None:
+        ref = EvidenceRef(
+            kind="file",
+            path="aragora/review/receipt.py",
+            line_range=(42, 58),
+            quote="def to_dict(self) -> dict[str, Any]:",
+        )
+        d = ref.to_dict()
+        assert d["line_range"] == [42, 58]
+        assert d["kind"] == "file"
+        assert d["path"] == "aragora/review/receipt.py"
+
+    def test_line_range_omitted_when_none(self) -> None:
+        ref = EvidenceRef(kind="commit", path="main@f1a640ee2", sha="f1a640ee2")
+        d = ref.to_dict()
+        assert d["line_range"] is None
+
+    def test_json_roundtrip(self) -> None:
+        ref = EvidenceRef(
+            kind="file",
+            path="aragora/cli/commands/review_queue.py",
+            line_range=(130, 151),
+            quote="class SettlementReceipt: ...",
+        )
+        roundtrip = json.loads(json.dumps(ref.to_dict()))
+        assert roundtrip["kind"] == "file"
+        assert roundtrip["line_range"] == [130, 151]
+
+
+# --- ValidationRef -------------------------------------------------------
+
+
+class TestValidationRef:
+    def test_frozen(self) -> None:
+        ref = ValidationRef(kind="ci_check", name="lint", result="success")
+        with pytest.raises((AttributeError, TypeError)):
+            ref.result = "failure"  # type: ignore[misc]
+
+    def test_to_dict_roundtrip(self) -> None:
+        ref = ValidationRef(
+            kind="ci_check",
+            name="Version Alignment",
+            result="success",
+            url="https://github.com/synaptent/aragora/actions/runs/12345",
+        )
+        roundtrip = json.loads(json.dumps(ref.to_dict()))
+        assert roundtrip["kind"] == "ci_check"
+        assert roundtrip["name"] == "Version Alignment"
+        assert roundtrip["result"] == "success"
+
+
+# --- BriefReceipt --------------------------------------------------------
+
+
+class TestBriefReceipt:
+    def test_advisory_only_default_is_true(self) -> None:
+        # Acceptance criterion: BriefReceipt wraps the machine brief, which
+        # is advisory. Settlement is a separate human action elsewhere.
+        receipt = _minimal_receipt()
+        assert receipt.advisory_only is True
+
+    def test_settlement_note_default_says_advisory(self) -> None:
+        receipt = _minimal_receipt()
+        assert "advisory" in receipt.settlement_note.lower()
+        assert "human settlement" in receipt.settlement_note.lower()
+
+    def test_to_dict_nests_brief_and_refs(self) -> None:
+        receipt = _minimal_receipt(
+            evidence_refs=(EvidenceRef(kind="file", path="aragora/review/protocol.py"),),
+            validation_refs=(ValidationRef(kind="ci_check", name="lint", result="success"),),
+        )
+        d = receipt.to_dict()
+        assert d["brief"]["pr_number"] == 6307
+        assert d["brief"]["recommendation"] == "approve_candidate"
+        assert d["evidence_refs"][0]["path"] == "aragora/review/protocol.py"
+        assert d["validation_refs"][0]["name"] == "lint"
+
+    def test_frozen(self) -> None:
+        receipt = _minimal_receipt()
+        with pytest.raises((AttributeError, TypeError)):
+            receipt.advisory_only = False  # type: ignore[misc]
+
+    def test_sequence_fields_are_immutable_tuples(self) -> None:
+        # Same safety property as ReviewBrief: attribute reassignment is
+        # blocked, but without tuple types `receipt.evidence_refs.append(...)`
+        # would still be possible mid-flight and break receipt_id binding.
+        receipt = _minimal_receipt(
+            evidence_refs=(EvidenceRef(kind="file", path="x.py"),),
+            validation_refs=(ValidationRef(kind="ci_check", name="lint", result="success"),),
+        )
+        assert isinstance(receipt.evidence_refs, tuple)
+        assert isinstance(receipt.validation_refs, tuple)
+        with pytest.raises(AttributeError):
+            receipt.evidence_refs.append(EvidenceRef(kind="file", path="y.py"))  # type: ignore[attr-defined]
+        with pytest.raises(AttributeError):
+            receipt.validation_refs.append(  # type: ignore[attr-defined]
+                ValidationRef(kind="ci_check", name="x", result="success")
+            )
+
+    def test_dissent_survives_in_receipt(self) -> None:
+        # Acceptance criterion (#6307 body): "Dissent survives in receipts
+        # instead of being collapsed into one summary line."
+        brief = _minimal_brief(
+            dissent=(
+                DissentingView(
+                    agent="grok-3",
+                    position=DissentPosition.REQUEST_CHANGES,
+                    reason="Security concern in auth path.",
+                    role=ReviewRole.SECURITY,
+                ),
+                DissentingView(
+                    agent="gpt-5-4",
+                    position=DissentPosition.DEFER,
+                    reason="Needs more validation data.",
+                ),
+            ),
+        )
+        receipt = _minimal_receipt(brief=brief)
+        d = receipt.to_dict()
+        assert len(d["brief"]["dissent"]) == 2
+        assert d["brief"]["dissent"][0]["position"] == "request_changes"
+        assert d["brief"]["dissent"][1]["position"] == "defer"
+        # Per-dissent reasons are preserved; no collapse into a summary line.
+        assert d["brief"]["dissent"][0]["reason"] == "Security concern in auth path."
+        assert d["brief"]["dissent"][1]["reason"] == "Needs more validation data."
+
+    def test_brief_sha_binding_survives_receipt(self) -> None:
+        # Acceptance criterion: "A settled PR can be traced back to the
+        # exact brief packet and head SHA."
+        brief = _minimal_brief(
+            head_sha="f1a640ee2deadbeef",
+            packet_sha="packet-sha-locked",
+        )
+        receipt = _minimal_receipt(brief=brief)
+        d = receipt.to_dict()
+        assert d["brief"]["head_sha"] == "f1a640ee2deadbeef"
+        assert d["brief"]["packet_sha"] == "packet-sha-locked"
+
+    def test_receipt_id_preimage_is_documented(self) -> None:
+        # The preimage rule lives in the docstring (not in code) because
+        # this module is intentionally behavior-free. The orchestrator
+        # (#6306 successor) implements the hash and holds it under test.
+        # This guard is here so #6304/#6305 can't drift silently.
+        from aragora.review.receipt import BriefReceipt as BR
+
+        doc = BR.__doc__ or ""
+        assert "Receipt-ID preimage" in doc
+        assert 'Remove the ``"receipt_id"`` key' in doc
+        assert "canonical JSON" in doc
+        assert "sha256" in doc.lower()
+
+    def test_json_roundtrip(self) -> None:
+        receipt = _minimal_receipt()
+        roundtrip = json.loads(json.dumps(receipt.to_dict()))
+        assert roundtrip["brief"]["pr_number"] == 6307
+        assert roundtrip["advisory_only"] is True
+
+
+# --- SettlementLinkage --------------------------------------------------
+
+
+class TestSettlementLinkage:
+    def _minimal_linkage(self, **overrides) -> SettlementLinkage:
+        defaults = dict(
+            brief_receipt_id="receipt-sha-xyz",
+            settlement_receipt_path=".aragora/review-queue/settlements/pr-6307-f1a640ee2def-approve.json",
+            head_sha="f1a640ee2deadbeef",
+            packet_sha="packet-sha-locked",
+            pr_number=6307,
+            repo="synaptent/aragora",
+            action="approve",
+            settled_at=datetime.now(UTC).isoformat(),
+        )
+        defaults.update(overrides)
+        return SettlementLinkage(**defaults)
+
+    def test_advisory_only_defaults_to_false_because_settlement_is_human(self) -> None:
+        # Settlement is a human action, not an advisory machine output.
+        # Unlike BriefReceipt.advisory_only=True, SettlementLinkage tracks
+        # a human settlement decision.
+        linkage = self._minimal_linkage()
+        assert linkage.advisory_only is False
+
+    def test_frozen(self) -> None:
+        linkage = self._minimal_linkage()
+        with pytest.raises((AttributeError, TypeError)):
+            linkage.action = "request_changes"  # type: ignore[misc]
+
+    def test_repair_receipt_paths_is_immutable_tuple(self) -> None:
+        linkage = self._minimal_linkage(
+            repair_receipt_paths=(".aragora/repair/pr-6307-attempt-1.json",),
+        )
+        assert isinstance(linkage.repair_receipt_paths, tuple)
+        with pytest.raises(AttributeError):
+            linkage.repair_receipt_paths.append(  # type: ignore[attr-defined]
+                ".aragora/repair/pr-6307-attempt-2.json"
+            )
+
+    def test_to_dict_serializes_repair_paths_as_list(self) -> None:
+        linkage = self._minimal_linkage(
+            repair_receipt_paths=(
+                ".aragora/repair/pr-6307-attempt-1.json",
+                ".aragora/repair/pr-6307-attempt-2.json",
+            ),
+        )
+        d = linkage.to_dict()
+        assert d["repair_receipt_paths"] == [
+            ".aragora/repair/pr-6307-attempt-1.json",
+            ".aragora/repair/pr-6307-attempt-2.json",
+        ]
+
+    def test_empty_brief_receipt_id_allowed_for_legacy_settlements(self) -> None:
+        # Pre-#6307 settlements already on disk have no associated
+        # BriefReceipt. Consumers must still be able to link them.
+        linkage = self._minimal_linkage(brief_receipt_id="")
+        assert linkage.brief_receipt_id == ""
+
+    def test_trace_contract_brief_to_settlement_to_repair(self) -> None:
+        # Acceptance: "Preserve linkage between machine brief, human
+        # settlement, and later repair receipts."
+        linkage = self._minimal_linkage(
+            brief_receipt_id="brief-001",
+            settlement_receipt_path=".aragora/review-queue/settlements/pr-6307-request_changes.json",
+            action="request_changes",
+            repair_receipt_paths=(
+                ".aragora/repair/pr-6307-attempt-1.json",
+                ".aragora/repair/pr-6307-attempt-2.json",
+            ),
+        )
+        d = linkage.to_dict()
+        # All three audit-trail elements are present and connected.
+        assert d["brief_receipt_id"] == "brief-001"
+        assert "settlements/" in d["settlement_receipt_path"]
+        assert len(d["repair_receipt_paths"]) == 2
+
+    def test_json_roundtrip(self) -> None:
+        linkage = self._minimal_linkage()
+        roundtrip = json.loads(json.dumps(linkage.to_dict()))
+        assert roundtrip["pr_number"] == 6307
+        assert roundtrip["action"] == "approve"
+        assert roundtrip["advisory_only"] is False
+
+
+# --- Cross-module contract coherence --------------------------------------
+
+
+class TestContractCoherence:
+    def test_brief_receipt_composes_with_protocol_brief(self) -> None:
+        # BriefReceipt must accept the exact ReviewBrief shape defined in
+        # aragora.review.protocol without any adapter. If this test fails,
+        # #6307 has drifted from #6334.
+        from aragora.review.protocol import ReviewBrief as ProtocolBrief
+
+        assert ReviewBrief is ProtocolBrief  # same module, same class
+        receipt = _minimal_receipt(brief=_minimal_brief())
+        assert isinstance(receipt.brief, ProtocolBrief)


### PR DESCRIPTION
## Summary

Smallest credible foundation for #6307 (receipt + settlement schema). Schema-only module: dataclasses for PR intelligence brief receipts and their linkage to human settlement actions. **No behavior, no I/O, no hashing** — that ships in the #6306 orchestrator + #6304 UI + #6305 policy.

Same pattern as #6334 (just merged): frozen dataclasses, tuple sequences, advisory-only invariants, deterministic preimage spec documented in docstring for successor PRs to implement.

## Scope (#6307)

Closes part of: #6307 (foundation only — receipt schema contracts)
Depends on: #6334 (merged — provides `ReviewBrief` wrapped by `BriefReceipt`)
Parent design: `docs/plans/2026-04-19-pr-intelligence-brief.md` (#6309)

## What's defined

| Type | Purpose |
|------|---------|
| `EvidenceRef` | pointer to supporting evidence: `kind` (file/test/commit/artifact/issue/pr/external) + `path` + optional `line_range` + short `quote` |
| `ValidationRef` | pointer to automated check: `kind` (ci_check/test_suite/receipt/benchmark/manual_review) + `name` + `result` + optional `url` |
| `BriefReceipt` | wraps `ReviewBrief` + adds `evidence_refs` + `validation_refs`; `advisory_only=True` frozen; deterministic `receipt_id` preimage documented |
| `SettlementLinkage` | binds `brief_receipt_id` → `settlement_receipt_path` → tuple of `repair_receipt_paths`; `advisory_only=False` (settlement is a human action) |

## Acceptance-criteria coverage (from #6307 body)

| Criterion | Covered by |
|-----------|-----------|
| "A settled PR can be traced back to the exact brief packet and head SHA" | `SettlementLinkage.head_sha` + `.packet_sha` duplicate the brief's for fast lookup; regression test `test_trace_contract_brief_to_settlement_to_repair` |
| "Dissent survives in receipts instead of being collapsed into one summary line" | `BriefReceipt.brief.dissent` preserved verbatim as `tuple[DissentingView, ...]`; regression test `test_dissent_survives_in_receipt` |
| "Receipt payload is stable enough for operator UI and external export" | frozen dataclasses + tuple sequences + deterministic `receipt_id` preimage in docstring; regression test `test_receipt_id_preimage_is_documented` |

## Backwards compatibility preserved

- Existing `SettlementReceipt` in `aragora/cli/commands/review_queue.py` unchanged
- `SettlementLinkage` references it **by path**, not by re-embedding fields, so pre-#6307 settlement receipts on disk still resolve
- `SettlementLinkage.brief_receipt_id=""` allowed for legacy settlements without an associated `BriefReceipt`

## Safety invariants enforced by the schema itself

- `BriefReceipt.advisory_only` / `.settlement_note` frozen (mirrors #6334 `ReviewBrief`)
- All sequence fields are `tuple[...]` not `list[...]` (immutability against mid-flight mutation that would break `receipt_id` binding)
- Module is intentionally behavior-free; runtime validation of empty fields / URL shapes / SHA formats deferred to the orchestrator

## Validation (literal)

```
pytest tests/review/test_receipt.py tests/review/test_protocol.py -q
60 passed in 1.59s   (23 new + 37 existing)

reconcile_status_docs --strict           Result: PASS
check_capability_matrix_sync             Capability matrix files are up to date.
generate_cli_reference --check           CLI reference files are up to date.
check_version_alignment                  All versions aligned!
```

Pre-commit hooks: passed (gitleaks, large files, merge conflicts, private key, ruff format).

## Files

- `aragora/review/__init__.py` (+8 lines, new public re-exports)
- `aragora/review/receipt.py` (new, ~160 LOC after ruff format)
- `tests/review/test_receipt.py` (new, 23 tests)

## Non-goals

- Not implementing the orchestrator (a #6306 successor PR)
- Not computing `receipt_id` (the orchestrator implements the hash under test; preimage rule is documented in `BriefReceipt` docstring)
- Not writing receipts to disk (storage path ownership lives in the orchestrator)
- Not modifying existing `SettlementReceipt` or `merge_arbiter` code
- Not using `--admin` to bypass review

## Capability vs hygiene vs accounting

**Capability** — new type contracts the #6306 orchestrator, #6304 UI, and #6305 policy will all import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)