### PR TITLE
fix(swarm): persist acceptance-gate session verdict

### DIFF
--- a/aragora/swarm/supervisor_workers.py
+++ b/aragora/swarm/supervisor_workers.py
@@ -1618,10 +1618,13 @@ def _lease_work_order(
 
 def _release_terminal_lease(self, item: dict[str, Any]) -> None:
     # BC-01: Record terminal session state
+    qualification = qualify_work_order_terminal_state(item)
     wo_status = str(item.get("status", "")).strip().lower()
     terminal_status = "completed" if wo_status in {"completed", "merged"} else "failed"
+    if qualification.terminal_outcome == "needs_human":
+        terminal_status = "needs_human"
     blocker_evidence = None
-    if terminal_status == "failed" or wo_status == "needs_human":
+    if terminal_status in {"failed", "needs_human"}:
         blocker_evidence = _persist_terminal_blocker_evidence(item)
     _record_session_state(
         item,

--- a/aragora/swarm/supervisor_workers.py
+++ b/aragora/swarm/supervisor_workers.py
@@ -24,8 +24,6 @@ DEFAULT_BREAKER_FAILURE_THRESHOLD = _supervisor.DEFAULT_BREAKER_FAILURE_THRESHOL
 DEFAULT_BREAKER_RESET_TIMEOUT_SECONDS = _supervisor.DEFAULT_BREAKER_RESET_TIMEOUT_SECONDS
 LAUNCHER_CONFIG_METADATA_KEY = _supervisor.LAUNCHER_CONFIG_METADATA_KEY
 SESSION_LOCK_FILES = _supervisor.SESSION_LOCK_FILES
-SupervisorRun = _supervisor.SupervisorRun
-SwarmApprovalPolicy = _supervisor.SwarmApprovalPolicy
 WORKER_TYPE_CIRCUIT_BREAKERS_KEY = _supervisor.WORKER_TYPE_CIRCUIT_BREAKERS_KEY
 WORKER_TYPE_CIRCUIT_BREAKER_POLICY_KEY = _supervisor.WORKER_TYPE_CIRCUIT_BREAKER_POLICY_KEY
 WorkerOutcome = _supervisor.WorkerOutcome
@@ -455,7 +453,9 @@ def refresh_run(self, run_id: str) -> SupervisorRun:
                     work_order=item,
                     work_orders=work_orders,
                     managed_dir_pattern=managed_dir_pattern,
-                    approval_policy=SwarmApprovalPolicy.from_dict(record.get("approval_policy")),
+                    approval_policy=_supervisor.SwarmApprovalPolicy.from_dict(
+                        record.get("approval_policy")
+                    ),
                 )
                 if leased:
                     active_count += 1
@@ -469,7 +469,7 @@ def refresh_run(self, run_id: str) -> SupervisorRun:
                             work_order=item,
                             work_orders=work_orders,
                             managed_dir_pattern=managed_dir_pattern,
-                            approval_policy=SwarmApprovalPolicy.from_dict(
+                            approval_policy=_supervisor.SwarmApprovalPolicy.from_dict(
                                 record.get("approval_policy")
                             ),
                         )
@@ -510,7 +510,7 @@ def refresh_run(self, run_id: str) -> SupervisorRun:
         work_orders=work_orders,
         metadata=final_metadata,
     )
-    return SupervisorRun.from_record(refreshed)
+    return _supervisor.SupervisorRun.from_record(refreshed)
 
 
 def _collect_finished_workers_sync(self, run_id: str) -> None:
@@ -966,7 +966,7 @@ def reset_worker_type_circuit_breaker(
             circuit_breakers,
         ),
     )
-    return SupervisorRun.from_record(updated)
+    return _supervisor.SupervisorRun.from_record(updated)
 
 
 async def dispatch_workers(self, run_id: str) -> list[WorkerProcess]:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -14,6 +14,7 @@ import pytest
 from aragora.nomic.dev_coordination import DevCoordinationStore, FileScopeViolationError
 from aragora.nomic.task_decomposer import SubTask, TaskDecomposition
 from aragora.swarm.spec import SwarmSpec
+from aragora.swarm.session_state import SessionStateStore
 from aragora.swarm.supervisor_probes import _finalize_completed_work_order_result
 from aragora.swarm.supervisor import (
     CAMPAIGN_OUTCOME_METADATA_KEY,
@@ -4478,6 +4479,42 @@ def test_finalize_completed_work_order_preserves_salvage_outcome_on_merge_gate_f
     assert item["worker_outcome"] == salvage_outcome
     assert item["failure_reason"] == "merge_gate_failed"
     assert item["receipt_id"] is None
+
+
+def test_release_terminal_lease_persists_needs_human_for_merge_gate_failure(
+    repo: Path, store: DevCoordinationStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    supervisor = SwarmSupervisor(repo_root=repo, store=store)
+    item = {
+        "work_order_id": "wo-acceptance-bind",
+        "issue_number": 6260,
+        "status": "completed",
+        "worker_outcome": "merge_gate_failed",
+        "target_agent": "codex",
+        "branch": "codex/session-state-retry-persistence-20260418",
+        "worktree_path": str(repo),
+        "review_status": "changes_requested",
+        "dispatch_error": "merge gate blocked: verification failed: pytest tests/swarm/test_supervisor.py -q",
+        "blockers": [
+            "merge gate blocked: verification failed: pytest tests/swarm/test_supervisor.py -q"
+        ],
+        "metadata": {},
+    }
+
+    supervisor._release_terminal_lease(item)
+
+    session_data = item["metadata"]["session_state"]
+    assert session_data["status"] == "needs_human"
+    assert session_data["blocker_evidence"] == item["dispatch_error"]
+    assert session_data["attempts"][-1]["worker_outcome"] == "merge_gate_failed"
+
+    store = SessionStateStore()
+    restored = store.load(session_data["session_id"])
+    assert restored is not None
+    assert restored.status == "needs_human"
+    assert restored.blocker_evidence == item["dispatch_error"]
+    assert restored.last_attempt()["worker_outcome"] == "merge_gate_failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist merge-gate terminal outcomes as `needs_human` in supervisor session state
- add regression coverage that terminal lease release keeps the acceptance-gate blocker verdict durable
- drop supervisor runtime type aliases in `supervisor_workers.py`

## Validation
- python -m pytest tests/swarm/test_supervisor.py -q
- python -m mypy aragora/swarm/supervisor_workers.py
- python -m ruff check aragora/swarm/supervisor_workers.py tests/swarm/test_supervisor.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Context
Salvaged as the still-unique supervisor/session verdict residue from the older pr6260 session-state branch family; broader session-state restack commits were not republished in this PR.