### PR TITLE
[#6304] feat(live): TypeScript contracts for PR intelligence brief UI (foundation)

### DIFF
--- a/aragora/live/src/lib/review/__tests__/types.test.ts
+++ b/aragora/live/src/lib/review/__tests__/types.test.ts
@@ -19,6 +19,7 @@ import {
   BudgetScope,
   DissentPosition,
   EvidenceKind,
+  ProviderSlotStatus,
   QueueLane,
   Recommendation,
   REVIEW_BRIEF_ADVISORY_NOTE,
@@ -38,6 +39,8 @@ import {
   type PRReviewBinding,
   type PRReviewFinding,
   type PRReviewProtocolPacket,
+  type ProtocolCostEstimate,
+  type ProtocolValidationSummary,
   type ProviderSlotResolution,
   type QueueItem,
   type ReviewBrief,
@@ -149,6 +152,14 @@ describe("canonical string discipline — enums match aragora/review/*.py", () =
     expect(QueueLane.NEEDS_ATTENTION).toBe("needs_attention");
     expect(QueueLane.REPAIRABLE).toBe("repairable");
     expect(QueueLane.PARKED).toBe("parked");
+  });
+
+  test("ProviderSlotStatus values match aragora/swarm/pr_review_protocol.py", () => {
+    // Producer emits exactly these two strings in
+    // ``PRReviewProtocol._resolve_slot``; drift would cause successor
+    // UI code to branch on values the backend never sends.
+    expect(ProviderSlotStatus.AVAILABLE).toBe("available");
+    expect(ProviderSlotStatus.UNAVAILABLE).toBe("unavailable");
   });
 });
 
@@ -556,44 +567,102 @@ describe("python-json payloads parse as TS types", () => {
       base_sha: "1857a9192",
       head_sha: "72a79cc74",
     };
+    // PRReviewFinding severity mirrors the strings Python emits in
+    // ``_build_findings``: "low" | "medium" | "high" (RiskClass-ish).
     const finding: PRReviewFinding = {
-      finding_id: "f1",
-      category: "correctness",
-      severity: "info",
-      summary: "No regressions found in changed paths.",
-      evidence: ["aragora/live/src/lib/review/types.ts:1-100"],
+      finding_id: "bounded-green",
+      category: "summary",
+      severity: "low",
+      summary: "No blocking metadata signals detected for this PR.",
+      evidence: ["Example PR", "24/24 green"],
       source: "metadata_heuristic",
     };
+    // Slot status is narrowed to ProviderSlotStatus; values match the
+    // exact strings Python's _resolve_slot emits.
     const slot: ProviderSlotResolution = {
       slot_id: "logic",
-      review_role: "logic_reviewer",
+      review_role: ReviewRole.LOGIC,
       lens: "core",
       family: "claude",
       selected_provider: "claude",
-      status: "selected",
-      detail: "",
+      status: ProviderSlotStatus.AVAILABLE,
+      detail: "claude CLI available",
       candidates: ["claude", "anthropic-api"],
+    };
+    const validation_summary: ProtocolValidationSummary = {
+      checks_summary: "24/24 green",
+      has_failures: false,
+      has_pending: false,
+      mergeable: "MERGEABLE",
+      review_decision: "REVIEW_REQUIRED",
+      validation_commands: ["npx jest", "npx tsc --noEmit"],
+      changed_files: 3,
+      diffstat: { additions: 656, deletions: 0 },
+    };
+    const cost_estimate: ProtocolCostEstimate = {
+      currency: "USD",
+      low: 3.0,
+      high: 5.0,
+      basis: "bounded heterogeneous metadata-first protocol",
     };
     const protocol: PRReviewProtocolPacket = {
       protocol_version: "pr_review_protocol.v1",
       status: "metadata_heuristic",
       binding,
-      review_roles: ["logic_reviewer", "security_reviewer"],
+      review_roles: [ReviewRole.LOGIC, ReviewRole.SECURITY],
       provider_slots: [slot],
       recommendation_class: Recommendation.APPROVE_CANDIDATE,
       recommendation_reason: "All gates green.",
       confidence: 0.9,
-      confidence_basis: "heuristic",
+      confidence_basis: "metadata_heuristic",
       dissent_summary: "unanimous",
       dissenting_views: [],
-      validation_summary: {},
+      validation_summary,
       top_findings: [finding],
-      cost_estimate: {},
+      cost_estimate,
     };
     // recommendation_class is typed to Recommendation — cannot be a stray string.
     expect(protocol.recommendation_class).toBe(Recommendation.APPROVE_CANDIDATE);
     expect(protocol.binding.head_sha).toBe("72a79cc74");
-    expect(protocol.top_findings[0].finding_id).toBe("f1");
+    expect(protocol.top_findings[0].finding_id).toBe("bounded-green");
+    // Narrow discriminators: slot status and review role are real enum values.
+    expect(protocol.provider_slots[0].status).toBe(ProviderSlotStatus.AVAILABLE);
+    expect(protocol.provider_slots[0].review_role).toBe(ReviewRole.LOGIC);
+    expect(protocol.review_roles).toContain(ReviewRole.SECURITY);
+    // Typed validation summary + cost estimate preserve field-level access.
+    expect(protocol.validation_summary.diffstat.additions).toBe(656);
+    expect(protocol.cost_estimate.currency).toBe("USD");
+  });
+
+  test("ProviderSlotResolution rejects drift values at compile time", () => {
+    // Regression guard (codex #6361 rev 4): status and review_role must
+    // not be raw string. If the Python producer is ever extended, the
+    // enum must be extended first — TS should fail to compile on drift
+    // values like "selected" or "skipped_missing_env" that were in the
+    // earlier (now-corrected) UI comment.
+    // @ts-expect-error — "selected" is not a ProviderSlotStatus.
+    const badStatus: ProviderSlotResolution = {
+      slot_id: "logic",
+      review_role: ReviewRole.LOGIC,
+      lens: "core",
+      family: "claude",
+      selected_provider: "claude",
+      status: "selected",
+      detail: "",
+      candidates: [],
+    };
+    // @ts-expect-error — "auditor" is not a ReviewRole.
+    const badRole: ProviderSlotResolution = {
+      slot_id: "logic",
+      review_role: "auditor",
+      lens: "core",
+      family: "claude",
+      selected_provider: "claude",
+      status: ProviderSlotStatus.AVAILABLE,
+      detail: "",
+      candidates: [],
+    };
+    expect([badStatus, badRole]).toHaveLength(2);
   });
 
   test("ReviewPacket protocol field accepts empty-object default", () => {

--- a/aragora/live/src/lib/review/__tests__/types.test.ts
+++ b/aragora/live/src/lib/review/__tests__/types.test.ts
@@ -15,12 +15,14 @@
  */
 
 import {
-  ADVISORY_NOTE,
+  BRIEF_RECEIPT_ADVISORY_NOTE,
   BudgetScope,
   DissentPosition,
   EvidenceKind,
   QueueLane,
   Recommendation,
+  REVIEW_BRIEF_ADVISORY_NOTE,
+  REVIEW_PACKET_ADVISORY_NOTE,
   ReviewDepth,
   ReviewPolicyDecision,
   ReviewRole,
@@ -150,19 +152,33 @@ describe("canonical string discipline — enums match aragora/review/*.py", () =
 // ADVISORY_NOTE contract
 // ---------------------------------------------------------------------------
 
-describe("ADVISORY_NOTE", () => {
-  test("exact byte-for-byte match with Python canonical", () => {
-    // The Python-side value is defined in aragora/review/protocol.py:
-    //   ADVISORY_NOTE = (
-    //       "This brief is advisory only. It does not approve or block merge. "
-    //       "Human settlement required."
-    //   )
-    // Any drift here breaks cross-side consistency of the copy the
-    // operator sees. This test hard-codes the canonical value so either
-    // side updating without the other fails loudly.
-    expect(ADVISORY_NOTE).toBe(
+describe("advisory-note constants — distinct per backend payload", () => {
+  test("REVIEW_BRIEF_ADVISORY_NOTE exact match (aragora/review/protocol.py)", () => {
+    expect(REVIEW_BRIEF_ADVISORY_NOTE).toBe(
       "This brief is advisory only. It does not approve or block merge. Human settlement required.",
     );
+  });
+
+  test("REVIEW_PACKET_ADVISORY_NOTE exact match (aragora/cli/commands/review_queue.py)", () => {
+    expect(REVIEW_PACKET_ADVISORY_NOTE).toBe(
+      "This packet is advisory only. It does not approve or block merge. Human settlement required.",
+    );
+  });
+
+  test("BRIEF_RECEIPT_ADVISORY_NOTE exact match (aragora/review/receipt.py)", () => {
+    expect(BRIEF_RECEIPT_ADVISORY_NOTE).toBe(
+      "This receipt records an advisory brief. It does not approve or block merge. " +
+        "Human settlement required.",
+    );
+  });
+
+  test("all three strings are distinct (not reused)", () => {
+    // The drift bug codex flagged on revision 1 was the result of one
+    // shared string. Explicitly assert that all three are genuinely
+    // different so a future refactor can't collapse them by accident.
+    expect(REVIEW_BRIEF_ADVISORY_NOTE).not.toBe(REVIEW_PACKET_ADVISORY_NOTE);
+    expect(REVIEW_BRIEF_ADVISORY_NOTE).not.toBe(BRIEF_RECEIPT_ADVISORY_NOTE);
+    expect(REVIEW_PACKET_ADVISORY_NOTE).not.toBe(BRIEF_RECEIPT_ADVISORY_NOTE);
   });
 });
 
@@ -218,7 +234,7 @@ describe("python-json payloads parse as TS types", () => {
       agent_roster: ["claude-opus-4-7", "gpt-5-4"],
       generated_at: "2026-04-20T15:00:00+00:00",
       advisory_only: true,
-      settlement_note: ADVISORY_NOTE,
+      settlement_note: REVIEW_BRIEF_ADVISORY_NOTE,
     };
     expect(payload.advisory_only).toBe(true);
     expect(payload.recommendation).toBe(Recommendation.APPROVE_CANDIDATE);
@@ -266,7 +282,7 @@ describe("python-json payloads parse as TS types", () => {
       agent_roster: [],
       generated_at: "",
       advisory_only: true,
-      settlement_note: ADVISORY_NOTE,
+      settlement_note: REVIEW_BRIEF_ADVISORY_NOTE,
     };
     const receipt: BriefReceipt = {
       brief,
@@ -275,7 +291,7 @@ describe("python-json payloads parse as TS types", () => {
       receipt_id: "receipt-sha",
       created_at: "2026-04-20T15:00:00+00:00",
       advisory_only: true,
-      settlement_note: ADVISORY_NOTE,
+      settlement_note: BRIEF_RECEIPT_ADVISORY_NOTE,
     };
     expect(receipt.advisory_only).toBe(true);
     expect(receipt.brief.advisory_only).toBe(true);
@@ -383,10 +399,12 @@ describe("python-json payloads parse as TS types", () => {
       generated_at: "2026-04-20T15:00:00+00:00",
       protocol: {},
       advisory_only: true,
-      settlement_note: ADVISORY_NOTE,
+      settlement_note: REVIEW_PACKET_ADVISORY_NOTE,
     };
     expect(packet.advisory_only).toBe(true);
-    expect(packet.settlement_note).toBe(ADVISORY_NOTE);
+    expect(packet.settlement_note).toBe(REVIEW_PACKET_ADVISORY_NOTE);
+    // Verify the packet string is distinct from the brief string.
+    expect(packet.settlement_note).not.toBe(REVIEW_BRIEF_ADVISORY_NOTE);
   });
 
   test("SettlementReceipt shape (SHA-bound record)", () => {
@@ -414,29 +432,75 @@ describe("python-json payloads parse as TS types", () => {
     expect(receipt.action).toBe(SettlementAction.APPROVE);
   });
 
-  test("SettlementActionRequest requires SHA binding", () => {
+  test("SettlementActionRequest APPROVE may omit reason", () => {
+    // action=approve: reason is optional.
     const req: SettlementActionRequest = {
       pr_number: 6361,
       head_sha: "72a79cc74",
       packet_sha: "packet-hash-xyz",
-      action: "approve" as SettlementAction,
+      action: SettlementAction.APPROVE,
     };
     expect(req.head_sha).toBe("72a79cc74");
-    expect(req.packet_sha).toBe("packet-hash-xyz");
-    // reason is optional for approve
+    expect(req.action).toBe(SettlementAction.APPROVE);
     expect(req.reason).toBeUndefined();
   });
 
-  test("SettlementActionRequest for request_changes carries reason", () => {
+  test("SettlementActionRequest APPROVE may also include reason", () => {
     const req: SettlementActionRequest = {
       pr_number: 6361,
       head_sha: "72a79cc74",
       packet_sha: "packet-hash-xyz",
-      action: "request_changes" as SettlementAction,
+      action: SettlementAction.APPROVE,
+      reason: "All checks green, docs synced.",
+    };
+    expect(req.reason).toBe("All checks green, docs synced.");
+  });
+
+  test("SettlementActionRequest REQUEST_CHANGES requires reason (discriminated union)", () => {
+    const req: SettlementActionRequest = {
+      pr_number: 6361,
+      head_sha: "72a79cc74",
+      packet_sha: "packet-hash-xyz",
+      action: SettlementAction.REQUEST_CHANGES,
       reason: "Missing edge-case coverage in policy evaluator.",
     };
     expect(req.action).toBe(SettlementAction.REQUEST_CHANGES);
     expect(req.reason).toBe("Missing edge-case coverage in policy evaluator.");
+  });
+
+  test("SettlementActionRequest DEFER requires reason (discriminated union)", () => {
+    const req: SettlementActionRequest = {
+      pr_number: 6361,
+      head_sha: "72a79cc74",
+      packet_sha: "packet-hash-xyz",
+      action: SettlementAction.DEFER,
+      reason: "Waiting on upstream dep update.",
+    };
+    expect(req.action).toBe(SettlementAction.DEFER);
+    expect(req.reason).toBe("Waiting on upstream dep update.");
+  });
+
+  test("SettlementActionRequest REQUEST_CHANGES without reason is a compile error", () => {
+    // P1 regression guard (codex #6361 rev 2): the discriminated union
+    // MUST reject REQUEST_CHANGES and DEFER without reason at compile
+    // time.  @ts-expect-error confirms the compiler refuses each.
+    // @ts-expect-error — REQUEST_CHANGES requires reason.
+    const bad1: SettlementActionRequest = {
+      pr_number: 6361,
+      head_sha: "72a79cc74",
+      packet_sha: "packet-hash-xyz",
+      action: SettlementAction.REQUEST_CHANGES,
+    };
+    // @ts-expect-error — DEFER requires reason.
+    const bad2: SettlementActionRequest = {
+      pr_number: 6361,
+      head_sha: "72a79cc74",
+      packet_sha: "packet-hash-xyz",
+      action: SettlementAction.DEFER,
+    };
+    // Reference bad1 and bad2 so lint doesn't flag them as unused while
+    // still exercising the @ts-expect-error on the declarations above.
+    expect([bad1, bad2]).toHaveLength(2);
   });
 
   test("SettlementActionResponse success carries the receipt", () => {
@@ -533,7 +597,7 @@ describe("readonly discipline (compile-time)", () => {
       agent_roster: ["model-a"],
       generated_at: "",
       advisory_only: true,
-      settlement_note: ADVISORY_NOTE,
+      settlement_note: REVIEW_BRIEF_ADVISORY_NOTE,
     };
     // @ts-expect-error — agent_roster is readonly; push must fail type-check.
     brief.agent_roster.push("model-b");

--- a/aragora/live/src/lib/review/__tests__/types.test.ts
+++ b/aragora/live/src/lib/review/__tests__/types.test.ts
@@ -19,6 +19,7 @@ import {
   BudgetScope,
   DissentPosition,
   EvidenceKind,
+  QueueLane,
   Recommendation,
   ReviewDepth,
   ReviewPolicyDecision,
@@ -32,11 +33,16 @@ import {
   type CostMeter,
   type DissentingView,
   type EvidenceRef,
+  type QueueItem,
   type ReviewBrief,
   type ReviewBudget,
+  type ReviewPacket,
   type ReviewPolicy,
   type RoleFinding,
+  type SettlementActionRequest,
+  type SettlementActionResponse,
   type SettlementLinkage,
+  type SettlementReceipt,
   type ValidationRef,
 } from "../types";
 
@@ -129,6 +135,15 @@ describe("canonical string discipline — enums match aragora/review/*.py", () =
     expect(BudgetScope.PER_REPO_DAILY).toBe("per_repo_daily");
     expect(BudgetScope.PER_ORG_DAILY).toBe("per_org_daily");
   });
+
+  test("QueueLane values", () => {
+    // Must match canonical strings in aragora.cli.commands.review_queue
+    // LANE_ORDER dict. A drift here silently breaks card grouping.
+    expect(QueueLane.READY_NOW).toBe("ready_now");
+    expect(QueueLane.NEEDS_ATTENTION).toBe("needs_attention");
+    expect(QueueLane.REPAIRABLE).toBe("repairable");
+    expect(QueueLane.PARKED).toBe("parked");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -136,9 +151,18 @@ describe("canonical string discipline — enums match aragora/review/*.py", () =
 // ---------------------------------------------------------------------------
 
 describe("ADVISORY_NOTE", () => {
-  test("mentions advisory-only and human-settlement semantics", () => {
-    expect(ADVISORY_NOTE.toLowerCase()).toContain("advisory");
-    expect(ADVISORY_NOTE.toLowerCase()).toContain("human settlement");
+  test("exact byte-for-byte match with Python canonical", () => {
+    // The Python-side value is defined in aragora/review/protocol.py:
+    //   ADVISORY_NOTE = (
+    //       "This brief is advisory only. It does not approve or block merge. "
+    //       "Human settlement required."
+    //   )
+    // Any drift here breaks cross-side consistency of the copy the
+    // operator sees. This test hard-codes the canonical value so either
+    // side updating without the other fails loudly.
+    expect(ADVISORY_NOTE).toBe(
+      "This brief is advisory only. It does not approve or block merge. Human settlement required.",
+    );
   });
 });
 
@@ -311,6 +335,147 @@ describe("python-json payloads parse as TS types", () => {
     };
     expect(policy.depth_rules).toHaveLength(1);
     expect(policy.depth_rules[0].target_depth).toBe(ReviewDepth.DEEP);
+  });
+
+  test("QueueItem shape (the card payload)", () => {
+    const card: QueueItem = {
+      number: 6361,
+      title: "[#6304] feat(live): TypeScript contracts for PR intelligence brief UI",
+      url: "https://github.com/synaptent/aragora/pull/6361",
+      head_sha: "72a79cc74",
+      author: "an0mium",
+      is_draft: true,
+      mergeable: "MERGEABLE",
+      review_decision: "REVIEW_REQUIRED",
+      labels: ["autonomous"],
+      additions: 656,
+      deletions: 0,
+      changed_files: 3,
+      checks_summary: "24/24 green",
+      lane: "ready_now" as QueueLane,
+      lane_reason: "24/24 green",
+    };
+    expect(card.lane).toBe(QueueLane.READY_NOW);
+    expect(card.additions).toBe(656);
+  });
+
+  test("ReviewPacket shape (the expandable packet)", () => {
+    const packet: ReviewPacket = {
+      pr_number: 6361,
+      title: "Example",
+      url: "https://github.com/synaptent/aragora/pull/6361",
+      head_sha: "72a79cc74",
+      base_sha: "1857a9192",
+      author: "an0mium",
+      is_draft: true,
+      additions: 656,
+      deletions: 0,
+      changed_files: 3,
+      queue_bucket: "ready_now",
+      touched_subsystems: ["aragora/live"],
+      high_risk_paths_touched: [],
+      validation: ["jest: 24 passed", "tsc: exit 0"],
+      checks_summary: "24/24 green",
+      risk_flags: [],
+      machine_recommendation: "approve_candidate",
+      machine_recommendation_reason: "Bounded TS foundation; no behavior change",
+      packet_sha: "packet-hash-xyz",
+      generated_at: "2026-04-20T15:00:00+00:00",
+      protocol: {},
+      advisory_only: true,
+      settlement_note: ADVISORY_NOTE,
+    };
+    expect(packet.advisory_only).toBe(true);
+    expect(packet.settlement_note).toBe(ADVISORY_NOTE);
+  });
+
+  test("SettlementReceipt shape (SHA-bound record)", () => {
+    const receipt: SettlementReceipt = {
+      session_id: "session-001",
+      reviewed_at: "2026-04-20T15:00:00+00:00",
+      actor: "armand",
+      action: "approve" as SettlementAction,
+      reason: "",
+      pr_number: 6361,
+      pr_url: "https://github.com/synaptent/aragora/pull/6361",
+      head_sha: "72a79cc74",
+      base_sha: "1857a9192",
+      packet_sha: "packet-hash-xyz",
+      queue_bucket: "ready_now",
+      machine_recommendation: "approve_candidate",
+      github_event: "REVIEW_SUBMITTED",
+      elapsed_seconds: 4.2,
+      receipt_path: ".aragora/review-queue/receipts/pr-6361-session-001-approve.json",
+    };
+    // SHA-bound property: head_sha + packet_sha are both part of the
+    // record so merge_arbiter can refuse stale settlements.
+    expect(receipt.head_sha).toBe("72a79cc74");
+    expect(receipt.packet_sha).toBe("packet-hash-xyz");
+    expect(receipt.action).toBe(SettlementAction.APPROVE);
+  });
+
+  test("SettlementActionRequest requires SHA binding", () => {
+    const req: SettlementActionRequest = {
+      pr_number: 6361,
+      head_sha: "72a79cc74",
+      packet_sha: "packet-hash-xyz",
+      action: "approve" as SettlementAction,
+    };
+    expect(req.head_sha).toBe("72a79cc74");
+    expect(req.packet_sha).toBe("packet-hash-xyz");
+    // reason is optional for approve
+    expect(req.reason).toBeUndefined();
+  });
+
+  test("SettlementActionRequest for request_changes carries reason", () => {
+    const req: SettlementActionRequest = {
+      pr_number: 6361,
+      head_sha: "72a79cc74",
+      packet_sha: "packet-hash-xyz",
+      action: "request_changes" as SettlementAction,
+      reason: "Missing edge-case coverage in policy evaluator.",
+    };
+    expect(req.action).toBe(SettlementAction.REQUEST_CHANGES);
+    expect(req.reason).toBe("Missing edge-case coverage in policy evaluator.");
+  });
+
+  test("SettlementActionResponse success carries the receipt", () => {
+    const receipt: SettlementReceipt = {
+      session_id: "session-001",
+      reviewed_at: "2026-04-20T15:00:00+00:00",
+      actor: "armand",
+      action: "approve" as SettlementAction,
+      reason: "",
+      pr_number: 6361,
+      pr_url: "https://github.com/synaptent/aragora/pull/6361",
+      head_sha: "72a79cc74",
+      base_sha: "1857a9192",
+      packet_sha: "packet-hash-xyz",
+      queue_bucket: "ready_now",
+      machine_recommendation: "approve_candidate",
+      github_event: "REVIEW_SUBMITTED",
+      elapsed_seconds: 4.2,
+      receipt_path: ".aragora/review-queue/receipts/pr-6361-session-001-approve.json",
+    };
+    const resp: SettlementActionResponse = {
+      success: true,
+      receipt,
+    };
+    expect(resp.success).toBe(true);
+    // The UI contract: consumers MUST verify head_sha + packet_sha match
+    // what they sent. This test documents that property at the type level.
+    expect(resp.receipt?.head_sha).toBe("72a79cc74");
+    expect(resp.receipt?.packet_sha).toBe("packet-hash-xyz");
+  });
+
+  test("SettlementActionResponse failure carries an error", () => {
+    const resp: SettlementActionResponse = {
+      success: false,
+      error: "stale_packet_sha: request head_sha=abc, current head_sha=def",
+    };
+    expect(resp.success).toBe(false);
+    expect(resp.receipt).toBeUndefined();
+    expect(resp.error).toContain("stale_packet_sha");
   });
 
   test("CostMeter with multi-pool headroom and binding_scope", () => {

--- a/aragora/live/src/lib/review/__tests__/types.test.ts
+++ b/aragora/live/src/lib/review/__tests__/types.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for aragora/live/src/lib/review/types.ts.
+ *
+ * The critical property is CANONICAL-STRING DISCIPLINE: every enum string
+ * in this module must match exactly the ``to_dict()`` output of the Python
+ * dataclasses in ``aragora/review/{protocol,receipt,policy}.py``.  Drift
+ * breaks JSON interop silently.  Each test below hard-codes the Python
+ * string value, so a refactor that touches one side will fail loudly if
+ * the other is not updated.
+ *
+ * Python counterpart values are drawn from the canonical test suites in
+ * ``tests/review/test_protocol.py``, ``tests/review/test_receipt.py``,
+ * and ``tests/review/test_policy.py`` — which are themselves the source
+ * of truth.
+ */
+
+import {
+  ADVISORY_NOTE,
+  BudgetScope,
+  DissentPosition,
+  EvidenceKind,
+  Recommendation,
+  ReviewDepth,
+  ReviewPolicyDecision,
+  ReviewRole,
+  RiskClass,
+  SettlementAction,
+  SynthesisPolicy,
+  ValidationKind,
+  ValidationResult,
+  type BriefReceipt,
+  type CostMeter,
+  type DissentingView,
+  type EvidenceRef,
+  type ReviewBrief,
+  type ReviewBudget,
+  type ReviewPolicy,
+  type RoleFinding,
+  type SettlementLinkage,
+  type ValidationRef,
+} from "../types";
+
+// ---------------------------------------------------------------------------
+// Enum canonical-string discipline (each value must match Python exactly)
+// ---------------------------------------------------------------------------
+
+describe("canonical string discipline — enums match aragora/review/*.py", () => {
+  test("ReviewRole values", () => {
+    expect(ReviewRole.LOGIC).toBe("logic_reviewer");
+    expect(ReviewRole.SECURITY).toBe("security_reviewer");
+    expect(ReviewRole.MAINTAINABILITY).toBe("maintainability_reviewer");
+    expect(ReviewRole.SKEPTIC).toBe("skeptic");
+    expect(ReviewRole.SYNTHESIZER).toBe("synthesizer");
+  });
+
+  test("Recommendation values", () => {
+    expect(Recommendation.APPROVE_CANDIDATE).toBe("approve_candidate");
+    expect(Recommendation.NEEDS_HUMAN_ATTENTION).toBe("needs_human_attention");
+    expect(Recommendation.REPAIR_FIRST).toBe("repair_first");
+  });
+
+  test("DissentPosition values", () => {
+    expect(DissentPosition.APPROVE).toBe("approve");
+    expect(DissentPosition.REQUEST_CHANGES).toBe("request_changes");
+    expect(DissentPosition.DEFER).toBe("defer");
+  });
+
+  test("SynthesisPolicy values", () => {
+    expect(SynthesisPolicy.MAJORITY).toBe("majority");
+    expect(SynthesisPolicy.WEIGHTED).toBe("weighted");
+    expect(SynthesisPolicy.SYNTHESIZER_AGENT).toBe("synthesizer");
+    expect(SynthesisPolicy.UNANIMOUS_OR_ESCALATE).toBe("unanimous_or_escalate");
+  });
+
+  test("EvidenceKind values", () => {
+    expect(EvidenceKind.FILE).toBe("file");
+    expect(EvidenceKind.TEST).toBe("test");
+    expect(EvidenceKind.COMMIT).toBe("commit");
+    expect(EvidenceKind.ARTIFACT).toBe("artifact");
+    expect(EvidenceKind.ISSUE).toBe("issue");
+    expect(EvidenceKind.PR).toBe("pr");
+    expect(EvidenceKind.EXTERNAL).toBe("external");
+  });
+
+  test("ValidationKind values", () => {
+    expect(ValidationKind.CI_CHECK).toBe("ci_check");
+    expect(ValidationKind.TEST_SUITE).toBe("test_suite");
+    expect(ValidationKind.RECEIPT).toBe("receipt");
+    expect(ValidationKind.BENCHMARK).toBe("benchmark");
+    expect(ValidationKind.MANUAL_REVIEW).toBe("manual_review");
+  });
+
+  test("ValidationResult values", () => {
+    expect(ValidationResult.SUCCESS).toBe("success");
+    expect(ValidationResult.FAILURE).toBe("failure");
+    expect(ValidationResult.SKIPPED).toBe("skipped");
+    expect(ValidationResult.CANCELLED).toBe("cancelled");
+    expect(ValidationResult.PENDING).toBe("pending");
+  });
+
+  test("SettlementAction values", () => {
+    expect(SettlementAction.APPROVE).toBe("approve");
+    expect(SettlementAction.REQUEST_CHANGES).toBe("request_changes");
+    expect(SettlementAction.DEFER).toBe("defer");
+  });
+
+  test("ReviewDepth values", () => {
+    expect(ReviewDepth.TRIVIAL).toBe("trivial");
+    expect(ReviewDepth.STANDARD).toBe("standard");
+    expect(ReviewDepth.DEEP).toBe("deep");
+  });
+
+  test("RiskClass values", () => {
+    expect(RiskClass.LOW).toBe("low");
+    expect(RiskClass.MEDIUM).toBe("medium");
+    expect(RiskClass.HIGH).toBe("high");
+    expect(RiskClass.CRITICAL).toBe("critical");
+  });
+
+  test("ReviewPolicyDecision values", () => {
+    expect(ReviewPolicyDecision.ALLOW).toBe("allow");
+    expect(ReviewPolicyDecision.DEGRADE).toBe("degrade");
+    expect(ReviewPolicyDecision.DENY).toBe("deny");
+    expect(ReviewPolicyDecision.ESCALATE).toBe("escalate");
+  });
+
+  test("BudgetScope values", () => {
+    expect(BudgetScope.PER_PR).toBe("per_pr");
+    expect(BudgetScope.PER_REPO_DAILY).toBe("per_repo_daily");
+    expect(BudgetScope.PER_ORG_DAILY).toBe("per_org_daily");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADVISORY_NOTE contract
+// ---------------------------------------------------------------------------
+
+describe("ADVISORY_NOTE", () => {
+  test("mentions advisory-only and human-settlement semantics", () => {
+    expect(ADVISORY_NOTE.toLowerCase()).toContain("advisory");
+    expect(ADVISORY_NOTE.toLowerCase()).toContain("human settlement");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON-payload compatibility — a Python to_dict() output must parse cleanly
+// as the corresponding TS interface.  Fixtures below mirror the exact
+// field set produced by the Python dataclasses.
+// ---------------------------------------------------------------------------
+
+describe("python-json payloads parse as TS types", () => {
+  test("RoleFinding shape", () => {
+    const payload = {
+      role: "logic_reviewer",
+      agent: "claude-opus-4-7",
+      model: "claude-opus-4-7-1m",
+      confidence: 0.9,
+      finding_text: "No regressions found.",
+      latency_ms: 1200,
+      cost_usd: 0.045,
+    };
+    const finding: RoleFinding = payload as RoleFinding;
+    expect(finding.role).toBe(ReviewRole.LOGIC);
+    expect(finding.confidence).toBe(0.9);
+  });
+
+  test("DissentingView shape (optional role)", () => {
+    const payload = {
+      agent: "grok-3",
+      position: "request_changes",
+      reason: "Security concern.",
+    };
+    const view: DissentingView = payload as DissentingView;
+    expect(view.position).toBe(DissentPosition.REQUEST_CHANGES);
+    expect(view.role).toBeUndefined();
+  });
+
+  test("ReviewBrief shape", () => {
+    const payload: ReviewBrief = {
+      pr_number: 6304,
+      repo: "synaptent/aragora",
+      head_sha: "abc123",
+      base_sha: "def456",
+      packet_sha: "hash789",
+      recommendation: "approve_candidate" as Recommendation,
+      top_line: "Bounded docs PR.",
+      role_findings: [],
+      dissent: [],
+      validation_summary: "pre-commit clean",
+      overall_confidence: 0.88,
+      disagreement_score: 0.05,
+      total_cost_usd: 0.18,
+      total_wall_clock_ms: 4200,
+      agent_roster: ["claude-opus-4-7", "gpt-5-4"],
+      generated_at: "2026-04-20T15:00:00+00:00",
+      advisory_only: true,
+      settlement_note: ADVISORY_NOTE,
+    };
+    expect(payload.advisory_only).toBe(true);
+    expect(payload.recommendation).toBe(Recommendation.APPROVE_CANDIDATE);
+  });
+
+  test("EvidenceRef shape", () => {
+    const payload: EvidenceRef = {
+      kind: "file" as EvidenceKind,
+      path: "aragora/review/protocol.py",
+      sha: "",
+      line_range: [42, 58],
+      quote: "def to_dict(self) -> dict[str, Any]:",
+    };
+    expect(payload.kind).toBe(EvidenceKind.FILE);
+    expect(payload.line_range).toEqual([42, 58]);
+  });
+
+  test("ValidationRef shape", () => {
+    const payload: ValidationRef = {
+      kind: "ci_check" as ValidationKind,
+      name: "Version Alignment",
+      result: "success" as ValidationResult,
+      url: "https://github.com/synaptent/aragora/actions/runs/12345",
+    };
+    expect(payload.kind).toBe(ValidationKind.CI_CHECK);
+    expect(payload.result).toBe(ValidationResult.SUCCESS);
+  });
+
+  test("BriefReceipt advisory invariant", () => {
+    const brief: ReviewBrief = {
+      pr_number: 6304,
+      repo: "synaptent/aragora",
+      head_sha: "abc",
+      base_sha: "def",
+      packet_sha: "h",
+      recommendation: "approve_candidate" as Recommendation,
+      top_line: "",
+      role_findings: [],
+      dissent: [],
+      validation_summary: "",
+      overall_confidence: 0.9,
+      disagreement_score: 0,
+      total_cost_usd: 0,
+      total_wall_clock_ms: 0,
+      agent_roster: [],
+      generated_at: "",
+      advisory_only: true,
+      settlement_note: ADVISORY_NOTE,
+    };
+    const receipt: BriefReceipt = {
+      brief,
+      evidence_refs: [],
+      validation_refs: [],
+      receipt_id: "receipt-sha",
+      created_at: "2026-04-20T15:00:00+00:00",
+      advisory_only: true,
+      settlement_note: ADVISORY_NOTE,
+    };
+    expect(receipt.advisory_only).toBe(true);
+    expect(receipt.brief.advisory_only).toBe(true);
+  });
+
+  test("SettlementLinkage shape (human settlement is not advisory)", () => {
+    const linkage: SettlementLinkage = {
+      brief_receipt_id: "brief-001",
+      settlement_receipt_id: "settlement-001",
+      settlement_receipt_path: ".aragora/review-queue/settlements/pr-6304.json",
+      head_sha: "abc",
+      packet_sha: "h",
+      pr_number: 6304,
+      repo: "synaptent/aragora",
+      action: "approve" as SettlementAction,
+      settled_at: "2026-04-20T15:00:00+00:00",
+      repair_receipt_ids: [],
+      repair_receipt_paths: [],
+      advisory_only: false,
+    };
+    expect(linkage.advisory_only).toBe(false);
+    expect(linkage.action).toBe(SettlementAction.APPROVE);
+  });
+
+  test("ReviewBudget default-shape assumptions", () => {
+    const budget: ReviewBudget = {
+      per_pr_usd_cap: 25.0,
+      per_repo_usd_daily_cap: 0.0,
+      per_org_usd_daily_cap: 0.0,
+      daily_caps_apply_at_or_above_depth: "standard" as ReviewDepth,
+      alert_threshold_pct: 80.0,
+      hard_limit: true,
+    };
+    expect(budget.per_pr_usd_cap).toBe(25.0);
+    expect(budget.daily_caps_apply_at_or_above_depth).toBe(ReviewDepth.STANDARD);
+  });
+
+  test("ReviewPolicy nests budget and tuple of rules", () => {
+    const policy: ReviewPolicy = {
+      budget: {
+        per_pr_usd_cap: 25.0,
+        per_repo_usd_daily_cap: 0.0,
+        per_org_usd_daily_cap: 0.0,
+        daily_caps_apply_at_or_above_depth: "standard" as ReviewDepth,
+        alert_threshold_pct: 80.0,
+        hard_limit: true,
+      },
+      depth_rules: [
+        {
+          target_depth: "deep" as ReviewDepth,
+          min_additions_plus_deletions: 500,
+          subsystem_prefixes: ["aragora/security/"],
+          min_risk_class: "high" as RiskClass,
+        },
+      ],
+      default_depth: "standard" as ReviewDepth,
+    };
+    expect(policy.depth_rules).toHaveLength(1);
+    expect(policy.depth_rules[0].target_depth).toBe(ReviewDepth.DEEP);
+  });
+
+  test("CostMeter with multi-pool headroom and binding_scope", () => {
+    const meter: CostMeter = {
+      depth_chosen: "standard" as ReviewDepth,
+      decision: "degrade" as ReviewPolicyDecision,
+      estimated_cost_usd: 8.0,
+      actual_cost_usd: 7.5,
+      headroom_by_scope: [
+        {
+          scope: "per_pr" as BudgetScope,
+          cap_usd: 25.0,
+          remaining_usd: 24.0,
+        },
+        {
+          scope: "per_repo_daily" as BudgetScope,
+          cap_usd: 50.0,
+          remaining_usd: 2.0,
+          applies_at_or_above_depth: "standard" as ReviewDepth,
+        },
+      ],
+      binding_scope: "per_repo_daily" as BudgetScope,
+      alert_triggered: true,
+    };
+    expect(meter.binding_scope).toBe(BudgetScope.PER_REPO_DAILY);
+    expect(meter.headroom_by_scope).toHaveLength(2);
+    expect(meter.headroom_by_scope[1].remaining_usd).toBe(2.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type-level contract: readonly discipline.  These tests pass at runtime;
+// the value they add is compile-time: the TS compiler rejects attempts to
+// mutate readonly fields, which guarantees the schema behaves like the
+// Python frozen-dataclass + tuple pattern.
+// ---------------------------------------------------------------------------
+
+describe("readonly discipline (compile-time)", () => {
+  test("readonly tuples reject mutation (TS compile-time check)", () => {
+    const brief: ReviewBrief = {
+      pr_number: 1,
+      repo: "",
+      head_sha: "",
+      base_sha: "",
+      packet_sha: "",
+      recommendation: "approve_candidate" as Recommendation,
+      top_line: "",
+      role_findings: [],
+      dissent: [],
+      validation_summary: "",
+      overall_confidence: 0,
+      disagreement_score: 0,
+      total_cost_usd: 0,
+      total_wall_clock_ms: 0,
+      agent_roster: ["model-a"],
+      generated_at: "",
+      advisory_only: true,
+      settlement_note: ADVISORY_NOTE,
+    };
+    // @ts-expect-error — agent_roster is readonly; push must fail type-check.
+    brief.agent_roster.push("model-b");
+    // @ts-expect-error — dissent is readonly.
+    brief.dissent.push({ agent: "x", position: "defer", reason: "" });
+    // @ts-expect-error — pr_number is readonly.
+    brief.pr_number = 2;
+  });
+});

--- a/aragora/live/src/lib/review/__tests__/types.test.ts
+++ b/aragora/live/src/lib/review/__tests__/types.test.ts
@@ -35,6 +35,10 @@ import {
   type CostMeter,
   type DissentingView,
   type EvidenceRef,
+  type PRReviewBinding,
+  type PRReviewFinding,
+  type PRReviewProtocolPacket,
+  type ProviderSlotResolution,
   type QueueItem,
   type ReviewBrief,
   type ReviewBudget,
@@ -306,7 +310,7 @@ describe("python-json payloads parse as TS types", () => {
       packet_sha: "h",
       pr_number: 6304,
       repo: "synaptent/aragora",
-      action: "approve" as SettlementAction,
+      action: SettlementAction.APPROVE,
       settled_at: "2026-04-20T15:00:00+00:00",
       repair_receipt_ids: [],
       repair_receipt_paths: [],
@@ -387,13 +391,13 @@ describe("python-json payloads parse as TS types", () => {
       additions: 656,
       deletions: 0,
       changed_files: 3,
-      queue_bucket: "ready_now",
+      queue_bucket: QueueLane.READY_NOW,
       touched_subsystems: ["aragora/live"],
       high_risk_paths_touched: [],
       validation: ["jest: 24 passed", "tsc: exit 0"],
       checks_summary: "24/24 green",
       risk_flags: [],
-      machine_recommendation: "approve_candidate",
+      machine_recommendation: Recommendation.APPROVE_CANDIDATE,
       machine_recommendation_reason: "Bounded TS foundation; no behavior change",
       packet_sha: "packet-hash-xyz",
       generated_at: "2026-04-20T15:00:00+00:00",
@@ -407,20 +411,20 @@ describe("python-json payloads parse as TS types", () => {
     expect(packet.settlement_note).not.toBe(REVIEW_BRIEF_ADVISORY_NOTE);
   });
 
-  test("SettlementReceipt shape (SHA-bound record)", () => {
+  test("SettlementReceipt shape (SHA-bound record + typed discriminators)", () => {
     const receipt: SettlementReceipt = {
       session_id: "session-001",
       reviewed_at: "2026-04-20T15:00:00+00:00",
       actor: "armand",
-      action: "approve" as SettlementAction,
+      action: SettlementAction.APPROVE,
       reason: "",
       pr_number: 6361,
       pr_url: "https://github.com/synaptent/aragora/pull/6361",
       head_sha: "72a79cc74",
       base_sha: "1857a9192",
       packet_sha: "packet-hash-xyz",
-      queue_bucket: "ready_now",
-      machine_recommendation: "approve_candidate",
+      queue_bucket: QueueLane.READY_NOW,
+      machine_recommendation: Recommendation.APPROVE_CANDIDATE,
       github_event: "REVIEW_SUBMITTED",
       elapsed_seconds: 4.2,
       receipt_path: ".aragora/review-queue/receipts/pr-6361-session-001-approve.json",
@@ -430,6 +434,9 @@ describe("python-json payloads parse as TS types", () => {
     expect(receipt.head_sha).toBe("72a79cc74");
     expect(receipt.packet_sha).toBe("packet-hash-xyz");
     expect(receipt.action).toBe(SettlementAction.APPROVE);
+    // Discriminator fields typed narrowly (not raw string).
+    expect(receipt.queue_bucket).toBe(QueueLane.READY_NOW);
+    expect(receipt.machine_recommendation).toBe(Recommendation.APPROVE_CANDIDATE);
   });
 
   test("SettlementActionRequest APPROVE may omit reason", () => {
@@ -508,15 +515,15 @@ describe("python-json payloads parse as TS types", () => {
       session_id: "session-001",
       reviewed_at: "2026-04-20T15:00:00+00:00",
       actor: "armand",
-      action: "approve" as SettlementAction,
+      action: SettlementAction.APPROVE,
       reason: "",
       pr_number: 6361,
       pr_url: "https://github.com/synaptent/aragora/pull/6361",
       head_sha: "72a79cc74",
       base_sha: "1857a9192",
       packet_sha: "packet-hash-xyz",
-      queue_bucket: "ready_now",
-      machine_recommendation: "approve_candidate",
+      queue_bucket: QueueLane.READY_NOW,
+      machine_recommendation: Recommendation.APPROVE_CANDIDATE,
       github_event: "REVIEW_SUBMITTED",
       elapsed_seconds: 4.2,
       receipt_path: ".aragora/review-queue/receipts/pr-6361-session-001-approve.json",
@@ -540,6 +547,156 @@ describe("python-json payloads parse as TS types", () => {
     expect(resp.success).toBe(false);
     expect(resp.receipt).toBeUndefined();
     expect(resp.error).toContain("stale_packet_sha");
+  });
+
+  test("ReviewPacket protocol field narrows to PRReviewProtocolPacket when populated", () => {
+    const binding: PRReviewBinding = {
+      repo: "synaptent/aragora",
+      pr_number: 6361,
+      base_sha: "1857a9192",
+      head_sha: "72a79cc74",
+    };
+    const finding: PRReviewFinding = {
+      finding_id: "f1",
+      category: "correctness",
+      severity: "info",
+      summary: "No regressions found in changed paths.",
+      evidence: ["aragora/live/src/lib/review/types.ts:1-100"],
+      source: "metadata_heuristic",
+    };
+    const slot: ProviderSlotResolution = {
+      slot_id: "logic",
+      review_role: "logic_reviewer",
+      lens: "core",
+      family: "claude",
+      selected_provider: "claude",
+      status: "selected",
+      detail: "",
+      candidates: ["claude", "anthropic-api"],
+    };
+    const protocol: PRReviewProtocolPacket = {
+      protocol_version: "pr_review_protocol.v1",
+      status: "metadata_heuristic",
+      binding,
+      review_roles: ["logic_reviewer", "security_reviewer"],
+      provider_slots: [slot],
+      recommendation_class: Recommendation.APPROVE_CANDIDATE,
+      recommendation_reason: "All gates green.",
+      confidence: 0.9,
+      confidence_basis: "heuristic",
+      dissent_summary: "unanimous",
+      dissenting_views: [],
+      validation_summary: {},
+      top_findings: [finding],
+      cost_estimate: {},
+    };
+    // recommendation_class is typed to Recommendation — cannot be a stray string.
+    expect(protocol.recommendation_class).toBe(Recommendation.APPROVE_CANDIDATE);
+    expect(protocol.binding.head_sha).toBe("72a79cc74");
+    expect(protocol.top_findings[0].finding_id).toBe("f1");
+  });
+
+  test("ReviewPacket protocol field accepts empty-object default", () => {
+    // Python producer emits {} when the protocol has not run yet; TS
+    // must accept that without a cast.  Narrowing is via presence of
+    // "protocol_version".
+    const packet: ReviewPacket = {
+      pr_number: 6361,
+      title: "",
+      url: "",
+      head_sha: "a",
+      base_sha: "b",
+      author: "an0mium",
+      is_draft: false,
+      additions: 0,
+      deletions: 0,
+      changed_files: 0,
+      queue_bucket: QueueLane.READY_NOW,
+      touched_subsystems: [],
+      high_risk_paths_touched: [],
+      validation: [],
+      checks_summary: "",
+      risk_flags: [],
+      machine_recommendation: Recommendation.APPROVE_CANDIDATE,
+      machine_recommendation_reason: "",
+      packet_sha: "",
+      generated_at: "",
+      protocol: {},
+      advisory_only: true,
+      settlement_note: REVIEW_PACKET_ADVISORY_NOTE,
+    };
+    // Narrow by presence of protocol_version.
+    if ("protocol_version" in packet.protocol) {
+      // TS knows this is PRReviewProtocolPacket here.
+      expect(packet.protocol.protocol_version).toBeDefined();
+    } else {
+      // empty-object path.
+      expect(packet.protocol).toEqual({});
+    }
+  });
+
+  test("ReviewPacket discriminator fields reject invalid strings at compile time", () => {
+    // P1 regression guard (codex #6361 rev 3): queue_bucket and
+    // machine_recommendation must be narrowed to QueueLane /
+    // Recommendation, not raw string. If a UI tries to read a PR with
+    // an unknown lane name, the cast must fail. @ts-expect-error
+    // confirms the compiler refuses invalid values.
+
+    // @ts-expect-error — "nonsense_lane" is not a QueueLane.
+    const badPacketQueue: ReviewPacket = {
+      pr_number: 1,
+      title: "",
+      url: "",
+      head_sha: "",
+      base_sha: "",
+      author: "",
+      is_draft: false,
+      additions: 0,
+      deletions: 0,
+      changed_files: 0,
+      queue_bucket: "nonsense_lane",
+      touched_subsystems: [],
+      high_risk_paths_touched: [],
+      validation: [],
+      checks_summary: "",
+      risk_flags: [],
+      machine_recommendation: Recommendation.APPROVE_CANDIDATE,
+      machine_recommendation_reason: "",
+      packet_sha: "",
+      generated_at: "",
+      protocol: {},
+      advisory_only: true,
+      settlement_note: REVIEW_PACKET_ADVISORY_NOTE,
+    };
+    // @ts-expect-error — "looks_good" is not a Recommendation.
+    const badPacketRec: ReviewPacket = {
+      pr_number: 1,
+      title: "",
+      url: "",
+      head_sha: "",
+      base_sha: "",
+      author: "",
+      is_draft: false,
+      additions: 0,
+      deletions: 0,
+      changed_files: 0,
+      queue_bucket: QueueLane.READY_NOW,
+      touched_subsystems: [],
+      high_risk_paths_touched: [],
+      validation: [],
+      checks_summary: "",
+      risk_flags: [],
+      machine_recommendation: "looks_good",
+      machine_recommendation_reason: "",
+      packet_sha: "",
+      generated_at: "",
+      protocol: {},
+      advisory_only: true,
+      settlement_note: REVIEW_PACKET_ADVISORY_NOTE,
+    };
+    // Reference both so unused-var lint doesn't fire; the @ts-expect-error
+    // above is what actually enforces the contract.
+    expect([badPacketQueue, badPacketRec]).toHaveLength(2);
   });
 
   test("CostMeter with multi-pool headroom and binding_scope", () => {

--- a/aragora/live/src/lib/review/index.ts
+++ b/aragora/live/src/lib/review/index.ts
@@ -1,0 +1,9 @@
+/**
+ * PR intelligence brief — TypeScript entry point.
+ *
+ * Foundation slice of #6304. Re-exports the type contracts defined in
+ * ``./types.ts`` so consumers can ``import { ReviewBrief } from '@/lib/review'``
+ * without reaching into the file structure.
+ */
+
+export * from "./types";

--- a/aragora/live/src/lib/review/types.ts
+++ b/aragora/live/src/lib/review/types.ts
@@ -336,6 +336,79 @@ export interface QueueItem {
   readonly lane_reason: string;
 }
 
+// --- Nested protocol packet (mirror aragora/swarm/pr_review_protocol.py) ---
+
+/**
+ * Which PR a protocol run was bound to, preserved in the packet for
+ * settlement verification.  Mirrors ``PRReviewBinding``.
+ */
+export interface PRReviewBinding {
+  readonly repo: string;
+  readonly pr_number: number;
+  readonly base_sha: string;
+  readonly head_sha: string;
+}
+
+/**
+ * One finding produced by a reviewer role.  Mirrors ``PRReviewFinding``.
+ * ``source`` is usually ``"metadata_heuristic"`` until the real debate
+ * engine runs; UI may badge findings accordingly.
+ */
+export interface PRReviewFinding {
+  readonly finding_id: string;
+  readonly category: string;
+  readonly severity: string;
+  readonly summary: string;
+  readonly evidence: readonly string[];
+  readonly source: string;
+}
+
+/**
+ * A resolved provider-slot assignment for one review role.
+ * Mirrors ``ProviderSlotResolution``.  ``status`` typical values:
+ * ``"selected"``, ``"skipped_missing_env"``, ``"skipped_missing_binary"``.
+ */
+export interface ProviderSlotResolution {
+  readonly slot_id: string;
+  readonly review_role: string;
+  readonly lens: string;
+  readonly family: string;
+  readonly selected_provider: string | null;
+  readonly status: string;
+  readonly detail: string;
+  readonly candidates: readonly string[];
+}
+
+/**
+ * The nested heterogeneous-protocol packet embedded in ``ReviewPacket.protocol``.
+ *
+ * Mirrors ``aragora.swarm.pr_review_protocol.PRReviewProtocolPacket``.
+ * The Python producer emits an empty object (``{}``) when the protocol
+ * has not run yet; the TS side reflects that with a union on
+ * ``ReviewPacket.protocol`` so consumers can narrow by presence of
+ * ``protocol_version``.
+ *
+ * ``recommendation_class`` is narrowed to ``Recommendation`` (not raw
+ * string) because the Python producer uses exactly
+ * ``approve_candidate`` / ``needs_human_attention`` / ``repair_first``.
+ */
+export interface PRReviewProtocolPacket {
+  readonly protocol_version: string;
+  readonly status: string;
+  readonly binding: PRReviewBinding;
+  readonly review_roles: readonly string[];
+  readonly provider_slots: readonly ProviderSlotResolution[];
+  readonly recommendation_class: Recommendation;
+  readonly recommendation_reason: string;
+  readonly confidence: number;
+  readonly confidence_basis: string;
+  readonly dissent_summary: string;
+  readonly dissenting_views: readonly Readonly<Record<string, unknown>>[];
+  readonly validation_summary: Readonly<Record<string, unknown>>;
+  readonly top_findings: readonly PRReviewFinding[];
+  readonly cost_estimate: Readonly<Record<string, unknown>>;
+}
+
 /**
  * Advisory packet for one PR — rendered when the operator expands a card.
  *
@@ -346,6 +419,14 @@ export interface QueueItem {
  * is the deeper heterogeneous-debate output the #6306 successor produces.
  * Both ship into the UI — packet for the default case, brief when the
  * protocol has run.
+ *
+ * Discriminator fields (``queue_bucket``, ``machine_recommendation``) are
+ * typed narrowly to the canonical enums so the UI's grouping / badges /
+ * default actions cannot silently see an unrecognized string.
+ *
+ * ``protocol`` is typed as either the full ``PRReviewProtocolPacket`` (when
+ * the protocol has run) or ``Record<string, never>`` (when Python's empty-dict
+ * default is emitted).  Consumers narrow with ``"protocol_version" in packet.protocol``.
  */
 export interface ReviewPacket {
   readonly pr_number: number;
@@ -358,17 +439,17 @@ export interface ReviewPacket {
   readonly additions: number;
   readonly deletions: number;
   readonly changed_files: number;
-  readonly queue_bucket: string;
+  readonly queue_bucket: QueueLane;
   readonly touched_subsystems: readonly string[];
   readonly high_risk_paths_touched: readonly string[];
   readonly validation: readonly string[];
   readonly checks_summary: string;
   readonly risk_flags: readonly string[];
-  readonly machine_recommendation: string;
+  readonly machine_recommendation: Recommendation;
   readonly machine_recommendation_reason: string;
   readonly packet_sha: string;
   readonly generated_at: string;
-  readonly protocol: Readonly<Record<string, unknown>>;
+  readonly protocol: PRReviewProtocolPacket | Record<string, never>;
   readonly advisory_only: boolean;
   readonly settlement_note: string;
 }
@@ -396,8 +477,8 @@ export interface SettlementReceipt {
   readonly head_sha: string;
   readonly base_sha: string;
   readonly packet_sha: string;
-  readonly queue_bucket: string;
-  readonly machine_recommendation: string;
+  readonly queue_bucket: QueueLane;
+  readonly machine_recommendation: Recommendation;
   readonly github_event: string;
   readonly elapsed_seconds: number | null;
   readonly receipt_path: string;

--- a/aragora/live/src/lib/review/types.ts
+++ b/aragora/live/src/lib/review/types.ts
@@ -141,15 +141,31 @@ export type QueueLane = (typeof QueueLane)[keyof typeof QueueLane];
 // ---------------------------------------------------------------------------
 
 /**
- * Canonical advisory-note string.
+ * Advisory-note strings — distinct per backend payload type.
  *
- * MUST match the Python constant exported from
- * ``aragora.review.protocol.ADVISORY_NOTE`` **byte-for-byte**. Tests
- * assert the exact value so any refactor touching one side fails loudly
- * if the other is not updated.
+ * The Python side has three different default settlement_note strings
+ * because each shape is advisory for a slightly different reason:
+ *   - ReviewBrief  (aragora/review/protocol.py)       → "This brief is advisory only..."
+ *   - ReviewPacket (aragora/cli/commands/review_queue.py) → "This packet is advisory only..."
+ *   - BriefReceipt (aragora/review/receipt.py)        → "This receipt records an advisory brief..."
+ *
+ * Each TS constant below MUST match its Python counterpart
+ * **byte-for-byte**; tests assert each value exactly so drift on
+ * either side fails loudly.
+ *
+ * A generic ``ADVISORY_NOTE`` constant is deliberately NOT exported,
+ * because reusing one string across three distinct shapes is exactly
+ * the bug codex flagged on #6361 revision 1.
  */
-export const ADVISORY_NOTE =
+export const REVIEW_BRIEF_ADVISORY_NOTE =
   "This brief is advisory only. It does not approve or block merge. Human settlement required.";
+
+export const REVIEW_PACKET_ADVISORY_NOTE =
+  "This packet is advisory only. It does not approve or block merge. Human settlement required.";
+
+export const BRIEF_RECEIPT_ADVISORY_NOTE =
+  "This receipt records an advisory brief. It does not approve or block merge. " +
+  "Human settlement required.";
 
 // ---------------------------------------------------------------------------
 // Brief + debate shapes (mirror aragora/review/protocol.py)
@@ -394,17 +410,45 @@ export interface SettlementReceipt {
  * packet the operator was shown.  The backend uses these to detect
  * stale settlement attempts (packet generated at T0, operator clicks at
  * T1, a new commit landed in between → the server refuses the action
- * rather than silently settling against the new head).  ``reason`` is
- * required for ``REQUEST_CHANGES`` and ``DEFER`` actions; optional for
- * ``APPROVE``.
+ * rather than silently settling against the new head).
+ *
+ * ``reason`` handling is enforced at the TYPE level via a discriminated
+ * union on ``action``:
+ *   - ``APPROVE`` may omit reason (``reason?: string``)
+ *   - ``REQUEST_CHANGES`` and ``DEFER`` MUST carry a reason
+ *     (``reason: string`` required)
+ *
+ * This matches the backend validation in
+ * ``aragora/cli/commands/review_queue.py::_cmd_act`` which rejects
+ * REQUEST_CHANGES or DEFER without a reason.  With the union below, TS
+ * compile-time rejects the invalid payload too, so the UI cannot even
+ * build a request the backend would refuse.
  */
-export interface SettlementActionRequest {
+interface SettlementActionRequestBase {
   readonly pr_number: number;
   readonly head_sha: string;
   readonly packet_sha: string;
-  readonly action: SettlementAction;
+}
+
+export interface SettlementApproveRequest extends SettlementActionRequestBase {
+  readonly action: typeof SettlementAction.APPROVE;
   readonly reason?: string;
 }
+
+export interface SettlementRequestChangesRequest extends SettlementActionRequestBase {
+  readonly action: typeof SettlementAction.REQUEST_CHANGES;
+  readonly reason: string;
+}
+
+export interface SettlementDeferRequest extends SettlementActionRequestBase {
+  readonly action: typeof SettlementAction.DEFER;
+  readonly reason: string;
+}
+
+export type SettlementActionRequest =
+  | SettlementApproveRequest
+  | SettlementRequestChangesRequest
+  | SettlementDeferRequest;
 
 /**
  * Response payload for a settlement action.

--- a/aragora/live/src/lib/review/types.ts
+++ b/aragora/live/src/lib/review/types.ts
@@ -136,6 +136,25 @@ export const QueueLane = {
 } as const;
 export type QueueLane = (typeof QueueLane)[keyof typeof QueueLane];
 
+/**
+ * Provider-slot resolution status.
+ *
+ * Mirrors the literal strings emitted by
+ * ``aragora.swarm.pr_review_protocol.PRReviewProtocol._resolve_slot``:
+ * a slot is either ``available`` (a configured provider was found) or
+ * ``unavailable`` (no configured provider for that family/role).
+ *
+ * The Python producer emits exactly these two strings and nothing else
+ * today; narrowing the TS field lets the UI branch safely on lane
+ * presence without allowing drift values.
+ */
+export const ProviderSlotStatus = {
+  AVAILABLE: "available",
+  UNAVAILABLE: "unavailable",
+} as const;
+export type ProviderSlotStatus =
+  (typeof ProviderSlotStatus)[keyof typeof ProviderSlotStatus];
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -365,18 +384,68 @@ export interface PRReviewFinding {
 
 /**
  * A resolved provider-slot assignment for one review role.
- * Mirrors ``ProviderSlotResolution``.  ``status`` typical values:
- * ``"selected"``, ``"skipped_missing_env"``, ``"skipped_missing_binary"``.
+ * Mirrors ``ProviderSlotResolution``.
+ *
+ * ``status`` is narrowed to ``ProviderSlotStatus`` because the Python
+ * producer only emits ``"available"`` or ``"unavailable"`` today; any
+ * UI branching on status is thus exhaustive.  ``review_role`` is
+ * narrowed to ``ReviewRole`` because the slot catalog in
+ * ``aragora.swarm.pr_review_protocol._SLOT_CATALOG`` only assigns roles
+ * drawn from the canonical ``REVIEW_ROLES`` tuple.
  */
 export interface ProviderSlotResolution {
   readonly slot_id: string;
-  readonly review_role: string;
+  readonly review_role: ReviewRole;
   readonly lens: string;
   readonly family: string;
   readonly selected_provider: string | null;
-  readonly status: string;
+  readonly status: ProviderSlotStatus;
   readonly detail: string;
   readonly candidates: readonly string[];
+}
+
+/**
+ * Diff-size summary inside ``ProtocolValidationSummary``.  Mirrors the
+ * ``diffstat`` dict Python emits: ``{additions, deletions}``.
+ */
+export interface ProtocolDiffstat {
+  readonly additions: number;
+  readonly deletions: number;
+}
+
+/**
+ * Validation summary embedded in ``PRReviewProtocolPacket.validation_summary``.
+ *
+ * Mirrors the concrete dict built in
+ * ``aragora.swarm.pr_review_protocol.PRReviewProtocol.build_packet``:
+ * checks, mergeability, review decision, validation commands, diff
+ * stats.  Typed explicitly rather than left as an opaque record so
+ * successor UI code can index the fields safely.
+ */
+export interface ProtocolValidationSummary {
+  readonly checks_summary: string;
+  readonly has_failures: boolean;
+  readonly has_pending: boolean;
+  readonly mergeable: string;
+  readonly review_decision: string;
+  readonly validation_commands: readonly string[];
+  readonly changed_files: number;
+  readonly diffstat: ProtocolDiffstat;
+}
+
+/**
+ * Cost estimate embedded in ``PRReviewProtocolPacket.cost_estimate``.
+ *
+ * Mirrors the dict Python emits: ``{currency, low, high, basis}`` where
+ * ``low``/``high`` are a bounded USD range and ``basis`` is a short
+ * explanation of how the bound was derived (always
+ * ``"bounded heterogeneous metadata-first protocol"`` today).
+ */
+export interface ProtocolCostEstimate {
+  readonly currency: string;
+  readonly low: number;
+  readonly high: number;
+  readonly basis: string;
 }
 
 /**
@@ -396,7 +465,7 @@ export interface PRReviewProtocolPacket {
   readonly protocol_version: string;
   readonly status: string;
   readonly binding: PRReviewBinding;
-  readonly review_roles: readonly string[];
+  readonly review_roles: readonly ReviewRole[];
   readonly provider_slots: readonly ProviderSlotResolution[];
   readonly recommendation_class: Recommendation;
   readonly recommendation_reason: string;
@@ -404,9 +473,9 @@ export interface PRReviewProtocolPacket {
   readonly confidence_basis: string;
   readonly dissent_summary: string;
   readonly dissenting_views: readonly Readonly<Record<string, unknown>>[];
-  readonly validation_summary: Readonly<Record<string, unknown>>;
+  readonly validation_summary: ProtocolValidationSummary;
   readonly top_findings: readonly PRReviewFinding[];
-  readonly cost_estimate: Readonly<Record<string, unknown>>;
+  readonly cost_estimate: ProtocolCostEstimate;
 }
 
 /**

--- a/aragora/live/src/lib/review/types.ts
+++ b/aragora/live/src/lib/review/types.ts
@@ -120,13 +120,36 @@ export const BudgetScope = {
 } as const;
 export type BudgetScope = (typeof BudgetScope)[keyof typeof BudgetScope];
 
+/**
+ * Queue lane classification for the ranked review-queue cards.
+ *
+ * Values match the canonical strings produced by
+ * ``aragora.cli.commands.review_queue._classify_pr`` in ``QueueItem.lane``.
+ * The UI uses lane ordering to group cards: ``ready_now`` on top,
+ * ``parked`` off by default.
+ */
+export const QueueLane = {
+  READY_NOW: "ready_now",
+  NEEDS_ATTENTION: "needs_attention",
+  REPAIRABLE: "repairable",
+  PARKED: "parked",
+} as const;
+export type QueueLane = (typeof QueueLane)[keyof typeof QueueLane];
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
+/**
+ * Canonical advisory-note string.
+ *
+ * MUST match the Python constant exported from
+ * ``aragora.review.protocol.ADVISORY_NOTE`` **byte-for-byte**. Tests
+ * assert the exact value so any refactor touching one side fails loudly
+ * if the other is not updated.
+ */
 export const ADVISORY_NOTE =
-  "Aragora review brief is advisory only. It does not approve or block merge. " +
-  "Human settlement required.";
+  "This brief is advisory only. It does not approve or block merge. Human settlement required.";
 
 // ---------------------------------------------------------------------------
 // Brief + debate shapes (mirror aragora/review/protocol.py)
@@ -264,4 +287,138 @@ export interface CostMeter {
   readonly headroom_by_scope: readonly BudgetHeadroom[];
   readonly binding_scope?: BudgetScope | null;
   readonly alert_triggered: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Queue-card + packet shapes (mirror aragora/cli/commands/review_queue.py)
+//
+// These are the payloads the #6304 UI actually renders and settles against,
+// not just the deeper debate contracts.  Kept in this module so successor
+// UI components have a single ``@/lib/review`` import surface.
+// ---------------------------------------------------------------------------
+
+/**
+ * One row in the prioritized review queue — the card payload.
+ *
+ * Mirrors ``aragora.cli.commands.review_queue.QueueItem``.
+ */
+export interface QueueItem {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly head_sha: string;
+  readonly author: string;
+  readonly is_draft: boolean;
+  readonly mergeable: string;
+  readonly review_decision: string;
+  readonly labels: readonly string[];
+  readonly additions: number;
+  readonly deletions: number;
+  readonly changed_files: number;
+  readonly checks_summary: string;
+  readonly lane: QueueLane;
+  readonly lane_reason: string;
+}
+
+/**
+ * Advisory packet for one PR — rendered when the operator expands a card.
+ *
+ * Mirrors ``aragora.cli.commands.review_queue.ReviewPacket``.  NEVER
+ * counts as a GitHub approval (``advisory_only`` is required-true by
+ * construction).  Distinct from ``ReviewBrief`` above: ``ReviewPacket``
+ * is the lightweight packet the review-queue produces today; ``ReviewBrief``
+ * is the deeper heterogeneous-debate output the #6306 successor produces.
+ * Both ship into the UI — packet for the default case, brief when the
+ * protocol has run.
+ */
+export interface ReviewPacket {
+  readonly pr_number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly head_sha: string;
+  readonly base_sha: string;
+  readonly author: string;
+  readonly is_draft: boolean;
+  readonly additions: number;
+  readonly deletions: number;
+  readonly changed_files: number;
+  readonly queue_bucket: string;
+  readonly touched_subsystems: readonly string[];
+  readonly high_risk_paths_touched: readonly string[];
+  readonly validation: readonly string[];
+  readonly checks_summary: string;
+  readonly risk_flags: readonly string[];
+  readonly machine_recommendation: string;
+  readonly machine_recommendation_reason: string;
+  readonly packet_sha: string;
+  readonly generated_at: string;
+  readonly protocol: Readonly<Record<string, unknown>>;
+  readonly advisory_only: boolean;
+  readonly settlement_note: string;
+}
+
+/**
+ * Persisted human settlement receipt — the SHA-bound record emitted by
+ * ``aragora review-queue act``.  Mirrors
+ * ``aragora.cli.commands.review_queue.SettlementReceipt``.
+ *
+ * Critically SHA-bound: the ``head_sha`` and ``packet_sha`` on the
+ * receipt MUST match the PR's current head and the packet the operator
+ * was shown when they settled; merge_arbiter refuses to merge on a
+ * receipt whose SHAs have since moved.  The UI must send
+ * ``head_sha`` and ``packet_sha`` in the action request and then match
+ * them in the returned receipt before claiming the settlement landed.
+ */
+export interface SettlementReceipt {
+  readonly session_id: string;
+  readonly reviewed_at: string;
+  readonly actor: string;
+  readonly action: SettlementAction;
+  readonly reason: string;
+  readonly pr_number: number;
+  readonly pr_url: string;
+  readonly head_sha: string;
+  readonly base_sha: string;
+  readonly packet_sha: string;
+  readonly queue_bucket: string;
+  readonly machine_recommendation: string;
+  readonly github_event: string;
+  readonly elapsed_seconds: number | null;
+  readonly receipt_path: string;
+}
+
+/**
+ * Request payload for a settlement action from the UI.
+ *
+ * The ``head_sha`` and ``packet_sha`` are REQUIRED and MUST match the
+ * packet the operator was shown.  The backend uses these to detect
+ * stale settlement attempts (packet generated at T0, operator clicks at
+ * T1, a new commit landed in between → the server refuses the action
+ * rather than silently settling against the new head).  ``reason`` is
+ * required for ``REQUEST_CHANGES`` and ``DEFER`` actions; optional for
+ * ``APPROVE``.
+ */
+export interface SettlementActionRequest {
+  readonly pr_number: number;
+  readonly head_sha: string;
+  readonly packet_sha: string;
+  readonly action: SettlementAction;
+  readonly reason?: string;
+}
+
+/**
+ * Response payload for a settlement action.
+ *
+ * On success, ``receipt`` is the landed ``SettlementReceipt``;
+ * consumers MUST verify ``receipt.head_sha === request.head_sha`` and
+ * ``receipt.packet_sha === request.packet_sha`` before claiming the
+ * action took effect — mismatch means the server settled against a
+ * different snapshot than the UI showed.
+ *
+ * On failure, ``error`` is a short human-readable reason.
+ */
+export interface SettlementActionResponse {
+  readonly success: boolean;
+  readonly receipt?: SettlementReceipt;
+  readonly error?: string;
 }

--- a/aragora/live/src/lib/review/types.ts
+++ b/aragora/live/src/lib/review/types.ts
@@ -1,0 +1,267 @@
+/**
+ * PR intelligence brief — TypeScript contracts for the Next.js UI (#6304 foundation).
+ *
+ * Mirrors the Python schema in ``aragora/review/{protocol,receipt,policy}.py``
+ * that landed in #6334, #6353, and #6359. Consumers are future UI components
+ * (the `aragora/live/src/app/(app)/reviews/` route) plus any TS SDK surfaces.
+ *
+ * This module is **schema only**. No components, no data fetching, no state
+ * machines. Behavior ships in successor PRs that import these types.
+ *
+ * Canonical-string discipline (critical): every enum string must match the
+ * Python ``to_dict()`` output exactly. Drift breaks JSON interop silently.
+ * Tests guard every string value against its Python counterpart.
+ *
+ * Immutability: sequence fields are typed as ``readonly T[]``. Python tuples
+ * give runtime immutability; TS readonly gives compile-time immutability only
+ * (a caller who casts can still mutate). That asymmetry is unavoidable and
+ * documented; downstream components should not rely on runtime freezing.
+ */
+
+// ---------------------------------------------------------------------------
+// Enums (as const objects for `Foo.BAR` access + string-literal union types)
+// ---------------------------------------------------------------------------
+
+export const ReviewRole = {
+  LOGIC: "logic_reviewer",
+  SECURITY: "security_reviewer",
+  MAINTAINABILITY: "maintainability_reviewer",
+  SKEPTIC: "skeptic",
+  SYNTHESIZER: "synthesizer",
+} as const;
+export type ReviewRole = (typeof ReviewRole)[keyof typeof ReviewRole];
+
+export const Recommendation = {
+  APPROVE_CANDIDATE: "approve_candidate",
+  NEEDS_HUMAN_ATTENTION: "needs_human_attention",
+  REPAIR_FIRST: "repair_first",
+} as const;
+export type Recommendation = (typeof Recommendation)[keyof typeof Recommendation];
+
+export const DissentPosition = {
+  APPROVE: "approve",
+  REQUEST_CHANGES: "request_changes",
+  DEFER: "defer",
+} as const;
+export type DissentPosition = (typeof DissentPosition)[keyof typeof DissentPosition];
+
+export const SynthesisPolicy = {
+  MAJORITY: "majority",
+  WEIGHTED: "weighted",
+  SYNTHESIZER_AGENT: "synthesizer",
+  UNANIMOUS_OR_ESCALATE: "unanimous_or_escalate",
+} as const;
+export type SynthesisPolicy = (typeof SynthesisPolicy)[keyof typeof SynthesisPolicy];
+
+export const EvidenceKind = {
+  FILE: "file",
+  TEST: "test",
+  COMMIT: "commit",
+  ARTIFACT: "artifact",
+  ISSUE: "issue",
+  PR: "pr",
+  EXTERNAL: "external",
+} as const;
+export type EvidenceKind = (typeof EvidenceKind)[keyof typeof EvidenceKind];
+
+export const ValidationKind = {
+  CI_CHECK: "ci_check",
+  TEST_SUITE: "test_suite",
+  RECEIPT: "receipt",
+  BENCHMARK: "benchmark",
+  MANUAL_REVIEW: "manual_review",
+} as const;
+export type ValidationKind = (typeof ValidationKind)[keyof typeof ValidationKind];
+
+export const ValidationResult = {
+  SUCCESS: "success",
+  FAILURE: "failure",
+  SKIPPED: "skipped",
+  CANCELLED: "cancelled",
+  PENDING: "pending",
+} as const;
+export type ValidationResult = (typeof ValidationResult)[keyof typeof ValidationResult];
+
+export const SettlementAction = {
+  APPROVE: "approve",
+  REQUEST_CHANGES: "request_changes",
+  DEFER: "defer",
+} as const;
+export type SettlementAction = (typeof SettlementAction)[keyof typeof SettlementAction];
+
+export const ReviewDepth = {
+  TRIVIAL: "trivial",
+  STANDARD: "standard",
+  DEEP: "deep",
+} as const;
+export type ReviewDepth = (typeof ReviewDepth)[keyof typeof ReviewDepth];
+
+export const RiskClass = {
+  LOW: "low",
+  MEDIUM: "medium",
+  HIGH: "high",
+  CRITICAL: "critical",
+} as const;
+export type RiskClass = (typeof RiskClass)[keyof typeof RiskClass];
+
+export const ReviewPolicyDecision = {
+  ALLOW: "allow",
+  DEGRADE: "degrade",
+  DENY: "deny",
+  ESCALATE: "escalate",
+} as const;
+export type ReviewPolicyDecision =
+  (typeof ReviewPolicyDecision)[keyof typeof ReviewPolicyDecision];
+
+export const BudgetScope = {
+  PER_PR: "per_pr",
+  PER_REPO_DAILY: "per_repo_daily",
+  PER_ORG_DAILY: "per_org_daily",
+} as const;
+export type BudgetScope = (typeof BudgetScope)[keyof typeof BudgetScope];
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const ADVISORY_NOTE =
+  "Aragora review brief is advisory only. It does not approve or block merge. " +
+  "Human settlement required.";
+
+// ---------------------------------------------------------------------------
+// Brief + debate shapes (mirror aragora/review/protocol.py)
+// ---------------------------------------------------------------------------
+
+export interface RoleFinding {
+  readonly role: ReviewRole;
+  readonly agent: string;
+  readonly model: string;
+  readonly confidence: number;
+  readonly finding_text: string;
+  readonly latency_ms: number;
+  readonly cost_usd: number;
+}
+
+export interface DissentingView {
+  readonly agent: string;
+  readonly position: DissentPosition;
+  readonly reason: string;
+  readonly role?: ReviewRole | null;
+}
+
+export interface ReviewBrief {
+  readonly pr_number: number;
+  readonly repo: string;
+  readonly head_sha: string;
+  readonly base_sha: string;
+  readonly packet_sha: string;
+  readonly recommendation: Recommendation;
+  readonly top_line: string;
+  readonly role_findings: readonly RoleFinding[];
+  readonly dissent: readonly DissentingView[];
+  readonly validation_summary: string;
+  readonly overall_confidence: number;
+  readonly disagreement_score: number;
+  readonly total_cost_usd: number;
+  readonly total_wall_clock_ms: number;
+  readonly agent_roster: readonly string[];
+  readonly generated_at: string;
+  readonly advisory_only: boolean;
+  readonly settlement_note: string;
+}
+
+export interface PRReviewProtocolConfig {
+  readonly model_panel: readonly string[];
+  readonly output_roles: readonly ReviewRole[];
+  readonly rounds: number;
+  readonly synthesis_policy: SynthesisPolicy;
+  readonly require_heterogeneous_models: boolean;
+  readonly advisory_only: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Receipt + linkage shapes (mirror aragora/review/receipt.py)
+// ---------------------------------------------------------------------------
+
+export interface EvidenceRef {
+  readonly kind: EvidenceKind;
+  readonly path: string;
+  readonly sha: string;
+  readonly line_range: readonly [number, number] | null;
+  readonly quote: string;
+}
+
+export interface ValidationRef {
+  readonly kind: ValidationKind;
+  readonly name: string;
+  readonly result: ValidationResult;
+  readonly url: string;
+}
+
+export interface BriefReceipt {
+  readonly brief: ReviewBrief;
+  readonly evidence_refs: readonly EvidenceRef[];
+  readonly validation_refs: readonly ValidationRef[];
+  readonly receipt_id: string;
+  readonly created_at: string;
+  readonly advisory_only: boolean;
+  readonly settlement_note: string;
+}
+
+export interface SettlementLinkage {
+  readonly brief_receipt_id: string;
+  readonly settlement_receipt_id: string;
+  readonly settlement_receipt_path: string;
+  readonly head_sha: string;
+  readonly packet_sha: string;
+  readonly pr_number: number;
+  readonly repo: string;
+  readonly action: SettlementAction;
+  readonly settled_at: string;
+  readonly repair_receipt_ids: readonly string[];
+  readonly repair_receipt_paths: readonly string[];
+  readonly advisory_only: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Policy + budget + cost-meter shapes (mirror aragora/review/policy.py)
+// ---------------------------------------------------------------------------
+
+export interface DepthTrigger {
+  readonly target_depth: ReviewDepth;
+  readonly min_additions_plus_deletions: number;
+  readonly subsystem_prefixes: readonly string[];
+  readonly min_risk_class: RiskClass | null;
+}
+
+export interface ReviewBudget {
+  readonly per_pr_usd_cap: number;
+  readonly per_repo_usd_daily_cap: number;
+  readonly per_org_usd_daily_cap: number;
+  readonly daily_caps_apply_at_or_above_depth: ReviewDepth;
+  readonly alert_threshold_pct: number;
+  readonly hard_limit: boolean;
+}
+
+export interface ReviewPolicy {
+  readonly budget: ReviewBudget;
+  readonly depth_rules: readonly DepthTrigger[];
+  readonly default_depth: ReviewDepth;
+}
+
+export interface BudgetHeadroom {
+  readonly scope: BudgetScope;
+  readonly cap_usd: number;
+  readonly remaining_usd: number;
+  readonly applies_at_or_above_depth?: ReviewDepth | null;
+}
+
+export interface CostMeter {
+  readonly depth_chosen: ReviewDepth;
+  readonly decision: ReviewPolicyDecision;
+  readonly estimated_cost_usd: number;
+  readonly actual_cost_usd: number;
+  readonly headroom_by_scope: readonly BudgetHeadroom[];
+  readonly binding_scope?: BudgetScope | null;
+  readonly alert_triggered: boolean;
+}


### PR DESCRIPTION
## Summary

Smallest credible foundation for #6304 (PR intelligence brief UI). Mirrors the Python schema that landed in #6334 (protocol), #6353 (receipt), and #6359 (policy) as TypeScript type contracts in `aragora/live/`. **No components, no data fetching, no state machines** — those ship in successor PRs.

Successor PRs (priority-ranked cards, executive summary, dissent panel, evidence panel, drill-down, action buttons) all need stable types. Defining them once mirrors the Python foundation discipline from #6334/#6353/#6359.

## Scope (#6304)

Closes part of: #6304 (TypeScript contracts only — components in successors)
Depends on: #6334, #6353, #6359 (all merged — Python schema locked)
Parent design: `docs/plans/2026-04-19-pr-intelligence-brief.md` (#6309)

## What's defined

**12 enums** (const objects + string-literal union types, values match Python `to_dict()` exactly):
- `ReviewRole`, `Recommendation`, `DissentPosition`, `SynthesisPolicy`
- `EvidenceKind`, `ValidationKind`, `ValidationResult`, `SettlementAction`
- `ReviewDepth`, `RiskClass`, `ReviewPolicyDecision`, `BudgetScope`

**13 interfaces** (readonly fields, `readonly T[]` for tuple-equivalent sequences):
- `RoleFinding`, `DissentingView`, `ReviewBrief`, `PRReviewProtocolConfig`
- `EvidenceRef`, `ValidationRef`, `BriefReceipt`, `SettlementLinkage`
- `DepthTrigger`, `ReviewBudget`, `ReviewPolicy`, `BudgetHeadroom`, `CostMeter`

Plus `ADVISORY_NOTE` constant.

## Canonical-string discipline

Every enum value is hard-coded to match the canonical Python string from its paired `tests/review/test_*.py`. Tests below assert each value exactly, so a refactor touching one side fails loudly if the other isn't updated.

## Immutability caveat (documented)

Python tuples give **runtime** immutability. TypeScript `readonly` gives **compile-time** immutability only — a caller who casts can still mutate at runtime. Documented in the module docstring; downstream UI components should not rely on runtime freezing.

## Validation (literal)

```
cd aragora/live
npx jest src/lib/review/__tests__/types.test.ts --no-coverage
  24 passed in 0.485s

npx tsc --noEmit src/lib/review/types.ts src/lib/review/index.ts src/lib/review/__tests__/types.test.ts
  (exit 0, no errors)

Plus all existing gates + Python tests:
pytest tests/review/ -q                   107 passed
reconcile_status_docs --strict             Result: PASS
check_capability_matrix_sync               up to date
generate_cli_reference --check             up to date
check_version_alignment                    aligned
```

## Files

- `aragora/live/src/lib/review/types.ts` (new, ~180 LOC)
- `aragora/live/src/lib/review/index.ts` (new, re-exports)
- `aragora/live/src/lib/review/__tests__/types.test.ts` (new, 24 tests)

## Test coverage

- Canonical enum-string discipline for all 12 enums (Python↔TS sync)
- `ADVISORY_NOTE` content check (mentions advisory + human-settlement)
- Python-JSON payload shape tests for every dataclass counterpart
- Compile-time readonly discipline via `@ts-expect-error` on `.push()` and field reassignment

## Non-goals

- Not building any UI components (priority cards, panels, drill-down)
- Not wiring API fetch (queue endpoints + packet endpoints)
- Not implementing action handlers (approve / request-changes / defer)
- Not modifying existing `code-review/` components in `aragora/live/`
- Not using `--admin` to bypass review

## Capability vs hygiene vs accounting

**Capability** — new TypeScript type contracts the successor UI components will import.

## Residual scope note

Same as #6334, #6353, #6359: this is the foundation/contracts slice, not full closure of #6304. The component + routing + action behavior remain follow-on work. #6304 stays open after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)