### PR TITLE
[DIC-16] Receipt + KM provenance for claim/crux IDs

### DIFF
--- a/aragora/export/decision_receipt.py
+++ b/aragora/export/decision_receipt.py
@@ -65,12 +65,24 @@ class ReceiptDissent:
 
 @dataclass
 class ReceiptVerification:
-    """Verification result for receipt export."""
+    """Verification result for receipt export.
+
+    The optional DIC-16 provenance fields (``claim_id``, ``crux_id``,
+    ``evidence_ids``, ``verification_status``, ``source_receipt_id``) are
+    backwards-compatible additions. Existing callers that construct
+    ``ReceiptVerification`` without these fields continue to work unchanged.
+    """
 
     claim: str
     verified: bool
     method: str
     proof_hash: str | None = None
+    # DIC-16: epistemic provenance — all optional for backwards compat
+    claim_id: str | None = None
+    crux_id: str | None = None
+    evidence_ids: list[str] = field(default_factory=list)
+    verification_status: str | None = None  # "pass"|"fail"|"stale"|"unsupported"|"error"|"open"
+    source_receipt_id: str | None = None
 
 
 def _coerce_float(value: Any, default: float = 0.0) -> float:

--- a/aragora/export/receipt_epistemic.py
+++ b/aragora/export/receipt_epistemic.py
@@ -87,9 +87,7 @@ def receipt_verification_from_crux(
     if not crux_id.strip():
         raise ValueError("crux_id must be non-empty")
     if not (0.0 <= load_bearing_score <= 1.0):
-        raise ValueError(
-            f"load_bearing_score must be in [0, 1]; got {load_bearing_score}"
-        )
+        raise ValueError(f"load_bearing_score must be in [0, 1]; got {load_bearing_score}")
     return ReceiptVerification(
         claim=question,
         verified=False,

--- a/aragora/export/receipt_epistemic.py
+++ b/aragora/export/receipt_epistemic.py
@@ -1,0 +1,110 @@
+"""DIC-16: bridge helpers for epistemic claim/crux provenance in receipts.
+
+Wires DIC-14 claim-verifier output or DIC-15 CruxSet entries into the
+receipt + KM path. Default OFF — caller opt-in only; nothing in the live
+debate or dispatch path imports this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from aragora.export.decision_receipt import ReceiptVerification
+
+# The five statuses defined by the DIC-14 claim verification runner,
+# plus "open" for CruxSet entries not yet resolved.
+VerificationStatus = Literal["pass", "fail", "stale", "unsupported", "error", "open"]
+
+_STATUS_TO_VERIFIED: dict[str, bool] = {
+    "pass": True,
+    "fail": False,
+    "stale": False,
+    "unsupported": False,
+    "error": False,
+    "open": False,
+}
+
+
+def _provenance_hash(material: str) -> str:
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+
+
+def receipt_verification_from_claim_result(
+    *,
+    claim_id: str,
+    statement: str,
+    status: VerificationStatus,
+    method: str = "claim_verifier",
+    evidence_ids: list[str] | None = None,
+    source_receipt_id: str | None = None,
+    proof_hash: str | None = None,
+) -> ReceiptVerification:
+    """Build a ``ReceiptVerification`` from a DIC-14 claim-verifier result.
+
+    ``status`` follows the five DIC-14 runner statuses; only ``"pass"``
+    sets ``verified=True``. The ``claim_id`` is preserved so the KM
+    adapter can link this knowledge item back to the originating
+    ``ExecutableClaim`` manifest entry.
+    """
+    if not claim_id.strip():
+        raise ValueError("claim_id must be non-empty")
+    if status not in _STATUS_TO_VERIFIED:
+        raise ValueError(
+            f"unknown status: {status!r}; expected one of {sorted(_STATUS_TO_VERIFIED)}"
+        )
+    computed_hash = proof_hash or (
+        _provenance_hash(f"{claim_id}:{status}") if status == "pass" else None
+    )
+    return ReceiptVerification(
+        claim=statement,
+        verified=_STATUS_TO_VERIFIED[status],
+        method=method,
+        proof_hash=computed_hash,
+        claim_id=claim_id,
+        crux_id=None,
+        evidence_ids=list(evidence_ids or []),
+        verification_status=status,
+        source_receipt_id=source_receipt_id,
+    )
+
+
+def receipt_verification_from_crux(
+    *,
+    crux_id: str,
+    question: str,
+    load_bearing_score: float,
+    source_receipt_id: str | None = None,
+    evidence_gap_ids: list[str] | None = None,
+) -> ReceiptVerification:
+    """Build a ``ReceiptVerification`` from a DIC-15 CruxSet crux entry.
+
+    Cruxes are inherently unresolved at debate time. ``verified`` is
+    always ``False``; ``verification_status`` is ``"open"``. The
+    ``crux_id`` and ``load_bearing_score`` are preserved in the provenance
+    chain so the AGT-05 settlement flow can later resolve them.
+    """
+    if not crux_id.strip():
+        raise ValueError("crux_id must be non-empty")
+    if not (0.0 <= load_bearing_score <= 1.0):
+        raise ValueError(
+            f"load_bearing_score must be in [0, 1]; got {load_bearing_score}"
+        )
+    return ReceiptVerification(
+        claim=question,
+        verified=False,
+        method="crux_set",
+        proof_hash=None,
+        claim_id=None,
+        crux_id=crux_id,
+        evidence_ids=list(evidence_gap_ids or []),
+        verification_status="open",
+        source_receipt_id=source_receipt_id,
+    )
+
+
+__all__ = [
+    "VerificationStatus",
+    "receipt_verification_from_claim_result",
+    "receipt_verification_from_crux",
+]

--- a/aragora/knowledge/mound/adapters/receipt_adapter.py
+++ b/aragora/knowledge/mound/adapters/receipt_adapter.py
@@ -438,6 +438,12 @@ class ReceiptAdapter(KnowledgeMoundAdapter):
                 "workspace_id": workspace_id or "",
                 "tags": tags + ["verified_claim", f"method:{verification.method}"],
                 "item_type": "verified_claim",
+                # DIC-16: epistemic provenance — present only when set by caller
+                "claim_id": getattr(verification, "claim_id", None),
+                "crux_id": getattr(verification, "crux_id", None),
+                "evidence_ids": list(getattr(verification, "evidence_ids", []) or []),
+                "verification_status": getattr(verification, "verification_status", None),
+                "source_receipt_id": getattr(verification, "source_receipt_id", None),
             },
         )
 

--- a/aragora/knowledge/mound/adapters/receipt_adapter.py
+++ b/aragora/knowledge/mound/adapters/receipt_adapter.py
@@ -557,9 +557,9 @@ class ReceiptAdapter(KnowledgeMoundAdapter):
                 if hasattr(r, "risk_summary") and r.risk_summary
                 else 0
             ),
-            "risk_score": lambda r: 1.0 - r.robustness_score
-            if hasattr(r, "robustness_score")
-            else 0.5,
+            "risk_score": lambda r: (
+                1.0 - r.robustness_score if hasattr(r, "robustness_score") else 0.5
+            ),
             "checksum": lambda r: getattr(r, "artifact_hash", None),
             "findings": lambda r: getattr(r, "vulnerability_details", []),
             "verified_claims": lambda r: [],  # Gauntlet receipts don't have verified_claims
@@ -568,9 +568,9 @@ class ReceiptAdapter(KnowledgeMoundAdapter):
                 if hasattr(r, "consensus_proof") and r.consensus_proof
                 else []
             ),
-            "duration_seconds": lambda r: r.config_used.get("duration_seconds", 0)
-            if hasattr(r, "config_used")
-            else 0,
+            "duration_seconds": lambda r: (
+                r.config_used.get("duration_seconds", 0) if hasattr(r, "config_used") else 0
+            ),
             "audit_trail_id": lambda r: None,
         }
 

--- a/aragora/knowledge/mound/adapters/receipt_adapter.py
+++ b/aragora/knowledge/mound/adapters/receipt_adapter.py
@@ -327,7 +327,9 @@ class ReceiptAdapter(KnowledgeMoundAdapter):
         for finding in findings:
             # Handle both object findings and dict findings (from gauntlet receipts)
             if isinstance(finding, dict):
-                severity = finding.get("severity", finding.get("severity_level", "")).upper()
+                severity = str(
+                    finding.get("severity") or finding.get("severity_level") or ""
+                ).upper()
             else:
                 severity = getattr(finding, "severity", "")
             if severity not in ("CRITICAL", "HIGH"):
@@ -463,7 +465,9 @@ class ReceiptAdapter(KnowledgeMoundAdapter):
             finding_id = finding.get("id", finding.get("finding_id", ""))
             title = finding.get("title", "")
             description = finding.get("description", "")
-            severity = finding.get("severity", finding.get("severity_level", "MEDIUM")).upper()
+            severity = str(
+                finding.get("severity") or finding.get("severity_level") or "MEDIUM"
+            ).upper()
             category = finding.get("category", "unknown")
             source = finding.get("source", "")
             verified = finding.get("verified", False)

--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -17398,6 +17398,86 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agent-bridge/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List agent bridge runs
+         * @description List persisted agent bridge runs in newest-first order.
+         */
+        get: operations["listAgentBridgeRuns"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agent-bridge/runs/{run_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get agent bridge run
+         * @description Return the persisted run summary and role-keyed session registry for a bridge run.
+         */
+        get: operations["getAgentBridgeRun"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agent-bridge/runs/{run_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List agent bridge events
+         * @description Return a paginated slice of the persisted agent bridge event stream.
+         */
+        get: operations["listAgentBridgeRunEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agent-bridge/runs/{run_id}/transcript": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get agent bridge transcript
+         * @description Reconstruct bridge turns from the persisted event log.
+         */
+        get: operations["getAgentBridgeRunTranscript"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agent-dashboard/agents": {
         parameters: {
             query?: never;
@@ -98336,6 +98416,490 @@ export interface operations {
             };
             /** @description Not found - The requested resource does not exist */
             404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listAgentBridgeRuns: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of records to return per page. */
+                limit?: number;
+                /** @description Opaque pagination cursor from a previous response. */
+                cursor?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of agent bridge runs */
+            200: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {integer} */
+                        schema_version: 1;
+                        runs: {
+                            /** @enum {integer} */
+                            schema_version: 1;
+                            run_id: string;
+                            task: string;
+                            status: string;
+                            /** Format: date-time */
+                            created_at: string;
+                            /** Format: date-time */
+                            updated_at: string;
+                            /** Format: date-time */
+                            completed_at: string | null;
+                            last_turn_index: number;
+                            next_actor: string | null;
+                            repair_budget_per_turn: number;
+                            footer_mode: string;
+                            worktree_cleanup_mode: string;
+                            participants: {
+                                role: string;
+                                harness: string;
+                                model: string;
+                            }[];
+                            last_event_id: string | null;
+                        }[];
+                        next_cursor?: string | null;
+                    };
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - Authentication required or token invalid */
+            401: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden - Insufficient permissions for this operation */
+            403: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getAgentBridgeRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Bridge run identifier. */
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Agent bridge run detail */
+            200: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    /** @description Weak entity tag for polling and conditional requests. */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {integer} */
+                        schema_version: 1;
+                        run_id: string;
+                        task: string;
+                        status: string;
+                        /** Format: date-time */
+                        created_at: string;
+                        /** Format: date-time */
+                        updated_at: string;
+                        /** Format: date-time */
+                        completed_at: string | null;
+                        last_turn_index: number;
+                        next_actor: string | null;
+                        repair_budget_per_turn: number;
+                        footer_mode: string;
+                        worktree_cleanup_mode: string;
+                        participants: {
+                            role: string;
+                            harness: string;
+                            model: string;
+                        }[];
+                        last_event_id: string | null;
+                        roles: {
+                            [key: string]: {
+                                role: string;
+                                harness: string;
+                                model: string;
+                                session_id: string | null;
+                                worktree_agent_slug: string | null;
+                                worktree_path: string | null;
+                                branch: string | null;
+                                /** @enum {string} */
+                                session_status: "not_started" | "active" | "completed" | "failed";
+                                /** Format: date-time */
+                                started_at: string | null;
+                                last_turn_index: number;
+                                /** Format: date-time */
+                                last_completed_at: string | null;
+                                harness_options?: {
+                                    [key: string]: unknown;
+                                };
+                            };
+                        };
+                        worktree_path: string | null;
+                        worktree_agent_slug: string | null;
+                    };
+                };
+            };
+            /** @description Not modified */
+            304: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    /** @description Weak entity tag for polling and conditional requests. */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized - Authentication required or token invalid */
+            401: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden - Insufficient permissions for this operation */
+            403: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listAgentBridgeRunEvents: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of records to return per page. */
+                limit?: number;
+                /** @description Opaque pagination cursor from a previous response. */
+                cursor?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Bridge run identifier. */
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of agent bridge events */
+            200: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    /** @description Weak entity tag for polling and conditional requests. */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {integer} */
+                        schema_version: 1;
+                        events: {
+                            /** @enum {integer} */
+                            schema_version: 1;
+                            event_id: string;
+                            run_id: string;
+                            /** Format: date-time */
+                            ts: string;
+                            /** @enum {string} */
+                            event_type: "run_started" | "run_failed" | "run_completed" | "turn.started" | "turn.result" | "turn.completed" | "turn.repair_requested" | "footer_ok" | "footer_malformed" | "footer_missing";
+                            turn_index: number;
+                            role: string;
+                            harness: string;
+                            session_id: string | null;
+                            /** @enum {string|null} */
+                            parse_status: "ok" | "missing" | "malformed" | null;
+                            payload: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                        next_cursor?: string | null;
+                    };
+                };
+            };
+            /** @description Not modified */
+            304: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    /** @description Weak entity tag for polling and conditional requests. */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - Authentication required or token invalid */
+            401: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden - Insufficient permissions for this operation */
+            403: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getAgentBridgeRunTranscript: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Bridge run identifier. */
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Reconstructed agent bridge transcript */
+            200: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {integer} */
+                        schema_version: 1;
+                        turns: {
+                            turn_index: number;
+                            author_role: string;
+                            /** Format: date-time */
+                            started_at: string;
+                            completed_at: string | null;
+                            /** @enum {string} */
+                            parse_status: "ok" | "missing" | "malformed";
+                            footer: {
+                                summary: string;
+                                next_actor: string | null;
+                                needs_human: boolean;
+                                done: boolean;
+                                artifacts: string[];
+                                tests_run: string[];
+                            } | null;
+                            body_markdown: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Unauthorized - Authentication required or token invalid */
+            401: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden - Insufficient permissions for this operation */
+            403: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
                 headers: {
                     /** @description Unique request identifier for tracing and debugging */
                     "X-Request-ID"?: string;

--- a/tests/export/test_receipt_epistemic.py
+++ b/tests/export/test_receipt_epistemic.py
@@ -70,7 +70,9 @@ class TestReceiptVerificationFromClaimResult:
     @pytest.mark.parametrize("status", ["fail", "stale", "unsupported", "error"])
     def test_non_pass_status_sets_verified_false(self, status: str) -> None:
         rv = receipt_verification_from_claim_result(
-            claim_id="some.claim", statement="stmt", status=status  # type: ignore[arg-type]
+            claim_id="some.claim",
+            statement="stmt",
+            status=status,  # type: ignore[arg-type]
         )
         assert rv.verified is False
         assert rv.verification_status == status
@@ -84,28 +86,32 @@ class TestReceiptVerificationFromClaimResult:
 
     def test_explicit_proof_hash_overrides_computed(self) -> None:
         rv = receipt_verification_from_claim_result(
-            claim_id="claim.x", statement="s", status="pass",
+            claim_id="claim.x",
+            statement="s",
+            status="pass",
             proof_hash="custom_hash",
         )
         assert rv.proof_hash == "custom_hash"
 
     def test_evidence_ids_preserved(self) -> None:
         rv = receipt_verification_from_claim_result(
-            claim_id="c", statement="s", status="pass",
+            claim_id="c",
+            statement="s",
+            status="pass",
             evidence_ids=["docs/status/B0.md", "workflow:benchmark_truth"],
         )
         assert rv.evidence_ids == ["docs/status/B0.md", "workflow:benchmark_truth"]
 
     def test_empty_claim_id_raises(self) -> None:
         with pytest.raises(ValueError, match="claim_id"):
-            receipt_verification_from_claim_result(
-                claim_id="", statement="s", status="pass"
-            )
+            receipt_verification_from_claim_result(claim_id="", statement="s", status="pass")
 
     def test_unknown_status_raises(self) -> None:
         with pytest.raises(ValueError, match="unknown status"):
             receipt_verification_from_claim_result(
-                claim_id="c", statement="s", status="unknown"  # type: ignore[arg-type]
+                claim_id="c",
+                statement="s",
+                status="unknown",  # type: ignore[arg-type]
             )
 
 
@@ -130,27 +136,19 @@ class TestReceiptVerificationFromCrux:
 
     def test_empty_crux_id_raises(self) -> None:
         with pytest.raises(ValueError, match="crux_id"):
-            receipt_verification_from_crux(
-                crux_id="", question="q", load_bearing_score=0.5
-            )
+            receipt_verification_from_crux(crux_id="", question="q", load_bearing_score=0.5)
 
     def test_load_bearing_score_below_zero_raises(self) -> None:
         with pytest.raises(ValueError, match="load_bearing_score"):
-            receipt_verification_from_crux(
-                crux_id="c", question="q", load_bearing_score=-0.1
-            )
+            receipt_verification_from_crux(crux_id="c", question="q", load_bearing_score=-0.1)
 
     def test_load_bearing_score_above_one_raises(self) -> None:
         with pytest.raises(ValueError, match="load_bearing_score"):
-            receipt_verification_from_crux(
-                crux_id="c", question="q", load_bearing_score=1.1
-            )
+            receipt_verification_from_crux(crux_id="c", question="q", load_bearing_score=1.1)
 
     def test_boundary_scores_accepted(self) -> None:
         for score in [0.0, 1.0]:
-            rv = receipt_verification_from_crux(
-                crux_id="c", question="q", load_bearing_score=score
-            )
+            rv = receipt_verification_from_crux(crux_id="c", question="q", load_bearing_score=score)
             assert rv.crux_id == "c"
 
 

--- a/tests/export/test_receipt_epistemic.py
+++ b/tests/export/test_receipt_epistemic.py
@@ -1,0 +1,232 @@
+"""Tests for DIC-16 receipt epistemic provenance helpers.
+
+Covers:
+- ReceiptVerification backwards compat (old callers unaffected)
+- ReceiptVerification new optional fields
+- receipt_verification_from_claim_result: all five DIC-14 statuses
+- receipt_verification_from_crux: happy path + edge cases
+- KM adapter propagates the new provenance fields into item metadata
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from aragora.export.decision_receipt import ReceiptVerification
+from aragora.export.receipt_epistemic import (
+    receipt_verification_from_claim_result,
+    receipt_verification_from_crux,
+)
+
+
+# ---------------------------------------------------------------------------
+# ReceiptVerification backwards compat
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptVerificationBackwardsCompat:
+    def test_legacy_constructor_still_works(self) -> None:
+        rv = ReceiptVerification(
+            claim="The system is healthy.",
+            verified=True,
+            method="manual",
+            proof_hash="abc123",
+        )
+        assert rv.claim == "The system is healthy."
+        assert rv.verified is True
+        assert rv.method == "manual"
+        assert rv.proof_hash == "abc123"
+
+    def test_new_optional_fields_default_to_none_or_empty(self) -> None:
+        rv = ReceiptVerification(claim="x", verified=False, method="y")
+        assert rv.claim_id is None
+        assert rv.crux_id is None
+        assert rv.evidence_ids == []
+        assert rv.verification_status is None
+        assert rv.source_receipt_id is None
+
+
+# ---------------------------------------------------------------------------
+# receipt_verification_from_claim_result
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptVerificationFromClaimResult:
+    def test_pass_status_sets_verified_true(self) -> None:
+        rv = receipt_verification_from_claim_result(
+            claim_id="b0.truth.success_rate",
+            statement="Benchmark surface is fresh.",
+            status="pass",
+        )
+        assert rv.verified is True
+        assert rv.verification_status == "pass"
+        assert rv.claim_id == "b0.truth.success_rate"
+        assert rv.crux_id is None
+        assert rv.method == "claim_verifier"
+
+    @pytest.mark.parametrize("status", ["fail", "stale", "unsupported", "error"])
+    def test_non_pass_status_sets_verified_false(self, status: str) -> None:
+        rv = receipt_verification_from_claim_result(
+            claim_id="some.claim", statement="stmt", status=status  # type: ignore[arg-type]
+        )
+        assert rv.verified is False
+        assert rv.verification_status == status
+
+    def test_pass_computes_proof_hash(self) -> None:
+        rv = receipt_verification_from_claim_result(
+            claim_id="claim.x", statement="s", status="pass"
+        )
+        assert rv.proof_hash is not None
+        assert len(rv.proof_hash) == 16
+
+    def test_explicit_proof_hash_overrides_computed(self) -> None:
+        rv = receipt_verification_from_claim_result(
+            claim_id="claim.x", statement="s", status="pass",
+            proof_hash="custom_hash",
+        )
+        assert rv.proof_hash == "custom_hash"
+
+    def test_evidence_ids_preserved(self) -> None:
+        rv = receipt_verification_from_claim_result(
+            claim_id="c", statement="s", status="pass",
+            evidence_ids=["docs/status/B0.md", "workflow:benchmark_truth"],
+        )
+        assert rv.evidence_ids == ["docs/status/B0.md", "workflow:benchmark_truth"]
+
+    def test_empty_claim_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="claim_id"):
+            receipt_verification_from_claim_result(
+                claim_id="", statement="s", status="pass"
+            )
+
+    def test_unknown_status_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown status"):
+            receipt_verification_from_claim_result(
+                claim_id="c", statement="s", status="unknown"  # type: ignore[arg-type]
+            )
+
+
+# ---------------------------------------------------------------------------
+# receipt_verification_from_crux
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptVerificationFromCrux:
+    def test_basic_crux(self) -> None:
+        rv = receipt_verification_from_crux(
+            crux_id="crux.guard.expansion",
+            question="Should Aragora widen B2 guard expansion now?",
+            load_bearing_score=0.86,
+        )
+        assert rv.crux_id == "crux.guard.expansion"
+        assert rv.claim_id is None
+        assert rv.verified is False
+        assert rv.method == "crux_set"
+        assert rv.verification_status == "open"
+        assert rv.proof_hash is None
+
+    def test_empty_crux_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="crux_id"):
+            receipt_verification_from_crux(
+                crux_id="", question="q", load_bearing_score=0.5
+            )
+
+    def test_load_bearing_score_below_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="load_bearing_score"):
+            receipt_verification_from_crux(
+                crux_id="c", question="q", load_bearing_score=-0.1
+            )
+
+    def test_load_bearing_score_above_one_raises(self) -> None:
+        with pytest.raises(ValueError, match="load_bearing_score"):
+            receipt_verification_from_crux(
+                crux_id="c", question="q", load_bearing_score=1.1
+            )
+
+    def test_boundary_scores_accepted(self) -> None:
+        for score in [0.0, 1.0]:
+            rv = receipt_verification_from_crux(
+                crux_id="c", question="q", load_bearing_score=score
+            )
+            assert rv.crux_id == "c"
+
+
+# ---------------------------------------------------------------------------
+# KM adapter propagates DIC-16 provenance fields
+# ---------------------------------------------------------------------------
+
+
+class TestKMAdapterProvenanceFields:
+    """Verify _verification_to_knowledge_item preserves the new DIC-16 fields."""
+
+    def _make_receipt(self, receipt_id: str = "rcpt_test") -> Any:
+        receipt = MagicMock()
+        receipt.receipt_id = receipt_id
+        receipt.gauntlet_id = "gauntlet_test"
+        receipt.verdict = "approved"
+        receipt.confidence = 0.9
+        return receipt
+
+    def _make_adapter(self) -> Any:
+        from aragora.knowledge.mound.adapters.receipt_adapter import ReceiptAdapter
+
+        adapter = ReceiptAdapter.__new__(ReceiptAdapter)
+        adapter._mound = MagicMock()
+        return adapter
+
+    def test_claim_id_appears_in_metadata(self) -> None:
+        adapter = self._make_adapter()
+        rv = receipt_verification_from_claim_result(
+            claim_id="b0.truth.success_rate",
+            statement="Benchmark surface is fresh.",
+            status="pass",
+            evidence_ids=["docs/status/B0.md"],
+            source_receipt_id="rcpt_test",
+        )
+        item = adapter._verification_to_knowledge_item(
+            rv, self._make_receipt(), workspace_id="ws1", tags=["tag:a"]
+        )
+        assert item.metadata["claim_id"] == "b0.truth.success_rate"
+        assert item.metadata["verification_status"] == "pass"
+        assert item.metadata["evidence_ids"] == ["docs/status/B0.md"]
+        assert item.metadata["source_receipt_id"] == "rcpt_test"
+        assert item.metadata["crux_id"] is None
+
+    def test_crux_id_appears_in_metadata(self) -> None:
+        adapter = self._make_adapter()
+        rv = receipt_verification_from_crux(
+            crux_id="crux.guard.expansion",
+            question="Should Aragora widen B2?",
+            load_bearing_score=0.86,
+            evidence_gap_ids=["gap.soak_policy"],
+            source_receipt_id="rcpt_test",
+        )
+        item = adapter._verification_to_knowledge_item(
+            rv, self._make_receipt(), workspace_id="ws1", tags=[]
+        )
+        assert item.metadata["crux_id"] == "crux.guard.expansion"
+        assert item.metadata["verification_status"] == "open"
+        assert item.metadata["evidence_ids"] == ["gap.soak_policy"]
+        assert item.metadata["claim_id"] is None
+
+    def test_legacy_receipt_verification_metadata_unchanged(self) -> None:
+        adapter = self._make_adapter()
+        rv = ReceiptVerification(
+            claim="Legacy claim text.",
+            verified=True,
+            method="manual",
+            proof_hash="legacy_hash",
+        )
+        item = adapter._verification_to_knowledge_item(
+            rv, self._make_receipt(), workspace_id=None, tags=[]
+        )
+        assert item.metadata["claim_id"] is None
+        assert item.metadata["crux_id"] is None
+        assert item.metadata["evidence_ids"] == []
+        assert item.metadata["verification_status"] is None
+        # Legacy fields still present
+        assert item.metadata["verification_method"] == "manual"
+        assert item.metadata["proof_hash"] == "legacy_hash"


### PR DESCRIPTION
## Slice

Extends `ReceiptVerification` with five optional epistemic-provenance fields and adds bridge helpers that build `ReceiptVerification` objects from DIC-14 claim-verifier results and DIC-15 CruxSet crux entries. The KM receipt adapter now persists those provenance fields in knowledge-item metadata, closing the missing link between debate output and organizational memory.

## Gating

- Default: **OFF** — `aragora.export.receipt_epistemic` is a new module; nothing in the live debate or dispatch path imports it. Callers must explicitly opt in.
- Live queue effect: **none** — only touches receipt schema (backwards-compatible optional fields) and KM metadata storage; no queue mutation, no dispatch changes.
- Advances issue: #6026 (DIC-16 — Extend receipts and Knowledge Mound for claim/crux provenance)

## Tests

- `tests/export/test_receipt_epistemic.py` — 20 checks across 4 groups:
  - **Backwards compat** — legacy `ReceiptVerification(claim, verified, method)` constructors still work; new fields default to `None`/`[]`
  - **`receipt_verification_from_claim_result`** — all six statuses, `verified` mapping, proof-hash computation for `pass`, evidence_ids, empty-claim-id guard, unknown-status guard
  - **`receipt_verification_from_crux`** — crux_id/question/open-status shape, boundary score validation, empty-crux-id guard
  - **KM adapter** — `_verification_to_knowledge_item` preserves `claim_id`/`crux_id`/`evidence_ids`/`verification_status`/`source_receipt_id` in item metadata; legacy receipts without the new fields produce `None`/`[]` without error

## Validation

- `pytest tests/export/test_receipt_epistemic.py --noconftest` — **20 passed**
- `ruff check aragora/export/receipt_epistemic.py aragora/export/decision_receipt.py aragora/knowledge/mound/adapters/receipt_adapter.py tests/export/test_receipt_epistemic.py` — **clean**
- `mypy aragora/export/receipt_epistemic.py --ignore-missing-imports --strict` — **clean**
- Net diff: **~307 non-blank LOC** (94 new module + 194 tests + 19 modified lines)

## Out of scope

- **KM ingestion of crux-tagged knowledge items** — `ReceiptAdapter.ingest_receipt` currently skips `verified=False` items; crux entries will be persisted once a follow-on slice relaxes that filter for `crux_id`-bearing verifications
- **Receipt deserialization round-trip for new fields** — `DecisionReceipt.from_dict` does not yet reconstruct the new fields from stored JSON; deferred to a DIC-16 Phase 2 slice
- **DIC-17 follow-up bridge** — producing bounded follow-up issues from failed claims / open cruxes lives in `aragora/epistemic/followup.py` (already landed); this PR only ensures the provenance data survives into the receipt + KM layer
