### PR TITLE
feat(pdb): PR 2 — Protocol B executor + panel config + budget

### DIFF
--- a/aragora/config/pdb_panel.yaml
+++ b/aragora/config/pdb_panel.yaml
@@ -1,0 +1,96 @@
+# PDB Mode 3 default panel configuration.
+#
+# Transport-neutral default roster and budget caps for Protocol B. The
+# shape is validated by :mod:`aragora.pdb.panel_config`; the executor in
+# :mod:`aragora.pdb.protocol` consumes the validated structure.
+#
+# This file is committed configuration — NOT a secret store. Credentials
+# (API keys, CLI binaries) are resolved at runtime via the provider-slot
+# resolver, not hard-coded here.
+#
+# Required shape (see
+# docs/plans/2026-04-21-pdb-mode3-pr2-spec.md):
+#   - ``version`` must be 1
+#   - ``default_panel`` must match a ``panels`` entry
+#   - ``synthesizer_slot`` must match a ``slots`` entry
+#   - each slot must define ``review_role``, ``lens``, ``family``,
+#     ``candidates``
+#   - the default panel must include both required core slots and at
+#     least one non-core lens
+#   - budgets are in USD; ``per_brief_usd`` is the maximum a single
+#     Protocol B run may reserve, ``per_day_usd`` is the rolling 24h
+#     cap across all briefs.
+version: 1
+default_panel: protocol_b_default
+default_prompt_set: protocol_b_v1
+budgets:
+  per_brief_usd: 8.0
+  per_day_usd: 200.0
+  reserve_for_manual_escalation_usd: 40.0
+slots:
+  claude_core:
+    review_role: logic_reviewer
+    lens: core
+    family: claude
+    candidates: [claude, anthropic-api]
+    required: true
+  gpt_core:
+    review_role: security_reviewer
+    lens: core
+    family: gpt
+    candidates: [codex, openai-api, openai]
+    required: true
+  gemini_heterodox:
+    review_role: maintainability_reviewer
+    lens: heterodox
+    family: gemini
+    candidates: [gemini-cli, gemini]
+    required: false
+  grok_heterodox:
+    review_role: skeptic
+    lens: heterodox
+    family: grok
+    candidates: [grok-cli, grok]
+    required: false
+  deepseek_heterodox:
+    review_role: skeptic
+    lens: heterodox
+    family: deepseek
+    candidates: [deepseek-cli, deepseek]
+    required: false
+  kimi_heterodox:
+    review_role: skeptic
+    lens: heterodox
+    family: kimi
+    candidates: [kimi]
+    required: false
+  qwen_heterodox:
+    review_role: skeptic
+    lens: heterodox
+    family: qwen
+    candidates: [qwen-cli, qwen]
+    required: false
+  mistral_regulatory:
+    review_role: skeptic
+    lens: regulatory
+    family: mistral
+    candidates: [mistral-api, mistral]
+    required: false
+panels:
+  protocol_b_default:
+    findings_slots:
+      - claude_core
+      - gpt_core
+      - gemini_heterodox
+      - grok_heterodox
+      - deepseek_heterodox
+      - kimi_heterodox
+      - qwen_heterodox
+      - mistral_regulatory
+    critique_slots: same_as_findings
+    synthesizer_slot: claude_core
+prompt_sets:
+  protocol_b_v1:
+    findings_prompt: protocol_b_findings
+    critique_prompt: protocol_b_critique
+    synthesis_prompt: protocol_b_synthesis

--- a/aragora/pdb/budget.py
+++ b/aragora/pdb/budget.py
@@ -1,0 +1,400 @@
+"""PDB Mode 3 Protocol B budget reservation and denial logic.
+
+Layered on top of the :class:`aragora.review.policy.ReviewPolicy` +
+:class:`aragora.review.policy.ReviewBudget` schema, this module adds
+Protocol-B-specific reservation semantics:
+
+- estimate the full configured-panel spend before any findings round
+- reserve spend against per-brief and per-day caps
+- release unused reserve once a run finishes (or never starts)
+- record which slots the reserved budget actually funded
+
+**Never silently degrade to metadata-heuristic output.** A breach
+yields an explicit :data:`PDBBudgetStatus.BUDGET_EXCEEDED` decision
+that the executor propagates to its caller. Callers may pair the
+denial with a pre-existing heuristic packet for UX, but this module
+does not fabricate one.
+
+The module is deterministic and side-effect free: a
+:class:`PDBBudgetLedger` captures the rolling daily spend the caller
+is responsible for maintaining (the storage layer in PR1 is one
+candidate store; callers may also supply an in-memory ledger for
+tests).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from aragora.pdb.panel_config import PDBBudgetConfig, PDBPanelSlot
+from aragora.review.policy import ReviewBudget
+
+__all__ = [
+    "DEFAULT_SLOT_COST_USD",
+    "DEFAULT_SYNTHESIS_COST_USD",
+    "PDBBudgetDecision",
+    "PDBBudgetLedger",
+    "PDBBudgetReservation",
+    "PDBBudgetStatus",
+    "SlotCostEstimator",
+    "estimate_slot_costs",
+    "evaluate_budget",
+    "per_brief_cap_usd",
+]
+
+
+DEFAULT_SLOT_COST_USD = 0.85
+"""Default per-slot findings+critique cost assumption (USD).
+
+Matches the heuristic upper band surfaced by
+:class:`aragora.swarm.pr_review_protocol.PRReviewProtocol.build_packet`
+so PDB estimates don't diverge from the metadata-heuristic packet the
+UI already shows.
+"""
+
+DEFAULT_SYNTHESIS_COST_USD = 1.1
+"""Default cost reservation for the single synthesis pass (USD)."""
+
+
+# ---------------------------------------------------------------------------
+# Status / decision / reservation dataclasses
+# ---------------------------------------------------------------------------
+
+
+class PDBBudgetStatus(str, Enum):
+    """Outcome of :func:`evaluate_budget`.
+
+    - ``ALLOWED`` — the full configured roster fits inside both caps.
+    - ``BUDGET_DEGRADED`` — at least one optional slot was dropped to
+      fit inside the per-brief cap while preserving the minimum safe
+      roster (both core slots + synthesis). Execution may proceed.
+    - ``BUDGET_EXCEEDED`` — neither the full nor the minimum safe
+      roster fits. Execution MUST NOT proceed; the caller is expected
+      to surface the denial and fall back to the pre-existing
+      heuristic packet labeled as such.
+    """
+
+    ALLOWED = "allowed"
+    BUDGET_DEGRADED = "budget_degraded"
+    BUDGET_EXCEEDED = "budget_exceeded"
+
+
+@dataclass(frozen=True, slots=True)
+class PDBBudgetDecision:
+    """The budget verdict plus enough context to explain itself."""
+
+    status: PDBBudgetStatus
+    total_estimated_usd: float
+    per_brief_cap_usd: float
+    per_day_cap_usd: float
+    per_day_spent_before_usd: float
+    per_day_remaining_before_usd: float
+    funded_slots: tuple[str, ...]
+    dropped_slots: tuple[str, ...]
+    slot_estimates_usd: Mapping[str, float]
+    synthesis_estimate_usd: float
+    reason: str
+    binding_cap: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "total_estimated_usd": round(self.total_estimated_usd, 4),
+            "per_brief_cap_usd": round(self.per_brief_cap_usd, 4),
+            "per_day_cap_usd": round(self.per_day_cap_usd, 4),
+            "per_day_spent_before_usd": round(self.per_day_spent_before_usd, 4),
+            "per_day_remaining_before_usd": round(self.per_day_remaining_before_usd, 4),
+            "funded_slots": list(self.funded_slots),
+            "dropped_slots": list(self.dropped_slots),
+            "slot_estimates_usd": {k: round(v, 4) for k, v in self.slot_estimates_usd.items()},
+            "synthesis_estimate_usd": round(self.synthesis_estimate_usd, 4),
+            "reason": self.reason,
+            "binding_cap": self.binding_cap,
+        }
+
+
+@dataclass(slots=True)
+class PDBBudgetReservation:
+    """Mutable reservation handle for a single Protocol B run.
+
+    The executor reserves once up-front (``reserve_total_usd``), then
+    charges actual spend as each phase completes via
+    :meth:`charge`. When findings/critique finish, any over-reserve
+    that did not land is released via :meth:`release_unused` so the
+    rolling daily pool recovers headroom.
+
+    ``release_unused`` is idempotent: re-releasing a finalized
+    reservation is a no-op. Charging after finalization raises
+    :class:`RuntimeError` because the budget ledger would silently
+    under-report daily spend otherwise.
+    """
+
+    decision: PDBBudgetDecision
+    reserve_total_usd: float
+    actual_spend_usd: float = 0.0
+    finalized: bool = False
+    _ledger: "PDBBudgetLedger | None" = field(default=None, repr=False)
+
+    def charge(self, usd: float) -> None:
+        """Record actual spend for an executed slot or synthesis pass.
+
+        Raises :class:`RuntimeError` after :meth:`release_unused` has
+        been called to prevent silent under-reporting of daily spend.
+        """
+        if self.finalized:
+            raise RuntimeError(
+                "cannot charge against a finalized PDB budget reservation; "
+                "the ledger has already been reconciled"
+            )
+        if usd < 0:
+            raise ValueError(f"charge must be >= 0; got {usd}")
+        self.actual_spend_usd = round(self.actual_spend_usd + usd, 6)
+
+    def released_unused_usd(self) -> float:
+        """Return the amount that will be returned to the daily pool."""
+        return max(0.0, round(self.reserve_total_usd - self.actual_spend_usd, 6))
+
+    def release_unused(self) -> float:
+        """Finalize the reservation and return unused spend to the ledger."""
+        if self.finalized:
+            return 0.0
+        released = self.released_unused_usd()
+        self.finalized = True
+        if self._ledger is not None:
+            # The ledger was debited ``reserve_total_usd`` at reserve-time.
+            # Return the unused portion so cumulative-daily-spend reflects
+            # the actual (not reserved) outlay.
+            self._ledger.credit(released)
+        return released
+
+
+@dataclass(slots=True)
+class PDBBudgetLedger:
+    """Simple in-process rolling-daily-spend ledger.
+
+    Callers that want to persist daily spend across workers should
+    subclass or compose this via dependency injection. The in-memory
+    default is sufficient for PR2's mocked-provider tests; PR3 wires a
+    durable backing store (storage from PR1, Redis, or similar).
+    """
+
+    daily_cap_usd: float
+    spent_today_usd: float = 0.0
+
+    def headroom_usd(self) -> float:
+        return max(0.0, round(self.daily_cap_usd - self.spent_today_usd, 6))
+
+    def debit(self, usd: float) -> None:
+        if usd < 0:
+            raise ValueError(f"debit must be >= 0; got {usd}")
+        self.spent_today_usd = round(self.spent_today_usd + usd, 6)
+
+    def credit(self, usd: float) -> None:
+        if usd < 0:
+            raise ValueError(f"credit must be >= 0; got {usd}")
+        self.spent_today_usd = round(max(0.0, self.spent_today_usd - usd), 6)
+
+
+# ---------------------------------------------------------------------------
+# Cost estimation
+# ---------------------------------------------------------------------------
+
+
+class SlotCostEstimator:
+    """Per-slot cost-estimation strategy.
+
+    Default implementation returns :data:`DEFAULT_SLOT_COST_USD` for
+    every slot. Tests and PR3 callers can inject bespoke estimators
+    (e.g., one that consults a model-cost table). The executor only
+    calls :meth:`estimate`; subclassing is NOT required.
+    """
+
+    def __init__(self, default_usd: float = DEFAULT_SLOT_COST_USD) -> None:
+        self._default_usd = default_usd
+
+    def estimate(self, slot: PDBPanelSlot) -> float:
+        return self._default_usd
+
+
+def estimate_slot_costs(
+    slots: Sequence[PDBPanelSlot],
+    estimator: SlotCostEstimator | None = None,
+) -> dict[str, float]:
+    """Return an ordered mapping ``slot_id -> estimated cost`` in USD."""
+    est = estimator or SlotCostEstimator()
+    return {slot.slot_id: est.estimate(slot) for slot in slots}
+
+
+def per_brief_cap_usd(budget: PDBBudgetConfig, review_budget: ReviewBudget | None = None) -> float:
+    """Resolve the effective per-brief cap.
+
+    When the caller supplies a :class:`ReviewBudget`, the stricter of
+    ``ReviewBudget.per_pr_usd_cap`` and
+    :attr:`PDBBudgetConfig.per_brief_usd` wins. This mirrors the
+    "compose with, do not replace" posture of
+    :mod:`aragora.review.policy`: the repo-level review budget can
+    tighten the PDB default but not silently loosen it.
+    """
+    cap = budget.per_brief_usd
+    if review_budget is not None and review_budget.per_pr_usd_cap > 0:
+        cap = min(cap, review_budget.per_pr_usd_cap)
+    return float(cap)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_budget(
+    *,
+    findings_slots: Sequence[PDBPanelSlot],
+    synthesizer_slot: PDBPanelSlot,
+    budget: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    estimator: SlotCostEstimator | None = None,
+    synthesis_cost_usd: float = DEFAULT_SYNTHESIS_COST_USD,
+    review_budget: ReviewBudget | None = None,
+) -> PDBBudgetDecision:
+    """Evaluate a panel roster against the per-brief and per-day caps.
+
+    Returns a :class:`PDBBudgetDecision` whose ``status`` is one of
+    :data:`PDBBudgetStatus.ALLOWED`, :data:`PDBBudgetStatus.BUDGET_DEGRADED`,
+    or :data:`PDBBudgetStatus.BUDGET_EXCEEDED`. The caller is expected
+    to then reserve the decided total via :func:`reserve` (or directly
+    construct a :class:`PDBBudgetReservation`) before running findings.
+
+    Rules (per ``docs/plans/2026-04-21-pdb-mode3-pr2-spec.md`` §Budget
+    rules):
+
+    1. If both required core slots + one synthesis pass fit in the
+       per-brief cap AND the per-day headroom, execution may run at
+       full roster → ``ALLOWED``.
+    2. If optional non-core slots don't fit, drop them greedily from
+       the end of ``findings_slots`` while preserving all required
+       slots plus the synthesizer → ``BUDGET_DEGRADED``.
+    3. If required slots + synthesis don't fit in either cap → return
+       ``BUDGET_EXCEEDED`` with no silent fallback.
+    """
+    if not findings_slots:
+        raise ValueError("findings_slots must be non-empty")
+    if synthesis_cost_usd < 0:
+        raise ValueError(f"synthesis_cost_usd must be >= 0; got {synthesis_cost_usd}")
+
+    per_brief = per_brief_cap_usd(budget, review_budget)
+    per_day_spent_before = ledger.spent_today_usd
+    per_day_remaining_before = ledger.headroom_usd()
+
+    slot_estimates = estimate_slot_costs(findings_slots, estimator)
+
+    required_slot_ids = {slot.slot_id for slot in findings_slots if slot.required}
+    optional_slot_ids = [slot.slot_id for slot in findings_slots if not slot.required]
+
+    # Minimum safe roster is all required slots plus the synthesizer.
+    minimum_slot_ids = set(required_slot_ids) | {synthesizer_slot.slot_id}
+    minimum_cost = (
+        sum(slot_estimates.get(sid, 0.0) for sid in minimum_slot_ids) + synthesis_cost_usd
+    )
+
+    # If the floor can't fit under either cap, fail closed.
+    if minimum_cost > per_brief or minimum_cost > per_day_remaining_before:
+        binding = "per_brief_usd" if minimum_cost > per_brief else "per_day_usd"
+        return PDBBudgetDecision(
+            status=PDBBudgetStatus.BUDGET_EXCEEDED,
+            total_estimated_usd=minimum_cost,
+            per_brief_cap_usd=per_brief,
+            per_day_cap_usd=budget.per_day_usd,
+            per_day_spent_before_usd=per_day_spent_before,
+            per_day_remaining_before_usd=per_day_remaining_before,
+            funded_slots=(),
+            dropped_slots=tuple(slot.slot_id for slot in findings_slots),
+            slot_estimates_usd=slot_estimates,
+            synthesis_estimate_usd=synthesis_cost_usd,
+            reason=(
+                f"minimum safe roster costs ${minimum_cost:.2f} which exceeds "
+                f"{binding} (per_brief cap=${per_brief:.2f}, "
+                f"per_day remaining=${per_day_remaining_before:.2f})"
+            ),
+            binding_cap=binding,
+        )
+
+    # Greedy fit: keep all required slots in their configured order,
+    # then pile on optional slots until adding one would overflow
+    # either cap.
+    ordered_required: list[str] = [
+        sid for sid in (s.slot_id for s in findings_slots) if sid in required_slot_ids
+    ]
+    funded: list[str] = list(ordered_required)
+    running_total = sum(slot_estimates[sid] for sid in funded) + synthesis_cost_usd
+
+    cap_headroom = min(per_brief, per_day_remaining_before)
+    dropped: list[str] = []
+    for sid in optional_slot_ids:
+        cost = slot_estimates[sid]
+        if running_total + cost <= cap_headroom + 1e-9:
+            funded.append(sid)
+            running_total += cost
+        else:
+            dropped.append(sid)
+
+    status = PDBBudgetStatus.ALLOWED if not dropped else PDBBudgetStatus.BUDGET_DEGRADED
+    if dropped:
+        binding = "per_brief_usd" if per_brief <= per_day_remaining_before else "per_day_usd"
+        reason = (
+            f"dropped optional slots {dropped} to fit within {binding} "
+            f"(cap_headroom=${cap_headroom:.2f}, ran=${running_total:.2f})"
+        )
+        binding_cap = binding
+    else:
+        reason = (
+            f"full configured roster funded at ${running_total:.2f} "
+            f"within cap_headroom=${cap_headroom:.2f}"
+        )
+        binding_cap = None
+
+    # Preserve panel order in funded_slots so the executor iterates
+    # findings in the intended order.
+    panel_order = [slot.slot_id for slot in findings_slots]
+    funded_ordered = tuple(sid for sid in panel_order if sid in set(funded))
+    dropped_ordered = tuple(sid for sid in panel_order if sid not in set(funded))
+
+    return PDBBudgetDecision(
+        status=status,
+        total_estimated_usd=running_total,
+        per_brief_cap_usd=per_brief,
+        per_day_cap_usd=budget.per_day_usd,
+        per_day_spent_before_usd=per_day_spent_before,
+        per_day_remaining_before_usd=per_day_remaining_before,
+        funded_slots=funded_ordered,
+        dropped_slots=dropped_ordered,
+        slot_estimates_usd=slot_estimates,
+        synthesis_estimate_usd=synthesis_cost_usd,
+        reason=reason,
+        binding_cap=binding_cap,
+    )
+
+
+def reserve(
+    decision: PDBBudgetDecision,
+    ledger: PDBBudgetLedger,
+) -> PDBBudgetReservation:
+    """Materialize a reservation and debit the rolling daily ledger.
+
+    Raises :class:`RuntimeError` if called with a
+    :data:`PDBBudgetStatus.BUDGET_EXCEEDED` decision — such a decision
+    must not be converted into a reservation, because that would bypass
+    the explicit-denial contract.
+    """
+    if decision.status is PDBBudgetStatus.BUDGET_EXCEEDED:
+        raise RuntimeError(
+            "cannot reserve against a BUDGET_EXCEEDED decision; "
+            "executor must fail closed with an explicit denial"
+        )
+    ledger.debit(decision.total_estimated_usd)
+    return PDBBudgetReservation(
+        decision=decision,
+        reserve_total_usd=decision.total_estimated_usd,
+        _ledger=ledger,
+    )

--- a/aragora/pdb/panel_config.py
+++ b/aragora/pdb/panel_config.py
@@ -1,0 +1,645 @@
+"""Panel configuration loader and validator for PDB Mode 3 Protocol B.
+
+This module owns the YAML-driven panel roster described in
+``docs/plans/2026-04-21-pdb-mode3-pr2-spec.md``. It is a pure
+schema + validation layer: no HTTP, no worker queues, no artifact
+writing. The executor in :mod:`aragora.pdb.protocol` is the only
+in-process consumer.
+
+Public surface
+--------------
+
+Dataclasses:
+
+- :class:`PDBBudgetConfig` — per-brief / per-day USD caps
+- :class:`PDBPanelSlot` — one slot's metadata (review role, lens,
+  family, candidate provider ids, ``required`` flag)
+- :class:`PDBPanelDefinition` — which slots participate in findings,
+  critique, and which one acts as synthesizer
+- :class:`PDBPromptSet` — which prompt templates this panel uses
+- :class:`PDBPanelConfig` — the validated top-level config
+
+Functions:
+
+- :func:`load_panel_config` — load and validate the committed default
+  or a caller-supplied path
+- :func:`validate_panel_config` — validate a raw ``Mapping`` (typically
+  the result of :func:`yaml.safe_load`) with exact field-path errors
+- :func:`provider_slot_definitions` — project panel slots into the
+  landed :class:`aragora.review.provider_slots.ProviderSlotDefinition`
+  sequence for the specified panel
+- :func:`panel_slots` — return the ordered :class:`PDBPanelSlot` objects
+  for a specific panel (preserves the panel-level ordering required by
+  the executor)
+
+Validation posture
+------------------
+
+The loader raises :class:`PDBPanelConfigError` with an exact
+``field_path`` attribute so callers can surface the failing key path
+to operators without string-matching. Every rule in the spec's
+"Validation rules" section is enforced:
+
+- ``version == 1``
+- ``default_panel`` exists in ``panels``
+- ``synthesizer_slot`` exists in ``slots``
+- every slot defines ``review_role``, ``lens``, ``family``,
+  ``candidates`` (and optionally ``required``)
+- ``findings_slots`` includes BOTH required core slots
+- the selected panel contains at least one non-core lens
+- ``same_as_findings`` is allowed only for ``critique_slots``
+
+The module is intentionally I/O-free aside from one explicit filesystem
+read in :func:`load_panel_config`. Mocked configs in tests call
+:func:`validate_panel_config` directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from aragora.review.provider_slots import ProviderSlotDefinition
+
+__all__ = [
+    "DEFAULT_CONFIG_PATH",
+    "PDBBudgetConfig",
+    "PDBPanelConfig",
+    "PDBPanelConfigError",
+    "PDBPanelDefinition",
+    "PDBPanelSlot",
+    "PDBPromptSet",
+    "load_panel_config",
+    "panel_slots",
+    "provider_slot_definitions",
+    "validate_panel_config",
+]
+
+
+DEFAULT_CONFIG_PATH: Path = Path(__file__).resolve().parent.parent / "config" / "pdb_panel.yaml"
+"""Filesystem path to the committed default config."""
+
+SUPPORTED_VERSION = 1
+SAME_AS_FINDINGS_SENTINEL = "same_as_findings"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class PDBPanelConfigError(ValueError):
+    """Raised when a panel config fails validation.
+
+    Inherits from :class:`ValueError` so callers that want to swallow
+    "bad input" errors without importing this package still catch it.
+    The ``field_path`` attribute is the dotted path inside the YAML
+    document so operators can locate the failing key without string
+    matching on the message.
+    """
+
+    def __init__(self, field_path: str, message: str) -> None:
+        self.field_path = field_path
+        super().__init__(f"{field_path}: {message}")
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PDBBudgetConfig:
+    """Per-brief and per-day USD caps plus a manual-escalation reserve.
+
+    ``reserve_for_manual_escalation_usd`` is retained out of the
+    rolling daily pool so escalated attention flows (e.g., a deep human
+    review triggered by the brief) still have spend available even
+    after automated runs have saturated ``per_day_usd``. The executor
+    in :mod:`aragora.pdb.protocol` does not dip into the reserve; it
+    is surfaced to the caller for downstream policy layers.
+    """
+
+    per_brief_usd: float
+    per_day_usd: float
+    reserve_for_manual_escalation_usd: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "per_brief_usd": self.per_brief_usd,
+            "per_day_usd": self.per_day_usd,
+            "reserve_for_manual_escalation_usd": self.reserve_for_manual_escalation_usd,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PDBPanelSlot:
+    """One configured slot in the panel roster.
+
+    ``required=True`` means Protocol B MUST fail closed if this slot
+    cannot be resolved or cannot be funded. ``required=False`` means
+    the executor may degrade by dropping the slot while preserving the
+    minimum safe roster (both core slots plus synthesizer).
+    """
+
+    slot_id: str
+    review_role: str
+    lens: str
+    family: str
+    candidates: tuple[str, ...]
+    required: bool = False
+
+    def to_provider_slot_definition(self) -> ProviderSlotDefinition:
+        """Project this slot into the landed resolver input shape."""
+        return ProviderSlotDefinition(
+            slot_id=self.slot_id,
+            review_role=self.review_role,
+            lens=self.lens,
+            family=self.family,
+            candidates=self.candidates,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slot_id": self.slot_id,
+            "review_role": self.review_role,
+            "lens": self.lens,
+            "family": self.family,
+            "candidates": list(self.candidates),
+            "required": self.required,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PDBPanelDefinition:
+    """Which slots participate in each phase of Protocol B.
+
+    ``critique_slots == findings_slots`` is the default (the YAML
+    sentinel ``same_as_findings`` expands to a copy of
+    ``findings_slots`` during validation). ``synthesizer_slot`` MUST
+    also appear in ``findings_slots`` so the synthesizer has first-hand
+    findings context.
+    """
+
+    panel_id: str
+    findings_slots: tuple[str, ...]
+    critique_slots: tuple[str, ...]
+    synthesizer_slot: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "panel_id": self.panel_id,
+            "findings_slots": list(self.findings_slots),
+            "critique_slots": list(self.critique_slots),
+            "synthesizer_slot": self.synthesizer_slot,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PDBPromptSet:
+    """Named prompt-template identifiers per phase.
+
+    Resolved to actual prompt text at invocation time via
+    :mod:`aragora.pdb.prompts`. This dataclass only carries the template
+    identifiers so the panel config remains behavior-free.
+    """
+
+    prompt_set_id: str
+    findings_prompt: str
+    critique_prompt: str
+    synthesis_prompt: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "prompt_set_id": self.prompt_set_id,
+            "findings_prompt": self.findings_prompt,
+            "critique_prompt": self.critique_prompt,
+            "synthesis_prompt": self.synthesis_prompt,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PDBPanelConfig:
+    """Top-level validated PDB panel configuration."""
+
+    version: int
+    default_panel: str
+    default_prompt_set: str
+    budget: PDBBudgetConfig
+    slots: Mapping[str, PDBPanelSlot]
+    panels: Mapping[str, PDBPanelDefinition]
+    prompt_sets: Mapping[str, PDBPromptSet]
+    source_path: Path | None = field(default=None, compare=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "default_panel": self.default_panel,
+            "default_prompt_set": self.default_prompt_set,
+            "budget": self.budget.to_dict(),
+            "slots": {sid: slot.to_dict() for sid, slot in self.slots.items()},
+            "panels": {pid: panel.to_dict() for pid, panel in self.panels.items()},
+            "prompt_sets": {pid: ps.to_dict() for pid, ps in self.prompt_sets.items()},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def load_panel_config(path: Path | None = None) -> PDBPanelConfig:
+    """Load and validate a panel config from disk.
+
+    ``path`` defaults to :data:`DEFAULT_CONFIG_PATH`. YAML is parsed via
+    :func:`yaml.safe_load` (so no code execution, no custom tags).
+    """
+    target = Path(path) if path is not None else DEFAULT_CONFIG_PATH
+    try:
+        raw_text = target.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise PDBPanelConfigError(
+            "<path>",
+            f"panel config file not found at {target}",
+        ) from exc
+
+    raw = yaml.safe_load(raw_text)
+    if raw is None:
+        raise PDBPanelConfigError("<root>", "panel config file is empty")
+    if not isinstance(raw, Mapping):
+        raise PDBPanelConfigError(
+            "<root>",
+            f"panel config top level must be a mapping; got {type(raw).__name__}",
+        )
+    config = validate_panel_config(raw)
+    return _with_source_path(config, target)
+
+
+def _with_source_path(config: PDBPanelConfig, path: Path) -> PDBPanelConfig:
+    """Return a copy of ``config`` with ``source_path`` set.
+
+    The dataclass is frozen, so we materialize a new instance rather
+    than mutating.
+    """
+    return PDBPanelConfig(
+        version=config.version,
+        default_panel=config.default_panel,
+        default_prompt_set=config.default_prompt_set,
+        budget=config.budget,
+        slots=config.slots,
+        panels=config.panels,
+        prompt_sets=config.prompt_sets,
+        source_path=path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_panel_config(raw: Mapping[str, Any]) -> PDBPanelConfig:
+    """Validate a parsed panel config ``Mapping`` into a typed dataclass.
+
+    Every spec rule is enforced with an exact ``field_path``. No data
+    outside ``raw`` is read; this function is a pure transform.
+    """
+    version = _require(raw, "version", int, path="version")
+    if version != SUPPORTED_VERSION:
+        raise PDBPanelConfigError(
+            "version",
+            f"unsupported panel config version: {version} (expected {SUPPORTED_VERSION})",
+        )
+
+    default_panel = _require(raw, "default_panel", str, path="default_panel")
+    default_prompt_set = _require(raw, "default_prompt_set", str, path="default_prompt_set")
+
+    budget_raw = _require(raw, "budgets", Mapping, path="budgets")
+    budget = _parse_budget(budget_raw)
+
+    slots_raw = _require(raw, "slots", Mapping, path="slots")
+    if not slots_raw:
+        raise PDBPanelConfigError("slots", "slots map must not be empty")
+    slots = {sid: _parse_slot(sid, cfg) for sid, cfg in slots_raw.items()}
+
+    panels_raw = _require(raw, "panels", Mapping, path="panels")
+    if not panels_raw:
+        raise PDBPanelConfigError("panels", "panels map must not be empty")
+    panels = {pid: _parse_panel(pid, cfg, slots) for pid, cfg in panels_raw.items()}
+
+    prompt_sets_raw = _require(raw, "prompt_sets", Mapping, path="prompt_sets")
+    if not prompt_sets_raw:
+        raise PDBPanelConfigError("prompt_sets", "prompt_sets map must not be empty")
+    prompt_sets = {pid: _parse_prompt_set(pid, cfg) for pid, cfg in prompt_sets_raw.items()}
+
+    if default_panel not in panels:
+        raise PDBPanelConfigError(
+            "default_panel",
+            f"default_panel {default_panel!r} is not defined in panels",
+        )
+    if default_prompt_set not in prompt_sets:
+        raise PDBPanelConfigError(
+            "default_prompt_set",
+            f"default_prompt_set {default_prompt_set!r} is not defined in prompt_sets",
+        )
+
+    for panel_id, panel in panels.items():
+        _validate_panel_against_slots(panel_id, panel, slots)
+
+    return PDBPanelConfig(
+        version=version,
+        default_panel=default_panel,
+        default_prompt_set=default_prompt_set,
+        budget=budget,
+        slots=slots,
+        panels=panels,
+        prompt_sets=prompt_sets,
+    )
+
+
+def _parse_budget(raw: Mapping[str, Any]) -> PDBBudgetConfig:
+    per_brief = _require_number(raw, "per_brief_usd", path="budgets.per_brief_usd")
+    per_day = _require_number(raw, "per_day_usd", path="budgets.per_day_usd")
+    reserve = _require_number(
+        raw,
+        "reserve_for_manual_escalation_usd",
+        path="budgets.reserve_for_manual_escalation_usd",
+    )
+    if per_brief <= 0:
+        raise PDBPanelConfigError(
+            "budgets.per_brief_usd",
+            f"per_brief_usd must be > 0; got {per_brief}",
+        )
+    if per_day <= 0:
+        raise PDBPanelConfigError(
+            "budgets.per_day_usd",
+            f"per_day_usd must be > 0; got {per_day}",
+        )
+    if reserve < 0:
+        raise PDBPanelConfigError(
+            "budgets.reserve_for_manual_escalation_usd",
+            f"reserve_for_manual_escalation_usd must be >= 0; got {reserve}",
+        )
+    if per_brief > per_day:
+        raise PDBPanelConfigError(
+            "budgets.per_brief_usd",
+            f"per_brief_usd ({per_brief}) exceeds per_day_usd ({per_day}); "
+            "a single brief cannot be allowed to exceed the daily pool",
+        )
+    return PDBBudgetConfig(
+        per_brief_usd=float(per_brief),
+        per_day_usd=float(per_day),
+        reserve_for_manual_escalation_usd=float(reserve),
+    )
+
+
+def _parse_slot(slot_id: str, raw: Any) -> PDBPanelSlot:
+    path = f"slots.{slot_id}"
+    if not isinstance(raw, Mapping):
+        raise PDBPanelConfigError(
+            path, f"slot definition must be a mapping; got {type(raw).__name__}"
+        )
+    review_role = _require(raw, "review_role", str, path=f"{path}.review_role")
+    lens = _require(raw, "lens", str, path=f"{path}.lens")
+    family = _require(raw, "family", str, path=f"{path}.family")
+    candidates_raw = _require(raw, "candidates", list, path=f"{path}.candidates")
+    if not candidates_raw:
+        raise PDBPanelConfigError(
+            f"{path}.candidates",
+            "candidates list must not be empty",
+        )
+    candidates: list[str] = []
+    for idx, cand in enumerate(candidates_raw):
+        if not isinstance(cand, str) or not cand:
+            raise PDBPanelConfigError(
+                f"{path}.candidates[{idx}]",
+                "candidate provider must be a non-empty string",
+            )
+        candidates.append(cand)
+    required_raw = raw.get("required", False)
+    if not isinstance(required_raw, bool):
+        raise PDBPanelConfigError(
+            f"{path}.required",
+            f"required must be a boolean; got {type(required_raw).__name__}",
+        )
+    return PDBPanelSlot(
+        slot_id=slot_id,
+        review_role=review_role,
+        lens=lens,
+        family=family,
+        candidates=tuple(candidates),
+        required=required_raw,
+    )
+
+
+def _parse_panel(
+    panel_id: str,
+    raw: Any,
+    slots: Mapping[str, PDBPanelSlot],
+) -> PDBPanelDefinition:
+    path = f"panels.{panel_id}"
+    if not isinstance(raw, Mapping):
+        raise PDBPanelConfigError(
+            path,
+            f"panel definition must be a mapping; got {type(raw).__name__}",
+        )
+    findings_slots_raw = _require(raw, "findings_slots", list, path=f"{path}.findings_slots")
+    if not findings_slots_raw:
+        raise PDBPanelConfigError(
+            f"{path}.findings_slots",
+            "findings_slots must not be empty",
+        )
+    findings_slots: list[str] = []
+    seen_findings: set[str] = set()
+    for idx, slot_id in enumerate(findings_slots_raw):
+        if not isinstance(slot_id, str):
+            raise PDBPanelConfigError(
+                f"{path}.findings_slots[{idx}]",
+                "slot id must be a string",
+            )
+        if slot_id in seen_findings:
+            raise PDBPanelConfigError(
+                f"{path}.findings_slots[{idx}]",
+                f"duplicate slot id {slot_id!r}",
+            )
+        seen_findings.add(slot_id)
+        findings_slots.append(slot_id)
+
+    critique_raw = raw.get("critique_slots", SAME_AS_FINDINGS_SENTINEL)
+    if critique_raw == SAME_AS_FINDINGS_SENTINEL:
+        critique_slots = tuple(findings_slots)
+    elif isinstance(critique_raw, list):
+        critique_slots_list: list[str] = []
+        seen_critique: set[str] = set()
+        for idx, slot_id in enumerate(critique_raw):
+            if not isinstance(slot_id, str):
+                raise PDBPanelConfigError(
+                    f"{path}.critique_slots[{idx}]",
+                    "slot id must be a string",
+                )
+            if slot_id in seen_critique:
+                raise PDBPanelConfigError(
+                    f"{path}.critique_slots[{idx}]",
+                    f"duplicate slot id {slot_id!r}",
+                )
+            seen_critique.add(slot_id)
+            critique_slots_list.append(slot_id)
+        critique_slots = tuple(critique_slots_list)
+    else:
+        raise PDBPanelConfigError(
+            f"{path}.critique_slots",
+            "critique_slots must be either 'same_as_findings' or a list of slot ids",
+        )
+
+    synthesizer_slot = _require(raw, "synthesizer_slot", str, path=f"{path}.synthesizer_slot")
+
+    return PDBPanelDefinition(
+        panel_id=panel_id,
+        findings_slots=tuple(findings_slots),
+        critique_slots=critique_slots,
+        synthesizer_slot=synthesizer_slot,
+    )
+
+
+def _parse_prompt_set(prompt_set_id: str, raw: Any) -> PDBPromptSet:
+    path = f"prompt_sets.{prompt_set_id}"
+    if not isinstance(raw, Mapping):
+        raise PDBPanelConfigError(
+            path,
+            f"prompt set definition must be a mapping; got {type(raw).__name__}",
+        )
+    findings_prompt = _require(raw, "findings_prompt", str, path=f"{path}.findings_prompt")
+    critique_prompt = _require(raw, "critique_prompt", str, path=f"{path}.critique_prompt")
+    synthesis_prompt = _require(raw, "synthesis_prompt", str, path=f"{path}.synthesis_prompt")
+    return PDBPromptSet(
+        prompt_set_id=prompt_set_id,
+        findings_prompt=findings_prompt,
+        critique_prompt=critique_prompt,
+        synthesis_prompt=synthesis_prompt,
+    )
+
+
+def _validate_panel_against_slots(
+    panel_id: str,
+    panel: PDBPanelDefinition,
+    slots: Mapping[str, PDBPanelSlot],
+) -> None:
+    path = f"panels.{panel_id}"
+
+    for idx, slot_id in enumerate(panel.findings_slots):
+        if slot_id not in slots:
+            raise PDBPanelConfigError(
+                f"{path}.findings_slots[{idx}]",
+                f"slot {slot_id!r} is not defined in slots",
+            )
+    for idx, slot_id in enumerate(panel.critique_slots):
+        if slot_id not in slots:
+            raise PDBPanelConfigError(
+                f"{path}.critique_slots[{idx}]",
+                f"slot {slot_id!r} is not defined in slots",
+            )
+    if panel.synthesizer_slot not in slots:
+        raise PDBPanelConfigError(
+            f"{path}.synthesizer_slot",
+            f"synthesizer_slot {panel.synthesizer_slot!r} is not defined in slots",
+        )
+
+    findings_lookup = {sid: slots[sid] for sid in panel.findings_slots}
+    required_missing = sorted(
+        slot.slot_id
+        for slot in slots.values()
+        if slot.required and slot.slot_id not in findings_lookup
+    )
+    if required_missing:
+        raise PDBPanelConfigError(
+            f"{path}.findings_slots",
+            "findings_slots must include every required=true slot; missing: "
+            + ", ".join(required_missing),
+        )
+
+    core_slots = [slot for slot in findings_lookup.values() if slot.lens == "core"]
+    if len(core_slots) < 2:
+        raise PDBPanelConfigError(
+            f"{path}.findings_slots",
+            f"findings_slots must include at least two core-lens slots; got {len(core_slots)}",
+        )
+
+    non_core = [slot for slot in findings_lookup.values() if slot.lens != "core"]
+    if not non_core:
+        raise PDBPanelConfigError(
+            f"{path}.findings_slots",
+            "findings_slots must include at least one non-core lens; "
+            "panel would otherwise collapse to core-only heterogeneity",
+        )
+
+    if panel.synthesizer_slot not in findings_lookup:
+        raise PDBPanelConfigError(
+            f"{path}.synthesizer_slot",
+            f"synthesizer_slot {panel.synthesizer_slot!r} must also appear in findings_slots",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Projection helpers
+# ---------------------------------------------------------------------------
+
+
+def panel_slots(config: PDBPanelConfig, panel_id: str) -> tuple[PDBPanelSlot, ...]:
+    """Return the ordered slot objects participating in the given panel.
+
+    Order mirrors ``findings_slots`` so deterministic downstream code
+    can iterate the roster without re-sorting.
+    """
+    if panel_id not in config.panels:
+        raise PDBPanelConfigError(
+            "panels",
+            f"panel {panel_id!r} is not defined in config.panels",
+        )
+    panel = config.panels[panel_id]
+    return tuple(config.slots[sid] for sid in panel.findings_slots)
+
+
+def provider_slot_definitions(
+    config: PDBPanelConfig,
+    panel_id: str,
+) -> tuple[ProviderSlotDefinition, ...]:
+    """Project the panel's slots into the landed provider-slot resolver shape.
+
+    The resolver in :mod:`aragora.review.provider_slots` is the single
+    source of truth for candidate availability; PDB does not fork it.
+    """
+    return tuple(slot.to_provider_slot_definition() for slot in panel_slots(config, panel_id))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _require(raw: Mapping[str, Any], key: str, kind: type, *, path: str) -> Any:
+    """Assert that ``raw[key]`` exists and is an instance of ``kind``."""
+    if key not in raw:
+        raise PDBPanelConfigError(path, f"required key {key!r} is missing")
+    value = raw[key]
+    if not isinstance(value, kind):
+        raise PDBPanelConfigError(
+            path,
+            f"expected {kind.__name__}; got {type(value).__name__}",
+        )
+    return value
+
+
+def _require_number(raw: Mapping[str, Any], key: str, *, path: str) -> float:
+    """Require a non-bool numeric value. YAML scalars may be ``int`` or ``float``."""
+    if key not in raw:
+        raise PDBPanelConfigError(path, f"required key {key!r} is missing")
+    value = raw[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise PDBPanelConfigError(
+            path,
+            f"expected numeric value; got {type(value).__name__}",
+        )
+    return float(value)

--- a/aragora/pdb/prompts.py
+++ b/aragora/pdb/prompts.py
@@ -1,0 +1,330 @@
+"""Prompt templates for PDB Mode 3 Protocol B.
+
+Three prompt families, one per phase:
+
+- :func:`findings_prompt` — first-round per-slot structured findings
+- :func:`critique_prompt` — second-round peer critique with peer
+  findings as context
+- :func:`synthesis_prompt` — single synthesis pass binding panel votes
+  into a final brief
+
+Every template binds the four PR anchors (``repo``, ``pr_number``,
+``base_sha``, ``head_sha``) so provider output can be cross-checked
+against the binding, and preserves ``core`` / ``heterodox`` /
+``regulatory`` lens identity so dissent does not collapse during
+critique or synthesis.
+
+This module is **prompt-only**. It does not invoke providers, does not
+stream, and does not parse responses. Tests in
+``tests/pdb/test_prompts.py`` assert the rendered text contains the
+binding fields and the lens identifiers.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from aragora.pdb.panel_config import PDBPanelSlot
+from aragora.review.builder import PanelVote
+from aragora.swarm.pr_review_protocol import PRReviewBinding
+
+__all__ = [
+    "LENS_INSTRUCTIONS",
+    "critique_prompt",
+    "findings_prompt",
+    "render_binding_header",
+    "synthesis_prompt",
+]
+
+
+LENS_INSTRUCTIONS: Mapping[str, str] = {
+    "core": (
+        "You hold the CORE lens. Read the diff with the assumption the change "
+        "compiles and ships; your job is to catch correctness, logic, and "
+        "security defects before merge. Stay close to the code."
+    ),
+    "heterodox": (
+        "You hold the HETERODOX lens. Deliberately argue the weakest case for "
+        "this PR: maintainability debt, hidden coupling, mis-scoped abstractions, "
+        "and long-tail risks the core reviewers will miss. Disagreement is the "
+        "point; do not defer to the majority."
+    ),
+    "regulatory": (
+        "You hold the REGULATORY lens. Read the diff from a European / regulated-"
+        "market perspective. Call out failures of duty-of-care, data-handling, "
+        "disclosure, or cross-border obligations WITHOUT claiming the code "
+        "itself is unlawful — you are a perspective, not a compliance oracle."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Binding header
+# ---------------------------------------------------------------------------
+
+
+def render_binding_header(
+    *,
+    binding: PRReviewBinding,
+    pr_title: str,
+    pr_body: str,
+    labels: Sequence[str],
+    changed_files: Sequence[str],
+) -> str:
+    """Render the shared PR-binding preamble used by all three phases.
+
+    Keeping this in one function ensures every prompt emits the exact
+    same binding text, which makes response cross-validation trivial:
+    any prompt that lacks ``repo`` / ``pr_number`` / ``base_sha`` /
+    ``head_sha`` is a bug.
+    """
+    labels_line = ", ".join(labels) if labels else "(none)"
+    changed_preview = "\n".join(f"- {path}" for path in changed_files[:40])
+    if len(changed_files) > 40:
+        changed_preview += f"\n- ... and {len(changed_files) - 40} more"
+    body_trimmed = (pr_body or "").strip()
+    if len(body_trimmed) > 2000:
+        body_trimmed = body_trimmed[:2000] + "\n... [truncated]"
+    return (
+        "## PR binding\n"
+        f"repo: {binding.repo}\n"
+        f"pr_number: {binding.pr_number}\n"
+        f"base_sha: {binding.base_sha}\n"
+        f"head_sha: {binding.head_sha}\n"
+        f"title: {pr_title}\n"
+        f"labels: {labels_line}\n\n"
+        "## PR description\n"
+        f"{body_trimmed or '(empty)'}\n\n"
+        "## Changed files\n"
+        f"{changed_preview or '(none)'}"
+    )
+
+
+def _lens_block(slot: PDBPanelSlot) -> str:
+    instructions = LENS_INSTRUCTIONS.get(
+        slot.lens,
+        f"You hold the {slot.lens.upper()} lens. Write findings grounded in the "
+        "diff; do not flatten your stance to match other reviewers.",
+    )
+    return (
+        "## Your assignment\n"
+        f"slot_id: {slot.slot_id}\n"
+        f"review_role: {slot.review_role}\n"
+        f"lens: {slot.lens}\n"
+        f"family: {slot.family}\n\n"
+        f"{instructions}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Findings round
+# ---------------------------------------------------------------------------
+
+
+def findings_prompt(
+    *,
+    slot: PDBPanelSlot,
+    binding: PRReviewBinding,
+    pr_title: str,
+    pr_body: str,
+    labels: Sequence[str],
+    changed_files: Sequence[str],
+    diff_excerpt: str,
+    validation_summary: Mapping[str, object] | None = None,
+) -> str:
+    """Render the first-round findings prompt for a single slot.
+
+    The template asks for STRUCTURED output, not essays. Response
+    parsing is PR3 territory; PR2 tests only assert the rendered text
+    carries the binding and lens identifiers.
+    """
+    header = render_binding_header(
+        binding=binding,
+        pr_title=pr_title,
+        pr_body=pr_body,
+        labels=labels,
+        changed_files=changed_files,
+    )
+    lens = _lens_block(slot)
+    validation_block = _format_validation_summary(validation_summary)
+    diff_block = (diff_excerpt or "(no diff provided)").rstrip()
+
+    return (
+        "# PR Decision Brief — findings round (Protocol B)\n\n"
+        f"{header}\n\n"
+        f"{lens}\n\n"
+        "## Validation signals\n"
+        f"{validation_block}\n\n"
+        "## Diff excerpt\n"
+        "```diff\n"
+        f"{diff_block}\n"
+        "```\n\n"
+        "## Output contract\n"
+        "Return a compact JSON object with these keys (no prose outside the JSON):\n"
+        '  - "recommendation": one of "approve", "request_changes", "defer".\n'
+        '  - "confidence": float in [0.0, 1.0].\n'
+        '  - "top_findings": array (up to 5) of objects with '
+        '{"finding_id", "category", "severity" ('
+        '"low"|"medium"|"high"), "summary", "evidence" (array of short strings)}.\n'
+        '  - "contested_finding_ids": array of finding_ids you expect other lenses\n'
+        "    may disagree on (may be empty).\n"
+        '  - "reason": one-to-two-sentence justification of your recommendation\n'
+        "    grounded in your lens; do not flatten your stance to match the\n"
+        "    majority.\n\n"
+        "Rules:\n"
+        "- Cite specific files or hunks in evidence when possible.\n"
+        "- Preserve your lens identity; disagreement is a feature, not a bug.\n"
+        "- Do not invent findings absent from the diff; prefer an empty list to\n"
+        "  fabricated risk.\n"
+    )
+
+
+def _format_validation_summary(summary: Mapping[str, object] | None) -> str:
+    if not summary:
+        return "(no validation signals provided)"
+    rows = []
+    for key, value in summary.items():
+        rows.append(f"- {key}: {value}")
+    return "\n".join(rows)
+
+
+# ---------------------------------------------------------------------------
+# Critique round
+# ---------------------------------------------------------------------------
+
+
+def critique_prompt(
+    *,
+    slot: PDBPanelSlot,
+    binding: PRReviewBinding,
+    pr_title: str,
+    pr_body: str,
+    labels: Sequence[str],
+    changed_files: Sequence[str],
+    peer_findings: Mapping[str, str],
+) -> str:
+    """Render the second-round critique prompt for a single slot.
+
+    ``peer_findings`` maps ``slot_id`` → a pre-serialized summary of
+    that peer's findings (JSON text is fine). The critique phase is
+    where dissent should crystallize, so the template explicitly
+    invites disagreement with other lenses.
+    """
+    header = render_binding_header(
+        binding=binding,
+        pr_title=pr_title,
+        pr_body=pr_body,
+        labels=labels,
+        changed_files=changed_files,
+    )
+    lens = _lens_block(slot)
+    peer_block_rows = []
+    for peer_slot_id, summary in peer_findings.items():
+        if peer_slot_id == slot.slot_id:
+            continue
+        peer_block_rows.append(
+            f"### peer slot: {peer_slot_id}\n{summary.strip() or '(empty summary)'}"
+        )
+    peer_block = "\n\n".join(peer_block_rows) if peer_block_rows else "(no peer findings)"
+
+    return (
+        "# PR Decision Brief — critique round (Protocol B)\n\n"
+        f"{header}\n\n"
+        f"{lens}\n\n"
+        "## Peer findings for critique\n"
+        f"{peer_block}\n\n"
+        "## Output contract\n"
+        "Return a compact JSON object with these keys (no prose outside the JSON):\n"
+        '  - "recommendation": one of "approve", "request_changes", "defer"\n'
+        "    (your updated position after reading peers).\n"
+        '  - "confidence": float in [0.0, 1.0].\n'
+        '  - "agrees_with": array of peer slot_ids you broadly agree with\n'
+        "    (may be empty).\n"
+        '  - "disagrees_with": array of peer slot_ids you push back on\n'
+        "    (may be empty).\n"
+        '  - "contested_finding_ids": array of finding_ids still in dispute.\n'
+        '  - "reason": one-to-two-sentence critique summary grounded in your\n'
+        "    lens.\n\n"
+        "Rules:\n"
+        "- Do not pretend to agree where you do not; record dissent explicitly.\n"
+        "- Keep peer-citation grounded: name the slot_id you are critiquing.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthesis pass
+# ---------------------------------------------------------------------------
+
+
+def synthesis_prompt(
+    *,
+    synthesizer_slot: PDBPanelSlot,
+    binding: PRReviewBinding,
+    pr_title: str,
+    pr_body: str,
+    labels: Sequence[str],
+    changed_files: Sequence[str],
+    votes: Sequence[PanelVote],
+) -> str:
+    """Render the single synthesis prompt for the panel.
+
+    The synthesizer is not a majority-averager. This template is
+    explicit: the synthesizer should surface disagreement rather than
+    flatten it, because the landed :func:`aragora.review.builder.build_brief`
+    already computes a deterministic recommendation from the votes.
+    The synthesizer's job in Protocol B is to produce the top-line
+    summary and validation-paragraph text surrounding those votes.
+    """
+    header = render_binding_header(
+        binding=binding,
+        pr_title=pr_title,
+        pr_body=pr_body,
+        labels=labels,
+        changed_files=changed_files,
+    )
+    lens = _lens_block(synthesizer_slot)
+    vote_rows = []
+    for vote in votes:
+        vote_rows.append(
+            "- {slot}: {role}/{lens_label} → {position} (confidence {conf:.2f}) — {reason}".format(
+                slot=vote.finding.agent,
+                role=vote.finding.role.value,
+                lens_label=_infer_lens_label(vote),
+                position=vote.position.value,
+                conf=vote.finding.confidence,
+                reason=(vote.reason or "").strip() or "(no reason given)",
+            )
+        )
+    vote_block = "\n".join(vote_rows) if vote_rows else "(no panel votes)"
+
+    return (
+        "# PR Decision Brief — synthesis (Protocol B)\n\n"
+        f"{header}\n\n"
+        f"{lens}\n\n"
+        "## Panel votes to synthesize\n"
+        f"{vote_block}\n\n"
+        "## Output contract\n"
+        "Return a compact JSON object with these keys (no prose outside the JSON):\n"
+        '  - "top_line": 1-3 sentence executive summary of the panel\'s verdict.\n'
+        '  - "validation_summary": one paragraph summarising validation signals,\n'
+        "    CI state, and evidence strength.\n"
+        '  - "preserved_dissent": array of {"slot_id", "lens", "position",\n'
+        '    "reason"} objects, one for every dissenting view, verbatim — do\n'
+        "    not collapse into one summary line.\n\n"
+        "Rules:\n"
+        "- Preserve disagreement explicitly in preserved_dissent; this is the\n"
+        "  layer that dissenters survive into the final brief.\n"
+        "- The brief's recommendation class is set by the builder from the\n"
+        "  votes; do NOT override it here.\n"
+    )
+
+
+def _infer_lens_label(vote: PanelVote) -> str:
+    """Best-effort lens label for the synthesis template.
+
+    :class:`PanelVote` does not carry a lens field (it comes from the
+    landed builder, which is lens-agnostic). We fall back to the role
+    suffix to give the synthesizer something stable to cite.
+    """
+    role = vote.finding.role.value
+    return role.split("_", 1)[0]

--- a/aragora/pdb/protocol.py
+++ b/aragora/pdb/protocol.py
@@ -1,0 +1,1054 @@
+"""Protocol B executor for PDB Mode 3.
+
+Runs the bounded three-phase Protocol B pipeline:
+
+1. Load + validate panel config.
+2. Resolve configured slots through
+   :class:`aragora.review.provider_slots.ProviderSlotResolver`.
+3. Evaluate + reserve budget with :mod:`aragora.pdb.budget`.
+4. Findings round — one prompt per active slot.
+5. Critique round — one prompt per active slot, with peer findings
+   as context.
+6. Synthesis pass — one prompt through the configured synthesizer slot.
+7. Return both packet-facing and brief-facing output via
+   :func:`aragora.review.builder.build_brief`.
+
+**PR 2 boundary**: this executor is transport-neutral. It does NOT
+enqueue workers, touch storage, write artifacts, or call HTTP routes.
+A :class:`ProviderInvoker` Protocol lets callers inject real or mocked
+per-phase provider execution; PR 2's tests exercise the full pipeline
+with a deterministic mock invoker.
+
+Dissent preservation is the core contract. At each of the three layers
+the spec requires — reviewer outputs, :class:`PRReviewProtocolPacket`,
+and :class:`aragora.review.protocol.ReviewBrief`\\ ``.dissent`` — the
+per-slot identity, lens, position, and reason survive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping, Protocol, Sequence
+
+from aragora.pdb import budget as budget_mod
+from aragora.pdb.budget import (
+    PDBBudgetDecision,
+    PDBBudgetLedger,
+    PDBBudgetStatus,
+    SlotCostEstimator,
+    evaluate_budget,
+)
+from aragora.pdb.panel_config import (
+    PDBPanelConfig,
+    PDBPanelSlot,
+    load_panel_config,
+    panel_slots as panel_slots_for,
+)
+from aragora.pdb.prompts import critique_prompt, findings_prompt, synthesis_prompt
+from aragora.review.builder import PanelVote, build_brief
+from aragora.review.policy import ReviewPolicy
+from aragora.review.protocol import (
+    DissentPosition,
+    Recommendation,
+    ReviewBrief,
+    ReviewRole,
+    RoleFinding,
+    SynthesisPolicy,
+)
+from aragora.review.provider_slots import (
+    ProviderSlotAvailabilitySummary,
+    ProviderSlotResolution,
+    ProviderSlotResolver,
+)
+from aragora.swarm.pr_review_protocol import (
+    PRReviewBinding,
+    PRReviewFinding,
+    PRReviewProtocolPacket,
+    PROTOCOL_VERSION,
+)
+
+__all__ = [
+    "PDBExecutionInput",
+    "PDBExecutionResult",
+    "PDBExecutionStatus",
+    "ProviderInvoker",
+    "SlotCritiqueResponse",
+    "SlotFindingsResponse",
+    "SynthesisResponse",
+    "run_protocol_b",
+    "STATUS_PANEL_EXECUTED",
+    "STATUS_PANEL_DEGRADED",
+    "STATUS_BUDGET_EXCEEDED",
+    "STATUS_FAILED_CLOSED",
+]
+
+
+STATUS_PANEL_EXECUTED = "panel_executed"
+STATUS_PANEL_DEGRADED = "panel_degraded"
+STATUS_BUDGET_EXCEEDED = "budget_exceeded"
+STATUS_FAILED_CLOSED = "failed_closed"
+
+_RECOMMENDATION_CLASS_BY_DECISION: Mapping[Recommendation, str] = {
+    Recommendation.APPROVE_CANDIDATE: "approve_candidate",
+    Recommendation.REPAIR_FIRST: "repair_first",
+    Recommendation.NEEDS_HUMAN_ATTENTION: "needs_human_attention",
+}
+
+# Map review_role string (stable across YAML + protocol.py) to the
+# enum used by the brief builder. Slots whose review_role does not
+# land in this table fall back to SKEPTIC so heterodox lenses still
+# route through the builder without masquerading as core reviewers.
+_REVIEW_ROLE_BY_NAME: Mapping[str, ReviewRole] = {
+    "logic_reviewer": ReviewRole.LOGIC,
+    "security_reviewer": ReviewRole.SECURITY,
+    "maintainability_reviewer": ReviewRole.MAINTAINABILITY,
+    "skeptic": ReviewRole.SKEPTIC,
+    "synthesizer": ReviewRole.SYNTHESIZER,
+}
+
+
+# ---------------------------------------------------------------------------
+# Status + input + output dataclasses
+# ---------------------------------------------------------------------------
+
+
+class PDBExecutionStatus(str, Enum):
+    """Outcome of :func:`run_protocol_b`."""
+
+    SUCCESS = "success"
+    DEGRADED = "degraded"
+    BUDGET_EXCEEDED = "budget_exceeded"
+    FAILED_CLOSED = "failed_closed"
+
+
+@dataclass(frozen=True, slots=True)
+class PDBExecutionInput:
+    """Transport-neutral payload accepted by :func:`run_protocol_b`.
+
+    No file handles, no live git processes, no HTTP request objects.
+    ``diff_excerpt`` is prepared text; PR3 callers that load diffs
+    lazily MUST materialize them before invoking the executor.
+    """
+
+    binding: PRReviewBinding
+    packet: PRReviewProtocolPacket
+    packet_sha: str
+    pr_title: str
+    pr_body: str
+    labels: tuple[str, ...]
+    changed_files: tuple[str, ...]
+    diff_excerpt: str
+    validation_summary: Mapping[str, Any]
+    panel_id: str
+    policy: ReviewPolicy
+
+
+@dataclass(frozen=True, slots=True)
+class SlotFindingsResponse:
+    """Structured output from one slot's findings phase."""
+
+    slot_id: str
+    provider: str
+    model: str
+    position: DissentPosition
+    confidence: float
+    summary: str
+    top_findings: tuple[PRReviewFinding, ...]
+    contested_finding_ids: tuple[str, ...]
+    reason: str
+    latency_ms: int = 0
+    cost_usd: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class SlotCritiqueResponse:
+    """Structured output from one slot's critique phase.
+
+    ``position`` and ``confidence`` are the *post-peer-read* values
+    that get piped into the synthesizer via :class:`PanelVote`. The
+    findings-phase values live in :class:`SlotFindingsResponse`.
+    """
+
+    slot_id: str
+    provider: str
+    position: DissentPosition
+    confidence: float
+    reason: str
+    agrees_with: tuple[str, ...] = ()
+    disagrees_with: tuple[str, ...] = ()
+    contested_finding_ids: tuple[str, ...] = ()
+    latency_ms: int = 0
+    cost_usd: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class SynthesisResponse:
+    """Structured output from the synthesis pass."""
+
+    slot_id: str
+    provider: str
+    model: str
+    top_line: str
+    validation_summary: str
+    position: DissentPosition
+    confidence: float
+    preserved_dissent: tuple[Mapping[str, str], ...] = ()
+    latency_ms: int = 0
+    cost_usd: float = 0.0
+
+
+class ProviderInvoker(Protocol):
+    """Phase-aware provider driver.
+
+    PR 2 only ships a :class:`Protocol` + a mocked test invoker. PR 3
+    wires a real provider-backed implementation behind the same
+    interface. The executor only depends on this Protocol, so wiring
+    stays testable.
+    """
+
+    def findings(
+        self,
+        *,
+        slot: PDBPanelSlot,
+        provider: str,
+        prompt: str,
+        binding: PRReviewBinding,
+    ) -> SlotFindingsResponse: ...
+
+    def critique(
+        self,
+        *,
+        slot: PDBPanelSlot,
+        provider: str,
+        prompt: str,
+        peer_findings: Mapping[str, SlotFindingsResponse],
+        binding: PRReviewBinding,
+    ) -> SlotCritiqueResponse: ...
+
+    def synthesize(
+        self,
+        *,
+        synthesizer_slot: PDBPanelSlot,
+        provider: str,
+        prompt: str,
+        votes: Sequence[PanelVote],
+        binding: PRReviewBinding,
+    ) -> SynthesisResponse: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PDBExecutionResult:
+    """Everything PR 3 needs to wire transport + artifact writing."""
+
+    status: PDBExecutionStatus
+    packet: PRReviewProtocolPacket
+    brief: ReviewBrief | None
+    budget_decision: PDBBudgetDecision
+    active_roster: tuple[str, ...]
+    missing_slots: tuple[str, ...]
+    degrade_reasons: tuple[str, ...]
+    failure_reason: str | None
+    findings_by_slot: Mapping[str, SlotFindingsResponse]
+    critiques_by_slot: Mapping[str, SlotCritiqueResponse]
+    synthesis: SynthesisResponse | None
+    resolutions: tuple[ProviderSlotResolution, ...]
+    availability_summary: ProviderSlotAvailabilitySummary
+    actual_cost_usd: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "active_roster": list(self.active_roster),
+            "missing_slots": list(self.missing_slots),
+            "degrade_reasons": list(self.degrade_reasons),
+            "failure_reason": self.failure_reason,
+            "budget_decision": self.budget_decision.to_dict(),
+            "actual_cost_usd": round(self.actual_cost_usd, 4),
+            "packet": self.packet.to_dict(),
+            "brief": self.brief.to_dict() if self.brief is not None else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Executor entry point
+# ---------------------------------------------------------------------------
+
+
+def run_protocol_b(
+    input: PDBExecutionInput,
+    *,
+    invoker: ProviderInvoker,
+    config: PDBPanelConfig | None = None,
+    ledger: PDBBudgetLedger | None = None,
+    resolver: ProviderSlotResolver | None = None,
+    cost_estimator: SlotCostEstimator | None = None,
+    clock: "_Clock | None" = None,
+) -> PDBExecutionResult:
+    """Run Protocol B end-to-end and return the structured outcome.
+
+    ``invoker`` is the only required non-input argument; everything
+    else has a default. Tests pass an in-memory ledger, a seeded
+    resolver, and a mock invoker for determinism.
+    """
+    cfg = config if config is not None else load_panel_config()
+    if input.panel_id not in cfg.panels:
+        raise ValueError(f"unknown panel_id {input.panel_id!r} (not in config.panels)")
+
+    now = (clock or _default_clock)()
+
+    slots = panel_slots_for(cfg, input.panel_id)
+    panel = cfg.panels[input.panel_id]
+    synthesizer_slot = cfg.slots[panel.synthesizer_slot]
+
+    resolver = resolver or ProviderSlotResolver()
+    resolutions = tuple(resolver.resolve_slot(slot.to_provider_slot_definition()) for slot in slots)
+    availability = resolver.summarize(list(resolutions))
+    provider_by_slot: dict[str, str] = {
+        res.slot_id: res.selected_provider
+        for res in resolutions
+        if res.selected_provider is not None
+    }
+
+    # --- fail-closed checks on resolution ---------------------------------
+    required_missing = tuple(
+        slot.slot_id for slot in slots if slot.required and slot.slot_id not in provider_by_slot
+    )
+    synth_missing = synthesizer_slot.slot_id not in provider_by_slot
+
+    if required_missing or synth_missing:
+        reason_parts = []
+        if required_missing:
+            reason_parts.append("required slots unresolved: " + ", ".join(required_missing))
+        if synth_missing:
+            reason_parts.append(f"synthesizer slot {synthesizer_slot.slot_id!r} unresolved")
+        failure_reason = "; ".join(reason_parts)
+        return _fail_closed_result(
+            input=input,
+            panel_slots=slots,
+            synthesizer_slot=synthesizer_slot,
+            resolutions=resolutions,
+            availability=availability,
+            missing=required_missing + ((synthesizer_slot.slot_id,) if synth_missing else ()),
+            failure_reason=failure_reason,
+            cfg_budget=cfg.budget,
+            ledger=ledger,
+            cost_estimator=cost_estimator,
+            now=now,
+        )
+
+    # --- budget evaluation ------------------------------------------------
+    working_ledger = ledger or PDBBudgetLedger(daily_cap_usd=cfg.budget.per_day_usd)
+    findings_available = tuple(slot for slot in slots if slot.slot_id in provider_by_slot)
+    decision = evaluate_budget(
+        findings_slots=findings_available,
+        synthesizer_slot=synthesizer_slot,
+        budget=cfg.budget,
+        ledger=working_ledger,
+        estimator=cost_estimator,
+        review_budget=input.policy.budget,
+    )
+
+    if decision.status is PDBBudgetStatus.BUDGET_EXCEEDED:
+        return _budget_exceeded_result(
+            input=input,
+            panel_slots=slots,
+            synthesizer_slot=synthesizer_slot,
+            resolutions=resolutions,
+            availability=availability,
+            decision=decision,
+            now=now,
+        )
+
+    reservation = budget_mod.reserve(decision, working_ledger)
+
+    # --- ensure heterogeneity floor --------------------------------------
+    funded_slot_ids = set(decision.funded_slots)
+    funded_slots = tuple(slot for slot in slots if slot.slot_id in funded_slot_ids)
+    distinct_families = {slot.family for slot in funded_slots}
+    if len(distinct_families) < 2:
+        reservation.release_unused()
+        return _fail_closed_result(
+            input=input,
+            panel_slots=slots,
+            synthesizer_slot=synthesizer_slot,
+            resolutions=resolutions,
+            availability=availability,
+            missing=tuple(decision.dropped_slots),
+            failure_reason=(
+                "funded panel collapsed below two model families "
+                f"(families={sorted(distinct_families)})"
+            ),
+            cfg_budget=cfg.budget,
+            ledger=working_ledger,
+            cost_estimator=cost_estimator,
+            now=now,
+        )
+
+    degrade_reasons: list[str] = []
+    missing_slots: list[str] = [sid for sid in decision.dropped_slots]
+    if missing_slots:
+        degrade_reasons.append(decision.reason)
+
+    # --- findings round ---------------------------------------------------
+    findings_by_slot: dict[str, SlotFindingsResponse] = {}
+    for slot in funded_slots:
+        provider = provider_by_slot[slot.slot_id]
+        prompt = findings_prompt(
+            slot=slot,
+            binding=input.binding,
+            pr_title=input.pr_title,
+            pr_body=input.pr_body,
+            labels=input.labels,
+            changed_files=input.changed_files,
+            diff_excerpt=input.diff_excerpt,
+            validation_summary=input.validation_summary,
+        )
+        try:
+            findings_response = invoker.findings(
+                slot=slot,
+                provider=provider,
+                prompt=prompt,
+                binding=input.binding,
+            )
+        except Exception as exc:  # noqa: BLE001 — handled per-slot
+            if slot.required or slot.slot_id == synthesizer_slot.slot_id:
+                reservation.release_unused()
+                return _fail_closed_result(
+                    input=input,
+                    panel_slots=slots,
+                    synthesizer_slot=synthesizer_slot,
+                    resolutions=resolutions,
+                    availability=availability,
+                    missing=(slot.slot_id,),
+                    failure_reason=(f"required slot {slot.slot_id!r} findings failed: {exc}"),
+                    cfg_budget=cfg.budget,
+                    ledger=working_ledger,
+                    cost_estimator=cost_estimator,
+                    now=now,
+                )
+            degrade_reasons.append(f"optional slot {slot.slot_id!r} findings failed: {exc}")
+            missing_slots.append(slot.slot_id)
+            continue
+        reservation.charge(findings_response.cost_usd)
+        findings_by_slot[slot.slot_id] = findings_response
+
+    active_findings_slots = tuple(slot for slot in funded_slots if slot.slot_id in findings_by_slot)
+    if not active_findings_slots:
+        reservation.release_unused()
+        return _fail_closed_result(
+            input=input,
+            panel_slots=slots,
+            synthesizer_slot=synthesizer_slot,
+            resolutions=resolutions,
+            availability=availability,
+            missing=tuple(missing_slots),
+            failure_reason="no findings completed; panel collapsed to empty",
+            cfg_budget=cfg.budget,
+            ledger=working_ledger,
+            cost_estimator=cost_estimator,
+            now=now,
+        )
+
+    # re-check heterogeneity floor after optional-slot findings failures
+    post_findings_families = {slot.family for slot in active_findings_slots}
+    if len(post_findings_families) < 2:
+        reservation.release_unused()
+        return _fail_closed_result(
+            input=input,
+            panel_slots=slots,
+            synthesizer_slot=synthesizer_slot,
+            resolutions=resolutions,
+            availability=availability,
+            missing=tuple(missing_slots),
+            failure_reason=("active roster collapsed below two model families after findings"),
+            cfg_budget=cfg.budget,
+            ledger=working_ledger,
+            cost_estimator=cost_estimator,
+            now=now,
+        )
+
+    # --- critique round ---------------------------------------------------
+    critiques_by_slot: dict[str, SlotCritiqueResponse] = {}
+    peer_findings_payload: dict[str, str] = {
+        sid: _summarize_findings_for_peers(resp) for sid, resp in findings_by_slot.items()
+    }
+    for slot in active_findings_slots:
+        provider = provider_by_slot[slot.slot_id]
+        prompt = critique_prompt(
+            slot=slot,
+            binding=input.binding,
+            pr_title=input.pr_title,
+            pr_body=input.pr_body,
+            labels=input.labels,
+            changed_files=input.changed_files,
+            peer_findings=peer_findings_payload,
+        )
+        try:
+            critique_response = invoker.critique(
+                slot=slot,
+                provider=provider,
+                prompt=prompt,
+                peer_findings=findings_by_slot,
+                binding=input.binding,
+            )
+        except Exception as exc:  # noqa: BLE001 — handled per-slot
+            if slot.required or slot.slot_id == synthesizer_slot.slot_id:
+                reservation.release_unused()
+                return _fail_closed_result(
+                    input=input,
+                    panel_slots=slots,
+                    synthesizer_slot=synthesizer_slot,
+                    resolutions=resolutions,
+                    availability=availability,
+                    missing=(slot.slot_id,),
+                    failure_reason=(f"required slot {slot.slot_id!r} critique failed: {exc}"),
+                    cfg_budget=cfg.budget,
+                    ledger=working_ledger,
+                    cost_estimator=cost_estimator,
+                    now=now,
+                )
+            # Optional-slot critique timeout after findings succeeded is
+            # an explicit degrade per spec §Degrade vs fail-closed.
+            degrade_reasons.append(f"optional slot {slot.slot_id!r} critique failed: {exc}")
+            missing_slots.append(slot.slot_id)
+            continue
+        reservation.charge(critique_response.cost_usd)
+        critiques_by_slot[slot.slot_id] = critique_response
+
+    # Panel votes: one per slot that completed both findings + critique.
+    panel_votes = tuple(
+        _panel_vote_for(
+            slot=slot,
+            findings=findings_by_slot[slot.slot_id],
+            critique=critiques_by_slot[slot.slot_id],
+        )
+        for slot in active_findings_slots
+        if slot.slot_id in critiques_by_slot
+    )
+    if not panel_votes:
+        reservation.release_unused()
+        return _fail_closed_result(
+            input=input,
+            panel_slots=slots,
+            synthesizer_slot=synthesizer_slot,
+            resolutions=resolutions,
+            availability=availability,
+            missing=tuple(missing_slots),
+            failure_reason="no critique votes completed; cannot synthesize",
+            cfg_budget=cfg.budget,
+            ledger=working_ledger,
+            cost_estimator=cost_estimator,
+            now=now,
+        )
+
+    # Ensure synthesizer slot finished both phases; otherwise fail closed.
+    if synthesizer_slot.slot_id not in critiques_by_slot:
+        reservation.release_unused()
+        return _fail_closed_result(
+            input=input,
+            panel_slots=slots,
+            synthesizer_slot=synthesizer_slot,
+            resolutions=resolutions,
+            availability=availability,
+            missing=(synthesizer_slot.slot_id,),
+            failure_reason=(
+                f"synthesizer slot {synthesizer_slot.slot_id!r} did not complete the critique phase"
+            ),
+            cfg_budget=cfg.budget,
+            ledger=working_ledger,
+            cost_estimator=cost_estimator,
+            now=now,
+        )
+
+    # --- synthesis pass ---------------------------------------------------
+    synth_provider = provider_by_slot[synthesizer_slot.slot_id]
+    synth_prompt_text = synthesis_prompt(
+        synthesizer_slot=synthesizer_slot,
+        binding=input.binding,
+        pr_title=input.pr_title,
+        pr_body=input.pr_body,
+        labels=input.labels,
+        changed_files=input.changed_files,
+        votes=panel_votes,
+    )
+    try:
+        synthesis = invoker.synthesize(
+            synthesizer_slot=synthesizer_slot,
+            provider=synth_provider,
+            prompt=synth_prompt_text,
+            votes=panel_votes,
+            binding=input.binding,
+        )
+    except Exception as exc:  # noqa: BLE001 — synthesizer is required
+        reservation.release_unused()
+        return _fail_closed_result(
+            input=input,
+            panel_slots=slots,
+            synthesizer_slot=synthesizer_slot,
+            resolutions=resolutions,
+            availability=availability,
+            missing=(synthesizer_slot.slot_id,),
+            failure_reason=f"synthesis pass failed: {exc}",
+            cfg_budget=cfg.budget,
+            ledger=working_ledger,
+            cost_estimator=cost_estimator,
+            now=now,
+        )
+    reservation.charge(synthesis.cost_usd)
+
+    # Build the brief via the landed builder. We append the synthesizer's
+    # own SYNTHESIZER-role vote as an extra, which the builder permits.
+    synthesizer_vote = _synthesizer_panel_vote(synthesizer_slot, synthesis)
+    votes_for_brief = panel_votes + (synthesizer_vote,)
+    brief = build_brief(
+        votes=votes_for_brief,
+        pr_number=input.binding.pr_number,
+        repo=input.binding.repo,
+        head_sha=input.binding.head_sha,
+        base_sha=input.binding.base_sha,
+        top_line=synthesis.top_line,
+        validation_summary=synthesis.validation_summary,
+        generated_at=now,
+        synthesis_policy=SynthesisPolicy.SYNTHESIZER_AGENT,
+        output_roles=None,
+        total_cost_usd=round(reservation.actual_spend_usd, 4),
+        total_wall_clock_ms=sum(resp.latency_ms for resp in findings_by_slot.values())
+        + sum(resp.latency_ms for resp in critiques_by_slot.values())
+        + synthesis.latency_ms,
+    )
+
+    # packet-facing projection
+    status_value = (
+        STATUS_PANEL_DEGRADED if missing_slots or degrade_reasons else STATUS_PANEL_EXECUTED
+    )
+    packet = _build_executed_packet(
+        input=input,
+        resolutions=resolutions,
+        availability=availability,
+        brief=brief,
+        active_slot_ids=tuple(slot.slot_id for slot in active_findings_slots),
+        missing_slots=tuple(missing_slots),
+        findings_by_slot=findings_by_slot,
+        critiques_by_slot=critiques_by_slot,
+        synthesis=synthesis,
+        status=status_value,
+        decision=decision,
+        actual_cost_usd=reservation.actual_spend_usd,
+        slot_lookup={slot.slot_id: slot for slot in slots},
+    )
+
+    released = reservation.release_unused()
+    _ = released  # the ledger already absorbed the release; kept for clarity
+
+    exec_status = (
+        PDBExecutionStatus.DEGRADED
+        if status_value == STATUS_PANEL_DEGRADED
+        else PDBExecutionStatus.SUCCESS
+    )
+    return PDBExecutionResult(
+        status=exec_status,
+        packet=packet,
+        brief=brief,
+        budget_decision=decision,
+        active_roster=tuple(slot.slot_id for slot in active_findings_slots),
+        missing_slots=tuple(missing_slots),
+        degrade_reasons=tuple(degrade_reasons),
+        failure_reason=None,
+        findings_by_slot=dict(findings_by_slot),
+        critiques_by_slot=dict(critiques_by_slot),
+        synthesis=synthesis,
+        resolutions=resolutions,
+        availability_summary=availability,
+        actual_cost_usd=round(reservation.actual_spend_usd, 4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _panel_vote_for(
+    *,
+    slot: PDBPanelSlot,
+    findings: SlotFindingsResponse,
+    critique: SlotCritiqueResponse,
+) -> PanelVote:
+    role = _REVIEW_ROLE_BY_NAME.get(slot.review_role, ReviewRole.SKEPTIC)
+    finding = RoleFinding(
+        role=role,
+        agent=f"{slot.slot_id}:{findings.provider}",
+        model=findings.model,
+        confidence=critique.confidence,
+        finding_text=findings.summary or findings.reason,
+        latency_ms=findings.latency_ms + critique.latency_ms,
+        cost_usd=round(findings.cost_usd + critique.cost_usd, 6),
+    )
+    return PanelVote(
+        finding=finding,
+        position=critique.position,
+        reason=critique.reason or findings.reason,
+    )
+
+
+def _synthesizer_panel_vote(
+    slot: PDBPanelSlot,
+    synthesis: SynthesisResponse,
+) -> PanelVote:
+    finding = RoleFinding(
+        role=ReviewRole.SYNTHESIZER,
+        agent=f"{slot.slot_id}:synthesizer:{synthesis.provider}",
+        model=synthesis.model,
+        confidence=synthesis.confidence,
+        finding_text=synthesis.top_line,
+        latency_ms=synthesis.latency_ms,
+        cost_usd=synthesis.cost_usd,
+    )
+    return PanelVote(
+        finding=finding,
+        position=synthesis.position,
+        reason=synthesis.top_line,
+    )
+
+
+def _summarize_findings_for_peers(resp: SlotFindingsResponse) -> str:
+    rows = [
+        f"recommendation: {resp.position.value}",
+        f"confidence: {resp.confidence:.2f}",
+        f"summary: {resp.summary}",
+    ]
+    for idx, finding in enumerate(resp.top_findings[:5], start=1):
+        rows.append(
+            f"  finding[{idx}] {finding.category}/{finding.severity} "
+            f"{finding.finding_id}: {finding.summary}"
+        )
+    if resp.contested_finding_ids:
+        rows.append("contested: " + ", ".join(resp.contested_finding_ids))
+    return "\n".join(rows)
+
+
+def _dissenting_views_for_packet(
+    brief_recommendation: Recommendation,
+    panel_votes: Sequence[PanelVote],
+    critiques: Mapping[str, SlotCritiqueResponse],
+    findings: Mapping[str, SlotFindingsResponse],
+    slots: Mapping[str, PDBPanelSlot],
+) -> list[dict[str, Any]]:
+    views: list[dict[str, Any]] = []
+    for vote in panel_votes:
+        slot_id = vote.finding.agent.split(":", 1)[0]
+        recommended_for_vote = _position_to_recommendation(vote.position)
+        if recommended_for_vote is brief_recommendation:
+            continue
+        slot = slots.get(slot_id)
+        contested = critiques[slot_id].contested_finding_ids if slot_id in critiques else ()
+        views.append(
+            {
+                "slot_id": slot_id,
+                "lens": slot.lens if slot else "unknown",
+                "recommendation": vote.position.value,
+                "reason": vote.reason,
+                "contested_finding_ids": list(contested),
+            }
+        )
+    return views
+
+
+def _position_to_recommendation(position: DissentPosition) -> Recommendation:
+    if position is DissentPosition.APPROVE:
+        return Recommendation.APPROVE_CANDIDATE
+    if position is DissentPosition.REQUEST_CHANGES:
+        return Recommendation.REPAIR_FIRST
+    return Recommendation.NEEDS_HUMAN_ATTENTION
+
+
+def _aggregate_top_findings(
+    findings_by_slot: Mapping[str, SlotFindingsResponse],
+    limit: int = 5,
+) -> list[PRReviewFinding]:
+    """Aggregate per-slot findings into the packet's top_findings array.
+
+    Preserves per-slot origin by prefixing the ``finding_id`` with the
+    slot id so duplicates across slots are never silently merged.
+    """
+    agg: list[PRReviewFinding] = []
+    for slot_id, resp in findings_by_slot.items():
+        for finding in resp.top_findings:
+            tagged_id = (
+                finding.finding_id
+                if finding.finding_id.startswith(f"{slot_id}:")
+                else f"{slot_id}:{finding.finding_id}"
+            )
+            agg.append(
+                PRReviewFinding(
+                    finding_id=tagged_id,
+                    category=finding.category,
+                    severity=finding.severity,
+                    summary=finding.summary,
+                    evidence=list(finding.evidence),
+                    source=f"slot:{slot_id}",
+                )
+            )
+    # Severity-weighted stable sort so HIGH severity leads the packet.
+    severity_rank = {"high": 0, "medium": 1, "low": 2}
+    agg.sort(key=lambda f: (severity_rank.get(f.severity, 3), f.finding_id))
+    return agg[:limit]
+
+
+def _build_executed_packet(
+    *,
+    input: PDBExecutionInput,
+    resolutions: tuple[ProviderSlotResolution, ...],
+    availability: ProviderSlotAvailabilitySummary,
+    brief: ReviewBrief,
+    active_slot_ids: tuple[str, ...],
+    missing_slots: tuple[str, ...],
+    findings_by_slot: Mapping[str, SlotFindingsResponse],
+    critiques_by_slot: Mapping[str, SlotCritiqueResponse],
+    synthesis: SynthesisResponse,
+    status: str,
+    decision: PDBBudgetDecision,
+    actual_cost_usd: float,
+    slot_lookup: Mapping[str, PDBPanelSlot],
+) -> PRReviewProtocolPacket:
+    # Re-derive panel votes keyed by the actual slot id (agent string
+    # uses "slot_id:provider" prefix).
+    panel_votes = [
+        PanelVote(
+            finding=RoleFinding(
+                role=_REVIEW_ROLE_BY_NAME.get(slot_lookup[sid].review_role, ReviewRole.SKEPTIC),
+                agent=f"{sid}:{findings_by_slot[sid].provider}",
+                model=findings_by_slot[sid].model,
+                confidence=critiques_by_slot[sid].confidence,
+                finding_text=findings_by_slot[sid].summary,
+                latency_ms=findings_by_slot[sid].latency_ms + critiques_by_slot[sid].latency_ms,
+                cost_usd=round(
+                    findings_by_slot[sid].cost_usd + critiques_by_slot[sid].cost_usd,
+                    6,
+                ),
+            ),
+            position=critiques_by_slot[sid].position,
+            reason=critiques_by_slot[sid].reason,
+        )
+        for sid in active_slot_ids
+        if sid in critiques_by_slot
+    ]
+
+    dissenting_views = _dissenting_views_for_packet(
+        brief_recommendation=brief.recommendation,
+        panel_votes=tuple(panel_votes),
+        critiques=critiques_by_slot,
+        findings=findings_by_slot,
+        slots=slot_lookup,
+    )
+    dissent_count = len(dissenting_views)
+    if dissent_count == 0:
+        dissent_summary = "Panel reached consensus after one critique round; no dissent recorded."
+    else:
+        dissent_summary = (
+            f"{dissent_count} slot(s) dissent from the top-line recommendation; "
+            "machine-readable detail in dissenting_views."
+        )
+
+    top_findings = _aggregate_top_findings(findings_by_slot, limit=5)
+
+    cost_estimate = {
+        "currency": "USD",
+        "estimated_total": round(decision.total_estimated_usd, 4),
+        "actual_total": round(actual_cost_usd, 4),
+        "per_brief_cap": round(decision.per_brief_cap_usd, 4),
+        "per_day_remaining_before": round(decision.per_day_remaining_before_usd, 4),
+        "funded_slots": list(decision.funded_slots),
+        "dropped_slots": list(decision.dropped_slots),
+        "basis": "protocol_b.v1 heterogeneous panel execution",
+    }
+
+    validation_summary = dict(input.validation_summary)
+    validation_summary.setdefault("synthesis_top_line", synthesis.top_line)
+    validation_summary.setdefault("synthesis_confidence", synthesis.confidence)
+    validation_summary["active_roster"] = list(active_slot_ids)
+    validation_summary["missing_slots"] = list(missing_slots)
+
+    return PRReviewProtocolPacket(
+        protocol_version=PROTOCOL_VERSION,
+        status=status,
+        binding=input.binding,
+        review_roles=list(input.packet.review_roles),
+        provider_slots=list(resolutions),
+        availability_summary=availability,
+        recommendation_class=_RECOMMENDATION_CLASS_BY_DECISION[brief.recommendation],
+        recommendation_reason=synthesis.top_line,
+        confidence=round(brief.overall_confidence, 2),
+        confidence_basis=status,
+        dissent_summary=dissent_summary,
+        dissenting_views=dissenting_views,
+        validation_summary=validation_summary,
+        top_findings=top_findings,
+        cost_estimate=cost_estimate,
+    )
+
+
+def _fail_closed_result(
+    *,
+    input: PDBExecutionInput,
+    panel_slots: tuple[PDBPanelSlot, ...],
+    synthesizer_slot: PDBPanelSlot,
+    resolutions: tuple[ProviderSlotResolution, ...],
+    availability: ProviderSlotAvailabilitySummary,
+    missing: tuple[str, ...],
+    failure_reason: str,
+    cfg_budget: Any,
+    ledger: PDBBudgetLedger | None,
+    cost_estimator: SlotCostEstimator | None,
+    now: str,
+) -> PDBExecutionResult:
+    decision = _placeholder_decision(
+        panel_slots=panel_slots,
+        synthesizer_slot=synthesizer_slot,
+        cfg_budget=cfg_budget,
+        ledger=ledger,
+        cost_estimator=cost_estimator,
+        status=PDBBudgetStatus.ALLOWED,  # budget wasn't the bind; resolution/heterogeneity was
+        reason=failure_reason,
+    )
+    packet = PRReviewProtocolPacket(
+        protocol_version=PROTOCOL_VERSION,
+        status=STATUS_FAILED_CLOSED,
+        binding=input.binding,
+        review_roles=list(input.packet.review_roles),
+        provider_slots=list(resolutions),
+        availability_summary=availability,
+        recommendation_class="needs_human_attention",
+        recommendation_reason=failure_reason,
+        confidence=0.0,
+        confidence_basis=STATUS_FAILED_CLOSED,
+        dissent_summary=(
+            "Protocol B failed closed before producing a heterogeneous brief; "
+            "no dissent is available to surface."
+        ),
+        dissenting_views=[],
+        validation_summary=dict(input.validation_summary),
+        top_findings=[],
+        cost_estimate={
+            "currency": "USD",
+            "estimated_total": 0.0,
+            "actual_total": 0.0,
+            "basis": "fail_closed",
+        },
+    )
+    return PDBExecutionResult(
+        status=PDBExecutionStatus.FAILED_CLOSED,
+        packet=packet,
+        brief=None,
+        budget_decision=decision,
+        active_roster=(),
+        missing_slots=missing,
+        degrade_reasons=(),
+        failure_reason=failure_reason,
+        findings_by_slot={},
+        critiques_by_slot={},
+        synthesis=None,
+        resolutions=resolutions,
+        availability_summary=availability,
+        actual_cost_usd=0.0,
+    )
+
+
+def _budget_exceeded_result(
+    *,
+    input: PDBExecutionInput,
+    panel_slots: tuple[PDBPanelSlot, ...],
+    synthesizer_slot: PDBPanelSlot,
+    resolutions: tuple[ProviderSlotResolution, ...],
+    availability: ProviderSlotAvailabilitySummary,
+    decision: PDBBudgetDecision,
+    now: str,
+) -> PDBExecutionResult:
+    packet = PRReviewProtocolPacket(
+        protocol_version=PROTOCOL_VERSION,
+        status=STATUS_BUDGET_EXCEEDED,
+        binding=input.binding,
+        review_roles=list(input.packet.review_roles),
+        provider_slots=list(resolutions),
+        availability_summary=availability,
+        recommendation_class="needs_human_attention",
+        recommendation_reason=decision.reason,
+        confidence=0.0,
+        confidence_basis=STATUS_BUDGET_EXCEEDED,
+        dissent_summary=(
+            "Protocol B was denied by budget before execution; no dissent is available."
+        ),
+        dissenting_views=[],
+        validation_summary=dict(input.validation_summary),
+        top_findings=[],
+        cost_estimate={
+            "currency": "USD",
+            "estimated_total": round(decision.total_estimated_usd, 4),
+            "actual_total": 0.0,
+            "per_brief_cap": round(decision.per_brief_cap_usd, 4),
+            "per_day_remaining_before": round(decision.per_day_remaining_before_usd, 4),
+            "binding_cap": decision.binding_cap,
+            "basis": "budget_exceeded",
+        },
+    )
+    return PDBExecutionResult(
+        status=PDBExecutionStatus.BUDGET_EXCEEDED,
+        packet=packet,
+        brief=None,
+        budget_decision=decision,
+        active_roster=(),
+        missing_slots=decision.dropped_slots,
+        degrade_reasons=(),
+        failure_reason=decision.reason,
+        findings_by_slot={},
+        critiques_by_slot={},
+        synthesis=None,
+        resolutions=resolutions,
+        availability_summary=availability,
+        actual_cost_usd=0.0,
+    )
+
+
+def _placeholder_decision(
+    *,
+    panel_slots: tuple[PDBPanelSlot, ...],
+    synthesizer_slot: PDBPanelSlot,
+    cfg_budget: Any,
+    ledger: PDBBudgetLedger | None,
+    cost_estimator: SlotCostEstimator | None,
+    status: PDBBudgetStatus,
+    reason: str,
+) -> PDBBudgetDecision:
+    working_ledger = ledger or PDBBudgetLedger(daily_cap_usd=cfg_budget.per_day_usd)
+    # Estimate but do not reserve; used only for reporting inside
+    # fail-closed results.
+    slot_estimates = {
+        slot.slot_id: (cost_estimator or SlotCostEstimator()).estimate(slot) for slot in panel_slots
+    }
+    return PDBBudgetDecision(
+        status=status,
+        total_estimated_usd=0.0,
+        per_brief_cap_usd=cfg_budget.per_brief_usd,
+        per_day_cap_usd=cfg_budget.per_day_usd,
+        per_day_spent_before_usd=working_ledger.spent_today_usd,
+        per_day_remaining_before_usd=working_ledger.headroom_usd(),
+        funded_slots=(),
+        dropped_slots=tuple(slot.slot_id for slot in panel_slots),
+        slot_estimates_usd=slot_estimates,
+        synthesis_estimate_usd=budget_mod.DEFAULT_SYNTHESIS_COST_USD,
+        reason=reason,
+        binding_cap=None,
+    )
+
+
+# Clock helpers ---------------------------------------------------------
+
+
+class _Clock(Protocol):
+    def __call__(self) -> str: ...
+
+
+def _default_clock() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()

--- a/tests/pdb/test_budget.py
+++ b/tests/pdb/test_budget.py
@@ -1,0 +1,480 @@
+"""Tests for :mod:`aragora.pdb.budget`.
+
+Covers every outcome of :func:`evaluate_budget`:
+
+- ``ALLOWED`` — full roster fits in both caps
+- ``BUDGET_DEGRADED`` — optional slots dropped greedily to fit
+- ``BUDGET_EXCEEDED`` — minimum safe roster cannot be funded under
+  either the per-brief or the per-day cap
+
+Plus reservation + ledger invariants:
+
+- reserving debits the ledger
+- releasing unused credits the ledger
+- charging after release is a hard error
+- double-release is a no-op
+- :func:`reserve` refuses to reserve against a BUDGET_EXCEEDED decision
+- per-day cap is enforced separately from per-brief cap
+- :class:`ReviewBudget` can tighten but not loosen the per-brief cap
+- no silent downgrade to ``metadata_heuristic`` — the caller gets an
+  explicit denial
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.pdb.budget import (
+    DEFAULT_SLOT_COST_USD,
+    DEFAULT_SYNTHESIS_COST_USD,
+    PDBBudgetDecision,
+    PDBBudgetLedger,
+    PDBBudgetReservation,
+    PDBBudgetStatus,
+    SlotCostEstimator,
+    estimate_slot_costs,
+    evaluate_budget,
+    per_brief_cap_usd,
+    reserve,
+)
+from aragora.pdb.panel_config import PDBBudgetConfig, PDBPanelSlot
+from aragora.review.policy import ReviewBudget
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _slot(slot_id: str, family: str, required: bool = False, lens: str = "core") -> PDBPanelSlot:
+    return PDBPanelSlot(
+        slot_id=slot_id,
+        review_role="logic_reviewer" if lens == "core" else "skeptic",
+        lens=lens,
+        family=family,
+        candidates=(f"{family}-cli",),
+        required=required,
+    )
+
+
+@pytest.fixture
+def budget_cfg() -> PDBBudgetConfig:
+    # 8.00 per brief, 200.00 per day, per spec default
+    return PDBBudgetConfig(
+        per_brief_usd=8.0, per_day_usd=200.0, reserve_for_manual_escalation_usd=40.0
+    )
+
+
+@pytest.fixture
+def ledger(budget_cfg: PDBBudgetConfig) -> PDBBudgetLedger:
+    return PDBBudgetLedger(daily_cap_usd=budget_cfg.per_day_usd)
+
+
+@pytest.fixture
+def slots() -> tuple[PDBPanelSlot, ...]:
+    return (
+        _slot("claude_core", "claude", required=True, lens="core"),
+        _slot("gpt_core", "gpt", required=True, lens="core"),
+        _slot("gemini_h", "gemini", lens="heterodox"),
+        _slot("grok_h", "grok", lens="heterodox"),
+        _slot("deepseek_h", "deepseek", lens="heterodox"),
+        _slot("mistral_r", "mistral", lens="regulatory"),
+    )
+
+
+@pytest.fixture
+def synthesizer(slots: tuple[PDBPanelSlot, ...]) -> PDBPanelSlot:
+    return slots[0]
+
+
+# ---------------------------------------------------------------------------
+# Cost estimation
+# ---------------------------------------------------------------------------
+
+
+def test_default_estimator_is_flat(slots: tuple[PDBPanelSlot, ...]) -> None:
+    est = estimate_slot_costs(slots)
+    assert all(cost == DEFAULT_SLOT_COST_USD for cost in est.values())
+    assert list(est.keys()) == [s.slot_id for s in slots]
+
+
+def test_custom_estimator_is_honored(slots: tuple[PDBPanelSlot, ...]) -> None:
+    class ExpensiveCore(SlotCostEstimator):
+        def estimate(self, slot: PDBPanelSlot) -> float:
+            return 3.0 if slot.lens == "core" else 0.25
+
+    est = estimate_slot_costs(slots, ExpensiveCore())
+    assert est["claude_core"] == 3.0
+    assert est["gemini_h"] == 0.25
+
+
+# ---------------------------------------------------------------------------
+# evaluate_budget — ALLOWED
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_budget_allows_full_roster_when_generous(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    # Cheap slots + cheap synthesis → full roster fits in $8.00 cap.
+    estimator = type(
+        "Tiny",
+        (SlotCostEstimator,),
+        {"estimate": lambda self, slot: 0.5},
+    )()
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=estimator,
+        synthesis_cost_usd=1.0,
+    )
+    assert decision.status is PDBBudgetStatus.ALLOWED
+    assert set(decision.funded_slots) == {s.slot_id for s in slots}
+    assert decision.dropped_slots == ()
+    assert decision.total_estimated_usd == pytest.approx(0.5 * len(slots) + 1.0)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_budget — BUDGET_DEGRADED
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_budget_degrades_optional_slots_greedy(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    # 6 slots × $1.50 + $1.50 synthesis = $10.50 — overruns the $8.00 cap.
+    estimator = type(
+        "Mid",
+        (SlotCostEstimator,),
+        {"estimate": lambda self, slot: 1.5},
+    )()
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=estimator,
+        synthesis_cost_usd=1.5,
+    )
+    assert decision.status is PDBBudgetStatus.BUDGET_DEGRADED
+    # Both required core slots must survive the degrade
+    assert "claude_core" in decision.funded_slots
+    assert "gpt_core" in decision.funded_slots
+    # Some optional slots must have been dropped
+    assert decision.dropped_slots
+    # Every dropped slot must be optional (required=False)
+    dropped_by_id = {s.slot_id for s in slots if not s.required}
+    assert set(decision.dropped_slots) <= dropped_by_id
+    # Total estimated is <= per_brief_usd cap (within rounding)
+    assert decision.total_estimated_usd <= budget_cfg.per_brief_usd + 1e-6
+    assert decision.binding_cap == "per_brief_usd"
+
+
+def test_evaluate_budget_degrades_preserves_panel_order(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    estimator = type(
+        "Mid",
+        (SlotCostEstimator,),
+        {"estimate": lambda self, slot: 1.5},
+    )()
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=estimator,
+        synthesis_cost_usd=1.5,
+    )
+    # funded_slots preserves the panel's original ordering
+    panel_order = [s.slot_id for s in slots]
+    assert decision.funded_slots == tuple(
+        sid for sid in panel_order if sid in set(decision.funded_slots)
+    )
+    assert decision.dropped_slots == tuple(
+        sid for sid in panel_order if sid in set(decision.dropped_slots)
+    )
+
+
+# ---------------------------------------------------------------------------
+# evaluate_budget — BUDGET_EXCEEDED
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_budget_rejects_when_core_plus_synth_overruns_per_brief(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    # Two core slots at $10 + synth $5 = $25 > $8 cap.
+    estimator = type(
+        "Huge",
+        (SlotCostEstimator,),
+        {"estimate": lambda self, slot: 10.0},
+    )()
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=estimator,
+        synthesis_cost_usd=5.0,
+    )
+    assert decision.status is PDBBudgetStatus.BUDGET_EXCEEDED
+    assert decision.funded_slots == ()
+    assert decision.binding_cap == "per_brief_usd"
+    assert "per_brief_usd" in decision.reason or "per_brief" in decision.reason
+
+
+def test_evaluate_budget_rejects_when_daily_pool_exhausted(
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    budget = PDBBudgetConfig(
+        per_brief_usd=50.0,
+        per_day_usd=60.0,
+        reserve_for_manual_escalation_usd=0.0,
+    )
+    ledger = PDBBudgetLedger(daily_cap_usd=budget.per_day_usd, spent_today_usd=58.0)
+    estimator = type(
+        "Mid",
+        (SlotCostEstimator,),
+        {"estimate": lambda self, slot: 1.5},
+    )()
+    # Minimum roster: claude_core + gpt_core + synth = $1.5 + $1.5 + $1.5 = $4.5
+    # Daily headroom: $60 - $58 = $2 — cannot fit minimum.
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget,
+        ledger=ledger,
+        estimator=estimator,
+        synthesis_cost_usd=1.5,
+    )
+    assert decision.status is PDBBudgetStatus.BUDGET_EXCEEDED
+    assert decision.binding_cap == "per_day_usd"
+
+
+def test_no_silent_downgrade_on_budget_exceeded(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    estimator = type(
+        "Huge",
+        (SlotCostEstimator,),
+        {"estimate": lambda self, slot: 20.0},
+    )()
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=estimator,
+        synthesis_cost_usd=5.0,
+    )
+    # The spec is categorical: budget_exceeded MUST be explicit, not a
+    # silent fallback to a cheaper roster.
+    assert decision.status is PDBBudgetStatus.BUDGET_EXCEEDED
+    assert decision.funded_slots == ()
+    # Reservation must refuse the decision as well.
+    with pytest.raises(RuntimeError):
+        reserve(decision, ledger)
+    # Ledger must not have been debited.
+    assert ledger.spent_today_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Reservation lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_reserve_debits_ledger_and_release_returns_unused(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    estimator = type(
+        "Tiny",
+        (SlotCostEstimator,),
+        {"estimate": lambda self, slot: 0.5},
+    )()
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=estimator,
+        synthesis_cost_usd=1.0,
+    )
+    assert decision.status is PDBBudgetStatus.ALLOWED
+    reservation = reserve(decision, ledger)
+    assert ledger.spent_today_usd == pytest.approx(decision.total_estimated_usd)
+    assert isinstance(reservation, PDBBudgetReservation)
+
+    # Charge partial real spend.
+    reservation.charge(0.5)
+    reservation.charge(1.0)
+    assert reservation.actual_spend_usd == pytest.approx(1.5)
+    unused = reservation.released_unused_usd()
+    assert unused == pytest.approx(decision.total_estimated_usd - 1.5)
+
+    released = reservation.release_unused()
+    assert released == pytest.approx(unused)
+    # Ledger must reflect the actual spend after release
+    assert ledger.spent_today_usd == pytest.approx(1.5)
+
+
+def test_release_unused_idempotent(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=SlotCostEstimator(default_usd=0.5),
+        synthesis_cost_usd=1.0,
+    )
+    reservation = reserve(decision, ledger)
+    reservation.release_unused()
+    assert reservation.release_unused() == 0.0
+
+
+def test_charge_after_release_is_rejected(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=SlotCostEstimator(default_usd=0.5),
+        synthesis_cost_usd=1.0,
+    )
+    reservation = reserve(decision, ledger)
+    reservation.release_unused()
+    with pytest.raises(RuntimeError):
+        reservation.charge(0.1)
+
+
+def test_charge_negative_rejected(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=SlotCostEstimator(default_usd=0.5),
+        synthesis_cost_usd=1.0,
+    )
+    reservation = reserve(decision, ledger)
+    with pytest.raises(ValueError):
+        reservation.charge(-0.1)
+
+
+# ---------------------------------------------------------------------------
+# per_brief_cap_usd
+# ---------------------------------------------------------------------------
+
+
+def test_review_budget_tightens_per_brief_cap(budget_cfg: PDBBudgetConfig) -> None:
+    review = ReviewBudget(per_pr_usd_cap=3.0)
+    assert per_brief_cap_usd(budget_cfg, review) == pytest.approx(3.0)
+
+
+def test_review_budget_cannot_loosen_per_brief_cap(budget_cfg: PDBBudgetConfig) -> None:
+    review = ReviewBudget(per_pr_usd_cap=100.0)
+    # PDB default ($8) is stricter and wins.
+    assert per_brief_cap_usd(budget_cfg, review) == pytest.approx(budget_cfg.per_brief_usd)
+
+
+def test_review_budget_zero_means_no_override(budget_cfg: PDBBudgetConfig) -> None:
+    review = ReviewBudget(per_pr_usd_cap=0.0)
+    assert per_brief_cap_usd(budget_cfg, review) == pytest.approx(budget_cfg.per_brief_usd)
+
+
+# ---------------------------------------------------------------------------
+# Ledger bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_debit_and_credit_round_trip() -> None:
+    ledger = PDBBudgetLedger(daily_cap_usd=100.0)
+    ledger.debit(30.0)
+    ledger.credit(5.0)
+    assert ledger.spent_today_usd == pytest.approx(25.0)
+    assert ledger.headroom_usd() == pytest.approx(75.0)
+
+
+def test_ledger_credit_cannot_go_negative() -> None:
+    ledger = PDBBudgetLedger(daily_cap_usd=100.0)
+    ledger.debit(5.0)
+    ledger.credit(100.0)  # over-credit
+    assert ledger.spent_today_usd == 0.0
+
+
+def test_decision_to_dict_is_json_friendly(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=SlotCostEstimator(default_usd=0.5),
+        synthesis_cost_usd=1.0,
+    )
+    import json
+
+    payload = decision.to_dict()
+    # Round-trip through JSON so we know every value is serializable.
+    assert json.loads(json.dumps(payload))["status"] == decision.status.value
+
+
+def test_decision_explicit_budget_exceeded_status_value(
+    budget_cfg: PDBBudgetConfig,
+    ledger: PDBBudgetLedger,
+    slots: tuple[PDBPanelSlot, ...],
+    synthesizer: PDBPanelSlot,
+) -> None:
+    estimator = SlotCostEstimator(default_usd=20.0)
+    decision = evaluate_budget(
+        findings_slots=slots,
+        synthesizer_slot=synthesizer,
+        budget=budget_cfg,
+        ledger=ledger,
+        estimator=estimator,
+        synthesis_cost_usd=5.0,
+    )
+    # No silent rewrite to "metadata_heuristic" — the caller sees exactly
+    # "budget_exceeded" so PR3 transport can honor the contract.
+    assert decision.status.value == "budget_exceeded"
+    assert decision.to_dict()["status"] == "budget_exceeded"

--- a/tests/pdb/test_panel_config.py
+++ b/tests/pdb/test_panel_config.py
@@ -1,0 +1,481 @@
+"""Tests for :mod:`aragora.pdb.panel_config`.
+
+Covers every rule in the PDB Mode 3 PR2 spec's "Validation rules"
+section:
+
+- ``version == 1`` (and explicit failure on other versions)
+- ``default_panel`` / ``synthesizer_slot`` / ``default_prompt_set`` existence
+- every slot defines ``review_role``, ``lens``, ``family``, ``candidates``
+- ``findings_slots`` must include both required core slots
+- the selected panel must include at least one non-core lens
+- ``same_as_findings`` sentinel only legal on ``critique_slots``
+- ``required: true`` signaling and required-slot propagation through the
+  provider-slot resolver projection
+- exact ``field_path`` attribute on every :class:`PDBPanelConfigError`
+- committed default config loads cleanly
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from aragora.pdb.panel_config import (
+    DEFAULT_CONFIG_PATH,
+    PDBBudgetConfig,
+    PDBPanelConfig,
+    PDBPanelConfigError,
+    PDBPanelDefinition,
+    PDBPanelSlot,
+    PDBPromptSet,
+    load_panel_config,
+    panel_slots,
+    provider_slot_definitions,
+    validate_panel_config,
+)
+from aragora.review.provider_slots import ProviderSlotDefinition
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _base_config() -> dict:
+    """Return a minimal valid config mirroring the committed default."""
+    return {
+        "version": 1,
+        "default_panel": "p",
+        "default_prompt_set": "ps",
+        "budgets": {
+            "per_brief_usd": 2.0,
+            "per_day_usd": 20.0,
+            "reserve_for_manual_escalation_usd": 5.0,
+        },
+        "slots": {
+            "claude_core": {
+                "review_role": "logic_reviewer",
+                "lens": "core",
+                "family": "claude",
+                "candidates": ["claude", "anthropic-api"],
+                "required": True,
+            },
+            "gpt_core": {
+                "review_role": "security_reviewer",
+                "lens": "core",
+                "family": "gpt",
+                "candidates": ["codex", "openai-api"],
+                "required": True,
+            },
+            "gemini_hetero": {
+                "review_role": "maintainability_reviewer",
+                "lens": "heterodox",
+                "family": "gemini",
+                "candidates": ["gemini-cli"],
+                "required": False,
+            },
+        },
+        "panels": {
+            "p": {
+                "findings_slots": ["claude_core", "gpt_core", "gemini_hetero"],
+                "critique_slots": "same_as_findings",
+                "synthesizer_slot": "claude_core",
+            },
+        },
+        "prompt_sets": {
+            "ps": {
+                "findings_prompt": "f",
+                "critique_prompt": "c",
+                "synthesis_prompt": "s",
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Committed default config
+# ---------------------------------------------------------------------------
+
+
+def test_load_committed_default_config_succeeds() -> None:
+    cfg = load_panel_config()
+    assert isinstance(cfg, PDBPanelConfig)
+    assert cfg.version == 1
+    assert cfg.default_panel in cfg.panels
+    assert cfg.default_prompt_set in cfg.prompt_sets
+    assert cfg.source_path == DEFAULT_CONFIG_PATH
+    # committed default must include both required core slots
+    required = {sid for sid, s in cfg.slots.items() if s.required}
+    assert {"claude_core", "gpt_core"} <= required
+
+
+def test_default_config_projects_to_provider_slot_definitions() -> None:
+    cfg = load_panel_config()
+    defs = provider_slot_definitions(cfg, cfg.default_panel)
+    assert defs
+    assert all(isinstance(d, ProviderSlotDefinition) for d in defs)
+    slot_ids = [d.slot_id for d in defs]
+    # Order preserves findings_slots order
+    expected = list(cfg.panels[cfg.default_panel].findings_slots)
+    assert slot_ids == expected
+
+
+# ---------------------------------------------------------------------------
+# Happy path on minimal config
+# ---------------------------------------------------------------------------
+
+
+def test_validate_panel_config_happy_path() -> None:
+    cfg = validate_panel_config(_base_config())
+    assert isinstance(cfg.budget, PDBBudgetConfig)
+    assert isinstance(cfg.slots["claude_core"], PDBPanelSlot)
+    assert isinstance(cfg.panels["p"], PDBPanelDefinition)
+    assert isinstance(cfg.prompt_sets["ps"], PDBPromptSet)
+    # same_as_findings sentinel expands to a tuple copy
+    assert cfg.panels["p"].critique_slots == cfg.panels["p"].findings_slots
+    assert cfg.panels["p"].critique_slots == ("claude_core", "gpt_core", "gemini_hetero")
+
+
+def test_panel_slots_preserves_order() -> None:
+    cfg = validate_panel_config(_base_config())
+    ordered = panel_slots(cfg, "p")
+    assert [s.slot_id for s in ordered] == ["claude_core", "gpt_core", "gemini_hetero"]
+
+
+def test_critique_slots_as_explicit_list() -> None:
+    raw = _base_config()
+    raw["panels"]["p"]["critique_slots"] = ["claude_core", "gpt_core"]
+    cfg = validate_panel_config(raw)
+    assert cfg.panels["p"].critique_slots == ("claude_core", "gpt_core")
+
+
+# ---------------------------------------------------------------------------
+# Version / top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_version_rejected() -> None:
+    raw = _base_config()
+    raw["version"] = 2
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "version"
+
+
+def test_missing_top_level_key_raises_with_exact_path() -> None:
+    raw = _base_config()
+    raw.pop("default_panel")
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "default_panel"
+
+
+def test_wrong_type_at_top_level_rejected() -> None:
+    raw = _base_config()
+    raw["version"] = "1"  # string instead of int
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "version"
+
+
+# ---------------------------------------------------------------------------
+# Budget validation
+# ---------------------------------------------------------------------------
+
+
+def test_budget_per_brief_must_be_positive() -> None:
+    raw = _base_config()
+    raw["budgets"]["per_brief_usd"] = 0
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "budgets.per_brief_usd"
+
+
+def test_budget_per_day_must_be_positive() -> None:
+    raw = _base_config()
+    raw["budgets"]["per_day_usd"] = -1
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "budgets.per_day_usd"
+
+
+def test_budget_reserve_must_be_nonnegative() -> None:
+    raw = _base_config()
+    raw["budgets"]["reserve_for_manual_escalation_usd"] = -0.5
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "budgets.reserve_for_manual_escalation_usd"
+
+
+def test_budget_per_brief_cannot_exceed_per_day() -> None:
+    raw = _base_config()
+    raw["budgets"]["per_brief_usd"] = 200.0
+    raw["budgets"]["per_day_usd"] = 50.0
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "budgets.per_brief_usd"
+
+
+def test_budget_numeric_only() -> None:
+    raw = _base_config()
+    raw["budgets"]["per_brief_usd"] = True  # bool is rejected
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "budgets.per_brief_usd"
+
+
+# ---------------------------------------------------------------------------
+# Slot validation
+# ---------------------------------------------------------------------------
+
+
+def test_slot_missing_review_role_rejected() -> None:
+    raw = _base_config()
+    raw["slots"]["claude_core"].pop("review_role")
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "slots.claude_core.review_role"
+
+
+def test_slot_missing_lens_rejected() -> None:
+    raw = _base_config()
+    raw["slots"]["claude_core"].pop("lens")
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "slots.claude_core.lens"
+
+
+def test_slot_missing_family_rejected() -> None:
+    raw = _base_config()
+    raw["slots"]["claude_core"].pop("family")
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "slots.claude_core.family"
+
+
+def test_slot_empty_candidates_rejected() -> None:
+    raw = _base_config()
+    raw["slots"]["claude_core"]["candidates"] = []
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "slots.claude_core.candidates"
+
+
+def test_slot_non_string_candidate_rejected() -> None:
+    raw = _base_config()
+    raw["slots"]["claude_core"]["candidates"] = ["claude", 42]
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "slots.claude_core.candidates[1]"
+
+
+def test_slot_required_must_be_bool() -> None:
+    raw = _base_config()
+    raw["slots"]["claude_core"]["required"] = "yes"
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "slots.claude_core.required"
+
+
+def test_slot_required_defaults_to_false() -> None:
+    raw = _base_config()
+    raw["slots"]["claude_core"]["required"] = False
+    raw["slots"]["gpt_core"]["required"] = False
+    # Introduce a required slot so findings_slots still validates
+    raw["slots"]["ext_core"] = {
+        "review_role": "logic_reviewer",
+        "lens": "core",
+        "family": "ext",
+        "candidates": ["ext-cli"],
+    }
+    raw["panels"]["p"]["findings_slots"] = [
+        "claude_core",
+        "gpt_core",
+        "ext_core",
+        "gemini_hetero",
+    ]
+    cfg = validate_panel_config(raw)
+    assert cfg.slots["ext_core"].required is False
+
+
+# ---------------------------------------------------------------------------
+# Panel validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_default_panel_rejected() -> None:
+    raw = _base_config()
+    raw["default_panel"] = "missing"
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "default_panel"
+
+
+def test_unknown_default_prompt_set_rejected() -> None:
+    raw = _base_config()
+    raw["default_prompt_set"] = "missing"
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "default_prompt_set"
+
+
+def test_panel_references_unknown_slot() -> None:
+    raw = _base_config()
+    raw["panels"]["p"]["findings_slots"].append("nope")
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "panels.p.findings_slots[3]"
+
+
+def test_panel_duplicate_slot_rejected() -> None:
+    raw = _base_config()
+    raw["panels"]["p"]["findings_slots"] = [
+        "claude_core",
+        "claude_core",
+        "gpt_core",
+        "gemini_hetero",
+    ]
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "panels.p.findings_slots[1]"
+
+
+def test_panel_missing_required_slot_rejected() -> None:
+    raw = _base_config()
+    # Drop gpt_core from findings_slots while leaving it required
+    raw["panels"]["p"]["findings_slots"] = ["claude_core", "gemini_hetero"]
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "panels.p.findings_slots"
+    assert "gpt_core" in str(exc.value)
+
+
+def test_panel_needs_two_core_slots() -> None:
+    raw = _base_config()
+    # Make gpt_core heterodox; findings_slots would then have only one core slot
+    raw["slots"]["gpt_core"]["lens"] = "heterodox"
+    raw["slots"]["gpt_core"]["required"] = False
+    # also need to keep both cores "required" invariant; loosen it
+    raw["slots"]["claude_core"]["required"] = True
+    raw["slots"]["gpt_core"]["required"] = False
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "panels.p.findings_slots"
+    assert "core-lens" in str(exc.value)
+
+
+def test_panel_needs_non_core_lens() -> None:
+    raw = _base_config()
+    # Drop the heterodox slot from findings_slots
+    raw["panels"]["p"]["findings_slots"] = ["claude_core", "gpt_core"]
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "panels.p.findings_slots"
+    assert "non-core" in str(exc.value)
+
+
+def test_synthesizer_slot_must_be_in_findings() -> None:
+    raw = _base_config()
+    raw["slots"]["extra"] = {
+        "review_role": "logic_reviewer",
+        "lens": "core",
+        "family": "extra",
+        "candidates": ["extra"],
+    }
+    raw["panels"]["p"]["synthesizer_slot"] = "extra"
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "panels.p.synthesizer_slot"
+
+
+def test_synthesizer_slot_must_exist() -> None:
+    raw = _base_config()
+    raw["panels"]["p"]["synthesizer_slot"] = "ghost"
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "panels.p.synthesizer_slot"
+
+
+def test_same_as_findings_only_for_critique_slots() -> None:
+    raw = _base_config()
+    # Putting the sentinel in findings_slots is invalid (it must be a list)
+    raw["panels"]["p"]["findings_slots"] = "same_as_findings"
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "panels.p.findings_slots"
+
+
+def test_critique_slots_unknown_string_rejected() -> None:
+    raw = _base_config()
+    raw["panels"]["p"]["critique_slots"] = "all_slots"
+    with pytest.raises(PDBPanelConfigError) as exc:
+        validate_panel_config(raw)
+    assert exc.value.field_path == "panels.p.critique_slots"
+
+
+# ---------------------------------------------------------------------------
+# I/O error paths
+# ---------------------------------------------------------------------------
+
+
+def test_load_panel_config_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(PDBPanelConfigError) as exc:
+        load_panel_config(tmp_path / "nope.yaml")
+    assert exc.value.field_path == "<path>"
+
+
+def test_load_panel_config_empty_file(tmp_path: Path) -> None:
+    p = tmp_path / "empty.yaml"
+    p.write_text("", encoding="utf-8")
+    with pytest.raises(PDBPanelConfigError) as exc:
+        load_panel_config(p)
+    assert exc.value.field_path == "<root>"
+
+
+def test_load_panel_config_non_mapping(tmp_path: Path) -> None:
+    p = tmp_path / "list.yaml"
+    p.write_text("- 1\n- 2\n", encoding="utf-8")
+    with pytest.raises(PDBPanelConfigError) as exc:
+        load_panel_config(p)
+    assert exc.value.field_path == "<root>"
+
+
+def test_load_panel_config_roundtrip(tmp_path: Path) -> None:
+    data = _base_config()
+    p = tmp_path / "ok.yaml"
+    p.write_text(yaml.safe_dump(data), encoding="utf-8")
+    cfg = load_panel_config(p)
+    assert cfg.source_path == p
+    assert cfg.default_panel == "p"
+
+
+# ---------------------------------------------------------------------------
+# panel_slots / provider_slot_definitions error cases
+# ---------------------------------------------------------------------------
+
+
+def test_panel_slots_unknown_panel() -> None:
+    cfg = validate_panel_config(_base_config())
+    with pytest.raises(PDBPanelConfigError):
+        panel_slots(cfg, "ghost")
+
+
+def test_provider_slot_definitions_preserve_required_metadata() -> None:
+    cfg = validate_panel_config(_base_config())
+    defs = provider_slot_definitions(cfg, "p")
+    # Mapping back to the PDBPanelSlot retains required flags — projection
+    # only drops the optional ``required`` attribute because
+    # ProviderSlotDefinition is generic and lens-agnostic.
+    assert [d.slot_id for d in defs] == list(cfg.panels["p"].findings_slots)
+    required = [cfg.slots[d.slot_id].required for d in defs]
+    assert required == [True, True, False]
+
+
+def test_raw_input_not_mutated() -> None:
+    raw = _base_config()
+    snapshot = copy.deepcopy(raw)
+    validate_panel_config(raw)
+    assert raw == snapshot

--- a/tests/pdb/test_prompts.py
+++ b/tests/pdb/test_prompts.py
@@ -1,0 +1,298 @@
+"""Tests for :mod:`aragora.pdb.prompts`.
+
+Covers the prompt-shape invariants required by the spec:
+
+- every phase binds ``repo``, ``pr_number``, ``base_sha``, ``head_sha``
+- findings/critique prompts preserve ``core`` / ``heterodox`` /
+  ``regulatory`` lens identity
+- findings prompt requests structured JSON (not essays) per the
+  "request structured findings, not essays" rule
+- critique prompt includes peer findings from OTHER slots only
+- synthesis prompt invites disagreement preservation and lists every
+  panel vote verbatim
+- binding header is shared across phases (one source of truth)
+"""
+
+from __future__ import annotations
+
+from aragora.pdb.panel_config import PDBPanelSlot
+from aragora.pdb.prompts import (
+    critique_prompt,
+    findings_prompt,
+    render_binding_header,
+    synthesis_prompt,
+)
+from aragora.review.builder import PanelVote
+from aragora.review.protocol import DissentPosition, ReviewRole, RoleFinding
+from aragora.swarm.pr_review_protocol import PRReviewBinding
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _binding() -> PRReviewBinding:
+    return PRReviewBinding(
+        repo="synaptent/aragora",
+        pr_number=4242,
+        base_sha="deadbeef1111",
+        head_sha="cafef00d2222",
+    )
+
+
+def _slot(slot_id: str, lens: str, review_role: str = "logic_reviewer") -> PDBPanelSlot:
+    return PDBPanelSlot(
+        slot_id=slot_id,
+        review_role=review_role,
+        lens=lens,
+        family=slot_id.split("_", 1)[0],
+        candidates=(f"{slot_id}-cli",),
+        required=(lens == "core"),
+    )
+
+
+def _vote(slot_id: str, role: ReviewRole, position: DissentPosition, reason: str) -> PanelVote:
+    return PanelVote(
+        finding=RoleFinding(
+            role=role,
+            agent=f"{slot_id}:mock",
+            model="mock-1",
+            confidence=0.8,
+            finding_text=f"{slot_id} says {position.value}",
+        ),
+        position=position,
+        reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Binding header
+# ---------------------------------------------------------------------------
+
+
+def test_binding_header_contains_all_four_anchors() -> None:
+    text = render_binding_header(
+        binding=_binding(),
+        pr_title="Refactor budget accounting",
+        pr_body="Description here",
+        labels=("backend", "priority:high"),
+        changed_files=("aragora/pdb/budget.py",),
+    )
+    for needle in ("synaptent/aragora", "4242", "deadbeef1111", "cafef00d2222"):
+        assert needle in text
+    assert "backend" in text
+    assert "priority:high" in text
+
+
+def test_binding_header_truncates_very_long_body() -> None:
+    text = render_binding_header(
+        binding=_binding(),
+        pr_title="t",
+        pr_body="x" * 5000,
+        labels=(),
+        changed_files=(),
+    )
+    assert "[truncated]" in text
+
+
+def test_binding_header_changed_files_truncation() -> None:
+    many = tuple(f"src/file_{i}.py" for i in range(60))
+    text = render_binding_header(
+        binding=_binding(),
+        pr_title="t",
+        pr_body="",
+        labels=(),
+        changed_files=many,
+    )
+    assert "and 20 more" in text
+
+
+# ---------------------------------------------------------------------------
+# Findings prompt
+# ---------------------------------------------------------------------------
+
+
+def _require_binding_anchors(text: str) -> None:
+    for needle in ("synaptent/aragora", "4242", "deadbeef1111", "cafef00d2222"):
+        assert needle in text, f"prompt missing anchor {needle!r}"
+
+
+def test_findings_prompt_binds_anchors_and_lens_core() -> None:
+    slot = _slot("claude_core", "core", "logic_reviewer")
+    text = findings_prompt(
+        slot=slot,
+        binding=_binding(),
+        pr_title="t",
+        pr_body="body",
+        labels=(),
+        changed_files=("a.py",),
+        diff_excerpt="diff --git a/a.py b/a.py\n+pass\n",
+        validation_summary={"checks": "green"},
+    )
+    _require_binding_anchors(text)
+    assert "CORE lens" in text
+    assert "slot_id: claude_core" in text
+    assert "review_role: logic_reviewer" in text
+    assert "family: claude" in text
+    # structured-JSON contract
+    assert '"recommendation"' in text
+    assert '"confidence"' in text
+    assert '"top_findings"' in text
+    assert '"contested_finding_ids"' in text
+    assert '"reason"' in text
+
+
+def test_findings_prompt_preserves_heterodox_lens_identity() -> None:
+    slot = _slot("grok_h", "heterodox", "skeptic")
+    text = findings_prompt(
+        slot=slot,
+        binding=_binding(),
+        pr_title="t",
+        pr_body="",
+        labels=(),
+        changed_files=(),
+        diff_excerpt="",
+    )
+    _require_binding_anchors(text)
+    assert "HETERODOX lens" in text
+    assert "Disagreement is the point" in text
+
+
+def test_findings_prompt_preserves_regulatory_lens_identity() -> None:
+    slot = _slot("mistral_r", "regulatory", "skeptic")
+    text = findings_prompt(
+        slot=slot,
+        binding=_binding(),
+        pr_title="t",
+        pr_body="",
+        labels=(),
+        changed_files=(),
+        diff_excerpt="",
+    )
+    _require_binding_anchors(text)
+    assert "REGULATORY lens" in text
+    # Must be framed as a perspective, not a compliance oracle
+    assert "perspective" in text
+    assert "compliance oracle" in text
+
+
+def test_findings_prompt_handles_missing_validation_summary() -> None:
+    slot = _slot("claude_core", "core", "logic_reviewer")
+    text = findings_prompt(
+        slot=slot,
+        binding=_binding(),
+        pr_title="t",
+        pr_body="",
+        labels=(),
+        changed_files=(),
+        diff_excerpt="",
+        validation_summary=None,
+    )
+    assert "no validation signals provided" in text
+
+
+# ---------------------------------------------------------------------------
+# Critique prompt
+# ---------------------------------------------------------------------------
+
+
+def test_critique_prompt_binds_anchors_and_peer_findings() -> None:
+    slot = _slot("gpt_core", "core", "security_reviewer")
+    text = critique_prompt(
+        slot=slot,
+        binding=_binding(),
+        pr_title="t",
+        pr_body="",
+        labels=(),
+        changed_files=(),
+        peer_findings={
+            "claude_core": "recommendation: approve\nsummary: looks good",
+            "grok_h": "recommendation: defer\nsummary: concerns with scope",
+        },
+    )
+    _require_binding_anchors(text)
+    assert "claude_core" in text
+    assert "grok_h" in text
+    # Must not include itself among peers
+    assert "### peer slot: gpt_core" not in text
+    # Structured-JSON contract for critique
+    assert '"agrees_with"' in text
+    assert '"disagrees_with"' in text
+    assert '"contested_finding_ids"' in text
+    # Heterogeneity instruction preserved
+    assert "record dissent explicitly" in text
+
+
+def test_critique_prompt_handles_empty_peers() -> None:
+    slot = _slot("claude_core", "core", "logic_reviewer")
+    text = critique_prompt(
+        slot=slot,
+        binding=_binding(),
+        pr_title="t",
+        pr_body="",
+        labels=(),
+        changed_files=(),
+        peer_findings={},
+    )
+    _require_binding_anchors(text)
+    assert "no peer findings" in text
+
+
+# ---------------------------------------------------------------------------
+# Synthesis prompt
+# ---------------------------------------------------------------------------
+
+
+def test_synthesis_prompt_lists_panel_votes_and_preserves_dissent() -> None:
+    slot = _slot("claude_core", "core", "logic_reviewer")
+    votes = (
+        _vote("claude_core", ReviewRole.LOGIC, DissentPosition.APPROVE, "Clean."),
+        _vote(
+            "gpt_core",
+            ReviewRole.SECURITY,
+            DissentPosition.REQUEST_CHANGES,
+            "Missing input validation.",
+        ),
+        _vote("grok_h", ReviewRole.SKEPTIC, DissentPosition.DEFER, "Unclear rollout plan."),
+    )
+    text = synthesis_prompt(
+        synthesizer_slot=slot,
+        binding=_binding(),
+        pr_title="t",
+        pr_body="",
+        labels=(),
+        changed_files=(),
+        votes=votes,
+    )
+    _require_binding_anchors(text)
+    # The synthesizer's own lens must still be visible
+    assert "CORE lens" in text
+    # Every vote must appear (slot position + reason)
+    assert "approve" in text.lower()
+    assert "request_changes" in text
+    assert "defer" in text
+    assert "Missing input validation" in text
+    # JSON contract
+    assert '"top_line"' in text
+    assert '"validation_summary"' in text
+    assert '"preserved_dissent"' in text
+    # Preserves dissent rather than flattening
+    assert "Preserve disagreement" in text
+    # Builder-controls-recommendation rule is explicit
+    assert "do NOT override it" in text
+
+
+def test_synthesis_prompt_handles_empty_votes() -> None:
+    slot = _slot("claude_core", "core", "logic_reviewer")
+    text = synthesis_prompt(
+        synthesizer_slot=slot,
+        binding=_binding(),
+        pr_title="t",
+        pr_body="",
+        labels=(),
+        changed_files=(),
+        votes=(),
+    )
+    _require_binding_anchors(text)
+    assert "no panel votes" in text

--- a/tests/pdb/test_protocol.py
+++ b/tests/pdb/test_protocol.py
@@ -1,0 +1,886 @@
+"""End-to-end tests for :mod:`aragora.pdb.protocol`.
+
+Covers the spec's acceptance criteria for the Protocol B executor:
+
+- all-core-green happy path → :class:`ReviewBrief` produced via the
+  landed :func:`aragora.review.builder.build_brief`
+- optional slot missing → degraded execution preserves reduced roster
+- required slot missing → fail-closed result, no brief written
+- synthesizer slot missing → fail-closed result
+- budget exceeded → explicit ``BUDGET_EXCEEDED`` status, no brief
+- dissent survives at all three layers: reviewer outputs, packet
+  ``dissenting_views``, and ``ReviewBrief.dissent``
+- heterogeneity floor: if funded roster collapses to < 2 families,
+  fail closed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence
+
+import pytest
+
+from aragora.pdb.budget import (
+    PDBBudgetLedger,
+    PDBBudgetStatus,
+    SlotCostEstimator,
+)
+from aragora.pdb.panel_config import (
+    PDBBudgetConfig,
+    PDBPanelConfig,
+    PDBPanelDefinition,
+    PDBPanelSlot,
+    PDBPromptSet,
+)
+from aragora.pdb.protocol import (
+    PDBExecutionInput,
+    PDBExecutionResult,
+    PDBExecutionStatus,
+    ProviderInvoker,
+    STATUS_BUDGET_EXCEEDED,
+    STATUS_FAILED_CLOSED,
+    STATUS_PANEL_DEGRADED,
+    STATUS_PANEL_EXECUTED,
+    SlotCritiqueResponse,
+    SlotFindingsResponse,
+    SynthesisResponse,
+    run_protocol_b,
+)
+from aragora.review.builder import PanelVote
+from aragora.review.policy import ReviewBudget, ReviewPolicy
+from aragora.review.protocol import (
+    DissentPosition,
+    Recommendation,
+    ReviewBrief,
+    ReviewRole,
+)
+from aragora.review.provider_slots import (
+    ProviderSlotAvailabilitySummary,
+    ProviderSlotDefinition,
+    ProviderSlotResolution,
+    ProviderSlotResolver,
+)
+from aragora.swarm.pr_review_protocol import (
+    PRReviewBinding,
+    PRReviewFinding,
+    PRReviewProtocol,
+    PRReviewProtocolPacket,
+    PROTOCOL_STATUS,
+    PROTOCOL_VERSION,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _slot(
+    slot_id: str,
+    *,
+    family: str,
+    review_role: str = "logic_reviewer",
+    lens: str = "core",
+    required: bool = False,
+    candidates: tuple[str, ...] = (),
+) -> PDBPanelSlot:
+    return PDBPanelSlot(
+        slot_id=slot_id,
+        review_role=review_role,
+        lens=lens,
+        family=family,
+        candidates=candidates or (f"{slot_id}-cli",),
+        required=required,
+    )
+
+
+def _mini_config(slots: Sequence[PDBPanelSlot], synthesizer: str) -> PDBPanelConfig:
+    slot_map = {s.slot_id: s for s in slots}
+    panel = PDBPanelDefinition(
+        panel_id="p",
+        findings_slots=tuple(s.slot_id for s in slots),
+        critique_slots=tuple(s.slot_id for s in slots),
+        synthesizer_slot=synthesizer,
+    )
+    return PDBPanelConfig(
+        version=1,
+        default_panel="p",
+        default_prompt_set="ps",
+        budget=PDBBudgetConfig(
+            per_brief_usd=20.0,
+            per_day_usd=200.0,
+            reserve_for_manual_escalation_usd=10.0,
+        ),
+        slots=slot_map,
+        panels={"p": panel},
+        prompt_sets={
+            "ps": PDBPromptSet(
+                prompt_set_id="ps",
+                findings_prompt="f",
+                critique_prompt="c",
+                synthesis_prompt="s",
+            ),
+        },
+    )
+
+
+def _binding() -> PRReviewBinding:
+    return PRReviewBinding(
+        repo="synaptent/aragora",
+        pr_number=4242,
+        base_sha="base0000",
+        head_sha="head1111",
+    )
+
+
+def _heuristic_packet() -> PRReviewProtocolPacket:
+    return PRReviewProtocolPacket(
+        protocol_version=PROTOCOL_VERSION,
+        status=PROTOCOL_STATUS,
+        binding=_binding(),
+        review_roles=list(PRReviewProtocol.default().review_roles),
+        provider_slots=[],
+        availability_summary=ProviderSlotAvailabilitySummary(
+            total_slots=0,
+            resolved_slots=0,
+        ),
+        recommendation_class="needs_human_attention",
+        recommendation_reason="pre-execution placeholder",
+        confidence=0.5,
+        confidence_basis=PROTOCOL_STATUS,
+        dissent_summary="pre-execution",
+        dissenting_views=[],
+        validation_summary={},
+        top_findings=[],
+        cost_estimate={},
+    )
+
+
+def _input(panel_id: str = "p") -> PDBExecutionInput:
+    return PDBExecutionInput(
+        binding=_binding(),
+        packet=_heuristic_packet(),
+        packet_sha="",
+        pr_title="Refactor rate limiter",
+        pr_body="Adds token bucket.",
+        labels=("backend",),
+        changed_files=("aragora/server/rate_limit.py",),
+        diff_excerpt="diff --git a/a b/a\n+pass\n",
+        validation_summary={"checks_summary": "green"},
+        panel_id=panel_id,
+        policy=ReviewPolicy(budget=ReviewBudget(per_pr_usd_cap=0.0)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class StubResolver(ProviderSlotResolver):
+    """A resolver that returns canned resolutions keyed by slot_id."""
+
+    def __init__(self, resolved: set[str], all_slots: Sequence[PDBPanelSlot]) -> None:
+        # Do not call super().__init__() — we don't need the real agent
+        # registry side effects for these tests.
+        self._resolved = set(resolved)
+        self._slots = {s.slot_id: s for s in all_slots}
+
+    def resolve_slot(self, slot: ProviderSlotDefinition) -> ProviderSlotResolution:
+        meta = self._slots[slot.slot_id]
+        if slot.slot_id in self._resolved:
+            return ProviderSlotResolution(
+                slot_id=slot.slot_id,
+                review_role=slot.review_role,
+                lens=slot.lens,
+                family=slot.family,
+                selected_provider=slot.candidates[0],
+                status="available",
+                detail="stubbed",
+                candidates=list(slot.candidates),
+            )
+        return ProviderSlotResolution(
+            slot_id=slot.slot_id,
+            review_role=slot.review_role,
+            lens=slot.lens,
+            family=slot.family,
+            selected_provider=None,
+            status="unavailable",
+            detail="stub: slot not resolved",
+            candidates=list(slot.candidates),
+        )
+
+    def resolve_slots(
+        self,
+        slot_definitions,
+    ) -> list[ProviderSlotResolution]:
+        return [self.resolve_slot(s) for s in slot_definitions]
+
+
+@dataclass
+class MockInvoker:
+    """Deterministic invoker that records every call it receives."""
+
+    slot_plan: Mapping[str, DissentPosition]
+    synthesis_position: DissentPosition = DissentPosition.APPROVE
+    per_slot_cost_usd: float = 0.4
+    synthesis_cost_usd: float = 0.6
+    fail_findings: set[str] = field(default_factory=set)
+    fail_critique: set[str] = field(default_factory=set)
+    fail_synthesis: bool = False
+    findings_calls: list[str] = field(default_factory=list)
+    critique_calls: list[str] = field(default_factory=list)
+    synth_calls: list[str] = field(default_factory=list)
+
+    def findings(
+        self,
+        *,
+        slot: PDBPanelSlot,
+        provider: str,
+        prompt: str,
+        binding: PRReviewBinding,
+    ) -> SlotFindingsResponse:
+        self.findings_calls.append(slot.slot_id)
+        if slot.slot_id in self.fail_findings:
+            raise RuntimeError(f"findings failure for {slot.slot_id}")
+        position = self.slot_plan.get(slot.slot_id, DissentPosition.APPROVE)
+        return SlotFindingsResponse(
+            slot_id=slot.slot_id,
+            provider=provider,
+            model=f"{provider}-model",
+            position=position,
+            confidence=0.75,
+            summary=f"{slot.slot_id} findings summary",
+            top_findings=(
+                PRReviewFinding(
+                    finding_id=f"{slot.slot_id}-F1",
+                    category="logic",
+                    severity="medium",
+                    summary=f"{slot.slot_id} noted a risk",
+                    evidence=["aragora/server/rate_limit.py:12"],
+                    source=f"slot:{slot.slot_id}",
+                ),
+            ),
+            contested_finding_ids=(f"{slot.slot_id}-F1",),
+            reason=f"{slot.slot_id} reasoned {position.value}",
+            latency_ms=100,
+            cost_usd=self.per_slot_cost_usd / 2,  # split across findings+critique
+        )
+
+    def critique(
+        self,
+        *,
+        slot: PDBPanelSlot,
+        provider: str,
+        prompt: str,
+        peer_findings: Mapping[str, SlotFindingsResponse],
+        binding: PRReviewBinding,
+    ) -> SlotCritiqueResponse:
+        self.critique_calls.append(slot.slot_id)
+        if slot.slot_id in self.fail_critique:
+            raise RuntimeError(f"critique failure for {slot.slot_id}")
+        position = self.slot_plan.get(slot.slot_id, DissentPosition.APPROVE)
+        return SlotCritiqueResponse(
+            slot_id=slot.slot_id,
+            provider=provider,
+            position=position,
+            confidence=0.7,
+            reason=f"{slot.slot_id} stood by {position.value} after critique",
+            contested_finding_ids=(f"{slot.slot_id}-F1",),
+            latency_ms=120,
+            cost_usd=self.per_slot_cost_usd / 2,
+        )
+
+    def synthesize(
+        self,
+        *,
+        synthesizer_slot: PDBPanelSlot,
+        provider: str,
+        prompt: str,
+        votes: Sequence[PanelVote],
+        binding: PRReviewBinding,
+    ) -> SynthesisResponse:
+        self.synth_calls.append(synthesizer_slot.slot_id)
+        if self.fail_synthesis:
+            raise RuntimeError("synthesis failure")
+        return SynthesisResponse(
+            slot_id=synthesizer_slot.slot_id,
+            provider=provider,
+            model=f"{provider}-synth",
+            top_line="Panel verdict: advisory-only synthesis summary.",
+            validation_summary="CI green; two dissents recorded.",
+            position=self.synthesis_position,
+            confidence=0.82,
+            preserved_dissent=tuple(
+                {
+                    "slot_id": v.finding.agent.split(":", 1)[0],
+                    "lens": "unknown",
+                    "position": v.position.value,
+                    "reason": v.reason,
+                }
+                for v in votes
+                if v.position is not self.synthesis_position
+            ),
+            latency_ms=150,
+            cost_usd=self.synthesis_cost_usd,
+        )
+
+
+def _fixed_clock(value: str = "2026-04-21T00:00:00+00:00"):
+    def clock() -> str:
+        return value
+
+    return clock
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_produces_real_brief_and_executes_full_roster() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gemini_h", family="gemini", review_role="maintainability_reviewer", lens="heterodox"
+        ),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    resolver = StubResolver({"claude_core", "gpt_core", "gemini_h"}, slots)
+    invoker = MockInvoker(
+        slot_plan={
+            "claude_core": DissentPosition.APPROVE,
+            "gpt_core": DissentPosition.APPROVE,
+            "gemini_h": DissentPosition.APPROVE,
+        },
+        synthesis_position=DissentPosition.APPROVE,
+    )
+    ledger = PDBBudgetLedger(daily_cap_usd=config.budget.per_day_usd)
+
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        ledger=ledger,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+
+    assert result.status is PDBExecutionStatus.SUCCESS
+    assert isinstance(result.brief, ReviewBrief)
+    assert result.brief.recommendation is Recommendation.APPROVE_CANDIDATE
+    assert result.brief.advisory_only is True
+    # Every active slot completed both phases
+    assert set(result.active_roster) == {"claude_core", "gpt_core", "gemini_h"}
+    assert result.missing_slots == ()
+    # Packet-level status reflects real execution, not metadata_heuristic
+    assert result.packet.status == STATUS_PANEL_EXECUTED
+    # The landed builder produced the brief — evidenced by a non-empty
+    # packet_sha and a SHA that matches a re-computation.
+    from aragora.review.builder import compute_packet_sha
+
+    assert result.brief.packet_sha
+    assert compute_packet_sha(result.brief) == result.brief.packet_sha
+    # Ledger returns unused reserve (actual < reserve) — residual recorded.
+    assert ledger.spent_today_usd == pytest.approx(result.actual_cost_usd)
+
+
+def test_happy_path_role_findings_contain_synthesizer_vote() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gemini_h", family="gemini", review_role="maintainability_reviewer", lens="heterodox"
+        ),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    resolver = StubResolver({"claude_core", "gpt_core", "gemini_h"}, slots)
+    invoker = MockInvoker(
+        slot_plan={s.slot_id: DissentPosition.APPROVE for s in slots},
+    )
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+    assert result.brief is not None
+    roles_present = {finding.role for finding in result.brief.role_findings}
+    # Both the lens-role of the synthesizer (LOGIC) and the SYNTHESIZER role
+    # survive — the builder accepts SYNTHESIZER as an extra role.
+    assert ReviewRole.LOGIC in roles_present
+    assert ReviewRole.SYNTHESIZER in roles_present
+    assert ReviewRole.SECURITY in roles_present
+    assert ReviewRole.MAINTAINABILITY in roles_present
+
+
+# ---------------------------------------------------------------------------
+# Dissent preservation at all three layers
+# ---------------------------------------------------------------------------
+
+
+def test_dissent_survives_reviewer_packet_and_brief_layers() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot("grok_h", family="grok", review_role="skeptic", lens="heterodox"),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    resolver = StubResolver({"claude_core", "gpt_core", "grok_h"}, slots)
+    invoker = MockInvoker(
+        slot_plan={
+            "claude_core": DissentPosition.APPROVE,  # majority
+            "gpt_core": DissentPosition.APPROVE,
+            "grok_h": DissentPosition.REQUEST_CHANGES,  # dissenter
+        },
+        synthesis_position=DissentPosition.APPROVE,
+    )
+
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+
+    # LAYER 1 — reviewer outputs retain per-slot identity + lens + position
+    assert result.critiques_by_slot["grok_h"].position is DissentPosition.REQUEST_CHANGES
+    assert result.findings_by_slot["grok_h"].contested_finding_ids
+    # LAYER 2 — packet.dissenting_views has a machine-readable array with
+    # slot_id / lens / recommendation / reason / contested_finding_ids
+    packet_dissent = result.packet.dissenting_views
+    assert len(packet_dissent) == 1
+    entry = packet_dissent[0]
+    assert entry["slot_id"] == "grok_h"
+    assert entry["lens"] == "heterodox"
+    assert entry["recommendation"] == "request_changes"
+    assert entry["reason"]
+    assert "grok_h-F1" in entry["contested_finding_ids"]
+    # dissent_summary is scan-oriented only (not the lossless store)
+    assert result.packet.dissent_summary.lower().startswith("1 slot(s) dissent")
+    # LAYER 3 — ReviewBrief.dissent preserves per-dissenter identity
+    assert result.brief is not None
+    brief_dissent = result.brief.dissent
+    assert any(d.position is DissentPosition.REQUEST_CHANGES for d in brief_dissent)
+    agents = {d.agent for d in brief_dissent}
+    # "grok_h:…" agent identifier survives
+    assert any(a.startswith("grok_h:") for a in agents)
+
+
+# ---------------------------------------------------------------------------
+# Degrade path — optional slot unavailable at resolution time
+# ---------------------------------------------------------------------------
+
+
+def test_optional_slot_missing_triggers_degrade() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gemini_h", family="gemini", review_role="maintainability_reviewer", lens="heterodox"
+        ),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    # Only core slots resolve; gemini_h is unavailable.
+    resolver = StubResolver({"claude_core", "gpt_core"}, slots)
+    invoker = MockInvoker(
+        slot_plan={s.slot_id: DissentPosition.APPROVE for s in slots},
+    )
+
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+
+    # Heterogeneity floor still met (claude + gpt = 2 families), so we
+    # execute — but wait, the spec requires at least one non-core lens in
+    # the panel config (enforced at validation). At runtime, the executor
+    # simply does not run unavailable slots; they aren't findings-funded
+    # because the resolver returned no provider. We still execute core
+    # slots so the packet reflects real heterogeneous execution.
+    assert result.status is PDBExecutionStatus.SUCCESS
+    assert "gemini_h" not in result.active_roster
+    # The brief was still produced.
+    assert isinstance(result.brief, ReviewBrief)
+
+
+def test_optional_critique_failure_after_findings_degrades() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot("grok_h", family="grok", review_role="skeptic", lens="heterodox"),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    resolver = StubResolver({"claude_core", "gpt_core", "grok_h"}, slots)
+    invoker = MockInvoker(
+        slot_plan={s.slot_id: DissentPosition.APPROVE for s in slots},
+        fail_critique={"grok_h"},
+    )
+
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+
+    assert result.status is PDBExecutionStatus.DEGRADED
+    assert "grok_h" in result.missing_slots
+    assert any("grok_h" in r for r in result.degrade_reasons)
+    # The brief is still produced with the reduced roster
+    assert isinstance(result.brief, ReviewBrief)
+    assert result.packet.status == STATUS_PANEL_DEGRADED
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed paths
+# ---------------------------------------------------------------------------
+
+
+def test_required_slot_missing_fails_closed() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot("grok_h", family="grok", review_role="skeptic", lens="heterodox"),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    # gpt_core (required) is unresolved.
+    resolver = StubResolver({"claude_core", "grok_h"}, slots)
+    invoker = MockInvoker(slot_plan={})
+
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+    assert result.status is PDBExecutionStatus.FAILED_CLOSED
+    assert result.brief is None
+    assert result.packet.status == STATUS_FAILED_CLOSED
+    assert result.failure_reason is not None
+    assert "gpt_core" in result.failure_reason
+
+
+def test_synthesizer_slot_missing_fails_closed() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gemini_h", family="gemini", review_role="maintainability_reviewer", lens="heterodox"
+        ),
+    ]
+    config = _mini_config(slots, synthesizer="gemini_h")
+    # gemini_h is unresolved; it's also the synthesizer.
+    resolver = StubResolver({"claude_core", "gpt_core"}, slots)
+    invoker = MockInvoker(slot_plan={})
+
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+    assert result.status is PDBExecutionStatus.FAILED_CLOSED
+    assert result.packet.status == STATUS_FAILED_CLOSED
+    assert result.failure_reason is not None
+    assert "synthesizer" in result.failure_reason
+
+
+def test_synthesis_pass_failure_fails_closed() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot("grok_h", family="grok", review_role="skeptic", lens="heterodox"),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    resolver = StubResolver({"claude_core", "gpt_core", "grok_h"}, slots)
+    invoker = MockInvoker(
+        slot_plan={s.slot_id: DissentPosition.APPROVE for s in slots},
+        fail_synthesis=True,
+    )
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+    assert result.status is PDBExecutionStatus.FAILED_CLOSED
+    assert result.packet.status == STATUS_FAILED_CLOSED
+    assert result.failure_reason is not None
+    assert "synthesis" in result.failure_reason.lower()
+
+
+def test_required_slot_findings_failure_fails_closed() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot("grok_h", family="grok", review_role="skeptic", lens="heterodox"),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    resolver = StubResolver({"claude_core", "gpt_core", "grok_h"}, slots)
+    invoker = MockInvoker(
+        slot_plan={s.slot_id: DissentPosition.APPROVE for s in slots},
+        fail_findings={"gpt_core"},
+    )
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+    assert result.status is PDBExecutionStatus.FAILED_CLOSED
+    assert result.packet.status == STATUS_FAILED_CLOSED
+
+
+# ---------------------------------------------------------------------------
+# Budget denial
+# ---------------------------------------------------------------------------
+
+
+def test_budget_exceeded_returns_explicit_denial_no_brief() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot("grok_h", family="grok", review_role="skeptic", lens="heterodox"),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    # Tighten per-brief cap to something the minimum roster cannot fit.
+    tight = PDBPanelConfig(
+        version=config.version,
+        default_panel=config.default_panel,
+        default_prompt_set=config.default_prompt_set,
+        budget=PDBBudgetConfig(
+            per_brief_usd=0.5, per_day_usd=200.0, reserve_for_manual_escalation_usd=0.0
+        ),
+        slots=config.slots,
+        panels=config.panels,
+        prompt_sets=config.prompt_sets,
+    )
+    resolver = StubResolver({"claude_core", "gpt_core", "grok_h"}, slots)
+    invoker = MockInvoker(
+        slot_plan={s.slot_id: DissentPosition.APPROVE for s in slots},
+    )
+
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=tight,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+    assert result.status is PDBExecutionStatus.BUDGET_EXCEEDED
+    assert result.brief is None
+    assert result.packet.status == STATUS_BUDGET_EXCEEDED
+    assert result.budget_decision.status is PDBBudgetStatus.BUDGET_EXCEEDED
+    # Explicit denial, not a silent downgrade to metadata_heuristic
+    assert result.packet.status != PROTOCOL_STATUS
+    assert invoker.findings_calls == []
+    assert invoker.critique_calls == []
+    assert invoker.synth_calls == []
+
+
+def test_budget_degraded_still_runs_and_drops_optional_slots() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot("grok_h", family="grok", review_role="skeptic", lens="heterodox"),
+        _slot(
+            "gemini_h", family="gemini", review_role="maintainability_reviewer", lens="heterodox"
+        ),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    # Cap tight enough that two core + synth fit but we cannot afford
+    # all four optional+core slots. Default per-slot cost is $0.85 and
+    # default synthesis cost is $1.10, so the floor (2 core + synth) is
+    # $2.80 and a full roster (4 slots + synth) is $4.50. A cap of $3.50
+    # admits the floor but forces one optional slot to drop.
+    budget = PDBBudgetConfig(
+        per_brief_usd=3.5, per_day_usd=200.0, reserve_for_manual_escalation_usd=0.0
+    )
+    tight = PDBPanelConfig(
+        version=config.version,
+        default_panel=config.default_panel,
+        default_prompt_set=config.default_prompt_set,
+        budget=budget,
+        slots=config.slots,
+        panels=config.panels,
+        prompt_sets=config.prompt_sets,
+    )
+    resolver = StubResolver(
+        {"claude_core", "gpt_core", "grok_h", "gemini_h"},
+        slots,
+    )
+    invoker = MockInvoker(
+        slot_plan={s.slot_id: DissentPosition.APPROVE for s in slots},
+    )
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=tight,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+    # Degraded status carries forward and a brief is still produced.
+    assert result.status is PDBExecutionStatus.DEGRADED
+    assert result.brief is not None
+    assert result.packet.status == STATUS_PANEL_DEGRADED
+    # Required slots survived, optional slots dropped to fit budget.
+    assert "claude_core" in result.active_roster
+    assert "gpt_core" in result.active_roster
+    assert len(result.missing_slots) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Heterogeneity floor
+# ---------------------------------------------------------------------------
+
+
+def test_heterogeneity_floor_below_two_families_fails_closed() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "claude_core_b",
+            family="claude",
+            review_role="security_reviewer",
+            lens="core",
+            required=True,
+        ),
+        _slot(
+            "gemini_h", family="gemini", review_role="maintainability_reviewer", lens="heterodox"
+        ),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    # Only claude-family slots resolve; heterogeneity floor collapses.
+    resolver = StubResolver({"claude_core", "claude_core_b"}, slots)
+    invoker = MockInvoker(
+        slot_plan={s.slot_id: DissentPosition.APPROVE for s in slots},
+    )
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+    assert result.status is PDBExecutionStatus.FAILED_CLOSED
+    assert result.failure_reason is not None
+    assert "two model families" in result.failure_reason
+
+
+# ---------------------------------------------------------------------------
+# Unknown panel guard
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_panel_id_raises() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot("grok_h", family="grok", review_role="skeptic", lens="heterodox"),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    resolver = StubResolver({"claude_core", "gpt_core", "grok_h"}, slots)
+    invoker = MockInvoker(slot_plan={})
+    with pytest.raises(ValueError):
+        run_protocol_b(
+            _input(panel_id="missing_panel"),
+            invoker=invoker,
+            config=config,
+            resolver=resolver,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Result shape / JSON-friendliness
+# ---------------------------------------------------------------------------
+
+
+def test_result_to_dict_is_json_serializable() -> None:
+    slots = [
+        _slot(
+            "claude_core", family="claude", review_role="logic_reviewer", lens="core", required=True
+        ),
+        _slot(
+            "gpt_core", family="gpt", review_role="security_reviewer", lens="core", required=True
+        ),
+        _slot("grok_h", family="grok", review_role="skeptic", lens="heterodox"),
+    ]
+    config = _mini_config(slots, synthesizer="claude_core")
+    resolver = StubResolver({"claude_core", "gpt_core", "grok_h"}, slots)
+    invoker = MockInvoker(
+        slot_plan={s.slot_id: DissentPosition.APPROVE for s in slots},
+    )
+    result = run_protocol_b(
+        _input(),
+        invoker=invoker,
+        config=config,
+        resolver=resolver,
+        clock=_fixed_clock(),
+    )
+    import json
+
+    payload = json.loads(json.dumps(result.to_dict()))
+    assert payload["status"] == "success"
+    assert payload["brief"] is not None


### PR DESCRIPTION
## Summary

Implements PR 2 of the Mode 3 on-demand PDB brief generation pipeline per
the authoritative spec [`docs/plans/2026-04-21-pdb-mode3-pr2-spec.md`](../blob/main/docs/plans/2026-04-21-pdb-mode3-pr2-spec.md).
This is the engine that turns a normalized input into a real settlement-ready
`ReviewBrief` via a bounded Protocol B panel + budget-aware execution.

**PR 2 is engine-only** — no HTTP, no worker queues, no storage state
transitions, no UI, no real provider I/O. PR 3 wires transport +
artifact writing; PR 4 adds UI.

## Files added (9)

**Engine (5):**
- `aragora/config/pdb_panel.yaml` — default panel roster + budget caps
- `aragora/pdb/panel_config.py` — typed YAML load + validation (exact `field_path` errors)
- `aragora/pdb/budget.py` — `PDBBudgetStatus` {`allowed`, `budget_degraded`, `budget_exceeded`}, reservation + release, per-brief/per-day caps
- `aragora/pdb/prompts.py` — findings/critique/synthesis templates that bind `repo`/`pr_number`/`base_sha`/`head_sha` and preserve `core`/`heterodox`/`regulatory` lens identity
- `aragora/pdb/protocol.py` — transport-neutral `PDBExecutionInput` + `PDBExecutionResult`, `ProviderInvoker` Protocol, `run_protocol_b()` executor

**Tests (4):**
- `tests/pdb/test_panel_config.py` — 38 tests covering every validation rule
- `tests/pdb/test_budget.py` — 19 tests covering `allowed`/`budget_degraded`/`budget_exceeded` paths, reservation lifecycle, per-day vs per-brief bounds
- `tests/pdb/test_prompts.py` — 11 tests asserting binding anchors + lens identity + structured-JSON contract
- `tests/pdb/test_protocol.py` — 14 tests covering happy path, optional slot missing (degrade), required slot missing (fail closed), synthesizer missing (fail closed), budget exceeded (explicit denial), budget degraded, heterogeneity floor, and dissent survival at all three layers

## Key contract guarantees

- **Synthesis delegates to `aragora.review.builder.build_brief`** — no reimplementation.
  From `protocol.py::run_protocol_b`:
  ```python
  brief = build_brief(
      votes=votes_for_brief,
      pr_number=input.binding.pr_number,
      ...
      synthesis_policy=SynthesisPolicy.SYNTHESIZER_AGENT,
      ...
  )
  ```
- **No silent `metadata_heuristic` downgrade** — on `BUDGET_EXCEEDED` the executor returns an explicit denial with `packet.status="budget_exceeded"` and `brief=None`.
- **Dissent survives at three layers**:
  1. per-slot `SlotFindingsResponse` + `SlotCritiqueResponse` carry identity, lens, position, contested finding ids
  2. `PRReviewProtocolPacket.dissenting_views` is a machine-readable array `{slot_id, lens, recommendation, reason, contested_finding_ids}`
  3. `ReviewBrief.dissent` carries per-dissenter `DissentingView` built by the landed builder
- **Degrade vs fail-closed** matches spec §Degrade vs fail-closed exactly:
  - degrade on optional slot unavailable / priced out / critique timeout after findings
  - fail closed on required or synthesizer slot unavailable, minimum roster can't fund, or heterogeneity floor (< 2 families) collapses

## Non-goals (deliberate, per spec §Out of scope)

- HTTP endpoints (`POST/GET/DELETE /brief/generate`) — PR 3
- `BriefGenerationWorker` — PR 3
- `aragora/pdb/input_loader.py` — PR 3
- `ARAGORA_PDB_BRIEF_GENERATION_ENABLED` feature flag — PR 3
- UI (`BriefPanel`, `ReviewQueueCard`, `useReviewQueue`) — PR 4
- Protocol C / dual-synthesis — out of Mode 3 entirely
- Real provider I/O — PR 3 territory (this PR tests with mocked provider only)
- Modifying `aragora/pdb/storage.py` or `brief_state.py` — PR 1 territory

## Test counts

- **82 new tests** (38 panel_config + 19 budget + 11 prompts + 14 protocol)
- Full `tests/pdb/` suite: **164 passing** (includes PR 1's existing 82 tests for storage + brief_state, untouched)
- Mocked-provider strategy: tests use a deterministic `MockInvoker` + `StubResolver` so every execution path is reproducible without CLI binaries or API keys.

## Validation

```
pytest tests/pdb/ -q             # 164 passed
ruff check aragora/pdb/ tests/pdb/ aragora/config/      # clean
ruff format --check aragora/pdb/ tests/pdb/             # clean
python3 -m mypy aragora/pdb/ --config-file=pyproject.toml  # 7 files, no issues
bash scripts/automation_pr_preflight.sh origin/main HEAD   # ok
```

## Next up

PR 3 will add the HTTP endpoints, the `BriefGenerationWorker`, the
`PDBExecutionInput` loader (which converts GitHub PR fetches into the
transport-neutral payload this PR consumes), and the feature flag. The
contracts here are stable — PR 3 should wire transport without
changing any of these interfaces.

Spec: `docs/plans/2026-04-21-pdb-mode3-pr2-spec.md`
Design: `docs/plans/2026-04-20-pdb-brief-generation-mode3-design.md`

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
