### PR TITLE
[#6306] feat(review): BriefBuilder — deterministic ReviewBrief assembly

### DIFF
--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -9,6 +9,11 @@ Design brief: docs/plans/2026-04-19-pr-intelligence-brief.md
 Tracking: #6306
 """
 
+from aragora.review.builder import (
+    PanelVote,
+    build_brief,
+    compute_packet_sha,
+)
 from aragora.review.protocol import (
     ADVISORY_NOTE,
     DissentingView,
@@ -66,6 +71,7 @@ __all__ = [
     "ProviderSlotDefinition",
     "ProviderSlotResolution",
     "ProviderSlotResolver",
+    "PanelVote",
     "Recommendation",
     "ReviewBrief",
     "ReviewBudget",
@@ -81,4 +87,6 @@ __all__ = [
     "ValidationKind",
     "ValidationRef",
     "ValidationResult",
+    "build_brief",
+    "compute_packet_sha",
 ]

--- a/aragora/review/builder.py
+++ b/aragora/review/builder.py
@@ -1,0 +1,244 @@
+"""BriefBuilder — deterministic ReviewBrief assembly from panel votes.
+
+Pure-function synthesis layer between agent outputs and the ``ReviewBrief``
+schema in ``aragora.review.protocol``. The caller (a successor PR's panel
+orchestrator) hands in a tuple of ``PanelVote`` values, and BriefBuilder
+produces a ``ReviewBrief`` deterministic in its inputs (same votes +
+binding → same packet_sha).
+
+Scope (#6306): closes the explicit-dissent + confidence-emission gap by
+routing each ``SynthesisPolicy`` to a deterministic recommendation,
+populating ``DissentingView`` for any vote whose position differs from
+the brief's recommendation, and computing both ``overall_confidence``
+and ``disagreement_score`` from the panel itself.
+
+Out of scope (deliberate, per #6306 sequencing):
+  - agent invocation, debate engine wiring (orchestrator successor PR)
+  - cost/budget enforcement (#6305 layer)
+  - receipt/evidence extension (#6307 layer)
+  - converting metadata-heuristic ``PRReviewProtocolPacket`` into a
+    ``ReviewBrief`` — those shapes are not lossless and should not
+    masquerade as real heterogeneous briefs.
+
+Determinism contract: same ``votes`` (in order) + same binding fields +
+same ``synthesis_policy`` + same ``generated_at`` ⇒ same ``packet_sha``.
+The caller is responsible for fixing ``generated_at``; the builder does
+not call ``datetime.now()``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from aragora.review.protocol import (
+    DissentingView,
+    DissentPosition,
+    Recommendation,
+    ReviewBrief,
+    ReviewRole,
+    RoleFinding,
+    SynthesisPolicy,
+)
+
+# Position → Recommendation mapping (canonical, stable across the codebase).
+#
+# Identical mapping the queue layer assumes when surfacing
+# packet recommendations, so a brief and a packet for the same PR never
+# disagree on what an APPROVE position implies.
+_POSITION_TO_RECOMMENDATION: dict[DissentPosition, Recommendation] = {
+    DissentPosition.APPROVE: Recommendation.APPROVE_CANDIDATE,
+    DissentPosition.REQUEST_CHANGES: Recommendation.REPAIR_FIRST,
+    DissentPosition.DEFER: Recommendation.NEEDS_HUMAN_ATTENTION,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PanelVote:
+    """One panel member's complete contribution to a brief.
+
+    Bundles the per-role finding (which becomes a row in
+    ``ReviewBrief.role_findings``) with the agent's vote (used for
+    synthesis + dissent emission).
+
+    ``reason`` is required even on majority votes so the builder can
+    construct a ``DissentingView`` later if the synthesis policy ends up
+    treating this vote as dissenting (e.g., a high-confidence APPROVE
+    that loses to a higher-confidence REQUEST_CHANGES under WEIGHTED).
+    """
+
+    finding: RoleFinding
+    position: DissentPosition
+    reason: str
+
+
+def build_brief(
+    *,
+    votes: Iterable[PanelVote],
+    pr_number: int,
+    repo: str,
+    head_sha: str,
+    base_sha: str,
+    top_line: str,
+    validation_summary: str,
+    generated_at: str,
+    synthesis_policy: SynthesisPolicy,
+    total_cost_usd: float = 0.0,
+    total_wall_clock_ms: int = 0,
+) -> ReviewBrief:
+    """Build a deterministic ReviewBrief from panel votes.
+
+    Pure function. Same inputs → same ``packet_sha``. The caller is
+    responsible for ensuring the votes come from a real heterogeneous
+    panel; this layer does not enforce heterogeneity (lives in the
+    orchestrator successor PR).
+
+    Raises:
+      ValueError: if ``votes`` is empty.
+      ValueError: if ``synthesis_policy`` is ``SYNTHESIZER_AGENT`` and
+        the panel does not contain exactly one ``ReviewRole.SYNTHESIZER``.
+    """
+    votes_tuple = tuple(votes)
+    if not votes_tuple:
+        raise ValueError("votes must be non-empty")
+
+    recommendation = _resolve_recommendation(votes_tuple, synthesis_policy)
+    dissent = _build_dissent(votes_tuple, recommendation)
+    overall_confidence = _aggregate_confidence(votes_tuple)
+    disagreement_score = _disagreement_score(votes_tuple)
+    role_findings = tuple(v.finding for v in votes_tuple)
+    agent_roster = tuple(v.finding.agent for v in votes_tuple)
+
+    def _make(packet_sha: str) -> ReviewBrief:
+        return ReviewBrief(
+            pr_number=pr_number,
+            repo=repo,
+            head_sha=head_sha,
+            base_sha=base_sha,
+            packet_sha=packet_sha,
+            recommendation=recommendation,
+            top_line=top_line,
+            role_findings=role_findings,
+            dissent=dissent,
+            validation_summary=validation_summary,
+            overall_confidence=overall_confidence,
+            disagreement_score=disagreement_score,
+            total_cost_usd=total_cost_usd,
+            total_wall_clock_ms=total_wall_clock_ms,
+            agent_roster=agent_roster,
+            generated_at=generated_at,
+        )
+
+    return _make(compute_packet_sha(_make("")))
+
+
+def compute_packet_sha(brief: ReviewBrief) -> str:
+    """Deterministic SHA-256 over the brief content, excluding ``packet_sha``.
+
+    Implements the preimage rule documented in
+    ``aragora.review.protocol.ReviewBrief``: serialize ``to_dict()``
+    minus the ``"packet_sha"`` key as canonical JSON
+    (``sort_keys=True``, no whitespace, ensure_ascii=False), UTF-8
+    encode, hash with SHA-256, return hex.
+    """
+    payload = brief.to_dict()
+    payload.pop("packet_sha", None)
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _resolve_recommendation(
+    votes: tuple[PanelVote, ...],
+    policy: SynthesisPolicy,
+) -> Recommendation:
+    if policy is SynthesisPolicy.MAJORITY:
+        return _majority(votes)
+    if policy is SynthesisPolicy.WEIGHTED:
+        return _weighted(votes)
+    if policy is SynthesisPolicy.SYNTHESIZER_AGENT:
+        return _synthesizer(votes)
+    if policy is SynthesisPolicy.UNANIMOUS_OR_ESCALATE:
+        return _unanimous(votes)
+    raise ValueError(f"unsupported synthesis policy: {policy!r}")
+
+
+def _majority(votes: tuple[PanelVote, ...]) -> Recommendation:
+    counts: dict[DissentPosition, int] = {}
+    for v in votes:
+        counts[v.position] = counts.get(v.position, 0) + 1
+    return _winner_or_escalate(counts)
+
+
+def _weighted(votes: tuple[PanelVote, ...]) -> Recommendation:
+    weights: dict[DissentPosition, float] = {}
+    for v in votes:
+        weights[v.position] = weights.get(v.position, 0.0) + max(0.0, v.finding.confidence)
+    return _winner_or_escalate(weights)
+
+
+def _synthesizer(votes: tuple[PanelVote, ...]) -> Recommendation:
+    synthesizers = [v for v in votes if v.finding.role is ReviewRole.SYNTHESIZER]
+    if len(synthesizers) != 1:
+        raise ValueError(
+            "SynthesisPolicy.SYNTHESIZER_AGENT requires exactly one panel "
+            f"member with role=ReviewRole.SYNTHESIZER; got {len(synthesizers)}"
+        )
+    return _POSITION_TO_RECOMMENDATION[synthesizers[0].position]
+
+
+def _unanimous(votes: tuple[PanelVote, ...]) -> Recommendation:
+    positions = {v.position for v in votes}
+    if len(positions) == 1:
+        return _POSITION_TO_RECOMMENDATION[positions.pop()]
+    return Recommendation.NEEDS_HUMAN_ATTENTION
+
+
+def _winner_or_escalate(scores: Mapping[DissentPosition, float]) -> Recommendation:
+    """Pick the highest-scored position, or escalate on a tie."""
+    if not scores:
+        return Recommendation.NEEDS_HUMAN_ATTENTION
+    top_score = max(scores.values())
+    winners = [p for p, s in scores.items() if s == top_score]
+    if len(winners) > 1:
+        return Recommendation.NEEDS_HUMAN_ATTENTION
+    return _POSITION_TO_RECOMMENDATION[winners[0]]
+
+
+def _build_dissent(
+    votes: tuple[PanelVote, ...],
+    recommendation: Recommendation,
+) -> tuple[DissentingView, ...]:
+    """Any vote whose position doesn't map to the brief recommendation."""
+    return tuple(
+        DissentingView(
+            agent=v.finding.agent,
+            position=v.position,
+            reason=v.reason,
+            role=v.finding.role,
+        )
+        for v in votes
+        if _POSITION_TO_RECOMMENDATION[v.position] is not recommendation
+    )
+
+
+def _aggregate_confidence(votes: tuple[PanelVote, ...]) -> float:
+    return sum(v.finding.confidence for v in votes) / len(votes)
+
+
+def _disagreement_score(votes: tuple[PanelVote, ...]) -> float:
+    """1 - (largest position-share fraction).
+
+    0.0 if every panel member votes the same; approaches 1.0 as the
+    panel splits more evenly across positions.
+    """
+    counts: dict[DissentPosition, int] = {}
+    for v in votes:
+        counts[v.position] = counts.get(v.position, 0) + 1
+    return round(1.0 - (max(counts.values()) / len(votes)), 4)

--- a/aragora/review/builder.py
+++ b/aragora/review/builder.py
@@ -188,10 +188,21 @@ def _majority(votes: tuple[PanelVote, ...]) -> Recommendation:
     return _winner_or_escalate(counts)
 
 
+def _clamp_confidence(value: float) -> float:
+    """Clamp a per-finding confidence into ``[0.0, 1.0]``.
+
+    Used by both ``_weighted`` (for recommendation policy) and
+    ``_aggregate_confidence`` (for the emitted brief), so a malformed
+    upstream confidence value cannot make the recommendation and the
+    brief disagree on what counts as "in range."
+    """
+    return min(1.0, max(0.0, value))
+
+
 def _weighted(votes: tuple[PanelVote, ...]) -> Recommendation:
     weights: dict[DissentPosition, float] = {}
     for v in votes:
-        weights[v.position] = weights.get(v.position, 0.0) + max(0.0, v.finding.confidence)
+        weights[v.position] = weights.get(v.position, 0.0) + _clamp_confidence(v.finding.confidence)
     return _winner_or_escalate(weights)
 
 
@@ -245,10 +256,10 @@ def _aggregate_confidence(votes: tuple[PanelVote, ...]) -> float:
 
     ``ReviewBrief.overall_confidence`` is documented as 0.0..1.0; raw
     means could escape that range if upstream emits malformed values.
-    Per-input clamping mirrors the defensive treatment in ``_weighted``
-    so the recommendation policy and the emitted brief stay consistent.
+    Shares ``_clamp_confidence`` with ``_weighted`` so the recommendation
+    policy and the emitted brief use the same definition of "in range."
     """
-    return sum(min(1.0, max(0.0, v.finding.confidence)) for v in votes) / len(votes)
+    return sum(_clamp_confidence(v.finding.confidence) for v in votes) / len(votes)
 
 
 def _validate_output_role_coverage(

--- a/aragora/review/builder.py
+++ b/aragora/review/builder.py
@@ -85,6 +85,7 @@ def build_brief(
     validation_summary: str,
     generated_at: str,
     synthesis_policy: SynthesisPolicy,
+    output_roles: tuple[ReviewRole, ...] | None = None,
     total_cost_usd: float = 0.0,
     total_wall_clock_ms: int = 0,
 ) -> ReviewBrief:
@@ -95,14 +96,25 @@ def build_brief(
     panel; this layer does not enforce heterogeneity (lives in the
     orchestrator successor PR).
 
+    ``output_roles`` enforces ``PRReviewProtocol.output_roles`` coverage
+    when provided: each declared role MUST appear in exactly one vote.
+    Panel members carrying roles NOT in ``output_roles`` (e.g., a
+    ``SYNTHESIZER`` panelist used by ``SYNTHESIZER_AGENT`` policy) are
+    permitted as extras and still appear in ``role_findings``. Pass
+    ``None`` (default) to skip the coverage check.
+
     Raises:
       ValueError: if ``votes`` is empty.
       ValueError: if ``synthesis_policy`` is ``SYNTHESIZER_AGENT`` and
         the panel does not contain exactly one ``ReviewRole.SYNTHESIZER``.
+      ValueError: if ``output_roles`` is provided and any declared role
+        is missing or appears in more than one vote.
     """
     votes_tuple = tuple(votes)
     if not votes_tuple:
         raise ValueError("votes must be non-empty")
+    if output_roles is not None:
+        _validate_output_role_coverage(votes_tuple, output_roles)
 
     recommendation = _resolve_recommendation(votes_tuple, synthesis_policy)
     dissent = _build_dissent(votes_tuple, recommendation)
@@ -229,7 +241,38 @@ def _build_dissent(
 
 
 def _aggregate_confidence(votes: tuple[PanelVote, ...]) -> float:
-    return sum(v.finding.confidence for v in votes) / len(votes)
+    """Mean of per-finding confidence, clamped per-input to [0.0, 1.0].
+
+    ``ReviewBrief.overall_confidence`` is documented as 0.0..1.0; raw
+    means could escape that range if upstream emits malformed values.
+    Per-input clamping mirrors the defensive treatment in ``_weighted``
+    so the recommendation policy and the emitted brief stay consistent.
+    """
+    return sum(min(1.0, max(0.0, v.finding.confidence)) for v in votes) / len(votes)
+
+
+def _validate_output_role_coverage(
+    votes: tuple[PanelVote, ...],
+    output_roles: tuple[ReviewRole, ...],
+) -> None:
+    """Enforce ``PRReviewProtocol.output_roles``: one finding per declared role.
+
+    Per the protocol docstring, a brief MUST cover every declared role
+    exactly once. Missing → non-conformant; duplicated → ambiguous which
+    finding to render in the role section.
+    """
+    counts: dict[ReviewRole, int] = {}
+    for v in votes:
+        counts[v.finding.role] = counts.get(v.finding.role, 0) + 1
+    missing = [r for r in output_roles if counts.get(r, 0) == 0]
+    duplicated = [r for r in output_roles if counts.get(r, 0) > 1]
+    if missing or duplicated:
+        parts = []
+        if missing:
+            parts.append(f"missing roles: {[r.value for r in missing]}")
+        if duplicated:
+            parts.append(f"duplicated roles: {[r.value for r in duplicated]}")
+        raise ValueError("PRReviewProtocol.output_roles coverage violated — " + "; ".join(parts))
 
 
 def _disagreement_score(votes: tuple[PanelVote, ...]) -> float:

--- a/tests/review/test_builder.py
+++ b/tests/review/test_builder.py
@@ -196,6 +196,29 @@ class TestWeightedPolicy:
         brief = _build(votes, policy=SynthesisPolicy.WEIGHTED)
         assert brief.recommendation is Recommendation.APPROVE_CANDIDATE
 
+    def test_above_one_confidence_is_capped_so_cannot_overpower_in_range_vote(self) -> None:
+        # Codex C rev 1 finding P2: _weighted previously only clamped the
+        # lower bound, so a 1.5 confidence vote could overpower a 1.0
+        # opposite vote — inconsistent with the brief's [0,1] clamping.
+        # With per-input clamping in place, both votes now compete at 1.0
+        # weight and the tie escalates to NEEDS_HUMAN_ATTENTION.
+        votes = [
+            _vote(
+                role=ReviewRole.LOGIC,
+                agent="a1",
+                position=DissentPosition.APPROVE,
+                confidence=1.5,
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.REQUEST_CHANGES,
+                confidence=1.0,
+            ),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.WEIGHTED)
+        assert brief.recommendation is Recommendation.NEEDS_HUMAN_ATTENTION
+
 
 # --- SYNTHESIZER_AGENT policy --------------------------------------------
 

--- a/tests/review/test_builder.py
+++ b/tests/review/test_builder.py
@@ -1,0 +1,417 @@
+"""Tests for aragora.review.builder — deterministic ReviewBrief assembly.
+
+The builder is a pure function that maps panel votes + a synthesis
+policy into a settlement-ready ReviewBrief. These tests pin the
+contract on:
+
+  - per-policy recommendation logic (majority / weighted / synthesizer /
+    unanimous_or_escalate), including ties and escalation
+  - dissent emission (any vote whose position differs from the brief
+    recommendation must appear in DissentingView)
+  - confidence + disagreement aggregation
+  - packet_sha determinism (same inputs ⇒ same SHA; different inputs ⇒
+    different SHA)
+  - input validation (empty panel, malformed synthesizer policy)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.review import (
+    DissentPosition,
+    PanelVote,
+    Recommendation,
+    ReviewBrief,
+    ReviewRole,
+    RoleFinding,
+    SynthesisPolicy,
+    build_brief,
+    compute_packet_sha,
+)
+
+
+# --- helpers -------------------------------------------------------------
+
+
+def _vote(
+    *,
+    role: ReviewRole,
+    agent: str,
+    position: DissentPosition,
+    confidence: float = 0.8,
+    text: str = "",
+    reason: str = "",
+) -> PanelVote:
+    return PanelVote(
+        finding=RoleFinding(
+            role=role,
+            agent=agent,
+            model=f"{agent}-model",
+            confidence=confidence,
+            finding_text=text or f"{role.value} finding",
+            latency_ms=100,
+            cost_usd=0.05,
+        ),
+        position=position,
+        reason=reason or f"{agent} reason",
+    )
+
+
+def _build(
+    votes: list[PanelVote],
+    *,
+    policy: SynthesisPolicy = SynthesisPolicy.MAJORITY,
+    head_sha: str = "deadbeef",
+    base_sha: str = "feedface",
+) -> ReviewBrief:
+    return build_brief(
+        votes=votes,
+        pr_number=6306,
+        repo="synaptent/aragora",
+        head_sha=head_sha,
+        base_sha=base_sha,
+        top_line="One-line top.",
+        validation_summary="checks green",
+        generated_at="2026-04-20T12:00:00+00:00",
+        synthesis_policy=policy,
+    )
+
+
+# --- MAJORITY policy ------------------------------------------------------
+
+
+class TestMajorityPolicy:
+    def test_unanimous_approve_yields_approve_candidate_no_dissent(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.MAINTAINABILITY, agent="a3", position=DissentPosition.APPROVE),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.MAJORITY)
+        assert brief.recommendation is Recommendation.APPROVE_CANDIDATE
+        assert brief.dissent == ()
+
+    def test_plurality_wins_with_dissent_for_minority(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.MAINTAINABILITY, agent="a3", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SKEPTIC, agent="a4", position=DissentPosition.REQUEST_CHANGES),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.MAJORITY)
+        assert brief.recommendation is Recommendation.APPROVE_CANDIDATE
+        assert len(brief.dissent) == 1
+        d = brief.dissent[0]
+        assert d.agent == "a4"
+        assert d.position is DissentPosition.REQUEST_CHANGES
+        assert d.role is ReviewRole.SKEPTIC
+
+    def test_tie_escalates_to_needs_human_attention(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+            _vote(
+                role=ReviewRole.MAINTAINABILITY,
+                agent="a3",
+                position=DissentPosition.REQUEST_CHANGES,
+            ),
+            _vote(role=ReviewRole.SKEPTIC, agent="a4", position=DissentPosition.REQUEST_CHANGES),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.MAJORITY)
+        # 2-vs-2 tie → escalation. Both APPROVE and REQUEST_CHANGES voters
+        # disagree with NEEDS_HUMAN_ATTENTION, so all four are dissent
+        # — that's the operator-visible signal that the panel split.
+        assert brief.recommendation is Recommendation.NEEDS_HUMAN_ATTENTION
+        assert len(brief.dissent) == 4
+
+
+# --- WEIGHTED policy ------------------------------------------------------
+
+
+class TestWeightedPolicy:
+    def test_high_confidence_minority_overrides_low_confidence_majority(self) -> None:
+        # Three low-confidence APPROVE votes (sum 0.3) vs. one
+        # high-confidence REQUEST_CHANGES (0.95): WEIGHTED chooses the
+        # heavier side, so the brief recommends REPAIR_FIRST and the
+        # three APPROVE voters become dissent.
+        votes = [
+            _vote(
+                role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE, confidence=0.1
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.APPROVE,
+                confidence=0.1,
+            ),
+            _vote(
+                role=ReviewRole.MAINTAINABILITY,
+                agent="a3",
+                position=DissentPosition.APPROVE,
+                confidence=0.1,
+            ),
+            _vote(
+                role=ReviewRole.SKEPTIC,
+                agent="a4",
+                position=DissentPosition.REQUEST_CHANGES,
+                confidence=0.95,
+            ),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.WEIGHTED)
+        assert brief.recommendation is Recommendation.REPAIR_FIRST
+        assert len(brief.dissent) == 3
+        assert {d.agent for d in brief.dissent} == {"a1", "a2", "a3"}
+
+    def test_weighted_tie_escalates(self) -> None:
+        votes = [
+            _vote(
+                role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE, confidence=0.5
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.REQUEST_CHANGES,
+                confidence=0.5,
+            ),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.WEIGHTED)
+        assert brief.recommendation is Recommendation.NEEDS_HUMAN_ATTENTION
+
+    def test_negative_confidence_is_clamped_so_does_not_subtract_weight(self) -> None:
+        # Defensive: a buggy upstream that emits negative confidence
+        # must not be able to flip an outcome by subtracting weight from
+        # its own bucket.
+        votes = [
+            _vote(
+                role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE, confidence=-1.0
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.APPROVE,
+                confidence=0.1,
+            ),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.WEIGHTED)
+        assert brief.recommendation is Recommendation.APPROVE_CANDIDATE
+
+
+# --- SYNTHESIZER_AGENT policy --------------------------------------------
+
+
+class TestSynthesizerPolicy:
+    def test_designated_synthesizer_position_wins_regardless_of_others(self) -> None:
+        votes = [
+            _vote(
+                role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE, confidence=0.95
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.APPROVE,
+                confidence=0.95,
+            ),
+            _vote(
+                role=ReviewRole.SYNTHESIZER,
+                agent="syn",
+                position=DissentPosition.DEFER,
+                confidence=0.4,
+            ),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.SYNTHESIZER_AGENT)
+        assert brief.recommendation is Recommendation.NEEDS_HUMAN_ATTENTION
+        # The two APPROVE voters now dissent (they disagree with the
+        # synthesizer-driven NEEDS_HUMAN_ATTENTION recommendation).
+        assert {d.agent for d in brief.dissent} == {"a1", "a2"}
+
+    def test_no_synthesizer_in_panel_raises(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+        ]
+        with pytest.raises(ValueError, match="exactly one panel member"):
+            _build(votes, policy=SynthesisPolicy.SYNTHESIZER_AGENT)
+
+    def test_multiple_synthesizers_raise(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.SYNTHESIZER, agent="s1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SYNTHESIZER, agent="s2", position=DissentPosition.APPROVE),
+        ]
+        with pytest.raises(ValueError, match="exactly one panel member"):
+            _build(votes, policy=SynthesisPolicy.SYNTHESIZER_AGENT)
+
+
+# --- UNANIMOUS_OR_ESCALATE policy ----------------------------------------
+
+
+class TestUnanimousOrEscalatePolicy:
+    def test_unanimous_yields_that_recommendation(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.REQUEST_CHANGES),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.REQUEST_CHANGES),
+            _vote(
+                role=ReviewRole.MAINTAINABILITY,
+                agent="a3",
+                position=DissentPosition.REQUEST_CHANGES,
+            ),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.UNANIMOUS_OR_ESCALATE)
+        assert brief.recommendation is Recommendation.REPAIR_FIRST
+        assert brief.dissent == ()
+
+    def test_any_disagreement_escalates(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.MAINTAINABILITY, agent="a3", position=DissentPosition.DEFER),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.UNANIMOUS_OR_ESCALATE)
+        assert brief.recommendation is Recommendation.NEEDS_HUMAN_ATTENTION
+        # The two APPROVE voters dissent; the DEFER voter aligns with
+        # the NEEDS_HUMAN_ATTENTION recommendation.
+        assert {d.agent for d in brief.dissent} == {"a1", "a2"}
+
+
+# --- aggregation: confidence + disagreement -------------------------------
+
+
+class TestAggregation:
+    def test_overall_confidence_is_arithmetic_mean(self) -> None:
+        votes = [
+            _vote(
+                role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE, confidence=0.8
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.APPROVE,
+                confidence=0.6,
+            ),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.MAJORITY)
+        assert brief.overall_confidence == pytest.approx(0.7)
+
+    def test_disagreement_zero_when_unanimous(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.MAJORITY)
+        assert brief.disagreement_score == 0.0
+
+    def test_disagreement_half_when_split_two_two(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+            _vote(
+                role=ReviewRole.MAINTAINABILITY,
+                agent="a3",
+                position=DissentPosition.REQUEST_CHANGES,
+            ),
+            _vote(role=ReviewRole.SKEPTIC, agent="a4", position=DissentPosition.REQUEST_CHANGES),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.MAJORITY)
+        assert brief.disagreement_score == 0.5
+
+    def test_disagreement_two_thirds_when_three_way_split(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.REQUEST_CHANGES),
+            _vote(role=ReviewRole.MAINTAINABILITY, agent="a3", position=DissentPosition.DEFER),
+        ]
+        brief = _build(votes, policy=SynthesisPolicy.MAJORITY)
+        # Largest faction = 1 of 3 → disagreement = 1 - 1/3 ≈ 0.6667.
+        assert brief.disagreement_score == pytest.approx(2 / 3, abs=1e-4)
+
+
+# --- packet_sha determinism ----------------------------------------------
+
+
+class TestPacketSha:
+    def _stable_votes(self) -> list[PanelVote]:
+        return [
+            _vote(
+                role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE, confidence=0.8
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.APPROVE,
+                confidence=0.7,
+            ),
+        ]
+
+    def test_packet_sha_is_deterministic(self) -> None:
+        b1 = _build(self._stable_votes())
+        b2 = _build(self._stable_votes())
+        assert b1.packet_sha == b2.packet_sha
+        assert len(b1.packet_sha) == 64  # sha256 hex
+
+    def test_packet_sha_changes_when_recommendation_changes(self) -> None:
+        approving = self._stable_votes()
+        rejecting = [
+            _vote(
+                role=ReviewRole.LOGIC,
+                agent="a1",
+                position=DissentPosition.REQUEST_CHANGES,
+                confidence=0.8,
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.REQUEST_CHANGES,
+                confidence=0.7,
+            ),
+        ]
+        assert _build(approving).packet_sha != _build(rejecting).packet_sha
+
+    def test_packet_sha_changes_when_head_sha_changes(self) -> None:
+        # SHA-bound: changing head_sha must produce a different packet_sha
+        # so settlement on a stale head fails the merge_arbiter check.
+        b1 = _build(self._stable_votes(), head_sha="aaa")
+        b2 = _build(self._stable_votes(), head_sha="bbb")
+        assert b1.packet_sha != b2.packet_sha
+
+    def test_packet_sha_excludes_itself_from_preimage(self) -> None:
+        # Re-computing on the brief's own to_dict() (which now contains
+        # packet_sha) must yield the same value the builder set.
+        brief = _build(self._stable_votes())
+        recomputed = compute_packet_sha(brief)
+        assert recomputed == brief.packet_sha
+
+
+# --- ordering + advisory invariants ---------------------------------------
+
+
+class TestStructure:
+    def test_role_findings_and_agent_roster_preserve_input_order(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="zeta", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="alpha", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SKEPTIC, agent="mu", position=DissentPosition.APPROVE),
+        ]
+        brief = _build(votes)
+        assert brief.agent_roster == ("zeta", "alpha", "mu")
+        assert tuple(f.role for f in brief.role_findings) == (
+            ReviewRole.LOGIC,
+            ReviewRole.SECURITY,
+            ReviewRole.SKEPTIC,
+        )
+
+    def test_advisory_only_remains_true(self) -> None:
+        # Brief defaults to advisory_only=True; the builder must not flip
+        # it. This is the safety boundary from the design brief.
+        brief = _build(
+            [_vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE)],
+        )
+        assert brief.advisory_only is True
+
+
+# --- input validation ----------------------------------------------------
+
+
+class TestValidation:
+    def test_empty_votes_raise(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            _build([])

--- a/tests/review/test_builder.py
+++ b/tests/review/test_builder.py
@@ -415,3 +415,180 @@ class TestValidation:
     def test_empty_votes_raise(self) -> None:
         with pytest.raises(ValueError, match="non-empty"):
             _build([])
+
+
+# --- output_roles coverage (codex rev 1 finding P1) ----------------------
+
+
+class TestOutputRoleCoverage:
+    """``output_roles`` enforces ``PRReviewProtocol.output_roles`` contract:
+    each declared role must appear in exactly one vote. Panel members with
+    roles outside ``output_roles`` are tolerated as extras (e.g., a
+    SYNTHESIZER panelist not declared as an output section).
+    """
+
+    def test_default_none_skips_coverage_check(self) -> None:
+        # Backwards-compatible: existing callers that don't pass
+        # output_roles get no enforcement (matches pre-revision behavior).
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+        ]
+        brief = _build(votes)
+        assert brief.recommendation is Recommendation.APPROVE_CANDIDATE
+
+    def test_full_coverage_passes(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.MAINTAINABILITY, agent="a3", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SKEPTIC, agent="a4", position=DissentPosition.APPROVE),
+        ]
+        brief = build_brief(
+            votes=votes,
+            pr_number=6306,
+            repo="synaptent/aragora",
+            head_sha="x",
+            base_sha="y",
+            top_line="",
+            validation_summary="",
+            generated_at="2026-04-20T12:00:00+00:00",
+            synthesis_policy=SynthesisPolicy.MAJORITY,
+            output_roles=(
+                ReviewRole.LOGIC,
+                ReviewRole.SECURITY,
+                ReviewRole.MAINTAINABILITY,
+                ReviewRole.SKEPTIC,
+            ),
+        )
+        assert brief.recommendation is Recommendation.APPROVE_CANDIDATE
+
+    def test_missing_required_role_raises(self) -> None:
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+        ]
+        with pytest.raises(ValueError, match="missing roles.*maintainability_reviewer"):
+            build_brief(
+                votes=votes,
+                pr_number=6306,
+                repo="synaptent/aragora",
+                head_sha="x",
+                base_sha="y",
+                top_line="",
+                validation_summary="",
+                generated_at="2026-04-20T12:00:00+00:00",
+                synthesis_policy=SynthesisPolicy.MAJORITY,
+                output_roles=(
+                    ReviewRole.LOGIC,
+                    ReviewRole.SECURITY,
+                    ReviewRole.MAINTAINABILITY,
+                ),
+            )
+
+    def test_duplicated_required_role_raises(self) -> None:
+        # Two LOGIC votes in the panel; the brief can't decide which one to
+        # render in the LOGIC section.
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.LOGIC, agent="a2", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a3", position=DissentPosition.APPROVE),
+        ]
+        with pytest.raises(ValueError, match="duplicated roles.*logic_reviewer"):
+            build_brief(
+                votes=votes,
+                pr_number=6306,
+                repo="synaptent/aragora",
+                head_sha="x",
+                base_sha="y",
+                top_line="",
+                validation_summary="",
+                generated_at="2026-04-20T12:00:00+00:00",
+                synthesis_policy=SynthesisPolicy.MAJORITY,
+                output_roles=(ReviewRole.LOGIC, ReviewRole.SECURITY),
+            )
+
+    def test_extra_panel_role_tolerated(self) -> None:
+        # SYNTHESIZER is in the panel (e.g., for SYNTHESIZER_AGENT policy)
+        # but NOT in output_roles. Should not raise.
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SYNTHESIZER, agent="syn", position=DissentPosition.APPROVE),
+        ]
+        brief = build_brief(
+            votes=votes,
+            pr_number=6306,
+            repo="synaptent/aragora",
+            head_sha="x",
+            base_sha="y",
+            top_line="",
+            validation_summary="",
+            generated_at="2026-04-20T12:00:00+00:00",
+            synthesis_policy=SynthesisPolicy.SYNTHESIZER_AGENT,
+            output_roles=(ReviewRole.LOGIC, ReviewRole.SECURITY),
+        )
+        assert brief.recommendation is Recommendation.APPROVE_CANDIDATE
+        # The SYNTHESIZER finding still appears in role_findings — extras
+        # are not stripped, only validated against output_roles.
+        assert any(f.role is ReviewRole.SYNTHESIZER for f in brief.role_findings)
+
+
+# --- confidence clamping (codex rev 1 finding P2) ------------------------
+
+
+class TestConfidenceClamping:
+    """``overall_confidence`` is documented as 0.0..1.0. Per-input clamping
+    in ``_aggregate_confidence`` mirrors ``_weighted``'s defensive treatment
+    so the brief stays within contract even if upstream emits malformed
+    confidence values.
+    """
+
+    def test_negative_confidence_clamped_to_zero(self) -> None:
+        votes = [
+            _vote(
+                role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE, confidence=-0.5
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.APPROVE,
+                confidence=0.8,
+            ),
+        ]
+        brief = _build(votes)
+        # -0.5 clamps to 0.0, so mean = (0.0 + 0.8) / 2 = 0.4 (not -0.35 / 2 = +0.15).
+        assert brief.overall_confidence == pytest.approx(0.4)
+        assert 0.0 <= brief.overall_confidence <= 1.0
+
+    def test_above_one_confidence_clamped_to_one(self) -> None:
+        votes = [
+            _vote(
+                role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE, confidence=1.5
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.APPROVE,
+                confidence=0.6,
+            ),
+        ]
+        brief = _build(votes)
+        # 1.5 clamps to 1.0, so mean = (1.0 + 0.6) / 2 = 0.8 (not 1.05).
+        assert brief.overall_confidence == pytest.approx(0.8)
+        assert 0.0 <= brief.overall_confidence <= 1.0
+
+    def test_in_range_confidence_unchanged(self) -> None:
+        # Clamping must be a no-op for well-formed input.
+        votes = [
+            _vote(
+                role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE, confidence=0.7
+            ),
+            _vote(
+                role=ReviewRole.SECURITY,
+                agent="a2",
+                position=DissentPosition.APPROVE,
+                confidence=0.5,
+            ),
+        ]
+        brief = _build(votes)
+        assert brief.overall_confidence == pytest.approx(0.6)


### PR DESCRIPTION
## Summary

Adds the bounded synthesis layer between heterogeneous panel outputs and the `ReviewBrief` schema landed in #6334. Pure function: same `votes` + binding + policy + `generated_at` ⇒ same `packet_sha`.

This is the next foundation slice for #6306 per codex's scoping: deterministic `ReviewBrief` assembly from explicit `RoleFinding` + `DissentingView` inputs, **no agent invocation, no I/O, no debate-engine wiring**. The orchestrator that runs a real heterogeneous panel ships in a successor PR.

## What this lands

- `aragora/review/builder.py` — `PanelVote` + `build_brief(...)` + `compute_packet_sha(...)`
- `tests/review/test_builder.py` — 22 tests covering all four `SynthesisPolicy` cases, dissent emission, confidence/disagreement aggregation, and packet_sha determinism
- `aragora/review/__init__.py` — re-exports for `from aragora.review import build_brief, PanelVote, ...`

## Synthesis policies

| Policy | Tie / missing-input rule |
|---|---|
| `MAJORITY` | Plurality wins; tie → `NEEDS_HUMAN_ATTENTION` |
| `WEIGHTED` | Highest summed `finding.confidence` (clamped ≥0); tie → `NEEDS_HUMAN_ATTENTION` |
| `SYNTHESIZER_AGENT` | Designated `ReviewRole.SYNTHESIZER` member's position wins; raises `ValueError` if 0 or >1 synthesizers in panel |
| `UNANIMOUS_OR_ESCALATE` | All positions agree → that recommendation; any disagreement → `NEEDS_HUMAN_ATTENTION` |

`Position → Recommendation` mapping (canonical and stable across the codebase):
- `APPROVE` → `APPROVE_CANDIDATE`
- `REQUEST_CHANGES` → `REPAIR_FIRST`
- `DEFER` → `NEEDS_HUMAN_ATTENTION`

## Dissent + confidence emission

- **Dissent**: any vote whose position doesn't map to the brief's recommendation appears as a `DissentingView` (with the panel member's `agent`, `position`, `reason`, and `role`).
- **`overall_confidence`**: arithmetic mean of `finding.confidence` across the panel.
- **`disagreement_score`**: `1 - (largest position-share fraction)`. `0.0` when unanimous; `0.5` on a 2-vs-2 split; ~`0.667` on a three-way 1-1-1 split.

## packet_sha

Implements the preimage rule already documented in `ReviewBrief`'s docstring:
1. `to_dict()`, drop the `packet_sha` key
2. canonical JSON: `sort_keys=True`, `separators=(",", ":")`, `ensure_ascii=False`
3. UTF-8 → `sha256` → hex

Tests pin: deterministic across re-runs, changes when recommendation changes, changes when `head_sha` changes (so settlement on a stale head fails the merge_arbiter check), self-excluding from preimage.

## Out of scope (deliberate)

- Agent invocation / debate engine wiring → orchestrator successor PR
- `PRReviewProtocolPacket` → `ReviewBrief` mapping → would let metadata-heuristic packets masquerade as real heterogeneous briefs (per codex's explicit warning on this slice)
- Cost/budget enforcement → `aragora/review/policy.py` layer (#6305)
- Receipt extension → `aragora/review/receipt.py` layer (#6307)

## Validation

```
$ python -m pytest tests/review/test_builder.py -v
22 passed in 1.34s

$ python -m pytest tests/review/
129 passed in 5.63s

$ python -m mypy aragora/review/builder.py
Success: no issues found in 1 source file

$ python -m ruff check aragora/review/ tests/review/
All checks passed!

$ python -m ruff format --check aragora/review/builder.py tests/review/test_builder.py
2 files already formatted
```

## Test plan

- [x] All four `SynthesisPolicy` cases produce expected recommendations on canonical inputs
- [x] Tie cases escalate to `NEEDS_HUMAN_ATTENTION` (MAJORITY tie, WEIGHTED tie)
- [x] WEIGHTED: high-confidence minority overrides low-confidence majority
- [x] WEIGHTED: negative confidence is clamped (does not subtract)
- [x] SYNTHESIZER_AGENT: 0 or >1 synthesizers raise `ValueError`
- [x] UNANIMOUS_OR_ESCALATE: any disagreement escalates
- [x] Dissent populated when vote position diverges from brief recommendation
- [x] `overall_confidence` = arithmetic mean
- [x] `disagreement_score` = `1 - max-share`
- [x] `packet_sha` deterministic, content-bound, self-excluding
- [x] Empty panel raises
- [x] `advisory_only` invariant preserved
- [x] Field ordering preserved (`role_findings`, `agent_roster`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)