### PR TITLE
docs(status): refresh April 21 project reality

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,68 +1,41 @@
 # Aragora Project Status
 
-*Last updated: March 23, 2026*
+*Last updated: April 21, 2026*
 
 > Compatibility mirror for older links. The canonical current-status document is [status/STATUS.md](status/STATUS.md).
 > See [README](../README.md) for the five pillars framework. See [Documentation Index](INDEX.md) for the curated technical reference map.
 
-## March 23, 2026 — Structural PMF Slices Landed, Live Gate Still Open
+## April 21, 2026 — Canonical Reality Moved to Thesis + PDB Execution
 
-The earlier March docs overstated readiness. Current `main` is materially better, but the right statement is:
+The older March note is no longer a truthful description of `main`.
 
-- the structural PMF slices are landed
-- the mocked founder-loop proof passes on `main`
-- the live founder loop still needs repeatable dogfood proof before external selling
+Current `main` is materially defined by:
 
-Focused verification on current `main`:
+- [#6370](https://github.com/synaptent/aragora/pull/6370) landing `docs/THESIS.md` as the canonical source of authority
+- the PDB lane moving from plan to code:
+  - [#6369](https://github.com/synaptent/aragora/pull/6369) lifecycle state/storage
+  - [#6389](https://github.com/synaptent/aragora/pull/6389) Protocol B executor + panel config + budget
+  - [#6391](https://github.com/synaptent/aragora/pull/6391) brief generation endpoints + in-process worker
+  - [#6393](https://github.com/synaptent/aragora/pull/6393) PR 4 UI design
+- the agent-bridge lane landing backend core in [#6392](https://github.com/synaptent/aragora/pull/6392)
+- the receipt/dissent substrate hardening via [#6353](https://github.com/synaptent/aragora/pull/6353) and [#6376](https://github.com/synaptent/aragora/pull/6376)
 
-```bash
-python3 -m pytest tests/e2e/test_user_journey.py tests/cli/test_quickstart.py -q
-```
+Important qualifier:
 
-Observed result on March 23, 2026: `57 passed` in `33.75s`.
+- `aragora/swarm/pr_review_protocol.py` still declares `PROTOCOL_STATUS = "metadata_heuristic"`
+- the newer `aragora/pdb/` execution path is shipping alongside it
+- so the canonical PR packet path is not yet fully upgraded to the thesis's heterogeneous-ensemble standard
 
-Recent `main` improvements relevant to the founder loop:
+The current bounded queue is:
 
-1. **ProviderRouter wired into DebateFactory** ([#1167](https://github.com/synaptent/aragora/pull/1167))
-2. **KnowledgeMound retrieval wired into DebateFactory** ([#1168](https://github.com/synaptent/aragora/pull/1168))
-3. **Versioned API key management endpoints** ([#1169](https://github.com/synaptent/aragora/pull/1169))
-4. **Interactive onboarding/get-started flow** ([#1170](https://github.com/synaptent/aragora/pull/1170))
-5. **Debate outcome -> KM ingestion** ([#1176](https://github.com/synaptent/aragora/pull/1176))
-6. **Demo wired to real backend** ([#1177](https://github.com/synaptent/aragora/pull/1177))
-7. **Wave 2 surfaces productized** ([#1188](https://github.com/synaptent/aragora/pull/1188))
-8. **Quickstart fails fast on bad TLS** ([#1180](https://github.com/synaptent/aragora/pull/1180))
-9. **Quickstart inline provider keys and structured receipts** ([#1192](https://github.com/synaptent/aragora/pull/1192))
-10. **Integrations dashboard uses truthful backend state** ([#1196](https://github.com/synaptent/aragora/pull/1196))
+1. close [#6374](https://github.com/synaptent/aragora/issues/6374) on the canonical PR-review path
+2. close [#6373](https://github.com/synaptent/aragora/issues/6373) with rolling-window triage metrics
+3. close [#6372](https://github.com/synaptent/aragora/issues/6372) with auto-handle calibration + drift gating
+4. close [#6375](https://github.com/synaptent/aragora/issues/6375) with empirical threshold grounding
 
-The current execution order is now:
+For the full current-status narrative, use the canonical doc:
 
-1. prove the canonical founder loop live
-2. harvest the concrete blockers from that proof
-3. feed only those blockers into the idea-to-execution / swarm machinery
-4. defer GTM and enterprise-assurance expansion until the live loop is repeatable
-
-Canonical references:
-
-- [docs/status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md)
-- [docs/status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md)
-- [docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md](plans/PMF_DOGFOOD_EXECUTION_PLAN.md)
-
-### Wave 2 Surface Productization
-
-| Surface | Status | Notes |
-|---------|--------|-------|
-| **Spectate** | productized | Frontend wired to real WebSocket + polling. Conditional auth redacts debate IDs for unauthenticated callers. |
-| **SME Onboarding** | productized | 3-step wizard wired to backend. 9 starter templates including SME-specific profiles. |
-| **Conditional Public Endpoints** | productized | `GET /api/v1/public/surfaces` lists all public surfaces with readiness. Auth manifest declares spectate + onboarding as public. |
-
-### Current Frontier
-
-The frontier is no longer building or wiring. It is:
-
-- **continuous operation** — run the product loop with real users, collect feedback, fix what breaks
-- **Wave 2 polish** — SME onboarding, spectate, conditional public endpoints ([#820](https://github.com/synaptent/aragora/issues/820))
-- **design partner refresh** — repeatable external usage ([#1011](https://github.com/synaptent/aragora/issues/1011))
-- **enterprise assurance when ready** — pentest, SOC 2, certification parked at P3
+- [docs/status/STATUS.md](status/STATUS.md)
 
 ## March 12-18, 2026 — Ralph Autonomous Loop Validation
 

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -1,88 +1,85 @@
 # Aragora Project Status
 
-*Last updated: March 29, 2026*
+*Last updated: April 21, 2026*
 
 > See [README](../README.md) for the five pillars framework. See [Documentation Index](../INDEX.md) for the curated technical reference map.
 > For roadmap extraction, doc drift, and partial-feature tracking, see [DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md](DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md).
 
-## March 29, 2026 — Public Debate Sharing Landed, Queue Needs Truthful Triage
+## April 21, 2026 — Thesis Landed, PDB Execution Is Shipping, Canonical Triage Still Needs Closure
 
 ### Canonical Current Reality
 
-- `main` is materially cleaner than it was on March 23:
-  - the open PR queue is back to zero
-  - the recent merge stream fixed shared CI noise, public debate auth/spectate gaps, debate-share host correctness, and workflow governance cleanup
-- The strongest current product proof on `main` is now the anonymous public debate share path:
-  - `POST /api/v1/debates/{id}/share` enables public sharing
-  - `GET /api/v1/debates/public/{id}` returns the public payload without auth
-  - the standalone `/debate/{id}` page renders the full shared argument, critiques, and transcript
-- The strongest focused verification on March 29, 2026 is:
-
-  ```bash
-  python3 -m pytest tests/e2e/test_demo_public_funnel.py tests/server/handlers/test_public_debate_viewer.py tests/handlers/test_debate_share.py -q
-  cd aragora/live && npx jest --ci --runInBand --runTestsByPath 'src/app/(standalone)/debate/__tests__/page.test.tsx' 'src/app/(standalone)/debate/__tests__/fetchDebate.test.ts'
-  ```
-
-  Results on March 29, 2026:
-  - `19 passed` in the Python public-share suites
-  - `27 passed` in the standalone debate page/fetch suites
-
-- That is enough to say the repo contains a working public proof surface for shared debates and a cleaner CI baseline.
-- It is **not** enough to say the full operator-facing proof pack is done. Telemetry, receipt UI, cost accounting, and dashboard visibility remain the most important open product work.
-- GitHub's open issues are **not** only enterprise-assurance items anymore. The active product backlog is [#1492](https://github.com/synaptent/aragora/issues/1492) through [#1503](https://github.com/synaptent/aragora/issues/1503), plus the enterprise-assurance issues [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), and [#509](https://github.com/synaptent/aragora/issues/509).
-- [#1498](https://github.com/synaptent/aragora/issues/1498) was closed as satisfied by the merged public-share work.
+- `main` moved materially beyond the late-March status:
+  - [#6370](https://github.com/synaptent/aragora/pull/6370) landed `docs/THESIS.md` as the canonical statement of authority, settlement, triage, and heterogeneous review commitments.
+  - The PDB lane is now real code on `main`, not only design work:
+    - [#6369](https://github.com/synaptent/aragora/pull/6369) brief lifecycle state machine + storage
+    - [#6389](https://github.com/synaptent/aragora/pull/6389) Protocol B executor + panel config + budget
+    - [#6391](https://github.com/synaptent/aragora/pull/6391) brief generation endpoints + in-process worker
+    - [#6393](https://github.com/synaptent/aragora/pull/6393) PR 4 UI design
+  - The agent-bridge lane advanced with [#6392](https://github.com/synaptent/aragora/pull/6392) backend core, plus scoping/design docs in [#6390](https://github.com/synaptent/aragora/pull/6390) and [#6386](https://github.com/synaptent/aragora/pull/6386).
+  - Receipt and dissent substrates also hardened via [#6353](https://github.com/synaptent/aragora/pull/6353) and [#6376](https://github.com/synaptent/aragora/pull/6376).
+- The open PR queue is small again: 6 open PRs at the time of this refresh, with 2 drafts and 4 ready.
+- `main` now contains a real `aragora/pdb/` module set:
+  - `brief_state.py`
+  - `storage.py`
+  - `panel_config.py`
+  - `budget.py`
+  - `protocol.py`
+  - `prompts.py`
+  - `input_loader.py`
+  - `worker.py`
+- The key honest qualifier is still active:
+  - `aragora/swarm/pr_review_protocol.py` still declares `PROTOCOL_STATUS = "metadata_heuristic"`
+  - the newer PDB execution path is shipping alongside it
+  - therefore the canonical PR review packet path is not yet fully upgraded to the thesis's heterogeneous-ensemble standard
+- The thesis implementation-gap issues are now explicit and open:
+  - [#6372](https://github.com/synaptent/aragora/issues/6372) auto-handle calibration + drift gating
+  - [#6373](https://github.com/synaptent/aragora/issues/6373) rolling-window triage metrics
+  - [#6374](https://github.com/synaptent/aragora/issues/6374) upgrade PR review from `metadata_heuristic` to `heterogeneous_ensemble_v1`
+  - [#6375](https://github.com/synaptent/aragora/issues/6375) empirical threshold grounding
 
 ### What Recently Landed On `main`
 
-The late-March merge stream materially improved the product proof surface:
+The April merge stream maps directly to the thesis and review-queue execution path:
 
-1. **Queue hygiene for founder/build intake artifacts** via [#1566](https://github.com/synaptent/aragora/pull/1566)
-2. **Shared CI baseline hardening** via [#1572](https://github.com/synaptent/aragora/pull/1572)
-3. **Frontend stale-test baseline cleanup** via [#1604](https://github.com/synaptent/aragora/pull/1604)
-4. **Public spectate/auth contract fix** via [#1601](https://github.com/synaptent/aragora/pull/1601)
-5. **Insights flip-detector initialization hardening** via [#1602](https://github.com/synaptent/aragora/pull/1602)
-6. **Governance workflow cancel guard** via [#1616](https://github.com/synaptent/aragora/pull/1616)
-7. **Public standalone debate share links from the detail view** via [#1617](https://github.com/synaptent/aragora/pull/1617)
-
-These are real product improvements. They also shift the next highest-value work away from more generic autonomy infrastructure and toward truthful proof surfaces.
+1. **Canonical thesis source of authority** via [#6370](https://github.com/synaptent/aragora/pull/6370)
+2. **PDB PR 1 — brief lifecycle state machine + storage** via [#6369](https://github.com/synaptent/aragora/pull/6369)
+3. **PDB PR 2 — Protocol B executor + panel config + budget** via [#6389](https://github.com/synaptent/aragora/pull/6389)
+4. **PDB PR 3 — brief generation endpoints + in-process worker** via [#6391](https://github.com/synaptent/aragora/pull/6391)
+5. **Mode 3 PR 4 UI design** via [#6393](https://github.com/synaptent/aragora/pull/6393)
+6. **Provider slot resolver and output schemas** via [#6368](https://github.com/synaptent/aragora/pull/6368), [#6380](https://github.com/synaptent/aragora/pull/6380), and [#6383](https://github.com/synaptent/aragora/pull/6383)
+7. **CI and baseline discipline** via [#6379](https://github.com/synaptent/aragora/pull/6379), [#6381](https://github.com/synaptent/aragora/pull/6381), and [#6394](https://github.com/synaptent/aragora/pull/6394)
+8. **Agent-bridge backend core** via [#6392](https://github.com/synaptent/aragora/pull/6392)
 
 ### Current Frontier
 
-The frontier is no longer “make more infrastructure exist.” It is:
+The frontier is now:
 
-- **telemetry foundation** — capture debate usage, latency, and cost data truthfully
-- **receipt proof surface** — expose that telemetry in the receipt UI and API
-- **dashboard proof** — show counts, confidence, spend, and top-agent performance from real data
-- **comparison/demo polish** — compare debate outcomes and make the public demo stronger only after the proof surface is trustworthy
-- **enterprise assurance later** — still real, but sequenced after product proof
+- **finish the canonical heterogeneous PR-review upgrade** — close [#6374](https://github.com/synaptent/aragora/issues/6374) by making the primary packet path genuinely ensemble-backed and dissent-preserving
+- **ship rolling-window triage metrics** — close [#6373](https://github.com/synaptent/aragora/issues/6373) so the triage layer is measured by outcomes, not daily counts only
+- **add auto-handle calibration + drift gating** — close [#6372](https://github.com/synaptent/aragora/issues/6372) so low-stakes automation is constrained by real outcome history
+- **ground threshold claims empirically** — close [#6375](https://github.com/synaptent/aragora/issues/6375) after the metrics layer exists
+- **keep queue growth bounded** — continue the single-slice cadence in the PDB lane rather than opening large successor chains in parallel
 
 ### Canonical Execution Order
 
-The current `boss-ready` queue should be treated in this order:
+The current bounded queue should be treated in this order:
 
-1. [#1492](https://github.com/synaptent/aragora/issues/1492) Backend telemetry pipeline and analytics store
-2. [#1493](https://github.com/synaptent/aragora/issues/1493) Cost calculation and API layer
-3. [#1494](https://github.com/synaptent/aragora/issues/1494) React receipt UI component
-4. [#1501](https://github.com/synaptent/aragora/issues/1501) Dashboard counts, confidence, spend, and agent performance
-5. [#1499](https://github.com/synaptent/aragora/issues/1499) Side-by-side debate comparison
-6. [#1496](https://github.com/synaptent/aragora/issues/1496) Live debate on the landing page
-7. [#1497](https://github.com/synaptent/aragora/issues/1497) Slack debated answer with receipt
-
-The remaining idea backlog should stay open but **not** be treated as the active queue until the proof surface above is stronger:
-
-- [#1500](https://github.com/synaptent/aragora/issues/1500) learn from past debates
-- [#1502](https://github.com/synaptent/aragora/issues/1502) automatic retry across models
-- [#1503](https://github.com/synaptent/aragora/issues/1503) run model combinations and pick the best result
+1. close [#6374](https://github.com/synaptent/aragora/issues/6374) on the canonical PR-review path
+2. close [#6373](https://github.com/synaptent/aragora/issues/6373) with rolling-window metrics and outcome linkage
+3. close [#6372](https://github.com/synaptent/aragora/issues/6372) with calibration + drift gating for auto-handle paths
+4. close [#6375](https://github.com/synaptent/aragora/issues/6375) using the metrics substrate above
+5. keep the agent-bridge lane scoped to bounded, observable increments rather than a parallel subsystem explosion
 
 ### Strategic Direction
 
-The strategy document is [ARAGORA_IDEA_TO_EXECUTION_STRATEGY](../plans/ARAGORA_IDEA_TO_EXECUTION_STRATEGY.md).
-The short version is now:
+The strategy document is now [docs/THESIS.md](../THESIS.md).
+The short version on April 21, 2026:
 
-- the repo has a working public debate proof surface
-- the next gate is truthful telemetry/receipt/dashboard proof, not more speculative expansion
-- the pipeline/workbench/swarm stack should be used on the bounded queue above, not on a flat wishlist
-- GTM starts after repeatable live proof, not before
+- the project is executing on the thesis in real code, especially in the PDB lane
+- the most important remaining gap is not “more infrastructure,” but closing the heuristic-to-ensemble upgrade on the canonical PR packet path
+- human settlement remains the controlling boundary
+- the next wins come from truthful metrics, calibration, and bounded slice discipline rather than wider speculative expansion
 
 ## March 2026 Sprint — Closed-Loop Backbone, Trust Wedge & Infrastructure
 


### PR DESCRIPTION
## Summary
- refresh the canonical status docs to reflect the April 21 reality instead of the stale March debate-sharing snapshot
- update both `docs/status/STATUS.md` and the compatibility mirror `docs/STATUS.md`
- name what has actually landed on `main`: thesis, PDB PR1-PR3, agent-bridge backend core, and the remaining thesis-gap queue

## Why
- the status docs were materially stale and no longer described the current product direction
- the repo's canonical status surface should honestly name that the PDB execution path is shipping while `aragora/swarm/pr_review_protocol.py` still remains `metadata_heuristic`
- this is a low-risk hygiene improvement that clarifies the real next bounded queue without widening implementation scope

## Validation
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
