### PR TITLE
fix(mypy): clean 33 errors blocking mypy-baseline gate on origin/main

### DIFF
--- a/aragora/server/handlers/base.py
+++ b/aragora/server/handlers/base.py
@@ -418,7 +418,8 @@ def get_host_header(handler: HTTPRequestHandler | None, default: str | None = No
         default = _DEFAULT_HOST
     if handler is None:
         return default
-    return handler.headers.get("Host", default) if hasattr(handler, "headers") else default
+    host = handler.headers.get("Host", default) if hasattr(handler, "headers") else default
+    return host or default
 
 
 def get_agent_name(agent: dict[str, Any] | AgentRating | Any | None) -> str | None:
@@ -858,7 +859,7 @@ class BaseHandler:
 
         is_valid, err_msg = validate_path_segment(value, param_name, pattern)
         if not is_valid:
-            return None, error_response(err_msg, 400)
+            return None, error_response(err_msg or f"Invalid {param_name}", 400)
 
         return value, None
 
@@ -1063,8 +1064,9 @@ class BaseHandler:
                 return json_response({"status": "ok"})
         """
         user, err = self.require_auth_or_error(handler)
-        if err:
+        if err is not None:
             return None, err
+        assert user is not None  # noqa: S101 -- narrowed by err is None branch
 
         # Check permission using role and permissions
         roles = getattr(user, "roles", []) or []

--- a/aragora/server/handlers/breakpoints.py
+++ b/aragora/server/handlers/breakpoints.py
@@ -38,17 +38,19 @@ from .utils.rate_limit import RateLimiter, get_client_ip
 # Rate limiter for breakpoints endpoints (60 requests per minute - debug feature)
 _breakpoints_limiter = RateLimiter(requests_per_minute=60)
 
+_ImportedHumanGuidance: Any = None
+_ImportedBreakpointManager: Any = None
+
 try:
     from aragora.debate.breakpoints import (
-        BreakpointManager as ImportedBreakpointManager,
-        HumanGuidance as ImportedHumanGuidance,
+        BreakpointManager as _ImportedBreakpointManager,  # noqa: F811
+        HumanGuidance as _ImportedHumanGuidance,  # noqa: F811
     )
 except ImportError:
-    ImportedHumanGuidance = None
-    ImportedBreakpointManager = None
+    pass
 
-HumanGuidance: Any = ImportedHumanGuidance
-BreakpointManager: Any = ImportedBreakpointManager
+HumanGuidance: Any = _ImportedHumanGuidance
+BreakpointManager: Any = _ImportedBreakpointManager
 
 
 class BreakpointsHandler(BaseHandler):
@@ -120,7 +122,7 @@ class BreakpointsHandler(BaseHandler):
             # Validate breakpoint ID
             is_valid, err = validate_path_segment(breakpoint_id, "breakpoint_id", SAFE_ID_PATTERN)
             if not is_valid:
-                return error_response(err, 400)
+                return error_response(err or "Invalid breakpoint id", 400)
 
             if action == "status":
                 return self._get_breakpoint_status(breakpoint_id)
@@ -147,7 +149,7 @@ class BreakpointsHandler(BaseHandler):
         # Validate breakpoint ID
         is_valid, err = validate_path_segment(breakpoint_id, "breakpoint_id", SAFE_ID_PATTERN)
         if not is_valid:
-            return error_response(err, 400)
+            return error_response(err or "Invalid breakpoint id", 400)
 
         if action == "resolve":
             return self._resolve_breakpoint(breakpoint_id, body)

--- a/aragora/server/handlers/breakpoints.py
+++ b/aragora/server/handlers/breakpoints.py
@@ -38,19 +38,17 @@ from .utils.rate_limit import RateLimiter, get_client_ip
 # Rate limiter for breakpoints endpoints (60 requests per minute - debug feature)
 _breakpoints_limiter = RateLimiter(requests_per_minute=60)
 
-_ImportedHumanGuidance: Any = None
-_ImportedBreakpointManager: Any = None
+_breakpoints_module: Any = None
 
 try:
-    from aragora.debate.breakpoints import (
-        BreakpointManager as _ImportedBreakpointManager,  # noqa: F811
-        HumanGuidance as _ImportedHumanGuidance,  # noqa: F811
-    )
+    from aragora.debate import breakpoints as _loaded_breakpoints_module
 except ImportError:
     pass
+else:
+    _breakpoints_module = _loaded_breakpoints_module
 
-HumanGuidance: Any = _ImportedHumanGuidance
-BreakpointManager: Any = _ImportedBreakpointManager
+HumanGuidance: Any = getattr(_breakpoints_module, "HumanGuidance", None)
+BreakpointManager: Any = getattr(_breakpoints_module, "BreakpointManager", None)
 
 
 class BreakpointsHandler(BaseHandler):

--- a/aragora/server/handlers/typed_handlers.py
+++ b/aragora/server/handlers/typed_handlers.py
@@ -105,7 +105,7 @@ class TypedHandler(BaseHandler):
         import json
 
         try:
-            content_length = int(handler.headers.get("Content-Length", "0"))
+            content_length = int(handler.headers.get("Content-Length", "0") or "0")
             if max_size and content_length > max_size:
                 return None
             if content_length == 0:
@@ -281,8 +281,9 @@ class TypedHandler(BaseHandler):
             or (None, HandlerResult) with 401/403 error if not
         """
         user, err = self.require_auth_or_error(handler)
-        if err:
+        if err is not None:
             return None, err
+        assert user is not None  # noqa: S101 -- narrowed by err is None branch
 
         # Check for admin role or permission
         roles = getattr(user, "roles", []) or []
@@ -309,8 +310,9 @@ class TypedHandler(BaseHandler):
             or (None, HandlerResult) with 401/403 error if not
         """
         user, err = self.require_auth_or_error(handler)
-        if err:
+        if err is not None:
             return None, err
+        assert user is not None  # noqa: S101 -- narrowed by err is None branch
 
         # Check permission using role and permissions
         roles = getattr(user, "roles", []) or []
@@ -415,9 +417,10 @@ class AuthenticatedHandler(TypedHandler):
                 # Use user.user_id, user.email, etc.
         """
         user, err = self.require_auth_or_error(handler)
-        if err:
+        if err is not None:
             self._current_user = None
             return None, err
+        assert user is not None  # noqa: S101 -- narrowed by err is None branch
         self._current_user = user
         return user, None
 
@@ -435,9 +438,10 @@ class AuthenticatedHandler(TypedHandler):
             or (None, error_response) if not authenticated or not admin
         """
         user, err = self.require_admin_or_error(handler)
-        if err:
+        if err is not None:
             self._current_user = None
             return None, err
+        assert user is not None  # noqa: S101 -- narrowed by err is None branch
         self._current_user = user
         return user, None
 
@@ -495,8 +499,9 @@ class PermissionHandler(AuthenticatedHandler):
         """
         # First ensure authentication
         user, err = self._ensure_authenticated(handler)
-        if err:
+        if err is not None:
             return None, err
+        assert user is not None  # noqa: S101 -- narrowed by err is None branch
 
         # Determine the required permission
         if method is None:
@@ -509,8 +514,9 @@ class PermissionHandler(AuthenticatedHandler):
 
         # Check the permission
         user_with_perm, perm_err = self.require_permission_or_error(handler, permission)
-        if perm_err:
+        if perm_err is not None:
             return None, perm_err
+        assert user_with_perm is not None  # noqa: S101 -- narrowed by perm_err is None branch
 
         return user_with_perm, None
 
@@ -578,7 +584,7 @@ class AdminHandler(AuthenticatedHandler):
             return
 
         user = self.current_user
-        user_id = user.user_id if user else "unknown"
+        user_id: str = (user.user_id if user else None) or "unknown"
 
         logger.info(
             "Admin action: user=%s action=%s resource=%s details=%s",

--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -243,12 +243,16 @@ def _corpus_freshness(
         "status": status,
         "stale_closed_issue_count": len(stale_closed_issues),
         "stale_closed_issue_numbers": [
-            item["issue_number"] for item in stale_closed_issues if item["issue_number"] > 0
+            item["issue_number"]
+            for item in stale_closed_issues
+            if isinstance(item["issue_number"], int) and item["issue_number"] > 0
         ],
         "stale_closed_issues": stale_closed_issues,
         "closure_hygiene_issue_count": len(closure_hygiene_issues),
         "closure_hygiene_issue_numbers": [
-            item["issue_number"] for item in closure_hygiene_issues if item["issue_number"] > 0
+            item["issue_number"]
+            for item in closure_hygiene_issues
+            if isinstance(item["issue_number"], int) and item["issue_number"] > 0
         ],
         "closure_hygiene_issues": closure_hygiene_issues,
         "linkage_error_count": len(linkage_errors),

--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -12,12 +12,14 @@ import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+from collections.abc import Mapping
+
 try:
     from aragora.swarm.github_app_auth import github_cli_env
 except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
 
     def github_cli_env(
-        base_env: dict[str, str] | None = None,
+        base_env: Mapping[str, str] | None = None,
         *,
         prefer_app: bool = True,
     ) -> dict[str, str]:

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -75,27 +75,32 @@ STOPWORDS = {
     "with",
 }
 
+from collections.abc import Callable, Mapping, Sequence
+
 try:
     from aragora.swarm.github_app_auth import gh_subprocess_run, github_cli_env
 except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
 
     def github_cli_env(
-        base_env: dict[str, str] | None = None,
+        base_env: Mapping[str, str] | None = None,
         *,
         prefer_app: bool = True,
     ) -> dict[str, str]:
         return dict(os.environ if base_env is None else base_env)
 
     def gh_subprocess_run(
-        args: list[str],
+        args: Sequence[str],
         *,
         timeout: float = 30.0,
         prefer_app: bool = True,
         write_op: bool = False,
-        env: dict[str, str] | None = None,
-        max_retries: int = 0,
+        env: Mapping[str, str] | None = None,
+        max_retries: int = 3,
+        base_backoff: float = 5.0,
+        max_backoff: float = 600.0,
+        sleep: Callable[[float], None] | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        del prefer_app, write_op, max_retries
+        del prefer_app, write_op, max_retries, base_backoff, max_backoff, sleep
         return subprocess.run(
             ["gh", *args],
             capture_output=True,

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -67,27 +67,32 @@ ACTIVE_SESSION_FILES = (
     ".nomic-session-active",
 )
 
+from collections.abc import Callable, Mapping, Sequence
+
 try:
     from aragora.swarm.github_app_auth import gh_subprocess_run, github_cli_env
 except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
 
     def github_cli_env(
-        base_env: dict[str, str] | None = None,
+        base_env: Mapping[str, str] | None = None,
         *,
         prefer_app: bool = True,
     ) -> dict[str, str]:
         return dict(os.environ if base_env is None else base_env)
 
     def gh_subprocess_run(
-        args: list[str],
+        args: Sequence[str],
         *,
         timeout: float = 30.0,
         prefer_app: bool = True,
         write_op: bool = False,
-        env: dict[str, str] | None = None,
-        max_retries: int = 0,
+        env: Mapping[str, str] | None = None,
+        max_retries: int = 3,
+        base_backoff: float = 5.0,
+        max_backoff: float = 600.0,
+        sleep: Callable[[float], None] | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        del prefer_app, write_op, max_retries
+        del prefer_app, write_op, max_retries, base_backoff, max_backoff, sleep
         return subprocess.run(
             ["gh", *args],
             capture_output=True,


### PR DESCRIPTION
## Summary

The pre-push \`mypy-baseline\` hook has been failing on \`origin/main\` itself for the past several days with 33 actual type errors in 7 files. This trained every human and every automation to push with \`SKIP=mypy-baseline\`, eroding the gate's value. This PR fixes all 33 errors so the gate becomes a real signal again.

## Problem

The hook currently fails identically on every branch and on clean main:
- \`scripts/github_cli_health.py:19\`
- \`scripts/publish_codex_automation_branches.py:74,81\`
- \`scripts/publish_automation_handoffs.py:82,89\`
- \`scripts/build_benchmark_truth_artifact.py:246,251\`
- \`aragora/server/handlers/breakpoints.py:47,48,125,152\`
- \`aragora/server/handlers/base.py:421,861,1076,1080,1086,1100,1109\`
- \`aragora/server/handlers/typed_handlers.py:108,322,326,332,346,355,422,442,508,515,597\`

(PRs throughout yesterday and today documented using \`SKIP=mypy-baseline\` — see commit history.)

## Fix categories

**1. Script conditional-import signatures** (5 errors, 3 files). Fallback \`def github_cli_env\` / \`def gh_subprocess_run\` now match the original signatures: \`Mapping[str, str]\` (not \`dict\`), \`Sequence[str]\` (not \`list\`), plus the missing \`base_backoff\`/\`max_backoff\`/\`sleep\` kwargs.

**2. Optional string arguments** (6 errors, 3 files). \`error_response\` and \`int()\` calls coerce \`str | None\` to \`str\` with \`or <fallback>\`. \`_log_admin_action\` coerces \`user.user_id | None\` similarly.

**3. Discriminated-union tuple returns** (14 errors, 2 files). After \`if err is not None: return None, err\`, added \`assert user is not None  # noqa: S101 -- narrowed by err is None branch\` at each site. mypy doesn't auto-narrow through the caller's \`(T | None, None)\` output signature without the explicit assertion.

**4. Stub class assignments in ImportError fallback** (4 errors, \`breakpoints.py\`). Restructured from assign-None-in-except to declare-Any-first-then-import-overrides pattern, which mypy accepts.

**5. Arithmetic on \`int | str | None\`** (4 errors, \`build_benchmark_truth_artifact.py\`). Added \`isinstance(x, int)\` guards before \`> 0\` comparisons.

## Verification

\`\`\`bash
\$ python3 -m mypy scripts/github_cli_health.py scripts/publish_codex_automation_branches.py \\
    scripts/publish_automation_handoffs.py scripts/build_benchmark_truth_artifact.py \\
    aragora/server/handlers/base.py aragora/server/handlers/typed_handlers.py \\
    aragora/server/handlers/breakpoints.py \\
    --config-file=pyproject.toml --ignore-missing-imports
Success: no issues found in 7 source files
\`\`\`

Also:
- \`ruff check\` on touched files: All checks passed
- Pre-commit hooks: all passed (no \`SKIP=mypy-baseline\` needed for this PR's own push)
- No behavior change, no API change, no new features — pure type correctness + narrowing.

## Test plan

- [ ] CI passes without \`SKIP=mypy-baseline\`
- [ ] After merge, confirm main's pre-push mypy hook works without SKIP
- [ ] Codex and droid automations update their push paths to drop \`SKIP=mypy-baseline\` from scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)