### PR TITLE
fix(spec-upgrader): flatten paginated audit comments

### DIFF
--- a/aragora/swarm/spec_upgrader.py
+++ b/aragora/swarm/spec_upgrader.py
@@ -532,7 +532,20 @@ class AuditPersistence:
             ],
             text=True,
         )
-        payload = json.loads(out or "[]")
+        try:
+            payload = json.loads(out or "[]")
+        except json.JSONDecodeError:
+            comments: list[dict] = []
+            for raw_page in out.splitlines():
+                raw_page = raw_page.strip()
+                if not raw_page:
+                    continue
+                page = json.loads(raw_page)
+                if isinstance(page, list):
+                    comments.extend(comment for comment in page if isinstance(comment, dict))
+                elif isinstance(page, dict):
+                    comments.append(page)
+            return comments
         if payload and all(isinstance(page, list) for page in payload):
             return [comment for page in payload for comment in page]
         return payload

--- a/aragora/swarm/spec_upgrader.py
+++ b/aragora/swarm/spec_upgrader.py
@@ -527,11 +527,15 @@ class AuditPersistence:
                 "gh",
                 "api",
                 "--paginate",
+                "--slurp",
                 f"/repos/{self.repo}/issues/{self.issue_number}/comments",
             ],
             text=True,
         )
-        return json.loads(out or "[]")
+        payload = json.loads(out or "[]")
+        if payload and all(isinstance(page, list) for page in payload):
+            return [comment for page in payload for comment in page]
+        return payload
 
     def _gh_create_comment(self, *, body: str) -> None:
         subprocess.check_call(

--- a/tests/swarm/test_spec_upgrader.py
+++ b/tests/swarm/test_spec_upgrader.py
@@ -433,6 +433,20 @@ def test_audit_list_comments_accepts_plain_array_payload():
     assert comments == [{"id": 1, "body": "first"}]
 
 
+def test_audit_list_comments_flattens_newline_delimited_pages():
+    ap = AuditPersistence(issue_number=5898)
+    with patch(
+        "aragora.swarm.spec_upgrader.subprocess.check_output",
+        return_value='[{"id": 1, "body": "first"}]\n[{"id": 2, "body": "second"}]\n',
+    ):
+        comments = ap._gh_list_comments()
+
+    assert comments == [
+        {"id": 1, "body": "first"},
+        {"id": 2, "body": "second"},
+    ]
+
+
 def test_audit_upsert_creates_when_missing():
     ap = AuditPersistence(issue_number=5898)
     with (

--- a/tests/swarm/test_spec_upgrader.py
+++ b/tests/swarm/test_spec_upgrader.py
@@ -407,6 +407,32 @@ def test_audit_read_attempt_count_gh_failure_fails_open():
     assert valid is True
 
 
+def test_audit_list_comments_flattens_paginated_pages():
+    ap = AuditPersistence(issue_number=5898)
+    with patch(
+        "aragora.swarm.spec_upgrader.subprocess.check_output",
+        return_value='[[{"id": 1, "body": "first"}], [{"id": 2, "body": "second"}]]',
+    ) as check_output:
+        comments = ap._gh_list_comments()
+
+    assert comments == [
+        {"id": 1, "body": "first"},
+        {"id": 2, "body": "second"},
+    ]
+    assert "--slurp" in check_output.call_args.args[0]
+
+
+def test_audit_list_comments_accepts_plain_array_payload():
+    ap = AuditPersistence(issue_number=5898)
+    with patch(
+        "aragora.swarm.spec_upgrader.subprocess.check_output",
+        return_value='[{"id": 1, "body": "first"}]',
+    ):
+        comments = ap._gh_list_comments()
+
+    assert comments == [{"id": 1, "body": "first"}]
+
+
 def test_audit_upsert_creates_when_missing():
     ap = AuditPersistence(issue_number=5898)
     with (


### PR DESCRIPTION
## Summary
- flatten paginated audit comment payloads returned by `gh api --paginate --slurp`
- accept newline-delimited JSON page output as a fail-open fallback when the gh payload is not wrapped as one array
- add focused coverage for slurped arrays, plain arrays, newline-delimited pages, and existing fail-open behavior

Closes #6147

## Validation
- `python3 -m pytest -q tests/swarm/test_spec_upgrader.py -k 'audit' -p no:rerunfailures -p no:cacheprovider`
- `python3 -m ruff check aragora/swarm/spec_upgrader.py tests/swarm/test_spec_upgrader.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
