### PR TITLE
[DIC-16] CruxReceipt — signed receipt artifact for crux-finder runs

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -2,6 +2,8 @@
 
 Exposes:
 - DIC-14: executable claim verification (:class:`ClaimVerifier`)
+- DIC-16: signed CruxReceipt for crux-finder debate runs
+  (:class:`CruxEntry`, :class:`CruxReceipt`, :func:`build_crux_receipt`)
 - DIC-17: follow-up-issue bridge for load-bearing cruxes and
   sharply-losing claims (:class:`FollowupProposal`,
   :func:`propose_followup_for_crux`, :func:`propose_followup_for_cruxset`,
@@ -30,6 +32,13 @@ from .coherence import (
     from_belief_node,
     scan_coherence,
 )
+from .crux_receipt import (
+    CruxEntry,
+    CruxReceipt,
+    build_crux_receipt,
+    crux_receipt_enabled,
+    enable_crux_receipt,
+)
 from .decay_monitor import DecayReason, DecaySignal, evaluate_unit
 from .followup import (
     DEFAULT_CRUX_LOAD_BEARING_THRESHOLD,
@@ -47,13 +56,18 @@ __all__ = [
     "ClaimVerifier",
     "CoherenceIssue",
     "CoherenceReport",
+    "CruxEntry",
+    "CruxReceipt",
     "DEFAULT_CRUX_LOAD_BEARING_THRESHOLD",
     "DEFAULT_DELTA_LOSS_THRESHOLD",
     "DecayReason",
     "DecaySignal",
     "FollowupProposal",
     "IncoherenceKind",
+    "build_crux_receipt",
     "coherence_monitor_enabled",
+    "crux_receipt_enabled",
+    "enable_crux_receipt",
     "enable_epistemic_followup",
     "epistemic_followup_enabled",
     "evaluate_unit",

--- a/aragora/epistemic/crux_receipt.py
+++ b/aragora/epistemic/crux_receipt.py
@@ -1,0 +1,145 @@
+"""Signed CruxReceipt for crux-finder debate runs (DIC-16 / #6026).
+
+Converts a :class:`~aragora.debate.crux_mode.CruxFinderResult` into a
+SHA-256-attested receipt where load-bearing cruxes are the headline.
+Flag: ``ARAGORA_CRUX_RECEIPT_ENABLED`` (default False).
+Construction is always safe; the flag gates downstream actions only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aragora.debate.crux_mode import CruxFinderResult
+
+
+def crux_receipt_enabled() -> bool:
+    """Return True if callers may act on CruxReceipt outputs."""
+    raw = str(os.environ.get("ARAGORA_CRUX_RECEIPT_ENABLED") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_crux_receipt() -> None:
+    """Enable DIC-16 receipt actions for the current process."""
+    os.environ["ARAGORA_CRUX_RECEIPT_ENABLED"] = "1"
+
+
+@dataclass(frozen=True)
+class CruxEntry:
+    """One load-bearing disagreement from a crux-finder run.
+
+    Field names align with DIC-13 claim manifests and
+    :class:`~aragora.epistemic.proof_unit.ProofCarryingCodeUnit`.
+    """
+
+    crux_id: str
+    statement: str
+    load_bearing_score: float
+    uncertainty_score: float
+    contesting_agents: list[str]
+    affected_claims: list[str]
+    resolution_impact: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "crux_id": self.crux_id,
+            "statement": self.statement,
+            "load_bearing_score": round(self.load_bearing_score, 4),
+            "uncertainty_score": round(self.uncertainty_score, 4),
+            "contesting_agents": list(self.contesting_agents),
+            "affected_claims": list(self.affected_claims),
+            "resolution_impact": round(self.resolution_impact, 4),
+        }
+
+
+@dataclass(frozen=True)
+class CruxReceipt:
+    """Signed receipt for a crux-finder debate run.
+
+    ``checksum`` is a 64-char SHA-256 hex digest over ``receipt_id``,
+    ``debate_id``, ``question``, ``cruxes``, ``convergence_barrier`` —
+    same convention as the quarantine_policy and repair DIC modules.
+    """
+
+    receipt_id: str
+    debate_id: str
+    question: str
+    cruxes: list[CruxEntry]
+    convergence_barrier: float
+    counterfactuals: list[dict[str, Any]]
+    agents: list[str]
+    rounds: int
+    metadata: dict[str, Any]
+    checksum: str  # 64-char lowercase SHA-256 hex
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "receipt_id": self.receipt_id,
+            "debate_id": self.debate_id,
+            "question": self.question,
+            "cruxes": [c.to_dict() for c in self.cruxes],
+            "convergence_barrier": round(self.convergence_barrier, 4),
+            "counterfactuals": list(self.counterfactuals),
+            "agents": list(self.agents),
+            "rounds": self.rounds,
+            "metadata": dict(self.metadata),
+            "checksum": self.checksum,
+        }
+
+
+def build_crux_receipt(result: "CruxFinderResult") -> CruxReceipt:
+    """Build a signed CruxReceipt from a CruxFinderResult.
+
+    Construction is always safe; callers acting on the receipt must check
+    :func:`crux_receipt_enabled` themselves.
+    """
+    receipt_id = "crux_rcpt_" + uuid.uuid4().hex[:16]
+    cruxes = [
+        CruxEntry(
+            crux_id=c.claim_id,
+            statement=c.statement,
+            load_bearing_score=c.crux_score,
+            uncertainty_score=c.uncertainty_score,
+            contesting_agents=list(c.contesting_agents),
+            affected_claims=list(c.affected_claims),
+            resolution_impact=c.resolution_impact,
+        )
+        for c in result.top_cruxes()
+    ]
+    content: dict[str, Any] = {
+        "receipt_id": receipt_id,
+        "debate_id": result.debate_id,
+        "question": result.question,
+        "cruxes": [c.to_dict() for c in cruxes],
+        "convergence_barrier": round(result.convergence_barrier(), 4),
+    }
+    checksum = hashlib.sha256(
+        json.dumps(content, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return CruxReceipt(
+        receipt_id=receipt_id,
+        debate_id=result.debate_id,
+        question=result.question,
+        cruxes=cruxes,
+        convergence_barrier=result.convergence_barrier(),
+        counterfactuals=list(result.counterfactuals),
+        agents=list(result.agents),
+        rounds=result.rounds,
+        metadata=dict(result.metadata),
+        checksum=checksum,
+    )
+
+
+__all__ = [
+    "CruxEntry",
+    "CruxReceipt",
+    "build_crux_receipt",
+    "crux_receipt_enabled",
+    "enable_crux_receipt",
+]

--- a/tests/epistemic/test_crux_receipt.py
+++ b/tests/epistemic/test_crux_receipt.py
@@ -1,0 +1,138 @@
+"""Tests for DIC-16 CruxReceipt (aragora/epistemic/crux_receipt.py)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from aragora.epistemic.crux_receipt import (
+    CruxEntry,
+    CruxReceipt,
+    build_crux_receipt,
+    crux_receipt_enabled,
+    enable_crux_receipt,
+)
+
+
+@dataclass
+class _Claim:
+    claim_id: str
+    statement: str
+    crux_score: float
+    uncertainty_score: float
+    contesting_agents: list[str]
+    affected_claims: list[str]
+    resolution_impact: float
+
+
+@dataclass
+class _Result:
+    debate_id: str
+    question: str
+    _cruxes: list[_Claim]
+    _barrier: float
+    counterfactuals: list[dict[str, Any]] = field(default_factory=list)
+    agents: list[str] = field(default_factory=list)
+    rounds: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def top_cruxes(self) -> list[_Claim]:
+        return self._cruxes
+
+    def convergence_barrier(self) -> float:
+        return self._barrier
+
+
+_S = [(0.8, 0.60, 0.40), (0.7, 0.55, 0.35), (0.6, 0.50, 0.30)]
+
+
+def _r(n: int = 2) -> _Result:
+    return _Result(
+        debate_id="d_x", question="Expand now?",
+        _cruxes=[
+            _Claim(f"c{i}", f"s{i}", _S[i][0], _S[i][1], ["ag_a"], [f"dep{i}"], _S[i][2])
+            for i in range(n)
+        ],
+        _barrier=0.73, agents=["ag_a", "ag_b"], rounds=3, metadata={"mode": "crux_finder"},
+    )
+
+
+def test_flag_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ARAGORA_CRUX_RECEIPT_ENABLED", raising=False)
+    assert crux_receipt_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_flag_on(monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+    monkeypatch.setenv("ARAGORA_CRUX_RECEIPT_ENABLED", val)
+    assert crux_receipt_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", ""])
+def test_flag_off_falsy(monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+    monkeypatch.setenv("ARAGORA_CRUX_RECEIPT_ENABLED", val)
+    assert crux_receipt_enabled() is False
+
+
+def test_enable_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ARAGORA_CRUX_RECEIPT_ENABLED", raising=False)
+    enable_crux_receipt()
+    assert crux_receipt_enabled() is True
+
+
+def test_crux_entry_to_dict_rounds_scores() -> None:
+    e = CruxEntry("x", "s", 0.123456789, 0.9, [], [], 0.333333)
+    d = e.to_dict()
+    assert d["load_bearing_score"] == round(0.123456789, 4)
+    assert d["resolution_impact"] == round(0.333333, 4)
+
+
+def test_receipt_fields_match_result() -> None:
+    rc = build_crux_receipt(_r(n=2))
+    assert rc.debate_id == "d_x"
+    assert len(rc.cruxes) == 2
+    assert rc.cruxes[0].crux_id == "c0"
+    assert rc.rounds == 3
+    assert rc.convergence_barrier == pytest.approx(0.73)
+    assert rc.receipt_id.startswith("crux_rcpt_")
+
+
+def test_empty_cruxes() -> None:
+    rc = build_crux_receipt(_r(n=0))
+    assert rc.cruxes == []
+    assert len(rc.checksum) == 64
+
+
+def test_checksum_64_char_hex() -> None:
+    rc = build_crux_receipt(_r())
+    assert len(rc.checksum) == 64
+    assert all(c in "0123456789abcdef" for c in rc.checksum)
+
+
+def test_two_builds_have_different_checksums() -> None:
+    r = _r()
+    ra, rb = build_crux_receipt(r), build_crux_receipt(r)
+    assert ra.receipt_id != rb.receipt_id
+    assert ra.checksum != rb.checksum
+    assert ra.cruxes == rb.cruxes
+
+
+def test_to_dict_json_serializable() -> None:
+    rc = build_crux_receipt(_r())
+    data = json.loads(json.dumps(rc.to_dict()))
+    assert data["debate_id"] == rc.debate_id
+    assert len(data["checksum"]) == 64
+
+
+def test_load_bearing_score_maps_from_crux_score() -> None:
+    rc = build_crux_receipt(_r(n=1))
+    assert rc.cruxes[0].load_bearing_score == pytest.approx(0.8)
+
+
+def test_metadata_pass_through() -> None:
+    r = _r()
+    r.metadata = {"mode": "crux_finder", "tag": 42}
+    assert build_crux_receipt(r).metadata["tag"] == 42

--- a/tests/epistemic/test_crux_receipt.py
+++ b/tests/epistemic/test_crux_receipt.py
@@ -51,12 +51,16 @@ _S = [(0.8, 0.60, 0.40), (0.7, 0.55, 0.35), (0.6, 0.50, 0.30)]
 
 def _r(n: int = 2) -> _Result:
     return _Result(
-        debate_id="d_x", question="Expand now?",
+        debate_id="d_x",
+        question="Expand now?",
         _cruxes=[
             _Claim(f"c{i}", f"s{i}", _S[i][0], _S[i][1], ["ag_a"], [f"dep{i}"], _S[i][2])
             for i in range(n)
         ],
-        _barrier=0.73, agents=["ag_a", "ag_b"], rounds=3, metadata={"mode": "crux_finder"},
+        _barrier=0.73,
+        agents=["ag_a", "ag_b"],
+        rounds=3,
+        metadata={"mode": "crux_finder"},
     )
 
 


### PR DESCRIPTION
## Slice

Adds `aragora/epistemic/crux_receipt.py` (DIC-16): converts a
`CruxFinderResult` (already on `main` via `aragora/debate/crux_mode.py`)
into a self-contained, SHA-256-attested receipt where load-bearing cruxes
are the headline deliverable. Two new types — `CruxEntry` (one disagreement)
and `CruxReceipt` (signed receipt) — plus a `build_crux_receipt()` builder.
Exported from `aragora/epistemic/__init__.py` alongside the other DIC modules.

## Gating

- Default: **OFF** (flag: `ARAGORA_CRUX_RECEIPT_ENABLED`; construction of
  `CruxReceipt` objects is always safe — the flag gates downstream actions
  such as KM writes and follow-up filing)
- Live queue effect: **none** — `build_crux_receipt` is a pure builder; no
  issue creation, no queue mutation, no dispatch changes
- Advances issue: #6026 (DIC-16 — CruxReceipt and Knowledge Mound provenance)

## Tests

- `tests/epistemic/test_crux_receipt.py` — 18 cases (expands to 18 via
  parametrize) covering:
  - Flag gate: off by default; `"1"`, `"true"`, `"yes"`, `"on"` enable it;
    `"0"`, `"false"`, `"no"`, `""` keep it off; `enable_crux_receipt()`
    helper sets it
  - `CruxEntry.to_dict()` rounds float scores to 4 decimal places
  - `build_crux_receipt` fields match source `CruxFinderResult` (debate_id,
    crux count, crux_id, rounds, convergence_barrier)
  - `receipt_id` carries `"crux_rcpt_"` prefix
  - Empty-crux run still emits a valid 64-char checksum
  - Checksum is 64-char lowercase SHA-256 hex
  - Two builds from the same result have different receipt IDs and checksums
    but identical crux content
  - `to_dict()` output is JSON-serializable
  - `load_bearing_score` maps from `CruxClaim.crux_score`
  - Metadata pass-through

## Validation

- `pytest tests/epistemic/test_crux_receipt.py --noconftest` — **18 passed**
- `ruff check aragora/epistemic/crux_receipt.py tests/epistemic/test_crux_receipt.py aragora/epistemic/__init__.py` — **clean**
- `mypy aragora/epistemic/crux_receipt.py aragora/epistemic/__init__.py --ignore-missing-imports` — **clean**
- Net diff: **297 LOC** (145 module + 138 tests + 14 `__init__.py`)

## Out of scope

- `CruxEntry.from_dict` / `CruxReceipt.from_dict` — deserialization path
  for KM ingestion; deferred to the next DIC-16 follow-on slice
- KM write path — wiring `CruxReceipt` into the `receipt_adapter` or
  `belief_adapter`; gated on `ARAGORA_CRUX_RECEIPT_ENABLED` being true and
  the proof-first Foreman gate opening for the DIC tranche
- `aragora crux` CLI verb — planned in the crux-mode design doc as a
  separate deliverable after the receipt shape stabilises
- Any live routing, dispatch, or Arena wiring change