### PR TITLE
[#6305] feat(review): ReviewPolicy + ReviewBudget + CostMeter schemas (foundation)

### DIFF
--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -20,6 +20,15 @@ from aragora.review.protocol import (
     RoleFinding,
     SynthesisPolicy,
 )
+from aragora.review.policy import (
+    CostMeter,
+    DepthTrigger,
+    ReviewBudget,
+    ReviewDepth,
+    ReviewPolicy,
+    ReviewPolicyDecision,
+    RiskClass,
+)
 from aragora.review.receipt import (
     BriefReceipt,
     EvidenceKind,
@@ -34,6 +43,8 @@ from aragora.review.receipt import (
 __all__ = [
     "ADVISORY_NOTE",
     "BriefReceipt",
+    "CostMeter",
+    "DepthTrigger",
     "DissentingView",
     "DissentPosition",
     "EvidenceKind",
@@ -41,7 +52,12 @@ __all__ = [
     "PRReviewProtocol",
     "Recommendation",
     "ReviewBrief",
+    "ReviewBudget",
+    "ReviewDepth",
+    "ReviewPolicy",
+    "ReviewPolicyDecision",
     "ReviewRole",
+    "RiskClass",
     "RoleFinding",
     "SettlementAction",
     "SettlementLinkage",

--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -21,6 +21,8 @@ from aragora.review.protocol import (
     SynthesisPolicy,
 )
 from aragora.review.policy import (
+    BudgetHeadroom,
+    BudgetScope,
     CostMeter,
     DepthTrigger,
     ReviewBudget,
@@ -43,6 +45,8 @@ from aragora.review.receipt import (
 __all__ = [
     "ADVISORY_NOTE",
     "BriefReceipt",
+    "BudgetHeadroom",
+    "BudgetScope",
     "CostMeter",
     "DepthTrigger",
     "DissentingView",

--- a/aragora/review/policy.py
+++ b/aragora/review/policy.py
@@ -79,6 +79,18 @@ class ReviewPolicyDecision(str, Enum):
     ESCALATE = "escalate"  # require human approval before running
 
 
+class BudgetScope(str, Enum):
+    """Which pool a budget cap / headroom line item applies to.
+
+    Used by ``BudgetHeadroom`` and ``CostMeter.binding_scope`` so a
+    packet-reader can tell which pool bound a DEGRADE/DENY decision.
+    """
+
+    PER_PR = "per_pr"
+    PER_REPO_DAILY = "per_repo_daily"
+    PER_ORG_DAILY = "per_org_daily"
+
+
 # --- Depth rules ----------------------------------------------------------
 
 
@@ -122,19 +134,30 @@ class ReviewBudget:
     The generic BudgetPolicy tracks monthly/daily/per-debate workspace spend;
     ReviewBudget carves out the review slice with per-PR and per-repo/org caps.
 
-    Defaults (per-PR $25, 80% alert threshold) are the dogfood-safe
-    posture for Aragora's own PRs. Wider rollout requires an explicit
-    override — tests lock the defaults so silent drift fails loudly.
+    Depth scoping (#6305 AC: "Per-repo / per-org caps for deep review
+    runs"): daily repo/org pools only count runs at or above
+    ``daily_caps_apply_at_or_above_depth``. This prevents a flood of
+    TRIVIAL typo-only reviews from exhausting the daily pool and then
+    denying a legitimate DEEP review later in the day. The per-PR cap
+    has no depth scoping — it always applies to every single run.
+
+    Defaults (per-PR $25, 80% alert threshold, daily caps apply at
+    STANDARD+) are the dogfood-safe posture for Aragora's own PRs.
+    Wider rollout requires an explicit override — tests lock the
+    defaults so silent drift fails loudly.
     """
 
-    per_pr_usd_cap: float = 25.0  # market anchor: Anthropic ~$25/PR
-    per_repo_usd_daily_cap: float = 0.0  # 0 = unlimited
-    per_org_usd_daily_cap: float = 0.0  # 0 = unlimited
+    per_pr_usd_cap: float = 25.0  # market anchor: Anthropic ~$25/PR; applies to ALL depths
+    per_repo_usd_daily_cap: float = 0.0  # 0 = unlimited; depth-scoped
+    per_org_usd_daily_cap: float = 0.0  # 0 = unlimited; depth-scoped
+    daily_caps_apply_at_or_above_depth: ReviewDepth = ReviewDepth.STANDARD
     alert_threshold_pct: float = 80.0
     hard_limit: bool = True  # deny when cap reached; mirrors billing.BudgetPolicy
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        d = asdict(self)
+        d["daily_caps_apply_at_or_above_depth"] = self.daily_caps_apply_at_or_above_depth.value
+        return d
 
 
 # --- Policy ---------------------------------------------------------------
@@ -170,6 +193,28 @@ class ReviewPolicy:
 
 
 @dataclass(frozen=True, slots=True)
+class BudgetHeadroom:
+    """Remaining/cap pair for one budget pool at decision time.
+
+    Enables a packet-reader to answer "which pool was binding?" and
+    "how much headroom did we have in each pool?" — not just a single
+    anonymous remainder.
+    """
+
+    scope: BudgetScope
+    cap_usd: float  # configured cap for this pool; 0.0 = unlimited
+    remaining_usd: float  # headroom after this run; negative if over
+    applies_at_or_above_depth: ReviewDepth | None = None  # None for per_pr (all depths)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["scope"] = self.scope.value
+        if self.applies_at_or_above_depth is not None:
+            d["applies_at_or_above_depth"] = self.applies_at_or_above_depth.value
+        return d
+
+
+@dataclass(frozen=True, slots=True)
 class CostMeter:
     """Cost-and-budget context embedded in a review packet.
 
@@ -177,22 +222,32 @@ class CostMeter:
     used and budget context." Consumed by the UI (#6304) for the
     "packet cost:" line in the rendered brief, and by exporters so an
     operator reading an exported brief on another machine can still see
-    whether the run was under budget.
+    whether the run was under budget AND which pool constrained it.
 
-    All four numeric fields are USD; units are implicit-by-convention
-    because mixing currencies is out of scope for the foundation.
+    Multi-pool disclosure (#6305 AC "bound deep-review spend without
+    disabling the feature entirely"): when a DEGRADE or DENY decision
+    is issued because a specific budget pool is exhausted, ``binding_scope``
+    names which pool was binding and ``headroom_by_scope`` carries the
+    per-pool remaining/cap tuple so the UI can explain to the operator
+    exactly why the decision went the way it did.
+
+    All cost fields are USD; units are implicit-by-convention because
+    mixing currencies is out of scope for the foundation.
     """
 
     depth_chosen: ReviewDepth
     decision: ReviewPolicyDecision
     estimated_cost_usd: float  # what the runner estimated BEFORE running
     actual_cost_usd: float  # what the run actually spent (0 if pre-run)
-    budget_remaining_usd: float  # how much of the cap is left, post-this-run
-    per_pr_cap_usd: float  # the cap this run was evaluated against
-    alert_triggered: bool = False  # True if usage_pct crossed alert threshold
+    headroom_by_scope: tuple[BudgetHeadroom, ...]  # per-pool remaining+cap
+    binding_scope: BudgetScope | None = None  # which pool bound the decision; None if unbounded
+    alert_triggered: bool = False  # True if any pool's usage_pct crossed alert threshold
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
         d["depth_chosen"] = self.depth_chosen.value
         d["decision"] = self.decision.value
+        d["headroom_by_scope"] = [h.to_dict() for h in self.headroom_by_scope]
+        if self.binding_scope is not None:
+            d["binding_scope"] = self.binding_scope.value
         return d

--- a/aragora/review/policy.py
+++ b/aragora/review/policy.py
@@ -1,0 +1,198 @@
+"""PR intelligence brief — cost-aware policy + budget controls (#6305 foundation).
+
+Type contracts for the review-depth policy and review budget described in
+docs/plans/2026-04-19-pr-intelligence-brief.md (#6305).
+
+This module is **schema only**. No I/O, no evaluation, no metering.
+Behavior — applying policy to a PR, reading cost tracker state, denying
+a run that exceeds budget — ships in the #6306 orchestrator + review-queue
+writer. This module just defines what configuring and reporting on policy
+looks like.
+
+Composes with, does not duplicate, existing billing infrastructure:
+  - ``aragora.billing.budget_policy.BudgetPolicy`` is the generic
+    workspace-level budget. ``ReviewBudget`` in this module is the
+    PR-review-specific slice. A caller that already has a generic
+    BudgetPolicy can derive a ReviewBudget from it; this module doesn't
+    force re-entry.
+  - ``aragora.policy.engine.PolicyDecision`` has its own
+    ALLOW/DENY/ESCALATE/BUDGET_EXCEEDED vocabulary for deploy decisions.
+    ``ReviewPolicyDecision`` here has a review-specific DEGRADE value
+    (drop to a cheaper review depth rather than refuse entirely) that
+    the generic enum does not express.
+
+Safe-default posture (per #6305 acceptance "Safe defaults for Aragora
+dogfood before wider rollout"): the defaults on this module are
+deliberately conservative — a $25/PR cap, 80% alert threshold, and
+STANDARD default depth. Tests lock those values so future wider-rollout
+decisions require explicit rewrites, not silent drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+
+# --- Enums ----------------------------------------------------------------
+
+
+class ReviewDepth(str, Enum):
+    """How deep a review run should go.
+
+    Ordered from cheapest to most thorough. The runner (a successor PR,
+    not this module) picks the panel / rounds / synthesis_policy
+    appropriate for a given depth.
+    """
+
+    TRIVIAL = "trivial"  # one cheap model, single pass, formatting/typos only
+    STANDARD = "standard"  # the default heterogeneous panel, single pass
+    DEEP = "deep"  # multi-round panel with synthesizer + deeper evidence fetch
+
+
+class RiskClass(str, Enum):
+    """How much blast radius a PR carries.
+
+    Distinct from ``aragora.policy.risk.RiskLevel`` (deployment blast
+    radius) — this one is specifically about PR-review depth selection.
+    """
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ReviewPolicyDecision(str, Enum):
+    """Outcome when a policy evaluates a candidate review run.
+
+    ``DEGRADE`` is the review-specific value that the generic
+    ``aragora.policy.engine.PolicyDecision`` does not express: drop to a
+    cheaper depth rather than refuse entirely. Keeps coverage non-zero
+    under budget pressure.
+    """
+
+    ALLOW = "allow"  # run at the selected depth
+    DEGRADE = "degrade"  # run, but at a cheaper depth than requested
+    DENY = "deny"  # refuse to run (budget exceeded or policy-forbidden)
+    ESCALATE = "escalate"  # require human approval before running
+
+
+# --- Depth rules ----------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class DepthTrigger:
+    """A single rule mapping a condition to a review depth.
+
+    The first matching trigger in ``ReviewPolicy.depth_rules`` wins.
+    A trigger matches when EVERY non-None / non-empty condition field
+    matches the candidate PR; fields left at their default do not
+    constrain the match.
+    """
+
+    target_depth: ReviewDepth
+    # Diff size: if set, trigger matches when (additions + deletions) >= this.
+    min_additions_plus_deletions: int = 0
+    # Subsystems: if non-empty, trigger matches when any of these path
+    # prefixes intersects the PR's touched-file list.
+    subsystem_prefixes: tuple[str, ...] = ()
+    # Risk: if set, trigger matches when the candidate PR's risk_class
+    # is >= this one (using the enum declaration order as severity).
+    min_risk_class: RiskClass | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["target_depth"] = self.target_depth.value
+        d["subsystem_prefixes"] = list(self.subsystem_prefixes)
+        if self.min_risk_class is not None:
+            d["min_risk_class"] = self.min_risk_class.value
+        return d
+
+
+# --- Budget ---------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewBudget:
+    """PR-review-specific spend caps.
+
+    Composes with, does not replace, ``aragora.billing.budget_policy.BudgetPolicy``.
+    The generic BudgetPolicy tracks monthly/daily/per-debate workspace spend;
+    ReviewBudget carves out the review slice with per-PR and per-repo/org caps.
+
+    Defaults (per-PR $25, 80% alert threshold) are the dogfood-safe
+    posture for Aragora's own PRs. Wider rollout requires an explicit
+    override — tests lock the defaults so silent drift fails loudly.
+    """
+
+    per_pr_usd_cap: float = 25.0  # market anchor: Anthropic ~$25/PR
+    per_repo_usd_daily_cap: float = 0.0  # 0 = unlimited
+    per_org_usd_daily_cap: float = 0.0  # 0 = unlimited
+    alert_threshold_pct: float = 80.0
+    hard_limit: bool = True  # deny when cap reached; mirrors billing.BudgetPolicy
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# --- Policy ---------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewPolicy:
+    """Full review-depth + budget policy for a repo or org.
+
+    Evaluation order (implementation lives in a successor PR, not here):
+      1. Walk ``depth_rules`` in order; first matching trigger sets the
+         chosen depth. If no trigger matches, use ``default_depth``.
+      2. Estimate the cost of running at that depth.
+      3. Apply ``budget`` caps: if estimate + spent-so-far would exceed
+         the cap, emit DEGRADE (drop to a cheaper depth) or DENY
+         (budget.hard_limit=True and no cheaper option).
+      4. Emit a ReviewPolicyDecision plus the final depth.
+    """
+
+    budget: ReviewBudget = field(default_factory=ReviewBudget)
+    depth_rules: tuple[DepthTrigger, ...] = ()
+    default_depth: ReviewDepth = ReviewDepth.STANDARD
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["budget"] = self.budget.to_dict()
+        d["depth_rules"] = [r.to_dict() for r in self.depth_rules]
+        d["default_depth"] = self.default_depth.value
+        return d
+
+
+# --- Cost meter (what goes into the review packet per #6305 AC) -----------
+
+
+@dataclass(frozen=True, slots=True)
+class CostMeter:
+    """Cost-and-budget context embedded in a review packet.
+
+    Addresses #6305 acceptance criterion: "Packet output includes cost
+    used and budget context." Consumed by the UI (#6304) for the
+    "packet cost:" line in the rendered brief, and by exporters so an
+    operator reading an exported brief on another machine can still see
+    whether the run was under budget.
+
+    All four numeric fields are USD; units are implicit-by-convention
+    because mixing currencies is out of scope for the foundation.
+    """
+
+    depth_chosen: ReviewDepth
+    decision: ReviewPolicyDecision
+    estimated_cost_usd: float  # what the runner estimated BEFORE running
+    actual_cost_usd: float  # what the run actually spent (0 if pre-run)
+    budget_remaining_usd: float  # how much of the cap is left, post-this-run
+    per_pr_cap_usd: float  # the cap this run was evaluated against
+    alert_triggered: bool = False  # True if usage_pct crossed alert threshold
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["depth_chosen"] = self.depth_chosen.value
+        d["decision"] = self.decision.value
+        return d

--- a/tests/review/test_policy.py
+++ b/tests/review/test_policy.py
@@ -7,6 +7,8 @@ import json
 import pytest
 
 from aragora.review import (
+    BudgetHeadroom,
+    BudgetScope,
     CostMeter,
     DepthTrigger,
     ReviewBudget,
@@ -110,6 +112,35 @@ class TestReviewBudget:
         assert budget.per_repo_usd_daily_cap == 0.0  # 0 = unlimited
         assert budget.per_org_usd_daily_cap == 0.0
 
+    def test_daily_caps_are_depth_scoped_by_default(self) -> None:
+        # Per #6305 AC: "Per-repo / per-org caps for deep review runs."
+        # Default scoping: daily caps apply at STANDARD+; TRIVIAL
+        # reviews don't count against the daily pool. Prevents a flood
+        # of typo-only reviews from exhausting the daily budget and
+        # then denying a legitimate DEEP review later in the day.
+        budget = ReviewBudget()
+        assert budget.daily_caps_apply_at_or_above_depth == ReviewDepth.STANDARD
+
+    def test_daily_cap_scoping_is_configurable(self) -> None:
+        # Teams that want the daily pools to cover STANDARD reviews too
+        # can set this to STANDARD; teams that only want DEEP runs to
+        # count against the daily pool can set it to DEEP.
+        budget = ReviewBudget(daily_caps_apply_at_or_above_depth=ReviewDepth.DEEP)
+        assert budget.daily_caps_apply_at_or_above_depth == ReviewDepth.DEEP
+
+    def test_per_pr_cap_is_not_depth_scoped(self) -> None:
+        # Per-PR cap applies to EVERY run regardless of depth. Only the
+        # daily repo/org pools carry the depth scoping. If a future
+        # refactor tries to add `per_pr_applies_at_or_above_depth`, this
+        # test fails loudly.
+        budget = ReviewBudget()
+        assert not hasattr(budget, "per_pr_applies_at_or_above_depth")
+
+    def test_to_dict_serializes_depth_enum(self) -> None:
+        budget = ReviewBudget(daily_caps_apply_at_or_above_depth=ReviewDepth.DEEP)
+        d = budget.to_dict()
+        assert d["daily_caps_apply_at_or_above_depth"] == "deep"
+
     def test_frozen(self) -> None:
         budget = ReviewBudget()
         with pytest.raises((AttributeError, TypeError)):
@@ -125,6 +156,7 @@ class TestReviewBudget:
         assert roundtrip["per_pr_usd_cap"] == 50.0
         assert roundtrip["per_repo_usd_daily_cap"] == 500.0
         assert roundtrip["alert_threshold_pct"] == 75.0
+        assert roundtrip["daily_caps_apply_at_or_above_depth"] == "standard"
 
 
 # --- ReviewPolicy --------------------------------------------------------
@@ -179,30 +211,80 @@ class TestReviewPolicy:
         assert roundtrip["budget"]["per_pr_usd_cap"] == 25.0
 
 
+# --- BudgetScope + BudgetHeadroom -----------------------------------------
+
+
+class TestBudgetScope:
+    def test_values(self) -> None:
+        assert BudgetScope.PER_PR.value == "per_pr"
+        assert BudgetScope.PER_REPO_DAILY.value == "per_repo_daily"
+        assert BudgetScope.PER_ORG_DAILY.value == "per_org_daily"
+
+    def test_three_scopes_match_review_budget_pools(self) -> None:
+        # BudgetScope must cover exactly the pools ReviewBudget defines.
+        # If a future ReviewBudget adds a fourth pool without extending
+        # BudgetScope, CostMeter would lose the ability to identify it.
+        budget = ReviewBudget()
+        pool_fields = {"per_pr_usd_cap", "per_repo_usd_daily_cap", "per_org_usd_daily_cap"}
+        for field_name in pool_fields:
+            assert hasattr(budget, field_name)
+        assert len(list(BudgetScope)) == 3
+
+
+class TestBudgetHeadroom:
+    def test_frozen(self) -> None:
+        h = BudgetHeadroom(scope=BudgetScope.PER_PR, cap_usd=25.0, remaining_usd=20.0)
+        with pytest.raises((AttributeError, TypeError)):
+            h.remaining_usd = 0.0  # type: ignore[misc]
+
+    def test_to_dict_serializes_scope(self) -> None:
+        h = BudgetHeadroom(
+            scope=BudgetScope.PER_REPO_DAILY,
+            cap_usd=500.0,
+            remaining_usd=350.0,
+            applies_at_or_above_depth=ReviewDepth.STANDARD,
+        )
+        d = h.to_dict()
+        assert d["scope"] == "per_repo_daily"
+        assert d["applies_at_or_above_depth"] == "standard"
+        assert d["cap_usd"] == 500.0
+        assert d["remaining_usd"] == 350.0
+
+    def test_per_pr_scope_has_no_depth_scoping(self) -> None:
+        # Per-PR cap applies to all depths; applies_at_or_above_depth=None
+        # is the canonical representation.
+        h = BudgetHeadroom(scope=BudgetScope.PER_PR, cap_usd=25.0, remaining_usd=15.0)
+        assert h.applies_at_or_above_depth is None
+
+
 # --- CostMeter ------------------------------------------------------------
 
 
 class TestCostMeter:
-    def test_frozen(self) -> None:
-        meter = CostMeter(
+    def _meter(self, **overrides) -> CostMeter:
+        defaults = dict(
             depth_chosen=ReviewDepth.STANDARD,
             decision=ReviewPolicyDecision.ALLOW,
             estimated_cost_usd=0.25,
             actual_cost_usd=0.24,
-            budget_remaining_usd=24.76,
-            per_pr_cap_usd=25.0,
+            headroom_by_scope=(
+                BudgetHeadroom(scope=BudgetScope.PER_PR, cap_usd=25.0, remaining_usd=24.76),
+            ),
         )
+        defaults.update(overrides)
+        return CostMeter(**defaults)
+
+    def test_frozen(self) -> None:
+        meter = self._meter()
         with pytest.raises((AttributeError, TypeError)):
             meter.depth_chosen = ReviewDepth.DEEP  # type: ignore[misc]
 
-    def test_to_dict_serializes_enums_as_strings(self) -> None:
-        meter = CostMeter(
+    def test_to_dict_serializes_enums(self) -> None:
+        meter = self._meter(
             depth_chosen=ReviewDepth.DEEP,
             decision=ReviewPolicyDecision.DEGRADE,
             estimated_cost_usd=8.0,
             actual_cost_usd=7.5,
-            budget_remaining_usd=17.5,
-            per_pr_cap_usd=25.0,
             alert_triggered=True,
         )
         d = meter.to_dict()
@@ -212,36 +294,63 @@ class TestCostMeter:
 
     def test_addresses_packet_cost_meter_acceptance_criterion(self) -> None:
         # Per #6305 acceptance: "Packet output includes cost used and
-        # budget context." CostMeter is the exact shape the future packet
-        # renderer will embed.
-        meter = CostMeter(
-            depth_chosen=ReviewDepth.STANDARD,
-            decision=ReviewPolicyDecision.ALLOW,
-            estimated_cost_usd=0.25,
-            actual_cost_usd=0.24,
-            budget_remaining_usd=24.76,
-            per_pr_cap_usd=25.0,
-        )
+        # budget context." CostMeter is the exact shape the future
+        # packet renderer will embed.
+        meter = self._meter()
         d = meter.to_dict()
         # "cost used" — actual_cost_usd
         assert "actual_cost_usd" in d
-        # "budget context" — budget_remaining_usd + per_pr_cap_usd
-        assert "budget_remaining_usd" in d
-        assert "per_pr_cap_usd" in d
+        # "budget context" — per-pool headroom (not just one number)
+        assert "headroom_by_scope" in d
+        assert isinstance(d["headroom_by_scope"], list)
+
+    def test_binding_scope_identifies_which_pool_was_limiting(self) -> None:
+        # Per codex's P1 finding on #6359: packet-readers must be able
+        # to tell which pool forced a DEGRADE/DENY decision. binding_scope
+        # is that dimension.
+        meter = self._meter(
+            depth_chosen=ReviewDepth.STANDARD,  # runner wanted DEEP but degraded
+            decision=ReviewPolicyDecision.DEGRADE,
+            headroom_by_scope=(
+                BudgetHeadroom(scope=BudgetScope.PER_PR, cap_usd=25.0, remaining_usd=24.0),
+                BudgetHeadroom(
+                    scope=BudgetScope.PER_REPO_DAILY,
+                    cap_usd=50.0,
+                    remaining_usd=2.0,  # nearly exhausted
+                    applies_at_or_above_depth=ReviewDepth.STANDARD,
+                ),
+            ),
+            binding_scope=BudgetScope.PER_REPO_DAILY,
+        )
+        d = meter.to_dict()
+        assert d["binding_scope"] == "per_repo_daily"
+        # Per-pool fields preserved so UI can show "repo pool: $2 left of $50"
+        assert len(d["headroom_by_scope"]) == 2
+        assert d["headroom_by_scope"][1]["scope"] == "per_repo_daily"
+        assert d["headroom_by_scope"][1]["remaining_usd"] == 2.0
+
+    def test_binding_scope_optional_for_allow_decisions(self) -> None:
+        # When a run is ALLOWED with no pool near its cap, binding_scope
+        # is None — there's no "limit that made the call."
+        meter = self._meter()
+        assert meter.binding_scope is None
+        d = meter.to_dict()
+        assert d.get("binding_scope") is None
+
+    def test_headroom_by_scope_is_immutable_tuple(self) -> None:
+        meter = self._meter()
+        assert isinstance(meter.headroom_by_scope, tuple)
+        with pytest.raises(AttributeError):
+            meter.headroom_by_scope.append(  # type: ignore[attr-defined]
+                BudgetHeadroom(scope=BudgetScope.PER_ORG_DAILY, cap_usd=1000.0, remaining_usd=500.0)
+            )
 
     def test_json_roundtrip(self) -> None:
-        meter = CostMeter(
-            depth_chosen=ReviewDepth.STANDARD,
-            decision=ReviewPolicyDecision.ALLOW,
-            estimated_cost_usd=0.5,
-            actual_cost_usd=0.45,
-            budget_remaining_usd=24.55,
-            per_pr_cap_usd=25.0,
-        )
+        meter = self._meter()
         roundtrip = json.loads(json.dumps(meter.to_dict()))
         assert roundtrip["depth_chosen"] == "standard"
         assert roundtrip["decision"] == "allow"
-        assert roundtrip["per_pr_cap_usd"] == 25.0
+        assert roundtrip["headroom_by_scope"][0]["scope"] == "per_pr"
 
 
 # --- Cross-module composition -------------------------------------------

--- a/tests/review/test_policy.py
+++ b/tests/review/test_policy.py
@@ -1,0 +1,285 @@
+"""Tests for aragora.review.policy — review-depth + budget contracts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aragora.review import (
+    CostMeter,
+    DepthTrigger,
+    ReviewBudget,
+    ReviewDepth,
+    ReviewPolicy,
+    ReviewPolicyDecision,
+    RiskClass,
+)
+
+
+# --- Enums ---------------------------------------------------------------
+
+
+class TestReviewDepth:
+    def test_values(self) -> None:
+        # Ordered cheapest -> most thorough; value strings are canonical.
+        assert ReviewDepth.TRIVIAL.value == "trivial"
+        assert ReviewDepth.STANDARD.value == "standard"
+        assert ReviewDepth.DEEP.value == "deep"
+
+    def test_exactly_three_levels(self) -> None:
+        # Foundation posture: three levels is enough; more is YAGNI until
+        # a real consumer wants a fourth.
+        assert len(list(ReviewDepth)) == 3
+
+
+class TestRiskClass:
+    def test_values(self) -> None:
+        assert RiskClass.LOW.value == "low"
+        assert RiskClass.MEDIUM.value == "medium"
+        assert RiskClass.HIGH.value == "high"
+        assert RiskClass.CRITICAL.value == "critical"
+
+
+class TestReviewPolicyDecision:
+    def test_values(self) -> None:
+        assert ReviewPolicyDecision.ALLOW.value == "allow"
+        assert ReviewPolicyDecision.DEGRADE.value == "degrade"
+        assert ReviewPolicyDecision.DENY.value == "deny"
+        assert ReviewPolicyDecision.ESCALATE.value == "escalate"
+
+    def test_degrade_exists_for_review_specific_semantics(self) -> None:
+        # `DEGRADE` is the review-specific value the generic
+        # aragora.policy.engine.PolicyDecision does not express. If a
+        # future refactor tries to unify the enums, it must preserve
+        # DEGRADE or the review substrate loses its cheapest-possible
+        # fallback.
+        assert ReviewPolicyDecision.DEGRADE in set(ReviewPolicyDecision)
+
+
+# --- DepthTrigger --------------------------------------------------------
+
+
+class TestDepthTrigger:
+    def test_frozen(self) -> None:
+        trigger = DepthTrigger(target_depth=ReviewDepth.DEEP)
+        with pytest.raises((AttributeError, TypeError)):
+            trigger.target_depth = ReviewDepth.TRIVIAL  # type: ignore[misc]
+
+    def test_subsystem_prefixes_is_tuple(self) -> None:
+        trigger = DepthTrigger(
+            target_depth=ReviewDepth.DEEP,
+            subsystem_prefixes=("aragora/security/", "aragora/auth/"),
+        )
+        assert isinstance(trigger.subsystem_prefixes, tuple)
+        with pytest.raises(AttributeError):
+            trigger.subsystem_prefixes.append("aragora/billing/")  # type: ignore[attr-defined]
+
+    def test_to_dict_serializes_enums_and_tuples(self) -> None:
+        trigger = DepthTrigger(
+            target_depth=ReviewDepth.DEEP,
+            min_additions_plus_deletions=500,
+            subsystem_prefixes=("aragora/security/",),
+            min_risk_class=RiskClass.HIGH,
+        )
+        d = trigger.to_dict()
+        assert d["target_depth"] == "deep"
+        assert d["subsystem_prefixes"] == ["aragora/security/"]
+        assert d["min_risk_class"] == "high"
+        assert d["min_additions_plus_deletions"] == 500
+
+    def test_min_risk_class_omitted_when_none(self) -> None:
+        trigger = DepthTrigger(target_depth=ReviewDepth.TRIVIAL)
+        d = trigger.to_dict()
+        # asdict preserves None in the dict; to_dict only overrides when set.
+        assert d.get("min_risk_class") is None
+
+
+# --- ReviewBudget --------------------------------------------------------
+
+
+class TestReviewBudget:
+    def test_defaults_are_dogfood_safe(self) -> None:
+        # Per #6305 acceptance: "Safe defaults for Aragora dogfood before
+        # wider rollout." Tests lock these so wider rollout requires an
+        # explicit rewrite, not silent drift.
+        budget = ReviewBudget()
+        assert budget.per_pr_usd_cap == 25.0  # Anthropic market anchor
+        assert budget.alert_threshold_pct == 80.0
+        assert budget.hard_limit is True
+        assert budget.per_repo_usd_daily_cap == 0.0  # 0 = unlimited
+        assert budget.per_org_usd_daily_cap == 0.0
+
+    def test_frozen(self) -> None:
+        budget = ReviewBudget()
+        with pytest.raises((AttributeError, TypeError)):
+            budget.per_pr_usd_cap = 100.0  # type: ignore[misc]
+
+    def test_to_dict_roundtrip(self) -> None:
+        budget = ReviewBudget(
+            per_pr_usd_cap=50.0,
+            per_repo_usd_daily_cap=500.0,
+            alert_threshold_pct=75.0,
+        )
+        roundtrip = json.loads(json.dumps(budget.to_dict()))
+        assert roundtrip["per_pr_usd_cap"] == 50.0
+        assert roundtrip["per_repo_usd_daily_cap"] == 500.0
+        assert roundtrip["alert_threshold_pct"] == 75.0
+
+
+# --- ReviewPolicy --------------------------------------------------------
+
+
+class TestReviewPolicy:
+    def test_defaults(self) -> None:
+        policy = ReviewPolicy()
+        assert policy.default_depth == ReviewDepth.STANDARD
+        assert policy.depth_rules == ()
+        # Nested dataclass default uses dogfood-safe budget.
+        assert policy.budget.per_pr_usd_cap == 25.0
+
+    def test_depth_rules_is_immutable_tuple(self) -> None:
+        policy = ReviewPolicy(
+            depth_rules=(
+                DepthTrigger(target_depth=ReviewDepth.DEEP, min_additions_plus_deletions=500),
+            ),
+        )
+        assert isinstance(policy.depth_rules, tuple)
+        with pytest.raises(AttributeError):
+            policy.depth_rules.append(  # type: ignore[attr-defined]
+                DepthTrigger(target_depth=ReviewDepth.TRIVIAL)
+            )
+
+    def test_frozen(self) -> None:
+        policy = ReviewPolicy()
+        with pytest.raises((AttributeError, TypeError)):
+            policy.default_depth = ReviewDepth.DEEP  # type: ignore[misc]
+
+    def test_to_dict_nests_budget_and_rules(self) -> None:
+        policy = ReviewPolicy(
+            depth_rules=(
+                DepthTrigger(
+                    target_depth=ReviewDepth.DEEP,
+                    subsystem_prefixes=("aragora/security/",),
+                    min_risk_class=RiskClass.HIGH,
+                ),
+            ),
+            default_depth=ReviewDepth.STANDARD,
+        )
+        d = policy.to_dict()
+        assert d["default_depth"] == "standard"
+        assert d["budget"]["per_pr_usd_cap"] == 25.0
+        assert d["depth_rules"][0]["target_depth"] == "deep"
+        assert d["depth_rules"][0]["subsystem_prefixes"] == ["aragora/security/"]
+
+    def test_json_roundtrip(self) -> None:
+        policy = ReviewPolicy()
+        roundtrip = json.loads(json.dumps(policy.to_dict()))
+        assert roundtrip["default_depth"] == "standard"
+        assert roundtrip["budget"]["per_pr_usd_cap"] == 25.0
+
+
+# --- CostMeter ------------------------------------------------------------
+
+
+class TestCostMeter:
+    def test_frozen(self) -> None:
+        meter = CostMeter(
+            depth_chosen=ReviewDepth.STANDARD,
+            decision=ReviewPolicyDecision.ALLOW,
+            estimated_cost_usd=0.25,
+            actual_cost_usd=0.24,
+            budget_remaining_usd=24.76,
+            per_pr_cap_usd=25.0,
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            meter.depth_chosen = ReviewDepth.DEEP  # type: ignore[misc]
+
+    def test_to_dict_serializes_enums_as_strings(self) -> None:
+        meter = CostMeter(
+            depth_chosen=ReviewDepth.DEEP,
+            decision=ReviewPolicyDecision.DEGRADE,
+            estimated_cost_usd=8.0,
+            actual_cost_usd=7.5,
+            budget_remaining_usd=17.5,
+            per_pr_cap_usd=25.0,
+            alert_triggered=True,
+        )
+        d = meter.to_dict()
+        assert d["depth_chosen"] == "deep"
+        assert d["decision"] == "degrade"
+        assert d["alert_triggered"] is True
+
+    def test_addresses_packet_cost_meter_acceptance_criterion(self) -> None:
+        # Per #6305 acceptance: "Packet output includes cost used and
+        # budget context." CostMeter is the exact shape the future packet
+        # renderer will embed.
+        meter = CostMeter(
+            depth_chosen=ReviewDepth.STANDARD,
+            decision=ReviewPolicyDecision.ALLOW,
+            estimated_cost_usd=0.25,
+            actual_cost_usd=0.24,
+            budget_remaining_usd=24.76,
+            per_pr_cap_usd=25.0,
+        )
+        d = meter.to_dict()
+        # "cost used" — actual_cost_usd
+        assert "actual_cost_usd" in d
+        # "budget context" — budget_remaining_usd + per_pr_cap_usd
+        assert "budget_remaining_usd" in d
+        assert "per_pr_cap_usd" in d
+
+    def test_json_roundtrip(self) -> None:
+        meter = CostMeter(
+            depth_chosen=ReviewDepth.STANDARD,
+            decision=ReviewPolicyDecision.ALLOW,
+            estimated_cost_usd=0.5,
+            actual_cost_usd=0.45,
+            budget_remaining_usd=24.55,
+            per_pr_cap_usd=25.0,
+        )
+        roundtrip = json.loads(json.dumps(meter.to_dict()))
+        assert roundtrip["depth_chosen"] == "standard"
+        assert roundtrip["decision"] == "allow"
+        assert roundtrip["per_pr_cap_usd"] == 25.0
+
+
+# --- Cross-module composition -------------------------------------------
+
+
+class TestContractComposition:
+    def test_review_policy_decision_disjoint_from_engine_policy_decision(self) -> None:
+        # Intentional non-reuse: aragora.policy.engine.PolicyDecision has
+        # ALLOW/DENY/ESCALATE/BUDGET_EXCEEDED for deployment decisions.
+        # ReviewPolicyDecision has ALLOW/DEGRADE/DENY/ESCALATE for review
+        # runs. They share three strings but diverge on the fourth, which
+        # is why review has its own enum. This test documents that the
+        # divergence is intentional.
+        from aragora.policy.engine import PolicyDecision as GenericPolicyDecision
+
+        review_values = {d.value for d in ReviewPolicyDecision}
+        generic_values = {d.value for d in GenericPolicyDecision}
+        # Review has DEGRADE, generic does not.
+        assert "degrade" in review_values
+        assert "degrade" not in generic_values
+        # Generic has BUDGET_EXCEEDED, review does not (review uses DENY
+        # with a reason for the same signal).
+        assert "budget_exceeded" in generic_values
+        assert "budget_exceeded" not in review_values
+
+    def test_review_budget_does_not_replace_generic_budget_policy(self) -> None:
+        # Intentional non-replacement: aragora.billing.budget_policy.BudgetPolicy
+        # is the generic workspace budget (monthly/daily/per-debate).
+        # ReviewBudget is the PR-review slice (per-pr/per-repo/per-org).
+        # They compose; neither replaces the other.
+        from aragora.billing.budget_policy import BudgetPolicy
+
+        budget = ReviewBudget()
+        generic = BudgetPolicy()
+        # ReviewBudget has per_pr_usd_cap; generic does not.
+        assert hasattr(budget, "per_pr_usd_cap")
+        assert not hasattr(generic, "per_pr_usd_cap")
+        # Generic has monthly_limit; ReviewBudget does not (that's a
+        # workspace-level concern, not per-review).
+        assert hasattr(generic, "monthly_limit")
+        assert not hasattr(budget, "monthly_limit")


### PR DESCRIPTION
## Summary

Smallest credible foundation for #6305 (cost-aware policy + budget controls). Schema-only module: PR-review-specific policy and budget contracts. **No evaluator, no cost metering, no storage** — that ships in the #6306 orchestrator + review-queue writer + #6304 UI.

Same pattern as #6334 (protocol) and #6353 (receipts): frozen dataclasses, tuple sequences, typed-enum discriminators, composition with existing infrastructure rather than duplication.

## Scope (#6305)

Closes part of: #6305 (foundation only — policy schema contracts)
Depends on: #6334 + #6353 (merged — `aragora/review/` package exists)
Parent design: `docs/plans/2026-04-19-pr-intelligence-brief.md` (#6309)

## What's defined

| Type | Purpose |
|------|---------|
| `ReviewDepth` | TRIVIAL / STANDARD / DEEP (three levels; more is YAGNI until a real consumer wants a fourth) |
| `RiskClass` | LOW / MEDIUM / HIGH / CRITICAL (review-depth concern, distinct from `aragora.policy.risk.RiskLevel` which is deployment blast-radius) |
| `ReviewPolicyDecision` | ALLOW / DEGRADE / DENY / ESCALATE (`DEGRADE` is the review-specific value the generic `PolicyDecision` doesn't express) |
| `DepthTrigger` | condition→target_depth rule: `min_additions_plus_deletions` + `subsystem_prefixes` + `min_risk_class` (first-match-wins) |
| `ReviewBudget` | per-PR / per-repo-daily / per-org-daily USD caps + alert_threshold_pct + hard_limit |
| `ReviewPolicy` | `depth_rules` tuple + `budget` + `default_depth` |
| `CostMeter` | packet-embeddable cost-and-budget context for #6304 UI + exports |

## Addresses all 4 acceptance criteria (foundation slice)

| Criterion | Covered by |
|-----------|-----------|
| "Per-repo / per-org caps for deep review runs" | `ReviewBudget.per_repo_usd_daily_cap` + `per_org_usd_daily_cap` |
| "Review-depth policy by diff size, risk class, or subsystem" | `DepthTrigger.min_additions_plus_deletions` + `subsystem_prefixes` + `min_risk_class` + `ReviewPolicy.depth_rules` |
| "Cost meter in the review packet" | `CostMeter` dataclass (estimated + actual cost, budget remaining, alert state) |
| "Safe defaults for Aragora dogfood before wider rollout" | Defaults locked in tests: $25/PR cap (Anthropic market anchor), 80% alert threshold, hard_limit=True, STANDARD default depth |

## Composition, not duplication

- `aragora.billing.budget_policy.BudgetPolicy` (generic workspace budget) stays as-is; `ReviewBudget` carves out the PR-review slice. Regression test `test_review_budget_does_not_replace_generic_budget_policy` documents the intentional separation.
- `aragora.policy.engine.PolicyDecision` (generic deploy decisions) stays as-is; `ReviewPolicyDecision` has its own `DEGRADE` value for review-specific cheapest-possible fallback. Regression test `test_review_policy_decision_disjoint_from_engine_policy_decision` documents the intentional divergence.

## Safety invariants

- Every public dataclass is frozen (no mutation of advisory surfaces)
- All sequence fields are `tuple[...]` (receipt-stable composition with #6353 `BriefReceipt` / `SettlementLinkage`)
- All discriminator fields are Enum-typed (per codex's P1 from #6353)
- No hardcoded runtime cost values beyond the dogfood-safe defaults

## Validation (literal)

```
pytest tests/review/ -q
95 passed in 3.41s   (23 new policy + 35 receipt + 37 protocol)

reconcile_status_docs --strict           Result: PASS
check_capability_matrix_sync             Capability matrix files are up to date.
generate_cli_reference --check           CLI reference files are up to date.
check_version_alignment                  All versions aligned!
```

Pre-commit hooks: passed (gitleaks, large files, merge conflicts, private key, ruff format).

## Files

- `aragora/review/__init__.py` (+11 lines, new public re-exports)
- `aragora/review/policy.py` (new, ~155 LOC after ruff format)
- `tests/review/test_policy.py` (new, 23 tests)

## Non-goals

- Not implementing the policy evaluator (a #6306 successor PR)
- Not metering actual cost (lives in existing `aragora/billing/`)
- Not populating `CostMeter` from a running review (the orchestrator does this)
- Not modifying `BudgetPolicy` or `PolicyDecision` in other modules
- Not using `--admin` to bypass review

## Capability vs hygiene vs accounting

**Capability** — new type contracts the #6306 orchestrator, #6304 UI, and review-queue writer will all import.

## Residual scope note

Same as #6334 and #6353: this is the foundation/contracts slice, not full closure of #6305. The evaluator and cost-metering behavior remain follow-on work. #6305 stays open after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)