### PR TITLE
fix(live): clear 3 ESLint warnings blocking Lint gate on main

### DIFF
--- a/aragora/live/__tests__/ReviewQueueCard.test.tsx
+++ b/aragora/live/__tests__/ReviewQueueCard.test.tsx
@@ -27,7 +27,7 @@ jest.mock('../src/hooks/useReviewQueue', () => ({
 
 import { ReviewQueueCard } from '../src/components/review-queue/ReviewQueueCard';
 import type { ReviewQueuePR } from '../src/hooks/useReviewQueue';
-import { fetchBrief, useBriefState } from '../src/hooks/useReviewQueue';
+import { fetchBrief } from '../src/hooks/useReviewQueue';
 
 function makePR(overrides: Partial<ReviewQueuePR> = {}): ReviewQueuePR {
   return {

--- a/aragora/live/src/components/landing/CompactDebateResult.tsx
+++ b/aragora/live/src/components/landing/CompactDebateResult.tsx
@@ -212,7 +212,6 @@ export function CompactDebateResult({ result, onWrongAnswer, onShare }: CompactD
               const displayName = agentDisplayName(agent);
               const round = proposalRound(agent);
               const isExpanded = expandedAgent === agent;
-              const proposalText = getProposalText(agent);
 
               return (
                 <button

--- a/aragora/live/src/components/review-queue/ReviewQueueCard.tsx
+++ b/aragora/live/src/components/review-queue/ReviewQueueCard.tsx
@@ -159,7 +159,6 @@ export function ReviewQueueCard({
       if (status === 503) {
         // Feature flag off mid-session. Fall back to legacy confirm.
         if (typeof window !== 'undefined') {
-          // eslint-disable-next-line no-console
           console.info('brief generation is disabled on this backend');
         }
       } else {


### PR DESCRIPTION
## Summary

ESLint runs with \`--max-warnings 0\` on the Lint CI workflow. Three warnings have been present on main for several days, causing every Lint run on PRs and main itself to fail. This PR clears them.

## Warnings addressed

| # | File | Line | Issue | Fix |
|---|---|---|---|---|
| 1 | \`aragora/live/__tests__/ReviewQueueCard.test.tsx\` | 30 | \`useBriefState\` imported but unused | Removed from import; jest.mock factory handles it |
| 2 | \`aragora/live/src/components/landing/CompactDebateResult.tsx\` | 215 | \`proposalText\` assigned but not used inside map callback | Removed dead assignment |
| 3 | \`aragora/live/src/components/review-queue/ReviewQueueCard.tsx\` | 162 | \`// eslint-disable-next-line no-console\` directive unused | Removed redundant directive; \`console.info\` below is legit feature-flag log |

## Verification

\`\`\`
cd aragora/live
npx eslint . --max-warnings 0
# exit: 0
\`\`\`

## Why this matters

Per Aragora thesis Commitment 4 ("the limits named in 'Where this thesis does NOT yet apply' are respected in product scope"), merging through failing Lint is a violation. This PR closes a multi-day gap.

## Test plan

- [x] \`npx eslint . --max-warnings 0\` exits clean locally
- [ ] Lint CI goes green on this PR
- [ ] Lint CI goes green on subsequent main-branch commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)