### PR TITLE
feat(review-queue): add browser settlement UI

### DIFF
--- a/aragora/live/src/app/(app)/review-queue/__tests__/page.test.tsx
+++ b/aragora/live/src/app/(app)/review-queue/__tests__/page.test.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+
+import { fireEvent, renderWithProviders, screen, waitFor } from '@/test-utils';
+
+import ReviewQueuePage from '../page';
+
+const mockFetch = jest.fn();
+
+global.fetch = mockFetch as typeof fetch;
+
+beforeAll(() => {
+  Object.defineProperty(window, 'open', {
+    writable: true,
+    value: jest.fn(),
+  });
+  Object.defineProperty(window, 'confirm', {
+    writable: true,
+    value: jest.fn(() => true),
+  });
+  Object.defineProperty(window, 'prompt', {
+    writable: true,
+    value: jest.fn(() => ''),
+  });
+});
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: () => 'application/json',
+    },
+    json: async () => data,
+  } as Response;
+}
+
+const LIST_RESPONSE = {
+  prs: [
+    {
+      number: 6308,
+      title: 'fix(ci): cancel test-fast only on synchronize events',
+      url: 'https://github.com/synaptent/aragora/pull/6308',
+      diff_url: 'https://github.com/synaptent/aragora/pull/6308/files',
+      head_sha: 'abc123def456',
+      author: 'an0mium',
+      is_draft: false,
+      mergeable: 'MERGEABLE',
+      review_decision: 'REVIEW_REQUIRED',
+      labels: ['codex'],
+      additions: 1,
+      deletions: 1,
+      changed_files: 1,
+      checks_summary: '5/5 green',
+      lane: 'ready_now',
+      lane_reason: 'all green',
+      created_at: '2026-04-19T12:00:00Z',
+      updated_at: '2026-04-19T12:05:00Z',
+      status_counts: { success: 5, failure: 0, pending: 0, cancelled: 0, total: 5 },
+      touched_subsystems: ['.github'],
+      high_risk_paths_touched: ['.github/workflows/test.yml'],
+      machine_recommendation: 'approve_candidate',
+      machine_recommendation_reason: 'all green, bounded diff, no high-risk paths',
+      brief_available: true,
+      brief: {
+        pr_number: 6308,
+        verdict: 'approve_candidate',
+        raw_verdict: '✓ APPROVE',
+        confidence: 5,
+        logic: 'Correct YAML.',
+        security: 'None.',
+        maintainability: 'Small follow-up likely.',
+        skeptic: 'If cancellations persist, root cause is elsewhere.',
+        recommended_action: 'Approve first.',
+      },
+    },
+  ],
+  count: 1,
+  generated_at: '2026-04-19T12:10:00Z',
+  source: 'local-review-queue',
+};
+
+const STATS_RESPONSE = {
+  decisions_today: 3,
+  approvals_today: 2,
+  median_decision_seconds: 18,
+  streak: 3,
+  source: 'local-review-queue',
+};
+
+const DETAIL_RESPONSE = {
+  pr: LIST_RESPONSE.prs[0],
+  packet: {
+    pr_number: 6308,
+    title: 'fix(ci): cancel test-fast only on synchronize events',
+    url: 'https://github.com/synaptent/aragora/pull/6308',
+    head_sha: 'abc123def456',
+    base_sha: 'base123',
+    author: 'an0mium',
+    is_draft: false,
+    additions: 1,
+    deletions: 1,
+    changed_files: 1,
+    queue_bucket: 'ready_now',
+    touched_subsystems: ['.github'],
+    high_risk_paths_touched: ['.github/workflows/test.yml'],
+    validation: ['pytest tests/server/handlers/test_review_queue_handler.py'],
+    checks_summary: '5/5 green',
+    risk_flags: ['touches high-risk paths: .github/workflows/test.yml'],
+    machine_recommendation: 'approve_candidate',
+    machine_recommendation_reason: 'all green, bounded diff, no high-risk paths',
+    packet_sha: 'sha256:test',
+    generated_at: '2026-04-19T12:10:00Z',
+    advisory_only: true,
+    settlement_note: 'Human settlement required.',
+  },
+  brief: LIST_RESPONSE.prs[0].brief,
+  checks: [
+    {
+      name: 'lint',
+      status: 'COMPLETED',
+      conclusion: 'SUCCESS',
+      details_url: 'https://github.com/example/lint',
+    },
+  ],
+  files: [
+    {
+      path: '.github/workflows/test.yml',
+      additions: 1,
+      deletions: 1,
+    },
+  ],
+  diff_url: 'https://github.com/synaptent/aragora/pull/6308/files',
+};
+
+function installFetchMocks() {
+  mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method || 'GET').toUpperCase();
+
+    if (url.includes('/api/v1/review-queue/prs/6308/approve') && method === 'POST') {
+      return Promise.resolve(jsonResponse({ receipt: { action: 'approve', pr_number: 6308 } }));
+    }
+
+    if (url.includes('/api/v1/review-queue/prs/6308') && method === 'GET') {
+      return Promise.resolve(jsonResponse(DETAIL_RESPONSE));
+    }
+
+    if (url.includes('/api/v1/review-queue/stats')) {
+      return Promise.resolve(jsonResponse(STATS_RESPONSE));
+    }
+
+    if (url.includes('/api/v1/review-queue/prs')) {
+      return Promise.resolve(jsonResponse(LIST_RESPONSE));
+    }
+
+    return Promise.reject(new Error(`Unhandled fetch: ${method} ${url}`));
+  });
+}
+
+describe('ReviewQueuePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installFetchMocks();
+  });
+
+  it('renders the queue and summary metrics', async () => {
+    renderWithProviders(<ReviewQueuePage />, {
+      authOverrides: {
+        isAuthenticated: true,
+        tokens: {
+          access_token: 'token',
+          refresh_token: 'refresh',
+          expires_at: '2099-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('fix(ci): cancel test-fast only on synchronize events')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Review Queue')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('18s')).toBeInTheDocument();
+  });
+
+  it('loads detail when a card is expanded', async () => {
+    renderWithProviders(<ReviewQueuePage />, {
+      authOverrides: {
+        isAuthenticated: true,
+        tokens: {
+          access_token: 'token',
+          refresh_token: 'refresh',
+          expires_at: '2099-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Expand')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Expand'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Correct YAML.')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Risk Flags')).toBeInTheDocument();
+    expect(screen.getByText('.github/workflows/test.yml')).toBeInTheDocument();
+  });
+
+  it('settles a PR from the browser surface', async () => {
+    renderWithProviders(<ReviewQueuePage />, {
+      authOverrides: {
+        isAuthenticated: true,
+        tokens: {
+          access_token: 'token',
+          refresh_token: 'refresh',
+          expires_at: '2099-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Approve')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Approve'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Approved #6308')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('fix(ci): cancel test-fast only on synchronize events')).not.toBeInTheDocument();
+  });
+});

--- a/aragora/live/src/app/(app)/review-queue/page.tsx
+++ b/aragora/live/src/app/(app)/review-queue/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { KeyboardHelp } from '@/components/review-queue/KeyboardHelp';
-import { ReviewQueueCard } from '@/components/review-queue/ReviewQueueCard';
+import { ReviewQueueList } from '@/components/review-queue/ReviewQueueList';
 import { StatsHeader } from '@/components/review-queue/StatsHeader';
 import type { ReviewQueueItem } from '@/components/review-queue/types';
 import { formatRelativeAge, riskRank, subsystemKey } from '@/components/review-queue/utils';
@@ -296,32 +296,27 @@ export default function ReviewQueuePage() {
                 </p>
               </div>
             ) : (
-              <div className="grid gap-4">
-                {sortedItems.map((item) => (
-                  <ReviewQueueCard
-                    key={item.number}
-                    item={item}
-                    selected={selectedNumber === item.number}
-                    expanded={expandedNumber === item.number}
-                    detail={details[item.number] || null}
-                    detailLoading={Boolean(detailLoading[item.number])}
-                    requestChangesOpen={requestChangesOpenFor === item.number}
-                    requestChangesDraft={requestChangesDrafts[item.number] || ''}
-                    actionLoading={actionLoading[item.number] || null}
-                    onSelect={() => setSelectedNumber(item.number)}
-                    onToggleExpand={() => void toggleExpand(item.number)}
-                    onApprove={() => void handleApprove(item)}
-                    onDefer={() => void handleDefer(item.number)}
-                    onOpenDiff={() => window.open(item.diff_url, '_blank', 'noopener,noreferrer')}
-                    onOpenRequestChanges={() => openRequestChanges(item.number)}
-                    onRequestChangesDraftChange={(value) =>
-                      setRequestChangesDrafts((current) => ({ ...current, [item.number]: value }))
-                    }
-                    onRequestChangesSubmit={() => void handleRequestChangesSubmit(item.number)}
-                    onRequestChangesCancel={() => setRequestChangesOpenFor(null)}
-                  />
-                ))}
-              </div>
+              <ReviewQueueList
+                items={sortedItems}
+                selectedNumber={selectedNumber}
+                expandedNumber={expandedNumber}
+                details={details}
+                detailLoading={detailLoading}
+                requestChangesOpenFor={requestChangesOpenFor}
+                requestChangesDrafts={requestChangesDrafts}
+                actionLoading={actionLoading}
+                onSelect={setSelectedNumber}
+                onToggleExpand={(number) => void toggleExpand(number)}
+                onApprove={(item) => void handleApprove(item)}
+                onDefer={(number) => void handleDefer(number)}
+                onOpenDiff={(item) => window.open(item.diff_url, '_blank', 'noopener,noreferrer')}
+                onOpenRequestChanges={openRequestChanges}
+                onRequestChangesDraftChange={(number, value) =>
+                  setRequestChangesDrafts((current) => ({ ...current, [number]: value }))
+                }
+                onRequestChangesSubmit={(number) => void handleRequestChangesSubmit(number)}
+                onRequestChangesCancel={() => setRequestChangesOpenFor(null)}
+              />
             )}
           </PanelErrorBoundary>
         </div>

--- a/aragora/live/src/app/(app)/review-queue/page.tsx
+++ b/aragora/live/src/app/(app)/review-queue/page.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import clsx from 'clsx';
+
+import { KeyboardHelp } from '@/components/review-queue/KeyboardHelp';
+import { ReviewQueueCard } from '@/components/review-queue/ReviewQueueCard';
+import { StatsHeader } from '@/components/review-queue/StatsHeader';
+import type { ReviewQueueItem } from '@/components/review-queue/types';
+import { formatRelativeAge, riskRank, subsystemKey } from '@/components/review-queue/utils';
+import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
+import { useReviewQueue } from '@/hooks/useReviewQueue';
+
+type SortMode = 'age' | 'risk' | 'subsystem';
+
+export default function ReviewQueuePage() {
+  const {
+    items,
+    stats,
+    listLoading,
+    listError,
+    actionError,
+    details,
+    detailLoading,
+    actionLoading,
+    loadDetail,
+    refreshAll,
+    approve,
+    requestChanges,
+    defer,
+  } = useReviewQueue();
+
+  const [sortBy, setSortBy] = useState<SortMode>('age');
+  const [selectedNumber, setSelectedNumber] = useState<number | null>(null);
+  const [expandedNumber, setExpandedNumber] = useState<number | null>(null);
+  const [requestChangesOpenFor, setRequestChangesOpenFor] = useState<number | null>(null);
+  const [requestChangesDrafts, setRequestChangesDrafts] = useState<Record<number, string>>({});
+  const [showKeyboardHelp, setShowKeyboardHelp] = useState(false);
+  const [flashMessage, setFlashMessage] = useState<string | null>(null);
+  const [showInboxZero, setShowInboxZero] = useState(false);
+  const previousPendingCount = useRef<number | null>(null);
+
+  const sortedItems = [...items].sort((left, right) => {
+    if (sortBy === 'risk') {
+      const riskDelta = riskRank(left) - riskRank(right);
+      if (riskDelta !== 0) return riskDelta;
+      return left.number - right.number;
+    }
+    if (sortBy === 'subsystem') {
+      const subsystemDelta = subsystemKey(left).localeCompare(subsystemKey(right));
+      if (subsystemDelta !== 0) return subsystemDelta;
+      return left.number - right.number;
+    }
+    const leftCreated = left.created_at || '';
+    const rightCreated = right.created_at || '';
+    if (leftCreated !== rightCreated) {
+      return leftCreated.localeCompare(rightCreated);
+    }
+    return left.number - right.number;
+  });
+
+  useEffect(() => {
+    if (!sortedItems.length) {
+      setSelectedNumber(null);
+      return;
+    }
+    if (!selectedNumber || !sortedItems.some((item) => item.number === selectedNumber)) {
+      setSelectedNumber(sortedItems[0].number);
+    }
+  }, [selectedNumber, sortedItems]);
+
+  useEffect(() => {
+    const previous = previousPendingCount.current;
+    if (previous !== null && previous > 0 && items.length === 0) {
+      setShowInboxZero(true);
+    }
+    previousPendingCount.current = items.length;
+  }, [items.length]);
+
+  const toggleExpand = useCallback(
+    async (number: number) => {
+      setSelectedNumber(number);
+      if (expandedNumber === number) {
+        setExpandedNumber(null);
+        return;
+      }
+      setExpandedNumber(number);
+      await loadDetail(number);
+    },
+    [expandedNumber, loadDetail]
+  );
+
+  const openRequestChanges = useCallback(
+    (number: number) => {
+      setSelectedNumber(number);
+      setRequestChangesOpenFor(number);
+      if (expandedNumber !== number) {
+        setExpandedNumber(number);
+      }
+      void loadDetail(number);
+    },
+    [expandedNumber, loadDetail]
+  );
+
+  const handleApprove = useCallback(
+    async (item: ReviewQueueItem) => {
+      const needsConfirm = !item.brief || item.brief.verdict !== 'approve_candidate';
+      if (
+        needsConfirm &&
+        !window.confirm(
+          item.brief
+            ? `Brief verdict is ${item.brief.raw_verdict || item.brief.verdict}. Approve anyway?`
+            : `No brief is available for #${item.number}. Approve anyway?`
+        )
+      ) {
+        return;
+      }
+      const ok = await approve(item.number);
+      if (ok) {
+        setFlashMessage(`Approved #${item.number}`);
+        if (selectedNumber === item.number) {
+          setExpandedNumber(null);
+          setRequestChangesOpenFor(null);
+        }
+      }
+    },
+    [approve, selectedNumber]
+  );
+
+  const handleRequestChangesSubmit = useCallback(
+    async (number: number) => {
+      const reason = (requestChangesDrafts[number] || '').trim();
+      if (!reason) return;
+      const ok = await requestChanges(number, reason);
+      if (ok) {
+        setFlashMessage(`Requested changes on #${number}`);
+        setRequestChangesOpenFor(null);
+        setExpandedNumber(null);
+      }
+    },
+    [requestChanges, requestChangesDrafts]
+  );
+
+  const handleDefer = useCallback(
+    async (number: number) => {
+      const reason = window.prompt('Optional defer note (local only)', '') ?? '';
+      const ok = await defer(number, reason);
+      if (ok) {
+        setFlashMessage(`Deferred #${number} for 4 hours`);
+        if (selectedNumber === number) {
+          setExpandedNumber(null);
+          setRequestChangesOpenFor(null);
+        }
+      }
+    },
+    [defer, selectedNumber]
+  );
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      const currentIndex = sortedItems.findIndex((item) => item.number === selectedNumber);
+      const currentItem = sortedItems[currentIndex] || null;
+
+      if (event.key === '?') {
+        event.preventDefault();
+        setShowKeyboardHelp((current) => !current);
+        return;
+      }
+
+      if (!currentItem) return;
+
+      if (event.key === 'j') {
+        event.preventDefault();
+        const next = sortedItems[Math.min(currentIndex + 1, sortedItems.length - 1)];
+        setSelectedNumber(next.number);
+        return;
+      }
+
+      if (event.key === 'k') {
+        event.preventDefault();
+        const next = sortedItems[Math.max(currentIndex - 1, 0)];
+        setSelectedNumber(next.number);
+        return;
+      }
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        void toggleExpand(currentItem.number);
+        return;
+      }
+
+      if (event.key === 'a') {
+        event.preventDefault();
+        void handleApprove(currentItem);
+        return;
+      }
+
+      if (event.key === 'r') {
+        event.preventDefault();
+        openRequestChanges(currentItem.number);
+        return;
+      }
+
+      if (event.key === 'd') {
+        event.preventDefault();
+        void handleDefer(currentItem.number);
+        return;
+      }
+
+      if (event.key === 'o') {
+        event.preventDefault();
+        window.open(currentItem.diff_url, '_blank', 'noopener,noreferrer');
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleApprove, handleDefer, openRequestChanges, selectedNumber, sortedItems, toggleExpand]);
+
+  return (
+    <>
+      <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(0,255,163,0.08),transparent_24%),linear-gradient(180deg,var(--bg),#05080b)] px-4 py-6 text-text md:px-6">
+        <div className="mx-auto max-w-7xl space-y-6">
+          <StatsHeader
+            pendingCount={sortedItems.length}
+            medianDecisionSeconds={stats.median_decision_seconds}
+            streak={stats.streak}
+            approvalsToday={stats.approvals_today}
+            sortBy={sortBy}
+            onSortChange={setSortBy}
+          />
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-2 text-[11px] font-theme-data uppercase tracking-[0.18em] text-text-muted">
+              <span>{sortedItems.length} PRs in scope</span>
+              {sortedItems[0]?.created_at ? (
+                <span>oldest {formatRelativeAge(sortedItems[0].created_at)}</span>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => void refreshAll()}
+                className="rounded-full border border-[var(--accent)]/25 px-3 py-1.5 text-xs font-theme-data text-[var(--accent)] hover:bg-[var(--accent)]/10"
+              >
+                Refresh
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowKeyboardHelp(true)}
+                className="rounded-full border border-border px-3 py-1.5 text-xs font-theme-data text-text-muted hover:text-text"
+              >
+                Shortcuts
+              </button>
+            </div>
+          </div>
+
+          {(listError || actionError) ? (
+            <div className="rounded-2xl border border-acid-red/30 bg-acid-red/10 px-4 py-3 text-sm font-theme-data text-acid-red">
+              {actionError || listError}
+            </div>
+          ) : null}
+
+          {flashMessage ? (
+            <div className="rounded-2xl border border-emerald-400/25 bg-emerald-400/10 px-4 py-3 text-sm font-theme-data text-emerald-300">
+              {flashMessage}
+            </div>
+          ) : null}
+
+          <PanelErrorBoundary panelName="Review Queue">
+            {listLoading ? (
+              <div className="rounded-2xl border border-[var(--accent)]/15 bg-surface/70 px-5 py-12 text-center text-sm font-theme-data text-text-muted">
+                Loading queue…
+              </div>
+            ) : sortedItems.length === 0 ? (
+              <div className="rounded-2xl border border-[var(--accent)]/15 bg-surface/70 px-5 py-12 text-center">
+                <p className="text-[11px] font-theme-data uppercase tracking-[0.28em] text-[var(--accent)]">
+                  Inbox Zero
+                </p>
+                <h2 className="mt-3 text-3xl font-theme-data text-text">
+                  Morning tranche cleared.
+                </h2>
+                <p className="mx-auto mt-3 max-w-xl text-sm font-theme-data text-text-muted">
+                  No pending PRs remain in scope. This surface is intentionally optimized for the daily settlement loop, not for camping in diffs.
+                </p>
+              </div>
+            ) : (
+              <div className="grid gap-4">
+                {sortedItems.map((item) => (
+                  <ReviewQueueCard
+                    key={item.number}
+                    item={item}
+                    selected={selectedNumber === item.number}
+                    expanded={expandedNumber === item.number}
+                    detail={details[item.number] || null}
+                    detailLoading={Boolean(detailLoading[item.number])}
+                    requestChangesOpen={requestChangesOpenFor === item.number}
+                    requestChangesDraft={requestChangesDrafts[item.number] || ''}
+                    actionLoading={actionLoading[item.number] || null}
+                    onSelect={() => setSelectedNumber(item.number)}
+                    onToggleExpand={() => void toggleExpand(item.number)}
+                    onApprove={() => void handleApprove(item)}
+                    onDefer={() => void handleDefer(item.number)}
+                    onOpenDiff={() => window.open(item.diff_url, '_blank', 'noopener,noreferrer')}
+                    onOpenRequestChanges={() => openRequestChanges(item.number)}
+                    onRequestChangesDraftChange={(value) =>
+                      setRequestChangesDrafts((current) => ({ ...current, [item.number]: value }))
+                    }
+                    onRequestChangesSubmit={() => void handleRequestChangesSubmit(item.number)}
+                    onRequestChangesCancel={() => setRequestChangesOpenFor(null)}
+                  />
+                ))}
+              </div>
+            )}
+          </PanelErrorBoundary>
+        </div>
+      </main>
+
+      <KeyboardHelp open={showKeyboardHelp} onClose={() => setShowKeyboardHelp(false)} />
+
+      {showInboxZero ? (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 px-4">
+          <div className="max-w-lg rounded-2xl border border-[var(--accent)]/25 bg-[linear-gradient(180deg,rgba(8,12,16,0.96),rgba(12,18,24,0.96))] p-6 text-center shadow-[0_30px_80px_rgba(0,0,0,0.38)]">
+            <p className="text-[11px] font-theme-data uppercase tracking-[0.28em] text-[var(--accent)]">
+              Queue Cleared
+            </p>
+            <h2 className="mt-3 text-3xl font-theme-data text-text">Inbox zero.</h2>
+            <p className="mt-3 text-sm font-theme-data text-text-muted">
+              The browser tranche is empty. This is the intended UX reward loop for the morning brief workflow.
+            </p>
+            <button
+              type="button"
+              onClick={() => setShowInboxZero(false)}
+              className={clsx(
+                'mt-5 rounded-full border border-[var(--accent)]/25 px-4 py-2 text-xs font-theme-data text-[var(--accent)] hover:bg-[var(--accent)]/10'
+              )}
+            >
+              Keep Moving
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/aragora/live/src/components/review-queue/BriefPanel.tsx
+++ b/aragora/live/src/components/review-queue/BriefPanel.tsx
@@ -1,0 +1,138 @@
+import clsx from 'clsx';
+
+import type { ReviewQueueDetail } from './types';
+import { verdictLabel, verdictTone } from './utils';
+
+interface BriefPanelProps {
+  detail: ReviewQueueDetail | null;
+  loading: boolean;
+}
+
+export function BriefPanel({ detail, loading }: BriefPanelProps) {
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-[var(--accent)]/15 bg-bg/45 px-4 py-5 text-sm font-theme-data text-text-muted">
+        Loading brief and packet details…
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div className="rounded-xl border border-dashed border-border bg-bg/35 px-4 py-5 text-sm font-theme-data text-text-muted">
+        No brief loaded yet.
+      </div>
+    );
+  }
+
+  const { brief, packet, checks, files, diff_url } = detail;
+  const verdict = brief?.verdict ?? packet.machine_recommendation;
+
+  return (
+    <div className="space-y-4 rounded-xl border border-[var(--accent)]/15 bg-[linear-gradient(180deg,rgba(12,18,24,0.92),rgba(9,13,18,0.92))] p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className={clsx('rounded-full border px-2.5 py-1 text-[11px] font-theme-data uppercase tracking-[0.16em]', verdictTone(verdict))}>
+              {verdictLabel(verdict)}
+            </span>
+            {brief?.confidence ? (
+              <span className="text-[11px] font-theme-data uppercase tracking-[0.16em] text-text-muted">
+                Confidence {brief.confidence}/5
+              </span>
+            ) : null}
+          </div>
+          <h3 className="text-lg font-theme-data text-text">{packet.title}</h3>
+          <p className="text-sm font-theme-data text-text-muted">
+            {brief?.recommended_action || packet.machine_recommendation_reason}
+          </p>
+        </div>
+        <a
+          href={diff_url}
+          target="_blank"
+          rel="noreferrer"
+          className="rounded-full border border-[var(--accent)]/25 px-3 py-1 text-xs font-theme-data text-[var(--accent)] hover:bg-[var(--accent)]/10"
+        >
+          Transcript / diff
+        </a>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <SectionCard title="Logic" body={brief?.logic || packet.machine_recommendation_reason} />
+        <SectionCard title="Security" body={brief?.security || 'No security-specific note in the available brief.'} />
+        <SectionCard
+          title="Maintainability"
+          body={brief?.maintainability || 'No maintainability note in the available brief.'}
+        />
+        <SectionCard title="Skeptic" body={brief?.skeptic || 'No skeptic pass captured in the available brief.'} />
+      </div>
+
+      {packet.risk_flags.length > 0 ? (
+        <div className="rounded-xl border border-[var(--acid-yellow)]/20 bg-[var(--acid-yellow)]/8 p-4">
+          <p className="text-[11px] font-theme-data uppercase tracking-[0.18em] text-[var(--acid-yellow)]">
+            Risk Flags
+          </p>
+          <ul className="mt-3 space-y-2 text-sm font-theme-data text-text-muted">
+            {packet.risk_flags.map((flag) => (
+              <li key={flag}>• {flag}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+        <div className="rounded-xl border border-[var(--accent)]/12 bg-bg/45 p-4">
+          <p className="text-[11px] font-theme-data uppercase tracking-[0.18em] text-text-muted">
+            Checks
+          </p>
+          <div className="mt-3 space-y-2">
+            {checks.slice(0, 8).map((check) => (
+              <div
+                key={`${check.name}-${check.details_url || check.status}`}
+                className="flex items-center justify-between gap-3 rounded-lg border border-[var(--accent)]/10 px-3 py-2"
+              >
+                <span className="text-sm font-theme-data text-text">{check.name}</span>
+                <span className="text-xs font-theme-data text-text-muted">
+                  {check.conclusion || check.status}
+                </span>
+              </div>
+            ))}
+            {checks.length === 0 ? (
+              <div className="text-sm font-theme-data text-text-muted">No check detail available.</div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-[var(--accent)]/12 bg-bg/45 p-4">
+          <p className="text-[11px] font-theme-data uppercase tracking-[0.18em] text-text-muted">
+            Changed Files
+          </p>
+          <div className="mt-3 space-y-2">
+            {files.slice(0, 10).map((file) => (
+              <div key={file.path} className="rounded-lg border border-[var(--accent)]/10 px-3 py-2">
+                <div className="truncate text-sm font-theme-data text-text">{file.path}</div>
+                <div className="mt-1 text-xs font-theme-data text-text-muted">
+                  +{file.additions} / -{file.deletions}
+                </div>
+              </div>
+            ))}
+            {files.length > 10 ? (
+              <div className="text-xs font-theme-data text-text-muted">+{files.length - 10} more files</div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectionCard({ title, body }: { title: string; body: string | null | undefined }) {
+  return (
+    <section className="rounded-xl border border-[var(--accent)]/12 bg-bg/45 p-4">
+      <p className="text-[11px] font-theme-data uppercase tracking-[0.18em] text-text-muted">{title}</p>
+      <p className="mt-3 text-sm font-theme-data leading-6 text-text">
+        {body || 'No signal captured.'}
+      </p>
+    </section>
+  );
+}

--- a/aragora/live/src/components/review-queue/KeyboardHelp.tsx
+++ b/aragora/live/src/components/review-queue/KeyboardHelp.tsx
@@ -1,0 +1,64 @@
+interface KeyboardHelpProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SHORTCUTS = [
+  ['j / k', 'Move down or up the queue'],
+  ['Enter / Space', 'Expand or collapse the selected card'],
+  ['a', 'Approve the selected PR'],
+  ['r', 'Open request-changes composer'],
+  ['d', 'Defer the selected PR for 4 hours'],
+  ['o', 'Open the GitHub diff in a new tab'],
+  ['?', 'Toggle this help overlay'],
+];
+
+export function KeyboardHelp({ open, onClose }: KeyboardHelpProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/65 px-4"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-xl rounded-2xl border border-[var(--accent)]/25 bg-[linear-gradient(180deg,rgba(10,14,19,0.96),rgba(16,22,28,0.96))] p-6 shadow-[0_30px_80px_rgba(0,0,0,0.42)]"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="review-queue-shortcuts-title"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-[11px] font-theme-data uppercase tracking-[0.26em] text-[var(--accent)]">
+              Keyboard
+            </p>
+            <h2 id="review-queue-shortcuts-title" className="mt-2 text-xl font-theme-data text-text">
+              Settlement Shortcuts
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-border px-3 py-1 text-xs font-theme-data text-text-muted hover:border-[var(--accent)]/30 hover:text-text"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-5 grid gap-2">
+          {SHORTCUTS.map(([keys, description]) => (
+            <div
+              key={keys}
+              className="grid grid-cols-[8rem_1fr] gap-3 rounded-xl border border-[var(--accent)]/10 bg-bg/45 px-4 py-3"
+            >
+              <div className="text-sm font-theme-data text-[var(--acid-cyan)]">{keys}</div>
+              <div className="text-sm font-theme-data text-text-muted">{description}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/aragora/live/src/components/review-queue/ReviewQueueCard.tsx
+++ b/aragora/live/src/components/review-queue/ReviewQueueCard.tsx
@@ -1,0 +1,244 @@
+import type { MouseEvent } from 'react';
+
+import clsx from 'clsx';
+
+import { BriefPanel } from './BriefPanel';
+import type { ReviewQueueDetail, ReviewQueueItem } from './types';
+import { formatRelativeAge, laneTone, verdictLabel, verdictTone } from './utils';
+
+interface ReviewQueueCardProps {
+  item: ReviewQueueItem;
+  selected: boolean;
+  expanded: boolean;
+  detail: ReviewQueueDetail | null;
+  detailLoading: boolean;
+  requestChangesOpen: boolean;
+  requestChangesDraft: string;
+  actionLoading?: 'approve' | 'request_changes' | 'defer' | null;
+  onSelect: () => void;
+  onToggleExpand: () => void;
+  onApprove: () => void;
+  onDefer: () => void;
+  onOpenDiff: () => void;
+  onOpenRequestChanges: () => void;
+  onRequestChangesDraftChange: (value: string) => void;
+  onRequestChangesSubmit: () => void;
+  onRequestChangesCancel: () => void;
+}
+
+export function ReviewQueueCard({
+  item,
+  selected,
+  expanded,
+  detail,
+  detailLoading,
+  requestChangesOpen,
+  requestChangesDraft,
+  actionLoading,
+  onSelect,
+  onToggleExpand,
+  onApprove,
+  onDefer,
+  onOpenDiff,
+  onOpenRequestChanges,
+  onRequestChangesDraftChange,
+  onRequestChangesSubmit,
+  onRequestChangesCancel,
+}: ReviewQueueCardProps) {
+  const verdict = item.brief?.verdict ?? item.machine_recommendation ?? null;
+
+  return (
+    <article
+      className={clsx(
+        'rounded-2xl border p-4 transition-all',
+        selected
+          ? 'border-[var(--accent)] bg-[linear-gradient(180deg,rgba(10,18,24,0.96),rgba(10,16,20,0.92))] shadow-[0_18px_50px_rgba(0,0,0,0.24)]'
+          : 'border-border bg-surface/70 hover:border-[var(--accent)]/25 hover:bg-surface'
+      )}
+    >
+      <div
+        className="w-full text-left"
+        onClick={onSelect}
+        role="presentation"
+      >
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={clsx('text-[11px] font-theme-data uppercase tracking-[0.18em]', laneTone(item.lane))}>
+                {item.lane.replace('_', ' ')}
+              </span>
+              <span className="text-[11px] font-theme-data uppercase tracking-[0.18em] text-text-muted">
+                #{item.number}
+              </span>
+              <span className="text-[11px] font-theme-data uppercase tracking-[0.18em] text-text-muted">
+                {formatRelativeAge(item.created_at)}
+              </span>
+            </div>
+            <h2 className="mt-2 truncate text-xl font-theme-data text-text">{item.title}</h2>
+            <p className="mt-2 text-sm font-theme-data text-text-muted">
+              {item.lane_reason}
+            </p>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              <span className={clsx('rounded-full border px-2.5 py-1 text-[11px] font-theme-data uppercase tracking-[0.14em]', verdictTone(verdict))}>
+                {verdictLabel(verdict)}
+              </span>
+              <span className="rounded-full border border-border px-2.5 py-1 text-[11px] font-theme-data uppercase tracking-[0.14em] text-text-muted">
+                {item.checks_summary}
+              </span>
+              <span className="rounded-full border border-border px-2.5 py-1 text-[11px] font-theme-data uppercase tracking-[0.14em] text-text-muted">
+                +{item.additions} / -{item.deletions}
+              </span>
+              {item.touched_subsystems.slice(0, 2).map((subsystem) => (
+                <span
+                  key={subsystem}
+                  className="rounded-full border border-[var(--accent)]/20 bg-[var(--accent)]/8 px-2.5 py-1 text-[11px] font-theme-data uppercase tracking-[0.14em] text-[var(--accent)]"
+                >
+                  {subsystem}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 lg:min-w-[15rem]">
+            <div className="grid grid-cols-3 gap-2 text-center">
+              <MiniMetric label="Pass" value={item.status_counts.success} tone="text-emerald-300" />
+              <MiniMetric label="Warn" value={item.status_counts.pending} tone="text-[var(--acid-yellow)]" />
+              <MiniMetric label="Fail" value={item.status_counts.failure} tone="text-acid-red" />
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <ActionButton
+                label="Approve"
+                tone="approve"
+                busy={actionLoading === 'approve'}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onApprove();
+                }}
+              />
+              <ActionButton
+                label="Request"
+                tone="warn"
+                busy={actionLoading === 'request_changes'}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onOpenRequestChanges();
+                }}
+              />
+              <ActionButton
+                label="Defer"
+                tone="muted"
+                busy={actionLoading === 'defer'}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDefer();
+                }}
+              />
+              <ActionButton
+                label="Diff"
+                tone="link"
+                busy={false}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onOpenDiff();
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {requestChangesOpen ? (
+        <div className="mt-4 rounded-xl border border-[var(--acid-yellow)]/20 bg-[var(--acid-yellow)]/8 p-4">
+          <label className="block text-[11px] font-theme-data uppercase tracking-[0.18em] text-[var(--acid-yellow)]">
+            Request changes reason
+          </label>
+          <textarea
+            value={requestChangesDraft}
+            onChange={(event) => onRequestChangesDraftChange(event.target.value)}
+            className="mt-3 min-h-24 w-full rounded-xl border border-[var(--accent)]/20 bg-bg/70 px-3 py-2 text-sm font-theme-data text-text focus:border-[var(--accent)] focus:outline-none"
+            placeholder="Keep the repair loop bounded with one concrete reason."
+          />
+          <div className="mt-3 flex gap-2">
+            <button
+              type="button"
+              onClick={onRequestChangesSubmit}
+              className="rounded-full border border-[var(--acid-yellow)]/35 px-3 py-1.5 text-xs font-theme-data text-[var(--acid-yellow)] hover:bg-[var(--acid-yellow)]/12"
+            >
+              Submit request
+            </button>
+            <button
+              type="button"
+              onClick={onRequestChangesCancel}
+              className="rounded-full border border-border px-3 py-1.5 text-xs font-theme-data text-text-muted hover:text-text"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {expanded ? (
+        <div className="mt-4">
+          <BriefPanel detail={detail} loading={detailLoading} />
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex items-center justify-between border-t border-[var(--accent)]/10 pt-3 text-[11px] font-theme-data uppercase tracking-[0.16em] text-text-muted">
+        <span>{item.author || 'unknown author'}</span>
+        <button
+          type="button"
+          onClick={onToggleExpand}
+          className="rounded-full border border-border px-3 py-1 text-[11px] font-theme-data text-text-muted hover:border-[var(--accent)]/25 hover:text-text"
+        >
+          {expanded ? 'Collapse' : 'Expand'}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function MiniMetric({ label, value, tone }: { label: string; value: number; tone: string }) {
+  return (
+    <div className="rounded-xl border border-[var(--accent)]/10 bg-bg/45 px-3 py-2">
+      <div className={clsx('text-lg font-theme-data', tone)}>{value}</div>
+      <div className="text-[10px] font-theme-data uppercase tracking-[0.16em] text-text-muted">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function ActionButton({
+  label,
+  tone,
+  busy,
+  onClick,
+}: {
+  label: string;
+  tone: 'approve' | 'warn' | 'muted' | 'link';
+  busy: boolean;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+}) {
+  const toneClass = {
+    approve: 'border-emerald-400/30 text-emerald-300 hover:bg-emerald-400/10',
+    warn: 'border-[var(--acid-yellow)]/30 text-[var(--acid-yellow)] hover:bg-[var(--acid-yellow)]/10',
+    muted: 'border-border text-text-muted hover:text-text',
+    link: 'border-[var(--accent)]/30 text-[var(--accent)] hover:bg-[var(--accent)]/10',
+  }[tone];
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      className={clsx(
+        'rounded-full border px-3 py-1.5 text-xs font-theme-data transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+        toneClass
+      )}
+    >
+      {busy ? 'Working…' : label}
+    </button>
+  );
+}

--- a/aragora/live/src/components/review-queue/ReviewQueueList.tsx
+++ b/aragora/live/src/components/review-queue/ReviewQueueList.tsx
@@ -1,0 +1,69 @@
+import { ReviewQueueCard } from './ReviewQueueCard';
+import type { ReviewQueueDetail, ReviewQueueItem } from './types';
+
+interface ReviewQueueListProps {
+  items: ReviewQueueItem[];
+  selectedNumber: number | null;
+  expandedNumber: number | null;
+  details: Record<number, ReviewQueueDetail>;
+  detailLoading: Record<number, boolean>;
+  requestChangesOpenFor: number | null;
+  requestChangesDrafts: Record<number, string>;
+  actionLoading: Record<number, 'approve' | 'request_changes' | 'defer' | null>;
+  onSelect: (number: number) => void;
+  onToggleExpand: (number: number) => void;
+  onApprove: (item: ReviewQueueItem) => void;
+  onDefer: (number: number) => void;
+  onOpenDiff: (item: ReviewQueueItem) => void;
+  onOpenRequestChanges: (number: number) => void;
+  onRequestChangesDraftChange: (number: number, value: string) => void;
+  onRequestChangesSubmit: (number: number) => void;
+  onRequestChangesCancel: () => void;
+}
+
+export function ReviewQueueList({
+  items,
+  selectedNumber,
+  expandedNumber,
+  details,
+  detailLoading,
+  requestChangesOpenFor,
+  requestChangesDrafts,
+  actionLoading,
+  onSelect,
+  onToggleExpand,
+  onApprove,
+  onDefer,
+  onOpenDiff,
+  onOpenRequestChanges,
+  onRequestChangesDraftChange,
+  onRequestChangesSubmit,
+  onRequestChangesCancel,
+}: ReviewQueueListProps) {
+  return (
+    <div className="grid gap-4">
+      {items.map((item) => (
+        <ReviewQueueCard
+          key={item.number}
+          item={item}
+          selected={selectedNumber === item.number}
+          expanded={expandedNumber === item.number}
+          detail={details[item.number] || null}
+          detailLoading={Boolean(detailLoading[item.number])}
+          requestChangesOpen={requestChangesOpenFor === item.number}
+          requestChangesDraft={requestChangesDrafts[item.number] || ''}
+          actionLoading={actionLoading[item.number] || null}
+          onSelect={() => onSelect(item.number)}
+          onToggleExpand={() => onToggleExpand(item.number)}
+          onApprove={() => onApprove(item)}
+          onDefer={() => onDefer(item.number)}
+          onOpenDiff={() => onOpenDiff(item)}
+          onOpenRequestChanges={() => onOpenRequestChanges(item.number)}
+          onRequestChangesDraftChange={(value) => onRequestChangesDraftChange(item.number, value)}
+          onRequestChangesSubmit={() => onRequestChangesSubmit(item.number)}
+          onRequestChangesCancel={onRequestChangesCancel}
+        />
+      ))}
+    </div>
+  );
+}

--- a/aragora/live/src/components/review-queue/StatsHeader.tsx
+++ b/aragora/live/src/components/review-queue/StatsHeader.tsx
@@ -1,0 +1,94 @@
+import clsx from 'clsx';
+
+interface StatsHeaderProps {
+  pendingCount: number;
+  medianDecisionSeconds: number;
+  streak: number;
+  approvalsToday: number;
+  sortBy: 'age' | 'risk' | 'subsystem';
+  onSortChange: (value: 'age' | 'risk' | 'subsystem') => void;
+}
+
+const SORT_OPTIONS: Array<{ value: 'age' | 'risk' | 'subsystem'; label: string }> = [
+  { value: 'age', label: 'Age' },
+  { value: 'risk', label: 'Risk' },
+  { value: 'subsystem', label: 'Subsystem' },
+];
+
+export function StatsHeader({
+  pendingCount,
+  medianDecisionSeconds,
+  streak,
+  approvalsToday,
+  sortBy,
+  onSortChange,
+}: StatsHeaderProps) {
+  return (
+    <section className="rounded-2xl border border-[var(--accent)]/25 bg-[radial-gradient(circle_at_top_left,rgba(0,255,163,0.12),transparent_42%),linear-gradient(180deg,rgba(14,22,28,0.94),rgba(10,14,19,0.94))] p-5 shadow-[0_24px_60px_rgba(0,0,0,0.28)]">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-[11px] font-theme-data uppercase tracking-[0.28em] text-[var(--accent)]">
+            Morning Brief
+          </p>
+          <h1 className="text-3xl font-theme-data text-text">
+            Review Queue
+          </h1>
+          <p className="max-w-2xl text-sm font-theme-data text-text-muted">
+            Brief first, evidence second, diff third. Clear the morning tranche without living in GitHub tabs.
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <MetricCard label="Pending" value={String(pendingCount)} tone="text-[var(--accent)]" />
+          <MetricCard
+            label="Median Decision"
+            value={`${medianDecisionSeconds.toFixed(0)}s`}
+            tone="text-[var(--acid-cyan)]"
+          />
+          <MetricCard label="Streak" value={String(streak)} tone="text-[var(--acid-yellow)]" />
+          <MetricCard label="Approved Today" value={String(approvalsToday)} tone="text-emerald-300" />
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-2 border-t border-[var(--accent)]/15 pt-4">
+        <span className="text-[11px] font-theme-data uppercase tracking-[0.24em] text-text-muted">
+          Sort
+        </span>
+        {SORT_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onSortChange(option.value)}
+            className={clsx(
+              'rounded-full border px-3 py-1 text-xs font-theme-data transition-colors',
+              sortBy === option.value
+                ? 'border-[var(--accent)] bg-[var(--accent)]/15 text-[var(--accent)]'
+                : 'border-border bg-bg/50 text-text-muted hover:border-[var(--accent)]/30 hover:text-text'
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone: string;
+}) {
+  return (
+    <div className="min-w-[8rem] rounded-xl border border-[var(--accent)]/15 bg-bg/45 px-4 py-3">
+      <div className={clsx('text-2xl font-theme-data', tone)}>{value}</div>
+      <div className="mt-1 text-[11px] font-theme-data uppercase tracking-[0.18em] text-text-muted">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/aragora/live/src/components/review-queue/types.ts
+++ b/aragora/live/src/components/review-queue/types.ts
@@ -1,0 +1,116 @@
+export type ReviewQueueVerdict =
+  | 'approve_candidate'
+  | 'needs_human_attention'
+  | 'repair_first'
+  | null;
+
+export interface ReviewQueueBrief {
+  pr_number: number;
+  title?: string | null;
+  source?: string | null;
+  source_path?: string | null;
+  head_sha?: string | null;
+  verdict: ReviewQueueVerdict;
+  raw_verdict?: string | null;
+  confidence?: number | null;
+  scope?: string | null;
+  logic?: string | null;
+  security?: string | null;
+  maintainability?: string | null;
+  skeptic?: string | null;
+  recommended_action?: string | null;
+}
+
+export interface ReviewQueueStatusCounts {
+  success: number;
+  failure: number;
+  pending: number;
+  cancelled: number;
+  total: number;
+}
+
+export interface ReviewQueueItem {
+  number: number;
+  title: string;
+  url: string;
+  diff_url: string;
+  head_sha: string;
+  author: string;
+  is_draft: boolean;
+  mergeable: string;
+  review_decision: string;
+  labels: string[];
+  additions: number;
+  deletions: number;
+  changed_files: number;
+  checks_summary: string;
+  lane: string;
+  lane_reason: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  status_counts: ReviewQueueStatusCounts;
+  touched_subsystems: string[];
+  high_risk_paths_touched: string[];
+  machine_recommendation?: ReviewQueueVerdict;
+  machine_recommendation_reason?: string | null;
+  brief?: ReviewQueueBrief | null;
+  brief_available: boolean;
+  deferred_until?: string | null;
+  deferred_reason?: string | null;
+}
+
+export interface ReviewQueueDetail {
+  pr: ReviewQueueItem;
+  packet: {
+    pr_number: number;
+    title: string;
+    url: string;
+    head_sha: string;
+    base_sha: string;
+    author: string;
+    is_draft: boolean;
+    additions: number;
+    deletions: number;
+    changed_files: number;
+    queue_bucket: string;
+    touched_subsystems: string[];
+    high_risk_paths_touched: string[];
+    validation: string[];
+    checks_summary: string;
+    risk_flags: string[];
+    machine_recommendation: ReviewQueueVerdict;
+    machine_recommendation_reason: string;
+    packet_sha: string;
+    generated_at: string;
+    advisory_only: boolean;
+    settlement_note: string;
+  };
+  brief?: ReviewQueueBrief | null;
+  checks: Array<{
+    name: string;
+    status: string;
+    conclusion: string;
+    details_url?: string | null;
+  }>;
+  files: Array<{
+    path: string;
+    additions: number;
+    deletions: number;
+  }>;
+  diff_url: string;
+}
+
+export interface ReviewQueueListResponse {
+  prs: ReviewQueueItem[];
+  count: number;
+  generated_at: string;
+  source: string;
+}
+
+export interface ReviewQueueStats {
+  decisions_today: number;
+  approvals_today: number;
+  median_decision_seconds: number;
+  streak: number;
+  source: string;
+}

--- a/aragora/live/src/components/review-queue/utils.ts
+++ b/aragora/live/src/components/review-queue/utils.ts
@@ -1,0 +1,65 @@
+import type { ReviewQueueItem, ReviewQueueVerdict } from './types';
+
+export function verdictLabel(verdict: ReviewQueueVerdict | undefined): string {
+  switch (verdict) {
+    case 'approve_candidate':
+      return 'APPROVE';
+    case 'needs_human_attention':
+      return 'ATTENTION';
+    case 'repair_first':
+      return 'REPAIR';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+export function verdictTone(verdict: ReviewQueueVerdict | undefined): string {
+  switch (verdict) {
+    case 'approve_candidate':
+      return 'border-emerald-400/40 bg-emerald-400/10 text-emerald-300';
+    case 'needs_human_attention':
+      return 'border-[var(--acid-yellow)]/40 bg-[var(--acid-yellow)]/10 text-[var(--acid-yellow)]';
+    case 'repair_first':
+      return 'border-acid-red/40 bg-acid-red/10 text-acid-red';
+    default:
+      return 'border-border bg-bg/40 text-text-muted';
+  }
+}
+
+export function laneTone(lane: string): string {
+  switch (lane) {
+    case 'repairable':
+      return 'text-acid-red';
+    case 'needs_attention':
+      return 'text-[var(--acid-yellow)]';
+    case 'ready_now':
+      return 'text-emerald-300';
+    default:
+      return 'text-text-muted';
+  }
+}
+
+export function formatRelativeAge(value?: string | null): string {
+  if (!value) return 'unknown age';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'unknown age';
+  const deltaMs = Date.now() - date.getTime();
+  const deltaHours = Math.max(0, deltaMs / (1000 * 60 * 60));
+  if (deltaHours < 1) return '<1h old';
+  if (deltaHours < 24) return `${Math.floor(deltaHours)}h old`;
+  return `${Math.floor(deltaHours / 24)}d old`;
+}
+
+export function riskRank(item: ReviewQueueItem): number {
+  if (item.machine_recommendation === 'repair_first') return 0;
+  if (item.lane === 'repairable') return 1;
+  if (item.machine_recommendation === 'needs_human_attention') return 2;
+  if (item.lane === 'needs_attention') return 3;
+  if (item.brief?.verdict === 'needs_human_attention') return 4;
+  if (item.brief?.verdict === 'approve_candidate') return 5;
+  return 6;
+}
+
+export function subsystemKey(item: ReviewQueueItem): string {
+  return item.touched_subsystems[0] || 'zzz';
+}

--- a/aragora/live/src/hooks/useReviewQueue.ts
+++ b/aragora/live/src/hooks/useReviewQueue.ts
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { useAuthFetch, useAuthenticatedFetch } from '@/hooks/useAuthenticatedFetch';
+import type {
+  ReviewQueueDetail,
+  ReviewQueueItem,
+  ReviewQueueListResponse,
+  ReviewQueueStats,
+} from '@/components/review-queue/types';
+
+const DEFAULT_LIST: ReviewQueueListResponse = {
+  prs: [],
+  count: 0,
+  generated_at: '',
+  source: 'local-review-queue',
+};
+
+const DEFAULT_STATS: ReviewQueueStats = {
+  decisions_today: 0,
+  approvals_today: 0,
+  median_decision_seconds: 0,
+  streak: 0,
+  source: 'local-review-queue',
+};
+
+type ActionName = 'approve' | 'request_changes' | 'defer';
+
+export function useReviewQueue() {
+  const listState = useAuthenticatedFetch<ReviewQueueListResponse>('/api/v1/review-queue/prs', {
+    defaultData: DEFAULT_LIST,
+  });
+  const statsState = useAuthenticatedFetch<ReviewQueueStats>('/api/v1/review-queue/stats', {
+    defaultData: DEFAULT_STATS,
+  });
+  const { authFetch } = useAuthFetch();
+
+  const [items, setItems] = useState<ReviewQueueItem[]>([]);
+  const [details, setDetails] = useState<Record<number, ReviewQueueDetail>>({});
+  const [detailLoading, setDetailLoading] = useState<Record<number, boolean>>({});
+  const [actionLoading, setActionLoading] = useState<Record<number, ActionName | null>>({});
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setItems(listState.data?.prs || []);
+  }, [listState.data]);
+
+  async function refreshAll(): Promise<void> {
+    await Promise.all([listState.refetch(), statsState.refetch()]);
+  }
+
+  async function loadDetail(number: number): Promise<void> {
+    if (details[number] || detailLoading[number]) return;
+    setDetailLoading((current) => ({ ...current, [number]: true }));
+    setActionError(null);
+    try {
+      const result = await authFetch<ReviewQueueDetail>(`/api/v1/review-queue/prs/${number}`);
+      if (result) {
+        setDetails((current) => ({ ...current, [number]: result }));
+      }
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'Failed to load PR detail');
+    } finally {
+      setDetailLoading((current) => ({ ...current, [number]: false }));
+    }
+  }
+
+  async function runAction(
+    number: number,
+    action: ActionName,
+    body: Record<string, unknown> = {}
+  ): Promise<boolean> {
+    setActionLoading((current) => ({ ...current, [number]: action }));
+    setActionError(null);
+    try {
+      const result = await authFetch(
+        `/api/v1/review-queue/prs/${number}/${action === 'request_changes' ? 'request-changes' : action}`,
+        {
+          method: 'POST',
+          body: JSON.stringify(body),
+        }
+      );
+      if (!result) return false;
+      setItems((current) => current.filter((item) => item.number !== number));
+      setDetails((current) => {
+        const next = { ...current };
+        delete next[number];
+        return next;
+      });
+      await statsState.refetch();
+      return true;
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'Action failed');
+      return false;
+    } finally {
+      setActionLoading((current) => ({ ...current, [number]: null }));
+    }
+  }
+
+  return {
+    items,
+    setItems,
+    stats: statsState.data || DEFAULT_STATS,
+    listLoading: listState.loading,
+    listError: listState.error,
+    actionError,
+    details,
+    detailLoading,
+    actionLoading,
+    loadDetail,
+    refreshAll,
+    approve: (number: number) => runAction(number, 'approve'),
+    requestChanges: (number: number, reason: string) =>
+      runAction(number, 'request_changes', { reason }),
+    defer: (number: number, reason: string) => runAction(number, 'defer', { reason }),
+  };
+}

--- a/aragora/server/handler_registry/admin.py
+++ b/aragora/server/handler_registry/admin.py
@@ -346,6 +346,7 @@ MonitoringHandler = _safe_import(
 UnifiedApprovalsHandler = _safe_import(
     "aragora.server.handlers.approvals_inbox", "UnifiedApprovalsHandler"
 )
+ReviewQueueHandler = _safe_import("aragora.server.handlers.review_queue", "ReviewQueueHandler")
 RBACHandler = _safe_import("aragora.server.handlers.rbac", "RBACHandler")
 
 # Federation status
@@ -623,6 +624,7 @@ ADMIN_HANDLER_REGISTRY: list[tuple[str, object]] = [
     ("_monitoring_handler", MonitoringHandler),
     # Approvals, RBAC, and management
     ("_unified_approvals_handler", UnifiedApprovalsHandler),
+    ("_review_queue_handler", ReviewQueueHandler),
     ("_rbac_handler", RBACHandler),
     ("_feature_flag_admin_handler", FeatureFlagAdminHandler),
     ("_emergency_access_handler", EmergencyAccessHandler),

--- a/aragora/server/handlers/review_queue.py
+++ b/aragora/server/handlers/review_queue.py
@@ -1,0 +1,826 @@
+"""Local-first review queue HTTP surface for the PDB UI v0.
+
+This handler intentionally reuses the existing ``aragora review-queue`` CLI
+contracts for queue classification, advisory packets, and settlement receipts.
+The web UI becomes a thinner browser layer over the same local truth rather
+than a second review system with different semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.cli.commands.review_queue import (
+    REVIEW_QUEUE_ARTIFACT_DIR,
+    _GhError,
+    _build_packet,
+    _gh_json,
+    _require_clean_worktree,
+    _session_id,
+    _settle_packet,
+)
+from aragora.server.handlers.base import BaseHandler, HandlerResult, error_response, json_response
+from aragora.server.validation.query_params import safe_query_int
+from aragora.server.versioning.compat import strip_version_prefix
+from aragora.worktree.fleet import resolve_repo_root
+
+logger = logging.getLogger(__name__)
+
+UTC = timezone.utc
+_PR_PATH_RE = re.compile(r"^/api/review-queue/prs/(?P<number>\d+)(?:/(?P<action>[a-z-]+))?$")
+_MANUAL_BRIEF_HEADING_RE = re.compile(r"^##\s+#(?P<number>\d+)\s+·\s+`(?P<title>[^`]+)`\s*$", re.M)
+_VERDICT_RE = re.compile(
+    r"\*\*Verdict:\*\*\s*(?P<verdict>.+?)\s*·\s*\*\*Confidence:\*\*\s*(?P<confidence>\d+)/5(?:.*?)(?:·\s*\*\*Scope:\*\*\s*(?P<scope>[^\n]+))?",
+    re.S,
+)
+
+
+@dataclass(slots=True)
+class ReviewQueueRow:
+    """Queue item plus metadata the web UI needs for ordering and display."""
+
+    number: int
+    title: str
+    url: str
+    head_sha: str
+    author: str
+    is_draft: bool
+    mergeable: str
+    review_decision: str
+    labels: list[str]
+    additions: int
+    deletions: int
+    changed_files: int
+    checks_summary: str
+    lane: str
+    lane_reason: str
+    created_at: str | None
+    updated_at: str | None
+    status_check_rollup: list[dict[str, Any]]
+
+
+class ReviewQueueHandler(BaseHandler):
+    """Serve the local-first review queue surface used by Aragora Live."""
+
+    ROUTES = [
+        "/api/review-queue/prs",
+        "/api/review-queue/prs/*",
+        "/api/review-queue/prs/*/brief",
+        "/api/review-queue/prs/*/approve",
+        "/api/review-queue/prs/*/request-changes",
+        "/api/review-queue/prs/*/defer",
+        "/api/review-queue/stats",
+        "/api/v1/review-queue/prs",
+        "/api/v1/review-queue/prs/*",
+        "/api/v1/review-queue/prs/*/brief",
+        "/api/v1/review-queue/prs/*/approve",
+        "/api/v1/review-queue/prs/*/request-changes",
+        "/api/v1/review-queue/prs/*/defer",
+        "/api/v1/review-queue/stats",
+    ]
+
+    def __init__(self, ctx: dict | None = None):
+        self.ctx = ctx or {}
+
+    def can_handle(self, path: str, method: str = "GET") -> bool:
+        normalized = strip_version_prefix(path)
+        return normalized.startswith("/api/review-queue/")
+
+    def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
+        method = getattr(handler, "command", "GET").upper() if handler else "GET"
+        normalized = strip_version_prefix(path)
+
+        if normalized == "/api/review-queue/stats" and method == "GET":
+            return self._handle_stats(handler)
+
+        if normalized == "/api/review-queue/prs" and method == "GET":
+            return self._handle_list_prs(query_params, handler)
+
+        match = _PR_PATH_RE.match(normalized)
+        if not match:
+            return error_response("Review queue endpoint not found", 404)
+
+        pr_number = int(match.group("number"))
+        action = str(match.group("action") or "").strip()
+
+        if not action and method == "GET":
+            return self._handle_pr_detail(pr_number, handler)
+        if action == "brief" and method == "GET":
+            return self._handle_brief(pr_number, handler)
+        if action == "approve" and method == "POST":
+            return self._handle_settlement(pr_number, "approve", handler)
+        if action == "request-changes" and method == "POST":
+            return self._handle_settlement(pr_number, "request_changes", handler)
+        if action == "defer" and method == "POST":
+            return self._handle_defer(pr_number, handler)
+
+        return error_response("Method not allowed", 405)
+
+    def _handle_list_prs(self, query_params: dict[str, Any], handler: Any) -> HandlerResult:
+        _, perm_err = self.require_permission_or_error(handler, "approval:read")
+        if perm_err:
+            return perm_err
+
+        limit = safe_query_int(query_params, "limit", default=30, min_val=1, max_val=100)
+        ready_only = _query_bool(query_params, "ready_only", default=False)
+        include_parked = _query_bool(query_params, "include_parked", default=False)
+        include_deferred = _query_bool(query_params, "include_deferred", default=False)
+
+        repo_root = _resolve_storage_repo_root(_current_repo_root())
+        active_deferred = _load_active_deferred(repo_root)
+
+        try:
+            queue_items = _build_queue_rows(limit=limit)
+        except _GhError as exc:
+            logger.warning("review queue list failed: %s", exc)
+            return error_response(str(exc), 502)
+
+        payload: list[dict[str, Any]] = []
+        for item in queue_items:
+            if ready_only and item.lane != "ready_now":
+                continue
+            if not include_parked and item.lane == "parked":
+                continue
+
+            deferred_entry = active_deferred.get(item.number)
+            if deferred_entry and not include_deferred:
+                continue
+
+            try:
+                packet = _build_packet(str(item.number), repo_override=None)
+            except _GhError as exc:
+                logger.warning("review queue packet hydration failed for #%s: %s", item.number, exc)
+                packet = None
+
+            brief = _load_brief(repo_root, pr_number=item.number, head_sha=item.head_sha)
+            payload.append(
+                _serialize_queue_item(
+                    item=item,
+                    packet=packet,
+                    brief=brief,
+                    deferred_entry=deferred_entry,
+                )
+            )
+
+        payload.sort(key=_queue_sort_key)
+        return json_response(
+            {
+                "prs": payload,
+                "count": len(payload),
+                "generated_at": datetime.now(UTC).isoformat(),
+                "source": "local-review-queue",
+            }
+        )
+
+    def _handle_pr_detail(self, pr_number: int, handler: Any) -> HandlerResult:
+        _, perm_err = self.require_permission_or_error(handler, "approval:read")
+        if perm_err:
+            return perm_err
+
+        repo_root = _resolve_storage_repo_root(_current_repo_root())
+        try:
+            packet = _build_packet(str(pr_number), repo_override=None)
+            payload = _gh_json(
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--json",
+                    ",".join(
+                        [
+                            "number",
+                            "title",
+                            "url",
+                            "headRefOid",
+                            "baseRefOid",
+                            "createdAt",
+                            "updatedAt",
+                            "body",
+                            "files",
+                            "statusCheckRollup",
+                            "author",
+                            "mergeable",
+                            "reviewDecision",
+                            "isDraft",
+                            "labels",
+                            "additions",
+                            "deletions",
+                            "changedFiles",
+                        ]
+                    ),
+                ]
+            )
+        except _GhError as exc:
+            logger.warning("review queue detail failed for #%s: %s", pr_number, exc)
+            return error_response(str(exc), 502)
+
+        if not isinstance(payload, dict):
+            return error_response(f"PR #{pr_number} not found", 404)
+
+        item = _row_from_payload(payload)
+        brief = _load_brief(repo_root, pr_number=pr_number, head_sha=packet.head_sha)
+        return json_response(
+            {
+                "pr": _serialize_queue_item(
+                    item=item, packet=packet, brief=brief, deferred_entry=None
+                ),
+                "packet": packet.to_dict(),
+                "brief": brief,
+                "checks": _normalize_checks(payload.get("statusCheckRollup") or []),
+                "files": _normalize_files(payload.get("files") or []),
+                "diff_url": f"{packet.url}/files",
+            }
+        )
+
+    def _handle_brief(self, pr_number: int, handler: Any) -> HandlerResult:
+        _, perm_err = self.require_permission_or_error(handler, "approval:read")
+        if perm_err:
+            return perm_err
+
+        repo_root = _resolve_storage_repo_root(_current_repo_root())
+        try:
+            packet = _build_packet(str(pr_number), repo_override=None)
+        except _GhError as exc:
+            return error_response(str(exc), 502)
+
+        brief = _load_brief(repo_root, pr_number=pr_number, head_sha=packet.head_sha)
+        if brief is None:
+            return error_response("Brief not found", 404)
+        return json_response({"brief": brief})
+
+    def _handle_settlement(self, pr_number: int, action: str, handler: Any) -> HandlerResult:
+        _, perm_err = self.require_permission_or_error(handler, "approvals:manage")
+        if perm_err:
+            return perm_err
+
+        body = self.read_json_body(handler) or {}
+        reason = str(body.get("reason", "") or "").strip()
+        if action == "request_changes" and not reason:
+            return error_response("request_changes requires a non-empty reason", 400)
+
+        worktree_root = _current_repo_root()
+        repo_root = _resolve_storage_repo_root(worktree_root)
+
+        try:
+            _require_clean_worktree(worktree_root)
+            packet = _build_packet(str(pr_number), repo_override=None)
+            receipt = _settle_packet(
+                packet=packet,
+                action=action,
+                reason=reason,
+                repo_root=repo_root,
+                repo_override=None,
+                session_id=_session_id(),
+            )
+            _clear_deferred(repo_root, pr_number)
+        except _GhError as exc:
+            status = 409 if "head changed" in str(exc) else 400
+            logger.warning("review queue settlement failed for #%s: %s", pr_number, exc)
+            return error_response(str(exc), status)
+
+        return json_response({"receipt": receipt.to_dict()})
+
+    def _handle_defer(self, pr_number: int, handler: Any) -> HandlerResult:
+        _, perm_err = self.require_permission_or_error(handler, "approvals:manage")
+        if perm_err:
+            return perm_err
+
+        body = self.read_json_body(handler) or {}
+        reason = str(body.get("reason", "") or "").strip()
+        repo_root = _resolve_storage_repo_root(_current_repo_root())
+        deferred_until = datetime.now(UTC) + timedelta(hours=4)
+        entry = {
+            "pr_number": pr_number,
+            "reason": reason,
+            "deferred_at": datetime.now(UTC).isoformat(),
+            "deferred_until": deferred_until.isoformat(),
+        }
+        state = _load_deferred_state(repo_root)
+        state[str(pr_number)] = entry
+        _write_json(_deferred_path(repo_root), state)
+        return json_response({"deferred": entry})
+
+    def _handle_stats(self, handler: Any) -> HandlerResult:
+        _, perm_err = self.require_permission_or_error(handler, "approval:read")
+        if perm_err:
+            return perm_err
+
+        repo_root = _resolve_storage_repo_root(_current_repo_root())
+        receipts = _load_receipts(repo_root)
+        today_local = datetime.now().astimezone().date()
+        todays_receipts = [
+            receipt
+            for receipt in receipts
+            if _receipt_local_date(receipt.get("reviewed_at")) == today_local
+        ]
+
+        elapsed = sorted(
+            float(item.get("elapsed_seconds"))
+            for item in todays_receipts
+            if isinstance(item.get("elapsed_seconds"), (int, float))
+        )
+        median = 0.0
+        if elapsed:
+            mid = len(elapsed) // 2
+            median = elapsed[mid] if len(elapsed) % 2 else (elapsed[mid - 1] + elapsed[mid]) / 2
+
+        approvals_today = sum(1 for item in todays_receipts if item.get("action") == "approve")
+        return json_response(
+            {
+                "decisions_today": len(todays_receipts),
+                "approvals_today": approvals_today,
+                "median_decision_seconds": round(median, 2),
+                "streak": len(todays_receipts),
+                "source": "local-review-queue",
+            }
+        )
+
+
+def _current_repo_root() -> Path:
+    return resolve_repo_root(Path.cwd())
+
+
+def _resolve_storage_repo_root(repo_root: Path) -> Path:
+    override = os.environ.get("ARAGORA_REVIEW_QUEUE_STORAGE_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    if (_review_queue_root(repo_root)).exists():
+        return repo_root
+    parts = repo_root.parts
+    if ".worktrees" in parts:
+        index = parts.index(".worktrees")
+        candidate = Path(*parts[:index]) if index > 0 else repo_root
+        if _review_queue_root(candidate).exists():
+            return candidate
+    return repo_root
+
+
+def _review_queue_root(repo_root: Path) -> Path:
+    return repo_root / REVIEW_QUEUE_ARTIFACT_DIR
+
+
+def _briefs_dir(repo_root: Path) -> Path:
+    return _review_queue_root(repo_root) / "briefs"
+
+
+def _deferred_path(repo_root: Path) -> Path:
+    return _review_queue_root(repo_root) / "deferred.json"
+
+
+def _receipts_dir(repo_root: Path) -> Path:
+    return _review_queue_root(repo_root) / "receipts"
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _query_bool(query_params: dict[str, Any], key: str, *, default: bool) -> bool:
+    raw = query_params.get(key)
+    if raw is None:
+        return default
+    if isinstance(raw, list):
+        raw = raw[0] if raw else None
+    if raw is None:
+        return default
+    text = str(raw).strip().lower()
+    if not text:
+        return default
+    return text in {"1", "true", "yes", "on"}
+
+
+def _load_deferred_state(repo_root: Path) -> dict[str, dict[str, Any]]:
+    path = _deferred_path(repo_root)
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    entries: dict[str, dict[str, Any]] = {}
+    for key, value in payload.items():
+        if isinstance(value, dict):
+            entries[str(key)] = value
+    return entries
+
+
+def _load_active_deferred(repo_root: Path) -> dict[int, dict[str, Any]]:
+    now = datetime.now(UTC)
+    active: dict[int, dict[str, Any]] = {}
+    dirty = False
+    state = _load_deferred_state(repo_root)
+    for key, value in state.items():
+        until_text = str(value.get("deferred_until", "") or "").strip()
+        try:
+            until = _parse_iso_datetime(until_text)
+        except ValueError:
+            dirty = True
+            continue
+        if until <= now:
+            dirty = True
+            continue
+        try:
+            active[int(key)] = value
+        except ValueError:
+            dirty = True
+    if dirty:
+        cleaned = {str(number): value for number, value in active.items()}
+        _write_json(_deferred_path(repo_root), cleaned)
+    return active
+
+
+def _clear_deferred(repo_root: Path, pr_number: int) -> None:
+    state = _load_deferred_state(repo_root)
+    key = str(pr_number)
+    if key not in state:
+        return
+    del state[key]
+    _write_json(_deferred_path(repo_root), state)
+
+
+def _load_receipts(repo_root: Path) -> list[dict[str, Any]]:
+    directory = _receipts_dir(repo_root)
+    if not directory.exists():
+        return []
+    receipts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            receipts.append(payload)
+    receipts.sort(key=lambda item: str(item.get("reviewed_at", "")))
+    return receipts
+
+
+def _receipt_local_date(value: Any) -> datetime.date | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return _parse_iso_datetime(value).astimezone().date()
+    except ValueError:
+        return None
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _load_brief(repo_root: Path, *, pr_number: int, head_sha: str | None) -> dict[str, Any] | None:
+    brief = _load_json_brief(repo_root, pr_number=pr_number, head_sha=head_sha)
+    if brief is not None:
+        return brief
+    return _load_manual_markdown_brief(repo_root, pr_number=pr_number)
+
+
+def _load_json_brief(
+    repo_root: Path, *, pr_number: int, head_sha: str | None
+) -> dict[str, Any] | None:
+    directory = _briefs_dir(repo_root)
+    if not directory.exists():
+        return None
+
+    candidates = sorted(directory.glob(f"pr-{pr_number}-*.json"))
+    if head_sha:
+        prefix = head_sha[:12]
+        exact = [path for path in candidates if path.name == f"pr-{pr_number}-{prefix}.json"]
+        if exact:
+            candidates = exact
+
+    for path in reversed(candidates):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        verdict = _normalize_verdict(payload.get("verdict"))
+        return {
+            "pr_number": pr_number,
+            "title": str(payload.get("title", "") or "").strip() or None,
+            "source": "brief_json",
+            "source_path": str(path),
+            "head_sha": str(payload.get("head_sha", "") or head_sha or "").strip() or None,
+            "verdict": verdict,
+            "raw_verdict": str(payload.get("verdict", "") or "").strip() or None,
+            "confidence": _safe_int(payload.get("confidence")),
+            "scope": str(payload.get("scope", "") or "").strip() or None,
+            "logic": _clean_text(payload.get("logic")),
+            "security": _clean_text(payload.get("security")),
+            "maintainability": _clean_text(payload.get("maintainability")),
+            "skeptic": _clean_text(payload.get("skeptic")),
+            "recommended_action": _clean_text(
+                payload.get("recommended_action") or payload.get("recommendedAction")
+            ),
+        }
+    return None
+
+
+def _load_manual_markdown_brief(repo_root: Path, *, pr_number: int) -> dict[str, Any] | None:
+    files = sorted(_review_queue_root(repo_root).glob("manual-briefs-*.md"))
+    for path in reversed(files):
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        brief = _parse_manual_brief_markdown(content, pr_number=pr_number)
+        if brief is not None:
+            brief["source"] = "manual_markdown"
+            brief["source_path"] = str(path)
+            return brief
+    return None
+
+
+def _parse_manual_brief_markdown(content: str, *, pr_number: int) -> dict[str, Any] | None:
+    matches = list(_MANUAL_BRIEF_HEADING_RE.finditer(content))
+    for index, match in enumerate(matches):
+        number = int(match.group("number"))
+        if number != pr_number:
+            continue
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(content)
+        section = content[start:end].strip()
+        verdict_match = _VERDICT_RE.search(section)
+        verdict_raw = verdict_match.group("verdict").strip() if verdict_match else None
+        confidence = (
+            int(verdict_match.group("confidence"))
+            if verdict_match and verdict_match.group("confidence")
+            else None
+        )
+        scope = (
+            verdict_match.group("scope").strip()
+            if verdict_match and verdict_match.group("scope")
+            else None
+        )
+        return {
+            "pr_number": pr_number,
+            "title": match.group("title").strip(),
+            "head_sha": None,
+            "verdict": _normalize_verdict(verdict_raw),
+            "raw_verdict": verdict_raw,
+            "confidence": confidence,
+            "scope": scope,
+            "logic": _extract_markdown_field(section, "Logic"),
+            "security": _extract_markdown_field(section, "Security"),
+            "maintainability": _extract_markdown_field(section, "Maintainability"),
+            "skeptic": _extract_markdown_field(section, "Skeptic"),
+            "recommended_action": _extract_markdown_field(section, "Recommended action"),
+        }
+    return None
+
+
+def _extract_markdown_field(section: str, label: str) -> str | None:
+    labels = [
+        "Verdict",
+        "Confidence",
+        "Scope",
+        "Logic",
+        "Security",
+        "Maintainability",
+        "Skeptic",
+        "Recommended action",
+    ]
+    next_labels = [candidate for candidate in labels if candidate != label]
+    terminator = "|".join(re.escape(item) for item in next_labels)
+    pattern = re.compile(
+        rf"\*\*{re.escape(label)}:\*\*\s*(?P<value>.+?)(?=(?:\n\n\*\*(?:{terminator}):\*\*)|\Z)",
+        re.S,
+    )
+    match = pattern.search(section)
+    if not match:
+        return None
+    return _clean_text(match.group("value"))
+
+
+def _normalize_verdict(value: Any) -> str | None:
+    text = str(value or "").strip().lower()
+    if not text:
+        return None
+    if "repair_first" in text or "repair first" in text or "fix before review" in text:
+        return "repair_first"
+    if "needs_human_attention" in text or "needs human attention" in text or "⚠" in text:
+        return "needs_human_attention"
+    if "approve_candidate" in text or "approve" in text or "✓" in text:
+        return "approve_candidate"
+    return None
+
+
+def _clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_checks(raw_checks: Iterable[Any]) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    for item in raw_checks:
+        if not isinstance(item, dict):
+            continue
+        checks.append(
+            {
+                "name": str(item.get("name", "") or "").strip(),
+                "status": str(item.get("status", "") or "").strip(),
+                "conclusion": str(item.get("conclusion", "") or "").strip(),
+                "details_url": str(item.get("detailsUrl", "") or "").strip() or None,
+            }
+        )
+    return checks
+
+
+def _normalize_files(raw_files: Iterable[Any]) -> list[dict[str, Any]]:
+    files: list[dict[str, Any]] = []
+    for item in raw_files:
+        if not isinstance(item, dict):
+            continue
+        path = str(item.get("path", "") or "").strip()
+        if not path:
+            continue
+        files.append(
+            {
+                "path": path,
+                "additions": _safe_int(item.get("additions")) or 0,
+                "deletions": _safe_int(item.get("deletions")) or 0,
+            }
+        )
+    return files
+
+
+def _classify_pr_from_payload(payload: dict[str, Any]) -> Any:
+    from aragora.cli.commands.review_queue import _classify_pr
+
+    return _classify_pr(payload)
+
+
+def _build_queue_rows(*, limit: int) -> list[ReviewQueueRow]:
+    fields = ",".join(
+        [
+            "number",
+            "title",
+            "url",
+            "headRefOid",
+            "isDraft",
+            "mergeable",
+            "reviewDecision",
+            "labels",
+            "author",
+            "additions",
+            "deletions",
+            "changedFiles",
+            "statusCheckRollup",
+            "createdAt",
+            "updatedAt",
+        ]
+    )
+    payload = _gh_json(
+        [
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            fields,
+        ]
+    )
+    rows: list[ReviewQueueRow] = []
+    for item in payload or []:
+        if not isinstance(item, dict):
+            continue
+        rows.append(_row_from_payload(item))
+    rows.sort(
+        key=lambda row: (
+            _queue_sort_key({"lane": row.lane, "created_at": row.created_at, "number": row.number})
+        )
+    )
+    return rows
+
+
+def _row_from_payload(payload: dict[str, Any]) -> ReviewQueueRow:
+    queue_item = _classify_pr_from_payload(payload)
+    return ReviewQueueRow(
+        number=queue_item.number,
+        title=queue_item.title,
+        url=queue_item.url,
+        head_sha=queue_item.head_sha,
+        author=queue_item.author,
+        is_draft=queue_item.is_draft,
+        mergeable=queue_item.mergeable,
+        review_decision=queue_item.review_decision,
+        labels=queue_item.labels,
+        additions=queue_item.additions,
+        deletions=queue_item.deletions,
+        changed_files=queue_item.changed_files,
+        checks_summary=queue_item.checks_summary,
+        lane=queue_item.lane,
+        lane_reason=queue_item.lane_reason,
+        created_at=_clean_text(payload.get("createdAt")),
+        updated_at=_clean_text(payload.get("updatedAt")),
+        status_check_rollup=[
+            entry for entry in (payload.get("statusCheckRollup") or []) if isinstance(entry, dict)
+        ],
+    )
+
+
+def _check_counts(status_check_rollup: Iterable[Any]) -> dict[str, int]:
+    counts = {"success": 0, "failure": 0, "pending": 0, "cancelled": 0, "total": 0}
+    for item in status_check_rollup:
+        if not isinstance(item, dict):
+            continue
+        counts["total"] += 1
+        status = str(item.get("status", "") or "").upper()
+        conclusion = str(item.get("conclusion", "") or "").upper()
+        if conclusion == "SUCCESS":
+            counts["success"] += 1
+        elif conclusion in {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED"}:
+            counts["failure"] += 1
+        elif conclusion in {"CANCELLED", "SKIPPED", "NEUTRAL", "STALE"}:
+            counts["cancelled"] += 1
+        elif status in {"IN_PROGRESS", "QUEUED", "PENDING"} or not conclusion:
+            counts["pending"] += 1
+    return counts
+
+
+def _serialize_queue_item(
+    *,
+    item: Any,
+    packet: Any | None,
+    brief: dict[str, Any] | None,
+    deferred_entry: dict[str, Any] | None,
+) -> dict[str, Any]:
+    created_at = getattr(item, "created_at", None)
+    updated_at = getattr(item, "updated_at", None)
+    checks_rollup = getattr(item, "status_check_rollup", None) or []
+    return {
+        "number": item.number,
+        "title": item.title,
+        "url": item.url,
+        "diff_url": f"{item.url}/files",
+        "head_sha": item.head_sha,
+        "author": item.author,
+        "is_draft": item.is_draft,
+        "mergeable": item.mergeable,
+        "review_decision": item.review_decision,
+        "labels": item.labels,
+        "additions": item.additions,
+        "deletions": item.deletions,
+        "changed_files": item.changed_files,
+        "checks_summary": item.checks_summary,
+        "lane": item.lane,
+        "lane_reason": item.lane_reason,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "status_counts": _check_counts(checks_rollup),
+        "touched_subsystems": list(packet.touched_subsystems) if packet else [],
+        "high_risk_paths_touched": list(packet.high_risk_paths_touched) if packet else [],
+        "machine_recommendation": getattr(packet, "machine_recommendation", None),
+        "machine_recommendation_reason": getattr(packet, "machine_recommendation_reason", None),
+        "brief": brief,
+        "brief_available": brief is not None,
+        "deferred_until": deferred_entry.get("deferred_until") if deferred_entry else None,
+        "deferred_reason": deferred_entry.get("reason") if deferred_entry else None,
+    }
+
+
+def _queue_sort_key(item: dict[str, Any]) -> tuple[int, str, int]:
+    lane_order = {
+        "repairable": 0,
+        "needs_attention": 1,
+        "ready_now": 2,
+        "parked": 3,
+    }
+    created_at = str(item.get("created_at", "") or "")
+    return (
+        lane_order.get(str(item.get("lane", "") or ""), 99),
+        created_at,
+        int(item.get("number", 0) or 0),
+    )
+
+
+__all__ = ["ReviewQueueHandler"]

--- a/aragora/server/handlers/review_queue.py
+++ b/aragora/server/handlers/review_queue.py
@@ -14,7 +14,7 @@ import os
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -322,11 +322,12 @@ class ReviewQueueHandler(BaseHandler):
             if _receipt_local_date(receipt.get("reviewed_at")) == today_local
         ]
 
-        elapsed = sorted(
-            float(item.get("elapsed_seconds"))
-            for item in todays_receipts
-            if isinstance(item.get("elapsed_seconds"), (int, float))
-        )
+        elapsed: list[float] = []
+        for item in todays_receipts:
+            elapsed_seconds = item.get("elapsed_seconds")
+            if isinstance(elapsed_seconds, (int, float)):
+                elapsed.append(float(elapsed_seconds))
+        elapsed.sort()
         median = 0.0
         if elapsed:
             mid = len(elapsed) // 2
@@ -465,7 +466,7 @@ def _load_receipts(repo_root: Path) -> list[dict[str, Any]]:
     return receipts
 
 
-def _receipt_local_date(value: Any) -> datetime.date | None:
+def _receipt_local_date(value: Any) -> date | None:
     if not isinstance(value, str) or not value.strip():
         return None
     try:

--- a/tests/server/handlers/test_review_queue_handler.py
+++ b/tests/server/handlers/test_review_queue_handler.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.server.handlers.review_queue import ReviewQueueHandler, ReviewQueueRow
+from aragora.server.handlers.utils.responses import HandlerResult
+
+
+def _parse_body(result: HandlerResult) -> dict:
+    return json.loads(result.body)
+
+
+def _make_handler(method: str = "GET", body: bytes = b"") -> MagicMock:
+    handler = MagicMock()
+    handler.command = method
+    handler.client_address = ("127.0.0.1", 12345)
+    handler.headers = {
+        "Authorization": "Bearer test-token",
+        "Content-Length": str(len(body)),
+        "Content-Type": "application/json",
+    }
+    handler.rfile = MagicMock()
+    handler.rfile.read.return_value = body
+    return handler
+
+
+@pytest.fixture
+def handler() -> ReviewQueueHandler:
+    return ReviewQueueHandler(ctx={})
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    (root / ".aragora" / "review-queue").mkdir(parents=True)
+    return root
+
+
+def _row(number: int = 6308) -> ReviewQueueRow:
+    return ReviewQueueRow(
+        number=number,
+        title=f"PR {number}",
+        url=f"https://github.com/synaptent/aragora/pull/{number}",
+        head_sha="abc123def456",
+        author="an0mium",
+        is_draft=False,
+        mergeable="MERGEABLE",
+        review_decision="REVIEW_REQUIRED",
+        labels=["codex"],
+        additions=12,
+        deletions=3,
+        changed_files=2,
+        checks_summary="5/5 green",
+        lane="ready_now",
+        lane_reason="all green",
+        created_at="2026-04-19T12:00:00Z",
+        updated_at="2026-04-19T12:30:00Z",
+        status_check_rollup=[
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "typecheck", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ],
+    )
+
+
+class TestReviewQueueHandlerBasics:
+    def test_can_handle_versioned_route(self, handler: ReviewQueueHandler) -> None:
+        assert handler.can_handle("/api/v1/review-queue/prs") is True
+        assert handler.can_handle("/api/v1/review-queue/stats") is True
+        assert handler.can_handle("/api/v1/debates") is False
+
+
+class TestManualBriefFallback:
+    def test_brief_endpoint_reads_manual_markdown(
+        self, handler: ReviewQueueHandler, repo_root: Path
+    ) -> None:
+        brief_file = repo_root / ".aragora" / "review-queue" / "manual-briefs-2026-04-19.md"
+        brief_file.write_text(
+            """
+# Manual PDB Briefs
+
+## #6308 · `fix(ci): cancel test-fast only on synchronize events`
+
+**Verdict:** ✓ APPROVE · **Confidence:** 5/5 (single-model) · **Scope:** 1 line in `.github/workflows/test.yml`
+
+**Logic:** Correct YAML.
+
+**Security:** None.
+
+**Maintainability:** Small follow-up likely.
+
+**Skeptic:** If cancellations persist, root cause is elsewhere.
+
+**Recommended action:** Approve first.
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        mock_http = _make_handler()
+        with patch(
+            "aragora.server.handlers.review_queue._current_repo_root", return_value=repo_root
+        ):
+            with patch(
+                "aragora.server.handlers.review_queue._build_packet",
+                return_value=SimpleNamespace(head_sha="abc123def456"),
+            ):
+                result = handler.handle("/api/v1/review-queue/prs/6308/brief", {}, mock_http)
+
+        assert result is not None
+        assert result.status_code == 200
+        body = _parse_body(result)
+        assert body["brief"]["source"] == "manual_markdown"
+        assert body["brief"]["verdict"] == "approve_candidate"
+        assert body["brief"]["confidence"] == 5
+        assert body["brief"]["logic"] == "Correct YAML."
+
+
+class TestListAndDefer:
+    def test_list_excludes_deferred_prs_by_default(
+        self, handler: ReviewQueueHandler, repo_root: Path
+    ) -> None:
+        deferred_path = repo_root / ".aragora" / "review-queue" / "deferred.json"
+        deferred_path.write_text(
+            json.dumps(
+                {
+                    "6308": {
+                        "pr_number": 6308,
+                        "reason": "later",
+                        "deferred_at": "2026-04-19T12:00:00+00:00",
+                        "deferred_until": "2099-04-19T16:00:00+00:00",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        mock_http = _make_handler()
+        with patch(
+            "aragora.server.handlers.review_queue._current_repo_root", return_value=repo_root
+        ):
+            with patch(
+                "aragora.server.handlers.review_queue._build_queue_rows",
+                return_value=[_row(6308)],
+            ):
+                with patch(
+                    "aragora.server.handlers.review_queue._build_packet",
+                    return_value=SimpleNamespace(
+                        touched_subsystems=("aragora/swarm",),
+                        high_risk_paths_touched=(),
+                        machine_recommendation="approve_candidate",
+                        machine_recommendation_reason="all green",
+                    ),
+                ):
+                    result = handler.handle("/api/v1/review-queue/prs", {}, mock_http)
+
+        assert result is not None
+        assert result.status_code == 200
+        body = _parse_body(result)
+        assert body["prs"] == []
+
+    def test_defer_endpoint_persists_local_state(
+        self, handler: ReviewQueueHandler, repo_root: Path
+    ) -> None:
+        mock_http = _make_handler("POST", body=b'{"reason":"needs fresh eyes"}')
+
+        with patch(
+            "aragora.server.handlers.review_queue._current_repo_root", return_value=repo_root
+        ):
+            result = handler.handle("/api/v1/review-queue/prs/6308/defer", {}, mock_http)
+
+        assert result is not None
+        assert result.status_code == 200
+        body = _parse_body(result)
+        assert body["deferred"]["pr_number"] == 6308
+        saved = json.loads((repo_root / ".aragora" / "review-queue" / "deferred.json").read_text())
+        assert saved["6308"]["reason"] == "needs fresh eyes"
+
+
+class TestSettlement:
+    def test_approve_endpoint_wraps_existing_settlement_flow(
+        self, handler: ReviewQueueHandler, repo_root: Path
+    ) -> None:
+        packet = SimpleNamespace(
+            pr_number=6308,
+            url="https://github.com/synaptent/aragora/pull/6308",
+            head_sha="abc123def456",
+            base_sha="base123",
+            queue_bucket="ready_now",
+            machine_recommendation="approve_candidate",
+            packet_sha="sha256:test",
+        )
+        receipt = {
+            "pr_number": 6308,
+            "action": "approve",
+            "receipt_path": str(repo_root / ".aragora" / "review-queue" / "receipts" / "test.json"),
+        }
+        mock_http = _make_handler("POST", body=b"{}")
+
+        with patch(
+            "aragora.server.handlers.review_queue._current_repo_root", return_value=repo_root
+        ):
+            with patch(
+                "aragora.server.handlers.review_queue._require_clean_worktree"
+            ) as require_clean:
+                with patch(
+                    "aragora.server.handlers.review_queue._build_packet", return_value=packet
+                ):
+                    with patch(
+                        "aragora.server.handlers.review_queue._settle_packet",
+                        return_value=SimpleNamespace(to_dict=lambda: receipt),
+                    ) as settle_packet:
+                        result = handler.handle(
+                            "/api/v1/review-queue/prs/6308/approve", {}, mock_http
+                        )
+
+        assert result is not None
+        assert result.status_code == 200
+        body = _parse_body(result)
+        assert body["receipt"]["action"] == "approve"
+        require_clean.assert_called_once_with(repo_root)
+        settle_packet.assert_called_once()
+
+    def test_request_changes_requires_reason(
+        self, handler: ReviewQueueHandler, repo_root: Path
+    ) -> None:
+        mock_http = _make_handler("POST", body=b"{}")
+
+        with patch(
+            "aragora.server.handlers.review_queue._current_repo_root", return_value=repo_root
+        ):
+            result = handler.handle(
+                "/api/v1/review-queue/prs/6308/request-changes",
+                {},
+                mock_http,
+            )
+
+        assert result is not None
+        assert result.status_code == 400
+        body = _parse_body(result)
+        assert "requires a non-empty reason" in body["error"]


### PR DESCRIPTION
## Summary
- add a browser-first review queue surface in `aragora/live` for local morning PR settlement
- expose local review-queue data and settlement actions through a dedicated admin handler
- carry forward the useful `#6329` work onto a fresh branch after the bake-off PR was closed

## Validation
- python3 scripts/check_version_alignment.py
- python3 -m pytest -q tests/server/handlers/test_review_queue_handler.py
- python3 -m mypy aragora/server/handlers/review_queue.py tests/server/handlers/test_review_queue_handler.py --config-file=pyproject.toml --ignore-missing-imports
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- cd aragora/live && npx eslint "src/app/(app)/review-queue/page.tsx" "src/app/(app)/review-queue/__tests__/page.test.tsx" src/components/review-queue/*.tsx src/components/review-queue/*.ts src/hooks/useReviewQueue.ts
- cd aragora/live && npx jest --runInBand --testPathPatterns="review-queue/.+page.test.tsx"
- cd aragora/live && npm run build:local

## Notes
- preserves human settlement by wrapping the existing local review-queue/receipt path rather than introducing bot approvals
- supports markdown manual-brief fallback so the UI is usable before automated brief generation lands