### PR TITLE
test(webhooks): align missing-url error expectation

### DIFF
--- a/tests/handlers/test_webhooks.py
+++ b/tests/handlers/test_webhooks.py
@@ -325,7 +325,7 @@ class TestWebhookHandlerRegister:
         result = handler._handle_register_webhook({"events": ["debate_end"]}, mock_handler)
 
         assert result.status_code == 400
-        assert b"URL is required" in result.body
+        assert b"URL must be a non-empty string" in result.body
 
     def test_register_webhook_missing_events(self, handler):
         """Test registration without events."""


### PR DESCRIPTION
## Summary
- align the missing-url webhook test with the current handler error text
- keep the fix narrowly scoped to the stale smoke assertion

## Validation
- python3 -m pytest -q tests/handlers/test_webhooks.py::TestWebhookHandlerRegister::test_register_webhook_missing_url
- python3 -m pytest -q tests/handlers/test_webhooks.py -k "TestWebhookHandlerRegister"
- bash scripts/automation_pr_preflight.sh origin/main HEAD