### PR TITLE
feat(epistemic): salvage quarantine policy, repair spec, and stress test helpers

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -1,4 +1,4 @@
-"""Epistemic CI and crux-engine helpers (DIC-13..22 + DIC-26 tranche).
+"""Epistemic CI and crux-engine helpers (DIC-13..22 + DIC-25/26 tranche).
 
 Exposes:
 - DIC-14: executable claim verification (:class:`ClaimVerifier`)
@@ -15,12 +15,18 @@ Exposes:
 - DIC-21: fail-closed quarantine policy (:class:`QuarantineDecision`,
   :class:`QuarantinePolicy`, :func:`apply_quarantine_policy`,
   :func:`quarantine_policy_enabled`)
+- DIC-22: bounded repair-spec producer (:class:`RepairSpec`,
+  :func:`propose_repair`, :func:`repair_pipeline_enabled`)
+- DIC-25: adversarial world-state stress-test (:class:`StressPerturbation`,
+  :class:`FragilityReport`, :class:`StressTestResult`,
+  :func:`run_stress_test`, :func:`stress_test_enabled`)
+  Flag gate: ``ARAGORA_STRESS_TEST_ENABLED`` (default off).
 - DIC-26: belief coherence monitor (:class:`BeliefEntry`,
   :class:`CoherenceReport`, :func:`scan_coherence`)
 
 See ``docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md`` for the full
-DIC-13..22 sequence and ``docs/status/NEXT_STEPS_CANONICAL.md`` for
-the queue-governance activation gate.
+DIC-13..22 + DIC-23..28 sequence and ``docs/status/NEXT_STEPS_CANONICAL.md``
+for the queue-governance activation gate.
 """
 
 from __future__ import annotations
@@ -59,6 +65,19 @@ from .quarantine_policy import (
     apply_quarantine_policy,
     quarantine_policy_enabled,
 )
+from .repair import (
+    RepairSpec,
+    enable_repair_pipeline,
+    propose_repair,
+    repair_pipeline_enabled,
+)
+from .stress_test import (
+    FragilityReport,
+    StressPerturbation,
+    StressTestResult,
+    run_stress_test,
+    stress_test_enabled,
+)
 from .truth_map import (
     OrgTruthMapReport,
     build_truth_map,
@@ -79,9 +98,13 @@ __all__ = [
     "DecayReason",
     "DecaySignal",
     "FollowupProposal",
+    "FragilityReport",
     "OrgTruthMapReport",
     "QuarantineDecision",
     "QuarantinePolicy",
+    "RepairSpec",
+    "StressPerturbation",
+    "StressTestResult",
     "IncoherenceKind",
     "apply_quarantine_policy",
     "build_crux_receipt",
@@ -91,14 +114,19 @@ __all__ = [
     "crux_receipt_enabled",
     "enable_crux_receipt",
     "enable_epistemic_followup",
+    "enable_repair_pipeline",
     "epistemic_followup_enabled",
     "evaluate_unit",
     "from_belief_node",
     "propose_followup_for_crux",
     "propose_followup_for_cruxset",
     "propose_followup_for_failed_claim",
+    "propose_repair",
     "quarantine_policy_enabled",
+    "repair_pipeline_enabled",
+    "run_stress_test",
     "scan_coherence",
+    "stress_test_enabled",
 ]
 
 

--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -1,4 +1,4 @@
-"""Epistemic CI and crux-engine helpers (DIC-13..22 tranche).
+"""Epistemic CI and crux-engine helpers (DIC-13..22 + DIC-26 tranche).
 
 Exposes:
 - DIC-14: executable claim verification (:class:`ClaimVerifier`)
@@ -8,8 +8,13 @@ Exposes:
   sharply-losing claims (:class:`FollowupProposal`,
   :func:`propose_followup_for_crux`, :func:`propose_followup_for_cruxset`,
   :func:`propose_followup_for_failed_claim`)
+- DIC-18: organizational truth map report (:class:`OrgTruthMapReport`,
+  :func:`build_truth_map`, :func:`build_truth_map_from_manifests`)
 - DIC-20: epistemic decay monitor (:class:`DecaySignal`,
   :class:`DecayReason`, :func:`evaluate_unit`)
+- DIC-21: fail-closed quarantine policy (:class:`QuarantineDecision`,
+  :class:`QuarantinePolicy`, :func:`apply_quarantine_policy`,
+  :func:`quarantine_policy_enabled`)
 - DIC-26: belief coherence monitor (:class:`BeliefEntry`,
   :class:`CoherenceReport`, :func:`scan_coherence`)
 
@@ -48,6 +53,17 @@ from .followup import (
     propose_followup_for_cruxset,
     propose_followup_for_failed_claim,
 )
+from .quarantine_policy import (
+    QuarantineDecision,
+    QuarantinePolicy,
+    apply_quarantine_policy,
+    quarantine_policy_enabled,
+)
+from .truth_map import (
+    OrgTruthMapReport,
+    build_truth_map,
+    build_truth_map_from_manifests,
+)
 
 __all__ = [
     "BeliefEntry",
@@ -63,8 +79,14 @@ __all__ = [
     "DecayReason",
     "DecaySignal",
     "FollowupProposal",
+    "OrgTruthMapReport",
+    "QuarantineDecision",
+    "QuarantinePolicy",
     "IncoherenceKind",
+    "apply_quarantine_policy",
     "build_crux_receipt",
+    "build_truth_map",
+    "build_truth_map_from_manifests",
     "coherence_monitor_enabled",
     "crux_receipt_enabled",
     "enable_crux_receipt",
@@ -75,6 +97,7 @@ __all__ = [
     "propose_followup_for_crux",
     "propose_followup_for_cruxset",
     "propose_followup_for_failed_claim",
+    "quarantine_policy_enabled",
     "scan_coherence",
 ]
 

--- a/aragora/epistemic/quarantine_policy.py
+++ b/aragora/epistemic/quarantine_policy.py
@@ -1,0 +1,174 @@
+"""Fail-closed quarantine policy for proof-carrying code units (DIC-21 / #6032).
+
+Translates a :class:`~aragora.epistemic.decay_monitor.DecaySignal` into a
+concrete :class:`QuarantineDecision`. Three invariants are non-negotiable:
+
+1. Live routing is always blocked unless the unit ID is in a non-empty
+   ``live_swap_allowlist``.
+2. Integrity below ``fail_closed_threshold`` always produces ``"fail_closed"``.
+3. Every non-``report_only`` decision carries a deterministic SHA-256
+   provenance hash for downstream receipt generation.
+
+Flag gate: ``ARAGORA_QUARANTINE_POLICY_ENABLED`` (default off).
+Building and inspecting decisions is always safe; acting on them must be
+gated. DIC-22 (Verified Replacement Pipeline) consumes
+:class:`QuarantineDecision` to produce bounded repair specs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from aragora.epistemic.decay_monitor import DecaySignal
+
+PolicyAction = Literal[
+    "report_only", "degrade", "fallback", "quarantine", "repair_required", "fail_closed"
+]
+
+_RANK: dict[str, int] = {
+    "report_only": 0,
+    "degrade": 1,
+    "fallback": 2,
+    "quarantine": 3,
+    "repair_required": 4,
+    "fail_closed": 5,
+}
+_RANK_TO_ACTION: dict[int, PolicyAction] = {v: k for k, v in _RANK.items()}  # type: ignore[misc]
+
+
+@dataclass(frozen=True)
+class EscalationMap:
+    report_only: PolicyAction = "report_only"
+    repair_required: PolicyAction = "repair_required"
+    fail_closed: PolicyAction = "fail_closed"
+
+    def resolve(self, action: str) -> PolicyAction:
+        return getattr(self, action, "fail_closed")  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class QuarantinePolicy:
+    code_unit_class: str = "default"
+    escalation_map: EscalationMap = field(default_factory=EscalationMap)
+    fail_closed_threshold: float = 0.4
+    live_swap_allowlist: frozenset[str] = field(default_factory=frozenset)
+
+
+DEFAULT_POLICIES: dict[str, QuarantinePolicy] = {
+    "live_dispatch": QuarantinePolicy(
+        code_unit_class="live_dispatch",
+        escalation_map=EscalationMap(report_only="report_only", repair_required="quarantine"),
+        fail_closed_threshold=0.6,
+    ),
+    "report_surface": QuarantinePolicy(
+        code_unit_class="report_surface",
+        escalation_map=EscalationMap(report_only="report_only", repair_required="degrade"),
+        fail_closed_threshold=0.3,
+    ),
+    "demo": QuarantinePolicy(
+        code_unit_class="demo",
+        escalation_map=EscalationMap(report_only="report_only", repair_required="fallback"),
+        fail_closed_threshold=0.2,
+    ),
+    "pure_policy": QuarantinePolicy(code_unit_class="pure_policy"),
+    "default": QuarantinePolicy(),
+}
+
+
+@dataclass
+class QuarantineDecision:
+    code_unit_id: str
+    policy_action: PolicyAction
+    rationale: str
+    provenance_hash: str  # SHA-256; empty for report_only
+    fail_closed: bool
+    live_swap_blocked: bool
+    integrity_score: float
+
+    def to_dict(self) -> dict:
+        return {
+            "code_unit_id": self.code_unit_id,
+            "policy_action": self.policy_action,
+            "rationale": self.rationale,
+            "provenance_hash": self.provenance_hash,
+            "fail_closed": self.fail_closed,
+            "live_swap_blocked": self.live_swap_blocked,
+            "integrity_score": self.integrity_score,
+        }
+
+
+def apply_quarantine_policy(
+    signal: "DecaySignal",
+    policy: QuarantinePolicy | None = None,
+    *,
+    code_unit_class: str = "default",
+    request_live_swap: bool = False,
+) -> QuarantineDecision:
+    """Apply policy to a decay signal. Pure function — no side effects."""
+    if policy is None:
+        policy = DEFAULT_POLICIES.get(code_unit_class, DEFAULT_POLICIES["default"])
+
+    uid, score = signal.code_unit_id, signal.integrity_score
+    is_fail_closed = score < policy.fail_closed_threshold
+
+    if is_fail_closed:
+        action: PolicyAction = "fail_closed"
+        rationale = (
+            f"Integrity {score:.3f} < threshold {policy.fail_closed_threshold:.3f} "
+            f"(class={policy.code_unit_class!r})."
+        )
+    else:
+        action = policy.escalation_map.resolve(signal.recommended_action)
+        rationale = (
+            f"Signal recommended {signal.recommended_action!r}; "
+            f"escalated to {action!r} (class={policy.code_unit_class!r})."
+        )
+
+    live_swap_blocked = True
+    if request_live_swap and policy.live_swap_allowlist and uid in policy.live_swap_allowlist:
+        live_swap_blocked = False
+        rationale += f" Live routing permitted (allowlist: {uid!r})."
+    elif request_live_swap:
+        if _RANK.get(action, 0) < _RANK["quarantine"]:
+            action = "quarantine"
+        rationale += f" Live routing blocked: {uid!r} not in allowlist."
+
+    if action != "report_only":
+        material = json.dumps(
+            {
+                "code_unit_id": uid,
+                "integrity_score": score,
+                "recommended_action": signal.recommended_action,
+                "policy_action": action,
+                "reason_kinds": sorted({r.kind for r in signal.reasons}),
+            },
+            sort_keys=True,
+        )
+        provenance_hash = hashlib.sha256(material.encode()).hexdigest()
+    else:
+        provenance_hash = ""
+
+    return QuarantineDecision(
+        code_unit_id=uid,
+        policy_action=action,
+        rationale=rationale,
+        provenance_hash=provenance_hash,
+        fail_closed=is_fail_closed,
+        live_swap_blocked=live_swap_blocked,
+        integrity_score=score,
+    )
+
+
+def quarantine_policy_enabled() -> bool:
+    """Return True when ``ARAGORA_QUARANTINE_POLICY_ENABLED`` is set. Default: False."""
+    return str(os.environ.get("ARAGORA_QUARANTINE_POLICY_ENABLED") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }

--- a/aragora/epistemic/repair.py
+++ b/aragora/epistemic/repair.py
@@ -1,0 +1,163 @@
+"""Bounded repair-spec producer for decayed proof-carrying code units (DIC-22 / #6033).
+
+Turns a :class:`~aragora.epistemic.decay_monitor.DecaySignal` into a
+:class:`RepairSpec` — a bounded, auditable repair candidate that can be
+reviewed by an operator, submitted as a PR, or run in shadow mode.
+
+Invariants (never relaxed):
+- ``repair_kind`` defaults to ``"report_only"``.
+- ``"live_swap"`` is permanently blocked — raises ``ValueError`` unconditionally.
+- Non-``"report_only"`` kinds require ``ARAGORA_REPAIR_PIPELINE_ENABLED``.
+- Every non-``"report_only"`` spec carries a 64-char SHA-256 provenance hash.
+- No queue mutation, no live dispatch routing, no issue creation.
+
+``repair.py`` produces the *spec*; downstream code (Arena debate, verifier
+calls, PR creation) is deferred to consumers of :class:`RepairSpec`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from aragora.epistemic.decay_monitor import DecaySignal
+
+RepairKind = Literal["report_only", "shadow_candidate", "pr_candidate"]
+
+_BLOCKED_KINDS: frozenset[str] = frozenset({"live_swap"})
+_ALLOWED_KINDS: frozenset[str] = frozenset({"report_only", "shadow_candidate", "pr_candidate"})
+
+
+def repair_pipeline_enabled() -> bool:
+    """Return True when non-report-only repairs are permitted for this process."""
+    raw = str(os.environ.get("ARAGORA_REPAIR_PIPELINE_ENABLED") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_repair_pipeline() -> None:
+    """Enable non-report-only repair specs for the current process (tests/demo)."""
+    os.environ["ARAGORA_REPAIR_PIPELINE_ENABLED"] = "1"
+
+
+@dataclass(frozen=True)
+class RepairSpec:
+    """Bounded repair candidate produced from a DecaySignal.
+
+    ``repair_kind`` is ``"report_only"`` by default.  ``"shadow_candidate"``
+    runs the replacement in parallel without routing; ``"pr_candidate"`` emits a
+    draft PR for human review.  ``"live_swap"`` is permanently blocked.
+
+    Non-``"report_only"`` specs carry a 64-char SHA-256 ``provenance_hash``
+    over their canonical content; report-only specs have an empty hash.
+    """
+
+    spec_id: str
+    code_unit_id: str
+    decay_signal: DecaySignal
+    repair_kind: RepairKind
+    linked_claims: list[str]
+    linked_crux_ids: list[str]
+    validation_commands: list[str]
+    receipt_context: dict[str, Any]
+    proposed_patch: str
+    created_at: str
+    provenance_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["decay_signal"] = self.decay_signal.to_dict()
+        return d
+
+
+def propose_repair(
+    decay_signal: DecaySignal,
+    *,
+    repair_kind: RepairKind = "report_only",
+    linked_claims: list[str] | None = None,
+    linked_crux_ids: list[str] | None = None,
+    validation_commands: list[str] | None = None,
+    receipt_context: dict[str, Any] | None = None,
+    proposed_patch: str = "",
+) -> RepairSpec:
+    """Build a :class:`RepairSpec` from a :class:`DecaySignal`.
+
+    ``linked_claims`` and ``linked_crux_ids`` default to claim/crux IDs
+    extracted from ``decay_signal.reasons`` when not provided.
+    """
+    if repair_kind in _BLOCKED_KINDS:
+        raise ValueError(
+            f"repair_kind {repair_kind!r} is permanently blocked; "
+            "live hot-swap may not be produced by propose_repair"
+        )
+    if repair_kind not in _ALLOWED_KINDS:
+        raise ValueError(
+            f"repair_kind {repair_kind!r} is not a known kind; "
+            f"expected one of {sorted(_ALLOWED_KINDS)}"
+        )
+    if repair_kind != "report_only" and not repair_pipeline_enabled():
+        raise ValueError(
+            f"repair_kind {repair_kind!r} requires ARAGORA_REPAIR_PIPELINE_ENABLED=1; "
+            "set the flag or use repair_kind='report_only'"
+        )
+
+    claims: list[str] = list(linked_claims or [])
+    if not claims:
+        claims = [r.claim_id for r in decay_signal.reasons if r.claim_id]
+
+    crux_ids: list[str] = list(linked_crux_ids or [])
+    if not crux_ids:
+        crux_ids = [r.crux_id for r in decay_signal.reasons if r.crux_id]
+
+    commands = list(validation_commands or [])
+    context: dict[str, Any] = dict(receipt_context or {"code_unit_id": decay_signal.code_unit_id})
+    created_at = datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+    id_material = {
+        "code_unit_id": decay_signal.code_unit_id,
+        "integrity_score": decay_signal.integrity_score,
+        "repair_kind": repair_kind,
+        "created_at": created_at,
+    }
+    digest = hashlib.sha256(json.dumps(id_material, sort_keys=True).encode()).hexdigest()[:16]
+    spec_id = f"repair-{digest}"
+
+    provenance_hash = ""
+    if repair_kind != "report_only":
+        hash_material = {
+            "spec_id": spec_id,
+            "code_unit_id": decay_signal.code_unit_id,
+            "repair_kind": repair_kind,
+            "linked_claims": sorted(claims),
+            "linked_crux_ids": sorted(crux_ids),
+            "created_at": created_at,
+        }
+        provenance_hash = hashlib.sha256(
+            json.dumps(hash_material, sort_keys=True).encode()
+        ).hexdigest()
+
+    return RepairSpec(
+        spec_id=spec_id,
+        code_unit_id=decay_signal.code_unit_id,
+        decay_signal=decay_signal,
+        repair_kind=repair_kind,
+        linked_claims=claims,
+        linked_crux_ids=crux_ids,
+        validation_commands=commands,
+        receipt_context=context,
+        proposed_patch=proposed_patch,
+        created_at=created_at,
+        provenance_hash=provenance_hash,
+    )
+
+
+__all__ = [
+    "RepairKind",
+    "RepairSpec",
+    "enable_repair_pipeline",
+    "propose_repair",
+    "repair_pipeline_enabled",
+]

--- a/aragora/epistemic/stress_test.py
+++ b/aragora/epistemic/stress_test.py
@@ -1,0 +1,248 @@
+"""Adversarial world-state stress-test (DIC-25 / #6219).
+
+Operator-curated catalog of plausible-future perturbations (CVE drops,
+API rate-limit shifts, corpus revisions, dependency drops) that probe
+proof-carrying code units *offline* and report fragility deltas before
+reality invalidates them.
+
+Flag gate
+---------
+``ARAGORA_STRESS_TEST_ENABLED`` must be truthy (``1``/``true``/``yes``/``on``)
+for ``run_stress_test()`` to proceed.  Constructing ``StressPerturbation``
+and ``FragilityReport`` objects is always safe; only the aggregate runner
+requires the flag so report-only consumers can freely build objects for
+inspection without enabling the gate.
+
+Live queue effect
+-----------------
+None.  All results are report-only.  No issue creation, no queue mutation,
+no dispatch changes.  Activation gate: DIC-20/21/22 production-green plus
+the same proof-first Foreman gate that governs the entire DIC-23..28
+dialectical-runtime-synthesis layer.
+
+See
+---
+- ``docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md`` §DIC-25
+- Issue: https://github.com/synaptent/aragora/issues/6219
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+PerturbationKind = Literal[
+    "cve_drop",
+    "api_rate_limit_shift",
+    "corpus_revision",
+    "dependency_drop",
+    "claim_evidence_stale",
+    "receipt_missing",
+    "verifier_error",
+]
+
+
+def stress_test_enabled(*, override: bool | None = None) -> bool:
+    """Return True when the stress-test subsystem is enabled.
+
+    Priority: ``override`` kwarg > ``ARAGORA_STRESS_TEST_ENABLED`` env var.
+    Default: False.
+    """
+    if override is not None:
+        return override
+    raw = os.environ.get("ARAGORA_STRESS_TEST_ENABLED", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Data contracts
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StressPerturbation:
+    """A single plausible-future world-state perturbation.
+
+    ``simulated_impact`` is the fraction of integrity lost (0.0-1.0) when
+    this perturbation strikes an in-scope proof unit.  An empty
+    ``affected_proof_unit_ids`` list means *all* units are in scope.
+    """
+
+    perturbation_id: str
+    kind: PerturbationKind
+    description: str
+    simulated_impact: float = 0.0
+    affected_claim_ids: list[str] = field(default_factory=list)
+    affected_proof_unit_ids: list[str] = field(default_factory=list)
+    source: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "perturbation_id": self.perturbation_id,
+            "kind": self.kind,
+            "description": self.description,
+            "simulated_impact": self.simulated_impact,
+            "affected_claim_ids": self.affected_claim_ids,
+            "affected_proof_unit_ids": self.affected_proof_unit_ids,
+            "source": self.source,
+        }
+
+
+@dataclass
+class FragilityReport:
+    """Fragility assessment for one proof unit under one perturbation."""
+
+    proof_unit_id: str
+    perturbation_id: str
+    baseline_integrity: float
+    stressed_integrity: float
+    fragility_delta: float
+    reason: str
+    recommended_action: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "proof_unit_id": self.proof_unit_id,
+            "perturbation_id": self.perturbation_id,
+            "baseline_integrity": self.baseline_integrity,
+            "stressed_integrity": self.stressed_integrity,
+            "fragility_delta": self.fragility_delta,
+            "reason": self.reason,
+            "recommended_action": self.recommended_action,
+        }
+
+
+@dataclass
+class StressTestResult:
+    """Aggregate result of a stress-test run across all perturbations × units."""
+
+    perturbations_tested: int
+    proof_units_probed: int
+    reports: list[FragilityReport] = field(default_factory=list)
+    most_fragile_unit_id: str = ""
+    max_fragility_delta: float = 0.0
+
+    @property
+    def high_fragility_units(self) -> list[FragilityReport]:
+        """Reports where fragility_delta > 0.3 — warrant operator attention."""
+        return [r for r in self.reports if r.fragility_delta > 0.3]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "perturbations_tested": self.perturbations_tested,
+            "proof_units_probed": self.proof_units_probed,
+            "reports": [r.to_dict() for r in self.reports],
+            "most_fragile_unit_id": self.most_fragile_unit_id,
+            "max_fragility_delta": self.max_fragility_delta,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_ACTION_THRESHOLDS: tuple[tuple[float, float, str], ...] = (
+    # (max_stressed_integrity, min_fragility_delta, action)
+    # Ordered from most-severe to least; first match wins.
+    (0.3, 0.0, "fail_closed"),
+    (1.0, 0.4, "repair_required"),
+    (1.0, 0.2, "monitor"),
+)
+
+
+def _recommended_action(fragility_delta: float, stressed_integrity: float) -> str:
+    for max_stressed, min_delta, action in _ACTION_THRESHOLDS:
+        if stressed_integrity <= max_stressed and fragility_delta >= min_delta:
+            return action
+    return "pass"
+
+
+def _probe_unit(
+    proof_unit_id: str,
+    baseline_integrity: float,
+    perturbation: StressPerturbation,
+) -> FragilityReport:
+    in_scope = (
+        not perturbation.affected_proof_unit_ids
+        or proof_unit_id in perturbation.affected_proof_unit_ids
+    )
+    if in_scope:
+        stressed = round(max(0.0, baseline_integrity - perturbation.simulated_impact), 4)
+        delta = round(baseline_integrity - stressed, 4)
+        reason = f"{perturbation.kind}: {perturbation.description[:120]}"
+    else:
+        stressed = round(baseline_integrity, 4)
+        delta = 0.0
+        reason = "not in perturbation scope"
+
+    return FragilityReport(
+        proof_unit_id=proof_unit_id,
+        perturbation_id=perturbation.perturbation_id,
+        baseline_integrity=round(baseline_integrity, 4),
+        stressed_integrity=stressed,
+        fragility_delta=delta,
+        reason=reason,
+        recommended_action=_recommended_action(delta, stressed),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_stress_test(
+    perturbations: list[StressPerturbation],
+    proof_unit_integrities: dict[str, float],
+    *,
+    enabled: bool | None = None,
+) -> StressTestResult:
+    """Run offline stress-tests for all perturbations × proof units.
+
+    Args:
+        perturbations: Operator-curated catalog of plausible-future
+            perturbations.
+        proof_unit_integrities: Mapping of ``proof_unit_id`` →
+            current integrity score (0.0–1.0) from the DIC-20 decay
+            monitor (``evaluate_unit``).
+        enabled: Explicit override for the flag gate.  Pass ``True``
+            in tests to bypass the env-var check.
+
+    Returns:
+        :class:`StressTestResult` with per-unit fragility reports.
+        Always report-only; no queue mutation.
+
+    Raises:
+        RuntimeError: When the flag gate is off and ``enabled`` is not
+            ``True``.
+    """
+    if not stress_test_enabled(override=enabled):
+        raise RuntimeError(
+            "Stress-test subsystem is disabled. "
+            "Set ARAGORA_STRESS_TEST_ENABLED=1 to enable, "
+            "or pass enabled=True in tests."
+        )
+
+    reports: list[FragilityReport] = []
+    for perturbation in perturbations:
+        for unit_id, baseline in proof_unit_integrities.items():
+            reports.append(_probe_unit(unit_id, baseline, perturbation))
+
+    if reports:
+        max_delta = max(r.fragility_delta for r in reports)
+        most_fragile = next(
+            (r.proof_unit_id for r in reports if r.fragility_delta == max_delta),
+            "",
+        )
+    else:
+        max_delta = 0.0
+        most_fragile = ""
+
+    return StressTestResult(
+        perturbations_tested=len(perturbations),
+        proof_units_probed=len(proof_unit_integrities),
+        reports=reports,
+        most_fragile_unit_id=most_fragile,
+        max_fragility_delta=round(max_delta, 4),
+    )

--- a/aragora/epistemic/stress_test.py
+++ b/aragora/epistemic/stress_test.py
@@ -1,29 +1,9 @@
 """Adversarial world-state stress-test (DIC-25 / #6219).
 
-Operator-curated catalog of plausible-future perturbations (CVE drops,
-API rate-limit shifts, corpus revisions, dependency drops) that probe
-proof-carrying code units *offline* and report fragility deltas before
-reality invalidates them.
-
-Flag gate
----------
-``ARAGORA_STRESS_TEST_ENABLED`` must be truthy (``1``/``true``/``yes``/``on``)
-for ``run_stress_test()`` to proceed.  Constructing ``StressPerturbation``
-and ``FragilityReport`` objects is always safe; only the aggregate runner
-requires the flag so report-only consumers can freely build objects for
-inspection without enabling the gate.
-
-Live queue effect
------------------
-None.  All results are report-only.  No issue creation, no queue mutation,
-no dispatch changes.  Activation gate: DIC-20/21/22 production-green plus
-the same proof-first Foreman gate that governs the entire DIC-23..28
-dialectical-runtime-synthesis layer.
-
-See
----
-- ``docs/plans/EPISTEMIC_CI_AND_CRUX_ENGINE.md`` §DIC-25
-- Issue: https://github.com/synaptent/aragora/issues/6219
+Operator-curated perturbations probe proof-carrying code units *offline*
+and report fragility deltas before reality invalidates them.
+Flag: ``ARAGORA_STRESS_TEST_ENABLED`` (default off).  No queue mutation.
+Issue: https://github.com/synaptent/aragora/issues/6219
 """
 
 from __future__ import annotations
@@ -44,29 +24,23 @@ PerturbationKind = Literal[
 
 
 def stress_test_enabled(*, override: bool | None = None) -> bool:
-    """Return True when the stress-test subsystem is enabled.
-
-    Priority: ``override`` kwarg > ``ARAGORA_STRESS_TEST_ENABLED`` env var.
-    Default: False.
-    """
+    """Return True when the gate is open (override kwarg > env var)."""
     if override is not None:
         return override
-    raw = os.environ.get("ARAGORA_STRESS_TEST_ENABLED", "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
-
-
-# ---------------------------------------------------------------------------
-# Data contracts
-# ---------------------------------------------------------------------------
+    return os.environ.get("ARAGORA_STRESS_TEST_ENABLED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 @dataclass
 class StressPerturbation:
-    """A single plausible-future world-state perturbation.
+    """A plausible-future world-state perturbation.
 
-    ``simulated_impact`` is the fraction of integrity lost (0.0-1.0) when
-    this perturbation strikes an in-scope proof unit.  An empty
-    ``affected_proof_unit_ids`` list means *all* units are in scope.
+    Empty ``affected_proof_unit_ids`` → all units in scope.
+    ``simulated_impact`` is the integrity fraction lost (0.0–1.0).
     """
 
     perturbation_id: str
@@ -75,7 +49,6 @@ class StressPerturbation:
     simulated_impact: float = 0.0
     affected_claim_ids: list[str] = field(default_factory=list)
     affected_proof_unit_ids: list[str] = field(default_factory=list)
-    source: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -85,13 +58,12 @@ class StressPerturbation:
             "simulated_impact": self.simulated_impact,
             "affected_claim_ids": self.affected_claim_ids,
             "affected_proof_unit_ids": self.affected_proof_unit_ids,
-            "source": self.source,
         }
 
 
 @dataclass
 class FragilityReport:
-    """Fragility assessment for one proof unit under one perturbation."""
+    """Fragility of one proof unit under one perturbation."""
 
     proof_unit_id: str
     perturbation_id: str
@@ -115,7 +87,7 @@ class FragilityReport:
 
 @dataclass
 class StressTestResult:
-    """Aggregate result of a stress-test run across all perturbations × units."""
+    """Aggregate result across all perturbations × proof units."""
 
     perturbations_tested: int
     proof_units_probed: int
@@ -125,7 +97,7 @@ class StressTestResult:
 
     @property
     def high_fragility_units(self) -> list[FragilityReport]:
-        """Reports where fragility_delta > 0.3 — warrant operator attention."""
+        """Reports with fragility_delta > 0.3 — warrant operator attention."""
         return [r for r in self.reports if r.fragility_delta > 0.3]
 
     def to_dict(self) -> dict[str, Any]:
@@ -138,58 +110,33 @@ class StressTestResult:
         }
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-_ACTION_THRESHOLDS: tuple[tuple[float, float, str], ...] = (
-    # (max_stressed_integrity, min_fragility_delta, action)
-    # Ordered from most-severe to least; first match wins.
-    (0.3, 0.0, "fail_closed"),
-    (1.0, 0.4, "repair_required"),
-    (1.0, 0.2, "monitor"),
-)
-
-
-def _recommended_action(fragility_delta: float, stressed_integrity: float) -> str:
-    for max_stressed, min_delta, action in _ACTION_THRESHOLDS:
-        if stressed_integrity <= max_stressed and fragility_delta >= min_delta:
-            return action
+def _recommended_action(delta: float, stressed: float) -> str:
+    if stressed < 0.3:
+        return "fail_closed"
+    if delta > 0.4:
+        return "repair_required"
+    if delta > 0.2:
+        return "monitor"
     return "pass"
 
 
-def _probe_unit(
-    proof_unit_id: str,
-    baseline_integrity: float,
-    perturbation: StressPerturbation,
-) -> FragilityReport:
-    in_scope = (
-        not perturbation.affected_proof_unit_ids
-        or proof_unit_id in perturbation.affected_proof_unit_ids
-    )
+def _probe_unit(uid: str, baseline: float, p: StressPerturbation) -> FragilityReport:
+    in_scope = not p.affected_proof_unit_ids or uid in p.affected_proof_unit_ids
     if in_scope:
-        stressed = round(max(0.0, baseline_integrity - perturbation.simulated_impact), 4)
-        delta = round(baseline_integrity - stressed, 4)
-        reason = f"{perturbation.kind}: {perturbation.description[:120]}"
+        stressed = round(max(0.0, baseline - p.simulated_impact), 4)
+        delta = round(baseline - stressed, 4)
+        reason = f"{p.kind}: {p.description[:120]}"
     else:
-        stressed = round(baseline_integrity, 4)
-        delta = 0.0
-        reason = "not in perturbation scope"
-
+        stressed, delta, reason = round(baseline, 4), 0.0, "not in perturbation scope"
     return FragilityReport(
-        proof_unit_id=proof_unit_id,
-        perturbation_id=perturbation.perturbation_id,
-        baseline_integrity=round(baseline_integrity, 4),
-        stressed_integrity=stressed,
-        fragility_delta=delta,
-        reason=reason,
-        recommended_action=_recommended_action(delta, stressed),
+        uid,
+        p.perturbation_id,
+        round(baseline, 4),
+        stressed,
+        delta,
+        reason,
+        _recommended_action(delta, stressed),
     )
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
 
 
 def run_stress_test(
@@ -201,48 +148,26 @@ def run_stress_test(
     """Run offline stress-tests for all perturbations × proof units.
 
     Args:
-        perturbations: Operator-curated catalog of plausible-future
-            perturbations.
-        proof_unit_integrities: Mapping of ``proof_unit_id`` →
-            current integrity score (0.0–1.0) from the DIC-20 decay
-            monitor (``evaluate_unit``).
-        enabled: Explicit override for the flag gate.  Pass ``True``
-            in tests to bypass the env-var check.
+        perturbations: Operator-curated perturbation catalog.
+        proof_unit_integrities: ``proof_unit_id`` → integrity score (0–1)
+            from the DIC-20 decay monitor.
+        enabled: Flag override; pass ``True`` in tests.
 
-    Returns:
-        :class:`StressTestResult` with per-unit fragility reports.
-        Always report-only; no queue mutation.
-
-    Raises:
-        RuntimeError: When the flag gate is off and ``enabled`` is not
-            ``True``.
+    Returns: Report-only :class:`StressTestResult`; no queue mutation.
+    Raises: ``RuntimeError`` when gate is off and ``enabled`` is not ``True``.
     """
     if not stress_test_enabled(override=enabled):
-        raise RuntimeError(
-            "Stress-test subsystem is disabled. "
-            "Set ARAGORA_STRESS_TEST_ENABLED=1 to enable, "
-            "or pass enabled=True in tests."
-        )
-
-    reports: list[FragilityReport] = []
-    for perturbation in perturbations:
-        for unit_id, baseline in proof_unit_integrities.items():
-            reports.append(_probe_unit(unit_id, baseline, perturbation))
-
+        raise RuntimeError("Set ARAGORA_STRESS_TEST_ENABLED=1 to enable the stress-test subsystem.")
+    reports = [
+        _probe_unit(uid, baseline, p)
+        for p in perturbations
+        for uid, baseline in proof_unit_integrities.items()
+    ]
     if reports:
         max_delta = max(r.fragility_delta for r in reports)
-        most_fragile = next(
-            (r.proof_unit_id for r in reports if r.fragility_delta == max_delta),
-            "",
-        )
+        most_fragile = next(r.proof_unit_id for r in reports if r.fragility_delta == max_delta)
     else:
-        max_delta = 0.0
-        most_fragile = ""
-
+        max_delta, most_fragile = 0.0, ""
     return StressTestResult(
-        perturbations_tested=len(perturbations),
-        proof_units_probed=len(proof_unit_integrities),
-        reports=reports,
-        most_fragile_unit_id=most_fragile,
-        max_fragility_delta=round(max_delta, 4),
+        len(perturbations), len(proof_unit_integrities), reports, most_fragile, round(max_delta, 4)
     )

--- a/tests/epistemic/test_quarantine_policy.py
+++ b/tests/epistemic/test_quarantine_policy.py
@@ -1,0 +1,124 @@
+"""Tests for DIC-21 Fail-Closed Quarantine Policy (aragora.epistemic.quarantine_policy)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from aragora.epistemic.quarantine_policy import (
+    DEFAULT_POLICIES,
+    EscalationMap,
+    QuarantinePolicy,
+    apply_quarantine_policy,
+    quarantine_policy_enabled,
+)
+
+
+@dataclass
+class _R:
+    kind: str
+    detail: str = ""
+    claim_id: str = ""
+    crux_id: str = ""
+
+
+@dataclass
+class _S:
+    code_unit_id: str = "u"
+    integrity_score: float = 0.9
+    recommended_action: str = "report_only"
+    reasons: list[_R] = field(default_factory=list)
+
+
+class TestHappyPath:
+    def test_healthy_report_only(self) -> None:
+        d = apply_quarantine_policy(_S())
+        assert d.policy_action == "report_only" and not d.fail_closed
+
+    def test_report_only_empty_provenance(self) -> None:
+        assert apply_quarantine_policy(_S()).provenance_hash == ""
+
+    def test_non_report_only_sha256_provenance(self) -> None:
+        assert (
+            len(apply_quarantine_policy(_S(recommended_action="repair_required")).provenance_hash)
+            == 64
+        )
+
+    def test_provenance_deterministic(self) -> None:
+        s = _S(integrity_score=0.75, recommended_action="repair_required")
+        assert (
+            apply_quarantine_policy(s).provenance_hash == apply_quarantine_policy(s).provenance_hash
+        )
+
+    def test_score_and_uid_copied(self) -> None:
+        d = apply_quarantine_policy(_S(code_unit_id="foo", integrity_score=0.72))
+        assert d.code_unit_id == "foo" and d.integrity_score == pytest.approx(0.72)
+
+
+class TestFailClosed:
+    def test_below_threshold(self) -> None:
+        d = apply_quarantine_policy(
+            _S(integrity_score=0.3), policy=QuarantinePolicy(fail_closed_threshold=0.4)
+        )
+        assert d.policy_action == "fail_closed" and d.fail_closed
+
+    def test_at_threshold_safe(self) -> None:
+        d = apply_quarantine_policy(
+            _S(integrity_score=0.4), policy=QuarantinePolicy(fail_closed_threshold=0.4)
+        )
+        assert not d.fail_closed
+
+    def test_fail_closed_overrides_escalation(self) -> None:
+        policy = QuarantinePolicy(fail_closed_threshold=0.5)
+        d = apply_quarantine_policy(
+            _S(integrity_score=0.2, recommended_action="repair_required"), policy=policy
+        )
+        assert d.policy_action == "fail_closed"
+
+    def test_fail_closed_has_provenance(self) -> None:
+        assert apply_quarantine_policy(_S(integrity_score=0.1)).provenance_hash != ""
+
+
+class TestLiveSwap:
+    def test_blocked_by_default(self) -> None:
+        assert apply_quarantine_policy(_S(), request_live_swap=True).live_swap_blocked
+
+    def test_permitted_when_in_allowlist(self) -> None:
+        policy = QuarantinePolicy(live_swap_allowlist=frozenset({"u"}), fail_closed_threshold=0.0)
+        d = apply_quarantine_policy(_S(code_unit_id="u"), policy=policy, request_live_swap=True)
+        assert not d.live_swap_blocked
+
+    def test_blocked_swap_escalates_to_quarantine(self) -> None:
+        policy = QuarantinePolicy(fail_closed_threshold=0.0)
+        d = apply_quarantine_policy(_S(integrity_score=0.9), policy=policy, request_live_swap=True)
+        assert d.policy_action in {"quarantine", "repair_required", "fail_closed"}
+
+
+class TestDefaults:
+    def test_all_classes_present(self) -> None:
+        for c in ("live_dispatch", "report_surface", "demo", "pure_policy", "default"):
+            assert c in DEFAULT_POLICIES
+
+    def test_all_allowlists_empty(self) -> None:
+        assert all(len(p.live_swap_allowlist) == 0 for p in DEFAULT_POLICIES.values())
+
+    def test_class_lookup(self) -> None:
+        d = apply_quarantine_policy(
+            _S(recommended_action="repair_required"), code_unit_class="report_surface"
+        )
+        assert d.policy_action == "degrade"
+
+    def test_unknown_class_falls_back(self) -> None:
+        assert apply_quarantine_policy(_S(), code_unit_class="nope").policy_action == "report_only"
+
+
+class TestFlagGate:
+    def test_off_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_QUARANTINE_POLICY_ENABLED", raising=False)
+        assert not quarantine_policy_enabled()
+
+    @pytest.mark.parametrize("v", ["1", "true", "yes", "on"])
+    def test_truthy(self, monkeypatch: pytest.MonkeyPatch, v: str) -> None:
+        monkeypatch.setenv("ARAGORA_QUARANTINE_POLICY_ENABLED", v)
+        assert quarantine_policy_enabled()

--- a/tests/epistemic/test_repair.py
+++ b/tests/epistemic/test_repair.py
@@ -1,0 +1,127 @@
+"""Unit tests for DIC-22 repair-spec producer (aragora.epistemic.repair)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.decay_monitor import DecayReason, DecaySignal
+from aragora.epistemic.repair import (
+    RepairSpec,
+    enable_repair_pipeline,
+    propose_repair,
+    repair_pipeline_enabled,
+)
+
+
+def _signal(*, reasons: list[DecayReason] | None = None) -> DecaySignal:
+    return DecaySignal(
+        code_unit_id="unit.test",
+        integrity_score=0.4,
+        reasons=reasons or [],
+        recommended_action="repair_required",
+    )
+
+
+class TestFlagGate:
+    def test_flag_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        assert not repair_pipeline_enabled()
+
+    def test_flag_truthy_values(self, monkeypatch):
+        for val in ("1", "true", "yes", "on"):
+            monkeypatch.setenv("ARAGORA_REPAIR_PIPELINE_ENABLED", val)
+            assert repair_pipeline_enabled()
+
+    def test_enable_helper(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        enable_repair_pipeline()
+        assert repair_pipeline_enabled()
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+
+
+class TestNoHotswapInvariant:
+    def test_live_swap_always_blocked(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_REPAIR_PIPELINE_ENABLED", "1")
+        with pytest.raises(ValueError, match="permanently blocked"):
+            propose_repair(_signal(), repair_kind="live_swap")  # type: ignore[arg-type]
+
+    def test_live_swap_blocked_without_flag(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        with pytest.raises(ValueError, match="permanently blocked"):
+            propose_repair(_signal(), repair_kind="live_swap")  # type: ignore[arg-type]
+
+    def test_unknown_kind_raises(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_REPAIR_PIPELINE_ENABLED", "1")
+        with pytest.raises(ValueError, match="not a known kind"):
+            propose_repair(_signal(), repair_kind="rewrite_production")  # type: ignore[arg-type]
+
+    def test_shadow_blocked_without_flag(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        with pytest.raises(ValueError, match="ARAGORA_REPAIR_PIPELINE_ENABLED"):
+            propose_repair(_signal(), repair_kind="shadow_candidate")
+
+    def test_pr_candidate_blocked_without_flag(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        with pytest.raises(ValueError, match="ARAGORA_REPAIR_PIPELINE_ENABLED"):
+            propose_repair(_signal(), repair_kind="pr_candidate")
+
+
+class TestReportOnly:
+    def test_default_is_report_only(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        spec = propose_repair(_signal())
+        assert spec.repair_kind == "report_only"
+
+    def test_report_only_has_empty_provenance_hash(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        assert propose_repair(_signal()).provenance_hash == ""
+
+
+class TestProvenanceHash:
+    def test_shadow_carries_64char_hash(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_REPAIR_PIPELINE_ENABLED", "1")
+        spec = propose_repair(_signal(), repair_kind="shadow_candidate")
+        assert len(spec.provenance_hash) == 64
+        assert all(c in "0123456789abcdef" for c in spec.provenance_hash)
+
+    def test_pr_candidate_carries_hash(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_REPAIR_PIPELINE_ENABLED", "1")
+        spec = propose_repair(_signal(), repair_kind="pr_candidate")
+        assert len(spec.provenance_hash) == 64
+
+
+class TestLinkedFields:
+    def test_claims_and_cruxes_extracted_from_reasons(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        reasons = [
+            DecayReason(kind="failed_claim", detail="x", claim_id="claim.a"),
+            DecayReason(kind="unresolved_crux", detail="y", crux_id="crux.z"),
+        ]
+        spec = propose_repair(_signal(reasons=reasons))
+        assert "claim.a" in spec.linked_claims
+        assert "crux.z" in spec.linked_crux_ids
+
+    def test_explicit_overrides_default(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        reasons = [DecayReason(kind="failed_claim", detail="x", claim_id="auto")]
+        spec = propose_repair(_signal(reasons=reasons), linked_claims=["manual"])
+        assert spec.linked_claims == ["manual"]
+        assert "auto" not in spec.linked_claims
+
+
+class TestSerialization:
+    def test_to_dict_round_trips_key_fields(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPAIR_PIPELINE_ENABLED", raising=False)
+        spec = propose_repair(
+            _signal(),
+            validation_commands=["pytest tests/"],
+            receipt_context={"receipt_id": "rec-1"},
+        )
+        d = spec.to_dict()
+        assert d["repair_kind"] == "report_only"
+        assert d["validation_commands"] == ["pytest tests/"]
+        assert d["receipt_context"] == {"receipt_id": "rec-1"}
+        assert "decay_signal" in d
+        assert d["decay_signal"]["code_unit_id"] == "unit.test"
+        assert d["spec_id"].startswith("repair-")
+        assert len(d["spec_id"]) == len("repair-") + 16

--- a/tests/epistemic/test_stress_test.py
+++ b/tests/epistemic/test_stress_test.py
@@ -1,0 +1,236 @@
+"""Tests for DIC-25 adversarial world-state stress-test (#6219).
+
+All tests run without network, queue, or database access.
+Flag gate is exercised via ``enabled`` kwarg to avoid env-var pollution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.stress_test import (
+    FragilityReport,
+    StressPerturbation,
+    StressTestResult,
+    _probe_unit,
+    _recommended_action,
+    run_stress_test,
+    stress_test_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _perturb(
+    pid: str = "p-001",
+    kind: str = "cve_drop",
+    impact: float = 0.4,
+    affected_units: list[str] | None = None,
+    affected_claims: list[str] | None = None,
+    source: str = "CVE-2026-0001",
+) -> StressPerturbation:
+    return StressPerturbation(
+        perturbation_id=pid,
+        kind=kind,  # type: ignore[arg-type]
+        description="Synthetic perturbation for testing.",
+        simulated_impact=impact,
+        affected_proof_unit_ids=affected_units or [],
+        affected_claim_ids=affected_claims or [],
+        source=source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag gate
+# ---------------------------------------------------------------------------
+
+
+def test_stress_test_disabled_by_default() -> None:
+    """Gate must be off unless the env var or kwarg enables it."""
+    with pytest.raises(RuntimeError, match="ARAGORA_STRESS_TEST_ENABLED"):
+        run_stress_test([], {})
+
+
+def test_stress_test_enabled_via_kwarg() -> None:
+    result = run_stress_test([], {}, enabled=True)
+    assert result.perturbations_tested == 0
+    assert result.proof_units_probed == 0
+
+
+def test_stress_test_enabled_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for truthy in ("1", "true", "yes", "on"):
+        monkeypatch.setenv("ARAGORA_STRESS_TEST_ENABLED", truthy)
+        assert stress_test_enabled() is True
+    monkeypatch.setenv("ARAGORA_STRESS_TEST_ENABLED", "0")
+    assert stress_test_enabled() is False
+
+
+def test_stress_test_override_takes_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARAGORA_STRESS_TEST_ENABLED", "0")
+    # explicit True wins over env-var False
+    result = run_stress_test([], {}, enabled=True)
+    assert isinstance(result, StressTestResult)
+
+
+# ---------------------------------------------------------------------------
+# _probe_unit
+# ---------------------------------------------------------------------------
+
+
+def test_probe_unit_reduces_integrity_when_in_scope() -> None:
+    p = _perturb(impact=0.3, affected_units=["u1"])
+    report = _probe_unit("u1", 0.8, p)
+    assert report.stressed_integrity == pytest.approx(0.5, abs=1e-4)
+    assert report.fragility_delta == pytest.approx(0.3, abs=1e-4)
+
+
+def test_probe_unit_floors_at_zero() -> None:
+    p = _perturb(impact=2.0, affected_units=["u1"])
+    report = _probe_unit("u1", 0.6, p)
+    assert report.stressed_integrity == 0.0
+    assert report.fragility_delta == pytest.approx(0.6, abs=1e-4)
+
+
+def test_probe_unit_out_of_scope_unchanged() -> None:
+    p = _perturb(impact=0.9, affected_units=["other"])
+    report = _probe_unit("u1", 0.75, p)
+    assert report.fragility_delta == 0.0
+    assert report.stressed_integrity == pytest.approx(0.75, abs=1e-4)
+    assert report.reason == "not in perturbation scope"
+
+
+def test_probe_unit_empty_scope_applies_to_all() -> None:
+    """Empty affected_proof_unit_ids means every unit is in scope."""
+    p = _perturb(impact=0.35, affected_units=[])
+    report = _probe_unit("any-unit", 0.9, p)
+    assert report.fragility_delta == pytest.approx(0.35, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# _recommended_action
+# ---------------------------------------------------------------------------
+
+
+def test_action_fail_closed_on_very_low_stressed_integrity() -> None:
+    # stressed below 0.3 threshold → fail_closed regardless of delta
+    assert _recommended_action(0.1, 0.25) == "fail_closed"
+
+
+def test_action_repair_required_on_high_delta() -> None:
+    assert _recommended_action(0.45, 0.55) == "repair_required"
+
+
+def test_action_monitor_on_moderate_delta() -> None:
+    assert _recommended_action(0.25, 0.7) == "monitor"
+
+
+def test_action_pass_on_low_delta() -> None:
+    assert _recommended_action(0.05, 0.9) == "pass"
+
+
+# ---------------------------------------------------------------------------
+# run_stress_test aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_run_stress_test_identifies_most_fragile_unit() -> None:
+    perturbations = [
+        _perturb(pid="p1", impact=0.6, affected_units=["u1"]),
+        _perturb(pid="p2", impact=0.15, affected_units=["u2"]),
+    ]
+    result = run_stress_test(perturbations, {"u1": 0.9, "u2": 0.8}, enabled=True)
+    assert result.perturbations_tested == 2
+    assert result.proof_units_probed == 2
+    assert result.most_fragile_unit_id == "u1"
+    assert result.max_fragility_delta == pytest.approx(0.6, abs=1e-4)
+
+
+def test_run_stress_test_report_count() -> None:
+    """Result must have one report per perturbation × proof-unit pair."""
+    perturbations = [_perturb(pid="p1"), _perturb(pid="p2")]
+    integrities = {"u1": 0.9, "u2": 0.7, "u3": 0.5}
+    result = run_stress_test(perturbations, integrities, enabled=True)
+    assert len(result.reports) == 2 * 3
+
+
+def test_run_stress_test_empty_returns_zero_delta() -> None:
+    result = run_stress_test([], {}, enabled=True)
+    assert result.max_fragility_delta == 0.0
+    assert result.most_fragile_unit_id == ""
+
+
+def test_high_fragility_filter() -> None:
+    reports = [
+        FragilityReport(
+            proof_unit_id="u1",
+            perturbation_id="p1",
+            baseline_integrity=0.9,
+            stressed_integrity=0.4,
+            fragility_delta=0.5,
+            reason="test",
+            recommended_action="repair_required",
+        ),
+        FragilityReport(
+            proof_unit_id="u2",
+            perturbation_id="p1",
+            baseline_integrity=0.8,
+            stressed_integrity=0.75,
+            fragility_delta=0.05,
+            reason="test",
+            recommended_action="pass",
+        ),
+    ]
+    result = StressTestResult(
+        perturbations_tested=1,
+        proof_units_probed=2,
+        reports=reports,
+        most_fragile_unit_id="u1",
+        max_fragility_delta=0.5,
+    )
+    high = result.high_fragility_units
+    assert len(high) == 1
+    assert high[0].proof_unit_id == "u1"
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_perturbation_to_dict_round_trips() -> None:
+    p = _perturb(kind="corpus_revision", impact=0.25, affected_units=["u3"])
+    d = p.to_dict()
+    assert d["kind"] == "corpus_revision"
+    assert d["simulated_impact"] == 0.25
+    assert "u3" in d["affected_proof_unit_ids"]
+
+
+def test_fragility_report_to_dict() -> None:
+    p = _perturb(impact=0.5, affected_units=["u1"])
+    report = _probe_unit("u1", 0.85, p)
+    d = report.to_dict()
+    assert set(d) >= {
+        "proof_unit_id",
+        "perturbation_id",
+        "baseline_integrity",
+        "stressed_integrity",
+        "fragility_delta",
+        "reason",
+        "recommended_action",
+    }
+
+
+def test_stress_test_result_to_dict() -> None:
+    result = run_stress_test(
+        [_perturb(impact=0.4, affected_units=["u1"])],
+        {"u1": 0.9},
+        enabled=True,
+    )
+    d = result.to_dict()
+    assert d["perturbations_tested"] == 1
+    assert d["proof_units_probed"] == 1
+    assert len(d["reports"]) == 1
+    assert d["max_fragility_delta"] > 0

--- a/tests/epistemic/test_stress_test.py
+++ b/tests/epistemic/test_stress_test.py
@@ -1,7 +1,6 @@
 """Tests for DIC-25 adversarial world-state stress-test (#6219).
 
-All tests run without network, queue, or database access.
-Flag gate is exercised via ``enabled`` kwarg to avoid env-var pollution.
+No network, queue, or database access.
 """
 
 from __future__ import annotations
@@ -19,218 +18,106 @@ from aragora.epistemic.stress_test import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _perturb(
-    pid: str = "p-001",
-    kind: str = "cve_drop",
-    impact: float = 0.4,
-    affected_units: list[str] | None = None,
-    affected_claims: list[str] | None = None,
-    source: str = "CVE-2026-0001",
-) -> StressPerturbation:
+def _p(pid: str = "p1", impact: float = 0.4, units: list[str] | None = None) -> StressPerturbation:
     return StressPerturbation(
-        perturbation_id=pid,
-        kind=kind,  # type: ignore[arg-type]
-        description="Synthetic perturbation for testing.",
-        simulated_impact=impact,
-        affected_proof_unit_ids=affected_units or [],
-        affected_claim_ids=affected_claims or [],
-        source=source,
+        pid, "cve_drop", "Synthetic.", impact, affected_proof_unit_ids=units or []
     )
 
 
-# ---------------------------------------------------------------------------
-# Flag gate
-# ---------------------------------------------------------------------------
+# --- Flag gate ---
 
 
-def test_stress_test_disabled_by_default() -> None:
-    """Gate must be off unless the env var or kwarg enables it."""
+def test_disabled_by_default() -> None:
     with pytest.raises(RuntimeError, match="ARAGORA_STRESS_TEST_ENABLED"):
         run_stress_test([], {})
 
 
-def test_stress_test_enabled_via_kwarg() -> None:
-    result = run_stress_test([], {}, enabled=True)
-    assert result.perturbations_tested == 0
-    assert result.proof_units_probed == 0
+def test_enabled_via_kwarg() -> None:
+    assert run_stress_test([], {}, enabled=True).perturbations_tested == 0
 
 
-def test_stress_test_enabled_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for truthy in ("1", "true", "yes", "on"):
-        monkeypatch.setenv("ARAGORA_STRESS_TEST_ENABLED", truthy)
+def test_env_var_truthiness(monkeypatch: pytest.MonkeyPatch) -> None:
+    for val in ("1", "true", "yes", "on"):
+        monkeypatch.setenv("ARAGORA_STRESS_TEST_ENABLED", val)
         assert stress_test_enabled() is True
     monkeypatch.setenv("ARAGORA_STRESS_TEST_ENABLED", "0")
     assert stress_test_enabled() is False
 
 
-def test_stress_test_override_takes_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ARAGORA_STRESS_TEST_ENABLED", "0")
-    # explicit True wins over env-var False
-    result = run_stress_test([], {}, enabled=True)
-    assert isinstance(result, StressTestResult)
+# --- _probe_unit ---
 
 
-# ---------------------------------------------------------------------------
-# _probe_unit
-# ---------------------------------------------------------------------------
+def test_probe_reduces_integrity() -> None:
+    rep = _probe_unit("u1", 0.8, _p(impact=0.3, units=["u1"]))
+    assert rep.stressed_integrity == pytest.approx(0.5, abs=1e-4)
+    assert rep.fragility_delta == pytest.approx(0.3, abs=1e-4)
 
 
-def test_probe_unit_reduces_integrity_when_in_scope() -> None:
-    p = _perturb(impact=0.3, affected_units=["u1"])
-    report = _probe_unit("u1", 0.8, p)
-    assert report.stressed_integrity == pytest.approx(0.5, abs=1e-4)
-    assert report.fragility_delta == pytest.approx(0.3, abs=1e-4)
+def test_probe_floors_at_zero() -> None:
+    rep = _probe_unit("u1", 0.6, _p(impact=2.0, units=["u1"]))
+    assert rep.stressed_integrity == 0.0
+    assert rep.fragility_delta == pytest.approx(0.6, abs=1e-4)
 
 
-def test_probe_unit_floors_at_zero() -> None:
-    p = _perturb(impact=2.0, affected_units=["u1"])
-    report = _probe_unit("u1", 0.6, p)
-    assert report.stressed_integrity == 0.0
-    assert report.fragility_delta == pytest.approx(0.6, abs=1e-4)
+def test_probe_out_of_scope_unchanged() -> None:
+    rep = _probe_unit("u1", 0.75, _p(impact=0.9, units=["other"]))
+    assert rep.fragility_delta == 0.0 and rep.reason == "not in perturbation scope"
 
 
-def test_probe_unit_out_of_scope_unchanged() -> None:
-    p = _perturb(impact=0.9, affected_units=["other"])
-    report = _probe_unit("u1", 0.75, p)
-    assert report.fragility_delta == 0.0
-    assert report.stressed_integrity == pytest.approx(0.75, abs=1e-4)
-    assert report.reason == "not in perturbation scope"
+def test_probe_empty_scope_hits_all() -> None:
+    assert _probe_unit("any", 0.9, _p(impact=0.35, units=[])).fragility_delta == pytest.approx(
+        0.35, abs=1e-4
+    )
 
 
-def test_probe_unit_empty_scope_applies_to_all() -> None:
-    """Empty affected_proof_unit_ids means every unit is in scope."""
-    p = _perturb(impact=0.35, affected_units=[])
-    report = _probe_unit("any-unit", 0.9, p)
-    assert report.fragility_delta == pytest.approx(0.35, abs=1e-4)
+# --- _recommended_action ---
 
 
-# ---------------------------------------------------------------------------
-# _recommended_action
-# ---------------------------------------------------------------------------
-
-
-def test_action_fail_closed_on_very_low_stressed_integrity() -> None:
-    # stressed below 0.3 threshold → fail_closed regardless of delta
-    assert _recommended_action(0.1, 0.25) == "fail_closed"
-
-
-def test_action_repair_required_on_high_delta() -> None:
+def test_recommended_actions() -> None:
+    assert _recommended_action(0.1, 0.25) == "fail_closed"  # stressed < 0.3
     assert _recommended_action(0.45, 0.55) == "repair_required"
-
-
-def test_action_monitor_on_moderate_delta() -> None:
     assert _recommended_action(0.25, 0.7) == "monitor"
-
-
-def test_action_pass_on_low_delta() -> None:
     assert _recommended_action(0.05, 0.9) == "pass"
 
 
-# ---------------------------------------------------------------------------
-# run_stress_test aggregate
-# ---------------------------------------------------------------------------
+# --- run_stress_test ---
 
 
-def test_run_stress_test_identifies_most_fragile_unit() -> None:
-    perturbations = [
-        _perturb(pid="p1", impact=0.6, affected_units=["u1"]),
-        _perturb(pid="p2", impact=0.15, affected_units=["u2"]),
-    ]
-    result = run_stress_test(perturbations, {"u1": 0.9, "u2": 0.8}, enabled=True)
-    assert result.perturbations_tested == 2
-    assert result.proof_units_probed == 2
+def test_identifies_most_fragile_unit() -> None:
+    result = run_stress_test(
+        [_p("p1", 0.6, ["u1"]), _p("p2", 0.15, ["u2"])],
+        {"u1": 0.9, "u2": 0.8},
+        enabled=True,
+    )
     assert result.most_fragile_unit_id == "u1"
     assert result.max_fragility_delta == pytest.approx(0.6, abs=1e-4)
 
 
-def test_run_stress_test_report_count() -> None:
-    """Result must have one report per perturbation × proof-unit pair."""
-    perturbations = [_perturb(pid="p1"), _perturb(pid="p2")]
-    integrities = {"u1": 0.9, "u2": 0.7, "u3": 0.5}
-    result = run_stress_test(perturbations, integrities, enabled=True)
-    assert len(result.reports) == 2 * 3
-
-
-def test_run_stress_test_empty_returns_zero_delta() -> None:
-    result = run_stress_test([], {}, enabled=True)
-    assert result.max_fragility_delta == 0.0
-    assert result.most_fragile_unit_id == ""
+def test_empty_run() -> None:
+    r = run_stress_test([], {}, enabled=True)
+    assert r.max_fragility_delta == 0.0 and r.most_fragile_unit_id == ""
 
 
 def test_high_fragility_filter() -> None:
     reports = [
-        FragilityReport(
-            proof_unit_id="u1",
-            perturbation_id="p1",
-            baseline_integrity=0.9,
-            stressed_integrity=0.4,
-            fragility_delta=0.5,
-            reason="test",
-            recommended_action="repair_required",
-        ),
-        FragilityReport(
-            proof_unit_id="u2",
-            perturbation_id="p1",
-            baseline_integrity=0.8,
-            stressed_integrity=0.75,
-            fragility_delta=0.05,
-            reason="test",
-            recommended_action="pass",
-        ),
+        FragilityReport("u1", "p1", 0.9, 0.4, 0.5, "t", "repair_required"),
+        FragilityReport("u2", "p1", 0.8, 0.75, 0.05, "t", "pass"),
     ]
     result = StressTestResult(
-        perturbations_tested=1,
-        proof_units_probed=2,
-        reports=reports,
-        most_fragile_unit_id="u1",
-        max_fragility_delta=0.5,
+        1, 2, reports=reports, most_fragile_unit_id="u1", max_fragility_delta=0.5
     )
-    high = result.high_fragility_units
-    assert len(high) == 1
-    assert high[0].proof_unit_id == "u1"
+    assert [r.proof_unit_id for r in result.high_fragility_units] == ["u1"]
 
 
-# ---------------------------------------------------------------------------
-# Serialisation
-# ---------------------------------------------------------------------------
+# --- Serialisation ---
 
 
-def test_perturbation_to_dict_round_trips() -> None:
-    p = _perturb(kind="corpus_revision", impact=0.25, affected_units=["u3"])
-    d = p.to_dict()
-    assert d["kind"] == "corpus_revision"
-    assert d["simulated_impact"] == 0.25
-    assert "u3" in d["affected_proof_unit_ids"]
-
-
-def test_fragility_report_to_dict() -> None:
-    p = _perturb(impact=0.5, affected_units=["u1"])
-    report = _probe_unit("u1", 0.85, p)
-    d = report.to_dict()
-    assert set(d) >= {
-        "proof_unit_id",
-        "perturbation_id",
-        "baseline_integrity",
-        "stressed_integrity",
-        "fragility_delta",
-        "reason",
-        "recommended_action",
-    }
-
-
-def test_stress_test_result_to_dict() -> None:
-    result = run_stress_test(
-        [_perturb(impact=0.4, affected_units=["u1"])],
-        {"u1": 0.9},
-        enabled=True,
-    )
-    d = result.to_dict()
-    assert d["perturbations_tested"] == 1
-    assert d["proof_units_probed"] == 1
-    assert len(d["reports"]) == 1
-    assert d["max_fragility_delta"] > 0
+def test_serialisation_round_trips() -> None:
+    result = run_stress_test([_p(impact=0.4, units=["u1"])], {"u1": 0.9}, enabled=True)
+    rd = result.to_dict()
+    assert rd["max_fragility_delta"] > 0 and len(rd["reports"]) == 1
+    pd = result.reports[0].to_dict()
+    assert {"proof_unit_id", "fragility_delta", "recommended_action"} <= pd.keys()
+    sp = StressPerturbation("p1", "corpus_revision", "d", 0.25, [], ["u3"])
+    sd = sp.to_dict()
+    assert sd["kind"] == "corpus_revision" and "u3" in sd["affected_proof_unit_ids"]


### PR DESCRIPTION
## Summary
- salvage unpublished epistemic tranche work from `codex/reconcile-6247-20260420`, `codex/reconcile-6275-20260420`, and `codex/reconcile-6302-20260420`
- add the DIC-21 quarantine policy, DIC-22 repair-spec producer, and DIC-25 stress-test helpers
- reconcile the shared `aragora/epistemic/__init__.py` barrel into one mainline-compatible export surface

## Validation
- `python -m pytest tests/epistemic/test_quarantine_policy.py tests/epistemic/test_repair.py tests/epistemic/test_stress_test.py -q`
- `python -m ruff check aragora/epistemic/__init__.py aragora/epistemic/quarantine_policy.py aragora/epistemic/repair.py aragora/epistemic/stress_test.py tests/epistemic/test_quarantine_policy.py tests/epistemic/test_repair.py tests/epistemic/test_stress_test.py`
- `python -m mypy aragora/epistemic/quarantine_policy.py aragora/epistemic/repair.py aragora/epistemic/stress_test.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Provenance
This PR harvests and reconciles valuable unpublished work from stale worktrees instead of reviving the source branches directly.
