### PR TITLE
feat(pdb): PR 3 — brief generation endpoints + in-process worker

### DIFF
--- a/aragora/pdb/input_loader.py
+++ b/aragora/pdb/input_loader.py
@@ -1,0 +1,487 @@
+"""Transport-neutral :class:`PDBExecutionInput` builder for PR 3.
+
+Given ``(repo, pr_number)``, this module shells out to ``gh`` to
+materialize everything the Protocol B executor needs:
+
+- the current head SHA
+- the PR title, body, labels, changed-file list
+- a bounded diff excerpt
+- a heuristic :class:`PRReviewProtocolPacket` built from the PR metadata
+
+The output is a :class:`aragora.pdb.protocol.PDBExecutionInput` plus the
+current head SHA (so the HTTP caller can key storage lookups on it).
+
+Design constraints
+------------------
+
+- **No HTTP concerns.** This is a plain I/O module. The HTTP handler
+  translates :class:`InputLoaderError` into the appropriate status
+  code, not the loader.
+- **No asyncio.** The worker wraps calls into this module through
+  ``run_in_executor`` — keeping the loader synchronous means the tests
+  can call it directly without an event loop.
+- **Fails fast on missing input.** A missing PR (``gh`` returns
+  non-zero) or a missing ``gh`` binary raises
+  :class:`InputLoaderError` with ``reason=<enum>`` so callers can
+  distinguish infrastructure faults from user-input faults.
+- **No cached SHA reads.** The head SHA is always refreshed from the
+  PR metadata; stale detection in storage depends on truthful SHAs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from aragora.pdb.protocol import PDBExecutionInput
+from aragora.review.policy import ReviewPolicy
+from aragora.swarm.pr_review_protocol import (
+    PRReviewBinding,
+    PRReviewProtocolPacket,
+    default_pr_review_protocol,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_DIFF_EXCERPT_CHARS",
+    "GH_TIMEOUT_SECONDS",
+    "InputLoaderError",
+    "InputLoaderErrorReason",
+    "LoadedExecutionInput",
+    "load_execution_input",
+]
+
+
+DEFAULT_DIFF_EXCERPT_CHARS = 80_000
+"""Soft cap on how many characters of the diff feed into the executor.
+
+8K × 10 reviewers is a reasonable context budget. Truncation happens
+at a line boundary so the ``diff --git`` header of the last included
+hunk is not cut mid-line.
+"""
+
+GH_TIMEOUT_SECONDS = 30
+"""Per-``gh`` invocation timeout. Matches the existing review-queue handler."""
+
+
+_PR_VIEW_FIELDS = [
+    "number",
+    "title",
+    "body",
+    "url",
+    "headRefOid",
+    "baseRefOid",
+    "isDraft",
+    "mergeable",
+    "reviewDecision",
+    "labels",
+    "author",
+    "additions",
+    "deletions",
+    "changedFiles",
+    "statusCheckRollup",
+    "files",
+]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class InputLoaderErrorReason(str, Enum):
+    """Why the loader failed. Stable across versions; HTTP maps to codes."""
+
+    GH_MISSING = "gh_missing"
+    GH_AUTHENTICATION = "gh_authentication"
+    PR_NOT_FOUND = "pr_not_found"
+    GH_ERROR = "gh_error"
+    MALFORMED_RESPONSE = "malformed_response"
+    EMPTY_HEAD_SHA = "empty_head_sha"
+    TIMEOUT = "timeout"
+
+
+class InputLoaderError(RuntimeError):
+    """Raised when :func:`load_execution_input` cannot build its payload."""
+
+    def __init__(self, reason: InputLoaderErrorReason, detail: str = "") -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason.value}: {detail}" if detail else reason.value)
+
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedExecutionInput:
+    """Return value from :func:`load_execution_input`.
+
+    ``head_sha`` is the PR's current head SHA and MUST be used as the
+    storage key by the caller (worker + state endpoints). It can differ
+    from ``input.binding.head_sha`` only if the loader is called with a
+    stale cache — in practice they are identical, but the dataclass
+    makes the invariant explicit.
+    """
+
+    input: PDBExecutionInput
+    head_sha: str
+    base_sha: str
+    panel_models: tuple[str, ...]
+    repo: str
+
+
+# ---------------------------------------------------------------------------
+# gh shell helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_gh(args: Sequence[str], *, capture: bool = True) -> tuple[int, str, str]:
+    """Run a ``gh`` command, returning ``(rc, stdout, stderr)``.
+
+    Raises :class:`InputLoaderError` for infrastructure faults
+    (missing binary, timeout). Returning a non-zero rc without raising
+    lets the caller inspect stderr and classify the error.
+    """
+
+    try:
+        proc = subprocess.run(  # noqa: S603 — args are code-controlled lists
+            ["gh", *args],
+            capture_output=capture,
+            text=True,
+            check=False,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError as exc:
+        raise InputLoaderError(
+            InputLoaderErrorReason.GH_MISSING,
+            "gh CLI not found on PATH",
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise InputLoaderError(
+            InputLoaderErrorReason.TIMEOUT,
+            f"gh {' '.join(args)} exceeded {GH_TIMEOUT_SECONDS}s",
+        ) from exc
+    return proc.returncode, proc.stdout or "", proc.stderr or ""
+
+
+def _classify_gh_error(stderr: str, *, pr_number: int) -> InputLoaderErrorReason:
+    lower = stderr.lower()
+    if "not found" in lower or "no pull request found" in lower or "could not find" in lower:
+        return InputLoaderErrorReason.PR_NOT_FOUND
+    if "authentication" in lower or "not logged" in lower or "auth token" in lower:
+        return InputLoaderErrorReason.GH_AUTHENTICATION
+    return InputLoaderErrorReason.GH_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+
+def _subsystem_for(path: str) -> str:
+    parts = [p for p in path.split("/") if p]
+    if not parts:
+        return "(root)"
+    top = parts[0]
+    if top in ("aragora", "tests") and len(parts) >= 2:
+        return f"{top}/{parts[1]}"
+    return top
+
+
+def _labels(payload: Any) -> tuple[str, ...]:
+    result: list[str] = []
+    if isinstance(payload, list):
+        for entry in payload:
+            if isinstance(entry, dict):
+                name = str(entry.get("name", "")).strip()
+                if name:
+                    result.append(name)
+    return tuple(result)
+
+
+def _changed_files(payload: Any) -> tuple[str, ...]:
+    result: list[str] = []
+    if isinstance(payload, list):
+        for entry in payload:
+            if isinstance(entry, dict):
+                path = str(entry.get("path", "")).strip()
+                if path:
+                    result.append(path)
+    return tuple(result)
+
+
+def _repo_from_url(url: str) -> str:
+    """Parse ``github.com/<owner>/<repo>`` → ``<owner>/<repo>``.
+
+    Falls back to empty string when the URL is malformed; the caller's
+    validation of required inputs catches that case.
+    """
+    url = (url or "").strip()
+    if not url:
+        return ""
+    for prefix in ("https://github.com/", "http://github.com/", "github.com/"):
+        if url.startswith(prefix):
+            rest = url[len(prefix) :]
+            parts = rest.split("/")
+            if len(parts) >= 2:
+                return f"{parts[0]}/{parts[1]}"
+    return ""
+
+
+def _summarize_checks(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, list):
+        return {"success": 0, "failure": 0, "pending": 0, "total": 0}
+    success = failure = pending = 0
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        status = str(entry.get("status", "")).upper()
+        conclusion = str(entry.get("conclusion", "")).upper()
+        if conclusion == "SUCCESS":
+            success += 1
+        elif conclusion in ("FAILURE", "TIMED_OUT", "ACTION_REQUIRED"):
+            failure += 1
+        elif conclusion in ("CANCELLED", "SKIPPED", "NEUTRAL", "STALE"):
+            continue
+        elif status in ("IN_PROGRESS", "QUEUED", "PENDING") or not conclusion:
+            pending += 1
+    return {
+        "success": success,
+        "failure": failure,
+        "pending": pending,
+        "total": success + failure + pending,
+    }
+
+
+def _truncate_diff(text: str, limit: int = DEFAULT_DIFF_EXCERPT_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    # Truncate at the last full line before the byte cap so ``diff --git``
+    # headers remain intact.
+    head = text[:limit]
+    last_nl = head.rfind("\n")
+    if last_nl >= 0:
+        head = head[:last_nl]
+    return head + "\n[diff truncated]\n"
+
+
+def _heuristic_packet_from_pr(
+    *,
+    binding: PRReviewBinding,
+    pr: Mapping[str, Any],
+    labels: Sequence[str],
+    changed_files_count: int,
+    additions: int,
+    deletions: int,
+    high_risk_paths: Sequence[str],
+) -> PRReviewProtocolPacket:
+    """Build the metadata-heuristic packet using the landed protocol builder.
+
+    We delegate to :func:`default_pr_review_protocol().build_packet` to
+    keep the packet field layout in lock-step with the rest of the
+    review surface. The executor will overwrite this with its
+    ``panel_executed`` packet — we just need a shape-valid placeholder.
+    """
+    checks_summary_dict = _summarize_checks(pr.get("statusCheckRollup"))
+    has_failures = checks_summary_dict["failure"] > 0
+    has_pending = checks_summary_dict["pending"] > 0
+    checks_summary = (
+        f"{checks_summary_dict['success']}/{checks_summary_dict['total']} checks passing"
+        if checks_summary_dict["total"]
+        else "no checks reported"
+    )
+    review_decision = str(pr.get("reviewDecision", "")).strip().upper()
+    mergeable = str(pr.get("mergeable", "")).strip().upper()
+    title = str(pr.get("title", "")).strip()
+
+    machine_recommendation = "approve_candidate" if not has_failures else "needs_human_attention"
+    machine_recommendation_reason = "metadata-heuristic placeholder; panel execution will refine."
+
+    return default_pr_review_protocol().build_packet(
+        repo=binding.repo,
+        pr_number=binding.pr_number,
+        title=title,
+        base_sha=binding.base_sha,
+        head_sha=binding.head_sha,
+        mergeable=mergeable,
+        review_decision=review_decision,
+        checks_summary=checks_summary,
+        has_failures=has_failures,
+        has_pending=has_pending,
+        additions=additions,
+        deletions=deletions,
+        changed_files=changed_files_count,
+        labels=list(labels),
+        high_risk_paths=list(high_risk_paths),
+        validation_commands=[],
+        machine_recommendation=machine_recommendation,
+        machine_recommendation_reason=machine_recommendation_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def load_execution_input(
+    *,
+    pr_number: int,
+    repo: str | None = None,
+    policy: ReviewPolicy | None = None,
+    panel_id: str = "protocol_b_default",
+    diff_excerpt_char_limit: int = DEFAULT_DIFF_EXCERPT_CHARS,
+) -> LoadedExecutionInput:
+    """Build a :class:`PDBExecutionInput` for ``pr_number``.
+
+    Parameters
+    ----------
+    pr_number:
+        GitHub PR number; must be positive.
+    repo:
+        Optional repo override (``owner/name``). When provided it is
+        passed to ``gh`` via ``--repo``. When omitted ``gh`` uses its
+        own repo inference.
+    policy:
+        The :class:`ReviewPolicy` to attach to the execution input.
+        Defaults to a vanilla :class:`ReviewPolicy`.
+    panel_id:
+        Panel id to run; defaults to ``protocol_b_default`` which is
+        the value shipped in ``aragora/config/pdb_panel.yaml``.
+    diff_excerpt_char_limit:
+        Overrides :data:`DEFAULT_DIFF_EXCERPT_CHARS`. Zero or negative
+        disables the diff fetch entirely.
+
+    Raises
+    ------
+    InputLoaderError:
+        With a machine-readable :class:`InputLoaderErrorReason` on any
+        upstream fault.
+    """
+    if not isinstance(pr_number, int) or pr_number <= 0:
+        raise ValueError("pr_number must be a positive integer")
+
+    view_args = ["pr", "view", str(pr_number), "--json", ",".join(_PR_VIEW_FIELDS)]
+    if repo:
+        view_args.extend(["--repo", repo])
+    rc, stdout, stderr = _run_gh(view_args)
+    if rc != 0:
+        reason = _classify_gh_error(stderr, pr_number=pr_number)
+        raise InputLoaderError(reason, stderr.strip() or f"gh rc={rc}")
+    try:
+        pr = json.loads(stdout) if stdout.strip() else None
+    except json.JSONDecodeError as exc:
+        raise InputLoaderError(
+            InputLoaderErrorReason.MALFORMED_RESPONSE,
+            f"gh pr view stdout is not valid JSON: {exc}",
+        ) from exc
+    if not isinstance(pr, dict):
+        raise InputLoaderError(
+            InputLoaderErrorReason.MALFORMED_RESPONSE,
+            f"gh pr view did not return an object (got {type(pr).__name__})",
+        )
+
+    head_sha = str(pr.get("headRefOid", "")).strip()
+    base_sha = str(pr.get("baseRefOid", "")).strip()
+    if not head_sha:
+        raise InputLoaderError(
+            InputLoaderErrorReason.EMPTY_HEAD_SHA,
+            "gh pr view response lacks headRefOid",
+        )
+
+    url = str(pr.get("url", "")).strip()
+    resolved_repo = repo or _repo_from_url(url)
+    if not resolved_repo:
+        raise InputLoaderError(
+            InputLoaderErrorReason.MALFORMED_RESPONSE,
+            "could not infer repo from gh response",
+        )
+    # Fail fast before spending a diff call on an invalid record.
+    labels = _labels(pr.get("labels"))
+    changed_files = _changed_files(pr.get("files"))
+    title = str(pr.get("title", "")).strip()
+    body_text = str(pr.get("body", "")).strip()
+    additions = int(pr.get("additions", 0) or 0)
+    deletions = int(pr.get("deletions", 0) or 0)
+    changed_files_count = int(pr.get("changedFiles", 0) or len(changed_files))
+
+    # Diff excerpt -----------------------------------------------------
+    diff_excerpt = ""
+    if diff_excerpt_char_limit > 0:
+        diff_args = ["pr", "diff", str(pr_number)]
+        if repo:
+            diff_args.extend(["--repo", repo])
+        rc_d, stdout_d, stderr_d = _run_gh(diff_args)
+        if rc_d != 0:
+            # A diff fetch failure is not fatal — the executor can still
+            # reason from metadata and the heuristic packet. Log loudly.
+            logger.warning(
+                "pdb.input_loader: gh pr diff %s failed (rc=%s): %s",
+                pr_number,
+                rc_d,
+                stderr_d.strip(),
+            )
+        else:
+            diff_excerpt = _truncate_diff(stdout_d, diff_excerpt_char_limit)
+
+    binding = PRReviewBinding(
+        repo=resolved_repo,
+        pr_number=pr_number,
+        base_sha=base_sha,
+        head_sha=head_sha,
+    )
+
+    validation_summary: dict[str, Any] = {
+        "checks_summary": _summarize_checks(pr.get("statusCheckRollup")),
+        "mergeable": str(pr.get("mergeable", "")).strip().upper(),
+        "review_decision": str(pr.get("reviewDecision", "")).strip().upper(),
+        "additions": additions,
+        "deletions": deletions,
+        "changed_files": changed_files_count,
+        "labels": list(labels),
+        "is_draft": bool(pr.get("isDraft", False)),
+    }
+
+    packet = _heuristic_packet_from_pr(
+        binding=binding,
+        pr=pr,
+        labels=labels,
+        changed_files_count=changed_files_count,
+        additions=additions,
+        deletions=deletions,
+        high_risk_paths=[],  # resolver does not need it; executor overrides
+    )
+
+    # Panel models list for the storage queued record — surfaces in
+    # ``state`` polls. Derived from candidate ids on the default
+    # protocol so we don't double-couple to the YAML.
+    panel_models = tuple(res.slot_id for res in packet.provider_slots)
+
+    exec_input = PDBExecutionInput(
+        binding=binding,
+        packet=packet,
+        packet_sha="",  # successor signing layer owns sha; empty is OK for executor
+        pr_title=title,
+        pr_body=body_text,
+        labels=labels,
+        changed_files=changed_files,
+        diff_excerpt=diff_excerpt,
+        validation_summary=validation_summary,
+        panel_id=panel_id,
+        policy=policy or ReviewPolicy(),
+    )
+    return LoadedExecutionInput(
+        input=exec_input,
+        head_sha=head_sha,
+        base_sha=base_sha,
+        panel_models=panel_models,
+        repo=resolved_repo,
+    )

--- a/aragora/pdb/worker.py
+++ b/aragora/pdb/worker.py
@@ -1,0 +1,562 @@
+"""In-process brief-generation worker.
+
+A :class:`BriefGenerationWorker` singleton owns the Protocol B pipeline
+invocations that the HTTP layer schedules on-demand. Key invariants:
+
+- **Bounded concurrency.** ``asyncio.Semaphore(max_concurrent)``
+  caps how many briefs can run at once.
+- **Dedupe.** For a given ``(repo, pr_number, head_sha)`` tuple, only
+  one task is accepted at a time. A concurrent ``POST`` for the same
+  tuple returns the existing task without enqueuing a second one.
+- **Cancel-safe.** :meth:`BriefGenerationWorker.cancel` triggers
+  ``Task.cancel()`` which interrupts awaitable boundaries. The
+  underlying ``run_protocol_b`` call runs in a thread executor; we
+  treat cancellation as best-effort while that call is in flight and
+  record ``failed`` with ``failed_phase="cancelled"``.
+- **Self-owned event loop.** The worker starts a dedicated background
+  thread with its own asyncio loop so the sync HTTP handler can hand
+  work off without blocking. Shutdown joins the thread.
+- **Storage is truth.** On every transition the worker updates the
+  :mod:`aragora.pdb.storage` lifecycle record. If the process dies
+  mid-run the disk state still reflects where things stopped.
+
+The worker is intentionally minimal — no retry, no scheduling. PR 4 /
+successor PRs layer retry and batch semantics on top.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from typing import Callable
+
+from aragora.pdb import storage
+from aragora.pdb.brief_state import BriefLifecycleState
+from aragora.pdb.protocol import (
+    PDBExecutionInput,
+    PDBExecutionResult,
+    PDBExecutionStatus,
+    ProviderInvoker,
+    run_protocol_b,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AlreadyRunningError",
+    "BriefGenerationWorker",
+    "JobKey",
+    "JobRequest",
+    "get_worker",
+    "reset_worker",
+    "set_worker",
+]
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class JobKey:
+    """Dedupe key for a single brief-generation job."""
+
+    repo: str
+    pr_number: int
+    head_sha: str
+
+
+@dataclass(frozen=True, slots=True)
+class JobRequest:
+    """Everything needed to run one Protocol B execution.
+
+    ``invoker_factory`` is a zero-arg callable that returns a
+    :class:`ProviderInvoker`. The factory pattern lets the worker run
+    on its own thread without sharing mutable state with the HTTP
+    layer.
+    """
+
+    key: JobKey
+    input: PDBExecutionInput
+    invoker_factory: Callable[[], ProviderInvoker]
+    panel_models: tuple[str, ...] = field(default_factory=tuple)
+
+
+class AlreadyRunningError(RuntimeError):
+    """Raised by :meth:`BriefGenerationWorker.submit` for duplicate keys.
+
+    Carries the current :class:`BriefLifecycleState` so the HTTP layer
+    can emit a 409 with useful context.
+    """
+
+    def __init__(self, key: JobKey, state: BriefLifecycleState) -> None:
+        self.key = key
+        self.state = state
+        super().__init__(
+            f"generation already active for repo={key.repo!r} pr={key.pr_number} "
+            f"head_sha={key.head_sha[:12]!r} (state={state.value})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Worker
+# ---------------------------------------------------------------------------
+
+
+class BriefGenerationWorker:
+    """Bounded-concurrency worker for on-demand Protocol B runs."""
+
+    def __init__(self, *, max_concurrent: int = 5) -> None:
+        if max_concurrent <= 0:
+            raise ValueError("max_concurrent must be positive")
+        self._max_concurrent = max_concurrent
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+        self._lock = threading.Lock()
+        # Dedupe map: JobKey → asyncio.Task (live on the worker loop)
+        self._tasks: dict[JobKey, asyncio.Task[PDBExecutionResult]] = {}
+        self._semaphore: asyncio.Semaphore | None = None
+        self._shutting_down = False
+
+    # -- lifecycle --------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the background event-loop thread if not already running."""
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._ready.clear()
+            self._shutting_down = False
+            self._thread = threading.Thread(
+                target=self._run_loop,
+                name="pdb-brief-worker",
+                daemon=True,
+            )
+            self._thread.start()
+        self._ready.wait(timeout=5)
+        if not self._ready.is_set():
+            raise RuntimeError("BriefGenerationWorker failed to start its loop")
+
+    def stop(self, *, timeout: float = 5.0) -> None:
+        """Stop the worker loop, cancelling in-flight tasks."""
+        with self._lock:
+            loop = self._loop
+            thread = self._thread
+            self._shutting_down = True
+        if loop is None or thread is None:
+            return
+
+        def _cancel_all() -> None:
+            for task in list(self._tasks.values()):
+                task.cancel()
+
+        try:
+            loop.call_soon_threadsafe(_cancel_all)
+            loop.call_soon_threadsafe(loop.stop)
+        except RuntimeError:
+            # Loop may have already stopped.
+            pass
+        thread.join(timeout=timeout)
+        with self._lock:
+            self._loop = None
+            self._thread = None
+            self._tasks.clear()
+            self._semaphore = None
+
+    # -- submission -------------------------------------------------------
+
+    def submit(self, request: JobRequest) -> "Future[PDBExecutionResult]":
+        """Accept a new job. Returns a :class:`concurrent.futures.Future`.
+
+        The future resolves when the generation task terminates (success
+        or failure). Callers generally don't block on it — the storage
+        layer is the authoritative source for state — but the future is
+        useful for tests.
+
+        Raises
+        ------
+        AlreadyRunningError:
+            If an in-flight task already owns the same
+            ``(repo, pr_number, head_sha)`` key.
+        """
+        self.start()
+        loop = self._loop
+        if loop is None:
+            raise RuntimeError("worker loop is not running")
+
+        def _schedule() -> asyncio.Task[PDBExecutionResult]:
+            if request.key in self._tasks:
+                current = storage.get_state(request.key.pr_number, request.key.head_sha)
+                raise AlreadyRunningError(request.key, current)
+            task = loop.create_task(self._run_job(request))
+            self._tasks[request.key] = task
+            task.add_done_callback(lambda _t: self._tasks.pop(request.key, None))
+            return task
+
+        # Dispatch scheduling onto the worker loop and wait for the
+        # coroutine-safe result.
+        sched_future: Future[asyncio.Task[PDBExecutionResult]] = Future()
+
+        def _runner() -> None:
+            try:
+                sched_future.set_result(_schedule())
+            except BaseException as exc:  # noqa: BLE001
+                sched_future.set_exception(exc)
+
+        loop.call_soon_threadsafe(_runner)
+        task = sched_future.result(timeout=5)
+        return asyncio.run_coroutine_threadsafe(
+            _await_task(task),
+            loop,
+        )
+
+    def cancel(self, key: JobKey) -> bool:
+        """Cancel the job for ``key`` if present.
+
+        Returns ``True`` if a task was cancelled, ``False`` otherwise.
+        The cancellation is best-effort — if the job is inside
+        ``run_protocol_b`` on the executor thread the actual work may
+        continue until it returns; the storage layer records the
+        cancel via :func:`_finalize_cancel`.
+        """
+        with self._lock:
+            loop = self._loop
+        if loop is None:
+            return False
+        cancel_done: Future[bool] = Future()
+
+        def _do_cancel() -> None:
+            task = self._tasks.get(key)
+            if task is None:
+                cancel_done.set_result(False)
+                return
+            task.cancel()
+            cancel_done.set_result(True)
+
+        loop.call_soon_threadsafe(_do_cancel)
+        try:
+            return cancel_done.result(timeout=2)
+        except TimeoutError:
+            return False
+
+    def is_active(self, key: JobKey) -> bool:
+        """Return ``True`` if a live task exists for ``key``."""
+        return key in self._tasks
+
+    def active_count(self) -> int:
+        return len(self._tasks)
+
+    # -- loop thread ------------------------------------------------------
+
+    def _run_loop(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        self._semaphore = asyncio.Semaphore(self._max_concurrent)
+        self._ready.set()
+        try:
+            loop.run_forever()
+        finally:
+            try:
+                pending = asyncio.all_tasks(loop)
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            finally:
+                loop.close()
+
+    # -- task body --------------------------------------------------------
+
+    async def _run_job(self, request: JobRequest) -> PDBExecutionResult:
+        sem = self._semaphore
+        if sem is None:
+            raise RuntimeError("semaphore must be created on loop startup")
+        key = request.key
+        # Track whether mark_running has run so cancel/exception paths
+        # know the on-disk state they need to transition from.
+        marked_running = False
+        try:
+            async with sem:
+                state = await asyncio.to_thread(storage.get_state, key.pr_number, key.head_sha)
+                if state != BriefLifecycleState.QUEUED:
+                    logger.warning(
+                        "pdb.worker: job %s launched without queued state (saw %s)",
+                        key,
+                        state.value,
+                    )
+                    # Only mark_failed when the source state permits the
+                    # queued|running → failed transition.
+                    if state in (
+                        BriefLifecycleState.QUEUED,
+                        BriefLifecycleState.RUNNING,
+                    ):
+                        await asyncio.to_thread(
+                            storage.mark_failed,
+                            key.pr_number,
+                            key.head_sha,
+                            f"worker found state={state.value}, expected queued",
+                            "pre_run",
+                            0.0,
+                        )
+                    return _empty_failed_result()
+
+                await asyncio.to_thread(
+                    storage.mark_running,
+                    key.pr_number,
+                    key.head_sha,
+                    "findings",
+                )
+                marked_running = True
+
+                invoker = request.invoker_factory()
+
+                # run_protocol_b is synchronous — hand it to the default
+                # thread executor so Task.cancel can at least unblock
+                # the coroutine even if the sync work keeps going.
+                result: PDBExecutionResult = await asyncio.to_thread(
+                    run_protocol_b,
+                    request.input,
+                    invoker=invoker,
+                )
+
+                await _finalize_result(request.key, result)
+                return result
+        except asyncio.CancelledError:
+            # Best-effort mark_failed — only valid from running/queued.
+            # Swallow any downstream storage errors so cancel always
+            # propagates to the submitter.
+            try:
+                if marked_running:
+                    current = await asyncio.to_thread(
+                        storage.get_state, key.pr_number, key.head_sha
+                    )
+                    if current == BriefLifecycleState.RUNNING:
+                        await asyncio.to_thread(
+                            storage.mark_failed,
+                            key.pr_number,
+                            key.head_sha,
+                            "generation cancelled",
+                            "cancelled",
+                            0.0,
+                        )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "pdb.worker: failed to record cancel for pr=%s sha=%s",
+                    key.pr_number,
+                    key.head_sha,
+                )
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "pdb.worker: run_protocol_b failed for pr=%s sha=%s",
+                key.pr_number,
+                key.head_sha,
+            )
+            try:
+                current = await asyncio.to_thread(storage.get_state, key.pr_number, key.head_sha)
+                if current in (BriefLifecycleState.QUEUED, BriefLifecycleState.RUNNING):
+                    await asyncio.to_thread(
+                        storage.mark_failed,
+                        key.pr_number,
+                        key.head_sha,
+                        str(exc),
+                        "run_protocol_b_exception",
+                        0.0,
+                    )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "pdb.worker: failed to record exception state for pr=%s sha=%s",
+                    key.pr_number,
+                    key.head_sha,
+                )
+            return _empty_failed_result()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _await_task(task: asyncio.Task[PDBExecutionResult]) -> PDBExecutionResult:
+    return await task
+
+
+async def _finalize_result(key: JobKey, result: PDBExecutionResult) -> None:
+    """Persist the terminal lifecycle state for a completed job."""
+
+    cost = float(result.actual_cost_usd)
+
+    if result.status == PDBExecutionStatus.SUCCESS:
+        if result.brief is None:
+            await asyncio.to_thread(
+                storage.mark_failed,
+                key.pr_number,
+                key.head_sha,
+                "protocol_b success without brief payload",
+                "run_protocol_b_missing_brief",
+                cost,
+            )
+            return
+        await asyncio.to_thread(
+            storage.mark_ready,
+            key.pr_number,
+            key.head_sha,
+            result.brief.to_dict(),
+            None,
+        )
+        return
+
+    if result.status == PDBExecutionStatus.DEGRADED:
+        # A degraded outcome still has a brief — record it as ready so
+        # the founder can consult it. Degrade context survives inside
+        # the brief payload's ``cost_estimate`` / packet metadata.
+        if result.brief is None:
+            await asyncio.to_thread(
+                storage.mark_failed,
+                key.pr_number,
+                key.head_sha,
+                "protocol_b degraded without brief payload",
+                "run_protocol_b_missing_brief",
+                cost,
+            )
+            return
+        await asyncio.to_thread(
+            storage.mark_ready,
+            key.pr_number,
+            key.head_sha,
+            result.brief.to_dict(),
+            None,
+        )
+        return
+
+    if result.status == PDBExecutionStatus.BUDGET_EXCEEDED:
+        await asyncio.to_thread(
+            storage.mark_failed,
+            key.pr_number,
+            key.head_sha,
+            result.failure_reason or "budget exhausted",
+            "budget_exhausted",
+            cost,
+        )
+        return
+
+    # FAILED_CLOSED
+    await asyncio.to_thread(
+        storage.mark_failed,
+        key.pr_number,
+        key.head_sha,
+        result.failure_reason or "protocol_b failed closed",
+        "fail_closed",
+        cost,
+    )
+
+
+def _empty_failed_result() -> PDBExecutionResult:
+    """Return a minimal failed :class:`PDBExecutionResult` for worker errors."""
+    from aragora.pdb.budget import PDBBudgetDecision, PDBBudgetStatus
+    from aragora.review.provider_slots import ProviderSlotAvailabilitySummary
+    from aragora.swarm.pr_review_protocol import PRReviewBinding, PRReviewProtocolPacket
+
+    binding = PRReviewBinding(repo="", pr_number=0, base_sha="", head_sha="")
+    return PDBExecutionResult(
+        status=PDBExecutionStatus.FAILED_CLOSED,
+        packet=PRReviewProtocolPacket(
+            protocol_version="pr_review_protocol.v1",
+            status="failed_closed",
+            binding=binding,
+            review_roles=[],
+            provider_slots=[],
+            availability_summary=ProviderSlotAvailabilitySummary(total_slots=0, resolved_slots=0),
+            recommendation_class="needs_human_attention",
+            recommendation_reason="worker-level failure",
+            confidence=0.0,
+            confidence_basis="failed_closed",
+            dissent_summary="",
+            dissenting_views=[],
+            validation_summary={},
+            top_findings=[],
+            cost_estimate={},
+        ),
+        brief=None,
+        budget_decision=PDBBudgetDecision(
+            status=PDBBudgetStatus.ALLOWED,
+            total_estimated_usd=0.0,
+            per_brief_cap_usd=0.0,
+            per_day_cap_usd=0.0,
+            per_day_spent_before_usd=0.0,
+            per_day_remaining_before_usd=0.0,
+            funded_slots=(),
+            dropped_slots=(),
+            slot_estimates_usd={},
+            synthesis_estimate_usd=0.0,
+            reason="worker-level failure",
+            binding_cap=None,
+        ),
+        active_roster=(),
+        missing_slots=(),
+        degrade_reasons=(),
+        failure_reason="worker-level failure",
+        findings_by_slot={},
+        critiques_by_slot={},
+        synthesis=None,
+        resolutions=(),
+        availability_summary=ProviderSlotAvailabilitySummary(total_slots=0, resolved_slots=0),
+        actual_cost_usd=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+
+_worker_lock = threading.Lock()
+_worker_singleton: BriefGenerationWorker | None = None
+
+
+def get_worker(*, max_concurrent: int | None = None) -> BriefGenerationWorker:
+    """Return the process-wide worker singleton, creating it if needed."""
+    global _worker_singleton
+    with _worker_lock:
+        if _worker_singleton is None:
+            import os
+
+            mc = max_concurrent
+            if mc is None:
+                env = os.environ.get("ARAGORA_PDB_MAX_CONCURRENT_BRIEFS")
+                if env:
+                    try:
+                        mc = int(env)
+                    except ValueError:
+                        mc = 5
+                else:
+                    mc = 5
+            _worker_singleton = BriefGenerationWorker(max_concurrent=mc)
+        return _worker_singleton
+
+
+def set_worker(worker: BriefGenerationWorker | None) -> None:
+    """Replace (or clear) the process-wide worker singleton.
+
+    Intended for tests that want to inject a worker with specific
+    concurrency settings or stop the singleton between runs.
+    """
+    global _worker_singleton
+    with _worker_lock:
+        if _worker_singleton is not None and _worker_singleton is not worker:
+            _worker_singleton.stop()
+        _worker_singleton = worker
+
+
+def reset_worker() -> None:
+    """Stop and clear the process-wide worker singleton.
+
+    Tests call this in a fixture so each test gets a fresh loop.
+    """
+    set_worker(None)

--- a/aragora/server/handlers/review_queue.py
+++ b/aragora/server/handlers/review_queue.py
@@ -43,6 +43,8 @@ from pathlib import Path
 from typing import Any
 
 from aragora.pdb import storage as brief_storage
+from aragora.pdb import worker as brief_worker
+from aragora.server.handlers import review_queue_brief
 from aragora.server.versioning.compat import strip_version_prefix
 
 from .base import BaseHandler, HandlerResult, error_response, json_response
@@ -413,6 +415,8 @@ class ReviewQueueHandler(BaseHandler):
     def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
         """Route GET requests under ``/api/v1/review-queue``."""
         method = (getattr(handler, "command", None) or "GET").upper()
+        if method == "DELETE":
+            return self.handle_delete(path, query_params, handler)
         if method != "GET":
             return self.handle_post(path, query_params, handler)
 
@@ -441,12 +445,17 @@ class ReviewQueueHandler(BaseHandler):
                 if pr_number is None:
                     return error_response("Invalid PR number", 400)
                 return self._get_brief(pr_number)
+            if len(segments) == 3 and segments[1] == "brief" and segments[2] == "state":
+                pr_number = _parse_pr_number(segments[0])
+                if pr_number is None:
+                    return error_response("Invalid PR number", 400)
+                return review_queue_brief.handle_state(pr_number)
         return error_response("Not found", 404)
 
     def handle_post(
         self, path: str, query_params: dict[str, Any], handler: Any
     ) -> HandlerResult | None:
-        """Route POST requests (approve / request-changes / defer)."""
+        """Route POST requests (approve / request-changes / defer / brief-generate)."""
         client_ip = get_client_ip(handler) if handler else "unknown"
         if not _review_queue_limiter.is_allowed(client_ip):
             return error_response("Rate limit exceeded", 429)
@@ -468,6 +477,20 @@ class ReviewQueueHandler(BaseHandler):
             return error_response("Not found", 404)
         tail = subpath[len("/prs/") :]
         segments = [seg for seg in tail.split("/") if seg]
+
+        # /prs/{n}/brief/generate → Mode 3 on-demand generation
+        if len(segments) == 3 and segments[1] == "brief" and segments[2] == "generate":
+            pr_number = _parse_pr_number(segments[0])
+            if pr_number is None:
+                return error_response("Invalid PR number", 400)
+            body = self.read_json_body(handler) or {}
+            return review_queue_brief.handle_generate(
+                pr_number,
+                body,
+                user,
+                worker=brief_worker.get_worker(),
+            )
+
         if len(segments) != 2:
             return error_response("Not found", 404)
         pr_number = _parse_pr_number(segments[0])
@@ -483,6 +506,39 @@ class ReviewQueueHandler(BaseHandler):
             return self._post_request_changes(pr_number, body, user)
         if action == "defer":
             return self._post_defer(pr_number, body, user)
+        return error_response("Not found", 404)
+
+    def handle_delete(
+        self, path: str, query_params: dict[str, Any], handler: Any
+    ) -> HandlerResult | None:
+        """Route DELETE /api/v1/review-queue/prs/{n}/brief/generate."""
+        client_ip = get_client_ip(handler) if handler else "unknown"
+        if not _review_queue_limiter.is_allowed(client_ip):
+            return error_response("Rate limit exceeded", 429)
+
+        user, err = self.require_auth_or_error(handler)
+        if err is not None:
+            return err
+
+        normalized = strip_version_prefix(path).rstrip("/")
+        subpath = (
+            normalized[len("/api/review-queue") :]
+            if normalized.startswith("/api/review-queue")
+            else ""
+        )
+        if not subpath.startswith("/prs/"):
+            return error_response("Not found", 404)
+        tail = subpath[len("/prs/") :]
+        segments = [seg for seg in tail.split("/") if seg]
+        if len(segments) == 3 and segments[1] == "brief" and segments[2] == "generate":
+            pr_number = _parse_pr_number(segments[0])
+            if pr_number is None:
+                return error_response("Invalid PR number", 400)
+            return review_queue_brief.handle_cancel(
+                pr_number,
+                user,
+                worker=brief_worker.get_worker(),
+            )
         return error_response("Not found", 404)
 
     # ------------------------------------------------------------------

--- a/aragora/server/handlers/review_queue_brief.py
+++ b/aragora/server/handlers/review_queue_brief.py
@@ -1,0 +1,463 @@
+"""HTTP handlers for Mode 3 on-demand brief generation.
+
+Three endpoints layered on top of the existing
+:class:`aragora.server.handlers.review_queue.ReviewQueueHandler`:
+
+- ``POST   /api/v1/review-queue/prs/{number}/brief/generate``
+- ``GET    /api/v1/review-queue/prs/{number}/brief/state``
+- ``DELETE /api/v1/review-queue/prs/{number}/brief/generate``
+
+All three are gated by the feature flag
+``ARAGORA_PDB_BRIEF_GENERATION_ENABLED``. When off, each returns 503 —
+the existing ``GET /brief`` read path and the ``/review-queue`` list are
+unaffected (they live in ``review_queue.py``).
+
+Invariants:
+
+- On ``POST``, the caller's current head SHA is refreshed from ``gh``
+  and used to key storage. Any older ``ready`` brief is moved to
+  ``invalidated/``.
+- Dedupe runs in the worker, not here. This module only enforces the
+  409 path via the worker's :class:`AlreadyRunningError`.
+- The ``invoker_factory`` passed to the worker is a placeholder that
+  raises a clear error — PR 3 ships without a real provider wiring.
+  Integration tests use a mocked factory via the
+  ``ARAGORA_PDB_TEST_INVOKER`` attribute hook.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "BRIEF_GENERATION_FLAG",
+    "DEFAULT_ESTIMATED_SECONDS",
+    "feature_enabled",
+    "handle_generate",
+    "handle_state",
+    "handle_cancel",
+]
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from aragora.pdb import storage
+from aragora.pdb.brief_state import BriefLifecycleState
+from aragora.pdb.input_loader import (
+    InputLoaderError,
+    InputLoaderErrorReason,
+    LoadedExecutionInput,
+    load_execution_input,
+)
+from aragora.pdb.protocol import ProviderInvoker
+from aragora.pdb.worker import (
+    AlreadyRunningError,
+    BriefGenerationWorker,
+    JobKey,
+    JobRequest,
+)
+from aragora.review.policy import ReviewPolicy
+
+from .utils.responses import HandlerResult, error_response, json_response
+
+logger = logging.getLogger(__name__)
+
+UTC = timezone.utc
+
+BRIEF_GENERATION_FLAG = "ARAGORA_PDB_BRIEF_GENERATION_ENABLED"
+DEFAULT_ESTIMATED_SECONDS = 180  # aligns with design doc §Single generation flow
+
+
+# Hook for test-time invoker injection. Tests set this to a callable that
+# returns a :class:`ProviderInvoker`; production leaves it None so the
+# handler raises the "not yet wired" error before scheduling real work.
+_INVOKER_FACTORY_OVERRIDE: Callable[[], ProviderInvoker] | None = None
+
+
+def set_test_invoker_factory(factory: Callable[[], ProviderInvoker] | None) -> None:
+    """Install (or clear) a test-only invoker factory."""
+    global _INVOKER_FACTORY_OVERRIDE
+    _INVOKER_FACTORY_OVERRIDE = factory
+
+
+# Hook for test-time input loader injection. Tests can stub this to
+# bypass `gh` entirely.
+_INPUT_LOADER_OVERRIDE: (
+    Callable[[int, str | None, ReviewPolicy | None], LoadedExecutionInput] | None
+) = None
+
+
+def set_test_input_loader(
+    loader: Callable[[int, str | None, ReviewPolicy | None], LoadedExecutionInput] | None,
+) -> None:
+    """Install (or clear) a test-only input loader."""
+    global _INPUT_LOADER_OVERRIDE
+    _INPUT_LOADER_OVERRIDE = loader
+
+
+# ---------------------------------------------------------------------------
+# Flag + helpers
+# ---------------------------------------------------------------------------
+
+
+def feature_enabled() -> bool:
+    """Return True if Mode 3 brief generation is enabled via env flag."""
+    raw = os.environ.get(BRIEF_GENERATION_FLAG, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _feature_disabled_response() -> HandlerResult:
+    return error_response(
+        f"Mode 3 brief generation is disabled. Set {BRIEF_GENERATION_FLAG}=1 to enable.",
+        status=503,
+    )
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _load_input(
+    pr_number: int, repo: str | None, policy: ReviewPolicy | None
+) -> LoadedExecutionInput:
+    loader = _INPUT_LOADER_OVERRIDE
+    if loader is not None:
+        return loader(pr_number, repo, policy)
+    return load_execution_input(
+        pr_number=pr_number,
+        repo=repo,
+        policy=policy,
+    )
+
+
+def _translate_input_error(err: InputLoaderError) -> HandlerResult:
+    reason = err.reason
+    if reason is InputLoaderErrorReason.PR_NOT_FOUND:
+        return error_response(err.detail or "PR not found", status=404)
+    if reason is InputLoaderErrorReason.GH_MISSING:
+        return error_response(
+            "gh CLI not found on server. Install and authenticate `gh` to "
+            "generate briefs from the web UI.",
+            status=503,
+        )
+    if reason is InputLoaderErrorReason.GH_AUTHENTICATION:
+        return error_response(
+            "gh CLI not authenticated. Run `gh auth login` to attach your GitHub identity.",
+            status=403,
+        )
+    if reason is InputLoaderErrorReason.TIMEOUT:
+        return error_response(err.detail or "gh CLI timed out", status=504)
+    if reason is InputLoaderErrorReason.EMPTY_HEAD_SHA:
+        return error_response(err.detail or "PR has no head SHA", status=422)
+    if reason is InputLoaderErrorReason.MALFORMED_RESPONSE:
+        return error_response(err.detail or "malformed gh response", status=502)
+    return error_response(err.detail or reason.value, status=502)
+
+
+def _resolve_invoker_factory() -> Callable[[], ProviderInvoker]:
+    if _INVOKER_FACTORY_OVERRIDE is not None:
+        return _INVOKER_FACTORY_OVERRIDE
+
+    def _default_factory() -> ProviderInvoker:
+        raise NotImplementedError(
+            "default ProviderInvoker is not yet wired — tests inject via "
+            "set_test_invoker_factory(). PR 4+ will install the real one."
+        )
+
+    return _default_factory
+
+
+def _state_payload(pr_number: int, head_sha: str) -> dict[str, Any]:
+    """Read the on-disk state for ``(pr_number, head_sha)`` and project to JSON."""
+    state = storage.get_state(pr_number, head_sha)
+    payload: dict[str, Any] = {
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "state": state.value,
+    }
+    # Surface phase / cost / timestamps when they exist on disk.
+    briefs_root = storage.briefs_root()
+    filename = f"pr-{pr_number}-{head_sha[:12]}.json"
+    subdir: str | None = None
+    if state == BriefLifecycleState.QUEUED:
+        subdir = storage.QUEUED_SUBDIR
+    elif state == BriefLifecycleState.RUNNING:
+        subdir = storage.RUNNING_SUBDIR
+    elif state == BriefLifecycleState.FAILED:
+        subdir = storage.FAILED_SUBDIR
+    if subdir is not None:
+        path = briefs_root / subdir / filename
+        if path.exists():
+            try:
+                import json
+
+                record = json.loads(path.read_text(encoding="utf-8"))
+                for key in (
+                    "requested_at",
+                    "started_at",
+                    "current_phase",
+                    "cost_usd_so_far",
+                    "panel_models",
+                    "updated_at",
+                    "error_message",
+                    "failed_phase",
+                    "failed_at",
+                ):
+                    if key in record:
+                        payload[key] = record[key]
+            except (OSError, ValueError):
+                logger.warning("review_queue_brief: state file unreadable at %s", path)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Endpoint handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_generate(
+    pr_number: int,
+    body: dict[str, Any],
+    user: Any,
+    *,
+    worker: BriefGenerationWorker,
+) -> HandlerResult:
+    """Schedule a brief-generation job for ``pr_number``.
+
+    Behavior:
+
+    - Feature flag off → 503.
+    - Loads current head SHA via the input loader.
+    - Moves any older ``ready`` briefs to ``invalidated/``.
+    - Rejects with 409 when a live queued/running brief already exists.
+    - Writes the queued record atomically; submits to the worker.
+    - Returns ``{state: "queued"}`` + estimated completion seconds.
+    """
+    if not feature_enabled():
+        return _feature_disabled_response()
+
+    repo = None
+    if isinstance(body, dict):
+        raw = body.get("repo")
+        if isinstance(raw, str) and raw.strip():
+            repo = raw.strip()
+
+    try:
+        loaded = _load_input(pr_number, repo, None)
+    except InputLoaderError as exc:
+        return _translate_input_error(exc)
+    except NotImplementedError as exc:
+        logger.warning("review_queue_brief: generate hit test-only path: %s", exc)
+        return error_response(str(exc), status=503)
+
+    head_sha = loaded.head_sha
+
+    # Invalidate stale ready briefs before acting on this request.
+    storage.invalidate_if_head_changed(pr_number, head_sha)
+
+    current_state = storage.get_state(pr_number, head_sha)
+    if current_state in (
+        BriefLifecycleState.QUEUED,
+        BriefLifecycleState.RUNNING,
+        BriefLifecycleState.READY,
+    ):
+        return json_response(
+            {
+                "status": "conflict",
+                "pr_number": pr_number,
+                "head_sha": head_sha,
+                "state": current_state.value,
+                "message": (
+                    f"brief is already {current_state.value}; "
+                    "poll /brief/state for progress or DELETE to cancel."
+                ),
+            },
+            status=409,
+        )
+
+    panel_models = list(loaded.panel_models)
+    storage.queue_generation(
+        pr_number,
+        head_sha,
+        panel_models=panel_models,
+        extra_fields={
+            "repo": loaded.repo,
+            "requested_by": str(getattr(user, "user_id", "") or ""),
+        },
+    )
+
+    request = JobRequest(
+        key=JobKey(
+            repo=loaded.repo,
+            pr_number=pr_number,
+            head_sha=head_sha,
+        ),
+        input=loaded.input,
+        invoker_factory=_resolve_invoker_factory(),
+        panel_models=tuple(panel_models),
+    )
+
+    try:
+        worker.submit(request)
+    except AlreadyRunningError as exc:
+        # Worker-side dedupe raced a parallel request. Surface as 409
+        # with the observed state.
+        return json_response(
+            {
+                "status": "conflict",
+                "pr_number": pr_number,
+                "head_sha": head_sha,
+                "state": exc.state.value,
+                "message": str(exc),
+            },
+            status=409,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("review_queue_brief: worker.submit failed for pr=%s", pr_number)
+        storage.mark_failed(
+            pr_number,
+            head_sha,
+            str(exc),
+            "submit_exception",
+            0.0,
+        )
+        return error_response(f"worker submit failed: {exc}", status=500)
+
+    logger.info(
+        "review-queue-brief generate: pr=%s head=%s user=%s",
+        pr_number,
+        head_sha[:12],
+        getattr(user, "user_id", None),
+    )
+
+    return json_response(
+        {
+            "pr_number": pr_number,
+            "head_sha": head_sha,
+            "state": BriefLifecycleState.QUEUED.value,
+            "queued_at": _now_iso(),
+            "estimated_completion_seconds": DEFAULT_ESTIMATED_SECONDS,
+            "panel_models": panel_models,
+        },
+        status=202,
+    )
+
+
+def handle_state(pr_number: int) -> HandlerResult:
+    """Return the current lifecycle state for ``pr_number``.
+
+    Resolves the current head SHA via the input loader so polling sees
+    a fresh view. If the PR can't be reached we fall back to the
+    latest-on-disk ready-brief SHA when one exists, to keep polling
+    cheap after the head changes.
+    """
+    if not feature_enabled():
+        return _feature_disabled_response()
+
+    try:
+        loaded = _load_input(pr_number, None, None)
+        head_sha: str | None = loaded.head_sha
+    except InputLoaderError as exc:
+        if exc.reason is InputLoaderErrorReason.PR_NOT_FOUND:
+            return _translate_input_error(exc)
+        # gh unavailable, malformed, etc — try the latest ready brief fallback.
+        ready_paths = storage.find_ready_briefs_for_pr(pr_number)
+        if not ready_paths:
+            return _translate_input_error(exc)
+        # Extract the full sha from the on-disk record.
+        first = ready_paths[0]
+        try:
+            import json
+
+            data = json.loads(first.read_text(encoding="utf-8"))
+            head_sha = str(data.get("head_sha", "")).strip() or first.stem.split("-", 2)[-1]
+        except (OSError, ValueError):
+            head_sha = first.stem.split("-", 2)[-1]
+    if head_sha:
+        storage.invalidate_if_head_changed(pr_number, head_sha)
+
+    if not head_sha:
+        return error_response("could not resolve head SHA", status=502)
+
+    return json_response(_state_payload(pr_number, head_sha))
+
+
+def handle_cancel(
+    pr_number: int,
+    user: Any,
+    *,
+    worker: BriefGenerationWorker,
+) -> HandlerResult:
+    """Cancel an in-flight generation for ``pr_number``.
+
+    DELETE semantics:
+
+    - Flag off → 503.
+    - Resolves current head SHA. Looks up state — only queued/running
+      can be cancelled; other states are a no-op returning 200 with
+      the current state.
+    - Fires :meth:`BriefGenerationWorker.cancel` (best-effort).
+    - Calls :func:`storage.cancel_generation` to remove the queued
+      record if one is still present. Running state transitions to
+      ``failed`` by the worker when cancel propagates.
+    """
+    if not feature_enabled():
+        return _feature_disabled_response()
+
+    try:
+        loaded = _load_input(pr_number, None, None)
+        head_sha = loaded.head_sha
+        repo = loaded.repo
+    except InputLoaderError as exc:
+        return _translate_input_error(exc)
+
+    current = storage.get_state(pr_number, head_sha)
+    if current not in (BriefLifecycleState.QUEUED, BriefLifecycleState.RUNNING):
+        return json_response(
+            {
+                "pr_number": pr_number,
+                "head_sha": head_sha,
+                "state": current.value,
+                "cancelled": False,
+                "message": f"no active generation to cancel (state={current.value})",
+            }
+        )
+
+    cancelled_worker = worker.cancel(JobKey(repo=repo, pr_number=pr_number, head_sha=head_sha))
+    # Clear the queued record directly if the worker hadn't picked it up
+    # yet (queued records have no worker-side finalization path). For
+    # running work the worker transitions to ``failed`` when the cancel
+    # propagates — do NOT remove the running record here, that would
+    # race the worker's ``mark_failed`` call.
+    if current == BriefLifecycleState.QUEUED:
+        post_state = storage.cancel_generation(pr_number, head_sha)
+    else:
+        # RUNNING: wait briefly for the worker to emit its failed record.
+        import time as _time
+
+        deadline = _time.monotonic() + 2.0
+        while _time.monotonic() < deadline:
+            observed = storage.get_state(pr_number, head_sha)
+            if observed != BriefLifecycleState.RUNNING:
+                break
+            _time.sleep(0.02)
+        post_state = storage.get_state(pr_number, head_sha)
+
+    logger.info(
+        "review-queue-brief cancel: pr=%s head=%s user=%s worker_cancelled=%s state=%s",
+        pr_number,
+        head_sha[:12],
+        getattr(user, "user_id", None),
+        cancelled_worker,
+        post_state.value,
+    )
+    return json_response(
+        {
+            "pr_number": pr_number,
+            "head_sha": head_sha,
+            "state": post_state.value,
+            "cancelled": True,
+            "worker_cancelled": cancelled_worker,
+            "previous_state": current.value,
+        }
+    )

--- a/aragora/server/handlers/review_queue_brief.py
+++ b/aragora/server/handlers/review_queue_brief.py
@@ -12,6 +12,13 @@ All three are gated by the feature flag
 the existing ``GET /brief`` read path and the ``/review-queue`` list are
 unaffected (they live in ``review_queue.py``).
 
+Authentication: each handler function receives ``user`` from the
+dispatching :class:`ReviewQueueHandler.handle_post` / ``handle_get`` /
+``handle_delete`` methods, which call ``self.require_auth_or_error``
+on the request before routing here. As defense-in-depth, each handler
+below re-checks ``user is not None`` and returns 401 if the caller
+somehow reaches this module without an authenticated session.
+
 Invariants:
 
 - On ``POST``, the caller's current head SHA is refreshed from ``gh``
@@ -233,6 +240,9 @@ def handle_generate(
     - Writes the queued record atomically; submits to the worker.
     - Returns ``{state: "queued"}`` + estimated completion seconds.
     """
+    if user is None:
+        return error_response("Authentication required", status=401)
+
     if not feature_enabled():
         return _feature_disabled_response()
 
@@ -401,6 +411,9 @@ def handle_cancel(
       record if one is still present. Running state transitions to
       ``failed`` by the worker when cancel propagates.
     """
+    if user is None:
+        return error_response("Authentication required", status=401)
+
     if not feature_enabled():
         return _feature_disabled_response()
 

--- a/tests/pdb/test_input_loader.py
+++ b/tests/pdb/test_input_loader.py
@@ -1,0 +1,317 @@
+"""Tests for :mod:`aragora.pdb.input_loader`."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from aragora.pdb import input_loader as il
+from aragora.pdb.input_loader import (
+    DEFAULT_DIFF_EXCERPT_CHARS,
+    InputLoaderError,
+    InputLoaderErrorReason,
+    load_execution_input,
+)
+from aragora.pdb.protocol import PDBExecutionInput
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_pr_payload(
+    *,
+    number: int = 4242,
+    head_sha: str = "deadbeefcafe0011223344556677889900aabbcc",
+    base_sha: str = "feedface0011",
+    labels: list[str] | None = None,
+    files: list[str] | None = None,
+    additions: int = 20,
+    deletions: int = 3,
+    is_draft: bool = False,
+    url: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": "Tighten rate limiter tests",
+        "body": "Adds ring-buffer invariants.",
+        "url": url or f"https://github.com/synaptent/aragora/pull/{number}",
+        "headRefOid": head_sha,
+        "baseRefOid": base_sha,
+        "isDraft": is_draft,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "REVIEW_REQUIRED",
+        "labels": [{"name": lab} for lab in (labels or ["backend"])],
+        "author": {"login": "armand"},
+        "additions": additions,
+        "deletions": deletions,
+        "changedFiles": len(files or ["aragora/server/rate_limit.py"]),
+        "statusCheckRollup": [{"conclusion": "SUCCESS", "status": "COMPLETED"}],
+        "files": [{"path": p} for p in (files or ["aragora/server/rate_limit.py"])],
+    }
+
+
+def _run_gh_view_success(*, payload: dict[str, Any]) -> tuple[int, str, str]:
+    return (0, json.dumps(payload), "")
+
+
+class _RunGHStub:
+    """Queue-based replacement for ``_run_gh`` inside the loader."""
+
+    def __init__(self, responses: list[tuple[int, str, str]]) -> None:
+        self._responses = list(responses)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, *, capture: bool = True) -> tuple[int, str, str]:  # noqa: D401
+        self.calls.append(list(args))
+        if not self._responses:
+            raise AssertionError(f"unexpected gh call: {args}")
+        return self._responses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestLoadExecutionInputHappyPath:
+    def test_builds_pdb_execution_input(self):
+        payload = _fake_pr_payload(
+            head_sha="aaaabbbbccccddddeeeeffff0011223344556677",
+            base_sha="11112222333344445555",
+            labels=["backend", "needs-review"],
+            files=["aragora/server/rate_limit.py", "tests/server/test_rate_limit.py"],
+            additions=40,
+            deletions=5,
+        )
+        diff_text = "diff --git a/foo b/foo\n+pass\n"
+        stub = _RunGHStub(
+            [
+                _run_gh_view_success(payload=payload),
+                (0, diff_text, ""),
+            ]
+        )
+        with patch.object(il, "_run_gh", stub):
+            result = load_execution_input(pr_number=4242)
+
+        assert isinstance(result.input, PDBExecutionInput)
+        assert result.head_sha == "aaaabbbbccccddddeeeeffff0011223344556677"
+        assert result.base_sha == "11112222333344445555"
+        assert result.repo == "synaptent/aragora"
+        assert result.input.binding.pr_number == 4242
+        assert result.input.binding.head_sha == result.head_sha
+        assert result.input.binding.base_sha == result.base_sha
+        assert result.input.pr_title == "Tighten rate limiter tests"
+        assert result.input.pr_body == "Adds ring-buffer invariants."
+        assert result.input.labels == ("backend", "needs-review")
+        assert "aragora/server/rate_limit.py" in result.input.changed_files
+        assert result.input.diff_excerpt == diff_text
+        assert result.input.panel_id == "protocol_b_default"
+        assert result.input.validation_summary["additions"] == 40
+        assert result.input.validation_summary["labels"] == ["backend", "needs-review"]
+        # Panel models derived from the heuristic packet's resolved slots
+        assert isinstance(result.panel_models, tuple)
+        # One view call + one diff call
+        assert len(stub.calls) == 2
+        assert stub.calls[0][:3] == ["pr", "view", "4242"]
+        assert stub.calls[1][:3] == ["pr", "diff", "4242"]
+
+    def test_repo_override_is_forwarded(self):
+        stub = _RunGHStub(
+            [
+                _run_gh_view_success(payload=_fake_pr_payload()),
+                (0, "", ""),
+            ]
+        )
+        with patch.object(il, "_run_gh", stub):
+            result = load_execution_input(pr_number=10, repo="synaptent/aragora")
+
+        assert "--repo" in stub.calls[0]
+        assert "--repo" in stub.calls[1]
+        assert result.repo == "synaptent/aragora"
+
+    def test_diff_excerpt_truncated_at_char_limit(self):
+        huge_diff = "diff --git a/x b/x\n" + ("+" + "y" * 200 + "\n") * 5000
+        stub = _RunGHStub(
+            [
+                _run_gh_view_success(payload=_fake_pr_payload()),
+                (0, huge_diff, ""),
+            ]
+        )
+        with patch.object(il, "_run_gh", stub):
+            result = load_execution_input(pr_number=7, diff_excerpt_char_limit=5000)
+
+        assert len(result.input.diff_excerpt) <= 5000 + len("\n[diff truncated]\n") + 1
+        assert result.input.diff_excerpt.endswith("[diff truncated]\n")
+
+    def test_zero_diff_limit_skips_diff_call(self):
+        stub = _RunGHStub(
+            [
+                _run_gh_view_success(payload=_fake_pr_payload()),
+            ]
+        )
+        with patch.object(il, "_run_gh", stub):
+            result = load_execution_input(pr_number=7, diff_excerpt_char_limit=0)
+
+        assert result.input.diff_excerpt == ""
+        # Only the view call should be made when diff is disabled
+        assert len(stub.calls) == 1
+
+    def test_diff_failure_is_nonfatal(self, caplog):
+        stub = _RunGHStub(
+            [
+                _run_gh_view_success(payload=_fake_pr_payload()),
+                (1, "", "gh pr diff failed"),
+            ]
+        )
+        with patch.object(il, "_run_gh", stub), caplog.at_level("WARNING"):
+            result = load_execution_input(pr_number=7)
+
+        assert result.input.diff_excerpt == ""
+        assert any("gh pr diff" in rec.message for rec in caplog.records)
+
+    def test_panel_id_is_passed_through(self):
+        stub = _RunGHStub(
+            [
+                _run_gh_view_success(payload=_fake_pr_payload()),
+                (0, "diff", ""),
+            ]
+        )
+        with patch.object(il, "_run_gh", stub):
+            result = load_execution_input(pr_number=1, panel_id="custom_panel")
+
+        assert result.input.panel_id == "custom_panel"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestLoadExecutionInputErrors:
+    def test_invalid_pr_number_rejected(self):
+        with pytest.raises(ValueError):
+            load_execution_input(pr_number=0)
+        with pytest.raises(ValueError):
+            load_execution_input(pr_number=-5)
+
+    def test_gh_missing_raises(self):
+        def _raise_missing(args, *, capture: bool = True):
+            raise FileNotFoundError("no gh")
+
+        with patch.object(il.subprocess, "run", side_effect=FileNotFoundError("no gh")):
+            with pytest.raises(InputLoaderError) as excinfo:
+                load_execution_input(pr_number=1)
+        assert excinfo.value.reason is InputLoaderErrorReason.GH_MISSING
+
+    def test_gh_timeout_raises(self):
+        def _raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=5)
+
+        with patch.object(il.subprocess, "run", side_effect=_raise_timeout):
+            with pytest.raises(InputLoaderError) as excinfo:
+                load_execution_input(pr_number=1)
+        assert excinfo.value.reason is InputLoaderErrorReason.TIMEOUT
+
+    def test_pr_not_found_classified(self):
+        stub = _RunGHStub([(1, "", "could not find pull request 99")])
+        with patch.object(il, "_run_gh", stub):
+            with pytest.raises(InputLoaderError) as excinfo:
+                load_execution_input(pr_number=99)
+        assert excinfo.value.reason is InputLoaderErrorReason.PR_NOT_FOUND
+
+    def test_authentication_error_classified(self):
+        stub = _RunGHStub([(1, "", "authentication required; run gh auth login")])
+        with patch.object(il, "_run_gh", stub):
+            with pytest.raises(InputLoaderError) as excinfo:
+                load_execution_input(pr_number=1)
+        assert excinfo.value.reason is InputLoaderErrorReason.GH_AUTHENTICATION
+
+    def test_generic_gh_error_classified(self):
+        stub = _RunGHStub([(1, "", "some other failure")])
+        with patch.object(il, "_run_gh", stub):
+            with pytest.raises(InputLoaderError) as excinfo:
+                load_execution_input(pr_number=1)
+        assert excinfo.value.reason is InputLoaderErrorReason.GH_ERROR
+
+    def test_malformed_json_raises(self):
+        stub = _RunGHStub([(0, "not json at all", "")])
+        with patch.object(il, "_run_gh", stub):
+            with pytest.raises(InputLoaderError) as excinfo:
+                load_execution_input(pr_number=1)
+        assert excinfo.value.reason is InputLoaderErrorReason.MALFORMED_RESPONSE
+
+    def test_non_object_json_raises(self):
+        stub = _RunGHStub([(0, json.dumps([]), "")])
+        with patch.object(il, "_run_gh", stub):
+            with pytest.raises(InputLoaderError) as excinfo:
+                load_execution_input(pr_number=1)
+        assert excinfo.value.reason is InputLoaderErrorReason.MALFORMED_RESPONSE
+
+    def test_empty_head_sha_raises(self):
+        payload = _fake_pr_payload()
+        payload["headRefOid"] = ""
+        stub = _RunGHStub([_run_gh_view_success(payload=payload)])
+        with patch.object(il, "_run_gh", stub):
+            with pytest.raises(InputLoaderError) as excinfo:
+                load_execution_input(pr_number=1)
+        assert excinfo.value.reason is InputLoaderErrorReason.EMPTY_HEAD_SHA
+
+    def test_missing_repo_raises(self):
+        payload = _fake_pr_payload()
+        payload["url"] = ""  # bypass the fallback in _fake_pr_payload
+        stub = _RunGHStub([_run_gh_view_success(payload=payload)])
+        with patch.object(il, "_run_gh", stub):
+            with pytest.raises(InputLoaderError) as excinfo:
+                load_execution_input(pr_number=1)
+        assert excinfo.value.reason is InputLoaderErrorReason.MALFORMED_RESPONSE
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRepoParser:
+    def test_standard_url(self):
+        assert (
+            il._repo_from_url("https://github.com/synaptent/aragora/pull/42") == "synaptent/aragora"
+        )
+
+    def test_http_url(self):
+        assert il._repo_from_url("http://github.com/a/b/pull/1") == "a/b"
+
+    def test_malformed_returns_empty(self):
+        assert il._repo_from_url("not-a-url") == ""
+        assert il._repo_from_url("") == ""
+
+
+class TestChecksSummary:
+    def test_counts_success_failure_pending(self):
+        payload = [
+            {"conclusion": "SUCCESS", "status": "COMPLETED"},
+            {"conclusion": "FAILURE", "status": "COMPLETED"},
+            {"status": "IN_PROGRESS"},
+            {"conclusion": "SKIPPED"},
+        ]
+        out = il._summarize_checks(payload)
+        assert out["success"] == 1
+        assert out["failure"] == 1
+        assert out["pending"] == 1
+        assert out["total"] == 3
+
+
+class TestTruncateDiff:
+    def test_short_diff_passthrough(self):
+        assert il._truncate_diff("abc\n", limit=10) == "abc\n"
+
+    def test_long_diff_truncated(self):
+        text = "aa\nbb\ncc\ndd\nee\nff\n"
+        out = il._truncate_diff(text, limit=8)
+        assert "[diff truncated]" in out
+        assert len(out) < len(text) + 20

--- a/tests/pdb/test_worker.py
+++ b/tests/pdb/test_worker.py
@@ -1,0 +1,522 @@
+"""Tests for :mod:`aragora.pdb.worker`.
+
+The worker's contract is: dedupe by ``(repo, pr_number, head_sha)``,
+cap concurrency via a semaphore, transition storage records
+``queued → running → ready | failed`` in order, and treat cancellation
+as best-effort + failed-record-recording.
+
+We don't exercise the real executor in these tests. ``run_protocol_b``
+is monkey-patched to a controllable stub — the PR 2 test suite already
+exercises the real pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures import Future
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from aragora.pdb import budget as budget_mod
+from aragora.pdb import storage
+from aragora.pdb import worker as worker_mod
+from aragora.pdb.brief_state import BriefLifecycleState
+from aragora.pdb.protocol import (
+    PDBExecutionInput,
+    PDBExecutionResult,
+    PDBExecutionStatus,
+)
+from aragora.pdb.worker import (
+    AlreadyRunningError,
+    BriefGenerationWorker,
+    JobKey,
+    JobRequest,
+    get_worker,
+    reset_worker,
+    set_worker,
+)
+from aragora.review.policy import ReviewPolicy
+from aragora.review.provider_slots import ProviderSlotAvailabilitySummary
+from aragora.swarm.pr_review_protocol import PRReviewBinding, PRReviewProtocolPacket
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_storage_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARAGORA_REVIEW_QUEUE_ROOT", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _fresh_worker_singleton():
+    reset_worker()
+    yield
+    reset_worker()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _binding() -> PRReviewBinding:
+    return PRReviewBinding(
+        repo="synaptent/aragora",
+        pr_number=4242,
+        base_sha="base0000",
+        head_sha="deadbeefcafe",
+    )
+
+
+def _make_input(pr_number: int = 4242, head_sha: str = "deadbeefcafe") -> PDBExecutionInput:
+    binding = PRReviewBinding(
+        repo="synaptent/aragora",
+        pr_number=pr_number,
+        base_sha="base0000",
+        head_sha=head_sha,
+    )
+    packet = PRReviewProtocolPacket(
+        protocol_version="pr_review_protocol.v1",
+        status="metadata_heuristic",
+        binding=binding,
+        review_roles=[],
+        provider_slots=[],
+        availability_summary=ProviderSlotAvailabilitySummary(total_slots=0, resolved_slots=0),
+        recommendation_class="needs_human_attention",
+        recommendation_reason="stub",
+        confidence=0.5,
+        confidence_basis="metadata_heuristic",
+        dissent_summary="",
+        dissenting_views=[],
+        validation_summary={},
+        top_findings=[],
+        cost_estimate={},
+    )
+    return PDBExecutionInput(
+        binding=binding,
+        packet=packet,
+        packet_sha="",
+        pr_title="Tighten rate limiter",
+        pr_body="",
+        labels=(),
+        changed_files=(),
+        diff_excerpt="",
+        validation_summary={},
+        panel_id="p",
+        policy=ReviewPolicy(),
+    )
+
+
+def _make_key(pr_number: int = 4242, head_sha: str = "deadbeefcafe") -> JobKey:
+    return JobKey(repo="synaptent/aragora", pr_number=pr_number, head_sha=head_sha)
+
+
+def _make_success_result(
+    pr_number: int = 4242, head_sha: str = "deadbeefcafe"
+) -> PDBExecutionResult:
+    # Build a minimal success result with a brief payload whose
+    # ``to_dict`` shape survives a storage round-trip.
+    from aragora.pdb.budget import PDBBudgetDecision, PDBBudgetStatus
+
+    class _FakeBrief:
+        def to_dict(self) -> dict[str, Any]:
+            return {
+                "pr_number": pr_number,
+                "head_sha": head_sha,
+                "verdict": "approve_candidate",
+                "confidence": 4,
+            }
+
+    packet = PRReviewProtocolPacket(
+        protocol_version="pr_review_protocol.v1",
+        status="panel_executed",
+        binding=PRReviewBinding(
+            repo="synaptent/aragora",
+            pr_number=pr_number,
+            base_sha="base0000",
+            head_sha=head_sha,
+        ),
+        review_roles=[],
+        provider_slots=[],
+        availability_summary=ProviderSlotAvailabilitySummary(total_slots=0, resolved_slots=0),
+        recommendation_class="approve_candidate",
+        recommendation_reason="stub",
+        confidence=0.8,
+        confidence_basis="panel_executed",
+        dissent_summary="",
+        dissenting_views=[],
+        validation_summary={},
+        top_findings=[],
+        cost_estimate={},
+    )
+    return PDBExecutionResult(
+        status=PDBExecutionStatus.SUCCESS,
+        packet=packet,
+        brief=_FakeBrief(),
+        budget_decision=PDBBudgetDecision(
+            status=PDBBudgetStatus.ALLOWED,
+            total_estimated_usd=0.0,
+            per_brief_cap_usd=10.0,
+            per_day_cap_usd=100.0,
+            per_day_spent_before_usd=0.0,
+            per_day_remaining_before_usd=100.0,
+            funded_slots=(),
+            dropped_slots=(),
+            slot_estimates_usd={},
+            synthesis_estimate_usd=0.0,
+            reason="allowed",
+            binding_cap=None,
+        ),
+        active_roster=(),
+        missing_slots=(),
+        degrade_reasons=(),
+        failure_reason=None,
+        findings_by_slot={},
+        critiques_by_slot={},
+        synthesis=None,
+        resolutions=(),
+        availability_summary=ProviderSlotAvailabilitySummary(total_slots=0, resolved_slots=0),
+        actual_cost_usd=1.23,
+    )
+
+
+class _DummyInvoker:
+    """Placeholder — run_protocol_b is monkey-patched, so this is unused."""
+
+
+def _seed_queued(pr_number: int, head_sha: str) -> None:
+    storage.queue_generation(pr_number, head_sha, ("slot_a", "slot_b"))
+
+
+# ---------------------------------------------------------------------------
+# Construction / startup
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerLifecycle:
+    def test_rejects_nonpositive_concurrency(self):
+        with pytest.raises(ValueError):
+            BriefGenerationWorker(max_concurrent=0)
+
+    def test_start_stop_idempotent(self):
+        w = BriefGenerationWorker(max_concurrent=1)
+        w.start()
+        w.start()  # second call is a no-op
+        assert w._thread is not None
+        w.stop()
+        assert w._thread is None
+
+    def test_get_worker_creates_singleton(self):
+        w1 = get_worker()
+        w2 = get_worker()
+        assert w1 is w2
+
+    def test_set_worker_replaces_singleton(self):
+        w1 = get_worker()
+        w1.start()
+        replacement = BriefGenerationWorker(max_concurrent=2)
+        set_worker(replacement)
+        assert get_worker() is replacement
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_submit_transitions_queued_running_ready(self, monkeypatch):
+        _seed_queued(4242, "deadbeefcafe")
+
+        result = _make_success_result()
+
+        def _fake_run(input_: PDBExecutionInput, *, invoker) -> PDBExecutionResult:
+            return result
+
+        monkeypatch.setattr(worker_mod, "run_protocol_b", _fake_run)
+
+        worker = BriefGenerationWorker(max_concurrent=2)
+        set_worker(worker)
+        request = JobRequest(
+            key=_make_key(),
+            input=_make_input(),
+            invoker_factory=lambda: _DummyInvoker(),
+        )
+        fut = worker.submit(request)
+        fut.result(timeout=5)
+
+        assert storage.get_state(4242, "deadbeefcafe") == BriefLifecycleState.READY
+        payload = storage.load_ready_brief(4242, "deadbeefcafe")
+        assert payload is not None
+        assert payload["verdict"] == "approve_candidate"
+
+
+# ---------------------------------------------------------------------------
+# Dedupe
+# ---------------------------------------------------------------------------
+
+
+class TestDedupe:
+    def test_concurrent_submit_same_key_returns_409(self, monkeypatch):
+        _seed_queued(4242, "deadbeefcafe")
+
+        release_event = threading.Event()
+        call_count = {"n": 0}
+
+        def _blocking_run(input_: PDBExecutionInput, *, invoker) -> PDBExecutionResult:
+            call_count["n"] += 1
+            release_event.wait(timeout=5)
+            return _make_success_result()
+
+        monkeypatch.setattr(worker_mod, "run_protocol_b", _blocking_run)
+
+        worker = BriefGenerationWorker(max_concurrent=4)
+        set_worker(worker)
+        req = JobRequest(
+            key=_make_key(),
+            input=_make_input(),
+            invoker_factory=lambda: _DummyInvoker(),
+        )
+
+        first = worker.submit(req)
+        # Wait briefly for the task to actually start and claim the dedupe slot.
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and not worker.is_active(req.key):
+            time.sleep(0.01)
+        assert worker.is_active(req.key)
+
+        with pytest.raises(AlreadyRunningError):
+            worker.submit(req)
+
+        release_event.set()
+        first.result(timeout=5)
+
+        assert call_count["n"] == 1  # only one executor invocation
+
+
+# ---------------------------------------------------------------------------
+# Concurrency limit
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrencyLimit:
+    def test_semaphore_caps_parallel_work(self, monkeypatch):
+        # Seed queued records for 3 distinct keys.
+        keys = [_make_key(pr_number=i, head_sha=f"sha{i:012d}") for i in (1, 2, 3)]
+        for key in keys:
+            _seed_queued(key.pr_number, key.head_sha)
+
+        in_flight = 0
+        max_in_flight = 0
+        lock = threading.Lock()
+        release_event = threading.Event()
+
+        def _slow_run(input_, *, invoker) -> PDBExecutionResult:
+            nonlocal in_flight, max_in_flight
+            with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            try:
+                release_event.wait(timeout=5)
+                return _make_success_result(
+                    pr_number=input_.binding.pr_number,
+                    head_sha=input_.binding.head_sha,
+                )
+            finally:
+                with lock:
+                    in_flight -= 1
+
+        monkeypatch.setattr(worker_mod, "run_protocol_b", _slow_run)
+
+        worker = BriefGenerationWorker(max_concurrent=2)
+        set_worker(worker)
+        futs: list[Future[PDBExecutionResult]] = []
+        for key in keys:
+            req = JobRequest(
+                key=key,
+                input=_make_input(pr_number=key.pr_number, head_sha=key.head_sha),
+                invoker_factory=lambda: _DummyInvoker(),
+            )
+            futs.append(worker.submit(req))
+
+        # Let the first two start, verify we're capped at 2 in flight.
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and max_in_flight < 2:
+            time.sleep(0.01)
+
+        assert max_in_flight == 2, f"semaphore cap breached: max_in_flight={max_in_flight}"
+
+        release_event.set()
+        for fut in futs:
+            fut.result(timeout=5)
+
+        assert max_in_flight == 2  # final check after all drain
+
+
+# ---------------------------------------------------------------------------
+# Cancel
+# ---------------------------------------------------------------------------
+
+
+class TestCancel:
+    def test_cancel_queued_and_running_records_failed(self, monkeypatch):
+        _seed_queued(4242, "deadbeefcafe")
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _blocking_run(input_, *, invoker) -> PDBExecutionResult:
+            started.set()
+            release.wait(timeout=5)
+            return _make_success_result()
+
+        monkeypatch.setattr(worker_mod, "run_protocol_b", _blocking_run)
+
+        worker = BriefGenerationWorker(max_concurrent=1)
+        set_worker(worker)
+        req = JobRequest(
+            key=_make_key(),
+            input=_make_input(),
+            invoker_factory=lambda: _DummyInvoker(),
+        )
+        fut = worker.submit(req)
+        # Wait for the task to actually claim the semaphore and begin
+        # the executor call.
+        assert started.wait(timeout=2)
+
+        cancelled = worker.cancel(req.key)
+        assert cancelled is True
+
+        # Unblock the executor so the task can clean up.
+        release.set()
+        from concurrent.futures import CancelledError as _CfCancelled
+
+        with pytest.raises((asyncio.CancelledError, _CfCancelled)):
+            fut.result(timeout=5)
+
+        # Give the worker loop a moment to finalize the failed record
+        # after the cancel propagates.
+        deadline = time.monotonic() + 2
+        while (
+            time.monotonic() < deadline
+            and storage.get_state(4242, "deadbeefcafe") != BriefLifecycleState.FAILED
+        ):
+            time.sleep(0.01)
+
+        state = storage.get_state(4242, "deadbeefcafe")
+        assert state == BriefLifecycleState.FAILED
+
+    def test_cancel_missing_key_returns_false(self):
+        worker = BriefGenerationWorker(max_concurrent=1)
+        worker.start()
+        try:
+            assert worker.cancel(_make_key(pr_number=99, head_sha="x" * 12)) is False
+        finally:
+            worker.stop()
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorErrors:
+    def test_exception_records_failed(self, monkeypatch):
+        _seed_queued(4242, "deadbeefcafe")
+
+        def _raise(input_, *, invoker):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(worker_mod, "run_protocol_b", _raise)
+
+        worker = BriefGenerationWorker(max_concurrent=1)
+        set_worker(worker)
+        req = JobRequest(
+            key=_make_key(),
+            input=_make_input(),
+            invoker_factory=lambda: _DummyInvoker(),
+        )
+        fut = worker.submit(req)
+        fut.result(timeout=5)
+
+        state = storage.get_state(4242, "deadbeefcafe")
+        assert state == BriefLifecycleState.FAILED
+
+    def test_budget_exceeded_recorded_as_failed(self, monkeypatch):
+        _seed_queued(4242, "deadbeefcafe")
+
+        def _budget_exceeded(input_, *, invoker):
+            from aragora.pdb.budget import PDBBudgetDecision, PDBBudgetStatus
+
+            packet = PRReviewProtocolPacket(
+                protocol_version="pr_review_protocol.v1",
+                status="budget_exceeded",
+                binding=input_.binding,
+                review_roles=[],
+                provider_slots=[],
+                availability_summary=ProviderSlotAvailabilitySummary(
+                    total_slots=0, resolved_slots=0
+                ),
+                recommendation_class="needs_human_attention",
+                recommendation_reason="budget",
+                confidence=0.0,
+                confidence_basis="budget_exceeded",
+                dissent_summary="",
+                dissenting_views=[],
+                validation_summary={},
+                top_findings=[],
+                cost_estimate={},
+            )
+            return PDBExecutionResult(
+                status=PDBExecutionStatus.BUDGET_EXCEEDED,
+                packet=packet,
+                brief=None,
+                budget_decision=PDBBudgetDecision(
+                    status=PDBBudgetStatus.BUDGET_EXCEEDED,
+                    total_estimated_usd=42.0,
+                    per_brief_cap_usd=8.0,
+                    per_day_cap_usd=200.0,
+                    per_day_spent_before_usd=200.0,
+                    per_day_remaining_before_usd=0.0,
+                    funded_slots=(),
+                    dropped_slots=(),
+                    slot_estimates_usd={},
+                    synthesis_estimate_usd=0.0,
+                    reason="budget_exhausted_before_phase=findings",
+                    binding_cap="per_day",
+                ),
+                active_roster=(),
+                missing_slots=(),
+                degrade_reasons=(),
+                failure_reason="budget_exhausted_before_phase=findings",
+                findings_by_slot={},
+                critiques_by_slot={},
+                synthesis=None,
+                resolutions=(),
+                availability_summary=ProviderSlotAvailabilitySummary(
+                    total_slots=0, resolved_slots=0
+                ),
+                actual_cost_usd=0.0,
+            )
+
+        monkeypatch.setattr(worker_mod, "run_protocol_b", _budget_exceeded)
+        worker = BriefGenerationWorker(max_concurrent=1)
+        set_worker(worker)
+        req = JobRequest(
+            key=_make_key(),
+            input=_make_input(),
+            invoker_factory=lambda: _DummyInvoker(),
+        )
+        fut = worker.submit(req)
+        fut.result(timeout=5)
+
+        state = storage.get_state(4242, "deadbeefcafe")
+        assert state == BriefLifecycleState.FAILED

--- a/tests/server/handlers/test_review_queue_brief.py
+++ b/tests/server/handlers/test_review_queue_brief.py
@@ -1,0 +1,536 @@
+"""Tests for the Mode 3 brief-generation HTTP endpoints."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from aragora.pdb import storage, worker as worker_mod
+from aragora.pdb.brief_state import BriefLifecycleState
+from aragora.pdb.input_loader import (
+    InputLoaderError,
+    InputLoaderErrorReason,
+    LoadedExecutionInput,
+)
+from aragora.pdb.protocol import (
+    PDBExecutionInput,
+    PDBExecutionResult,
+    PDBExecutionStatus,
+)
+from aragora.pdb.worker import BriefGenerationWorker, set_worker, reset_worker
+from aragora.review.policy import ReviewPolicy
+from aragora.review.provider_slots import ProviderSlotAvailabilitySummary
+from aragora.server.handlers import review_queue as rq
+from aragora.server.handlers import review_queue_brief as rqb
+from aragora.swarm.pr_review_protocol import PRReviewBinding, PRReviewProtocolPacket
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_storage(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARAGORA_REVIEW_QUEUE_ROOT", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    rq._review_queue_limiter._buckets.clear()
+
+
+@pytest.fixture(autouse=True)
+def _enable_flag(monkeypatch):
+    monkeypatch.setenv("ARAGORA_PDB_BRIEF_GENERATION_ENABLED", "1")
+
+
+@pytest.fixture(autouse=True)
+def _fresh_worker():
+    reset_worker()
+    yield
+    reset_worker()
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    rqb.set_test_invoker_factory(None)
+    rqb.set_test_input_loader(None)
+    yield
+    rqb.set_test_invoker_factory(None)
+    rqb.set_test_input_loader(None)
+
+
+@pytest.fixture
+def handler():
+    return rq.ReviewQueueHandler(ctx={})
+
+
+# ---------------------------------------------------------------------------
+# Mock request handler
+# ---------------------------------------------------------------------------
+
+
+def _mock_http_handler(method: str = "POST", body: bytes = b"") -> MagicMock:
+    h = MagicMock()
+    h.command = method
+    h.client_address = ("127.0.0.1", 11111)
+    h.headers = {
+        "Content-Length": str(len(body)),
+        "Content-Type": "application/json",
+        "Authorization": "Bearer test",
+        "Host": "localhost:8080",
+    }
+    h.rfile = MagicMock()
+    h.rfile.read.return_value = body
+    return h
+
+
+def _parse(result) -> dict[str, Any]:
+    return json.loads(result.body)
+
+
+# ---------------------------------------------------------------------------
+# Authentication stub
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _authed(monkeypatch):
+    # Bypass token auth — test handler always treats requests as authenticated.
+    class _StubUser:
+        user_id = "test-user"
+
+    def _fake_require_auth(self, handler):
+        return _StubUser(), None
+
+    monkeypatch.setattr(rq.ReviewQueueHandler, "require_auth_or_error", _fake_require_auth)
+
+
+# ---------------------------------------------------------------------------
+# Input-loader + invoker stubs
+# ---------------------------------------------------------------------------
+
+
+def _make_loaded_input(
+    *,
+    pr_number: int = 4242,
+    head_sha: str = "deadbeefcafe0011",
+    repo: str = "synaptent/aragora",
+) -> LoadedExecutionInput:
+    binding = PRReviewBinding(
+        repo=repo, pr_number=pr_number, base_sha="base000011", head_sha=head_sha
+    )
+    packet = PRReviewProtocolPacket(
+        protocol_version="pr_review_protocol.v1",
+        status="metadata_heuristic",
+        binding=binding,
+        review_roles=[],
+        provider_slots=[],
+        availability_summary=ProviderSlotAvailabilitySummary(total_slots=0, resolved_slots=0),
+        recommendation_class="needs_human_attention",
+        recommendation_reason="test",
+        confidence=0.5,
+        confidence_basis="metadata_heuristic",
+        dissent_summary="",
+        dissenting_views=[],
+        validation_summary={},
+        top_findings=[],
+        cost_estimate={},
+    )
+    exec_input = PDBExecutionInput(
+        binding=binding,
+        packet=packet,
+        packet_sha="",
+        pr_title="Test",
+        pr_body="",
+        labels=(),
+        changed_files=(),
+        diff_excerpt="",
+        validation_summary={},
+        panel_id="protocol_b_default",
+        policy=ReviewPolicy(),
+    )
+    return LoadedExecutionInput(
+        input=exec_input,
+        head_sha=head_sha,
+        base_sha=binding.base_sha,
+        panel_models=("slot_a", "slot_b"),
+        repo=repo,
+    )
+
+
+def _make_ready_result(
+    *, pr_number: int, head_sha: str, repo: str = "synaptent/aragora"
+) -> PDBExecutionResult:
+    from aragora.pdb.budget import PDBBudgetDecision, PDBBudgetStatus
+
+    class _FakeBrief:
+        def to_dict(self) -> dict[str, Any]:
+            return {
+                "pr_number": pr_number,
+                "head_sha": head_sha,
+                "verdict": "approve_candidate",
+                "confidence": 4,
+            }
+
+    return PDBExecutionResult(
+        status=PDBExecutionStatus.SUCCESS,
+        packet=PRReviewProtocolPacket(
+            protocol_version="pr_review_protocol.v1",
+            status="panel_executed",
+            binding=PRReviewBinding(
+                repo=repo, pr_number=pr_number, base_sha="b", head_sha=head_sha
+            ),
+            review_roles=[],
+            provider_slots=[],
+            availability_summary=ProviderSlotAvailabilitySummary(total_slots=0, resolved_slots=0),
+            recommendation_class="approve_candidate",
+            recommendation_reason="",
+            confidence=0.8,
+            confidence_basis="panel_executed",
+            dissent_summary="",
+            dissenting_views=[],
+            validation_summary={},
+            top_findings=[],
+            cost_estimate={},
+        ),
+        brief=_FakeBrief(),
+        budget_decision=PDBBudgetDecision(
+            status=PDBBudgetStatus.ALLOWED,
+            total_estimated_usd=0.0,
+            per_brief_cap_usd=10.0,
+            per_day_cap_usd=100.0,
+            per_day_spent_before_usd=0.0,
+            per_day_remaining_before_usd=100.0,
+            funded_slots=(),
+            dropped_slots=(),
+            slot_estimates_usd={},
+            synthesis_estimate_usd=0.0,
+            reason="allowed",
+            binding_cap=None,
+        ),
+        active_roster=(),
+        missing_slots=(),
+        degrade_reasons=(),
+        failure_reason=None,
+        findings_by_slot={},
+        critiques_by_slot={},
+        synthesis=None,
+        resolutions=(),
+        availability_summary=ProviderSlotAvailabilitySummary(total_slots=0, resolved_slots=0),
+        actual_cost_usd=1.23,
+    )
+
+
+def _install_loader(head_sha: str = "deadbeefcafe0011", pr_number: int = 4242) -> None:
+    def _loader(pr: int, repo, policy):
+        return _make_loaded_input(pr_number=pr, head_sha=head_sha)
+
+    rqb.set_test_input_loader(_loader)
+
+
+def _install_fast_invoker(monkeypatch) -> None:
+    def _run(input_, *, invoker):
+        return _make_ready_result(
+            pr_number=input_.binding.pr_number, head_sha=input_.binding.head_sha
+        )
+
+    monkeypatch.setattr(worker_mod, "run_protocol_b", _run)
+    rqb.set_test_invoker_factory(lambda: object())
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureFlagOff:
+    def test_generate_returns_503(self, handler, _authed, monkeypatch):
+        monkeypatch.delenv("ARAGORA_PDB_BRIEF_GENERATION_ENABLED", raising=False)
+        mock_h = _mock_http_handler("POST")
+        result = handler.handle_post("/api/v1/review-queue/prs/42/brief/generate", {}, mock_h)
+        assert result.status_code == 503
+
+    def test_state_returns_503(self, handler, monkeypatch):
+        monkeypatch.delenv("ARAGORA_PDB_BRIEF_GENERATION_ENABLED", raising=False)
+        mock_h = _mock_http_handler("GET")
+        result = handler.handle("/api/v1/review-queue/prs/42/brief/state", {}, mock_h)
+        assert result.status_code == 503
+
+    def test_delete_returns_503(self, handler, _authed, monkeypatch):
+        monkeypatch.delenv("ARAGORA_PDB_BRIEF_GENERATION_ENABLED", raising=False)
+        mock_h = _mock_http_handler("DELETE")
+        result = handler.handle_delete("/api/v1/review-queue/prs/42/brief/generate", {}, mock_h)
+        assert result.status_code == 503
+
+    def test_get_brief_and_list_still_work_when_flag_off(self, handler, monkeypatch):
+        monkeypatch.delenv("ARAGORA_PDB_BRIEF_GENERATION_ENABLED", raising=False)
+        # List PRs: gh unavailable is degraded but not 503.
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(rq, "_run_gh", lambda *a, **k: (127, "", "no gh"))
+            mock_h = _mock_http_handler("GET")
+            result = handler.handle("/api/v1/review-queue/prs", {}, mock_h)
+        assert result.status_code == 200
+        # GET brief: returns 404 when none on disk (flag-independent).
+        mock_h = _mock_http_handler("GET")
+        result = handler.handle("/api/v1/review-queue/prs/42/brief", {}, mock_h)
+        assert result.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Full state machine flow
+# ---------------------------------------------------------------------------
+
+
+class TestFullFlow:
+    def test_generate_then_state_becomes_ready(self, handler, _authed, monkeypatch):
+        _install_loader(head_sha="deadbeefcafe0011", pr_number=4242)
+        _install_fast_invoker(monkeypatch)
+        worker = BriefGenerationWorker(max_concurrent=2)
+        set_worker(worker)
+
+        mock_h = _mock_http_handler("POST", body=b"{}")
+        result = handler.handle_post("/api/v1/review-queue/prs/4242/brief/generate", {}, mock_h)
+        assert result.status_code == 202
+        data = _parse(result)
+        assert data["state"] == "queued"
+        assert data["head_sha"] == "deadbeefcafe0011"
+        assert data["estimated_completion_seconds"] > 0
+
+        # Poll /brief/state until ready.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            mock_h_state = _mock_http_handler("GET")
+            state_result = handler.handle(
+                "/api/v1/review-queue/prs/4242/brief/state", {}, mock_h_state
+            )
+            payload = _parse(state_result)
+            if payload["state"] == "ready":
+                break
+            time.sleep(0.05)
+
+        final = _parse(state_result)
+        assert final["state"] == "ready"
+        # Final GET /brief returns the brief payload.
+        mock_h_brief = _mock_http_handler("GET")
+        brief_result = handler.handle("/api/v1/review-queue/prs/4242/brief", {}, mock_h_brief)
+        assert brief_result.status_code == 200
+        brief_payload = _parse(brief_result)["brief"]
+        assert brief_payload["verdict"] == "approve_candidate"
+
+
+# ---------------------------------------------------------------------------
+# Dedupe
+# ---------------------------------------------------------------------------
+
+
+class TestDedupe:
+    def test_409_when_already_running(self, handler, _authed, monkeypatch):
+        _install_loader(head_sha="aaaa0000", pr_number=100)
+        import threading
+
+        release = threading.Event()
+
+        def _slow_run(input_, *, invoker):
+            release.wait(timeout=5)
+            return _make_ready_result(
+                pr_number=input_.binding.pr_number, head_sha=input_.binding.head_sha
+            )
+
+        monkeypatch.setattr(worker_mod, "run_protocol_b", _slow_run)
+        rqb.set_test_invoker_factory(lambda: object())
+
+        worker = BriefGenerationWorker(max_concurrent=2)
+        set_worker(worker)
+
+        first = handler.handle_post(
+            "/api/v1/review-queue/prs/100/brief/generate",
+            {},
+            _mock_http_handler("POST", body=b"{}"),
+        )
+        assert first.status_code == 202
+
+        # Wait for the state to reflect queued on disk.
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            s = storage.get_state(100, "aaaa0000")
+            if s in (BriefLifecycleState.QUEUED, BriefLifecycleState.RUNNING):
+                break
+            time.sleep(0.01)
+
+        second = handler.handle_post(
+            "/api/v1/review-queue/prs/100/brief/generate",
+            {},
+            _mock_http_handler("POST", body=b"{}"),
+        )
+        assert second.status_code == 409
+        body2 = _parse(second)
+        assert body2["state"] in ("queued", "running")
+
+        release.set()
+        # Let the first complete.
+        deadline = time.monotonic() + 5
+        while (
+            time.monotonic() < deadline
+            and storage.get_state(100, "aaaa0000") != BriefLifecycleState.READY
+        ):
+            time.sleep(0.05)
+
+
+# ---------------------------------------------------------------------------
+# Cancel
+# ---------------------------------------------------------------------------
+
+
+class TestCancel:
+    def test_delete_cancels_running_work(self, handler, _authed, monkeypatch):
+        _install_loader(head_sha="bbbb1111", pr_number=77)
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _blocking(input_, *, invoker):
+            started.set()
+            release.wait(timeout=5)
+            return _make_ready_result(
+                pr_number=input_.binding.pr_number, head_sha=input_.binding.head_sha
+            )
+
+        monkeypatch.setattr(worker_mod, "run_protocol_b", _blocking)
+        rqb.set_test_invoker_factory(lambda: object())
+
+        worker = BriefGenerationWorker(max_concurrent=1)
+        set_worker(worker)
+
+        result = handler.handle_post(
+            "/api/v1/review-queue/prs/77/brief/generate",
+            {},
+            _mock_http_handler("POST", body=b"{}"),
+        )
+        assert result.status_code == 202
+        assert started.wait(timeout=2)
+
+        del_result = handler.handle_delete(
+            "/api/v1/review-queue/prs/77/brief/generate",
+            {},
+            _mock_http_handler("DELETE"),
+        )
+        assert del_result.status_code == 200
+        body = _parse(del_result)
+        assert body["cancelled"] is True
+        assert body["worker_cancelled"] is True
+
+        release.set()
+        # Eventually we should see failed.
+        deadline = time.monotonic() + 3
+        while (
+            time.monotonic() < deadline
+            and storage.get_state(77, "bbbb1111") != BriefLifecycleState.FAILED
+        ):
+            time.sleep(0.02)
+        assert storage.get_state(77, "bbbb1111") == BriefLifecycleState.FAILED
+
+    def test_delete_no_active_returns_200_with_state(self, handler, _authed, monkeypatch):
+        _install_loader(head_sha="eeee3333", pr_number=5)
+        worker = BriefGenerationWorker(max_concurrent=1)
+        set_worker(worker)
+        del_result = handler.handle_delete(
+            "/api/v1/review-queue/prs/5/brief/generate",
+            {},
+            _mock_http_handler("DELETE"),
+        )
+        assert del_result.status_code == 200
+        body = _parse(del_result)
+        assert body["cancelled"] is False
+        assert body["state"] == "absent"
+
+
+# ---------------------------------------------------------------------------
+# Stale invalidation
+# ---------------------------------------------------------------------------
+
+
+class TestStaleInvalidation:
+    def test_old_ready_brief_moved_on_new_head(self, handler, _authed, monkeypatch, tmp_path):
+        # Pre-seed a ready brief with an old head SHA.
+        briefs_root = tmp_path / "briefs"
+        briefs_root.mkdir(parents=True, exist_ok=True)
+        old_file = briefs_root / "pr-321-oldsha000000.json"
+        old_file.write_text(
+            json.dumps(
+                {
+                    "pr_number": 321,
+                    "head_sha": "oldsha00000011223344",
+                    "verdict": "approve_candidate",
+                    "confidence": 4,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        _install_loader(head_sha="newsha99999900", pr_number=321)
+        _install_fast_invoker(monkeypatch)
+        worker = BriefGenerationWorker(max_concurrent=1)
+        set_worker(worker)
+
+        result = handler.handle_post(
+            "/api/v1/review-queue/prs/321/brief/generate",
+            {},
+            _mock_http_handler("POST", body=b"{}"),
+        )
+        assert result.status_code == 202
+
+        # Old brief has been moved to invalidated/
+        invalidated = briefs_root / "invalidated" / "pr-321-oldsha000000.json"
+        assert invalidated.exists()
+        assert not old_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Input loader errors surfacing as HTTP codes
+# ---------------------------------------------------------------------------
+
+
+class TestLoaderErrors:
+    def test_pr_not_found_returns_404(self, handler, _authed):
+        def _raise(pr, repo, policy):
+            raise InputLoaderError(InputLoaderErrorReason.PR_NOT_FOUND, "no such PR")
+
+        rqb.set_test_input_loader(_raise)
+        result = handler.handle_post(
+            "/api/v1/review-queue/prs/999/brief/generate",
+            {},
+            _mock_http_handler("POST", body=b"{}"),
+        )
+        assert result.status_code == 404
+
+    def test_gh_missing_returns_503(self, handler, _authed):
+        def _raise(pr, repo, policy):
+            raise InputLoaderError(InputLoaderErrorReason.GH_MISSING, "")
+
+        rqb.set_test_input_loader(_raise)
+        result = handler.handle_post(
+            "/api/v1/review-queue/prs/999/brief/generate",
+            {},
+            _mock_http_handler("POST", body=b"{}"),
+        )
+        assert result.status_code == 503
+
+    def test_auth_returns_403(self, handler, _authed):
+        def _raise(pr, repo, policy):
+            raise InputLoaderError(InputLoaderErrorReason.GH_AUTHENTICATION, "")
+
+        rqb.set_test_input_loader(_raise)
+        result = handler.handle_post(
+            "/api/v1/review-queue/prs/999/brief/generate",
+            {},
+            _mock_http_handler("POST", body=b"{}"),
+        )
+        assert result.status_code == 403


### PR DESCRIPTION
PR 3 of the Mode 3 on-demand PDB brief-generation rollout
(docs/plans/2026-04-20-pdb-brief-generation-mode3-design.md §PR 3,
builds on PR 1 (#6369, merged) and PR 2 (#6389, still open)).

After this PR lands, \`curl -X POST /api/v1/review-queue/prs/N/brief/generate\`
produces a real brief end-to-end. No UI dependency; PR 4 layers the modal
on top.

## Dependency on PR 2 (#6389)

PR 2 (\`codex/pdb-mode3-executor\`) has not merged yet. Its commit
(\`615768eb — feat(pdb): PR 2 — Protocol B executor + panel config + budget\`)
has been **cherry-picked** onto this branch as the first commit so
reviewers can run the full test suite. When PR 2 merges to main, this
branch will rebase cleanly — the cherry-picked commit drops and only
this PR's single commit remains on top of main.

## New files

| File | Responsibility |
|---|---|
| \`aragora/pdb/input_loader.py\` | \`gh\`-backed \`PDBExecutionInput\` builder. Returns a \`LoadedExecutionInput\` (input + head_sha + repo) and typed \`InputLoaderErrorReason\` values for HTTP status mapping. |
| \`aragora/pdb/worker.py\` | \`BriefGenerationWorker\` singleton. \`asyncio.Semaphore(max_concurrent)\` bounded concurrency + dedupe by \`(repo, pr_number, head_sha)\`. Owns its own background event loop thread so sync HTTP handlers can hand work off without blocking. Cancel → best-effort + failed record via storage. |
| \`aragora/server/handlers/review_queue_brief.py\` | \`handle_generate\` / \`handle_state\` / \`handle_cancel\` module functions, feature-flag-gated. Stale-SHA invalidation runs on every generate call. |

## Light touches

- \`aragora/server/handlers/review_queue.py\` — dispatch new route paths
  to the new module. Existing approve / request-changes / defer /
  GET brief paths untouched.

## New tests (45 new tests)

- \`tests/pdb/test_input_loader.py\` (22 tests): happy path; diff
  truncation; repo override; gh-missing, timeout, PR-not-found,
  authentication, malformed, empty-head-sha, non-object-json error
  cases; helpers.
- \`tests/pdb/test_worker.py\` (11 tests): lifecycle; singleton;
  queued→running→ready happy path; dedupe returns 409; semaphore cap
  verified with \`max_concurrent=2\` and 3 submitted jobs; cancel mid-run
  records failed; executor exception records failed; budget-exceeded
  executor result maps to failed record.
- \`tests/server/handlers/test_review_queue_brief.py\` (12 tests):
  feature flag off → 503 on all three endpoints while existing \`GET /brief\`
  + \`/review-queue\` still work; full state machine via HTTP
  (queued→running→ready); concurrent POSTs → 409; DELETE cancels running
  and records failed; DELETE on absent → 200 with \`cancelled=false\`;
  stale ready briefs moved to \`invalidated/\` on new head; loader
  errors (404/503/403) surface to HTTP.

All 235 tests in \`tests/pdb/\` + review_queue handler tests pass locally.

## Feature flag

\`ARAGORA_PDB_BRIEF_GENERATION_ENABLED=1\` — default OFF. With flag off:

- \`POST /brief/generate\` → 503
- \`GET /brief/state\` → 503
- \`DELETE /brief/generate\` → 503
- \`GET /brief\` (existing) — unchanged
- \`GET /review-queue/prs\` (existing) — unchanged

## State machine flow

\`\`\`
absent ──POST──▶ queued ──worker picks up──▶ running ──success──▶ ready
                   │                          │
                   │                          └─cancel/exception▶ failed
                   │
                   └─DELETE (queued)▶ absent

ready ──new head SHA on POST/GET──▶ invalidated/  (stale)
\`\`\`

## Acceptance criteria (all satisfied)

- ✅ Full state-machine HTTP flow: \`test_generate_then_state_becomes_ready\`
- ✅ Dedupe: \`test_409_when_already_running\`
- ✅ Cancel correctness: \`test_delete_cancels_running_work\`,
  \`test_delete_no_active_returns_200_with_state\`
- ✅ Feature flag off: \`TestFeatureFlagOff\` class (4 tests)
- ✅ Stale invalidation: \`test_old_ready_brief_moved_on_new_head\`
- ✅ Existing endpoints unchanged: \`tests/server/handlers/test_review_queue.py\`
  passes without modification (26 tests)

## Non-goals (deferred)

- UI: \`useReviewQueue\` hook additions, \`ApproveDecisionModal\`,
  \`BriefPanel\` state-aware rendering — PR 4
- Webhook mode (Mode 1), batch mode (Mode 2), Protocol C — out of scope
- Real ProviderInvoker wiring — PR 4 (tests inject a mock via
  \`set_test_invoker_factory\`)
- CLI brief integration — out of scope
- Changes to approve/request-changes/defer/GET brief — unchanged

## Validation

\`\`\`bash
pytest tests/pdb/ tests/server/handlers/test_review_queue.py \\
       tests/server/handlers/test_review_queue_brief.py -q
# 235 passed

ruff check + format aragora/pdb/ aragora/server/handlers/ tests/pdb/ \\
       tests/server/handlers/
# All checks passed

python3 -m mypy aragora/pdb/ aragora/server/handlers/review_queue_brief.py \\
       aragora/server/handlers/review_queue.py
# Success: no issues found

bash scripts/automation_pr_preflight.sh origin/main HEAD
# preflight: ok
\`\`\`

## What lands next

PR 4 adds the UI modal and polling integration. At that point the
Mode 3 slice is complete — founder can click "Generate brief" on a PR
card, watch queued → running → ready, and see the role-structured
brief render in \`BriefPanel\`.