### PR TITLE
fix(types): repair mypy-baseline drift on main

### DIFF
--- a/aragora/server/handlers/base.py
+++ b/aragora/server/handlers/base.py
@@ -1065,6 +1065,7 @@ class BaseHandler:
         user, err = self.require_auth_or_error(handler)
         if err:
             return None, err
+        user = cast(UserAuthContext, user)
 
         # Check permission using role and permissions
         roles = getattr(user, "roles", []) or []

--- a/aragora/server/handlers/breakpoints.py
+++ b/aragora/server/handlers/breakpoints.py
@@ -38,14 +38,17 @@ from .utils.rate_limit import RateLimiter, get_client_ip
 # Rate limiter for breakpoints endpoints (60 requests per minute - debug feature)
 _breakpoints_limiter = RateLimiter(requests_per_minute=60)
 
-debate_breakpoints: Any = None
+_breakpoints_module: Any = None
+
 try:
-    from aragora.debate import breakpoints as debate_breakpoints
+    from aragora.debate import breakpoints as _loaded_breakpoints_module
 except ImportError:
     pass
+else:
+    _breakpoints_module = _loaded_breakpoints_module
 
-HumanGuidance: Any = getattr(debate_breakpoints, "HumanGuidance", None)
-BreakpointManager: Any = getattr(debate_breakpoints, "BreakpointManager", None)
+HumanGuidance: Any = getattr(_breakpoints_module, "HumanGuidance", None)
+BreakpointManager: Any = getattr(_breakpoints_module, "BreakpointManager", None)
 
 
 class BreakpointsHandler(BaseHandler):

--- a/aragora/server/handlers/breakpoints.py
+++ b/aragora/server/handlers/breakpoints.py
@@ -38,17 +38,14 @@ from .utils.rate_limit import RateLimiter, get_client_ip
 # Rate limiter for breakpoints endpoints (60 requests per minute - debug feature)
 _breakpoints_limiter = RateLimiter(requests_per_minute=60)
 
+debate_breakpoints: Any = None
 try:
-    from aragora.debate.breakpoints import (
-        BreakpointManager as ImportedBreakpointManager,
-        HumanGuidance as ImportedHumanGuidance,
-    )
+    from aragora.debate import breakpoints as debate_breakpoints
 except ImportError:
-    ImportedHumanGuidance = None
-    ImportedBreakpointManager = None
+    pass
 
-HumanGuidance: Any = ImportedHumanGuidance
-BreakpointManager: Any = ImportedBreakpointManager
+HumanGuidance: Any = getattr(debate_breakpoints, "HumanGuidance", None)
+BreakpointManager: Any = getattr(debate_breakpoints, "BreakpointManager", None)
 
 
 class BreakpointsHandler(BaseHandler):

--- a/aragora/server/handlers/typed_handlers.py
+++ b/aragora/server/handlers/typed_handlers.py
@@ -31,7 +31,7 @@ Usage:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 from collections.abc import Awaitable, Callable
 
 from aragora.billing.auth.context import UserAuthContext
@@ -311,6 +311,7 @@ class TypedHandler(BaseHandler):
         user, err = self.require_auth_or_error(handler)
         if err:
             return None, err
+        user = cast(UserAuthContext, user)
 
         # Check permission using role and permissions
         roles = getattr(user, "roles", []) or []
@@ -511,6 +512,7 @@ class PermissionHandler(AuthenticatedHandler):
         user_with_perm, perm_err = self.require_permission_or_error(handler, permission)
         if perm_err:
             return None, perm_err
+        user_with_perm = cast(UserAuthContext, user_with_perm)
 
         return user_with_perm, None
 

--- a/scripts/build_benchmark_truth_artifact.py
+++ b/scripts/build_benchmark_truth_artifact.py
@@ -239,17 +239,25 @@ def _corpus_freshness(
         status = "closure_hygiene_drift_detected"
     elif linkage_errors:
         status = "linkage_verification_incomplete"
+    stale_closed_issue_numbers = [
+        issue_number
+        for item in stale_closed_issues
+        for issue_number in [item.get("issue_number")]
+        if isinstance(issue_number, int) and issue_number > 0
+    ]
+    closure_hygiene_issue_numbers = [
+        issue_number
+        for item in closure_hygiene_issues
+        for issue_number in [item.get("issue_number")]
+        if isinstance(issue_number, int) and issue_number > 0
+    ]
     return {
         "status": status,
         "stale_closed_issue_count": len(stale_closed_issues),
-        "stale_closed_issue_numbers": [
-            item["issue_number"] for item in stale_closed_issues if item["issue_number"] > 0
-        ],
+        "stale_closed_issue_numbers": stale_closed_issue_numbers,
         "stale_closed_issues": stale_closed_issues,
         "closure_hygiene_issue_count": len(closure_hygiene_issues),
-        "closure_hygiene_issue_numbers": [
-            item["issue_number"] for item in closure_hygiene_issues if item["issue_number"] > 0
-        ],
+        "closure_hygiene_issue_numbers": closure_hygiene_issue_numbers,
         "closure_hygiene_issues": closure_hygiene_issues,
         "linkage_error_count": len(linkage_errors),
         "linkage_errors": linkage_errors,

--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -11,13 +11,14 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Mapping
 
 try:
     from aragora.swarm.github_app_auth import github_cli_env
 except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
 
     def github_cli_env(
-        base_env: dict[str, str] | None = None,
+        base_env: Mapping[str, str] | None = None,
         *,
         prefer_app: bool = True,
     ) -> dict[str, str]:

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -18,7 +18,7 @@ import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Mapping, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
@@ -80,22 +80,25 @@ try:
 except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
 
     def github_cli_env(
-        base_env: dict[str, str] | None = None,
+        base_env: Mapping[str, str] | None = None,
         *,
         prefer_app: bool = True,
     ) -> dict[str, str]:
         return dict(os.environ if base_env is None else base_env)
 
     def gh_subprocess_run(
-        args: list[str],
+        args: Sequence[str],
         *,
         timeout: float = 30.0,
         prefer_app: bool = True,
         write_op: bool = False,
-        env: dict[str, str] | None = None,
-        max_retries: int = 0,
+        env: Mapping[str, str] | None = None,
+        max_retries: int = 3,
+        base_backoff: float = 5.0,
+        max_backoff: float = 600.0,
+        sleep: Callable[[float], None] | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        del prefer_app, write_op, max_retries
+        del prefer_app, write_op, max_retries, base_backoff, max_backoff, sleep
         return subprocess.run(
             ["gh", *args],
             capture_output=True,

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -18,7 +18,7 @@ import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Mapping, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
@@ -72,22 +72,25 @@ try:
 except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
 
     def github_cli_env(
-        base_env: dict[str, str] | None = None,
+        base_env: Mapping[str, str] | None = None,
         *,
         prefer_app: bool = True,
     ) -> dict[str, str]:
         return dict(os.environ if base_env is None else base_env)
 
     def gh_subprocess_run(
-        args: list[str],
+        args: Sequence[str],
         *,
         timeout: float = 30.0,
         prefer_app: bool = True,
         write_op: bool = False,
-        env: dict[str, str] | None = None,
-        max_retries: int = 0,
+        env: Mapping[str, str] | None = None,
+        max_retries: int = 3,
+        base_backoff: float = 5.0,
+        max_backoff: float = 600.0,
+        sleep: Callable[[float], None] | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        del prefer_app, write_op, max_retries
+        del prefer_app, write_op, max_retries, base_backoff, max_backoff, sleep
         return subprocess.run(
             ["gh", *args],
             capture_output=True,


### PR DESCRIPTION
## Summary
- align GitHub CLI fallback helper signatures with the shared auth helper contract
- narrow handler auth return types without runtime assertions
- make the breakpoints lazy import and benchmark truth issue-number handling mypy-safe

## Verification
- `pre-commit run --hook-stage pre-push mypy-baseline --all-files`
- `ruff check scripts/build_benchmark_truth_artifact.py scripts/github_cli_health.py scripts/publish_codex_automation_branches.py scripts/publish_automation_handoffs.py aragora/server/handlers/base.py aragora/server/handlers/typed_handlers.py aragora/server/handlers/breakpoints.py`
- `ruff format --check scripts/build_benchmark_truth_artifact.py scripts/github_cli_health.py scripts/publish_codex_automation_branches.py scripts/publish_automation_handoffs.py aragora/server/handlers/base.py aragora/server/handlers/typed_handlers.py aragora/server/handlers/breakpoints.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Note
- preflight warns about source changes without test changes; this branch only updates typing and narrowing logic, and the repo-wide `mypy-baseline` gate was the primary check for the fix.
