### PR TITLE
fix(tests): repair baseline red demo and slack checks

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -2964,17 +2964,28 @@ class PlaygroundHandler(BaseHandler):
         try:
             from aragora.storage.debate_store import get_debate_store, normalize_cache_key
 
-            agent_tags = _get_available_live_agents(agent_count)
-            if not agent_tags:
-                raise ValueError("no live playground agents configured")
-            model_ids = [
-                tag.split(":", 1)[1] if tag.startswith("openrouter:") else tag for tag in agent_tags
-            ]
             effective_topic = question or topic
-            cache_key = normalize_cache_key(effective_topic, model_ids, rounds)
-
             store = get_debate_store()
-            cached = store.get_by_cache_key(cache_key)
+            agent_tags = _get_available_live_agents(agent_count)
+            cached = None
+
+            if agent_tags:
+                model_ids = [
+                    tag.split(":", 1)[1] if tag.startswith("openrouter:") else tag
+                    for tag in agent_tags
+                ]
+                cache_key = normalize_cache_key(effective_topic, model_ids, rounds)
+                cached = store.get_by_cache_key(cache_key)
+            elif source == "demo":
+                # The demo proof surface may replay a persisted live result even
+                # when the current process cannot run live agents locally.
+                cache_key = normalize_cache_key(effective_topic, model_ids, rounds)
+                cached = store.get_by_cache_key(cache_key)
+                if cached is None:
+                    cached = store.get_latest_live_by_topic(effective_topic, rounds)
+            else:
+                raise ValueError("no live playground agents configured")
+
             if cached is not None:
                 cached = _normalize_public_debate_payload(cached)
                 cached.setdefault("source", source)

--- a/aragora/storage/debate_store.py
+++ b/aragora/storage/debate_store.py
@@ -187,6 +187,45 @@ class DebateResultStore(SQLiteStore):
 
         return result
 
+    def get_latest_live_by_topic(self, topic: str, rounds: int) -> dict[str, Any] | None:
+        """Return the newest live cached debate for a topic/round count.
+
+        This supports replaying an already-persisted live result even when the
+        current process has no live debate agents configured locally.
+        """
+        topic_normalized = re.sub(r"\s+", " ", topic.strip().lower())
+        with self.connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT cache_key, debate_id FROM debate_cache_index
+                WHERE topic_normalized = ? AND rounds = ?
+                ORDER BY created_at DESC
+                """,
+                (topic_normalized, rounds),
+            ).fetchall()
+
+        for cache_key, debate_id in rows:
+            result = self.get(debate_id)
+            if result is None:
+                with self.connection() as conn:
+                    conn.execute(
+                        "DELETE FROM debate_cache_index WHERE cache_key = ?",
+                        (cache_key,),
+                    )
+                continue
+
+            if result.get("is_live") is not True:
+                continue
+
+            with self.connection() as conn:
+                conn.execute(
+                    "UPDATE debate_cache_index SET hit_count = hit_count + 1 WHERE cache_key = ?",
+                    (cache_key,),
+                )
+            return result
+
+        return None
+
     def cleanup_expired(self) -> int:
         """Delete expired entries. Returns count of deleted rows."""
         now = time.time()

--- a/tests/handlers/bots/slack/test_signature.py
+++ b/tests/handlers/bots/slack/test_signature.py
@@ -352,12 +352,12 @@ class TestSigningSecret:
     """Tests for signing secret variations."""
 
     def test_empty_signing_secret(self):
-        """Verification should work (or at least not crash) with an empty secret."""
+        """Verification should reject an empty signing secret without crashing."""
         ts = _current_timestamp()
         body = b"test body"
         sig = _make_signature(body, ts, "")
 
-        assert verify_slack_signature(body, ts, sig, "") is True
+        assert verify_slack_signature(body, ts, sig, "") is False
 
     def test_long_signing_secret(self):
         """Verification should work with a very long signing secret."""
@@ -417,10 +417,14 @@ class TestModuleExports:
         assert "verify_slack_signature" in signature.__all__
 
     def test_all_exports_length(self):
-        """__all__ should contain exactly one export."""
+        """__all__ should expose the documented signature helpers."""
         from aragora.server.handlers.bots.slack import signature
 
-        assert len(signature.__all__) == 1
+        assert signature.__all__ == [
+            "TIMESTAMP_TOLERANCE_SECONDS",
+            "compute_slack_signature",
+            "verify_slack_signature",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/handlers/test_demo_live_proof_surface.py
+++ b/tests/server/handlers/test_demo_live_proof_surface.py
@@ -13,6 +13,7 @@ from aragora.server.handlers.playground import (
     _reset_oracle_sessions,
     _reset_rate_limits,
 )
+from aragora.storage.debate_store import get_debate_store, normalize_cache_key
 
 
 class _MockHeaders:
@@ -164,6 +165,42 @@ def test_demo_source_can_replay_cached_live_results(handler):
             "aragora.storage.debate_store.DebateResultStore.get_by_cache_key",
             return_value=cached_live,
         ),
+        patch("aragora.server.handlers.playground._try_oracle_tentacles") as mock_tentacles,
+    ):
+        result = handler.handle_post("/api/v1/playground/debate", {}, request)
+
+    body, status = _parse_result(result)
+    assert status == 200
+    assert body["id"] == "cached-live-result"
+    assert body["is_live"] is True
+    assert body["cached"] is True
+    mock_tentacles.assert_not_called()
+
+
+def test_demo_source_can_replay_cached_live_results_without_live_agents(handler):
+    request = _make_http_handler(
+        {
+            "topic": "Should we require AI code review in CI?",
+            "question": "Should we require AI code review in CI?",
+            "source": "demo",
+        }
+    )
+    cached_live = _live_result("cached-live-result")
+    store = get_debate_store()
+    store.save(cached_live["id"], cached_live["topic"], cached_live)
+
+    model_ids = ["anthropic/claude-sonnet-4", "openai/gpt-4o", "google/gemini-2.0-flash-001"]
+    cache_key = normalize_cache_key(cached_live["topic"], model_ids, 2)
+    store.save_cache_index(
+        cache_key=cache_key,
+        debate_id=cached_live["id"],
+        topic_normalized=cached_live["topic"].strip().lower(),
+        model_ids="|".join(sorted(model_ids)),
+        rounds=2,
+    )
+
+    with (
+        patch("aragora.server.handlers.playground._get_available_live_agents", return_value=[]),
         patch("aragora.server.handlers.playground._try_oracle_tentacles") as mock_tentacles,
     ):
         result = handler.handle_post("/api/v1/playground/debate", {}, request)


### PR DESCRIPTION
## Summary
- let /demo replay a persisted live debate even when the current process has no live agents configured
- align slack signature tests with the current exported/public verification contract
- add coverage for replaying cached live demo results without local live agents

## Validation
- pytest -q tests/handlers/bots/slack/test_signature.py tests/server/handlers/test_demo_live_proof_surface.py tests/server/handlers/test_playground_cache.py
- ruff check aragora/storage/debate_store.py aragora/server/handlers/playground.py tests/handlers/bots/slack/test_signature.py tests/server/handlers/test_demo_live_proof_surface.py
- ruff format --check aragora/storage/debate_store.py aragora/server/handlers/playground.py tests/handlers/bots/slack/test_signature.py tests/server/handlers/test_demo_live_proof_surface.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
- targeted mypy on playground/storage still reports pre-existing playground.py errors that also reproduce on fresh origin/main; this PR does not introduce new mypy failures in the touched paths.
- this is intended to clear baseline-red failures reproduced from origin/main before restacking #6404.
