### PR TITLE
feat(agent-bridge): read-only autonomous UI on PR 2b API (PR 2c)

### DIFF
--- a/aragora/live/src/app/(app)/autonomous/bridge/[run_id]/page.tsx
+++ b/aragora/live/src/app/(app)/autonomous/bridge/[run_id]/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+
+import { BridgeRunDetail } from '@/components/autonomous/bridge/BridgeRunDetail';
+import { Scanlines, CRTVignette } from '@/components/MatrixRain';
+import { useRightSidebar } from '@/context/RightSidebarContext';
+
+export default function AgentBridgeRunDetailPage() {
+  const params = useParams();
+  const runId = Array.isArray(params.run_id) ? params.run_id[0] : params.run_id;
+  const { setContext, clearContext } = useRightSidebar();
+
+  useEffect(() => {
+    setContext({
+      title: 'Bridge Detail',
+      subtitle: runId ?? 'Run detail',
+      statsContent: (
+        <div className="space-y-4">
+          <div className="text-xs uppercase tracking-wider text-white/40">Panels</div>
+          <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-white/50">Transcript</span>
+              <span className="text-[var(--accent)]">Footer-aware</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-white/50">Events</span>
+              <span className="text-cyan-300">Parse status</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-white/50">Metadata</span>
+              <span className="text-white/60">run.json + sessions.json</span>
+            </div>
+          </div>
+        </div>
+      ),
+      actionsContent: (
+        <div className="space-y-2">
+          <a
+            href="/autonomous/bridge"
+            className="block w-full rounded bg-white/5 px-3 py-2 text-center text-sm transition-colors hover:bg-white/10"
+          >
+            All Bridge Runs
+          </a>
+        </div>
+      ),
+    });
+
+    return () => clearContext();
+  }, [clearContext, runId, setContext]);
+
+  if (!runId || typeof runId !== 'string') {
+    return null;
+  }
+
+  return (
+    <div className="relative min-h-screen bg-black text-white">
+      <Scanlines />
+      <CRTVignette />
+
+      <div className="relative z-10 p-6">
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          <div className="text-sm text-white/50">
+            <Link
+              href="/autonomous/bridge"
+              className="transition-colors hover:text-white"
+            >
+              Agent Bridge
+            </Link>
+            <span className="mx-2 text-white/25">/</span>
+            <span className="text-white/75">{runId}</span>
+          </div>
+        </div>
+
+        <BridgeRunDetail runId={runId} />
+      </div>
+    </div>
+  );
+}

--- a/aragora/live/src/app/(app)/autonomous/bridge/page.tsx
+++ b/aragora/live/src/app/(app)/autonomous/bridge/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+import { BridgeRunList } from '@/components/autonomous/bridge/BridgeRunList';
+import { Scanlines, CRTVignette } from '@/components/MatrixRain';
+import { useRightSidebar } from '@/context/RightSidebarContext';
+
+export default function AgentBridgeRunsPage() {
+  const { setContext, clearContext } = useRightSidebar();
+
+  useEffect(() => {
+    setContext({
+      title: 'Agent Bridge',
+      subtitle: 'Read-only broker state',
+      statsContent: (
+        <div className="space-y-4">
+          <div className="text-xs uppercase tracking-wider text-white/40">Mode</div>
+          <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-white/50">Surface</span>
+              <span className="text-[var(--accent)]">Read only</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-white/50">Transport</span>
+              <span className="text-cyan-300">HTTP polling</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-white/50">Broker store</span>
+              <span className="text-white/60">.aragora/agent_bridge</span>
+            </div>
+          </div>
+        </div>
+      ),
+      actionsContent: (
+        <div className="space-y-2">
+          <a
+            href="/autonomous"
+            className="block w-full rounded bg-white/5 px-3 py-2 text-center text-sm transition-colors hover:bg-white/10"
+          >
+            Autonomous Home
+          </a>
+        </div>
+      ),
+    });
+
+    return () => clearContext();
+  }, [clearContext, setContext]);
+
+  return (
+    <div className="relative min-h-screen bg-black text-white">
+      <Scanlines />
+      <CRTVignette />
+
+      <div className="relative z-10 p-6">
+        <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div className="mb-2 text-xs uppercase tracking-[0.25em] text-white/35">
+              Autonomous Bridge
+            </div>
+            <h1 className="text-3xl font-bold text-white">Agent Bridge Runs</h1>
+            <p className="mt-2 max-w-3xl text-sm text-white/55">
+              Inspect persistent bridge runs and role-keyed session state without mutation controls
+              or WebSocket transport.
+            </p>
+          </div>
+
+          <Link
+            href="/autonomous"
+            className="rounded border border-white/10 px-3 py-2 text-sm text-white/60 transition-colors hover:border-white/20 hover:text-white"
+          >
+            Back to Autonomous
+          </Link>
+        </div>
+
+        <BridgeRunList />
+      </div>
+    </div>
+  );
+}

--- a/aragora/live/src/components/autonomous/bridge/BridgeEventStream.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeEventStream.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import EmptyState from '@/components/ui/EmptyState';
+import { StatusBadge } from '@/components/shared/StatusBadge';
+
+import type {
+  AgentBridgeEvent,
+  AgentBridgeFooter,
+  BridgeApiError,
+  BridgeParseStatus,
+} from './types';
+import {
+  formatBridgeTimestamp,
+  getBridgeStringArray,
+  isBridgeRecord,
+  truncateBridgeSessionId,
+} from './types';
+
+interface BridgeEventStreamProps {
+  events: AgentBridgeEvent[];
+  isLoading?: boolean;
+  error?: BridgeApiError | null;
+}
+
+function getParseStatusVariant(parseStatus: BridgeParseStatus | null) {
+  switch (parseStatus) {
+    case 'ok':
+      return 'success' as const;
+    case 'missing':
+      return 'warning' as const;
+    case 'malformed':
+      return 'error' as const;
+    default:
+      return 'neutral' as const;
+  }
+}
+
+function readFooter(payload: Record<string, unknown>): AgentBridgeFooter | null {
+  const footer = payload.footer;
+  if (!isBridgeRecord(footer)) {
+    return null;
+  }
+
+  const summary = footer.summary;
+  const nextActor = footer.next_actor;
+  const needsHuman = footer.needs_human;
+  const done = footer.done;
+  const artifacts = getBridgeStringArray(footer.artifacts);
+  const testsRun = getBridgeStringArray(footer.tests_run);
+
+  if (
+    typeof summary !== 'string' ||
+    (nextActor !== null && typeof nextActor !== 'string') ||
+    typeof needsHuman !== 'boolean' ||
+    typeof done !== 'boolean'
+  ) {
+    return null;
+  }
+
+  return {
+    summary,
+    next_actor: nextActor,
+    needs_human: needsHuman,
+    done,
+    artifacts,
+    tests_run: testsRun,
+  };
+}
+
+function buildEventSummary(event: AgentBridgeEvent): string {
+  const footer = readFooter(event.payload);
+  if (footer?.summary) {
+    return footer.summary;
+  }
+
+  const reason = event.payload.reason;
+  if (typeof reason === 'string' && reason.length > 0) {
+    return reason;
+  }
+
+  const messageText = event.payload.message_text;
+  if (typeof messageText === 'string' && messageText.length > 0) {
+    return messageText;
+  }
+
+  return event.event_type;
+}
+
+export function BridgeEventStream({
+  events,
+  isLoading = false,
+  error = null,
+}: BridgeEventStreamProps) {
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+        Bridge API unreachable
+      </div>
+    );
+  }
+
+  if (isLoading && events.length === 0) {
+    return <div className="text-sm text-white/50">Loading events…</div>;
+  }
+
+  if (events.length === 0) {
+    return <EmptyState title="No bridge events yet" description="Event records will appear here." />;
+  }
+
+  return (
+    <div className="max-h-[34rem] space-y-3 overflow-y-auto pr-1">
+      {events.map((event) => (
+        <article
+          key={event.event_id}
+          className="rounded-xl border border-white/10 bg-white/5 p-4"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusBadge label={event.event_type} variant="neutral" />
+              <StatusBadge
+                label={event.parse_status ?? 'n/a'}
+                variant={getParseStatusVariant(event.parse_status)}
+              />
+            </div>
+            <div className="text-xs text-white/45">{formatBridgeTimestamp(event.ts)}</div>
+          </div>
+
+          <div className="mt-3 text-sm text-white/80">{buildEventSummary(event)}</div>
+
+          <div className="mt-3 flex flex-wrap gap-3 text-xs text-white/50">
+            <span>role: {event.role}</span>
+            <span>harness: {event.harness}</span>
+            <span>turn: {event.turn_index}</span>
+            <span title={event.session_id ?? ''}>
+              session: {truncateBridgeSessionId(event.session_id)}
+            </span>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/aragora/live/src/components/autonomous/bridge/BridgeRoleCard.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeRoleCard.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { StatusBadge } from '@/components/shared/StatusBadge';
+
+import type { AgentBridgeSessionEntry } from './types';
+import { formatBridgeTimestamp, truncateBridgeSessionId } from './types';
+
+interface BridgeRoleCardProps {
+  role: string;
+  session: AgentBridgeSessionEntry;
+}
+
+function getHarnessVariant(harness: string) {
+  const normalized = harness.toLowerCase();
+  if (normalized.startsWith('claude')) {
+    return 'purple' as const;
+  }
+  if (normalized.startsWith('codex')) {
+    return 'info' as const;
+  }
+  if (normalized.startsWith('droid')) {
+    return 'orange' as const;
+  }
+  return 'neutral' as const;
+}
+
+function getSessionStatusVariant(sessionStatus: AgentBridgeSessionEntry['session_status']) {
+  switch (sessionStatus) {
+    case 'active':
+      return 'success' as const;
+    case 'completed':
+      return 'info' as const;
+    case 'failed':
+      return 'error' as const;
+    default:
+      return 'warning' as const;
+  }
+}
+
+export function BridgeRoleCard({ role, session }: BridgeRoleCardProps) {
+  return (
+    <article className="rounded-xl border border-white/10 bg-white/5 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-xs uppercase tracking-[0.2em] text-white/35">Role</div>
+          <h3 className="mt-1 text-lg font-medium text-white">{role}</h3>
+          <div className="mt-1 text-sm text-white/55">{session.model}</div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <StatusBadge label={session.harness} variant={getHarnessVariant(session.harness)} />
+          <StatusBadge
+            label={session.session_status}
+            variant={getSessionStatusVariant(session.session_status)}
+          />
+        </div>
+      </div>
+
+      <dl className="mt-4 space-y-3 text-sm">
+        <div className="flex items-start justify-between gap-4">
+          <dt className="text-white/45">Session</dt>
+          <dd className="font-theme-data text-right text-white/80" title={session.session_id ?? ''}>
+            {truncateBridgeSessionId(session.session_id)}
+          </dd>
+        </div>
+        <div className="flex items-start justify-between gap-4">
+          <dt className="text-white/45">Last turn</dt>
+          <dd className="text-right text-white/80">
+            {formatBridgeTimestamp(session.last_completed_at)}
+          </dd>
+        </div>
+        <div className="flex items-start justify-between gap-4">
+          <dt className="text-white/45">Branch</dt>
+          <dd className="break-all text-right text-white/70">{session.branch ?? 'n/a'}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}

--- a/aragora/live/src/components/autonomous/bridge/BridgeRunDetail.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeRunDetail.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { TabPanel, Tabs } from '@/components/Tabs';
+import { StatusBadge } from '@/components/shared/StatusBadge';
+import { BridgeEventStream } from '@/components/autonomous/bridge/BridgeEventStream';
+import { BridgeRoleCard } from '@/components/autonomous/bridge/BridgeRoleCard';
+import { BridgeTranscriptView } from '@/components/autonomous/bridge/BridgeTranscriptView';
+import { useAgentBridgeEvents } from '@/hooks/useAgentBridgeEvents';
+import { useAgentBridgeRun } from '@/hooks/useAgentBridgeRun';
+import { useAgentBridgeTranscript } from '@/hooks/useAgentBridgeTranscript';
+
+import type { AgentBridgeRunDetail } from './types';
+import { formatBridgeTimestamp } from './types';
+
+interface BridgeRunDetailProps {
+  runId: string;
+}
+
+function getRunStatusVariant(status: AgentBridgeRunDetail['status']) {
+  switch (status) {
+    case 'running':
+      return 'info' as const;
+    case 'awaiting_human':
+      return 'warning' as const;
+    case 'completed':
+      return 'success' as const;
+    case 'failed':
+      return 'error' as const;
+  }
+}
+
+function buildRunJsonView(run: AgentBridgeRunDetail) {
+  return {
+    schema_version: run.schema_version,
+    run_id: run.run_id,
+    task: run.task,
+    status: run.status,
+    created_at: run.created_at,
+    updated_at: run.updated_at,
+    completed_at: run.completed_at,
+    last_turn_index: run.last_turn_index,
+    next_actor: run.next_actor,
+    repair_budget_per_turn: run.repair_budget_per_turn,
+    footer_mode: run.footer_mode,
+    worktree_cleanup_mode: run.worktree_cleanup_mode,
+    participants: run.participants,
+    worktree_path: run.worktree_path,
+    worktree_agent_slug: run.worktree_agent_slug,
+    last_event_id: run.last_event_id,
+  };
+}
+
+function buildSessionsJsonView(run: AgentBridgeRunDetail) {
+  return {
+    schema_version: run.schema_version,
+    run_id: run.run_id,
+    updated_at: run.updated_at,
+    sessions: run.roles,
+  };
+}
+
+function orderedRoleEntries(run: AgentBridgeRunDetail) {
+  const orderedEntries = run.participants
+    .map((participant) => [participant.role, run.roles[participant.role]] as const)
+    .filter(
+      (entry): entry is [string, AgentBridgeRunDetail['roles'][string]] => Boolean(entry[1])
+    );
+
+  const seenRoles = new Set(orderedEntries.map(([role]) => role));
+  const remainingEntries = Object.entries(run.roles).filter(([role]) => !seenRoles.has(role));
+
+  return [...orderedEntries, ...remainingEntries];
+}
+
+export function BridgeRunDetail({ runId }: BridgeRunDetailProps) {
+  const runQuery = useAgentBridgeRun(runId, { enabled: Boolean(runId) });
+  const shouldPoll = runQuery.run?.status === 'running';
+  const eventsQuery = useAgentBridgeEvents(runId, {
+    enabled: Boolean(runId),
+    poll: shouldPoll,
+    limit: 500,
+  });
+  const transcriptQuery = useAgentBridgeTranscript(runId, {
+    enabled: Boolean(runId),
+    poll: shouldPoll,
+  });
+
+  if (
+    runQuery.errorStatus === 403 ||
+    eventsQuery.errorStatus === 403 ||
+    transcriptQuery.errorStatus === 403
+  ) {
+    throw new Error('Forbidden: agent_bridge:read');
+  }
+
+  if (runQuery.isLoading && !runQuery.run) {
+    return <div className="text-sm text-white/50">Loading bridge run…</div>;
+  }
+
+  if (runQuery.error && !runQuery.run) {
+    return (
+      <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+        Bridge API unreachable
+        <button
+          onClick={runQuery.retry}
+          className="ml-3 underline underline-offset-2 hover:no-underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!runQuery.run) {
+    return null;
+  }
+
+  const run = runQuery.run;
+  const roleEntries = orderedRoleEntries(run);
+  const runJson = buildRunJsonView(run);
+  const sessionsJson = buildSessionsJsonView(run);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-xl border border-white/10 bg-white/5 p-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="text-xs uppercase tracking-[0.25em] text-white/35">Agent Bridge Run</div>
+            <h1 className="mt-1 text-3xl font-theme-display text-white">{run.run_id}</h1>
+            <p className="mt-2 max-w-3xl text-sm text-white/60">{run.task}</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <StatusBadge label={run.status} variant={getRunStatusVariant(run.status)} size="md" />
+            <StatusBadge label={run.footer_mode} variant="neutral" size="md" />
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-4 md:grid-cols-2">
+          <div className="rounded-lg border border-white/10 bg-black/20 p-4">
+            <div className="text-xs uppercase tracking-[0.2em] text-white/35">Worktree path</div>
+            <div className="mt-2 break-all text-sm text-white/80">{run.worktree_path ?? 'n/a'}</div>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-black/20 p-4">
+            <div className="text-xs uppercase tracking-[0.2em] text-white/35">Active role</div>
+            <div className="mt-2 text-sm text-white/80">{run.next_actor ?? 'none'}</div>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-4 text-xs text-white/50">
+          <span>created: {formatBridgeTimestamp(run.created_at)}</span>
+          <span>updated: {formatBridgeTimestamp(run.updated_at)}</span>
+          <span>turns: {run.last_turn_index}</span>
+          <span>cleanup: {run.worktree_cleanup_mode}</span>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="text-xs uppercase tracking-[0.25em] text-white/35">Participant sessions</div>
+        <div className="grid gap-4 lg:grid-cols-2">
+          {roleEntries.map(([role, session]) => (
+            <BridgeRoleCard key={role} role={role} session={session} />
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-white/10 bg-white/5 p-5">
+        <Tabs
+          ariaLabel="Bridge run detail tabs"
+          defaultTab="transcript"
+          tabs={[
+            {
+              id: 'transcript',
+              label: 'Transcript',
+              badge: transcriptQuery.turns.length,
+            },
+            {
+              id: 'events',
+              label: 'Events',
+              badge: eventsQuery.events.length,
+            },
+            {
+              id: 'metadata',
+              label: 'Metadata',
+            },
+          ]}
+          variant="underline"
+        >
+          <TabPanel tabId="transcript">
+            <BridgeTranscriptView
+              turns={transcriptQuery.turns}
+              isLoading={transcriptQuery.isLoading}
+              error={transcriptQuery.error}
+            />
+          </TabPanel>
+
+          <TabPanel tabId="events">
+            <BridgeEventStream
+              events={eventsQuery.events}
+              isLoading={eventsQuery.isLoading}
+              error={eventsQuery.error}
+            />
+          </TabPanel>
+
+          <TabPanel tabId="metadata">
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="rounded-lg border border-white/10 bg-black/20 p-4">
+                <div className="mb-3 text-xs uppercase tracking-[0.2em] text-white/35">
+                  run.json
+                </div>
+                <pre className="max-h-[32rem] overflow-auto whitespace-pre-wrap break-all text-xs text-white/70">
+                  {JSON.stringify(runJson, null, 2)}
+                </pre>
+              </div>
+              <div className="rounded-lg border border-white/10 bg-black/20 p-4">
+                <div className="mb-3 text-xs uppercase tracking-[0.2em] text-white/35">
+                  sessions.json
+                </div>
+                <pre className="max-h-[32rem] overflow-auto whitespace-pre-wrap break-all text-xs text-white/70">
+                  {JSON.stringify(sessionsJson, null, 2)}
+                </pre>
+              </div>
+            </div>
+          </TabPanel>
+        </Tabs>
+      </section>
+    </div>
+  );
+}

--- a/aragora/live/src/components/autonomous/bridge/BridgeRunList.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeRunList.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import Link from 'next/link';
+
+import { EmptyState } from '@/components/ui/EmptyState';
+import { StatusBadge } from '@/components/shared/StatusBadge';
+import { useAgentBridgeRuns } from '@/hooks/useAgentBridgeRuns';
+
+import type { AgentBridgeRunSummary } from './types';
+import { formatBridgeTimestamp } from './types';
+
+function getRunStatusVariant(status: AgentBridgeRunSummary['status']) {
+  switch (status) {
+    case 'running':
+      return 'info' as const;
+    case 'awaiting_human':
+      return 'warning' as const;
+    case 'completed':
+      return 'success' as const;
+    case 'failed':
+      return 'error' as const;
+  }
+}
+
+function renderParticipants(run: AgentBridgeRunSummary) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {run.participants.map((participant) => (
+        <span
+          key={`${run.run_id}-${participant.role}`}
+          className="rounded border border-white/10 bg-black/20 px-2 py-1 text-xs text-white/70"
+        >
+          {participant.role} · {participant.harness}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function BridgeRunList() {
+  const { runs, hasMore, isLoading, isLoadingMore, error, errorStatus, loadMore, retry } =
+    useAgentBridgeRuns();
+
+  if (errorStatus === 403) {
+    throw new Error('Forbidden: agent_bridge:read');
+  }
+
+  return (
+    <div className="space-y-4">
+      {error ? (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+          Bridge API unreachable
+          <button
+            onClick={retry}
+            className="ml-3 underline underline-offset-2 hover:no-underline"
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {isLoading ? <div className="text-sm text-white/50">Loading bridge runs…</div> : null}
+
+      {!isLoading && runs.length === 0 ? (
+        <EmptyState
+          title="No agent-bridge runs yet"
+          description="Read-only bridge runs will appear here as soon as the broker writes them."
+        />
+      ) : null}
+
+      {runs.length > 0 ? (
+        <div className="overflow-hidden rounded-xl border border-white/10 bg-white/5">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-white/10">
+              <thead className="bg-black/20">
+                <tr className="text-left text-xs uppercase tracking-[0.2em] text-white/35">
+                  <th className="px-4 py-3">run_id</th>
+                  <th className="px-4 py-3">status</th>
+                  <th className="px-4 py-3">active_role</th>
+                  <th className="px-4 py-3">participants</th>
+                  <th className="px-4 py-3">updated_at</th>
+                  <th className="px-4 py-3">turn_count</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10">
+                {runs.map((run) => (
+                  <tr key={run.run_id} className="align-top text-sm text-white/80">
+                    <td className="px-4 py-4 font-theme-data">
+                      <Link
+                        href={`/autonomous/bridge/${run.run_id}`}
+                        className="text-white transition-colors hover:text-[var(--accent)]"
+                      >
+                        {run.run_id}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-4">
+                      <StatusBadge label={run.status} variant={getRunStatusVariant(run.status)} />
+                    </td>
+                    <td className="px-4 py-4">{run.next_actor ?? 'none'}</td>
+                    <td className="px-4 py-4">{renderParticipants(run)}</td>
+                    <td className="px-4 py-4 text-white/60">
+                      {formatBridgeTimestamp(run.updated_at)}
+                    </td>
+                    <td className="px-4 py-4">{run.last_turn_index}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
+
+      {hasMore ? (
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={isLoadingMore}
+            className="rounded border border-white/10 px-4 py-2 text-sm text-white/70 transition-colors hover:border-white/20 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoadingMore ? 'Loading…' : 'Load more'}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/aragora/live/src/components/autonomous/bridge/BridgeTranscriptView.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeTranscriptView.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+
+import EmptyState from '@/components/ui/EmptyState';
+import { StatusBadge } from '@/components/shared/StatusBadge';
+
+import type { AgentBridgeTurnRecord, BridgeApiError, BridgeParseStatus } from './types';
+import { formatBridgeTimestamp } from './types';
+
+interface BridgeTranscriptViewProps {
+  turns: AgentBridgeTurnRecord[];
+  isLoading?: boolean;
+  error?: BridgeApiError | null;
+}
+
+function getParseStatusVariant(parseStatus: BridgeParseStatus) {
+  switch (parseStatus) {
+    case 'ok':
+      return 'success' as const;
+    case 'missing':
+      return 'warning' as const;
+    case 'malformed':
+      return 'error' as const;
+  }
+}
+
+export function BridgeTranscriptView({
+  turns,
+  isLoading = false,
+  error = null,
+}: BridgeTranscriptViewProps) {
+  const orderedTurns = [...turns].sort((left, right) => left.turn_index - right.turn_index);
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+        Bridge API unreachable
+      </div>
+    );
+  }
+
+  if (isLoading && orderedTurns.length === 0) {
+    return <div className="text-sm text-white/50">Loading transcript…</div>;
+  }
+
+  if (orderedTurns.length === 0) {
+    return <EmptyState title="No transcript turns yet" description="Bridge turns will appear here." />;
+  }
+
+  return (
+    <div className="space-y-4">
+      {orderedTurns.map((turn) => (
+        <article
+          key={`${turn.turn_index}-${turn.author_role}`}
+          className="rounded-xl border border-white/10 bg-white/5 p-4"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-xs uppercase tracking-[0.2em] text-white/35">
+                Turn {turn.turn_index}
+              </div>
+              <h3 className="mt-1 text-lg text-white">{turn.author_role}</h3>
+              <div className="mt-1 text-xs text-white/45">
+                {formatBridgeTimestamp(turn.started_at)} to {formatBridgeTimestamp(turn.completed_at)}
+              </div>
+            </div>
+            <StatusBadge
+              label={turn.parse_status}
+              variant={getParseStatusVariant(turn.parse_status)}
+            />
+          </div>
+
+          <div className="mt-4 rounded-lg border border-white/10 bg-black/20 p-4">
+            <div className="mb-2 text-xs uppercase tracking-[0.2em] text-white/35">Message</div>
+            {turn.body_markdown ? (
+              <div className="prose prose-invert max-w-none text-sm text-white/80">
+                <ReactMarkdown>{turn.body_markdown}</ReactMarkdown>
+              </div>
+            ) : (
+              <div className="text-sm text-white/45">No parsed message captured.</div>
+            )}
+          </div>
+
+          <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.03] p-4">
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              <div className="text-xs uppercase tracking-[0.2em] text-white/35">Bridge Footer</div>
+              <StatusBadge
+                label={turn.parse_status}
+                variant={getParseStatusVariant(turn.parse_status)}
+              />
+            </div>
+
+            {turn.footer ? (
+              <div className="space-y-3 text-sm text-white/80">
+                <div>
+                  <div className="text-xs uppercase tracking-[0.2em] text-white/35">Summary</div>
+                  <p className="mt-1">{turn.footer.summary}</p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <StatusBadge
+                    label={`next_actor: ${turn.footer.next_actor ?? 'null'}`}
+                    variant="neutral"
+                  />
+                  <StatusBadge
+                    label={turn.footer.done ? 'done: true' : 'done: false'}
+                    variant={turn.footer.done ? 'success' : 'neutral'}
+                  />
+                  <StatusBadge
+                    label={
+                      turn.footer.needs_human ? 'needs_human: true' : 'needs_human: false'
+                    }
+                    variant={turn.footer.needs_human ? 'warning' : 'neutral'}
+                  />
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <div className="text-xs uppercase tracking-[0.2em] text-white/35">
+                      Artifacts
+                    </div>
+                    <div className="mt-1 text-white/70">
+                      {turn.footer.artifacts.length > 0
+                        ? turn.footer.artifacts.join(', ')
+                        : 'None'}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase tracking-[0.2em] text-white/35">
+                      Tests Run
+                    </div>
+                    <div className="mt-1 text-white/70">
+                      {turn.footer.tests_run.length > 0
+                        ? turn.footer.tests_run.join(', ')
+                        : 'None'}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="text-sm text-white/55">
+                No valid bridge footer was parsed for this turn.
+              </div>
+            )}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/aragora/live/src/components/autonomous/bridge/__tests__/BridgeRunDetail.test.tsx
+++ b/aragora/live/src/components/autonomous/bridge/__tests__/BridgeRunDetail.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { useAgentBridgeEvents } from '@/hooks/useAgentBridgeEvents';
+import { useAgentBridgeRun } from '@/hooks/useAgentBridgeRun';
+import { useAgentBridgeTranscript } from '@/hooks/useAgentBridgeTranscript';
+
+import type {
+  AgentBridgeEvent,
+  AgentBridgeRunDetail,
+  AgentBridgeTurnRecord,
+} from '../types';
+import { BridgeRunDetail } from '../BridgeRunDetail';
+
+jest.mock('@/hooks/useAgentBridgeRun');
+jest.mock('@/hooks/useAgentBridgeEvents');
+jest.mock('@/hooks/useAgentBridgeTranscript');
+
+const mockUseAgentBridgeRun = useAgentBridgeRun as jest.MockedFunction<typeof useAgentBridgeRun>;
+const mockUseAgentBridgeEvents = useAgentBridgeEvents as jest.MockedFunction<
+  typeof useAgentBridgeEvents
+>;
+const mockUseAgentBridgeTranscript = useAgentBridgeTranscript as jest.MockedFunction<
+  typeof useAgentBridgeTranscript
+>;
+
+function buildRunDetail(overrides: Partial<AgentBridgeRunDetail> = {}): AgentBridgeRunDetail {
+  return {
+    schema_version: 1,
+    run_id: 'bridge_20260421T191953Z_pr6306',
+    task: 'Review and refine the protocol orchestrator implementation plan.',
+    status: 'running',
+    created_at: '2026-04-21T19:19:53Z',
+    updated_at: '2026-04-21T19:24:10Z',
+    completed_at: null,
+    last_turn_index: 2,
+    next_actor: 'reviewer',
+    repair_budget_per_turn: 1,
+    footer_mode: 'prompt_injected',
+    worktree_cleanup_mode: 'operator_triggered',
+    participants: [
+      { role: 'implementer', harness: 'codex', model: 'gpt-5.4' },
+      { role: 'reviewer', harness: 'claude', model: 'claude-opus-4-7' },
+    ],
+    last_event_id: 'bridge:event:002',
+    worktree_path: '/tmp/bridge-worktree',
+    worktree_agent_slug: 'bridge-pr6306',
+    roles: {
+      implementer: {
+        role: 'implementer',
+        harness: 'codex',
+        model: 'gpt-5.4',
+        session_id: '019db172-4d01-7072-860c-99114afe8792',
+        worktree_agent_slug: 'bridge-pr6306-implementer',
+        worktree_path: '/tmp/bridge-worktree/implementer',
+        branch: 'codex/bridge-pr6306-implementer',
+        session_status: 'active',
+        started_at: '2026-04-21T19:21:02Z',
+        last_turn_index: 2,
+        last_completed_at: '2026-04-21T19:24:10Z',
+      },
+      reviewer: {
+        role: 'reviewer',
+        harness: 'claude',
+        model: 'claude-opus-4-7',
+        session_id: null,
+        worktree_agent_slug: 'bridge-pr6306-reviewer',
+        worktree_path: '/tmp/bridge-worktree/reviewer',
+        branch: 'codex/bridge-pr6306-reviewer',
+        session_status: 'not_started',
+        started_at: null,
+        last_turn_index: 0,
+        last_completed_at: null,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function buildTranscriptTurn(overrides: Partial<AgentBridgeTurnRecord> = {}): AgentBridgeTurnRecord {
+  return {
+    turn_index: 1,
+    author_role: 'implementer',
+    started_at: '2026-04-21T19:23:40Z',
+    completed_at: '2026-04-21T19:24:09Z',
+    parse_status: 'ok',
+    footer: {
+      summary: 'Outlined the persistence and transport slices.',
+      next_actor: 'reviewer',
+      needs_human: false,
+      done: false,
+      artifacts: [],
+      tests_run: [],
+    },
+    body_markdown: 'Turn body',
+    ...overrides,
+  };
+}
+
+function buildEvent(overrides: Partial<AgentBridgeEvent> = {}): AgentBridgeEvent {
+  return {
+    schema_version: 1,
+    event_id: 'bridge:event:001',
+    run_id: 'bridge_20260421T191953Z_pr6306',
+    ts: '2026-04-21T19:24:09Z',
+    event_type: 'turn.completed',
+    turn_index: 1,
+    role: 'implementer',
+    harness: 'codex',
+    session_id: '019db172-4d01-7072-860c-99114afe8792',
+    parse_status: 'ok',
+    payload: {
+      footer: {
+        summary: 'Outlined the persistence and transport slices.',
+        next_actor: 'reviewer',
+        needs_human: false,
+        done: false,
+        artifacts: [],
+        tests_run: [],
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('BridgeRunDetail', () => {
+  beforeEach(() => {
+    mockUseAgentBridgeRun.mockReturnValue({
+      run: buildRunDetail(),
+      isLoading: false,
+      error: null,
+      errorStatus: null,
+      retry: jest.fn(),
+    });
+    mockUseAgentBridgeEvents.mockReturnValue({
+      events: [buildEvent()],
+      nextCursor: null,
+      isLoading: false,
+      error: null,
+      errorStatus: null,
+      retry: jest.fn(),
+    });
+    mockUseAgentBridgeTranscript.mockReturnValue({
+      turns: [buildTranscriptTurn()],
+      isLoading: false,
+      error: null,
+      errorStatus: null,
+      retry: jest.fn(),
+    });
+  });
+
+  it('renders transcript, events, and metadata tabs', () => {
+    render(<BridgeRunDetail runId="bridge-run" />);
+
+    expect(screen.getByText('Turn body')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Events/i }));
+    expect(screen.getByText('turn.completed')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Metadata/i }));
+    expect(screen.getByText('run.json')).toBeInTheDocument();
+    expect(screen.getByText('sessions.json')).toBeInTheDocument();
+  });
+
+  it('renders role cards from the role-keyed registry', () => {
+    render(<BridgeRunDetail runId="bridge-run" />);
+
+    expect(screen.getAllByText('implementer').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('reviewer').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('codex').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('claude').length).toBeGreaterThan(0);
+  });
+
+  it('stops polling when the run is not running', () => {
+    mockUseAgentBridgeRun.mockReturnValue({
+      run: buildRunDetail({ status: 'completed' }),
+      isLoading: false,
+      error: null,
+      errorStatus: null,
+      retry: jest.fn(),
+    });
+
+    render(<BridgeRunDetail runId="bridge-run" />);
+
+    expect(mockUseAgentBridgeEvents).toHaveBeenCalledWith(
+      'bridge-run',
+      expect.objectContaining({ poll: false })
+    );
+    expect(mockUseAgentBridgeTranscript).toHaveBeenCalledWith(
+      'bridge-run',
+      expect.objectContaining({ poll: false })
+    );
+  });
+});

--- a/aragora/live/src/components/autonomous/bridge/__tests__/BridgeRunList.test.tsx
+++ b/aragora/live/src/components/autonomous/bridge/__tests__/BridgeRunList.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { useAgentBridgeRuns } from '@/hooks/useAgentBridgeRuns';
+
+import type { AgentBridgeRunSummary } from '../types';
+import { BridgeRunList } from '../BridgeRunList';
+
+jest.mock('@/hooks/useAgentBridgeRuns');
+
+const mockUseAgentBridgeRuns = useAgentBridgeRuns as jest.MockedFunction<
+  typeof useAgentBridgeRuns
+>;
+
+function buildRunSummary(overrides: Partial<AgentBridgeRunSummary> = {}): AgentBridgeRunSummary {
+  return {
+    schema_version: 1,
+    run_id: 'bridge_20260421T191953Z_pr6306',
+    task: 'Review and refine the protocol orchestrator implementation plan.',
+    status: 'running',
+    created_at: '2026-04-21T19:19:53Z',
+    updated_at: '2026-04-21T19:24:10Z',
+    completed_at: null,
+    last_turn_index: 3,
+    next_actor: 'reviewer',
+    repair_budget_per_turn: 1,
+    footer_mode: 'prompt_injected',
+    worktree_cleanup_mode: 'operator_triggered',
+    participants: [
+      { role: 'implementer', harness: 'codex', model: 'gpt-5.4' },
+      { role: 'reviewer', harness: 'claude', model: 'claude-opus-4-7' },
+    ],
+    last_event_id: 'bridge:event:003',
+    ...overrides,
+  };
+}
+
+describe('BridgeRunList', () => {
+  beforeEach(() => {
+    mockUseAgentBridgeRuns.mockReturnValue({
+      schemaVersion: 1,
+      runs: [buildRunSummary()],
+      nextCursor: null,
+      hasMore: false,
+      isLoading: false,
+      isLoadingMore: false,
+      error: null,
+      errorStatus: null,
+      loadMore: jest.fn(),
+      retry: jest.fn(),
+    });
+  });
+
+  it('renders bridge runs in the table', () => {
+    render(<BridgeRunList />);
+
+    expect(screen.getByText('bridge_20260421T191953Z_pr6306')).toBeInTheDocument();
+    expect(screen.getByText('running')).toBeInTheDocument();
+    expect(screen.getByText('reviewer')).toBeInTheDocument();
+    expect(screen.getByText('implementer · codex')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('renders the empty state', () => {
+    mockUseAgentBridgeRuns.mockReturnValue({
+      schemaVersion: 1,
+      runs: [],
+      nextCursor: null,
+      hasMore: false,
+      isLoading: false,
+      isLoadingMore: false,
+      error: null,
+      errorStatus: null,
+      loadMore: jest.fn(),
+      retry: jest.fn(),
+    });
+
+    render(<BridgeRunList />);
+
+    expect(screen.getByText('No agent-bridge runs yet')).toBeInTheDocument();
+  });
+
+  it('calls loadMore when the cursor button is clicked', () => {
+    const loadMore = jest.fn();
+    mockUseAgentBridgeRuns.mockReturnValue({
+      schemaVersion: 1,
+      runs: [buildRunSummary()],
+      nextCursor: 'cursor-2',
+      hasMore: true,
+      isLoading: false,
+      isLoadingMore: false,
+      error: null,
+      errorStatus: null,
+      loadMore,
+      retry: jest.fn(),
+    });
+
+    render(<BridgeRunList />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the explicit bridge API error banner', () => {
+    mockUseAgentBridgeRuns.mockReturnValue({
+      schemaVersion: null,
+      runs: [],
+      nextCursor: null,
+      hasMore: false,
+      isLoading: false,
+      isLoadingMore: false,
+      error: Object.assign(new Error('bridge store unavailable'), { status: 500 }),
+      errorStatus: 500,
+      loadMore: jest.fn(),
+      retry: jest.fn(),
+    });
+
+    render(<BridgeRunList />);
+
+    expect(screen.getByText('Bridge API unreachable')).toBeInTheDocument();
+  });
+});

--- a/aragora/live/src/components/autonomous/bridge/__tests__/BridgeTranscriptView.test.tsx
+++ b/aragora/live/src/components/autonomous/bridge/__tests__/BridgeTranscriptView.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+
+import type { AgentBridgeTurnRecord } from '../types';
+import { BridgeTranscriptView } from '../BridgeTranscriptView';
+
+function buildTurn(overrides: Partial<AgentBridgeTurnRecord> = {}): AgentBridgeTurnRecord {
+  return {
+    turn_index: 1,
+    author_role: 'implementer',
+    started_at: '2026-04-21T19:23:40Z',
+    completed_at: '2026-04-21T19:24:09Z',
+    parse_status: 'ok',
+    footer: {
+      summary: 'Outlined the persistence and transport slices.',
+      next_actor: 'reviewer',
+      needs_human: false,
+      done: false,
+      artifacts: [],
+      tests_run: [],
+    },
+    body_markdown: 'First turn',
+    ...overrides,
+  };
+}
+
+describe('BridgeTranscriptView', () => {
+  it('renders turns in turn_index order', () => {
+    render(
+      <BridgeTranscriptView
+        turns={[
+          buildTurn({ turn_index: 2, author_role: 'reviewer', body_markdown: 'Second turn' }),
+          buildTurn({ turn_index: 1, author_role: 'implementer', body_markdown: 'First turn' }),
+        ]}
+      />
+    );
+
+    const turnOne = screen.getByText('Turn 1');
+    const turnTwo = screen.getByText('Turn 2');
+
+    expect(
+      turnOne.compareDocumentPosition(turnTwo) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('renders the bridge footer distinctly', () => {
+    render(<BridgeTranscriptView turns={[buildTurn()]} />);
+
+    expect(screen.getByText('Bridge Footer')).toBeInTheDocument();
+    expect(screen.getByText('Outlined the persistence and transport slices.')).toBeInTheDocument();
+    expect(screen.getByText('next_actor: reviewer')).toBeInTheDocument();
+  });
+
+  it('renders the parse_status badge', () => {
+    render(
+      <BridgeTranscriptView turns={[buildTurn({ parse_status: 'malformed', footer: null })]} />
+    );
+
+    expect(screen.getAllByText('malformed').length).toBeGreaterThan(0);
+  });
+});

--- a/aragora/live/src/components/autonomous/bridge/types.ts
+++ b/aragora/live/src/components/autonomous/bridge/types.ts
@@ -1,0 +1,150 @@
+'use client';
+
+export type BridgeSchemaVersion = 1;
+export type BridgeParseStatus = 'ok' | 'missing' | 'malformed';
+export type BridgeRunStatus = 'running' | 'awaiting_human' | 'completed' | 'failed';
+export type BridgeSessionStatus = 'not_started' | 'active' | 'completed' | 'failed';
+export type BridgeEventType =
+  | 'run_started'
+  | 'run_failed'
+  | 'run_completed'
+  | 'turn.started'
+  | 'turn.result'
+  | 'turn.completed'
+  | 'turn.repair_requested'
+  | 'footer_ok'
+  | 'footer_malformed'
+  | 'footer_missing';
+
+export interface AgentBridgeParticipant {
+  role: string;
+  harness: string;
+  model: string;
+}
+
+export interface AgentBridgeFooter {
+  summary: string;
+  next_actor: string | null;
+  needs_human: boolean;
+  done: boolean;
+  artifacts: string[];
+  tests_run: string[];
+}
+
+export interface AgentBridgeSessionEntry {
+  role: string;
+  harness: string;
+  model: string;
+  session_id: string | null;
+  worktree_agent_slug: string | null;
+  worktree_path: string | null;
+  branch: string | null;
+  session_status: BridgeSessionStatus;
+  started_at: string | null;
+  last_turn_index: number;
+  last_completed_at: string | null;
+  harness_options?: Record<string, unknown>;
+}
+
+export interface AgentBridgeRunSummary {
+  schema_version: BridgeSchemaVersion;
+  run_id: string;
+  task: string;
+  status: BridgeRunStatus;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  last_turn_index: number;
+  next_actor: string | null;
+  repair_budget_per_turn: number;
+  footer_mode: string;
+  worktree_cleanup_mode: string;
+  participants: AgentBridgeParticipant[];
+  last_event_id: string | null;
+}
+
+export interface AgentBridgeRunDetail extends AgentBridgeRunSummary {
+  roles: Record<string, AgentBridgeSessionEntry>;
+  worktree_path: string | null;
+  worktree_agent_slug: string | null;
+}
+
+export interface AgentBridgeEvent {
+  schema_version: BridgeSchemaVersion;
+  event_id: string;
+  run_id: string;
+  ts: string;
+  event_type: BridgeEventType;
+  turn_index: number;
+  role: string;
+  harness: string;
+  session_id: string | null;
+  parse_status: BridgeParseStatus | null;
+  payload: Record<string, unknown>;
+}
+
+export interface AgentBridgeTurnRecord {
+  turn_index: number;
+  author_role: string;
+  started_at: string;
+  completed_at: string | null;
+  parse_status: BridgeParseStatus;
+  footer: AgentBridgeFooter | null;
+  body_markdown: string;
+}
+
+export interface AgentBridgeRunListResponse {
+  schema_version: BridgeSchemaVersion;
+  runs: AgentBridgeRunSummary[];
+  next_cursor?: string | null;
+}
+
+export interface AgentBridgeEventsResponse {
+  schema_version: BridgeSchemaVersion;
+  events: AgentBridgeEvent[];
+  next_cursor?: string | null;
+}
+
+export interface AgentBridgeTranscriptResponse {
+  schema_version: BridgeSchemaVersion;
+  turns: AgentBridgeTurnRecord[];
+}
+
+export type BridgeApiError = Error & { status?: number };
+
+export function formatBridgeTimestamp(value: string | null): string {
+  if (!value) {
+    return 'n/a';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleString();
+}
+
+export function truncateBridgeSessionId(sessionId: string | null): string {
+  if (!sessionId) {
+    return 'not started';
+  }
+
+  if (sessionId.length <= 14) {
+    return sessionId;
+  }
+
+  return `${sessionId.slice(0, 8)}...${sessionId.slice(-4)}`;
+}
+
+export function isBridgeRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function getBridgeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string');
+}

--- a/aragora/live/src/hooks/useAgentBridgeEvents.ts
+++ b/aragora/live/src/hooks/useAgentBridgeEvents.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import type {
+  AgentBridgeEvent,
+  AgentBridgeEventsResponse,
+  BridgeApiError,
+} from '@/components/autonomous/bridge/types';
+import { useSWRFetch } from './useSWRFetch';
+
+const DEFAULT_EVENT_LIMIT = 500;
+
+export interface UseAgentBridgeEventsOptions {
+  enabled?: boolean;
+  poll?: boolean;
+  limit?: number;
+}
+
+export interface UseAgentBridgeEventsResult {
+  events: AgentBridgeEvent[];
+  nextCursor: string | null;
+  isLoading: boolean;
+  error: BridgeApiError | null;
+  errorStatus: number | null;
+  retry: () => void;
+}
+
+export function useAgentBridgeEvents(
+  runId: string | null,
+  options: UseAgentBridgeEventsOptions = {}
+): UseAgentBridgeEventsResult {
+  const { enabled = true, poll = false, limit = DEFAULT_EVENT_LIMIT } = options;
+  const endpoint = runId
+    ? `/api/v1/agent-bridge/runs/${encodeURIComponent(runId)}/events?limit=${limit}`
+    : null;
+
+  const query = useSWRFetch<AgentBridgeEventsResponse>(endpoint, {
+    enabled: enabled && Boolean(runId),
+    refreshInterval: poll ? 5000 : 0,
+  });
+
+  const error = query.error as BridgeApiError | null;
+
+  return {
+    events: query.data?.events ?? [],
+    nextCursor: query.data?.next_cursor ?? null,
+    isLoading: query.isLoading,
+    error,
+    errorStatus: typeof error?.status === 'number' ? error.status : null,
+    retry: () => {
+      void query.mutate();
+    },
+  };
+}

--- a/aragora/live/src/hooks/useAgentBridgeRun.ts
+++ b/aragora/live/src/hooks/useAgentBridgeRun.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import type {
+  AgentBridgeRunDetail,
+  BridgeApiError,
+} from '@/components/autonomous/bridge/types';
+import { useSWRFetch } from './useSWRFetch';
+
+export interface UseAgentBridgeRunOptions {
+  enabled?: boolean;
+}
+
+export interface UseAgentBridgeRunResult {
+  run: AgentBridgeRunDetail | null;
+  isLoading: boolean;
+  error: BridgeApiError | null;
+  errorStatus: number | null;
+  retry: () => void;
+}
+
+export function useAgentBridgeRun(
+  runId: string | null,
+  options: UseAgentBridgeRunOptions = {}
+): UseAgentBridgeRunResult {
+  const { enabled = true } = options;
+  const endpoint = runId ? `/api/v1/agent-bridge/runs/${encodeURIComponent(runId)}` : null;
+
+  const query = useSWRFetch<AgentBridgeRunDetail>(endpoint, {
+    enabled: enabled && Boolean(runId),
+    refreshInterval: (data) => (data?.status === 'running' ? 5000 : 0),
+  });
+
+  const error = query.error as BridgeApiError | null;
+
+  return {
+    run: query.data,
+    isLoading: query.isLoading,
+    error,
+    errorStatus: typeof error?.status === 'number' ? error.status : null,
+    retry: () => {
+      void query.mutate();
+    },
+  };
+}

--- a/aragora/live/src/hooks/useAgentBridgeRuns.ts
+++ b/aragora/live/src/hooks/useAgentBridgeRuns.ts
@@ -45,12 +45,13 @@ export function useAgentBridgeRuns(): UseAgentBridgeRunsResult {
   const query = useSWRFetch<AgentBridgeRunListResponse>(buildRunsEndpoint(requestCursor));
 
   useEffect(() => {
-    if (!query.data) {
+    const data = query.data;
+    if (!data) {
       return;
     }
 
     setPages((previousPages) => {
-      const nextPage = { cursor: requestCursor, response: query.data };
+      const nextPage: LoadedBridgeRunPage = { cursor: requestCursor, response: data };
       if (requestCursor === null) {
         return [nextPage];
       }

--- a/aragora/live/src/hooks/useAgentBridgeRuns.ts
+++ b/aragora/live/src/hooks/useAgentBridgeRuns.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import type {
+  AgentBridgeRunListResponse,
+  AgentBridgeRunSummary,
+  BridgeApiError,
+  BridgeSchemaVersion,
+} from '@/components/autonomous/bridge/types';
+import { useSWRFetch } from './useSWRFetch';
+
+const PAGE_SIZE = 100;
+
+interface LoadedBridgeRunPage {
+  cursor: string | null;
+  response: AgentBridgeRunListResponse;
+}
+
+export interface UseAgentBridgeRunsResult {
+  schemaVersion: BridgeSchemaVersion | null;
+  runs: AgentBridgeRunSummary[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  error: BridgeApiError | null;
+  errorStatus: number | null;
+  loadMore: () => void;
+  retry: () => void;
+}
+
+function buildRunsEndpoint(cursor: string | null): string {
+  const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+  if (cursor) {
+    params.set('cursor', cursor);
+  }
+  return `/api/v1/agent-bridge/runs?${params.toString()}`;
+}
+
+export function useAgentBridgeRuns(): UseAgentBridgeRunsResult {
+  const [requestCursor, setRequestCursor] = useState<string | null>(null);
+  const [pages, setPages] = useState<LoadedBridgeRunPage[]>([]);
+
+  const query = useSWRFetch<AgentBridgeRunListResponse>(buildRunsEndpoint(requestCursor));
+
+  useEffect(() => {
+    if (!query.data) {
+      return;
+    }
+
+    setPages((previousPages) => {
+      const nextPage = { cursor: requestCursor, response: query.data };
+      if (requestCursor === null) {
+        return [nextPage];
+      }
+
+      const filteredPages = previousPages.filter((page) => page.cursor !== requestCursor);
+      return [...filteredPages, nextPage];
+    });
+  }, [query.data, requestCursor]);
+
+  const runs = useMemo(() => {
+    const seenRunIds = new Set<string>();
+    return pages.flatMap((page) => page.response.runs).filter((run) => {
+      if (seenRunIds.has(run.run_id)) {
+        return false;
+      }
+
+      seenRunIds.add(run.run_id);
+      return true;
+    });
+  }, [pages]);
+
+  const lastPage = pages[pages.length - 1]?.response ?? null;
+  const nextCursor = lastPage?.next_cursor ?? null;
+  const hasMore = typeof nextCursor === 'string' && nextCursor.length > 0;
+  const currentPageLoaded = pages.some((page) => page.cursor === requestCursor);
+  const isLoadingMore =
+    requestCursor !== null && !currentPageLoaded && (query.isLoading || query.isValidating);
+  const error = query.error as BridgeApiError | null;
+  const errorStatus = typeof error?.status === 'number' ? error.status : null;
+
+  return {
+    schemaVersion: lastPage?.schema_version ?? null,
+    runs,
+    nextCursor,
+    hasMore,
+    isLoading: runs.length === 0 && query.isLoading,
+    isLoadingMore,
+    error,
+    errorStatus,
+    loadMore: () => {
+      if (!hasMore || !nextCursor || isLoadingMore) {
+        return;
+      }
+
+      setRequestCursor(nextCursor);
+    },
+    retry: () => {
+      void query.mutate();
+    },
+  };
+}

--- a/aragora/live/src/hooks/useAgentBridgeTranscript.ts
+++ b/aragora/live/src/hooks/useAgentBridgeTranscript.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import type {
+  AgentBridgeTranscriptResponse,
+  AgentBridgeTurnRecord,
+  BridgeApiError,
+} from '@/components/autonomous/bridge/types';
+import { useSWRFetch } from './useSWRFetch';
+
+export interface UseAgentBridgeTranscriptOptions {
+  enabled?: boolean;
+  poll?: boolean;
+}
+
+export interface UseAgentBridgeTranscriptResult {
+  turns: AgentBridgeTurnRecord[];
+  isLoading: boolean;
+  error: BridgeApiError | null;
+  errorStatus: number | null;
+  retry: () => void;
+}
+
+export function useAgentBridgeTranscript(
+  runId: string | null,
+  options: UseAgentBridgeTranscriptOptions = {}
+): UseAgentBridgeTranscriptResult {
+  const { enabled = true, poll = false } = options;
+  const endpoint = runId
+    ? `/api/v1/agent-bridge/runs/${encodeURIComponent(runId)}/transcript`
+    : null;
+
+  const query = useSWRFetch<AgentBridgeTranscriptResponse>(endpoint, {
+    enabled: enabled && Boolean(runId),
+    refreshInterval: poll ? 5000 : 0,
+  });
+
+  const error = query.error as BridgeApiError | null;
+
+  return {
+    turns: query.data?.turns ?? [],
+    isLoading: query.isLoading,
+    error,
+    errorStatus: typeof error?.status === 'number' ? error.status : null,
+    retry: () => {
+      void query.mutate();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Final layer of the agent-bridge redo. Adds the read-only autonomous bridge UI on top of PR 2b (#6407) read API. Closes the 4-PR sequence (scoping doc → backend core → API → UI) that replaced #6387.

- New page `/autonomous/bridge` (run list, cursor pagination)
- New page `/autonomous/bridge/[run_id]` (Transcript / Events / Metadata tabs)
- Role-keyed `BridgeRoleCard` per participant (NOT flat list — preserves PR 2a role-keyed schema discipline)
- 5s polling that stops automatically when status != "running"
- 4 typed hooks: useAgentBridgeRuns/Run/Events/Transcript
- 3 RTL component test files

## Schema discipline (would have re-broken #6387 otherwise)

- `roles` is dict keyed by logical role name, never a flat list
- `parse_status` preserved distinctly in event rendering (ok / missing / malformed)
- All schema_version fields passed through from API
- Polling stops on terminal states (no infinite poll on completed/failed)

## Salvage from closed #6387

- Page shell composition
- `/autonomous` layout integration
- Right-sidebar pattern

## Rejected from #6387

- Array-based `sessions` (must be role-keyed dict)
- Name-keyed rendering (must use role keys)
- Old types.ts shape (must mirror PR 2b backend schema)

## Test plan

- [x] `npx tsc --noEmit` clean (after one narrowing fix)
- [ ] `npm test -- --testPathPattern=bridge` — to be run by CI
- [ ] Manual smoke against fixture-backed dev server
- [ ] Lighthouse a11y check on detail page

## Dependencies

- PR 2a: backend core `1902fcb15` ✅ merged
- PR 2b: read API `d09fac6b5` ✅ merged
- PR 2c: this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)