### PR TITLE
fix(review): normalize auto-detected agent ids

### DIFF
--- a/aragora/cli/review.py
+++ b/aragora/cli/review.py
@@ -160,11 +160,11 @@ def get_available_agents() -> str:
     # Check OpenRouter as fallback
     if os.environ.get("OPENROUTER_API_KEY"):
         if len(agents) < 2:
-            agents.append("openrouter-api")
+            agents.append("openrouter")
 
     # Check other providers
     if os.environ.get("GEMINI_API_KEY") and len(agents) < 2:
-        agents.append("gemini-api")
+        agents.append("gemini")
 
     if os.environ.get("MISTRAL_API_KEY") and len(agents) < 2:
         agents.append("mistral-api")

--- a/tests/cli/test_review.py
+++ b/tests/cli/test_review.py
@@ -232,7 +232,18 @@ class TestGetAvailableAgents:
 
         result = get_available_agents()
         assert "anthropic-api" in result
-        assert "openrouter-api" in result
+        assert "openrouter" in result
+
+    def test_available_agent_ids_are_registered(self, monkeypatch):
+        """Auto-detected review agent IDs should map to registered agent types."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test")
+        monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+
+        result = get_available_agents()
+        assert result == "openrouter,gemini"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- normalize the auto-detected fallback review agent ids to registered agent types
- return `openrouter` and `gemini` instead of the stale unregistered `openrouter-api` and `gemini-api`
- lock the behavior with focused review CLI tests

## Validation
- `python -m pytest tests/cli/test_review.py -q`
- `python -m ruff check aragora/cli/review.py tests/cli/test_review.py`
- runtime repro on current `origin/main`: `get_available_agents()` with only `OPENROUTER_API_KEY` and `GEMINI_API_KEY` set returned `openrouter-api,gemini-api`
- runtime repro on this branch: same env returned `openrouter,gemini`

## Notes
- this republishes the unpublished local residue from `codex/review-agent-alias-normalization`
