### PR TITLE
codex/reconcile 6346 20260420

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -16,7 +16,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.0.0",
         "tsup": "^8.0.1",
-        "typescript": "^5.3.2",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.56.0",
         "vitest": "^4.0.18"
       },
@@ -3693,9 +3693,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -58,7 +58,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.0.0",
     "tsup": "^8.0.1",
-    "typescript": "^5.3.2",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.56.0",
     "vitest": "^4.0.18"
   },

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -16,6 +16,7 @@
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
     "forceConsistentCasingInFileNames": true,
     "outDir": "./dist",
     "rootDir": "./src"


### PR DESCRIPTION
- **chore(deps): bump typescript from 5.9.3 to 6.0.3 in /sdk/typescript**
- **fix(sdk): silence TS6 baseUrl deprecation in dts build**
