### PR TITLE
fix(review): reject malformed reviewer arrays

### DIFF
--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -53,6 +53,14 @@ from aragora.review.provider_slots import (
     ProviderSlotResolution,
     ProviderSlotResolver,
 )
+from aragora.review.reviewer_output import (
+    FindingCategory,
+    FindingSeverity,
+    REVIEWER_OUTPUT_SCHEMA_VERSION,
+    ReviewerFinding,
+    ReviewerOutput,
+    validate_reviewer_outputs,
+)
 
 __all__ = [
     "ADVISORY_NOTE",
@@ -65,6 +73,8 @@ __all__ = [
     "DissentPosition",
     "EvidenceKind",
     "EvidenceRef",
+    "FindingCategory",
+    "FindingSeverity",
     "PRReviewProtocol",
     "ProviderCandidateCheck",
     "ProviderSlotAvailabilitySummary",
@@ -72,10 +82,13 @@ __all__ = [
     "ProviderSlotResolution",
     "ProviderSlotResolver",
     "PanelVote",
+    "REVIEWER_OUTPUT_SCHEMA_VERSION",
     "Recommendation",
     "ReviewBrief",
     "ReviewBudget",
     "ReviewDepth",
+    "ReviewerFinding",
+    "ReviewerOutput",
     "ReviewPolicy",
     "ReviewPolicyDecision",
     "ReviewRole",
@@ -89,4 +102,5 @@ __all__ = [
     "ValidationResult",
     "build_brief",
     "compute_packet_sha",
+    "validate_reviewer_outputs",
 ]

--- a/aragora/review/reviewer_output.py
+++ b/aragora/review/reviewer_output.py
@@ -1,0 +1,277 @@
+"""Per-reviewer output contract for heterogeneous PR review execution.
+
+Schema layer for the execution-path follow-on to #6306. This module defines
+the structured payload each reviewer must emit before synthesis. It is still
+behavior-light by design: no model calls, no storage, no orchestration. The
+only logic here is contract validation and dict normalization so later slices
+can reject malformed reviewer payloads deterministically.
+
+Design source:
+  docs/plans/2026-04-20-pr-review-execution-path.md
+
+Contract boundary:
+  - one ``ReviewerOutput`` is one reviewer's structured payload for one round
+  - payloads are advisory inputs to synthesis, not settlement actions
+  - evidence refs reuse the stable receipt-layer ``EvidenceRef`` contract
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from aragora.review.protocol import Recommendation
+from aragora.review.receipt import EvidenceKind, EvidenceRef
+
+REVIEWER_OUTPUT_SCHEMA_VERSION = "reviewer_output.v1"
+
+
+class FindingCategory(str, Enum):
+    """Allowed categories for reviewer findings.
+
+    Values mirror the execution-path design doc's minimum reviewer payload.
+    Keeping them as enums prevents silent drift across executor, synthesis,
+    receipt, and UI layers.
+    """
+
+    LOGIC = "logic"
+    SECURITY = "security"
+    MAINTAINABILITY = "maintainability"
+    SKEPTIC = "skeptic"
+    VALIDATION = "validation"
+
+
+class FindingSeverity(str, Enum):
+    """Severity scale for reviewer findings."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+def _normalize_string_items(values: Sequence[Any] | None) -> tuple[str, ...]:
+    items: list[str] = []
+    seen: set[str] = set()
+    for raw in list(values or []):
+        item = str(raw or "").strip()
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        items.append(item)
+    return tuple(items)
+
+
+def _parse_enum(enum_cls: type[Enum], value: Any, field_name: str) -> Enum:
+    raw = str(value or "").strip()
+    if not raw:
+        raise ValueError(f"{field_name} is required")
+    try:
+        return enum_cls(raw)
+    except ValueError as exc:
+        allowed = ", ".join(sorted(member.value for member in enum_cls))  # type: ignore[attr-defined]
+        raise ValueError(f"{field_name} must be one of: {allowed}") from exc
+
+
+def _line_range_from_value(value: Any) -> tuple[int, int] | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        start = int(value[0])
+        end = int(value[1])
+        return (start, end)
+    raise ValueError("line_range must be a 2-item list or tuple when provided")
+
+
+def _evidence_ref_from_dict(data: Mapping[str, Any]) -> EvidenceRef:
+    return EvidenceRef(
+        kind=_parse_enum(EvidenceKind, data.get("kind"), "evidence_refs[].kind"),  # type: ignore[arg-type]
+        path=str(data.get("path", "") or "").strip(),
+        sha=str(data.get("sha", "") or "").strip(),
+        line_range=_line_range_from_value(data.get("line_range")),
+        quote=str(data.get("quote", "") or "").strip(),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewerFinding:
+    """One structured finding from a reviewer output."""
+
+    category: FindingCategory
+    severity: FindingSeverity
+    claim: str
+    evidence: tuple[str, ...]
+    files: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["category"] = self.category.value
+        d["severity"] = self.severity.value
+        d["evidence"] = list(self.evidence)
+        d["files"] = list(self.files)
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReviewerFinding":
+        finding = cls(
+            category=_parse_enum(FindingCategory, data.get("category"), "top_findings[].category"),  # type: ignore[arg-type]
+            severity=_parse_enum(FindingSeverity, data.get("severity"), "top_findings[].severity"),  # type: ignore[arg-type]
+            claim=str(data.get("claim", "") or "").strip(),
+            evidence=_normalize_string_items(data.get("evidence")),
+            files=_normalize_string_items(data.get("files")),
+        )
+        finding.validate()
+        return finding
+
+    def validate(self) -> None:
+        if not str(self.claim or "").strip():
+            raise ValueError("top_findings[].claim is required")
+        if not self.evidence:
+            raise ValueError("top_findings[].evidence must contain at least one item")
+        if self.category != FindingCategory.VALIDATION and not self.files:
+            raise ValueError(
+                "top_findings[].files must contain at least one path for non-validation findings"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewerOutput:
+    """Structured output emitted by one reviewer for one round."""
+
+    reviewer_id: str
+    slot_id: str
+    provider: str
+    lens: str
+    family: str
+    recommendation_class: Recommendation
+    confidence: float
+    summary: str
+    top_findings: tuple[ReviewerFinding, ...]
+    evidence_refs: tuple[EvidenceRef, ...]
+    risk_flags: tuple[str, ...] = ()
+    open_questions: tuple[str, ...] = ()
+    round_index: int = 1
+    latency_ms: int = 0
+    cost_usd: float = 0.0
+    schema_version: str = REVIEWER_OUTPUT_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "reviewer_id": self.reviewer_id,
+            "slot_id": self.slot_id,
+            "provider": self.provider,
+            "lens": self.lens,
+            "family": self.family,
+            "recommendation_class": self.recommendation_class.value,
+            "confidence": round(float(self.confidence), 4),
+            "summary": self.summary,
+            "top_findings": [finding.to_dict() for finding in self.top_findings],
+            "evidence_refs": [ref.to_dict() for ref in self.evidence_refs],
+            "risk_flags": list(self.risk_flags),
+            "open_questions": list(self.open_questions),
+            "round_index": self.round_index,
+            "latency_ms": self.latency_ms,
+            "cost_usd": round(float(self.cost_usd), 6),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReviewerOutput":
+        output = cls(
+            schema_version=str(
+                data.get("schema_version", REVIEWER_OUTPUT_SCHEMA_VERSION)
+                or REVIEWER_OUTPUT_SCHEMA_VERSION
+            ).strip(),
+            reviewer_id=str(data.get("reviewer_id", "") or "").strip(),
+            slot_id=str(data.get("slot_id", "") or "").strip(),
+            provider=str(data.get("provider", "") or "").strip(),
+            lens=str(data.get("lens", "") or "").strip(),
+            family=str(data.get("family", "") or "").strip(),
+            recommendation_class=_parse_enum(
+                Recommendation,
+                data.get("recommendation_class"),
+                "recommendation_class",
+            ),  # type: ignore[arg-type]
+            confidence=float(data.get("confidence", 0.0) or 0.0),
+            summary=str(data.get("summary", "") or "").strip(),
+            top_findings=tuple(
+                ReviewerFinding.from_dict(item)
+                for item in list(data.get("top_findings", []) or [])
+                if isinstance(item, Mapping)
+            ),
+            evidence_refs=tuple(
+                _evidence_ref_from_dict(item)
+                for item in list(data.get("evidence_refs", []) or [])
+                if isinstance(item, Mapping)
+            ),
+            risk_flags=_normalize_string_items(data.get("risk_flags")),
+            open_questions=_normalize_string_items(data.get("open_questions")),
+            round_index=int(data.get("round_index", 1) or 1),
+            latency_ms=int(data.get("latency_ms", 0) or 0),
+            cost_usd=float(data.get("cost_usd", 0.0) or 0.0),
+        )
+        output.validate()
+        return output
+
+    def validate(self) -> None:
+        required = {
+            "schema_version": self.schema_version,
+            "reviewer_id": self.reviewer_id,
+            "slot_id": self.slot_id,
+            "provider": self.provider,
+            "lens": self.lens,
+            "family": self.family,
+            "summary": self.summary,
+        }
+        missing = [key for key, value in required.items() if not str(value or "").strip()]
+        if missing:
+            raise ValueError(f"Reviewer output missing required fields: {', '.join(missing)}")
+        if self.schema_version != REVIEWER_OUTPUT_SCHEMA_VERSION:
+            raise ValueError(
+                f"schema_version must be {REVIEWER_OUTPUT_SCHEMA_VERSION}, got {self.schema_version}"
+            )
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0.0 and 1.0")
+        if self.round_index < 1:
+            raise ValueError("round_index must be >= 1")
+        if self.latency_ms < 0:
+            raise ValueError("latency_ms must be >= 0")
+        if self.cost_usd < 0:
+            raise ValueError("cost_usd must be >= 0")
+        if not self.top_findings:
+            raise ValueError("top_findings must contain at least one item")
+        if not self.evidence_refs:
+            raise ValueError("evidence_refs must contain at least one item")
+        for finding in self.top_findings:
+            finding.validate()
+
+
+def validate_reviewer_outputs(outputs: Sequence[ReviewerOutput]) -> None:
+    """Validate a batch of reviewer outputs.
+
+    The batch contract is intentionally minimal at this layer:
+      - at least one output must be present
+      - each output must satisfy ``ReviewerOutput.validate()``
+      - one reviewer cannot emit two payloads for the same round
+    """
+
+    if not outputs:
+        raise ValueError("at least one reviewer output is required")
+
+    seen: set[tuple[str, int]] = set()
+    for output in outputs:
+        output.validate()
+        identity = (output.reviewer_id, output.round_index)
+        if identity in seen:
+            raise ValueError("duplicate reviewer output for the same reviewer_id and round_index")
+        seen.add(identity)
+
+
+__all__ = [
+    "FindingCategory",
+    "FindingSeverity",
+    "REVIEWER_OUTPUT_SCHEMA_VERSION",
+    "ReviewerFinding",
+    "ReviewerOutput",
+    "validate_reviewer_outputs",
+]

--- a/aragora/review/reviewer_output.py
+++ b/aragora/review/reviewer_output.py
@@ -93,6 +93,16 @@ def _evidence_ref_from_dict(data: Mapping[str, Any]) -> EvidenceRef:
     )
 
 
+def _strict_mapping_items(values: Any, field_name: str) -> tuple[Mapping[str, Any], ...]:
+    items = list(values or [])
+    normalized: list[Mapping[str, Any]] = []
+    for index, item in enumerate(items):
+        if not isinstance(item, Mapping):
+            raise ValueError(f"{field_name}[{index}] must be an object")
+        normalized.append(item)
+    return tuple(normalized)
+
+
 @dataclass(frozen=True, slots=True)
 class ReviewerFinding:
     """One structured finding from a reviewer output."""
@@ -177,6 +187,12 @@ class ReviewerOutput:
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "ReviewerOutput":
+        """Parse one reviewer payload and reject malformed nested arrays strictly.
+
+        ``top_findings`` and ``evidence_refs`` are contract-bearing object arrays.
+        Any non-mapping item is a schema violation and raises ``ValueError``
+        instead of being silently dropped.
+        """
         output = cls(
             schema_version=str(
                 data.get("schema_version", REVIEWER_OUTPUT_SCHEMA_VERSION)
@@ -196,13 +212,11 @@ class ReviewerOutput:
             summary=str(data.get("summary", "") or "").strip(),
             top_findings=tuple(
                 ReviewerFinding.from_dict(item)
-                for item in list(data.get("top_findings", []) or [])
-                if isinstance(item, Mapping)
+                for item in _strict_mapping_items(data.get("top_findings"), "top_findings")
             ),
             evidence_refs=tuple(
                 _evidence_ref_from_dict(item)
-                for item in list(data.get("evidence_refs", []) or [])
-                if isinstance(item, Mapping)
+                for item in _strict_mapping_items(data.get("evidence_refs"), "evidence_refs")
             ),
             risk_flags=_normalize_string_items(data.get("risk_flags")),
             open_questions=_normalize_string_items(data.get("open_questions")),

--- a/tests/review/test_reviewer_output.py
+++ b/tests/review/test_reviewer_output.py
@@ -1,0 +1,274 @@
+"""Tests for reviewer-output execution schema validation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aragora.review import (
+    EvidenceKind,
+    EvidenceRef,
+    FindingCategory,
+    FindingSeverity,
+    Recommendation,
+    REVIEWER_OUTPUT_SCHEMA_VERSION,
+    ReviewerFinding,
+    ReviewerOutput,
+    validate_reviewer_outputs,
+)
+
+
+class TestEnums:
+    def test_finding_category_values_match_execution_design(self) -> None:
+        assert FindingCategory.LOGIC.value == "logic"
+        assert FindingCategory.SECURITY.value == "security"
+        assert FindingCategory.MAINTAINABILITY.value == "maintainability"
+        assert FindingCategory.SKEPTIC.value == "skeptic"
+        assert FindingCategory.VALIDATION.value == "validation"
+
+    def test_finding_severity_values(self) -> None:
+        assert FindingSeverity.LOW.value == "low"
+        assert FindingSeverity.MEDIUM.value == "medium"
+        assert FindingSeverity.HIGH.value == "high"
+
+
+class TestReviewerFinding:
+    def test_to_dict_serializes_enums(self) -> None:
+        finding = ReviewerFinding(
+            category=FindingCategory.SECURITY,
+            severity=FindingSeverity.HIGH,
+            claim="Potential auth bypass on missing org membership check.",
+            evidence=("membership guard absent in handler",),
+            files=("aragora/server/handlers/auth.py",),
+        )
+        payload = finding.to_dict()
+        assert payload["category"] == "security"
+        assert payload["severity"] == "high"
+        assert payload["files"] == ["aragora/server/handlers/auth.py"]
+
+    def test_from_dict_round_trip(self) -> None:
+        finding = ReviewerFinding.from_dict(
+            {
+                "category": "logic",
+                "severity": "medium",
+                "claim": "Branch misses stale-head invalidation case.",
+                "evidence": ["head_sha not compared during cache reuse"],
+                "files": ["aragora/review/cache.py"],
+            }
+        )
+        assert finding.category is FindingCategory.LOGIC
+        assert finding.files == ("aragora/review/cache.py",)
+        assert json.loads(json.dumps(finding.to_dict()))["evidence"] == [
+            "head_sha not compared during cache reuse"
+        ]
+
+    def test_non_validation_findings_require_files(self) -> None:
+        with pytest.raises(ValueError, match="files must contain at least one path"):
+            ReviewerFinding.from_dict(
+                {
+                    "category": "security",
+                    "severity": "high",
+                    "claim": "Something is wrong.",
+                    "evidence": ["trust boundary crossed"],
+                    "files": [],
+                }
+            )
+
+    def test_validation_findings_can_omit_files(self) -> None:
+        finding = ReviewerFinding.from_dict(
+            {
+                "category": "validation",
+                "severity": "medium",
+                "claim": "CI still pending on current head.",
+                "evidence": ["test-fast (server) pending"],
+            }
+        )
+        assert finding.files == ()
+
+    def test_claim_and_evidence_are_required(self) -> None:
+        with pytest.raises(ValueError, match="claim is required"):
+            ReviewerFinding.from_dict(
+                {
+                    "category": "logic",
+                    "severity": "low",
+                    "claim": "",
+                    "evidence": ["something"],
+                    "files": ["aragora/x.py"],
+                }
+            )
+        with pytest.raises(ValueError, match="evidence must contain at least one item"):
+            ReviewerFinding.from_dict(
+                {
+                    "category": "logic",
+                    "severity": "low",
+                    "claim": "Something.",
+                    "evidence": [],
+                    "files": ["aragora/x.py"],
+                }
+            )
+
+
+class TestReviewerOutput:
+    def _output(self, **overrides) -> ReviewerOutput:
+        defaults = dict(
+            reviewer_id="claude_core",
+            slot_id="logic",
+            provider="claude",
+            lens="core",
+            family="claude",
+            recommendation_class=Recommendation.NEEDS_HUMAN_ATTENTION,
+            confidence=0.62,
+            summary="Flags one stale-cache risk and otherwise bounded changes.",
+            top_findings=(
+                ReviewerFinding(
+                    category=FindingCategory.LOGIC,
+                    severity=FindingSeverity.MEDIUM,
+                    claim="Cache invalidation misses head SHA drift.",
+                    evidence=("cache key omits head sha",),
+                    files=("aragora/review/cache.py",),
+                ),
+            ),
+            evidence_refs=(
+                EvidenceRef(
+                    kind=EvidenceKind.FILE,
+                    path="aragora/review/cache.py",
+                    line_range=(10, 24),
+                    quote="cache key = repo/pr/base only",
+                ),
+            ),
+            risk_flags=("stale_cache",),
+            open_questions=("Should cache reuse require exact head SHA?",),
+            round_index=1,
+            latency_ms=1200,
+            cost_usd=0.18,
+        )
+        defaults.update(overrides)
+        return ReviewerOutput(**defaults)
+
+    def test_to_dict_serializes_nested_contract(self) -> None:
+        output = self._output()
+        payload = output.to_dict()
+        assert payload["schema_version"] == REVIEWER_OUTPUT_SCHEMA_VERSION
+        assert payload["recommendation_class"] == "needs_human_attention"
+        assert payload["top_findings"][0]["category"] == "logic"
+        assert payload["evidence_refs"][0]["kind"] == "file"
+
+    def test_from_dict_normalizes_and_validates(self) -> None:
+        output = ReviewerOutput.from_dict(
+            {
+                "reviewer_id": "gpt_core",
+                "slot_id": "security",
+                "provider": "openai-api",
+                "lens": "core",
+                "family": "gpt",
+                "recommendation_class": "repair_first",
+                "confidence": 0.91,
+                "summary": "Auth check missing on one route.",
+                "top_findings": [
+                    {
+                        "category": "security",
+                        "severity": "high",
+                        "claim": "Route omits authorization guard.",
+                        "evidence": ["guard decorator absent"],
+                        "files": ["aragora/server/handlers/runs.py"],
+                    }
+                ],
+                "evidence_refs": [
+                    {
+                        "kind": "file",
+                        "path": "aragora/server/handlers/runs.py",
+                        "line_range": [42, 65],
+                        "quote": "@router.get('/runs')",
+                    }
+                ],
+                "risk_flags": ["authz_gap", "authz_gap", ""],
+                "open_questions": ["Should this route require org admin?"],
+                "round_index": 2,
+                "latency_ms": 880,
+                "cost_usd": 0.22,
+            }
+        )
+        assert output.recommendation_class is Recommendation.REPAIR_FIRST
+        assert output.risk_flags == ("authz_gap",)
+        assert output.round_index == 2
+
+    def test_json_roundtrip(self) -> None:
+        output = self._output()
+        roundtrip = json.loads(json.dumps(output.to_dict()))
+        assert roundtrip["reviewer_id"] == "claude_core"
+        assert roundtrip["top_findings"][0]["claim"] == "Cache invalidation misses head SHA drift."
+        assert roundtrip["evidence_refs"][0]["path"] == "aragora/review/cache.py"
+
+    def test_validate_rejects_missing_required_fields(self) -> None:
+        output = self._output(summary="")
+        with pytest.raises(ValueError, match="missing required fields: summary"):
+            output.validate()
+
+    def test_validate_rejects_out_of_range_confidence(self) -> None:
+        with pytest.raises(ValueError, match="confidence must be between 0.0 and 1.0"):
+            self._output(confidence=1.2).validate()
+
+    def test_validate_rejects_missing_findings_or_evidence_refs(self) -> None:
+        with pytest.raises(ValueError, match="top_findings must contain at least one item"):
+            self._output(top_findings=()).validate()
+        with pytest.raises(ValueError, match="evidence_refs must contain at least one item"):
+            self._output(evidence_refs=()).validate()
+
+    def test_validate_rejects_negative_execution_metrics(self) -> None:
+        with pytest.raises(ValueError, match="round_index must be >= 1"):
+            self._output(round_index=0).validate()
+        with pytest.raises(ValueError, match="latency_ms must be >= 0"):
+            self._output(latency_ms=-1).validate()
+        with pytest.raises(ValueError, match="cost_usd must be >= 0"):
+            self._output(cost_usd=-0.1).validate()
+
+    def test_validate_rejects_wrong_schema_version(self) -> None:
+        with pytest.raises(ValueError, match="schema_version must be"):
+            self._output(schema_version="reviewer_output.v0").validate()
+
+    def test_sequence_fields_are_immutable_tuples(self) -> None:
+        output = self._output()
+        assert isinstance(output.top_findings, tuple)
+        assert isinstance(output.evidence_refs, tuple)
+        assert isinstance(output.risk_flags, tuple)
+        assert isinstance(output.open_questions, tuple)
+        with pytest.raises(AttributeError):
+            output.risk_flags.append("another")  # type: ignore[attr-defined]
+
+
+class TestReviewerOutputBatchValidation:
+    def test_batch_validation_requires_at_least_one_output(self) -> None:
+        with pytest.raises(ValueError, match="at least one reviewer output is required"):
+            validate_reviewer_outputs([])
+
+    def test_batch_validation_rejects_duplicate_reviewer_round_pairs(self) -> None:
+        output = ReviewerOutput.from_dict(
+            {
+                "reviewer_id": "claude_core",
+                "slot_id": "logic",
+                "provider": "claude",
+                "lens": "core",
+                "family": "claude",
+                "recommendation_class": "approve_candidate",
+                "confidence": 0.7,
+                "summary": "Looks bounded.",
+                "top_findings": [
+                    {
+                        "category": "logic",
+                        "severity": "low",
+                        "claim": "No blocking logic regressions found.",
+                        "evidence": ["small bounded diff"],
+                        "files": ["aragora/swarm/pr_review_protocol.py"],
+                    }
+                ],
+                "evidence_refs": [
+                    {
+                        "kind": "file",
+                        "path": "aragora/swarm/pr_review_protocol.py",
+                    }
+                ],
+            }
+        )
+        with pytest.raises(ValueError, match="duplicate reviewer output"):
+            validate_reviewer_outputs([output, output])

--- a/tests/review/test_reviewer_output.py
+++ b/tests/review/test_reviewer_output.py
@@ -200,6 +200,39 @@ class TestReviewerOutput:
         assert roundtrip["top_findings"][0]["claim"] == "Cache invalidation misses head SHA drift."
         assert roundtrip["evidence_refs"][0]["path"] == "aragora/review/cache.py"
 
+    def test_from_dict_rejects_non_mapping_items_in_nested_arrays(self) -> None:
+        with pytest.raises(ValueError, match=r"top_findings\[1\] must be an object"):
+            ReviewerOutput.from_dict(
+                {
+                    "reviewer_id": "gpt_core",
+                    "slot_id": "security",
+                    "provider": "openai-api",
+                    "lens": "core",
+                    "family": "gpt",
+                    "recommendation_class": "repair_first",
+                    "confidence": 0.91,
+                    "summary": "Auth check missing on one route.",
+                    "top_findings": [
+                        {
+                            "category": "security",
+                            "severity": "high",
+                            "claim": "Route omits authorization guard.",
+                            "evidence": ["guard decorator absent"],
+                            "files": ["aragora/server/handlers/runs.py"],
+                        },
+                        "junk-finding",
+                    ],
+                    "evidence_refs": [
+                        {
+                            "kind": "file",
+                            "path": "aragora/server/handlers/runs.py",
+                            "line_range": [42, 65],
+                            "quote": "@router.get('/runs')",
+                        }
+                    ],
+                }
+            )
+
     def test_validate_rejects_missing_required_fields(self) -> None:
         output = self._output(summary="")
         with pytest.raises(ValueError, match="missing required fields: summary"):


### PR DESCRIPTION
Strict-rejection fix for ReviewerOutput.from_dict. Previously held locally while #6381 cleared the false mypy-baseline gate. This push is the confirmation that the gate is truly cleared — no SKIP was used.