### PR TITLE
feat(agent-bridge): add CLI-resume broker and autonomous UI

### DIFF
--- a/aragora/live/src/app/(app)/autonomous/bridge/[runId]/page.tsx
+++ b/aragora/live/src/app/(app)/autonomous/bridge/[runId]/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { BridgeRunDetail } from '@/components/autonomous/bridge';
+import { Scanlines, CRTVignette } from '@/components/MatrixRain';
+import { useRightSidebar } from '@/context/RightSidebarContext';
+
+export default function AgentBridgeRunPage() {
+  const params = useParams<{ runId: string }>();
+  const runId = Array.isArray(params?.runId) ? params.runId[0] : params?.runId ?? '';
+  const { setContext, clearContext } = useRightSidebar();
+
+  useEffect(() => {
+    setContext({
+      title: 'Bridge Run',
+      subtitle: runId || 'Persistent multi-harness session',
+      statsContent: (
+        <div className="space-y-4">
+          <div className="text-xs uppercase tracking-wider text-white/40">Focus</div>
+          <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-white/50">Run ID</span>
+              <span className="text-[var(--accent)]">{runId || 'unknown'}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-white/50">Mode</span>
+              <span className="text-cyan-300">Read-only</span>
+            </div>
+          </div>
+        </div>
+      ),
+    });
+
+    return () => clearContext();
+  }, [clearContext, runId, setContext]);
+
+  return (
+    <div className="relative min-h-screen bg-black text-white">
+      <Scanlines />
+      <CRTVignette />
+
+      <div className="relative z-10 p-6">
+        <BridgeRunDetail runId={runId} />
+      </div>
+    </div>
+  );
+}

--- a/aragora/live/src/app/(app)/autonomous/bridge/page.tsx
+++ b/aragora/live/src/app/(app)/autonomous/bridge/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+import { BridgeRunList } from '@/components/autonomous/bridge';
+import { Scanlines, CRTVignette } from '@/components/MatrixRain';
+import { useRightSidebar } from '@/context/RightSidebarContext';
+
+export default function AgentBridgeRunsPage() {
+  const { setContext, clearContext } = useRightSidebar();
+
+  useEffect(() => {
+    setContext({
+      title: 'Agent Bridge',
+      subtitle: 'Persistent CLI-resume orchestration',
+      statsContent: (
+        <div className="space-y-4">
+          <div className="text-xs uppercase tracking-wider text-white/40">Transport</div>
+          <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-white/50">Primary path</span>
+              <span className="text-[var(--accent)]">CLI resume</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-white/50">Persistence</span>
+              <span className="text-cyan-300">Repo-local</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-white/50">Transport fallback</span>
+              <span className="text-white/60">tmux legacy</span>
+            </div>
+          </div>
+        </div>
+      ),
+      actionsContent: (
+        <div className="space-y-2">
+          <a
+            href="/autonomous"
+            className="block w-full rounded bg-white/5 px-3 py-2 text-center text-sm transition-colors hover:bg-white/10"
+          >
+            Autonomous Home
+          </a>
+        </div>
+      ),
+    });
+
+    return () => clearContext();
+  }, [clearContext, setContext]);
+
+  return (
+    <div className="relative min-h-screen bg-black text-white">
+      <Scanlines />
+      <CRTVignette />
+
+      <div className="relative z-10 p-6">
+        <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div className="mb-2 text-xs uppercase tracking-[0.25em] text-white/35">
+              Autonomous Bridge
+            </div>
+            <h1 className="font-theme-display text-3xl text-white">Agent Bridge Runs</h1>
+            <p className="mt-2 max-w-3xl text-sm text-white/55">
+              Observe persistent Codex, Claude, and Droid sessions without relying on tmux keystroke
+              transport. This surface reads broker state from <code className="text-white/75">.aragora/agent_bridge</code>.
+            </p>
+          </div>
+
+          <Link
+            href="/autonomous"
+            className="rounded border border-white/10 px-3 py-2 text-sm text-white/60 transition-colors hover:border-white/20 hover:text-white"
+          >
+            Back to Autonomous
+          </Link>
+        </div>
+
+        <BridgeRunList />
+      </div>
+    </div>
+  );
+}

--- a/aragora/live/src/app/(app)/autonomous/page.tsx
+++ b/aragora/live/src/app/(app)/autonomous/page.tsx
@@ -51,6 +51,12 @@ export default function AutonomousPage() {
           >
             View Analytics
           </a>
+          <a
+            href="/autonomous/bridge"
+            className="block w-full px-3 py-2 text-sm bg-white/5 hover:bg-white/10 rounded transition-colors text-center"
+          >
+            Agent Bridge
+          </a>
         </div>
       ),
     });
@@ -66,13 +72,23 @@ export default function AutonomousPage() {
       <div className="relative z-10 p-6">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-white mb-2">
-            Autonomous Operations
-          </h1>
-          <p className="text-white/50">
-            Self-improving system with human-in-the-loop oversight. Manage approvals,
-            alerts, scheduled triggers, and continuous learning.
-          </p>
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold text-white mb-2">
+                Autonomous Operations
+              </h1>
+              <p className="text-white/50">
+                Self-improving system with human-in-the-loop oversight. Manage approvals,
+                alerts, scheduled triggers, and continuous learning.
+              </p>
+            </div>
+            <a
+              href="/autonomous/bridge"
+              className="rounded border border-white/10 px-3 py-2 text-sm text-white/60 transition-colors hover:border-white/20 hover:text-white"
+            >
+              Open Agent Bridge
+            </a>
+          </div>
         </div>
 
         {/* Main Dashboard */}

--- a/aragora/live/src/components/autonomous/bridge/BridgeRunDetail.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeRunDetail.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import Link from 'next/link';
+
+import { useSWRFetch } from '@/hooks/useSWRFetch';
+
+import type { BridgeEvent, BridgeRunSummary, BridgeSession } from './types';
+
+interface BridgeRunDetailProps {
+  runId: string;
+}
+
+interface BridgeRunDetailResponse {
+  run: Omit<BridgeRunSummary, 'session_count' | 'agents'>;
+  sessions: BridgeSession[];
+}
+
+interface BridgeEventResponse {
+  events: BridgeEvent[];
+  count: number;
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function humanStatus(status: string): string {
+  if (status === 'waiting_human') return 'Awaiting human input';
+  if (status === 'completed') return 'Completed';
+  if (status === 'failed') return 'Failed';
+  return 'Running';
+}
+
+function eventSummary(event: BridgeEvent): string {
+  const footer = typeof event.footer === 'object' && event.footer ? event.footer : null;
+  if (footer && typeof footer.summary === 'string' && footer.summary) {
+    return footer.summary;
+  }
+  if (typeof event.reason === 'string' && event.reason) {
+    return event.reason;
+  }
+  return event.type.replaceAll('_', ' ');
+}
+
+export function BridgeRunDetail({ runId }: BridgeRunDetailProps) {
+  const run = useSWRFetch<BridgeRunDetailResponse>(`/api/v1/agent-bridge/runs/${runId}`, {
+    refreshInterval: 5000,
+  });
+  const events = useSWRFetch<BridgeEventResponse>(`/api/v1/agent-bridge/runs/${runId}/events`, {
+    refreshInterval: 5000,
+  });
+
+  if (run.error) {
+    return (
+      <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+        Failed to load bridge run {runId}.
+      </div>
+    );
+  }
+
+  if (run.isLoading || !run.data) {
+    return <div className="text-sm text-white/50">Loading bridge run…</div>;
+  }
+
+  const runData = run.data.run;
+  const sessions = run.data.sessions ?? [];
+  const eventItems = events.data?.events ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="mb-2 text-xs uppercase tracking-[0.25em] text-white/35">
+            Agent Bridge Run
+          </div>
+          <h1 className="font-theme-display text-3xl text-white">{runData.run_id}</h1>
+          <p className="mt-2 max-w-3xl text-sm text-white/70">{runData.task}</p>
+        </div>
+        <div className="flex gap-2">
+          <Link
+            href="/autonomous/bridge"
+            className="rounded border border-white/10 px-3 py-2 text-sm text-white/60 transition-colors hover:border-white/20 hover:text-white"
+          >
+            All runs
+          </Link>
+          <button
+            onClick={() => {
+              void run.mutate();
+              void events.mutate();
+            }}
+            className="rounded border border-[var(--accent)]/30 px-3 py-2 text-sm text-[var(--accent)] transition-colors hover:border-[var(--accent)]/60"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[1.3fr_0.9fr]">
+        <section className="rounded-xl border border-white/10 bg-white/5 p-4">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-sm uppercase tracking-[0.2em] text-white/40">Run State</h2>
+            <span className="rounded-full border border-white/10 px-2 py-1 text-xs text-white/70">
+              {humanStatus(runData.status)}
+            </span>
+          </div>
+
+          <dl className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <dt className="text-xs uppercase tracking-[0.2em] text-white/35">Base branch</dt>
+              <dd className="mt-1 text-sm text-white/85">{runData.base_branch}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-[0.2em] text-white/35">Active actor</dt>
+              <dd className="mt-1 text-sm text-white/85">{runData.active_actor ?? 'none'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-[0.2em] text-white/35">Created</dt>
+              <dd className="mt-1 text-sm text-white/85">{formatTimestamp(runData.created_at)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-[0.2em] text-white/35">Updated</dt>
+              <dd className="mt-1 text-sm text-white/85">{formatTimestamp(runData.updated_at)}</dd>
+            </div>
+          </dl>
+
+          {runData.status === 'waiting_human' ? (
+            <div className="mt-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm text-yellow-200">
+              This run is paused for a human decision before the baton can advance.
+            </div>
+          ) : null}
+
+          {runData.last_summary ? (
+            <div className="mt-4 rounded-lg border border-white/10 bg-black/20 p-3 text-sm text-white/70">
+              {runData.last_summary}
+            </div>
+          ) : null}
+        </section>
+
+        <section className="rounded-xl border border-white/10 bg-white/5 p-4">
+          <h2 className="mb-4 text-sm uppercase tracking-[0.2em] text-white/40">Sessions</h2>
+          <div className="space-y-3">
+            {sessions.map((session) => (
+              <div
+                key={session.name}
+                className="rounded-lg border border-white/10 bg-black/20 p-3"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-white">{session.name}</div>
+                    <div className="text-xs text-white/45">
+                      {session.harness}
+                      {session.model ? ` · ${session.model}` : ''}
+                    </div>
+                  </div>
+                  <div className="text-xs text-white/45">{session.turn_count} turns</div>
+                </div>
+                <div className="mt-3 space-y-1 text-xs text-white/50">
+                  <div>Role: {session.role || 'unassigned'}</div>
+                  <div>Branch: {session.branch ?? 'pending worktree'}</div>
+                  <div>Worktree: {session.worktree_path ?? 'pending worktree'}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <section className="rounded-xl border border-white/10 bg-white/5 p-4">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm uppercase tracking-[0.2em] text-white/40">Event Feed</h2>
+          <div className="text-xs text-white/40">{eventItems.length} events</div>
+        </div>
+
+        {events.error ? (
+          <div className="text-sm text-red-300">Failed to load event log.</div>
+        ) : eventItems.length === 0 ? (
+          <div className="text-sm text-white/50">No events recorded yet.</div>
+        ) : (
+          <ol className="space-y-3">
+            {eventItems.map((event, index) => (
+              <li
+                key={`${event.timestamp}-${event.type}-${index}`}
+                className="rounded-lg border border-white/10 bg-black/20 p-3"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="text-sm text-white">
+                    <span className="font-medium">{event.type}</span>
+                    {event.actor ? <span className="text-white/45"> · {event.actor}</span> : null}
+                  </div>
+                  <div className="text-xs text-white/45">{formatTimestamp(event.timestamp)}</div>
+                </div>
+
+                <div className="mt-2 text-sm text-white/65">{eventSummary(event)}</div>
+
+                {event.footer && Array.isArray(event.footer.tests_run) && event.footer.tests_run.length > 0 ? (
+                  <div className="mt-2 text-xs text-white/45">
+                    Tests: {event.footer.tests_run.join(', ')}
+                  </div>
+                ) : null}
+
+                {event.footer && Array.isArray(event.footer.artifacts) && event.footer.artifacts.length > 0 ? (
+                  <div className="mt-1 text-xs text-white/45">
+                    Artifacts: {event.footer.artifacts.join(', ')}
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/aragora/live/src/components/autonomous/bridge/BridgeRunList.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeRunList.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import Link from 'next/link';
+
+import { useSWRFetch } from '@/hooks/useSWRFetch';
+
+import type { BridgeRunSummary } from './types';
+
+interface BridgeRunListProps {
+  endpoint?: string;
+}
+
+interface BridgeRunListResponse {
+  runs: BridgeRunSummary[];
+  total: number;
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function statusLabel(status: string): string {
+  if (status === 'waiting_human') return 'Awaiting human input';
+  if (status === 'completed') return 'Completed';
+  if (status === 'failed') return 'Failed';
+  return 'Running';
+}
+
+function statusClasses(status: string): string {
+  if (status === 'completed') return 'border-[var(--accent)]/40 text-[var(--accent)]';
+  if (status === 'waiting_human') return 'border-yellow-500/40 text-yellow-300';
+  if (status === 'failed') return 'border-red-500/40 text-red-300';
+  return 'border-cyan-500/40 text-cyan-300';
+}
+
+export function BridgeRunList({
+  endpoint = '/api/v1/agent-bridge/runs',
+}: BridgeRunListProps) {
+  const { data, error, isLoading, mutate } = useSWRFetch<BridgeRunListResponse>(endpoint, {
+    refreshInterval: 5000,
+  });
+
+  const runs = data?.runs ?? [];
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+        Failed to load bridge runs.
+        <button
+          onClick={() => void mutate()}
+          className="ml-3 underline underline-offset-2 hover:no-underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading && runs.length === 0) {
+    return <div className="text-sm text-white/50">Loading bridge runs…</div>;
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="rounded-lg border border-white/10 bg-white/5 p-6 text-sm text-white/50">
+        No bridge runs recorded yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-white/50">
+          {data?.total ?? runs.length} persisted run{(data?.total ?? runs.length) === 1 ? '' : 's'}
+        </div>
+        <button
+          onClick={() => void mutate()}
+          className="text-xs text-white/50 hover:text-white"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {runs.map((run) => (
+          <Link
+            key={run.run_id}
+            href={`/autonomous/bridge/${run.run_id}`}
+            className="block rounded-xl border border-white/10 bg-white/5 p-4 transition-colors hover:border-[var(--accent)]/40 hover:bg-white/10"
+          >
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-theme-display text-lg text-white">{run.run_id}</span>
+                  <span className={`rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-[0.2em] ${statusClasses(run.status)}`}>
+                    {statusLabel(run.status)}
+                  </span>
+                </div>
+                <p className="text-sm text-white/85">{run.task}</p>
+                <div className="flex flex-wrap gap-4 text-xs text-white/45">
+                  <span>Base: {run.base_branch}</span>
+                  <span>Updated: {formatTimestamp(run.updated_at)}</span>
+                  <span>Active actor: {run.active_actor ?? 'none'}</span>
+                  <span>Sessions: {run.session_count}</span>
+                </div>
+              </div>
+
+              <div className="space-y-2 text-right">
+                <div className="text-xs uppercase tracking-[0.2em] text-white/35">Agents</div>
+                <div className="flex flex-wrap justify-end gap-2">
+                  {run.agents.map((agent) => (
+                    <span
+                      key={`${run.run_id}-${agent.name}`}
+                      className="rounded border border-white/10 bg-black/30 px-2 py-1 text-xs text-white/70"
+                    >
+                      {agent.name} · {agent.harness}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {run.last_summary ? (
+              <div className="mt-3 border-t border-white/10 pt-3 text-sm text-white/60">
+                {run.last_summary}
+              </div>
+            ) : null}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/aragora/live/src/components/autonomous/bridge/__tests__/BridgeRunDetail.test.tsx
+++ b/aragora/live/src/components/autonomous/bridge/__tests__/BridgeRunDetail.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+
+import { BridgeRunDetail } from '../BridgeRunDetail';
+
+const mockUseSWRFetch = jest.fn();
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}));
+
+jest.mock('@/hooks/useSWRFetch', () => ({
+  useSWRFetch: (...args: unknown[]) => mockUseSWRFetch(...args),
+}));
+
+describe('BridgeRunDetail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseSWRFetch.mockImplementation((endpoint: string) => {
+      if (endpoint === '/api/v1/agent-bridge/runs/run-123') {
+        return {
+          data: {
+            run: {
+              run_id: 'run-123',
+              task: 'Review the bounded bridge slice',
+              repo_root: '/repo',
+              base_branch: 'main',
+              status: 'waiting_human',
+              created_at: '2026-04-21T18:00:00Z',
+              updated_at: '2026-04-21T18:05:00Z',
+              active_actor: 'human',
+              last_summary: 'Reviewer requested a human choice.',
+            },
+            sessions: [
+              {
+                name: 'codex-a',
+                harness: 'codex',
+                role: 'implementer',
+                model: 'gpt-5.4',
+                session_id: 'thread-1',
+                worktree_path: '/repo/.worktrees/agent-bridge/codex-a',
+                branch: 'codex/bridge-a',
+                created_at: '2026-04-21T18:00:00Z',
+                updated_at: '2026-04-21T18:04:00Z',
+                turn_count: 2,
+              },
+            ],
+          },
+          error: null,
+          isLoading: false,
+          mutate: jest.fn(),
+        };
+      }
+
+      if (endpoint === '/api/v1/agent-bridge/runs/run-123/events') {
+        return {
+          data: {
+            count: 2,
+            events: [
+              {
+                timestamp: '2026-04-21T18:01:00Z',
+                type: 'turn_started',
+                run_id: 'run-123',
+                actor: 'codex-a',
+              },
+              {
+                timestamp: '2026-04-21T18:03:00Z',
+                type: 'turn_completed',
+                run_id: 'run-123',
+                actor: 'claude-review',
+                footer: {
+                  summary: 'Reviewer requested a human choice.',
+                  next_actor: null,
+                  needs_human: true,
+                  done: false,
+                  artifacts: ['turns/0002-claude-review.json'],
+                  tests_run: ['pytest tests/swarm/test_agent_bridge.py -q'],
+                },
+              },
+            ],
+          },
+          error: null,
+          isLoading: false,
+          mutate: jest.fn(),
+        };
+      }
+
+      return {
+        data: null,
+        error: null,
+        isLoading: false,
+        mutate: jest.fn(),
+      };
+    });
+  });
+
+  it('renders run detail, pending-human state, and ordered events', () => {
+    render(<BridgeRunDetail runId="run-123" />);
+
+    expect(screen.getByText('run-123')).toBeInTheDocument();
+    expect(screen.getByText('Awaiting human input')).toBeInTheDocument();
+    expect(screen.getByText('This run is paused for a human decision before the baton can advance.')).toBeInTheDocument();
+    expect(screen.getByText('codex-a')).toBeInTheDocument();
+    expect(screen.getByText('Branch: codex/bridge-a')).toBeInTheDocument();
+    expect(screen.getAllByText('Reviewer requested a human choice.')).toHaveLength(2);
+
+    const items = screen.getAllByRole('listitem');
+    expect(within(items[0]).getByText('turn_started')).toBeInTheDocument();
+    expect(within(items[1]).getByText('turn_completed')).toBeInTheDocument();
+    expect(within(items[1]).getByText(/Tests: pytest tests\/swarm\/test_agent_bridge.py -q/)).toBeInTheDocument();
+  });
+});

--- a/aragora/live/src/components/autonomous/bridge/__tests__/BridgeRunList.test.tsx
+++ b/aragora/live/src/components/autonomous/bridge/__tests__/BridgeRunList.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { BridgeRunList } from '../BridgeRunList';
+
+const mockUseSWRFetch = jest.fn();
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}));
+
+jest.mock('@/hooks/useSWRFetch', () => ({
+  useSWRFetch: (...args: unknown[]) => mockUseSWRFetch(...args),
+}));
+
+describe('BridgeRunList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders persisted runs and detail links', () => {
+    mockUseSWRFetch.mockReturnValue({
+      data: {
+        total: 1,
+        runs: [
+          {
+            run_id: 'run-123',
+            task: 'Review the bounded bridge slice',
+            repo_root: '/repo',
+            base_branch: 'main',
+            status: 'running',
+            created_at: '2026-04-21T18:00:00Z',
+            updated_at: '2026-04-21T18:05:00Z',
+            active_actor: 'claude-review',
+            last_summary: 'Codex implemented the bounded change.',
+            session_count: 2,
+            agents: [
+              { name: 'codex-a', harness: 'codex', role: 'implementer', model: 'gpt-5.4', turn_count: 1 },
+              { name: 'claude-review', harness: 'claude', role: 'reviewer', model: 'claude-opus-4-7', turn_count: 0 },
+            ],
+          },
+        ],
+      },
+      error: null,
+      isLoading: false,
+      mutate: jest.fn(),
+    });
+
+    render(<BridgeRunList />);
+
+    expect(screen.getByText('run-123')).toBeInTheDocument();
+    expect(screen.getByText('Review the bounded bridge slice')).toBeInTheDocument();
+    expect(screen.getByText('Codex implemented the bounded change.')).toBeInTheDocument();
+    expect(screen.getByText('codex-a · codex')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /run-123/i })).toHaveAttribute(
+      'href',
+      '/autonomous/bridge/run-123',
+    );
+  });
+});

--- a/aragora/live/src/components/autonomous/bridge/index.ts
+++ b/aragora/live/src/components/autonomous/bridge/index.ts
@@ -1,0 +1,9 @@
+export { BridgeRunDetail } from './BridgeRunDetail';
+export { BridgeRunList } from './BridgeRunList';
+export type {
+  BridgeAgentSummary,
+  BridgeEvent,
+  BridgeFooter,
+  BridgeRunSummary,
+  BridgeSession,
+} from './types';

--- a/aragora/live/src/components/autonomous/bridge/types.ts
+++ b/aragora/live/src/components/autonomous/bridge/types.ts
@@ -1,0 +1,56 @@
+export interface BridgeFooter {
+  summary: string;
+  next_actor: string | null;
+  needs_human: boolean;
+  done: boolean;
+  artifacts: string[];
+  tests_run: string[];
+}
+
+export interface BridgeAgentSummary {
+  name: string;
+  harness: string;
+  role: string;
+  model: string | null;
+  turn_count: number;
+}
+
+export interface BridgeRunSummary {
+  run_id: string;
+  task: string;
+  repo_root: string;
+  base_branch: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  active_actor: string | null;
+  last_summary: string;
+  session_count: number;
+  agents: BridgeAgentSummary[];
+}
+
+export interface BridgeSession {
+  name: string;
+  harness: string;
+  role: string;
+  model: string | null;
+  session_id: string | null;
+  worktree_path: string | null;
+  branch: string | null;
+  created_at: string;
+  updated_at: string;
+  turn_count: number;
+}
+
+export interface BridgeEvent {
+  timestamp: string;
+  type: string;
+  run_id: string;
+  actor?: string;
+  session_id?: string | null;
+  artifact_path?: string;
+  active_actor?: string | null;
+  run_status?: string;
+  footer?: BridgeFooter;
+  [key: string]: unknown;
+}

--- a/aragora/server/handler_registry/admin.py
+++ b/aragora/server/handler_registry/admin.py
@@ -335,6 +335,7 @@ PartnerHandler = _safe_import("aragora.server.handlers.partner", "PartnerHandler
 PlaygroundHandler = _safe_import("aragora.server.handlers.playground", "PlaygroundHandler")
 
 # Autonomous handlers
+AgentBridgeHandler = _safe_import("aragora.server.handlers", "AgentBridgeHandler")
 AlertHandler = _safe_import("aragora.server.handlers.autonomous.alerts", "AlertHandler")
 ApprovalHandler = _safe_import("aragora.server.handlers.autonomous.approvals", "ApprovalHandler")
 TriggerHandler = _safe_import("aragora.server.handlers.autonomous.triggers", "TriggerHandler")
@@ -617,6 +618,7 @@ ADMIN_HANDLER_REGISTRY: list[tuple[str, object]] = [
     ("_smart_upload_handler", SmartUploadHandler),
     ("_partner_handler", PartnerHandler),
     # Autonomous
+    ("_agent_bridge_handler", AgentBridgeHandler),
     ("_alert_handler", AlertHandler),
     ("_approval_handler", ApprovalHandler),
     ("_trigger_handler", TriggerHandler),
@@ -812,6 +814,7 @@ __all__ = [
     "SmartUploadHandler",
     "PartnerHandler",
     # Autonomous
+    "AgentBridgeHandler",
     "AlertHandler",
     "ApprovalHandler",
     "TriggerHandler",

--- a/aragora/server/handler_registry/core.py
+++ b/aragora/server/handler_registry/core.py
@@ -144,6 +144,7 @@ HANDLER_TIERS: dict[str, str] = {
     "_workflow_builder_handler": "extended",
     "_template_registry_handler": "extended",
     "_marketplace_pilot_handler": "extended",
+    "_agent_bridge_handler": "extended",
     # ── Enterprise (loaded only with ARAGORA_ENTERPRISE=1) ────────────
     "_admin_handler": "enterprise",
     "_control_plane_handler": "enterprise",

--- a/aragora/server/handlers/__init__.py
+++ b/aragora/server/handlers/__init__.py
@@ -684,6 +684,7 @@ __all__ = [
     "GauntletValidateReceiptHandler",
     "GAUNTLET_V1_HANDLERS",
     "ReviewQueueHandler",
+    "AgentBridgeHandler",
     "ReviewsHandler",
     "FormalVerificationHandler",
     "SlackHandler",

--- a/aragora/server/handlers/_lazy_imports.py
+++ b/aragora/server/handlers/_lazy_imports.py
@@ -54,6 +54,7 @@ HANDLER_MODULES: dict[str, str] = {
     "AudienceSuggestionsHandler": "aragora.server.handlers.audience_suggestions",
     "AutomationHandler": "aragora.server.handlers.integrations.automation",
     "AutonomousLearningHandler": "aragora.server.handlers.autonomous_learning",
+    "AgentBridgeHandler": "aragora.server.handlers.agent_bridge",
     # approvals inbox
     "UnifiedApprovalsHandler": "aragora.server.handlers.approvals_inbox",
     # bots/ directory
@@ -508,6 +509,7 @@ ALL_HANDLER_NAMES: list[str] = [
     "GauntletValidateReceiptHandler",
     "GauntletHandler",
     "ReviewQueueHandler",
+    "AgentBridgeHandler",
     "ReviewsHandler",
     "FormalVerificationHandler",
     "SlackHandler",

--- a/aragora/server/handlers/_stability.py
+++ b/aragora/server/handlers/_stability.py
@@ -98,6 +98,7 @@ HANDLER_STABILITY: dict[str, Stability] = {
     "KnowledgeChatHandler": Stability.STABLE,
     "ReviewsHandler": Stability.STABLE,
     "ReviewQueueHandler": Stability.STABLE,
+    "AgentBridgeHandler": Stability.EXPERIMENTAL,
     "FormalVerificationHandler": Stability.STABLE,
     "OrganizationsHandler": Stability.STABLE,
     "SocialMediaHandler": Stability.STABLE,

--- a/aragora/server/handlers/agent_bridge.py
+++ b/aragora/server/handlers/agent_bridge.py
@@ -1,0 +1,134 @@
+"""Read-only HTTP handler for CLI-resume agent bridge runs."""
+
+from __future__ import annotations
+
+__all__ = ["AgentBridgeHandler"]
+
+from pathlib import Path
+from typing import Any
+import os
+
+from aragora.server.versioning.compat import strip_version_prefix
+from aragora.swarm.agent_bridge import AgentBridgeBroker
+
+from .base import BaseHandler, HandlerResult, error_response, json_response
+
+
+def _bridge_repo_root() -> Path:
+    override = os.environ.get("ARAGORA_AGENT_BRIDGE_REPO")
+    if override:
+        return Path(override).resolve()
+    cwd = Path.cwd().resolve()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / ".git").exists() or (candidate / ".aragora").exists():
+            return candidate
+    return cwd
+
+
+def _parse_limit(raw: Any, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        value = int(str(raw or "").strip())
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, value))
+
+
+class AgentBridgeHandler(BaseHandler):
+    """Expose persisted agent bridge runs to the Autonomous UI."""
+
+    ROUTES = [
+        "/api/agent-bridge/*",
+        "/api/v1/agent-bridge/*",
+    ]
+
+    ROUTE_PREFIXES = [
+        "/api/agent-bridge",
+        "/api/agent-bridge/",
+        "/api/v1/agent-bridge",
+        "/api/v1/agent-bridge/",
+    ]
+
+    def __init__(self, ctx: dict[str, Any] | None = None) -> None:
+        self.ctx = ctx or {}
+        self._broker = AgentBridgeBroker(_bridge_repo_root())
+
+    def can_handle(self, path: str, method: str = "GET") -> bool:
+        if method.upper() != "GET":
+            return False
+        normalized = strip_version_prefix(path)
+        return normalized == "/api/agent-bridge" or normalized.startswith("/api/agent-bridge/")
+
+    def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
+        normalized = strip_version_prefix(path).rstrip("/")
+        subpath = (
+            normalized[len("/api/agent-bridge") :]
+            if normalized.startswith("/api/agent-bridge")
+            else ""
+        )
+
+        if subpath in ("", "/"):
+            return error_response("Not found", 404)
+
+        if subpath == "/runs":
+            limit = _parse_limit(query_params.get("limit"), default=50, minimum=1, maximum=500)
+            return self._list_runs(limit=limit)
+
+        if not subpath.startswith("/runs/"):
+            return error_response("Not found", 404)
+
+        tail = subpath[len("/runs/") :]
+        segments = [segment for segment in tail.split("/") if segment]
+        if not segments:
+            return error_response("Not found", 404)
+
+        run_id = segments[0]
+        if len(segments) == 1:
+            return self._get_run(run_id)
+        if len(segments) == 2 and segments[1] == "events":
+            limit = _parse_limit(query_params.get("limit"), default=200, minimum=1, maximum=5000)
+            return self._get_events(run_id, limit=limit)
+        return error_response("Not found", 404)
+
+    def _list_runs(self, *, limit: int) -> HandlerResult:
+        runs = self._broker.list_runs(limit=limit)
+        payload = []
+        for run in runs:
+            sessions = self._broker.load_sessions(run.run_id)
+            payload.append(
+                {
+                    **run.to_dict(),
+                    "session_count": len(sessions),
+                    "agents": [
+                        {
+                            "name": session.name,
+                            "harness": session.harness.value,
+                            "role": session.role,
+                            "model": session.model,
+                            "turn_count": session.turn_count,
+                        }
+                        for session in sessions
+                    ],
+                }
+            )
+        return json_response({"runs": payload, "total": len(payload)})
+
+    def _get_run(self, run_id: str) -> HandlerResult:
+        try:
+            run = self._broker.load_run(run_id)
+        except FileNotFoundError:
+            return error_response(f"Run not found: {run_id}", 404)
+        sessions = self._broker.load_sessions(run_id)
+        return json_response(
+            {
+                "run": run.to_dict(),
+                "sessions": [session.to_dict() for session in sessions],
+            }
+        )
+
+    def _get_events(self, run_id: str, *, limit: int) -> HandlerResult:
+        try:
+            self._broker.load_run(run_id)
+        except FileNotFoundError:
+            return error_response(f"Run not found: {run_id}", 404)
+        events = self._broker.load_events(run_id, limit=limit)
+        return json_response({"events": events, "count": len(events)})

--- a/aragora/swarm/agent_bridge/__init__.py
+++ b/aragora/swarm/agent_bridge/__init__.py
@@ -1,0 +1,41 @@
+from aragora.swarm.agent_bridge.broker import AgentBridgeBroker
+from aragora.swarm.agent_bridge.broker import default_sessions
+from aragora.swarm.agent_bridge.footer import FOOTER_PREFIX
+from aragora.swarm.agent_bridge.footer import build_footer_repair_prompt
+from aragora.swarm.agent_bridge.footer import extract_footer
+from aragora.swarm.agent_bridge.footer import footer_instructions
+from aragora.swarm.agent_bridge.store import BridgeStore
+from aragora.swarm.agent_bridge.transport import BaseTransport
+from aragora.swarm.agent_bridge.transport import BridgeTransportError
+from aragora.swarm.agent_bridge.transport import ClaudeTransport
+from aragora.swarm.agent_bridge.transport import CodexTransport
+from aragora.swarm.agent_bridge.transport import DroidTransport
+from aragora.swarm.agent_bridge.transport import transport_for
+from aragora.swarm.agent_bridge.types import BridgeFooter
+from aragora.swarm.agent_bridge.types import BridgeRun
+from aragora.swarm.agent_bridge.types import BridgeRunStatus
+from aragora.swarm.agent_bridge.types import BridgeSession
+from aragora.swarm.agent_bridge.types import BridgeTurnResult
+from aragora.swarm.agent_bridge.types import HarnessKind
+
+__all__ = [
+    "AgentBridgeBroker",
+    "BaseTransport",
+    "BridgeFooter",
+    "BridgeRun",
+    "BridgeRunStatus",
+    "BridgeSession",
+    "BridgeStore",
+    "BridgeTransportError",
+    "BridgeTurnResult",
+    "ClaudeTransport",
+    "CodexTransport",
+    "DroidTransport",
+    "FOOTER_PREFIX",
+    "HarnessKind",
+    "build_footer_repair_prompt",
+    "default_sessions",
+    "extract_footer",
+    "footer_instructions",
+    "transport_for",
+]

--- a/aragora/swarm/agent_bridge/broker.py
+++ b/aragora/swarm/agent_bridge/broker.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import subprocess
+import uuid
+from pathlib import Path
+
+from aragora.swarm.agent_bridge.footer import build_footer_repair_prompt
+from aragora.swarm.agent_bridge.footer import extract_footer
+from aragora.swarm.agent_bridge.footer import footer_instructions
+from aragora.swarm.agent_bridge.store import BridgeStore
+from aragora.swarm.agent_bridge.transport import BridgeTransportError
+from aragora.swarm.agent_bridge.transport import transport_for
+from aragora.swarm.agent_bridge.types import BridgeRun
+from aragora.swarm.agent_bridge.types import BridgeRunStatus
+from aragora.swarm.agent_bridge.types import BridgeSession
+from aragora.swarm.agent_bridge.types import BridgeTurnResult
+from aragora.swarm.agent_bridge.types import HarnessKind
+from aragora.swarm.agent_bridge.types import utc_now_iso
+
+
+class AgentBridgeBroker:
+    def __init__(self, repo_root: Path):
+        self.repo_root = Path(repo_root).resolve()
+        self.store = BridgeStore(self.repo_root)
+
+    def create_run(
+        self,
+        *,
+        task: str,
+        sessions: list[BridgeSession],
+        base_branch: str = "main",
+        run_id: str | None = None,
+    ) -> BridgeRun:
+        normalized_run_id = run_id or uuid.uuid4().hex[:12]
+        run = BridgeRun(
+            run_id=normalized_run_id,
+            task=task.strip(),
+            repo_root=str(self.repo_root),
+            base_branch=base_branch,
+        )
+        self.store.save_run(run)
+        self.store.save_sessions(normalized_run_id, sessions)
+        self.store.append_event(
+            normalized_run_id,
+            "run_created",
+            task=run.task,
+            base_branch=base_branch,
+            sessions=[session.to_dict() for session in sessions],
+        )
+        return run
+
+    def list_runs(self, *, limit: int | None = None) -> list[BridgeRun]:
+        return self.store.list_runs(limit=limit)
+
+    def load_run(self, run_id: str) -> BridgeRun:
+        return self.store.load_run(run_id)
+
+    def load_sessions(self, run_id: str) -> list[BridgeSession]:
+        return self.store.load_sessions(run_id)
+
+    def load_events(self, run_id: str, *, limit: int | None = None) -> list[dict]:
+        return self.store.load_events(run_id, limit=limit)
+
+    def dispatch_turn(self, *, run_id: str, actor: str, prompt: str) -> BridgeTurnResult:
+        run = self.store.load_run(run_id)
+        sessions = self.store.load_sessions(run_id)
+        session = next((item for item in sessions if item.name == actor), None)
+        if session is None:
+            raise KeyError(f"Unknown actor '{actor}' for run {run_id}")
+
+        self._ensure_worktree(session=session, base_branch=run.base_branch)
+        transport = transport_for(session)
+        prompt_text = f"{prompt.rstrip()}\n\n{footer_instructions()}"
+
+        self.store.append_event(
+            run_id,
+            "turn_started",
+            actor=actor,
+            session_id=session.session_id,
+            worktree_path=session.worktree_path,
+            branch=session.branch,
+        )
+
+        result = (
+            transport.resume_turn(session, prompt_text)
+            if session.session_id
+            else transport.start_session(session, prompt_text)
+        )
+        session.session_id = result.session_id
+        session.turn_count += 1
+        session.updated_at = utc_now_iso()
+
+        footer, response_body = extract_footer(result.response_text)
+        if footer is None:
+            self.store.append_event(
+                run_id,
+                "footer_repair_requested",
+                actor=actor,
+                session_id=session.session_id,
+            )
+            repair = transport.resume_turn(
+                session, build_footer_repair_prompt(result.response_text)
+            )
+            footer, _ = extract_footer(repair.response_text)
+            repair_artifact = self.store.write_turn_artifact(
+                run_id,
+                turn_index=session.turn_count,
+                actor=f"{actor}-repair",
+                payload={
+                    "actor": actor,
+                    "repair": True,
+                    "session_id": session.session_id,
+                    "stdout": repair.raw_stdout,
+                    "stderr": repair.raw_stderr,
+                    "response_text": repair.response_text,
+                },
+            )
+            self.store.append_event(
+                run_id,
+                "footer_repair_completed",
+                actor=actor,
+                session_id=session.session_id,
+                artifact_path=str(repair_artifact),
+                repaired=footer is not None,
+            )
+            if footer is None:
+                self._save_sessions(run_id, sessions)
+                run.status = BridgeRunStatus.FAILED
+                run.updated_at = utc_now_iso()
+                self.store.save_run(run)
+                self.store.append_event(
+                    run_id,
+                    "turn_failed",
+                    actor=actor,
+                    reason="footer_missing_after_repair",
+                )
+                raise BridgeTransportError(
+                    f"Agent '{actor}' did not return a valid bridge footer after repair"
+                )
+
+        result.footer = footer
+        result.response_text = response_body
+        artifact = self.store.write_turn_artifact(
+            run_id,
+            turn_index=session.turn_count,
+            actor=actor,
+            payload={
+                "actor": actor,
+                "session": session.to_dict(),
+                "result": result.to_dict(),
+            },
+        )
+
+        run.last_summary = footer.summary
+        run.active_actor = footer.next_actor
+        run.updated_at = utc_now_iso()
+        if footer.done:
+            run.status = BridgeRunStatus.COMPLETED
+        elif footer.needs_human:
+            run.status = BridgeRunStatus.WAITING_HUMAN
+        else:
+            run.status = BridgeRunStatus.RUNNING
+        self.store.save_run(run)
+        self._save_sessions(run_id, sessions)
+        self.store.append_event(
+            run_id,
+            "turn_completed",
+            actor=actor,
+            session_id=session.session_id,
+            artifact_path=str(artifact),
+            footer=footer.to_dict(),
+            active_actor=run.active_actor,
+            run_status=run.status.value,
+        )
+        return result
+
+    def healthcheck(self) -> dict[str, bool]:
+        return {
+            "claude": transport_for(
+                BridgeSession(name="claude", harness=HarnessKind.CLAUDE)
+            ).healthcheck(),
+            "codex": transport_for(
+                BridgeSession(name="codex", harness=HarnessKind.CODEX)
+            ).healthcheck(),
+            "droid": transport_for(
+                BridgeSession(name="droid", harness=HarnessKind.DROID)
+            ).healthcheck(),
+        }
+
+    def _save_sessions(self, run_id: str, sessions: list[BridgeSession]) -> None:
+        self.store.save_sessions(run_id, sessions)
+
+    def _ensure_worktree(self, *, session: BridgeSession, base_branch: str) -> None:
+        if session.worktree_path and Path(session.worktree_path).exists():
+            if not session.branch:
+                session.branch = self._git_branch(Path(session.worktree_path))
+            return
+
+        cmd = [
+            "python3",
+            str(self.repo_root / "scripts" / "codex_worktree_autopilot.py"),
+            "--repo",
+            str(self.repo_root),
+            "--managed-dir",
+            ".worktrees/agent-bridge",
+            "ensure",
+            "--agent",
+            session.name,
+            "--base",
+            base_branch,
+            "--print-path",
+        ]
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=self.repo_root,
+        )
+        if proc.returncode != 0:
+            detail = proc.stderr.strip() or proc.stdout.strip() or "worktree ensure failed"
+            raise RuntimeError(detail)
+        worktree_path = proc.stdout.strip()
+        if not worktree_path:
+            raise RuntimeError("worktree ensure did not return a path")
+        session.worktree_path = worktree_path
+        session.branch = self._git_branch(Path(worktree_path))
+        session.updated_at = utc_now_iso()
+
+    def _git_branch(self, worktree: Path) -> str | None:
+        proc = subprocess.run(
+            ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return None
+        branch = proc.stdout.strip()
+        return branch or None
+
+
+def default_sessions() -> list[BridgeSession]:
+    return [
+        BridgeSession(name="codex", harness=HarnessKind.CODEX),
+        BridgeSession(name="claude", harness=HarnessKind.CLAUDE),
+        BridgeSession(name="droid", harness=HarnessKind.DROID),
+    ]

--- a/aragora/swarm/agent_bridge/footer.py
+++ b/aragora/swarm/agent_bridge/footer.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from aragora.swarm.agent_bridge.types import BridgeFooter
+
+FOOTER_PREFIX = "AGENT_BRIDGE_FOOTER:"
+FOOTER_TEMPLATE = {
+    "summary": "One-sentence outcome summary",
+    "next_actor": "actor-name-or-null",
+    "needs_human": False,
+    "done": False,
+    "artifacts": [],
+    "tests_run": [],
+}
+
+
+def footer_instructions() -> str:
+    return (
+        "End your response with exactly one final line using this prefix and JSON shape:\n"
+        f"{FOOTER_PREFIX} " + json.dumps(FOOTER_TEMPLATE, separators=(", ", ": ")) + "\n"
+        "The footer must be the last non-empty line."
+    )
+
+
+def extract_footer(text: str) -> tuple[BridgeFooter | None, str]:
+    footer_payload: dict[str, Any] | None = None
+    footer_index = -1
+    lines = text.splitlines()
+    for index in range(len(lines) - 1, -1, -1):
+        line = lines[index].strip()
+        if not line:
+            continue
+        if line.startswith(FOOTER_PREFIX):
+            footer_index = index
+            raw_json = line.removeprefix(FOOTER_PREFIX).strip()
+            try:
+                parsed = json.loads(raw_json)
+            except json.JSONDecodeError:
+                return None, text
+            if not isinstance(parsed, dict):
+                return None, text
+            footer_payload = parsed
+            break
+        # The footer must be the last non-empty line.
+        return None, text
+
+    if footer_payload is None or footer_index < 0:
+        return None, text
+
+    try:
+        footer = BridgeFooter.from_dict(footer_payload)
+    except (TypeError, ValueError):
+        return None, text
+    if not footer.summary:
+        return None, text
+    body = "\n".join(lines[:footer_index]).rstrip()
+    return footer, body
+
+
+def build_footer_repair_prompt(previous_response: str) -> str:
+    excerpt = previous_response.strip()
+    if len(excerpt) > 1200:
+        excerpt = excerpt[:1197].rstrip() + "..."
+    return (
+        "Your previous response was missing the required agent bridge footer or the footer was malformed.\n"
+        "Do not repeat the full response. Return exactly one line containing only a corrected footer.\n"
+        f"Prefix it with {FOOTER_PREFIX} and include valid JSON with keys "
+        "summary, next_actor, needs_human, done, artifacts, tests_run.\n\n"
+        "Previous response excerpt:\n"
+        f"{excerpt}"
+    )

--- a/aragora/swarm/agent_bridge/store.py
+++ b/aragora/swarm/agent_bridge/store.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from aragora.swarm.agent_bridge.types import BridgeRun
+from aragora.swarm.agent_bridge.types import BridgeSession
+from aragora.swarm.agent_bridge.types import utc_now_iso
+
+
+class BridgeStore:
+    def __init__(self, repo_root: Path):
+        self.repo_root = Path(repo_root).resolve()
+        self.root = self.repo_root / ".aragora" / "agent_bridge" / "runs"
+
+    def runs_dir(self) -> Path:
+        self.root.mkdir(parents=True, exist_ok=True)
+        return self.root
+
+    def run_dir(self, run_id: str) -> Path:
+        path = self.runs_dir() / run_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def run_file(self, run_id: str) -> Path:
+        return self.run_dir(run_id) / "run.json"
+
+    def sessions_file(self, run_id: str) -> Path:
+        return self.run_dir(run_id) / "sessions.json"
+
+    def events_file(self, run_id: str) -> Path:
+        return self.run_dir(run_id) / "events.jsonl"
+
+    def turns_dir(self, run_id: str) -> Path:
+        path = self.run_dir(run_id) / "turns"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def save_run(self, run: BridgeRun) -> None:
+        self.run_file(run.run_id).write_text(
+            json.dumps(run.to_dict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def load_run(self, run_id: str) -> BridgeRun:
+        payload = json.loads(self.run_file(run_id).read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"Invalid run payload for {run_id}")
+        return BridgeRun.from_dict(payload)
+
+    def save_sessions(self, run_id: str, sessions: list[BridgeSession]) -> None:
+        payload = {"sessions": [session.to_dict() for session in sessions]}
+        self.sessions_file(run_id).write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def load_sessions(self, run_id: str) -> list[BridgeSession]:
+        path = self.sessions_file(run_id)
+        if not path.exists():
+            return []
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"Invalid sessions payload for {run_id}")
+        raw_sessions = payload.get("sessions", [])
+        if not isinstance(raw_sessions, list):
+            raise ValueError(f"Invalid sessions list for {run_id}")
+        return [BridgeSession.from_dict(item) for item in raw_sessions if isinstance(item, dict)]
+
+    def append_event(self, run_id: str, event_type: str, **data: Any) -> None:
+        event = {
+            "timestamp": utc_now_iso(),
+            "type": event_type,
+            "run_id": run_id,
+            **data,
+        }
+        with self.events_file(run_id).open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+    def load_events(self, run_id: str, *, limit: int | None = None) -> list[dict[str, Any]]:
+        path = self.events_file(run_id)
+        if not path.exists():
+            return []
+        events: list[dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                events.append(payload)
+        if limit is not None and limit > 0:
+            return events[-limit:]
+        return events
+
+    def write_turn_artifact(
+        self,
+        run_id: str,
+        *,
+        turn_index: int,
+        actor: str,
+        payload: dict[str, Any],
+    ) -> Path:
+        safe_actor = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in actor)
+        path = self.turns_dir(run_id) / f"{turn_index:04d}-{safe_actor}.json"
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
+    def list_runs(self, *, limit: int | None = None) -> list[BridgeRun]:
+        runs: list[BridgeRun] = []
+        for run_path in self.runs_dir().glob("*/run.json"):
+            try:
+                payload = json.loads(run_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(payload, dict):
+                try:
+                    runs.append(BridgeRun.from_dict(payload))
+                except (TypeError, ValueError):
+                    continue
+        runs.sort(key=lambda item: item.updated_at, reverse=True)
+        if limit is not None and limit > 0:
+            return runs[:limit]
+        return runs

--- a/aragora/swarm/agent_bridge/transport.py
+++ b/aragora/swarm/agent_bridge/transport.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import uuid
+from abc import ABC
+from abc import abstractmethod
+from pathlib import Path
+from typing import Any
+
+from aragora.swarm.agent_bridge.types import BridgeSession
+from aragora.swarm.agent_bridge.types import BridgeTurnResult
+from aragora.swarm.agent_bridge.types import HarnessKind
+
+
+class BridgeTransportError(RuntimeError):
+    pass
+
+
+class MissingSessionIdentityError(BridgeTransportError):
+    pass
+
+
+class BaseTransport(ABC):
+    binary_name: str
+
+    def healthcheck(self) -> bool:
+        result = subprocess.run(
+            [self.binary_name, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        return result.returncode == 0
+
+    def _run(self, cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=900,
+                check=False,
+                cwd=cwd,
+            )
+        except subprocess.TimeoutExpired as exc:  # pragma: no cover - exercised via live smoke
+            raise BridgeTransportError(f"{self.binary_name} timed out: {exc}") from exc
+
+    @abstractmethod
+    def start_session(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+        raise NotImplementedError
+
+    @abstractmethod
+    def resume_turn(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+        raise NotImplementedError
+
+
+class ClaudeTransport(BaseTransport):
+    binary_name = "claude"
+
+    def _build_cmd(
+        self,
+        session: BridgeSession,
+        prompt: str,
+        *,
+        resume: bool,
+    ) -> list[str]:
+        cmd = [self.binary_name, "-p", prompt, "--output-format", "json"]
+        if resume:
+            if not session.session_id:
+                raise MissingSessionIdentityError("Claude resume requested without session_id")
+            cmd.extend(["--resume", session.session_id])
+        else:
+            session_id = session.session_id or str(uuid.uuid4())
+            cmd.extend(["--session-id", session_id])
+        if session.model:
+            cmd.extend(["--model", session.model])
+        if session.allow_dangerous:
+            cmd.append("--dangerously-skip-permissions")
+        return cmd
+
+    def _parse(self, stdout: str, stderr: str) -> BridgeTurnResult:
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise BridgeTransportError(f"Failed to parse Claude JSON output: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise BridgeTransportError("Claude JSON output was not an object")
+        session_id = str(payload.get("session_id", "") or "").strip()
+        if not session_id:
+            raise MissingSessionIdentityError("Claude output did not include session_id")
+        response_text = str(payload.get("result", "") or "")
+        return BridgeTurnResult(
+            session_id=session_id,
+            response_text=response_text,
+            raw_stdout=stdout,
+            raw_stderr=stderr,
+            metadata={
+                "subtype": payload.get("subtype"),
+                "duration_ms": payload.get("duration_ms"),
+                "num_turns": payload.get("num_turns"),
+            },
+        )
+
+    def start_session(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+        cmd = self._build_cmd(session, prompt, resume=False)
+        proc = self._run(cmd, cwd=session.worktree or Path.cwd())
+        if proc.returncode != 0:
+            raise BridgeTransportError(
+                proc.stderr.strip() or proc.stdout.strip() or "Claude failed"
+            )
+        return self._parse(proc.stdout.strip(), proc.stderr.strip())
+
+    def resume_turn(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+        cmd = self._build_cmd(session, prompt, resume=True)
+        proc = self._run(cmd, cwd=session.worktree or Path.cwd())
+        if proc.returncode != 0:
+            raise BridgeTransportError(
+                proc.stderr.strip() or proc.stdout.strip() or "Claude failed"
+            )
+        return self._parse(proc.stdout.strip(), proc.stderr.strip())
+
+
+class CodexTransport(BaseTransport):
+    binary_name = "codex"
+
+    def _build_cmd(
+        self,
+        session: BridgeSession,
+        prompt: str,
+        *,
+        resume: bool,
+        output_file: Path,
+    ) -> list[str]:
+        base = [self.binary_name, "exec"]
+        if resume:
+            if not session.session_id:
+                raise MissingSessionIdentityError("Codex resume requested without thread_id")
+            base.extend(["resume", session.session_id])
+        base.extend(
+            [
+                "--json",
+                "-C",
+                str(session.worktree or Path.cwd()),
+                "-o",
+                str(output_file),
+            ]
+        )
+        if session.model:
+            base.extend(["-m", session.model])
+        if session.full_auto:
+            base.append("--full-auto")
+        if session.allow_dangerous:
+            base.append("--dangerously-bypass-approvals-and-sandbox")
+        base.append(prompt)
+        return base
+
+    def _parse(
+        self,
+        stdout: str,
+        stderr: str,
+        response_text: str,
+        *,
+        session_id_hint: str | None = None,
+    ) -> BridgeTurnResult:
+        thread_id = ""
+        turn_metadata: dict[str, Any] = {}
+        for raw_line in stdout.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            event_type = str(payload.get("type", "") or "")
+            if event_type == "thread.started":
+                thread_id = str(payload.get("thread_id", "") or "").strip()
+            elif event_type == "turn.completed":
+                turn_metadata["usage"] = payload.get("usage")
+                turn_metadata["stop_reason"] = payload.get("stop_reason")
+        if not thread_id and session_id_hint:
+            thread_id = session_id_hint
+        if not thread_id:
+            raise MissingSessionIdentityError("Codex output did not include thread_id")
+        return BridgeTurnResult(
+            session_id=thread_id,
+            response_text=response_text,
+            raw_stdout=stdout,
+            raw_stderr=stderr,
+            metadata=turn_metadata,
+        )
+
+    def start_session(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+        with tempfile.NamedTemporaryFile(prefix="agent-bridge-codex-", suffix=".txt") as handle:
+            cmd = self._build_cmd(session, prompt, resume=False, output_file=Path(handle.name))
+            proc = self._run(cmd, cwd=session.worktree or Path.cwd())
+            if proc.returncode != 0:
+                raise BridgeTransportError(
+                    proc.stderr.strip() or proc.stdout.strip() or "Codex failed"
+                )
+            response_text = Path(handle.name).read_text(encoding="utf-8").strip()
+        return self._parse(proc.stdout, proc.stderr, response_text)
+
+    def resume_turn(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+        with tempfile.NamedTemporaryFile(prefix="agent-bridge-codex-", suffix=".txt") as handle:
+            cmd = self._build_cmd(session, prompt, resume=True, output_file=Path(handle.name))
+            proc = self._run(cmd, cwd=session.worktree or Path.cwd())
+            if proc.returncode != 0:
+                raise BridgeTransportError(
+                    proc.stderr.strip() or proc.stdout.strip() or "Codex failed"
+                )
+            response_text = Path(handle.name).read_text(encoding="utf-8").strip()
+        return self._parse(
+            proc.stdout,
+            proc.stderr,
+            response_text,
+            session_id_hint=session.session_id,
+        )
+
+
+class DroidTransport(BaseTransport):
+    binary_name = "droid"
+
+    def _build_cmd(self, session: BridgeSession, prompt: str, *, resume: bool) -> list[str]:
+        cmd = [
+            self.binary_name,
+            "exec",
+            "--output-format",
+            "json",
+            "--cwd",
+            str(session.worktree or Path.cwd()),
+        ]
+        if resume:
+            if not session.session_id:
+                raise MissingSessionIdentityError("Droid resume requested without session_id")
+            cmd.extend(["-s", session.session_id])
+        if session.model:
+            cmd.extend(["-m", session.model])
+        if session.droid_auto:
+            cmd.extend(["--auto", session.droid_auto])
+        cmd.append(prompt)
+        return cmd
+
+    def _parse(self, stdout: str, stderr: str) -> BridgeTurnResult:
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise BridgeTransportError(f"Failed to parse Droid JSON output: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise BridgeTransportError("Droid JSON output was not an object")
+        session_id = str(payload.get("session_id", "") or "").strip()
+        if not session_id:
+            raise MissingSessionIdentityError("Droid output did not include session_id")
+        return BridgeTurnResult(
+            session_id=session_id,
+            response_text=str(payload.get("result", "") or ""),
+            raw_stdout=stdout,
+            raw_stderr=stderr,
+            metadata={
+                "duration_ms": payload.get("duration_ms"),
+                "num_turns": payload.get("num_turns"),
+            },
+        )
+
+    def start_session(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+        cmd = self._build_cmd(session, prompt, resume=False)
+        proc = self._run(cmd, cwd=session.worktree or Path.cwd())
+        if proc.returncode != 0:
+            raise BridgeTransportError(proc.stderr.strip() or proc.stdout.strip() or "Droid failed")
+        return self._parse(proc.stdout.strip(), proc.stderr.strip())
+
+    def resume_turn(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+        cmd = self._build_cmd(session, prompt, resume=True)
+        proc = self._run(cmd, cwd=session.worktree or Path.cwd())
+        if proc.returncode != 0:
+            raise BridgeTransportError(proc.stderr.strip() or proc.stdout.strip() or "Droid failed")
+        return self._parse(proc.stdout.strip(), proc.stderr.strip())
+
+
+def transport_for(session: BridgeSession) -> BaseTransport:
+    if session.harness is HarnessKind.CLAUDE:
+        return ClaudeTransport()
+    if session.harness is HarnessKind.CODEX:
+        return CodexTransport()
+    if session.harness is HarnessKind.DROID:
+        return DroidTransport()
+    raise BridgeTransportError(f"Unsupported harness: {session.harness.value}")

--- a/aragora/swarm/agent_bridge/types.py
+++ b/aragora/swarm/agent_bridge/types.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+def utc_now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class HarnessKind(str, Enum):
+    CLAUDE = "claude"
+    CODEX = "codex"
+    DROID = "droid"
+
+
+class BridgeRunStatus(str, Enum):
+    RUNNING = "running"
+    WAITING_HUMAN = "waiting_human"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass(slots=True)
+class BridgeFooter:
+    summary: str
+    next_actor: str | None
+    needs_human: bool
+    done: bool
+    artifacts: list[str] = field(default_factory=list)
+    tests_run: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "summary": self.summary,
+            "next_actor": self.next_actor,
+            "needs_human": self.needs_human,
+            "done": self.done,
+            "artifacts": list(self.artifacts),
+            "tests_run": list(self.tests_run),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "BridgeFooter":
+        return cls(
+            summary=str(payload.get("summary", "") or "").strip(),
+            next_actor=(
+                str(payload.get("next_actor", "")).strip()
+                if payload.get("next_actor") not in (None, "")
+                else None
+            ),
+            needs_human=bool(payload.get("needs_human", False)),
+            done=bool(payload.get("done", False)),
+            artifacts=[
+                str(item).strip()
+                for item in list(payload.get("artifacts", []) or [])
+                if str(item).strip()
+            ],
+            tests_run=[
+                str(item).strip()
+                for item in list(payload.get("tests_run", []) or [])
+                if str(item).strip()
+            ],
+        )
+
+
+@dataclass(slots=True)
+class BridgeSession:
+    name: str
+    harness: HarnessKind
+    role: str = ""
+    model: str | None = None
+    session_id: str | None = None
+    worktree_path: str | None = None
+    branch: str | None = None
+    created_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
+    turn_count: int = 0
+    full_auto: bool = False
+    allow_dangerous: bool = False
+    droid_auto: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "harness": self.harness.value,
+            "role": self.role,
+            "model": self.model,
+            "session_id": self.session_id,
+            "worktree_path": self.worktree_path,
+            "branch": self.branch,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "turn_count": self.turn_count,
+            "full_auto": self.full_auto,
+            "allow_dangerous": self.allow_dangerous,
+            "droid_auto": self.droid_auto,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "BridgeSession":
+        return cls(
+            name=str(payload.get("name", "") or ""),
+            harness=HarnessKind(str(payload.get("harness", HarnessKind.CODEX.value))),
+            role=str(payload.get("role", "") or ""),
+            model=str(payload.get("model")) if payload.get("model") else None,
+            session_id=str(payload.get("session_id")) if payload.get("session_id") else None,
+            worktree_path=(
+                str(payload.get("worktree_path")) if payload.get("worktree_path") else None
+            ),
+            branch=str(payload.get("branch")) if payload.get("branch") else None,
+            created_at=str(payload.get("created_at", utc_now_iso()) or utc_now_iso()),
+            updated_at=str(payload.get("updated_at", utc_now_iso()) or utc_now_iso()),
+            turn_count=int(payload.get("turn_count", 0) or 0),
+            full_auto=bool(payload.get("full_auto", False)),
+            allow_dangerous=bool(payload.get("allow_dangerous", False)),
+            droid_auto=str(payload.get("droid_auto")) if payload.get("droid_auto") else None,
+        )
+
+    @property
+    def worktree(self) -> Path | None:
+        if not self.worktree_path:
+            return None
+        return Path(self.worktree_path)
+
+
+@dataclass(slots=True)
+class BridgeRun:
+    run_id: str
+    task: str
+    repo_root: str
+    base_branch: str = "main"
+    status: BridgeRunStatus = BridgeRunStatus.RUNNING
+    created_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
+    active_actor: str | None = None
+    last_summary: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "task": self.task,
+            "repo_root": self.repo_root,
+            "base_branch": self.base_branch,
+            "status": self.status.value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "active_actor": self.active_actor,
+            "last_summary": self.last_summary,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "BridgeRun":
+        return cls(
+            run_id=str(payload.get("run_id", "") or ""),
+            task=str(payload.get("task", "") or ""),
+            repo_root=str(payload.get("repo_root", "") or ""),
+            base_branch=str(payload.get("base_branch", "main") or "main"),
+            status=BridgeRunStatus(str(payload.get("status", BridgeRunStatus.RUNNING.value))),
+            created_at=str(payload.get("created_at", utc_now_iso()) or utc_now_iso()),
+            updated_at=str(payload.get("updated_at", utc_now_iso()) or utc_now_iso()),
+            active_actor=(
+                str(payload.get("active_actor", "")).strip()
+                if payload.get("active_actor") not in (None, "")
+                else None
+            ),
+            last_summary=str(payload.get("last_summary", "") or ""),
+        )
+
+
+@dataclass(slots=True)
+class BridgeTurnResult:
+    session_id: str
+    response_text: str
+    raw_stdout: str
+    raw_stderr: str
+    footer: BridgeFooter | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "response_text": self.response_text,
+            "raw_stdout": self.raw_stdout,
+            "raw_stderr": self.raw_stderr,
+            "footer": self.footer.to_dict() if self.footer is not None else None,
+            "metadata": dict(self.metadata),
+        }

--- a/scripts/agent_bridge_broker.py
+++ b/scripts/agent_bridge_broker.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from aragora.swarm.agent_bridge import AgentBridgeBroker
+from aragora.swarm.agent_bridge import BridgeSession
+from aragora.swarm.agent_bridge import HarnessKind
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _print_json(payload: object) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _parse_agent_spec(raw: str) -> BridgeSession:
+    # format: name=harness[:model]
+    if "=" not in raw:
+        raise ValueError(f"Invalid agent spec '{raw}'. Use name=harness[:model]")
+    name, remainder = raw.split("=", 1)
+    harness_value, _, model = remainder.partition(":")
+    name = name.strip()
+    harness_value = harness_value.strip()
+    if not name or not harness_value:
+        raise ValueError(f"Invalid agent spec '{raw}'. Use name=harness[:model]")
+    return BridgeSession(
+        name=name,
+        harness=HarnessKind(harness_value),
+        role=name,
+        model=model.strip() or None,
+    )
+
+
+def _load_sessions(args: argparse.Namespace) -> list[BridgeSession]:
+    if args.agents_file:
+        payload = json.loads(Path(args.agents_file).read_text(encoding="utf-8"))
+        if not isinstance(payload, list):
+            raise ValueError("agents file must contain a JSON array")
+        return [BridgeSession.from_dict(item) for item in payload if isinstance(item, dict)]
+    if not args.agent:
+        raise ValueError("Provide at least one --agent or --agents-file")
+    return [_parse_agent_spec(item) for item in args.agent]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="CLI-resume broker for heterogeneous agent sessions"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create-run", help="Create a new bridge run")
+    create.add_argument("--task", required=True)
+    create.add_argument("--base", default="main")
+    create.add_argument("--agent", action="append")
+    create.add_argument("--agents-file")
+
+    send = sub.add_parser("dispatch-turn", help="Dispatch a turn to one actor in an existing run")
+    send.add_argument("--run-id", required=True)
+    send.add_argument("--actor", required=True)
+    prompt_group = send.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt")
+    prompt_group.add_argument("--prompt-file")
+
+    show = sub.add_parser("show-run", help="Show run detail with sessions")
+    show.add_argument("--run-id", required=True)
+
+    events = sub.add_parser("show-events", help="Show run events")
+    events.add_argument("--run-id", required=True)
+    events.add_argument("--limit", type=int, default=100)
+
+    list_runs = sub.add_parser("list-runs", help="List bridge runs")
+    list_runs.add_argument("--limit", type=int, default=50)
+
+    sub.add_parser("healthcheck", help="Check installed harness CLIs")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    broker = AgentBridgeBroker(_repo_root())
+
+    if args.command == "create-run":
+        sessions = _load_sessions(args)
+        run = broker.create_run(task=args.task, sessions=sessions, base_branch=args.base)
+        _print_json(
+            {
+                "run": run.to_dict(),
+                "sessions": [session.to_dict() for session in sessions],
+            }
+        )
+        return 0
+
+    if args.command == "dispatch-turn":
+        prompt = args.prompt
+        if args.prompt_file:
+            prompt = Path(args.prompt_file).read_text(encoding="utf-8")
+        if prompt is None:
+            raise ValueError("prompt is required")
+        result = broker.dispatch_turn(run_id=args.run_id, actor=args.actor, prompt=prompt)
+        _print_json(result.to_dict())
+        return 0
+
+    if args.command == "show-run":
+        run = broker.load_run(args.run_id)
+        sessions = broker.load_sessions(args.run_id)
+        _print_json({"run": run.to_dict(), "sessions": [session.to_dict() for session in sessions]})
+        return 0
+
+    if args.command == "show-events":
+        _print_json({"events": broker.load_events(args.run_id, limit=args.limit)})
+        return 0
+
+    if args.command == "list-runs":
+        _print_json({"runs": [run.to_dict() for run in broker.list_runs(limit=args.limit)]})
+        return 0
+
+    if args.command == "healthcheck":
+        _print_json({"health": broker.healthcheck()})
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_bridge_live_smoke.py
+++ b/scripts/agent_bridge_live_smoke.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import tempfile
+import uuid
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from aragora.swarm.agent_bridge.transport import ClaudeTransport
+from aragora.swarm.agent_bridge.transport import CodexTransport
+from aragora.swarm.agent_bridge.transport import DroidTransport
+from aragora.swarm.agent_bridge.types import BridgeSession
+from aragora.swarm.agent_bridge.types import HarnessKind
+from aragora.swarm.agent_bridge.types import utc_now_iso
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Live smoke test for the CLI-resume agent bridge")
+    parser.add_argument(
+        "--repo", default=str(Path.cwd()), help="Repository root to use for artifacts"
+    )
+    parser.add_argument("--codex-model", default=None)
+    parser.add_argument("--claude-model", default=None)
+    parser.add_argument("--droid-model", default=None)
+    parser.add_argument(
+        "--artifact-dir",
+        default=None,
+        help="Optional artifact directory (defaults to .aragora/agent_bridge/live_smoke)",
+    )
+    return parser
+
+
+def _require(binary: str) -> None:
+    if shutil.which(binary):
+        return
+    raise SystemExit(f"Required binary not found on PATH: {binary}")
+
+
+def _ensure_artifact_dir(repo_root: Path, override: str | None) -> Path:
+    path = (
+        Path(override).resolve()
+        if override
+        else repo_root / ".aragora" / "agent_bridge" / "live_smoke"
+    )
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _assert_contains(label: str, text: str, token: str) -> None:
+    if token not in text:
+        raise SystemExit(f"{label} did not preserve token {token!r}. Response: {text!r}")
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = Path(args.repo).resolve()
+    artifact_dir = _ensure_artifact_dir(repo_root, args.artifact_dir)
+
+    _require("codex")
+    _require("claude")
+    _require("droid")
+
+    with tempfile.TemporaryDirectory(prefix="agent-bridge-live-smoke-") as temp_dir:
+        worktree = Path(temp_dir)
+        shared_token = f"shared-{uuid.uuid4().hex[:10]}"
+        codex_token = f"codex-{uuid.uuid4().hex[:8]}"
+        droid_token = f"droid-{uuid.uuid4().hex[:8]}"
+        claude_token = f"claude-{uuid.uuid4().hex[:8]}"
+
+        codex_session = BridgeSession(
+            name="codex-live-smoke",
+            harness=HarnessKind.CODEX,
+            worktree_path=str(worktree),
+            model=args.codex_model,
+        )
+        droid_session = BridgeSession(
+            name="droid-live-smoke",
+            harness=HarnessKind.DROID,
+            worktree_path=str(worktree),
+            model=args.droid_model,
+        )
+        claude_session = BridgeSession(
+            name="claude-live-smoke",
+            harness=HarnessKind.CLAUDE,
+            worktree_path=str(worktree),
+            model=args.claude_model,
+        )
+
+        codex = CodexTransport()
+        droid = DroidTransport()
+        claude = ClaudeTransport()
+
+        codex_first = codex.start_session(
+            codex_session,
+            f"Remember this token for the next turn: {codex_token}. Reply with exactly READY.",
+        )
+        codex_session.session_id = codex_first.session_id
+        codex_second = codex.resume_turn(
+            codex_session,
+            "What token did I ask you to remember? Reply with the token only.",
+        )
+        _assert_contains("codex", codex_second.response_text, codex_token)
+
+        droid_first = droid.start_session(
+            droid_session,
+            f"Remember this token for the next turn: {droid_token}. Reply with exactly READY.",
+        )
+        droid_session.session_id = droid_first.session_id
+        droid_second = droid.resume_turn(
+            droid_session,
+            "What token did I ask you to remember? Reply with the token only.",
+        )
+        _assert_contains("droid", droid_second.response_text, droid_token)
+
+        claude_first = claude.start_session(
+            claude_session,
+            f"Remember this token for the next turn: {claude_token}. Reply with exactly READY.",
+        )
+        claude_session.session_id = claude_first.session_id
+        claude_second = claude.resume_turn(
+            claude_session,
+            "What token did I ask you to remember? Reply with the token only.",
+        )
+        _assert_contains("claude", claude_second.response_text, claude_token)
+
+        codex_handoff = codex.resume_turn(
+            codex_session,
+            f"Create a handoff sentence containing the shared token {shared_token}. Reply in one sentence.",
+        )
+        droid_handoff = droid.resume_turn(
+            droid_session,
+            (
+                "A peer agent handed you this sentence:\n"
+                f"{codex_handoff.response_text}\n\n"
+                f"Repeat the shared token {shared_token} exactly once in your response."
+            ),
+        )
+        _assert_contains("droid handoff", droid_handoff.response_text, shared_token)
+        claude_handoff = claude.resume_turn(
+            claude_session,
+            (
+                "Two peer agents are coordinating on a shared token.\n"
+                f"Codex said: {codex_handoff.response_text}\n"
+                f"Droid said: {droid_handoff.response_text}\n\n"
+                f"Confirm the shared token {shared_token} exactly once in your response."
+            ),
+        )
+        _assert_contains("claude handoff", claude_handoff.response_text, shared_token)
+
+        artifact = {
+            "timestamp": utc_now_iso(),
+            "repo_root": str(repo_root),
+            "worktree": str(worktree),
+            "shared_token": shared_token,
+            "sessions": {
+                "codex": codex_session.to_dict(),
+                "droid": droid_session.to_dict(),
+                "claude": claude_session.to_dict(),
+            },
+            "results": {
+                "codex_recall": codex_second.to_dict(),
+                "droid_recall": droid_second.to_dict(),
+                "claude_recall": claude_second.to_dict(),
+                "codex_handoff": codex_handoff.to_dict(),
+                "droid_handoff": droid_handoff.to_dict(),
+                "claude_handoff": claude_handoff.to_dict(),
+            },
+        }
+        artifact_path = artifact_dir / f"live-smoke-{uuid.uuid4().hex[:12]}.json"
+        artifact_path.write_text(
+            json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(
+            json.dumps({"ok": True, "artifact_path": str(artifact_path)}, indent=2, sort_keys=True)
+        )
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/agent_bridge/codex_first_turn.jsonl
+++ b/tests/fixtures/agent_bridge/codex_first_turn.jsonl
@@ -1,0 +1,2 @@
+{"type":"thread.started","thread_id":"019db14c-6f2d-75f6-856d-615d3cdcd7c9"}
+{"type":"turn.completed","usage":{"input_tokens":1278,"output_tokens":64},"stop_reason":"completed"}

--- a/tests/fixtures/agent_bridge/codex_resume_turn.jsonl
+++ b/tests/fixtures/agent_bridge/codex_resume_turn.jsonl
@@ -1,0 +1,1 @@
+{"type":"turn.completed","usage":{"input_tokens":1602,"output_tokens":52},"stop_reason":"completed"}

--- a/tests/fixtures/agent_bridge/droid_first_turn.json
+++ b/tests/fixtures/agent_bridge/droid_first_turn.json
@@ -1,0 +1,10 @@
+{
+  "subtype": "success",
+  "is_error": false,
+  "duration_ms": 24785,
+  "duration_api_ms": 24808,
+  "num_turns": 1,
+  "result": "OK",
+  "session_id": "16329fce-3484-47a4-ad98-6676fdfb7477",
+  "total_cost_usd": 0
+}

--- a/tests/handlers/test_agent_bridge_handler.py
+++ b/tests/handlers/test_agent_bridge_handler.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from aragora.server.handlers.agent_bridge import AgentBridgeHandler
+from aragora.swarm.agent_bridge import AgentBridgeBroker
+from aragora.swarm.agent_bridge import BridgeSession
+from aragora.swarm.agent_bridge import HarnessKind
+
+
+def _parse(result: object) -> dict:
+    return json.loads(result.body)  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def bridge_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setenv("ARAGORA_AGENT_BRIDGE_REPO", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def handler(bridge_repo: Path) -> AgentBridgeHandler:
+    broker = AgentBridgeBroker(bridge_repo)
+    run = broker.create_run(
+        task="Review the fix",
+        sessions=[
+            BridgeSession(name="codex-a", harness=HarnessKind.CODEX, role="implementer"),
+            BridgeSession(name="claude-b", harness=HarnessKind.CLAUDE, role="reviewer"),
+        ],
+        run_id="run-123",
+    )
+    broker.store.append_event(
+        run.run_id,
+        "turn_completed",
+        actor="codex-a",
+        footer={
+            "summary": "Implemented bounded slice",
+            "next_actor": "claude-b",
+            "needs_human": False,
+            "done": False,
+            "artifacts": ["turns/0001-codex-a.json"],
+            "tests_run": ["pytest tests/swarm/test_agent_bridge.py -q"],
+        },
+    )
+    return AgentBridgeHandler(ctx={})
+
+
+def test_can_handle_bridge_routes(handler: AgentBridgeHandler) -> None:
+    assert handler.can_handle("/api/v1/agent-bridge/runs")
+    assert handler.can_handle("/api/agent-bridge/runs/run-123")
+    assert not handler.can_handle("/api/v1/review-queue/prs")
+
+
+def test_list_runs_returns_session_summary(handler: AgentBridgeHandler) -> None:
+    result = handler.handle("/api/v1/agent-bridge/runs", {"limit": "10"}, MagicMock())
+
+    assert result is not None
+    assert result.status_code == 200
+    data = _parse(result)
+    assert data["total"] == 1
+    assert data["runs"][0]["run_id"] == "run-123"
+    assert data["runs"][0]["session_count"] == 2
+    assert {item["name"] for item in data["runs"][0]["agents"]} == {"codex-a", "claude-b"}
+
+
+def test_get_run_returns_sessions(handler: AgentBridgeHandler) -> None:
+    result = handler.handle("/api/v1/agent-bridge/runs/run-123", {}, MagicMock())
+
+    assert result is not None
+    assert result.status_code == 200
+    data = _parse(result)
+    assert data["run"]["run_id"] == "run-123"
+    assert len(data["sessions"]) == 2
+
+
+def test_get_events_returns_event_log(handler: AgentBridgeHandler) -> None:
+    result = handler.handle("/api/v1/agent-bridge/runs/run-123/events", {"limit": "5"}, MagicMock())
+
+    assert result is not None
+    assert result.status_code == 200
+    data = _parse(result)
+    assert data["count"] == 2
+    assert [event["type"] for event in data["events"]] == ["run_created", "turn_completed"]
+
+
+def test_unknown_run_returns_404(handler: AgentBridgeHandler) -> None:
+    result = handler.handle("/api/v1/agent-bridge/runs/missing", {}, MagicMock())
+
+    assert result is not None
+    assert result.status_code == 404

--- a/tests/swarm/test_agent_bridge.py
+++ b/tests/swarm/test_agent_bridge.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from aragora.swarm.agent_bridge.broker import AgentBridgeBroker
+from aragora.swarm.agent_bridge.footer import FOOTER_PREFIX
+from aragora.swarm.agent_bridge.footer import extract_footer
+from aragora.swarm.agent_bridge.store import BridgeStore
+from aragora.swarm.agent_bridge.transport import ClaudeTransport
+from aragora.swarm.agent_bridge.transport import CodexTransport
+from aragora.swarm.agent_bridge.transport import DroidTransport
+from aragora.swarm.agent_bridge.types import BridgeRun
+from aragora.swarm.agent_bridge.types import BridgeSession
+from aragora.swarm.agent_bridge.types import BridgeTurnResult
+from aragora.swarm.agent_bridge.types import HarnessKind
+
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "agent_bridge"
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_extract_footer_returns_body_and_footer() -> None:
+    text = (
+        "Implemented the bounded fix.\n"
+        f"{FOOTER_PREFIX} "
+        '{"summary":"Patched config loader","next_actor":"reviewer","needs_human":false,'
+        '"done":false,"artifacts":["tests/pdb/test_panel_config.py"],'
+        '"tests_run":["pytest tests/pdb/test_panel_config.py -q"]}'
+    )
+
+    footer, body = extract_footer(text)
+
+    assert footer is not None
+    assert footer.summary == "Patched config loader"
+    assert footer.next_actor == "reviewer"
+    assert footer.tests_run == ["pytest tests/pdb/test_panel_config.py -q"]
+    assert body == "Implemented the bounded fix."
+
+
+def test_bridge_store_round_trip(tmp_path: Path) -> None:
+    store = BridgeStore(tmp_path)
+    run = BridgeRun(run_id="run-123", task="Inspect cross-harness recall", repo_root=str(tmp_path))
+    session = BridgeSession(name="codex-a", harness=HarnessKind.CODEX, role="implementer")
+
+    store.save_run(run)
+    store.save_sessions(run.run_id, [session])
+    store.append_event(run.run_id, "run_created", actor="codex-a")
+
+    loaded_run = store.load_run(run.run_id)
+    loaded_sessions = store.load_sessions(run.run_id)
+    loaded_events = store.load_events(run.run_id)
+
+    assert loaded_run.to_dict() == run.to_dict()
+    assert [item.to_dict() for item in loaded_sessions] == [session.to_dict()]
+    assert loaded_events[0]["type"] == "run_created"
+
+
+def test_codex_parse_fixture_captures_thread_id() -> None:
+    transport = CodexTransport()
+
+    result = transport._parse(
+        _fixture("codex_first_turn.jsonl"),
+        "",
+        "Review completed.",
+    )
+
+    assert result.session_id == "019db14c-6f2d-75f6-856d-615d3cdcd7c9"
+    assert result.response_text == "Review completed."
+    assert result.metadata["usage"]["output_tokens"] == 64
+
+
+def test_codex_resume_parse_uses_existing_session_id_hint() -> None:
+    transport = CodexTransport()
+
+    result = transport._parse(
+        _fixture("codex_resume_turn.jsonl"),
+        "",
+        "Follow-up response.",
+        session_id_hint="thread-existing",
+    )
+
+    assert result.session_id == "thread-existing"
+    assert result.metadata["stop_reason"] == "completed"
+
+
+def test_droid_parse_fixture_captures_session_id() -> None:
+    transport = DroidTransport()
+
+    result = transport._parse(_fixture("droid_first_turn.json"), "")
+
+    assert result.session_id == "16329fce-3484-47a4-ad98-6676fdfb7477"
+    assert result.response_text == "OK"
+    assert result.metadata["num_turns"] == 1
+
+
+def test_claude_build_cmd_uses_resume_and_explicit_session_id() -> None:
+    transport = ClaudeTransport()
+    session = BridgeSession(name="claude-review", harness=HarnessKind.CLAUDE, session_id="sess-1")
+
+    start_cmd = transport._build_cmd(
+        BridgeSession(name="claude-review", harness=HarnessKind.CLAUDE),
+        "hello",
+        resume=False,
+    )
+    resume_cmd = transport._build_cmd(session, "again", resume=True)
+
+    assert "--session-id" in start_cmd
+    assert "--resume" in resume_cmd
+    assert resume_cmd[resume_cmd.index("--resume") + 1] == "sess-1"
+
+
+def test_broker_dispatch_turn_persists_run_and_events(monkeypatch, tmp_path: Path) -> None:
+    broker = AgentBridgeBroker(tmp_path)
+    sessions = [BridgeSession(name="codex-a", harness=HarnessKind.CODEX, role="implementer")]
+    run = broker.create_run(task="Implement a bounded fix", sessions=sessions, run_id="run-001")
+
+    def fake_ensure_worktree(*, session: BridgeSession, base_branch: str) -> None:
+        session.worktree_path = str(tmp_path)
+        session.branch = f"codex/{base_branch}/codex-a"
+
+    class FakeTransport:
+        def start_session(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+            assert "AGENT_BRIDGE_FOOTER:" in prompt
+            return BridgeTurnResult(
+                session_id="thread-1",
+                response_text=(
+                    "Implemented the change.\n"
+                    f"{FOOTER_PREFIX} "
+                    '{"summary":"Implemented the change","next_actor":"reviewer",'
+                    '"needs_human":false,"done":false,"artifacts":["artifact.json"],'
+                    '"tests_run":["pytest tests/swarm/test_agent_bridge.py -q"]}'
+                ),
+                raw_stdout="",
+                raw_stderr="",
+            )
+
+    monkeypatch.setattr(broker, "_ensure_worktree", fake_ensure_worktree)
+    monkeypatch.setattr(
+        "aragora.swarm.agent_bridge.broker.transport_for", lambda session: FakeTransport()
+    )
+
+    result = broker.dispatch_turn(
+        run_id=run.run_id, actor="codex-a", prompt="Make the bounded edit."
+    )
+    reloaded = AgentBridgeBroker(tmp_path)
+
+    assert result.footer is not None
+    assert result.footer.summary == "Implemented the change"
+    loaded_run = reloaded.load_run(run.run_id)
+    loaded_sessions = reloaded.load_sessions(run.run_id)
+    loaded_events = reloaded.load_events(run.run_id)
+    turn_artifact = (
+        tmp_path / ".aragora" / "agent_bridge" / "runs" / run.run_id / "turns" / "0001-codex-a.json"
+    )
+
+    assert loaded_run.active_actor == "reviewer"
+    assert loaded_sessions[0].session_id == "thread-1"
+    assert turn_artifact.exists()
+    assert any(event["type"] == "turn_completed" for event in loaded_events)
+
+
+def test_broker_requests_footer_repair_once(monkeypatch, tmp_path: Path) -> None:
+    broker = AgentBridgeBroker(tmp_path)
+    sessions = [BridgeSession(name="droid-review", harness=HarnessKind.DROID, role="reviewer")]
+    run = broker.create_run(task="Review the patch", sessions=sessions, run_id="run-002")
+
+    def fake_ensure_worktree(*, session: BridgeSession, base_branch: str) -> None:
+        session.worktree_path = str(tmp_path)
+        session.branch = f"droid/{base_branch}/review"
+
+    class FakeTransport:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def start_session(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+            self.calls += 1
+            return BridgeTurnResult(
+                session_id="droid-session",
+                response_text="Here is the review without the footer.",
+                raw_stdout="",
+                raw_stderr="",
+            )
+
+        def resume_turn(self, session: BridgeSession, prompt: str) -> BridgeTurnResult:
+            self.calls += 1
+            assert "Return exactly one line containing only a corrected footer." in prompt
+            return BridgeTurnResult(
+                session_id="droid-session",
+                response_text=(
+                    f"{FOOTER_PREFIX} "
+                    '{"summary":"Footer repaired","next_actor":null,"needs_human":true,'
+                    '"done":false,"artifacts":[],"tests_run":[]}'
+                ),
+                raw_stdout="",
+                raw_stderr="",
+            )
+
+    transport = FakeTransport()
+    monkeypatch.setattr(broker, "_ensure_worktree", fake_ensure_worktree)
+    monkeypatch.setattr(
+        "aragora.swarm.agent_bridge.broker.transport_for", lambda session: transport
+    )
+
+    result = broker.dispatch_turn(run_id=run.run_id, actor="droid-review", prompt="Review it.")
+    events = broker.load_events(run.run_id)
+
+    assert result.footer is not None
+    assert result.footer.summary == "Footer repaired"
+    assert transport.calls == 2
+    assert any(event["type"] == "footer_repair_requested" for event in events)
+    assert any(event["type"] == "footer_repair_completed" for event in events)


### PR DESCRIPTION
## Summary
- add a repo-local CLI-resume agent bridge broker for Codex, Claude, and Droid sessions
- expose read-only bridge run endpoints and add an Autonomous bridge UI for run list/detail observability
- add transport fixtures, backend/frontend tests, and a gated live smoke script for cross-harness recall/handoff validation

## What Changed
- broker core under `aragora/swarm/agent_bridge/`
- read-only handler at `aragora/server/handlers/agent_bridge.py`
- Autonomous pages under `/autonomous/bridge`
- CLI entrypoint: `scripts/agent_bridge_broker.py`
- live smoke probe: `scripts/agent_bridge_live_smoke.py`

## Validation
- `python3 -m pytest tests/swarm/test_agent_bridge.py tests/handlers/test_agent_bridge_handler.py`
- `python3 -m ruff check aragora/swarm/agent_bridge aragora/server/handlers/agent_bridge.py scripts/agent_bridge_broker.py scripts/agent_bridge_live_smoke.py tests/swarm/test_agent_bridge.py tests/handlers/test_agent_bridge_handler.py`
- `python3 -m mypy --follow-imports skip aragora/swarm/agent_bridge/types.py aragora/swarm/agent_bridge/footer.py aragora/swarm/agent_bridge/store.py aragora/swarm/agent_bridge/transport.py aragora/swarm/agent_bridge/broker.py aragora/server/handlers/agent_bridge.py scripts/agent_bridge_broker.py scripts/agent_bridge_live_smoke.py`
- `jest --runInBand src/components/autonomous/bridge/__tests__/BridgeRunList.test.tsx src/components/autonomous/bridge/__tests__/BridgeRunDetail.test.tsx`

## Boundaries
- no pause/resume/cancel controls yet
- no policy engine or decision cards yet
- no PR publish/merge automation yet
- tmux/session-mux remains intact as the legacy/manual surface
