### PR TITLE
test(review-queue): align stats header expectations

### DIFF
--- a/aragora/live/__tests__/ReviewQueueStatsHeader.test.tsx
+++ b/aragora/live/__tests__/ReviewQueueStatsHeader.test.tsx
@@ -20,7 +20,7 @@ function stats(partial: Partial<ReviewQueueStats> = {}): ReviewQueueStats {
 }
 
 describe('StatsHeader', () => {
-  it('renders visible/total/deferred counts and median decision time', () => {
+  it('renders visible/deferred counts and median decision time', () => {
     render(
       <StatsHeader
         visible={3}
@@ -34,8 +34,9 @@ describe('StatsHeader', () => {
     expect(screen.getByTestId('review-queue-deferred-count')).toHaveTextContent('2 deferred');
     expect(screen.getByTestId('review-queue-median')).toHaveTextContent('18.0s');
     expect(screen.getByTestId('review-queue-streak')).toHaveTextContent('4');
-    expect(screen.getByTestId('review-queue-approved-today')).toHaveTextContent('7 approved today');
-    expect(screen.getByText(/5 total/)).toBeInTheDocument();
+    expect(screen.getByTestId('review-queue-approved-today')).toHaveTextContent('7');
+    expect(screen.getByText('Approved today')).toBeInTheDocument();
+    expect(screen.queryByText(/5 total/)).not.toBeInTheDocument();
   });
 
   it('shows degraded banner when degraded is true', () => {


### PR DESCRIPTION
## Summary
- align `ReviewQueueStatsHeader` expectations to the current component markup
- assert the `Approved today` label separately from the numeric tile value
- stop expecting `total` text when `deferredCount > 0`, because that branch intentionally shows only deferred count

## Context
`#6368` merged before this stale frontend test expectation was repaired. The failing assertion is still present on `origin/main`, so this follow-up PR lifts the already-validated one-file fix onto a fresh branch from current `main`.

## Validation
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `npx jest __tests__/ReviewQueueCard.test.tsx __tests__/ReviewQueueStatsHeader.test.tsx src/lib/review/__tests__/types.test.ts --no-coverage`
- `npx tsc --noEmit`
