### PR TITLE
ci: scope PR coverage and analytics checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -450,7 +450,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Zero Coverage Check
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 15
     needs: baseline-determinism
 
     steps:
@@ -491,11 +491,51 @@ jobs:
           python -m pip install --upgrade pip
           bash scripts/ci_install_project.sh --extras test
 
+      - name: Fetch base ref
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+
+      - name: Get changed Python files
+        if: github.event_name == 'pull_request'
+        id: changed
+        run: |
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- 'aragora/**/*.py' 'tests/**/*.py' | tr '\n' ' ')
+          echo "files=$CHANGED" >> "$GITHUB_OUTPUT"
+
+      - name: Select relevant tests
+        if: github.event_name == 'pull_request'
+        id: selected
+        run: |
+          python scripts/nomic_ci_test_selector.py --changed-files ${{ steps.changed.outputs.files }} --dry-run
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          data = json.loads(Path(".nomic-ci-result.json").read_text())
+          test_paths = data.get("test_paths", [])
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as fh:
+              print(f"count={len(test_paths)}", file=fh)
+              print("paths<<EOF", file=fh)
+              print("\n".join(test_paths), file=fh)
+              print("EOF", file=fh)
+          PY
+
       - name: Check for new zero-coverage files
         run: |
-          # Run quick coverage collection
-          python -m pytest tests/debate tests/server -q --cov=aragora --cov-report=json:cov.json \
-            -m "not slow and not load and not e2e" --timeout=60 -x || true
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ -z "${{ steps.selected.outputs.paths }}" ]; then
+              echo "No relevant tests matched changed Python files; skipping zero-coverage probe."
+            else
+              TEST_PATHS_RAW='${{ steps.selected.outputs.paths }}'
+              mapfile -t TEST_PATHS <<< "$TEST_PATHS_RAW"
+              python -m pytest "${TEST_PATHS[@]}" -q --cov=aragora --cov-report=json:cov.json \
+                -m "not slow and not load and not e2e" --timeout=60 -x || true
+            fi
+          else
+            python -m pytest tests/debate tests/server -q --cov=aragora --cov-report=json:cov.json \
+              -m "not slow and not load and not e2e" --timeout=60 -x || true
+          fi
 
           # Check for new zero-coverage files not in baseline
           python -c "
@@ -536,7 +576,7 @@ jobs:
   test-fast:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: baseline-determinism
     strategy:
       fail-fast: false
@@ -2138,7 +2178,7 @@ jobs:
   test-analytics:
     name: Test Analytics
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 20
     needs: [test-fast]
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (always() && github.event_name == 'pull_request')
 
@@ -2180,19 +2220,52 @@ jobs:
           python -m pip install --upgrade pip
           bash scripts/ci_install_project.sh --extras dev
 
+      - name: Fetch base ref
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+
+      - name: Get changed Python files
+        id: changed
+        run: |
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- 'aragora/**/*.py' 'tests/**/*.py' | tr '\n' ' ')
+          echo "files=$CHANGED" >> "$GITHUB_OUTPUT"
+
+      - name: Select relevant tests
+        id: selected
+        run: |
+          python scripts/nomic_ci_test_selector.py --changed-files ${{ steps.changed.outputs.files }} --dry-run
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          data = json.loads(Path(".nomic-ci-result.json").read_text())
+          test_paths = data.get("test_paths", [])
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as fh:
+              print(f"count={len(test_paths)}", file=fh)
+              print("paths<<EOF", file=fh)
+              print("\n".join(test_paths), file=fh)
+              print("EOF", file=fh)
+          PY
+
       - name: Run tests with JUnit output
         id: tests
         # Non-blocking: This job is for flakiness analysis (--reruns=2), not a release gate.
         # Gating tests run in test-fast and test jobs above.
         continue-on-error: true
         run: |
-          python -m pytest -o addopts='' tests/debate tests/agents tests/server \
-            -m "not slow and not load and not e2e" \
-            --timeout=60 \
-            --reruns=2 \
-            --junit-xml=test-results.xml \
-            -v \
-            --tb=short
+          if [ -z "${{ steps.selected.outputs.paths }}" ]; then
+            echo "No relevant tests matched changed Python files; skipping Test Analytics run."
+          else
+            TEST_PATHS_RAW='${{ steps.selected.outputs.paths }}'
+            mapfile -t TEST_PATHS <<< "$TEST_PATHS_RAW"
+            python -m pytest -o addopts='' "${TEST_PATHS[@]}" \
+              -m "not slow and not load and not e2e" \
+              --timeout=60 \
+              --reruns=2 \
+              --junit-xml=test-results.xml \
+              -v \
+              --tb=short
+          fi
 
       - name: Analyze test results
         id: analyze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -514,7 +514,11 @@ jobs:
 
           data = json.loads(Path(".nomic-ci-result.json").read_text())
           test_paths = data.get("test_paths", [])
+          status = data.get("status", "")
+          changed_python_files = data.get("changed_python_files", [])
           with Path(os.environ["GITHUB_OUTPUT"]).open("a") as fh:
+              print(f"status={status}", file=fh)
+              print(f"changed_python_count={len(changed_python_files)}", file=fh)
               print(f"count={len(test_paths)}", file=fh)
               print("paths<<EOF", file=fh)
               print("\n".join(test_paths), file=fh)
@@ -524,8 +528,11 @@ jobs:
       - name: Check for new zero-coverage files
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            if [ -z "${{ steps.selected.outputs.paths }}" ]; then
-              echo "No relevant tests matched changed Python files; skipping zero-coverage probe."
+            if [ "${{ steps.selected.outputs.status }}" = "skipped" ]; then
+              echo "No changed Python files required PR-scoped zero-coverage probing; skipping."
+            elif [ -z "${{ steps.selected.outputs.paths }}" ]; then
+              echo "::error::PR-scoped coverage selector returned no tests for changed Python files"
+              exit 1
             else
               TEST_PATHS_RAW='${{ steps.selected.outputs.paths }}'
               mapfile -t TEST_PATHS <<< "$TEST_PATHS_RAW"

--- a/scripts/nomic_ci_test_selector.py
+++ b/scripts/nomic_ci_test_selector.py
@@ -42,6 +42,15 @@ def infer_test_paths(changed_files: list[str]) -> list[str]:
     return list(dict.fromkeys(test_paths))
 
 
+def changed_python_files(changed_files: list[str]) -> list[str]:
+    """Return changed Aragora Python source files relevant to PR-scoped coverage."""
+    return [
+        path
+        for path in changed_files
+        if path.strip() and path.startswith("aragora/") and path.endswith(".py")
+    ]
+
+
 def main():
     parser = argparse.ArgumentParser(description="Nomic CI test selector")
     parser.add_argument("--changed-files", nargs="*", default=[])
@@ -50,14 +59,24 @@ def main():
     args = parser.parse_args()
 
     test_paths = infer_test_paths(args.changed_files)
+    python_files = changed_python_files(args.changed_files)
 
     result = {
         "changed_files": args.changed_files,
+        "changed_python_files": python_files,
         "test_paths": test_paths,
         "test_count": len(test_paths),
     }
 
     if not test_paths:
+        if python_files:
+            print("No mapped test files found for changed Python files")
+            for path in python_files:
+                print(f"::error::untested new Python module: {path}")
+            result["status"] = "unmapped_python_changes"
+            result["exit_code"] = 1
+            Path(".nomic-ci-result.json").write_text(json.dumps(result, indent=2))
+            return 1
         print("No matching test files found for changed files")
         result["status"] = "skipped"
         Path(".nomic-ci-result.json").write_text(json.dumps(result, indent=2))

--- a/tests/nomic/test_ci_feedback.py
+++ b/tests/nomic/test_ci_feedback.py
@@ -583,6 +583,73 @@ class TestNomicCITestSelector:
         result = infer_test_paths(["scripts/foo.py"])
         assert result == []
 
+    def test_changed_python_files_filters_aragora_modules(self):
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+        from nomic_ci_test_selector import changed_python_files
+
+        result = changed_python_files(
+            [
+                "aragora/foo/bar.py",
+                "tests/foo/test_bar.py",
+                "docs/notes.md",
+                "aragora/foo/bar.txt",
+                "aragora/baz/qux.py",
+            ]
+        )
+
+        assert result == ["aragora/foo/bar.py", "aragora/baz/qux.py"]
+
+    def test_main_skips_when_no_changed_python_files(self, monkeypatch, tmp_path, capsys):
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+        import nomic_ci_test_selector
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["nomic_ci_test_selector.py", "--changed-files", "docs/notes.md", "--dry-run"],
+        )
+
+        exit_code = nomic_ci_test_selector.main()
+
+        assert exit_code == 0
+        result = json.loads((tmp_path / ".nomic-ci-result.json").read_text())
+        assert result["status"] == "skipped"
+        assert result["changed_python_files"] == []
+        assert "No matching test files found for changed files" in capsys.readouterr().out
+
+    def test_main_fails_for_changed_python_without_mapped_tests(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ):
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+        import nomic_ci_test_selector
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "nomic_ci_test_selector.py",
+                "--changed-files",
+                "aragora/foo/new_module.py",
+                "--dry-run",
+            ],
+        )
+
+        exit_code = nomic_ci_test_selector.main()
+
+        assert exit_code == 1
+        result = json.loads((tmp_path / ".nomic-ci-result.json").read_text())
+        assert result["status"] == "unmapped_python_changes"
+        assert result["exit_code"] == 1
+        assert result["changed_python_files"] == ["aragora/foo/new_module.py"]
+        captured = capsys.readouterr().out
+        assert "No mapped test files found for changed Python files" in captured
+        assert "::error::untested new Python module: aragora/foo/new_module.py" in captured
+
 
 # ============================================================
 # SemanticConflictDetector (basic wiring)


### PR DESCRIPTION
## Summary
- scope PR-only zero-coverage and test-analytics jobs to tests inferred from changed Python files
- fetch the PR base ref before running those scoped jobs
- raise `test-fast` timeout headroom from 20 to 30 minutes and `test-analytics` from 12 to 20 minutes

## Why
Several open PRs are failing on workflow budget rather than product-code regressions:
- `test-fast` jobs are canceling at the 20-minute timeout boundary
- `Zero Coverage Check` is trying to run very large suites under coverage for PR-time verification
- `Test Analytics` is a non-gating flakiness job but was still timing out on broad suites

This keeps the PR-only analytics/coverage jobs focused on relevant changed tests while preserving the broader mainline workflows.

## Validation
- `python3 - <<'PY'\nfrom pathlib import Path\nimport yaml\nyaml.safe_load(Path('.github/workflows/test.yml').read_text())\nprint('workflow yaml: ok')\nPY`
- `python3 scripts/nomic_ci_test_selector.py --changed-files aragora/debate/similarity/backends.py tests/debate/test_convergence_comprehensive.py --dry-run`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
