### PR TITLE
feat(pdb): PR 1 — brief lifecycle state machine + storage layer

### DIFF
--- a/aragora/pdb/__init__.py
+++ b/aragora/pdb/__init__.py
@@ -1,0 +1,35 @@
+"""PDB — PR Decision Brief lifecycle package.
+
+This package hosts the storage + state machine that back the Mode 3
+on-demand PR brief generation pipeline described in
+``docs/plans/2026-04-20-pdb-brief-generation-mode3-design.md``.
+
+Public surface:
+
+- :class:`BriefLifecycleState` — the six canonical lifecycle states
+  (``absent``, ``queued``, ``running``, ``ready``, ``failed``, ``stale``)
+- :class:`StateTransitionError` — raised when an illegal transition is
+  attempted or when asserting into the same state
+- :func:`validate_transition` — assert a transition is legal
+- :mod:`aragora.pdb.storage` — flat-file storage layer under
+  ``.aragora/review-queue/briefs/`` (see module docstring)
+
+Subsequent PRs layer on executor, panel config, budget enforcement, and
+backend endpoints. This package is storage + state only.
+"""
+
+from __future__ import annotations
+
+from aragora.pdb.brief_state import (
+    BriefLifecycleState,
+    LEGAL_TRANSITIONS,
+    StateTransitionError,
+    validate_transition,
+)
+
+__all__ = [
+    "BriefLifecycleState",
+    "LEGAL_TRANSITIONS",
+    "StateTransitionError",
+    "validate_transition",
+]

--- a/aragora/pdb/brief_state.py
+++ b/aragora/pdb/brief_state.py
@@ -1,0 +1,162 @@
+"""Brief lifecycle state machine.
+
+One authoritative state per ``(pr_number, head_sha)`` pair. This module is
+pure types — no filesystem I/O, no logging, no external imports beyond
+the standard library. The storage layer (:mod:`aragora.pdb.storage`) is
+the only place that materializes state on disk.
+
+States
+------
+
+``absent``   — no brief is known for this ``(pr, sha)`` pair.
+``queued``   — a generation request was accepted; worker will pick it up.
+``running``  — a worker is actively generating the brief.
+``ready``    — the final signed brief JSON is on disk.
+``failed``   — generation terminated abnormally; error record written.
+``stale``    — a ``ready`` brief whose ``head_sha`` no longer matches the
+               current GitHub PR head. Stale briefs are moved to
+               ``invalidated/`` and the tuple ``(pr, new_sha)`` begins a
+               fresh ``absent → queued → …`` cycle.
+
+Legal transitions
+-----------------
+
+::
+
+    absent  → queued
+    queued  → running
+    queued  → failed    (e.g., cancelled before pickup)
+    queued  → absent    (cancel before pickup; no artifact left behind)
+    running → ready
+    running → failed
+    running → absent    (cancel mid-run; partial cost preserved in failed
+                         record only if caller explicitly asks for it —
+                         see storage.cancel_generation)
+    ready   → stale     (head_sha advanced; artifact moved to
+                         invalidated/)
+    failed  → queued    (retry; storage layer enforces that the failed
+                         record is cleared atomically before the queued
+                         record lands)
+    stale   → queued    (regenerate for the same (pr, new_sha) — the new
+                         SHA is effectively a new lifecycle; this
+                         transition is expressed in state-machine terms
+                         for symmetry but should not occur in practice
+                         because ``get_state`` keys on ``(pr, sha)``)
+
+Any transition not in the table above raises :class:`StateTransitionError`.
+Transitioning into the same state is illegal (idempotency is the
+caller's responsibility, not the state machine's).
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Mapping
+
+__all__ = [
+    "BriefLifecycleState",
+    "LEGAL_TRANSITIONS",
+    "StateTransitionError",
+    "validate_transition",
+]
+
+
+class BriefLifecycleState(str, enum.Enum):
+    """Canonical lifecycle states for a PR brief.
+
+    Inherits from ``str`` so the enum values serialize cleanly into JSON
+    and comparisons with raw strings (``state == "ready"``) work as
+    expected at the API boundary.
+    """
+
+    ABSENT = "absent"
+    QUEUED = "queued"
+    RUNNING = "running"
+    READY = "ready"
+    FAILED = "failed"
+    STALE = "stale"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.value
+
+
+# Full transition table. Keyed by the source state; value is the set of
+# legal destination states. Re-entering the same state is NOT legal.
+LEGAL_TRANSITIONS: Mapping[BriefLifecycleState, frozenset[BriefLifecycleState]] = {
+    BriefLifecycleState.ABSENT: frozenset(
+        {
+            BriefLifecycleState.QUEUED,
+        }
+    ),
+    BriefLifecycleState.QUEUED: frozenset(
+        {
+            BriefLifecycleState.RUNNING,
+            BriefLifecycleState.FAILED,
+            BriefLifecycleState.ABSENT,
+        }
+    ),
+    BriefLifecycleState.RUNNING: frozenset(
+        {
+            BriefLifecycleState.READY,
+            BriefLifecycleState.FAILED,
+            BriefLifecycleState.ABSENT,
+        }
+    ),
+    BriefLifecycleState.READY: frozenset(
+        {
+            BriefLifecycleState.STALE,
+        }
+    ),
+    BriefLifecycleState.FAILED: frozenset(
+        {
+            BriefLifecycleState.QUEUED,
+        }
+    ),
+    BriefLifecycleState.STALE: frozenset(
+        {
+            BriefLifecycleState.QUEUED,
+        }
+    ),
+}
+
+
+class StateTransitionError(ValueError):
+    """Raised when an illegal lifecycle transition is requested.
+
+    Inherits from :class:`ValueError` so callers that want to swallow
+    "bad input" errors without depending on this package directly still
+    catch it naturally.
+    """
+
+    def __init__(
+        self,
+        source: BriefLifecycleState,
+        destination: BriefLifecycleState,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        self.source = source
+        self.destination = destination
+        detail = f"illegal brief lifecycle transition: {source.value} → {destination.value}"
+        if reason:
+            detail = f"{detail} ({reason})"
+        super().__init__(detail)
+
+
+def validate_transition(source: BriefLifecycleState, destination: BriefLifecycleState) -> None:
+    """Assert that ``source → destination`` is a legal transition.
+
+    Raises :class:`StateTransitionError` otherwise. Self-transitions
+    (same source and destination) are always rejected — callers must
+    express idempotent writes at a higher level.
+    """
+
+    if source == destination:
+        raise StateTransitionError(
+            source,
+            destination,
+            reason="self-transition; idempotency is the caller's responsibility",
+        )
+    allowed = LEGAL_TRANSITIONS.get(source, frozenset())
+    if destination not in allowed:
+        raise StateTransitionError(source, destination)

--- a/aragora/pdb/storage.py
+++ b/aragora/pdb/storage.py
@@ -1,0 +1,622 @@
+"""Flat-file storage layer for PR brief lifecycle artifacts.
+
+On-disk layout (rooted at ``.aragora/review-queue/briefs/`` — or the
+directory pointed to by ``ARAGORA_REVIEW_QUEUE_ROOT`` + ``/briefs`` for
+tests)::
+
+    briefs/
+    ├── pr-{n}-{sha12}.json           (ready)
+    ├── queued/pr-{n}-{sha12}.json    (queued)
+    ├── running/pr-{n}-{sha12}.json   (running)
+    ├── failed/pr-{n}-{sha12}.json    (failed)
+    ├── invalidated/pr-{n}-{sha12}.json (stale)
+    └── index.jsonl                   (append-only event log)
+
+The disk layout *is* the state — no separate database. ``get_state``
+infers the lifecycle state from file presence alone.
+
+Atomicity
+---------
+
+All artifact writes use the ``write-tmp → os.replace`` dance.
+``os.replace`` is POSIX-standard ``rename(2)`` semantics, which is
+atomic as long as the source and destination are on the same
+filesystem. The in-directory move between lifecycle subdirs
+(``queued/`` → ``running/``, etc.) is also a single ``os.replace`` and
+therefore atomic.
+
+No cross-filesystem operations are performed. The storage root is a
+single directory tree; a caller pointing the env var at a path that
+spans filesystems breaks the atomicity contract.
+
+Append-only events
+------------------
+
+``index.jsonl`` is a line-delimited event log. Each event is a single
+JSON object on one line; writes open in append mode and flush before
+returning. A crash mid-write can at worst leave a partial trailing line
+that downstream parsers should skip — this mirrors the
+``shift_ledger.jsonl`` pattern used elsewhere in the repo.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "briefs_root",
+    "QUEUED_SUBDIR",
+    "RUNNING_SUBDIR",
+    "FAILED_SUBDIR",
+    "INVALIDATED_SUBDIR",
+    "INDEX_FILENAME",
+    "get_state",
+    "load_ready_brief",
+    "load_latest_ready_brief",
+    "find_ready_briefs_for_pr",
+    "queue_generation",
+    "mark_running",
+    "write_running_phase",
+    "mark_ready",
+    "mark_failed",
+    "invalidate_if_head_changed",
+    "cancel_generation",
+    "append_index_event",
+]
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from aragora.pdb.brief_state import BriefLifecycleState, validate_transition
+
+logger = logging.getLogger(__name__)
+
+UTC = timezone.utc
+
+QUEUED_SUBDIR = "queued"
+RUNNING_SUBDIR = "running"
+FAILED_SUBDIR = "failed"
+INVALIDATED_SUBDIR = "invalidated"
+INDEX_FILENAME = "index.jsonl"
+
+# Short form used in filenames, matching addendum §6 and the existing
+# review-queue handler convention.
+_SHA_SHORT_LEN = 12
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _discover_review_queue_root() -> Path:
+    """Mirror the root-discovery logic of ``review_queue._review_queue_root``.
+
+    Resolution order:
+
+    1. ``ARAGORA_REVIEW_QUEUE_ROOT`` env var if set
+    2. Walk up from cwd looking for a ``.aragora`` or ``.git`` directory;
+       return ``{found}/.aragora/review-queue``
+    3. Fallback: ``cwd/.aragora/review-queue``
+    """
+    override = os.environ.get("ARAGORA_REVIEW_QUEUE_ROOT")
+    if override:
+        return Path(override)
+    cwd = Path.cwd()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / ".aragora").exists() or (candidate / ".git").exists():
+            return candidate / ".aragora" / "review-queue"
+    return cwd / ".aragora" / "review-queue"
+
+
+def briefs_root() -> Path:
+    """Return the ``briefs/`` directory (parent of all lifecycle subdirs)."""
+    return _discover_review_queue_root() / "briefs"
+
+
+def _short_sha(head_sha: str) -> str:
+    if not isinstance(head_sha, str) or not head_sha:
+        raise ValueError("head_sha must be a non-empty string")
+    return head_sha[:_SHA_SHORT_LEN]
+
+
+def _filename(pr_number: int, head_sha: str) -> str:
+    if not isinstance(pr_number, int) or pr_number <= 0:
+        raise ValueError("pr_number must be a positive integer")
+    return f"pr-{pr_number}-{_short_sha(head_sha)}.json"
+
+
+def _ready_path(pr_number: int, head_sha: str) -> Path:
+    return briefs_root() / _filename(pr_number, head_sha)
+
+
+def _subdir_path(subdir: str, pr_number: int, head_sha: str) -> Path:
+    return briefs_root() / subdir / _filename(pr_number, head_sha)
+
+
+def _index_path() -> Path:
+    return briefs_root() / INDEX_FILENAME
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Atomic I/O primitives
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(target: Path, data: Mapping[str, Any]) -> None:
+    """Write ``data`` as JSON to ``target`` atomically.
+
+    The write is performed to a sibling ``.tmp`` file which is then
+    renamed via :func:`os.replace`. A crash between the write and the
+    rename leaves only the ``.tmp`` visible; the ``target`` path either
+    holds the previous contents (if any) or does not exist.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    payload = json.dumps(data, indent=2, sort_keys=True, default=str) + "\n"
+    tmp.write_text(payload, encoding="utf-8")
+    os.replace(tmp, target)
+
+
+def _atomic_move(src: Path, dst: Path) -> None:
+    """Atomically move ``src`` to ``dst``.
+
+    Parent directories are created as needed. ``os.replace`` is atomic
+    on a single filesystem (POSIX ``rename(2)`` semantics).
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(src, dst)
+
+
+def _safe_read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("pdb.storage: could not read %s: %s", path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Index (append-only event log)
+# ---------------------------------------------------------------------------
+
+
+def append_index_event(
+    pr_number: int,
+    head_sha: str,
+    event_type: str,
+    fields: Mapping[str, Any] | None = None,
+) -> None:
+    """Append a single lifecycle event to ``index.jsonl``.
+
+    The event shape is a single-line JSON object with keys:
+
+    - ``timestamp`` (UTC ISO-8601)
+    - ``pr_number``
+    - ``head_sha`` (full SHA as provided)
+    - ``event`` (string tag, e.g., ``queued``, ``running``, ``ready``,
+      ``failed``, ``stale``, ``cancelled``)
+    - plus any caller-supplied ``fields``
+
+    Writes are append-only and open/close per call so concurrent
+    lifecycle transitions don't contend on a long-lived handle.
+    """
+    event = {
+        "timestamp": _now_iso(),
+        "pr_number": int(pr_number),
+        "head_sha": str(head_sha),
+        "event": str(event_type),
+    }
+    if fields:
+        for key, value in fields.items():
+            if key in event:
+                continue
+            event[key] = value
+    index = _index_path()
+    index.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(event, sort_keys=True, default=str) + "\n"
+    # Use 'a' mode — append is atomic for small writes on POSIX.
+    with index.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
+# ---------------------------------------------------------------------------
+# State inference
+# ---------------------------------------------------------------------------
+
+
+def get_state(pr_number: int, head_sha: str) -> BriefLifecycleState:
+    """Return the current lifecycle state for ``(pr_number, head_sha)``.
+
+    Precedence (in order): READY > FAILED > RUNNING > QUEUED > STALE.
+    ABSENT is returned when no artifact is found.
+
+    The ordering matters when a crash interleaves two states on disk
+    (e.g., a completed ``mark_ready`` before the ``running/`` record
+    could be removed). Terminal states (ready, failed) win over
+    in-progress states so the caller observes the most-advanced
+    outcome.
+    """
+    filename = _filename(pr_number, head_sha)
+    root = briefs_root()
+    if (root / filename).exists():
+        return BriefLifecycleState.READY
+    if (root / FAILED_SUBDIR / filename).exists():
+        return BriefLifecycleState.FAILED
+    if (root / RUNNING_SUBDIR / filename).exists():
+        return BriefLifecycleState.RUNNING
+    if (root / QUEUED_SUBDIR / filename).exists():
+        return BriefLifecycleState.QUEUED
+    if (root / INVALIDATED_SUBDIR / filename).exists():
+        return BriefLifecycleState.STALE
+    return BriefLifecycleState.ABSENT
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+
+
+def load_ready_brief(pr_number: int, head_sha: str) -> dict[str, Any] | None:
+    """Return the ready brief JSON for ``(pr_number, head_sha)``, or None.
+
+    Only returns the brief when state is ``ready``. Running / queued /
+    failed / invalidated records are NOT returned by this function —
+    callers that want those must read the subdir artifact explicitly.
+    """
+    path = _ready_path(pr_number, head_sha)
+    if not path.exists():
+        return None
+    return _safe_read_json(path)
+
+
+def find_ready_briefs_for_pr(pr_number: int) -> list[Path]:
+    """Return all on-disk ``ready`` briefs for a PR across SHAs.
+
+    Sorted newest-first by mtime. Used by :func:`load_latest_ready_brief`
+    and :func:`invalidate_if_head_changed`.
+    """
+    root = briefs_root()
+    if not root.exists():
+        return []
+    try:
+        candidates = [p for p in root.glob(f"pr-{pr_number}-*.json") if p.is_file()]
+    except OSError:
+        return []
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates
+
+
+def load_latest_ready_brief(pr_number: int) -> dict[str, Any] | None:
+    """Return the most-recently-modified ready brief for ``pr_number``.
+
+    This is the compatibility helper used by the legacy
+    ``GET /api/v1/review-queue/prs/{n}/brief`` handler, which doesn't
+    yet know the head SHA on the request. Prefer
+    :func:`load_ready_brief` for SHA-aware reads.
+    """
+    for path in find_ready_briefs_for_pr(pr_number):
+        data = _safe_read_json(path)
+        if data is not None:
+            return data
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle writes
+# ---------------------------------------------------------------------------
+
+
+def queue_generation(
+    pr_number: int,
+    head_sha: str,
+    panel_models: list[str] | tuple[str, ...],
+    *,
+    requested_at: str | None = None,
+    extra_fields: Mapping[str, Any] | None = None,
+) -> None:
+    """Transition ``absent → queued`` (or ``failed → queued``, ``stale → queued``).
+
+    Writes ``queued/pr-{n}-{sha12}.json`` atomically and appends a
+    ``queued`` event to the index. If a prior ``failed`` record exists
+    for this ``(pr, sha)``, it is cleared as part of the transition so
+    :func:`get_state` consistently reports QUEUED.
+    """
+    source = get_state(pr_number, head_sha)
+    validate_transition(source, BriefLifecycleState.QUEUED)
+
+    record = {
+        "pr_number": int(pr_number),
+        "head_sha": str(head_sha),
+        "state": BriefLifecycleState.QUEUED.value,
+        "panel_models": list(panel_models),
+        "requested_at": requested_at or _now_iso(),
+    }
+    if extra_fields:
+        for key, value in extra_fields.items():
+            record.setdefault(key, value)
+
+    target = _subdir_path(QUEUED_SUBDIR, pr_number, head_sha)
+    _atomic_write_json(target, record)
+
+    # Clean up a superseded failed record (failed → queued retry).
+    if source == BriefLifecycleState.FAILED:
+        failed_path = _subdir_path(FAILED_SUBDIR, pr_number, head_sha)
+        if failed_path.exists():
+            try:
+                failed_path.unlink()
+            except OSError:
+                logger.warning(
+                    "pdb.storage: could not clear failed record %s on retry", failed_path
+                )
+
+    append_index_event(
+        pr_number,
+        head_sha,
+        "queued",
+        {"panel_models": list(panel_models), "previous_state": source.value},
+    )
+
+
+def mark_running(pr_number: int, head_sha: str, phase: str) -> None:
+    """Transition ``queued → running``.
+
+    Atomically moves the queued record to ``running/`` and annotates it
+    with ``started_at`` + ``current_phase``.
+    """
+    source = get_state(pr_number, head_sha)
+    validate_transition(source, BriefLifecycleState.RUNNING)
+
+    queued_path = _subdir_path(QUEUED_SUBDIR, pr_number, head_sha)
+    running_path = _subdir_path(RUNNING_SUBDIR, pr_number, head_sha)
+
+    # Pull the queued record to preserve panel_models + requested_at.
+    prior = _safe_read_json(queued_path) or {}
+    record: dict[str, Any] = dict(prior)
+    record.update(
+        {
+            "pr_number": int(pr_number),
+            "head_sha": str(head_sha),
+            "state": BriefLifecycleState.RUNNING.value,
+            "current_phase": str(phase),
+            "started_at": _now_iso(),
+        }
+    )
+
+    # Write new running record atomically, then remove the queued record.
+    # Ordering: write-then-remove means an interrupted transition leaves
+    # BOTH records visible — get_state resolves to RUNNING (higher
+    # precedence) so the caller's view is correct.
+    _atomic_write_json(running_path, record)
+    try:
+        queued_path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        logger.warning("pdb.storage: could not remove queued record %s after start", queued_path)
+
+    append_index_event(
+        pr_number,
+        head_sha,
+        "running",
+        {"current_phase": str(phase)},
+    )
+
+
+def write_running_phase(
+    pr_number: int,
+    head_sha: str,
+    phase: str,
+    cost_usd_so_far: float,
+) -> None:
+    """Update the running record with current phase + cost.
+
+    Does NOT transition state — the state remains RUNNING. Used by the
+    executor between phases so UI polls see progress.
+    """
+    running_path = _subdir_path(RUNNING_SUBDIR, pr_number, head_sha)
+    prior = _safe_read_json(running_path) or {}
+    record: dict[str, Any] = dict(prior)
+    record.update(
+        {
+            "pr_number": int(pr_number),
+            "head_sha": str(head_sha),
+            "state": BriefLifecycleState.RUNNING.value,
+            "current_phase": str(phase),
+            "cost_usd_so_far": float(cost_usd_so_far),
+            "updated_at": _now_iso(),
+        }
+    )
+    _atomic_write_json(running_path, record)
+    append_index_event(
+        pr_number,
+        head_sha,
+        "running_phase",
+        {"current_phase": str(phase), "cost_usd_so_far": float(cost_usd_so_far)},
+    )
+
+
+def mark_ready(
+    pr_number: int,
+    head_sha: str,
+    brief_json: Mapping[str, Any],
+    signature: str | None = None,
+) -> None:
+    """Transition ``running → ready``.
+
+    Writes the final signed brief JSON at the flat filename, removes the
+    running record, and appends a ``ready`` index event.
+
+    If ``signature`` is provided it is merged into the stored brief as a
+    top-level ``signature`` field (matching addendum §5). If the brief
+    already carries a signature and a different value is passed, the
+    caller's explicit signature wins.
+    """
+    source = get_state(pr_number, head_sha)
+    validate_transition(source, BriefLifecycleState.READY)
+
+    payload: dict[str, Any] = dict(brief_json)
+    payload.setdefault("pr_number", int(pr_number))
+    payload.setdefault("head_sha", str(head_sha))
+    if signature is not None:
+        payload["signature"] = signature
+
+    ready_path = _ready_path(pr_number, head_sha)
+    _atomic_write_json(ready_path, payload)
+
+    running_path = _subdir_path(RUNNING_SUBDIR, pr_number, head_sha)
+    if running_path.exists():
+        try:
+            running_path.unlink()
+        except OSError:
+            logger.warning(
+                "pdb.storage: could not remove running record %s after ready",
+                running_path,
+            )
+
+    append_index_event(
+        pr_number,
+        head_sha,
+        "ready",
+        {"signature_present": signature is not None},
+    )
+
+
+def mark_failed(
+    pr_number: int,
+    head_sha: str,
+    error_message: str,
+    failed_phase: str,
+    cost_usd_so_far: float = 0.0,
+) -> None:
+    """Transition ``queued|running → failed``.
+
+    Writes a failure record to ``failed/`` with the error message,
+    phase, and cost-so-far. Removes the queued/running record. Appends
+    a ``failed`` index event.
+    """
+    source = get_state(pr_number, head_sha)
+    validate_transition(source, BriefLifecycleState.FAILED)
+
+    record = {
+        "pr_number": int(pr_number),
+        "head_sha": str(head_sha),
+        "state": BriefLifecycleState.FAILED.value,
+        "error_message": str(error_message),
+        "failed_phase": str(failed_phase),
+        "cost_usd_so_far": float(cost_usd_so_far),
+        "failed_at": _now_iso(),
+    }
+    failed_path = _subdir_path(FAILED_SUBDIR, pr_number, head_sha)
+    _atomic_write_json(failed_path, record)
+
+    # Remove the pre-failure record of the prior state.
+    for subdir in (QUEUED_SUBDIR, RUNNING_SUBDIR):
+        prior = _subdir_path(subdir, pr_number, head_sha)
+        if prior.exists():
+            try:
+                prior.unlink()
+            except OSError:
+                logger.warning(
+                    "pdb.storage: could not remove %s record %s after failure",
+                    subdir,
+                    prior,
+                )
+
+    append_index_event(
+        pr_number,
+        head_sha,
+        "failed",
+        {
+            "error_message": str(error_message),
+            "failed_phase": str(failed_phase),
+            "cost_usd_so_far": float(cost_usd_so_far),
+            "previous_state": source.value,
+        },
+    )
+
+
+def invalidate_if_head_changed(pr_number: int, current_head_sha: str) -> bool:
+    """Move any ready briefs under a different SHA to ``invalidated/``.
+
+    Returns ``True`` iff at least one ready brief was moved. A ``stale``
+    index event is appended for each moved brief.
+
+    The current-SHA brief (if any) is left in place — the intent is to
+    detect SHA advancement, not to clear the fresh brief.
+    """
+    current_short = _short_sha(current_head_sha)
+    current_filename = _filename(pr_number, current_head_sha)
+    moved_any = False
+    for path in find_ready_briefs_for_pr(pr_number):
+        if path.name == current_filename:
+            continue
+        # Extract the SHA-short from the filename for the event record.
+        # Filename shape: pr-{n}-{sha12}.json
+        stem = path.stem  # e.g., "pr-6328-6a7dfc5e5135"
+        prior_sha_short = stem.split("-", 2)[-1] if stem.count("-") >= 2 else ""
+        destination = path.parent / INVALIDATED_SUBDIR / path.name
+        try:
+            _atomic_move(path, destination)
+        except OSError as exc:
+            logger.warning("pdb.storage: could not invalidate ready brief %s: %s", path, exc)
+            continue
+        moved_any = True
+        append_index_event(
+            pr_number,
+            prior_sha_short,
+            "stale",
+            {
+                "reason": "head_advanced",
+                "new_head_sha_short": current_short,
+                "invalidated_path": str(destination),
+            },
+        )
+    return moved_any
+
+
+def cancel_generation(pr_number: int, head_sha: str) -> BriefLifecycleState:
+    """Cancel a queued or running generation.
+
+    Returns the post-cancel state. No-op for terminal / absent states;
+    the original state is returned in that case.
+
+    Semantics:
+
+    - QUEUED → ABSENT (queued record removed; no artifact left behind)
+    - RUNNING → ABSENT (running record removed; caller may subsequently
+      call :func:`mark_failed` to preserve partial cost, but cancel
+      itself is trace-free beyond the index event)
+    - READY / FAILED / ABSENT / STALE → no-op (original state returned)
+    """
+    source = get_state(pr_number, head_sha)
+    if source not in (BriefLifecycleState.QUEUED, BriefLifecycleState.RUNNING):
+        return source
+
+    validate_transition(source, BriefLifecycleState.ABSENT)
+
+    subdir = QUEUED_SUBDIR if source == BriefLifecycleState.QUEUED else RUNNING_SUBDIR
+    path = _subdir_path(subdir, pr_number, head_sha)
+    if path.exists():
+        try:
+            path.unlink()
+        except OSError:
+            logger.warning(
+                "pdb.storage: could not remove %s record %s on cancel",
+                subdir,
+                path,
+            )
+
+    append_index_event(
+        pr_number,
+        head_sha,
+        "cancelled",
+        {"previous_state": source.value},
+    )
+    return BriefLifecycleState.ABSENT

--- a/aragora/pdb/storage.py
+++ b/aragora/pdb/storage.py
@@ -557,10 +557,18 @@ def invalidate_if_head_changed(pr_number: int, current_head_sha: str) -> bool:
     for path in find_ready_briefs_for_pr(pr_number):
         if path.name == current_filename:
             continue
+        prior_payload = _safe_read_json(path)
         # Extract the SHA-short from the filename for the event record.
         # Filename shape: pr-{n}-{sha12}.json
         stem = path.stem  # e.g., "pr-6328-6a7dfc5e5135"
         prior_sha_short = stem.split("-", 2)[-1] if stem.count("-") >= 2 else ""
+        prior_head_sha = str((prior_payload or {}).get("head_sha") or "")
+        if not prior_head_sha:
+            logger.warning(
+                "pdb.storage: ready brief %s missing full head_sha; using filename short SHA in stale event",
+                path,
+            )
+            prior_head_sha = prior_sha_short
         destination = path.parent / INVALIDATED_SUBDIR / path.name
         try:
             _atomic_move(path, destination)
@@ -570,7 +578,7 @@ def invalidate_if_head_changed(pr_number: int, current_head_sha: str) -> bool:
         moved_any = True
         append_index_event(
             pr_number,
-            prior_sha_short,
+            prior_head_sha,
             "stale",
             {
                 "reason": "head_advanced",

--- a/aragora/server/handlers/review_queue.py
+++ b/aragora/server/handlers/review_queue.py
@@ -42,6 +42,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from aragora.pdb import storage as brief_storage
 from aragora.server.versioning.compat import strip_version_prefix
 
 from .base import BaseHandler, HandlerResult, error_response, json_response
@@ -84,10 +85,6 @@ def _review_queue_root() -> Path:
 
 # Exported for tests so they can patch a single value.
 REVIEW_QUEUE_ROOT = _review_queue_root
-
-
-def _briefs_dir() -> Path:
-    return REVIEW_QUEUE_ROOT() / "briefs"
 
 
 def _deferred_path() -> Path:
@@ -222,26 +219,18 @@ def _run_gh(args: list[str], *, input_text: str | None = None) -> tuple[int, str
 
 
 def _load_brief(pr_number: int) -> dict[str, Any] | None:
-    """Read a brief JSON from ``briefs/pr-{n}-*.json``.
+    """Read the latest ready brief for ``pr_number`` via the PDB storage layer.
 
-    If multiple files match (multiple head SHAs seen), returns the most
-    recently modified one. Returns ``None`` when nothing is on disk.
+    Delegates to :func:`aragora.pdb.storage.load_latest_ready_brief`.
+    Returns ``None`` when no ready brief is on disk.
+
+    Note: the eventual (Mode 3) brief generation API is SHA-aware and
+    keys on ``(pr_number, head_sha)``; the legacy response shape used
+    here is preserved deliberately to avoid breaking the current UI.
+    PR 3 of the Mode 3 rollout adds a SHA-aware ``/brief/state``
+    endpoint alongside this one.
     """
-    root = _briefs_dir()
-    if not root.exists():
-        return None
-    candidates = sorted(
-        root.glob(f"pr-{pr_number}-*.json"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    if not candidates:
-        return None
-    try:
-        return json.loads(candidates[0].read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("review-queue: could not read brief %s: %s", candidates[0], exc)
-        return None
+    return brief_storage.load_latest_ready_brief(pr_number)
 
 
 def _load_stats(when: datetime | None = None) -> dict[str, Any]:

--- a/tests/pdb/test_brief_state.py
+++ b/tests/pdb/test_brief_state.py
@@ -1,0 +1,119 @@
+"""Tests for :mod:`aragora.pdb.brief_state`.
+
+These tests pin the lifecycle transition table. Every legal transition is
+verified; every illegal transition (including self-transitions, which are
+explicitly rejected) raises :class:`StateTransitionError`.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from aragora.pdb.brief_state import (
+    LEGAL_TRANSITIONS,
+    BriefLifecycleState,
+    StateTransitionError,
+    validate_transition,
+)
+
+
+# ---------------------------------------------------------------------------
+# Enum surface
+# ---------------------------------------------------------------------------
+
+
+class TestEnumSurface:
+    def test_six_states_present(self):
+        assert {s.value for s in BriefLifecycleState} == {
+            "absent",
+            "queued",
+            "running",
+            "ready",
+            "failed",
+            "stale",
+        }
+
+    def test_states_are_str_subclass(self):
+        """String-mixin lets ``state == "ready"`` work at API boundary."""
+        assert BriefLifecycleState.READY == "ready"
+        assert BriefLifecycleState.QUEUED == "queued"
+
+    def test_stringification_returns_value(self):
+        assert str(BriefLifecycleState.RUNNING) == "running"
+
+
+# ---------------------------------------------------------------------------
+# Legal transitions (enumerated — each must pass)
+# ---------------------------------------------------------------------------
+
+
+LEGAL_PAIRS = [
+    (BriefLifecycleState.ABSENT, BriefLifecycleState.QUEUED),
+    (BriefLifecycleState.QUEUED, BriefLifecycleState.RUNNING),
+    (BriefLifecycleState.QUEUED, BriefLifecycleState.FAILED),
+    (BriefLifecycleState.QUEUED, BriefLifecycleState.ABSENT),
+    (BriefLifecycleState.RUNNING, BriefLifecycleState.READY),
+    (BriefLifecycleState.RUNNING, BriefLifecycleState.FAILED),
+    (BriefLifecycleState.RUNNING, BriefLifecycleState.ABSENT),
+    (BriefLifecycleState.READY, BriefLifecycleState.STALE),
+    (BriefLifecycleState.FAILED, BriefLifecycleState.QUEUED),
+    (BriefLifecycleState.STALE, BriefLifecycleState.QUEUED),
+]
+
+
+class TestLegalTransitions:
+    @pytest.mark.parametrize("source,destination", LEGAL_PAIRS)
+    def test_each_legal_transition_passes(
+        self, source: BriefLifecycleState, destination: BriefLifecycleState
+    ):
+        # Should not raise.
+        validate_transition(source, destination)
+
+    def test_legal_transitions_table_matches_documented_pairs(self):
+        documented = set(LEGAL_PAIRS)
+        actual = {(src, dst) for src, dests in LEGAL_TRANSITIONS.items() for dst in dests}
+        assert documented == actual, "LEGAL_TRANSITIONS table drifted from the documented pairs."
+
+
+# ---------------------------------------------------------------------------
+# Illegal transitions (exhaustive — every non-legal pair raises)
+# ---------------------------------------------------------------------------
+
+
+ALL_STATES = list(BriefLifecycleState)
+
+
+def _illegal_pairs() -> list[tuple[BriefLifecycleState, BriefLifecycleState]]:
+    """Enumerate every ordered pair not in the legal table.
+
+    Self-transitions are included because they are also rejected.
+    """
+    legal = set(LEGAL_PAIRS)
+    return [(a, b) for a, b in itertools.product(ALL_STATES, ALL_STATES) if (a, b) not in legal]
+
+
+class TestIllegalTransitions:
+    @pytest.mark.parametrize("source,destination", _illegal_pairs())
+    def test_each_illegal_transition_raises(
+        self, source: BriefLifecycleState, destination: BriefLifecycleState
+    ):
+        with pytest.raises(StateTransitionError) as exc_info:
+            validate_transition(source, destination)
+        err = exc_info.value
+        assert err.source == source
+        assert err.destination == destination
+        assert source.value in str(err)
+        assert destination.value in str(err)
+
+    @pytest.mark.parametrize("state", ALL_STATES)
+    def test_self_transition_rejected(self, state: BriefLifecycleState):
+        with pytest.raises(StateTransitionError) as exc_info:
+            validate_transition(state, state)
+        assert "self-transition" in str(exc_info.value)
+
+    def test_state_transition_error_is_value_error(self):
+        """Callers can catch as ValueError without importing this package."""
+        with pytest.raises(ValueError):
+            validate_transition(BriefLifecycleState.READY, BriefLifecycleState.QUEUED)

--- a/tests/pdb/test_storage.py
+++ b/tests/pdb/test_storage.py
@@ -300,6 +300,7 @@ class TestInvalidateIfHeadChanged:
         events = [e for e in _index_events(briefs_dir) if e["event"] == "stale"]
         assert len(events) == 1
         assert events[0]["reason"] == "head_advanced"
+        assert events[0]["head_sha"] == old_sha
         assert events[0]["new_head_sha_short"] == new_sha[:12]
 
     def test_no_move_when_sha_unchanged(self, briefs_dir):

--- a/tests/pdb/test_storage.py
+++ b/tests/pdb/test_storage.py
@@ -1,0 +1,449 @@
+"""Tests for :mod:`aragora.pdb.storage`.
+
+Covers:
+
+- ``get_state`` inference across all 6 on-disk layouts
+- Each lifecycle transition (``queue_generation``, ``mark_running``,
+  ``mark_ready``, ``mark_failed``, ``cancel_generation``,
+  ``invalidate_if_head_changed``)
+- Atomicity of writes under simulated interrupt (no partial ``.json``
+  file surfaces)
+- ``index.jsonl`` event append behavior
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aragora.pdb import storage
+from aragora.pdb.brief_state import BriefLifecycleState, StateTransitionError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def briefs_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the briefs root under a tmp dir and return the briefs dir."""
+    monkeypatch.setenv("ARAGORA_REVIEW_QUEUE_ROOT", str(tmp_path))
+    briefs = tmp_path / "briefs"
+    briefs.mkdir(parents=True, exist_ok=True)
+    return briefs
+
+
+PR = 1234
+SHA = "a" * 40
+SHA_SHORT = SHA[:12]
+FILENAME = f"pr-{PR}-{SHA_SHORT}.json"
+
+
+def _index_events(briefs: Path) -> list[dict]:
+    index = briefs / storage.INDEX_FILENAME
+    if not index.exists():
+        return []
+    return [
+        json.loads(line) for line in index.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# get_state: 6 on-disk layouts
+# ---------------------------------------------------------------------------
+
+
+class TestGetState:
+    def test_absent_returns_absent(self, briefs_dir):
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.ABSENT
+
+    def test_queued_layout(self, briefs_dir):
+        (briefs_dir / storage.QUEUED_SUBDIR).mkdir()
+        (briefs_dir / storage.QUEUED_SUBDIR / FILENAME).write_text("{}", encoding="utf-8")
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.QUEUED
+
+    def test_running_layout(self, briefs_dir):
+        (briefs_dir / storage.RUNNING_SUBDIR).mkdir()
+        (briefs_dir / storage.RUNNING_SUBDIR / FILENAME).write_text("{}", encoding="utf-8")
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.RUNNING
+
+    def test_ready_layout(self, briefs_dir):
+        (briefs_dir / FILENAME).write_text("{}", encoding="utf-8")
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.READY
+
+    def test_failed_layout(self, briefs_dir):
+        (briefs_dir / storage.FAILED_SUBDIR).mkdir()
+        (briefs_dir / storage.FAILED_SUBDIR / FILENAME).write_text("{}", encoding="utf-8")
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.FAILED
+
+    def test_stale_layout(self, briefs_dir):
+        (briefs_dir / storage.INVALIDATED_SUBDIR).mkdir()
+        (briefs_dir / storage.INVALIDATED_SUBDIR / FILENAME).write_text("{}", encoding="utf-8")
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.STALE
+
+    def test_terminal_state_wins_over_in_progress(self, briefs_dir):
+        """If a crash leaves both running/ and the final artifact, READY wins."""
+        (briefs_dir / storage.RUNNING_SUBDIR).mkdir()
+        (briefs_dir / storage.RUNNING_SUBDIR / FILENAME).write_text("{}", encoding="utf-8")
+        (briefs_dir / FILENAME).write_text("{}", encoding="utf-8")
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.READY
+
+    def test_different_sha_is_independent(self, briefs_dir):
+        (briefs_dir / FILENAME).write_text("{}", encoding="utf-8")
+        other_sha = "b" * 40
+        assert storage.get_state(PR, other_sha) == BriefLifecycleState.ABSENT
+
+
+# ---------------------------------------------------------------------------
+# queue_generation
+# ---------------------------------------------------------------------------
+
+
+class TestQueueGeneration:
+    def test_absent_to_queued(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude", "pdb.core.gpt"])
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.QUEUED
+        queued_file = briefs_dir / storage.QUEUED_SUBDIR / FILENAME
+        assert queued_file.exists()
+        record = json.loads(queued_file.read_text())
+        assert record["pr_number"] == PR
+        assert record["head_sha"] == SHA
+        assert record["panel_models"] == ["pdb.core.claude", "pdb.core.gpt"]
+        assert "requested_at" in record
+
+    def test_index_event_recorded(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        events = _index_events(briefs_dir)
+        assert len(events) == 1
+        assert events[0]["event"] == "queued"
+        assert events[0]["pr_number"] == PR
+        assert events[0]["head_sha"] == SHA
+        assert events[0]["panel_models"] == ["pdb.core.claude"]
+
+    def test_queued_to_queued_raises(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        with pytest.raises(StateTransitionError):
+            storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+
+    def test_running_to_queued_raises(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="findings_round")
+        with pytest.raises(StateTransitionError):
+            storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+
+    def test_failed_to_queued_clears_failed_record(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="findings_round")
+        storage.mark_failed(PR, SHA, "boom", "findings_round", cost_usd_so_far=1.5)
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.FAILED
+
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.QUEUED
+        assert not (briefs_dir / storage.FAILED_SUBDIR / FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# mark_running
+# ---------------------------------------------------------------------------
+
+
+class TestMarkRunning:
+    def test_queued_to_running_moves_record(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="findings_round")
+
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.RUNNING
+        assert not (briefs_dir / storage.QUEUED_SUBDIR / FILENAME).exists()
+        running_file = briefs_dir / storage.RUNNING_SUBDIR / FILENAME
+        assert running_file.exists()
+        record = json.loads(running_file.read_text())
+        assert record["current_phase"] == "findings_round"
+        assert record["panel_models"] == ["pdb.core.claude"]
+        assert "started_at" in record
+
+    def test_absent_to_running_raises(self, briefs_dir):
+        with pytest.raises(StateTransitionError):
+            storage.mark_running(PR, SHA, phase="findings_round")
+
+
+# ---------------------------------------------------------------------------
+# write_running_phase
+# ---------------------------------------------------------------------------
+
+
+class TestWriteRunningPhase:
+    def test_updates_phase_and_cost_without_state_change(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="findings_round")
+
+        storage.write_running_phase(PR, SHA, phase="critique_round", cost_usd_so_far=2.41)
+
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.RUNNING
+        record = json.loads((briefs_dir / storage.RUNNING_SUBDIR / FILENAME).read_text())
+        assert record["current_phase"] == "critique_round"
+        assert record["cost_usd_so_far"] == pytest.approx(2.41)
+
+        events = [e for e in _index_events(briefs_dir) if e["event"] == "running_phase"]
+        assert len(events) == 1
+        assert events[0]["current_phase"] == "critique_round"
+
+
+# ---------------------------------------------------------------------------
+# mark_ready
+# ---------------------------------------------------------------------------
+
+
+class TestMarkReady:
+    def test_running_to_ready(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="synthesis")
+
+        brief = {
+            "pr_number": PR,
+            "head_sha": SHA,
+            "verdict": "approve_candidate",
+            "confidence": 4,
+            "logic": "ok",
+            "security": "ok",
+            "maintainability": "ok",
+            "skeptic": "ok",
+        }
+        storage.mark_ready(PR, SHA, brief, signature="ed25519:sig-abc123")
+
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.READY
+        ready_path = briefs_dir / FILENAME
+        assert ready_path.exists()
+        loaded = json.loads(ready_path.read_text())
+        assert loaded["signature"] == "ed25519:sig-abc123"
+        assert loaded["verdict"] == "approve_candidate"
+        # Running record cleared
+        assert not (briefs_dir / storage.RUNNING_SUBDIR / FILENAME).exists()
+
+    def test_mark_ready_appends_index_event(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="synthesis")
+        storage.mark_ready(PR, SHA, {"verdict": "approve_candidate"}, signature=None)
+
+        events = [e for e in _index_events(briefs_dir) if e["event"] == "ready"]
+        assert len(events) == 1
+        assert events[0]["signature_present"] is False
+
+    def test_mark_ready_without_running_raises(self, briefs_dir):
+        with pytest.raises(StateTransitionError):
+            storage.mark_ready(PR, SHA, {"verdict": "approve_candidate"})
+
+    def test_load_ready_brief_roundtrip(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="synthesis")
+        storage.mark_ready(PR, SHA, {"verdict": "approve_candidate", "confidence": 5})
+
+        loaded = storage.load_ready_brief(PR, SHA)
+        assert loaded is not None
+        assert loaded["verdict"] == "approve_candidate"
+        assert loaded["confidence"] == 5
+
+
+# ---------------------------------------------------------------------------
+# mark_failed
+# ---------------------------------------------------------------------------
+
+
+class TestMarkFailed:
+    def test_running_to_failed(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="findings_round")
+        storage.mark_failed(PR, SHA, "rate limit exhausted", "critique_round", cost_usd_so_far=3.20)
+
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.FAILED
+        failed_file = briefs_dir / storage.FAILED_SUBDIR / FILENAME
+        record = json.loads(failed_file.read_text())
+        assert record["error_message"] == "rate limit exhausted"
+        assert record["failed_phase"] == "critique_round"
+        assert record["cost_usd_so_far"] == pytest.approx(3.20)
+        assert not (briefs_dir / storage.RUNNING_SUBDIR / FILENAME).exists()
+
+    def test_queued_to_failed(self, briefs_dir):
+        """Cancel-before-pickup may still choose to record a failed entry."""
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_failed(PR, SHA, "cancelled by user", "queued", cost_usd_so_far=0.0)
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.FAILED
+        assert not (briefs_dir / storage.QUEUED_SUBDIR / FILENAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# invalidate_if_head_changed
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidateIfHeadChanged:
+    def test_moves_ready_with_different_sha(self, briefs_dir):
+        old_sha = "oldsha1234567890" + "0" * 22
+        new_sha = "newsha9876543210" + "0" * 22
+
+        # Seed a ready brief under the old SHA via full lifecycle.
+        storage.queue_generation(PR, old_sha, ["pdb.core.claude"])
+        storage.mark_running(PR, old_sha, phase="synthesis")
+        storage.mark_ready(PR, old_sha, {"verdict": "approve_candidate"})
+
+        moved = storage.invalidate_if_head_changed(PR, new_sha)
+        assert moved is True
+
+        old_short = old_sha[:12]
+        old_name = f"pr-{PR}-{old_short}.json"
+        assert not (briefs_dir / old_name).exists()
+        assert (briefs_dir / storage.INVALIDATED_SUBDIR / old_name).exists()
+
+        events = [e for e in _index_events(briefs_dir) if e["event"] == "stale"]
+        assert len(events) == 1
+        assert events[0]["reason"] == "head_advanced"
+        assert events[0]["new_head_sha_short"] == new_sha[:12]
+
+    def test_no_move_when_sha_unchanged(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="synthesis")
+        storage.mark_ready(PR, SHA, {"verdict": "approve_candidate"})
+
+        moved = storage.invalidate_if_head_changed(PR, SHA)
+        assert moved is False
+        assert (briefs_dir / FILENAME).exists()
+        assert not (briefs_dir / storage.INVALIDATED_SUBDIR).exists() or not list(
+            (briefs_dir / storage.INVALIDATED_SUBDIR).glob("*.json")
+        )
+
+    def test_returns_false_when_no_ready_exists(self, briefs_dir):
+        moved = storage.invalidate_if_head_changed(PR, SHA)
+        assert moved is False
+
+
+# ---------------------------------------------------------------------------
+# cancel_generation
+# ---------------------------------------------------------------------------
+
+
+class TestCancelGeneration:
+    def test_cancel_queued_returns_absent(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        final = storage.cancel_generation(PR, SHA)
+        assert final == BriefLifecycleState.ABSENT
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.ABSENT
+        assert not (briefs_dir / storage.QUEUED_SUBDIR / FILENAME).exists()
+        events = [e for e in _index_events(briefs_dir) if e["event"] == "cancelled"]
+        assert len(events) == 1
+        assert events[0]["previous_state"] == "queued"
+
+    def test_cancel_running_returns_absent(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="findings_round")
+        final = storage.cancel_generation(PR, SHA)
+        assert final == BriefLifecycleState.ABSENT
+        assert not (briefs_dir / storage.RUNNING_SUBDIR / FILENAME).exists()
+
+    def test_cancel_ready_is_noop(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="synthesis")
+        storage.mark_ready(PR, SHA, {"verdict": "approve_candidate"})
+        final = storage.cancel_generation(PR, SHA)
+        assert final == BriefLifecycleState.READY
+        assert storage.get_state(PR, SHA) == BriefLifecycleState.READY
+
+    def test_cancel_absent_is_noop(self, briefs_dir):
+        final = storage.cancel_generation(PR, SHA)
+        assert final == BriefLifecycleState.ABSENT
+
+    def test_cancel_failed_is_noop(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_failed(PR, SHA, "oops", "queued")
+        final = storage.cancel_generation(PR, SHA)
+        assert final == BriefLifecycleState.FAILED
+
+
+# ---------------------------------------------------------------------------
+# load_latest_ready_brief (compat helper)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadLatestReadyBrief:
+    def test_returns_none_when_absent(self, briefs_dir):
+        assert storage.load_latest_ready_brief(PR) is None
+
+    def test_returns_most_recent_mtime(self, briefs_dir):
+        sha_a = "a" * 40
+        sha_b = "b" * 40
+
+        storage.queue_generation(PR, sha_a, ["pdb.core.claude"])
+        storage.mark_running(PR, sha_a, phase="synthesis")
+        storage.mark_ready(PR, sha_a, {"verdict": "approve_candidate", "tag": "older"})
+
+        storage.queue_generation(PR, sha_b, ["pdb.core.claude"])
+        storage.mark_running(PR, sha_b, phase="synthesis")
+        storage.mark_ready(PR, sha_b, {"verdict": "approve_candidate", "tag": "newer"})
+
+        # Nudge mtimes to guarantee ordering on fast-disk filesystems.
+        import os as _os
+        import time as _time
+
+        older = briefs_dir / f"pr-{PR}-{sha_a[:12]}.json"
+        newer = briefs_dir / f"pr-{PR}-{sha_b[:12]}.json"
+        _os.utime(older, (1_000_000.0, 1_000_000.0))
+        _os.utime(newer, (_time.time(), _time.time()))
+
+        loaded = storage.load_latest_ready_brief(PR)
+        assert loaded is not None
+        assert loaded["tag"] == "newer"
+
+
+# ---------------------------------------------------------------------------
+# Atomicity: an interrupted write leaves no partial .json
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicity:
+    def test_interrupted_atomic_write_leaves_tmp_only(self, briefs_dir):
+        """Simulate a KeyboardInterrupt mid-write; final file must not appear.
+
+        We patch ``os.replace`` (inside the storage module) to raise
+        KeyboardInterrupt. The tmp file may remain on disk; the final
+        target must NOT.
+        """
+        target = briefs_dir / storage.QUEUED_SUBDIR / FILENAME
+
+        with patch.object(storage.os, "replace", side_effect=KeyboardInterrupt("simulated")):
+            with pytest.raises(KeyboardInterrupt):
+                storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+
+        assert not target.exists(), "final .json must not be visible after interrupt"
+        # The tmp sibling may remain; that's expected and recoverable.
+        tmp_candidates = list((briefs_dir / storage.QUEUED_SUBDIR).glob("*.tmp"))
+        # Zero or one tmp files are acceptable; what matters is the
+        # final target was not created.
+        assert len(tmp_candidates) <= 1
+
+
+# ---------------------------------------------------------------------------
+# index.jsonl event log
+# ---------------------------------------------------------------------------
+
+
+class TestIndexEventLog:
+    def test_full_lifecycle_logged(self, briefs_dir):
+        storage.queue_generation(PR, SHA, ["pdb.core.claude"])
+        storage.mark_running(PR, SHA, phase="findings_round")
+        storage.write_running_phase(PR, SHA, "critique_round", cost_usd_so_far=1.1)
+        storage.mark_ready(PR, SHA, {"verdict": "approve_candidate"})
+
+        events = _index_events(briefs_dir)
+        event_types = [e["event"] for e in events]
+        assert event_types == ["queued", "running", "running_phase", "ready"]
+        for event in events:
+            assert "timestamp" in event
+            assert event["pr_number"] == PR
+
+    def test_append_only_across_calls(self, briefs_dir):
+        storage.append_index_event(PR, SHA, "custom_event", {"note": "one"})
+        storage.append_index_event(PR, SHA, "custom_event", {"note": "two"})
+        events = _index_events(briefs_dir)
+        assert [e["note"] for e in events] == ["one", "two"]


### PR DESCRIPTION
**Design:** [`docs/plans/2026-04-20-pdb-brief-generation-mode3-design.md`](https://github.com/synaptent/aragora/blob/main/docs/plans/2026-04-20-pdb-brief-generation-mode3-design.md)

First of four PRs implementing Mode 3 (on-demand) PR brief generation. This PR is **storage + state machine only** — no execution, no endpoints, no UI, no budget enforcement, no panel config.

## New files

- \`aragora/pdb/__init__.py\` — package doc + public re-exports
- \`aragora/pdb/brief_state.py\` — \`BriefLifecycleState\` enum (absent/queued/running/ready/failed/stale) + validated transition table. Pure types, no I/O.
- \`aragora/pdb/storage.py\` — flat-file storage under \`.aragora/review-queue/briefs/\` with atomic writes via \`os.replace()\`. Public API covers \`get_state\`, \`load_ready_brief\`, \`queue_generation\`, \`mark_running\`, \`write_running_phase\`, \`mark_ready\`, \`mark_failed\`, \`invalidate_if_head_changed\`, \`cancel_generation\`, and \`append_index_event\`.

## Refactor (pure — no behavior change)

- \`aragora/server/handlers/review_queue.py\`: \`_load_brief\` now delegates to \`storage.load_latest_ready_brief()\`. Response shape unchanged. All existing \`test_review_queue.py\` tests pass **unmodified**.

## New tests

- \`tests/pdb/test_brief_state.py\` (47 cases) — enumerates every legal transition; exhaustively asserts every illegal pair (including self-transitions) raises \`StateTransitionError\`.
- \`tests/pdb/test_storage.py\` (35 cases) — verifies \`get_state\` across all six on-disk layouts, each lifecycle transition, stale detection, cancel semantics, index.jsonl append behavior, and atomicity under simulated interrupt.

## State machine transition table

| From → To | Legal? | Notes |
|-----------|--------|-------|
| absent → queued | ✅ | queue_generation |
| queued → running | ✅ | mark_running |
| queued → failed | ✅ | mark_failed (cancelled before pickup) |
| queued → absent | ✅ | cancel_generation |
| running → ready | ✅ | mark_ready |
| running → failed | ✅ | mark_failed |
| running → absent | ✅ | cancel_generation |
| ready → stale | ✅ | invalidate_if_head_changed |
| failed → queued | ✅ | retry; clears failed record |
| stale → queued | ✅ | regenerate at new SHA |
| self → self | ❌ | always rejected |
| anything else | ❌ | raises \`StateTransitionError\` |

## Non-goals (explicitly deferred)

- **PR 2:** \`panel_config.py\`, \`pdb_panel.yaml\`, \`budget.py\`, \`PRReviewProtocol.run()\` — lands when model calls actually happen
- **PR 3:** \`POST /brief/generate\`, \`GET /brief/state\`, \`DELETE /brief/generate\` endpoints; in-process \`BriefGenerationWorker\`
- **PR 4:** UI wiring (\`BriefPanel\`, \`ApproveDecisionModal\`, \`ReviewQueueCard\` pulse animation, \`useReviewQueue\` hook additions)
- **Feature flag** \`ARAGORA_PDB_BRIEF_GENERATION_ENABLED\` — not added here because nothing user-visible is gated by this PR

## Test counts

- 47 state machine tests
- 35 storage tests
- 26 existing review-queue handler tests (unchanged, still pass)
- **108 total** — all green

## Validation

\`\`\`
$ pytest tests/pdb/ tests/server/handlers/test_review_queue.py -q
108 passed in 3.85s

$ ruff check aragora/pdb/ tests/pdb/ aragora/server/handlers/review_queue.py
All checks passed!

$ python3 -m mypy aragora/pdb/ --config-file=pyproject.toml --ignore-missing-imports
Success: no issues found in 3 source files

$ bash scripts/automation_pr_preflight.sh origin/main HEAD
preflight: ok
\`\`\`

## mypy-baseline note

The pre-push \`mypy-baseline\` hook reported ~332 new + ~445 fixed errors relative to \`.mypy-baseline\`, but targeted mypy on the files in this PR (\`aragora/pdb/\`, \`aragora/server/handlers/review_queue.py\`) reports **zero issues**. The baseline delta is pre-existing main-branch drift unrelated to this change — verified by running the same hook against \`origin/main\`. Pushed with \`SKIP=mypy-baseline\` per the mission's guidance; the baseline should be refreshed separately.

## Next up

**PR 2 — \`codex/pdb-mode3-executor\`:** Protocol B executor + panel config + budget enforcement. That's the first PR where model calls actually happen.