### PR TITLE
feat(review): execute bounded live reviewers for packets

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -31,7 +31,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from aragora.swarm.pr_review_protocol import default_pr_review_protocol
+from aragora.review.reviewer_output import ReviewerOutput
+from aragora.swarm.pr_review_protocol import PRReviewerExecutionFailure, default_pr_review_protocol
 from aragora.worktree.fleet import resolve_repo_root
 
 UTC = timezone.utc
@@ -194,6 +195,14 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="GitHub repo slug override (owner/name). Defaults to current repo context.",
     )
+    packet_p.add_argument(
+        "--execute-reviewers",
+        action="store_true",
+        help=(
+            "Attempt one bounded live heterogeneous reviewer pass before falling back to "
+            "the metadata-derived packet."
+        ),
+    )
     packet_p.add_argument("--json", action="store_true", help="Output as JSON")
 
     run_p = sub.add_parser("run", help="Interactively settle a prioritized PR queue")
@@ -283,7 +292,11 @@ def _cmd_build(args: argparse.Namespace) -> int:
 def _cmd_packet(args: argparse.Namespace) -> int:
     json_output = bool(getattr(args, "json", False) or getattr(args, "json_output", False))
     try:
-        packet = _build_packet(args.pr, repo_override=args.repo)
+        packet = _build_packet(
+            args.pr,
+            repo_override=args.repo,
+            execute_reviewers=bool(getattr(args, "execute_reviewers", False)),
+        )
     except _GhError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -624,7 +637,12 @@ def _filter_lanes(
     return items
 
 
-def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
+def _build_packet(
+    pr_ref: str,
+    *,
+    repo_override: str | None,
+    execute_reviewers: bool = False,
+) -> ReviewPacket:
     number = _parse_pr_number(pr_ref)
     fields = ",".join(
         [
@@ -718,7 +736,26 @@ def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
         author = str(author_payload.get("login", "")).strip()
 
     repo = _repo_from_url(str(pr.get("url", "")).strip())
-    protocol = default_pr_review_protocol().build_packet(
+    protocol_runner = default_pr_review_protocol()
+    reviewer_outputs: list[ReviewerOutput] = []
+    execution_failures: list[PRReviewerExecutionFailure] = []
+    if execute_reviewers:
+        diff_args = ["pr", "diff", str(number)]
+        if repo_override:
+            diff_args.extend(["--repo", repo_override])
+        reviewer_outputs, execution_failures = protocol_runner.execute_live_reviewers(
+            repo=repo,
+            pr_number=number,
+            title=str(pr.get("title", "")).strip(),
+            base_sha=str(pr.get("baseRefOid", "")).strip(),
+            head_sha=str(pr.get("headRefOid", "")).strip(),
+            checks_summary=checks_summary,
+            changed_files=files,
+            diff_text=_gh_text(diff_args),
+            machine_recommendation=recommendation,
+            machine_recommendation_reason=recommendation_reason,
+        )
+    protocol = protocol_runner.build_packet(
         repo=repo,
         pr_number=number,
         title=str(pr.get("title", "")).strip(),
@@ -737,6 +774,8 @@ def _build_packet(pr_ref: str, *, repo_override: str | None) -> ReviewPacket:
         validation_commands=validation,
         machine_recommendation=recommendation,
         machine_recommendation_reason=recommendation_reason,
+        reviewer_outputs=reviewer_outputs,
+        execution_failures=execution_failures,
     )
 
     packet = ReviewPacket(

--- a/aragora/swarm/pr_review_protocol.py
+++ b/aragora/swarm/pr_review_protocol.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
+import asyncio
+import json
+import time
 from dataclasses import asdict, dataclass, field
-from typing import Any
+from typing import Any, Sequence, cast
 
+from aragora.agents.base import AgentType, create_agent
+from aragora.review.protocol import DissentPosition, Recommendation
 from aragora.review.provider_slots import (
     ProviderSlotAvailabilitySummary,
     ProviderSlotDefinition,
     ProviderSlotResolution,
     ProviderSlotResolver,
 )
+from aragora.review.reviewer_output import ReviewerOutput, validate_reviewer_outputs
 
 PROTOCOL_VERSION = "pr_review_protocol.v1"
 PROTOCOL_STATUS = "metadata_heuristic"
+EXECUTED_PROTOCOL_STATUS = "heterogeneous_ensemble_v1"
+FALLBACK_PROTOCOL_STATUS = "metadata_heuristic_fallback"
 
 RECOMMEND_APPROVE = "approve_candidate"
 RECOMMEND_ATTENTION = "needs_human_attention"
@@ -24,6 +32,11 @@ REVIEW_ROLES: tuple[str, ...] = (
     "skeptic",
     "synthesizer",
 )
+
+MIN_EXECUTED_REVIEWERS = 3
+MAX_EXECUTED_REVIEWERS = 3
+LIVE_REVIEW_TIMEOUT_SECONDS = 60.0
+MAX_LIVE_DIFF_CHARS = 16_000
 
 _SLOT_CATALOG: tuple[tuple[str, str, str, str, tuple[str, ...]], ...] = (
     ("logic", "logic_reviewer", "core", "claude", ("claude", "anthropic-api")),
@@ -104,6 +117,17 @@ class PRReviewProtocolPacket:
 
 
 @dataclass(frozen=True, slots=True)
+class PRReviewerExecutionFailure:
+    slot_id: str
+    review_role: str
+    provider: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
 class PRReviewProtocol:
     protocol_version: str = PROTOCOL_VERSION
     review_roles: tuple[str, ...] = REVIEW_ROLES
@@ -127,6 +151,190 @@ class PRReviewProtocol:
     def resolve_provider_slots(self) -> list[ProviderSlotResolution]:
         return ProviderSlotResolver().resolve_slots(self.provider_slots)
 
+    def execute_live_reviewers(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        title: str,
+        base_sha: str,
+        head_sha: str,
+        checks_summary: str,
+        changed_files: list[str],
+        diff_text: str,
+        machine_recommendation: str,
+        machine_recommendation_reason: str,
+    ) -> tuple[list[ReviewerOutput], list[PRReviewerExecutionFailure]]:
+        return asyncio.run(
+            self._execute_live_reviewers_async(
+                repo=repo,
+                pr_number=pr_number,
+                title=title,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                checks_summary=checks_summary,
+                changed_files=changed_files,
+                diff_text=diff_text,
+                machine_recommendation=machine_recommendation,
+                machine_recommendation_reason=machine_recommendation_reason,
+            )
+        )
+
+    async def _execute_live_reviewers_async(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        title: str,
+        base_sha: str,
+        head_sha: str,
+        checks_summary: str,
+        changed_files: list[str],
+        diff_text: str,
+        machine_recommendation: str,
+        machine_recommendation_reason: str,
+    ) -> tuple[list[ReviewerOutput], list[PRReviewerExecutionFailure]]:
+        resolutions = self.resolve_provider_slots()
+        selected: list[ProviderSlotResolution] = []
+        failures: list[PRReviewerExecutionFailure] = []
+        for slot in resolutions:
+            if len(selected) >= MAX_EXECUTED_REVIEWERS:
+                break
+            if not slot.selected_provider:
+                failures.append(
+                    PRReviewerExecutionFailure(
+                        slot_id=slot.slot_id,
+                        review_role=slot.review_role,
+                        provider="",
+                        reason=slot.detail,
+                    )
+                )
+                continue
+            selected.append(slot)
+        if not selected:
+            return ([], failures)
+
+        results = await asyncio.gather(
+            *[
+                self._execute_single_reviewer(
+                    slot=slot,
+                    repo=repo,
+                    pr_number=pr_number,
+                    title=title,
+                    base_sha=base_sha,
+                    head_sha=head_sha,
+                    checks_summary=checks_summary,
+                    changed_files=changed_files,
+                    diff_text=diff_text,
+                    machine_recommendation=machine_recommendation,
+                    machine_recommendation_reason=machine_recommendation_reason,
+                )
+                for slot in selected
+            ]
+        )
+        outputs: list[ReviewerOutput] = []
+        for output, failure in results:
+            if output is not None:
+                outputs.append(output)
+            if failure is not None:
+                failures.append(failure)
+        return (outputs, failures)
+
+    async def _execute_single_reviewer(
+        self,
+        *,
+        slot: ProviderSlotResolution,
+        repo: str,
+        pr_number: int,
+        title: str,
+        base_sha: str,
+        head_sha: str,
+        checks_summary: str,
+        changed_files: list[str],
+        diff_text: str,
+        machine_recommendation: str,
+        machine_recommendation_reason: str,
+    ) -> tuple[ReviewerOutput | None, PRReviewerExecutionFailure | None]:
+        provider = slot.selected_provider or ""
+        if not provider:
+            return (
+                None,
+                PRReviewerExecutionFailure(
+                    slot_id=slot.slot_id,
+                    review_role=slot.review_role,
+                    provider="",
+                    reason="provider slot is unresolved",
+                ),
+            )
+        started = time.perf_counter()
+        try:
+            agent = create_agent(
+                cast(AgentType, provider),
+                name=f"pr_review_{slot.slot_id}",
+                role="critic",
+                timeout=LIVE_REVIEW_TIMEOUT_SECONDS,
+            )
+            prompt = self._build_live_review_prompt(
+                slot=slot,
+                repo=repo,
+                pr_number=pr_number,
+                title=title,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                checks_summary=checks_summary,
+                changed_files=changed_files,
+                diff_text=diff_text,
+                machine_recommendation=machine_recommendation,
+                machine_recommendation_reason=machine_recommendation_reason,
+            )
+            raw = await asyncio.wait_for(
+                agent.generate(prompt, context=None),
+                timeout=LIVE_REVIEW_TIMEOUT_SECONDS,
+            )
+            payload = self._extract_reviewer_payload(raw)
+            payload.update(
+                {
+                    "reviewer_id": f"{provider}:{slot.slot_id}",
+                    "slot_id": slot.slot_id,
+                    "provider": provider,
+                    "lens": slot.lens,
+                    "family": slot.family,
+                    "round_index": 1,
+                    "latency_ms": max(int((time.perf_counter() - started) * 1000), 0),
+                }
+            )
+            parsed = ReviewerOutput.from_dict(payload)
+            normalized = ReviewerOutput(
+                reviewer_id=f"{provider}:{slot.slot_id}",
+                slot_id=slot.slot_id,
+                provider=provider,
+                lens=slot.lens,
+                family=slot.family,
+                recommendation_class=parsed.recommendation_class,
+                confidence=parsed.confidence,
+                summary=parsed.summary,
+                top_findings=parsed.top_findings,
+                evidence_refs=parsed.evidence_refs,
+                risk_flags=parsed.risk_flags,
+                open_questions=parsed.open_questions,
+                round_index=1,
+                latency_ms=max(int((time.perf_counter() - started) * 1000), 0),
+                cost_usd=parsed.cost_usd,
+                schema_version=parsed.schema_version,
+            )
+            normalized.validate()
+            return (normalized, None)
+        except Exception as exc:  # pragma: no cover - exercised via tests through failure surface
+            return (
+                None,
+                PRReviewerExecutionFailure(
+                    slot_id=slot.slot_id,
+                    review_role=slot.review_role,
+                    provider=provider,
+                    reason=str(exc),
+                ),
+            )
+
     def build_packet(
         self,
         *,
@@ -148,6 +356,8 @@ class PRReviewProtocol:
         validation_commands: list[str],
         machine_recommendation: str,
         machine_recommendation_reason: str,
+        reviewer_outputs: Sequence[ReviewerOutput] | None = None,
+        execution_failures: Sequence[PRReviewerExecutionFailure] | None = None,
     ) -> PRReviewProtocolPacket:
         slot_resolver = ProviderSlotResolver()
         provider_slots = slot_resolver.resolve_slots(self.provider_slots)
@@ -163,18 +373,6 @@ class PRReviewProtocol:
             checks_summary=checks_summary,
             title=title,
         )
-        confidence = self._confidence_for(
-            machine_recommendation=machine_recommendation,
-            findings=findings,
-            has_pending=has_pending,
-        )
-        slot_count = max(len(provider_slots), 1)
-        cost_estimate = {
-            "currency": "USD",
-            "low": round(slot_count * 0.6, 2),
-            "high": round(slot_count * 1.0, 2),
-            "basis": "bounded heterogeneous metadata-first protocol",
-        }
         validation_summary = {
             "checks_summary": checks_summary,
             "has_failures": has_failures,
@@ -187,6 +385,83 @@ class PRReviewProtocol:
                 "additions": additions,
                 "deletions": deletions,
             },
+        }
+        normalized_failures = list(execution_failures or [])
+        valid_outputs: tuple[ReviewerOutput, ...] = ()
+        if reviewer_outputs:
+            try:
+                validate_reviewer_outputs(reviewer_outputs)
+                valid_outputs = tuple(reviewer_outputs)
+            except ValueError as exc:
+                normalized_failures.append(
+                    PRReviewerExecutionFailure(
+                        slot_id="validation",
+                        review_role="validation",
+                        provider="protocol",
+                        reason=str(exc),
+                    )
+                )
+
+        if len(valid_outputs) >= MIN_EXECUTED_REVIEWERS:
+            return self._build_executed_packet(
+                repo=repo,
+                pr_number=pr_number,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                provider_slots=provider_slots,
+                availability_summary=availability_summary,
+                reviewer_outputs=valid_outputs,
+                validation_summary=validation_summary,
+            )
+
+        packet = self._build_metadata_packet(
+            repo=repo,
+            pr_number=pr_number,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            provider_slots=provider_slots,
+            availability_summary=availability_summary,
+            findings=findings,
+            validation_summary=validation_summary,
+            machine_recommendation=machine_recommendation,
+            machine_recommendation_reason=machine_recommendation_reason,
+            has_pending=has_pending,
+        )
+        if valid_outputs or normalized_failures:
+            self._annotate_fallback_packet(
+                packet,
+                provider_slots=provider_slots,
+                reviewer_outputs=valid_outputs,
+                execution_failures=normalized_failures,
+            )
+        return packet
+
+    def _build_metadata_packet(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        base_sha: str,
+        head_sha: str,
+        provider_slots: list[ProviderSlotResolution],
+        availability_summary: ProviderSlotAvailabilitySummary,
+        findings: list[PRReviewFinding],
+        validation_summary: dict[str, Any],
+        machine_recommendation: str,
+        machine_recommendation_reason: str,
+        has_pending: bool,
+    ) -> PRReviewProtocolPacket:
+        confidence = self._confidence_for(
+            machine_recommendation=machine_recommendation,
+            findings=findings,
+            has_pending=has_pending,
+        )
+        slot_count = max(len(provider_slots), 1)
+        cost_estimate = {
+            "currency": "USD",
+            "low": round(slot_count * 0.6, 2),
+            "high": round(slot_count * 1.0, 2),
+            "basis": "bounded heterogeneous metadata-first protocol",
         }
         if machine_recommendation == RECOMMEND_APPROVE:
             dissent_summary = "No heterogeneous dissent recorded yet; packet is metadata-derived."
@@ -217,6 +492,108 @@ class PRReviewProtocol:
             top_findings=findings[:5],
             cost_estimate=cost_estimate,
         )
+
+    def _build_executed_packet(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        base_sha: str,
+        head_sha: str,
+        provider_slots: list[ProviderSlotResolution],
+        availability_summary: ProviderSlotAvailabilitySummary,
+        reviewer_outputs: Sequence[ReviewerOutput],
+        validation_summary: dict[str, Any],
+    ) -> PRReviewProtocolPacket:
+        (
+            recommendation_class,
+            recommendation_reason,
+            confidence,
+            confidence_basis,
+        ) = self._recommendation_from_outputs(reviewer_outputs)
+        dissenting_views = self._dissenting_views_from_outputs(
+            reviewer_outputs,
+            provider_slots=provider_slots,
+            final_recommendation=recommendation_class,
+        )
+        packet_validation = dict(validation_summary)
+        packet_validation["reviewer_execution"] = {
+            "status": EXECUTED_PROTOCOL_STATUS,
+            "reviewer_count": len(reviewer_outputs),
+            "reviewer_ids": [output.reviewer_id for output in reviewer_outputs],
+            "providers": [output.provider for output in reviewer_outputs],
+            "dissent_count": len(dissenting_views),
+        }
+        total_cost = round(sum(output.cost_usd for output in reviewer_outputs), 6)
+        return PRReviewProtocolPacket(
+            protocol_version=self.protocol_version,
+            status=EXECUTED_PROTOCOL_STATUS,
+            binding=PRReviewBinding(
+                repo=repo,
+                pr_number=pr_number,
+                base_sha=base_sha,
+                head_sha=head_sha,
+            ),
+            review_roles=list(self.review_roles),
+            provider_slots=provider_slots,
+            availability_summary=availability_summary,
+            recommendation_class=recommendation_class,
+            recommendation_reason=recommendation_reason,
+            confidence=confidence,
+            confidence_basis=confidence_basis,
+            dissent_summary=self._dissent_summary_from_outputs(
+                reviewer_outputs,
+                dissenting_views=dissenting_views,
+            ),
+            dissenting_views=dissenting_views,
+            validation_summary=packet_validation,
+            top_findings=self._build_findings_from_outputs(reviewer_outputs)[:5],
+            cost_estimate={
+                "currency": "USD",
+                "low": round(total_cost, 2),
+                "high": round(total_cost, 2),
+                "basis": "executed heterogeneous reviewer outputs",
+            },
+        )
+
+    def _annotate_fallback_packet(
+        self,
+        packet: PRReviewProtocolPacket,
+        *,
+        provider_slots: list[ProviderSlotResolution],
+        reviewer_outputs: Sequence[ReviewerOutput],
+        execution_failures: Sequence[PRReviewerExecutionFailure],
+    ) -> None:
+        partial_dissent = self._dissenting_views_from_outputs(
+            reviewer_outputs,
+            provider_slots=provider_slots,
+            final_recommendation=packet.recommendation_class,
+        )
+        failure_reason = "insufficient_live_reviews"
+        if not reviewer_outputs and execution_failures:
+            failure_reason = "execution_failed"
+        packet.status = f"{FALLBACK_PROTOCOL_STATUS}_{failure_reason}"
+        packet.confidence_basis = packet.status
+        packet.dissenting_views = partial_dissent
+        if partial_dissent:
+            packet.dissent_summary = (
+                "Partial live reviewer execution captured dissent, but not enough valid "
+                "heterogeneous reviewer outputs were available to upgrade the protocol status."
+            )
+        else:
+            packet.dissent_summary = (
+                "Live reviewer execution did not yield a complete bounded panel; falling back "
+                "to metadata-derived recommendation."
+            )
+        packet.validation_summary = {
+            **packet.validation_summary,
+            "reviewer_execution": {
+                "status": packet.status,
+                "partial_reviewer_count": len(reviewer_outputs),
+                "failure_count": len(execution_failures),
+                "failures": [failure.to_dict() for failure in execution_failures],
+            },
+        }
 
     def _build_findings(
         self,
@@ -308,6 +685,230 @@ class PRReviewProtocol:
             )
         return findings
 
+    def _build_findings_from_outputs(
+        self, reviewer_outputs: Sequence[ReviewerOutput]
+    ) -> list[PRReviewFinding]:
+        findings: list[PRReviewFinding] = []
+        for output in reviewer_outputs:
+            for index, finding in enumerate(output.top_findings[:2], start=1):
+                evidence = list(finding.evidence)
+                for file_path in finding.files:
+                    if file_path not in evidence:
+                        evidence.append(file_path)
+                findings.append(
+                    PRReviewFinding(
+                        finding_id=f"{output.slot_id}-{index}",
+                        category=finding.category.value,
+                        severity=finding.severity.value,
+                        summary=finding.claim,
+                        evidence=evidence[:5],
+                        source=output.reviewer_id,
+                    )
+                )
+        if not findings:
+            findings.append(
+                PRReviewFinding(
+                    finding_id="reviewer-output-missing",
+                    category="validation",
+                    severity="medium",
+                    summary="Live reviewers executed but returned no structured findings.",
+                    evidence=["reviewer execution returned empty findings"],
+                    source=EXECUTED_PROTOCOL_STATUS,
+                )
+            )
+        return findings
+
+    def _recommendation_from_outputs(
+        self, reviewer_outputs: Sequence[ReviewerOutput]
+    ) -> tuple[str, str, float, str]:
+        totals = {recommendation: 0.0 for recommendation in Recommendation}
+        counts = {recommendation: 0 for recommendation in Recommendation}
+        for output in reviewer_outputs:
+            weight = max(float(output.confidence), 0.05)
+            totals[output.recommendation_class] += weight
+            counts[output.recommendation_class] += 1
+        ordered = sorted(totals.items(), key=lambda item: item[1], reverse=True)
+        winner, winner_weight = ordered[0]
+        runner_up_weight = ordered[1][1] if len(ordered) > 1 else 0.0
+        average_confidence = sum(output.confidence for output in reviewer_outputs) / max(
+            len(reviewer_outputs), 1
+        )
+        split_margin = winner_weight - runner_up_weight
+        if split_margin < 0.15 and counts[winner] < len(reviewer_outputs):
+            confidence = max(0.25, round(average_confidence - 0.15, 2))
+            return (
+                RECOMMEND_ATTENTION,
+                (
+                    "executed panel split across reviewer recommendations; keep this in the "
+                    "human-attention lane"
+                ),
+                confidence,
+                f"{EXECUTED_PROTOCOL_STATUS}.split_panel",
+            )
+        dissent_count = len(reviewer_outputs) - counts[winner]
+        confidence = max(
+            0.2,
+            min(
+                0.98, round(average_confidence - ((dissent_count / len(reviewer_outputs)) * 0.1), 2)
+            ),
+        )
+        reason = (
+            f"{counts[winner]}/{len(reviewer_outputs)} executed reviewers recommend {winner.value}"
+        )
+        if dissent_count:
+            reason += f"; {dissent_count} reviewer(s) dissent"
+        return (winner.value, reason, confidence, EXECUTED_PROTOCOL_STATUS)
+
+    def _dissenting_views_from_outputs(
+        self,
+        reviewer_outputs: Sequence[ReviewerOutput],
+        *,
+        provider_slots: Sequence[ProviderSlotResolution],
+        final_recommendation: str,
+    ) -> list[dict[str, Any]]:
+        views: list[dict[str, Any]] = []
+        for output in reviewer_outputs:
+            if output.recommendation_class.value == final_recommendation:
+                continue
+            role = self._role_for_slot(output.slot_id, provider_slots)
+            entry: dict[str, Any] = {
+                "agent": output.reviewer_id,
+                "position": self._dissent_position_for(output.recommendation_class.value).value,
+                "reason": output.summary,
+            }
+            if role:
+                entry["role"] = role
+            views.append(entry)
+        return views
+
+    def _dissent_summary_from_outputs(
+        self,
+        reviewer_outputs: Sequence[ReviewerOutput],
+        *,
+        dissenting_views: Sequence[dict[str, Any]],
+    ) -> str:
+        if not dissenting_views:
+            return "Executed heterogeneous reviewers were unanimous on the current PR head."
+        return (
+            f"Executed heterogeneous reviewers recorded {len(dissenting_views)} dissenting "
+            f"view(s) across {len(reviewer_outputs)} reviewer outputs."
+        )
+
+    def _role_for_slot(
+        self, slot_id: str, provider_slots: Sequence[ProviderSlotResolution]
+    ) -> str | None:
+        for slot in provider_slots:
+            if slot.slot_id == slot_id:
+                return slot.review_role
+        return None
+
+    def _dissent_position_for(self, recommendation_class: str) -> DissentPosition:
+        if recommendation_class == RECOMMEND_APPROVE:
+            return DissentPosition.APPROVE
+        if recommendation_class == RECOMMEND_REPAIR:
+            return DissentPosition.REQUEST_CHANGES
+        return DissentPosition.DEFER
+
+    def _build_live_review_prompt(
+        self,
+        *,
+        slot: ProviderSlotResolution,
+        repo: str,
+        pr_number: int,
+        title: str,
+        base_sha: str,
+        head_sha: str,
+        checks_summary: str,
+        changed_files: list[str],
+        diff_text: str,
+        machine_recommendation: str,
+        machine_recommendation_reason: str,
+    ) -> str:
+        changed_files_text = (
+            "\n".join(f"- {path}" for path in changed_files[:25]) or "- (none listed)"
+        )
+        truncated_diff = diff_text.strip()
+        if len(truncated_diff) > MAX_LIVE_DIFF_CHARS:
+            truncated_diff = truncated_diff[:MAX_LIVE_DIFF_CHARS] + "\n...[diff truncated]..."
+        return (
+            "You are one reviewer in Aragora's bounded heterogeneous PR review protocol.\n"
+            "Return JSON only. No prose before or after the JSON.\n\n"
+            f"Role: {slot.review_role}\n"
+            f"Slot id: {slot.slot_id}\n"
+            f"Lens: {slot.lens}\n"
+            f"Family: {slot.family}\n"
+            f"Provider: {slot.selected_provider}\n"
+            f"Repo: {repo}\n"
+            f"PR: #{pr_number}\n"
+            f"Title: {title}\n"
+            f"Base SHA: {base_sha}\n"
+            f"Head SHA: {head_sha}\n"
+            f"Checks summary: {checks_summary}\n"
+            f"Current metadata recommendation: {machine_recommendation}\n"
+            f"Reason: {machine_recommendation_reason}\n\n"
+            "Changed files:\n"
+            f"{changed_files_text}\n\n"
+            "Diff excerpt:\n"
+            f"{truncated_diff}\n\n"
+            "Return a JSON object with this exact schema shape:\n"
+            "{\n"
+            '  "schema_version": "reviewer_output.v1",\n'
+            '  "reviewer_id": "set to any non-empty placeholder; caller will overwrite",\n'
+            '  "slot_id": "set to any non-empty placeholder; caller will overwrite",\n'
+            '  "provider": "set to any non-empty placeholder; caller will overwrite",\n'
+            '  "lens": "set to any non-empty placeholder; caller will overwrite",\n'
+            '  "family": "set to any non-empty placeholder; caller will overwrite",\n'
+            '  "recommendation_class": "approve_candidate | needs_human_attention | repair_first",\n'
+            '  "confidence": 0.0,\n'
+            '  "summary": "1-2 sentence reviewer summary",\n'
+            '  "top_findings": [\n'
+            "    {\n"
+            '      "category": "logic | security | maintainability | skeptic | validation",\n'
+            '      "severity": "low | medium | high",\n'
+            '      "claim": "specific issue or bounded-green claim",\n'
+            '      "evidence": ["short evidence string"],\n'
+            '      "files": ["repo/path.py"]\n'
+            "    }\n"
+            "  ],\n"
+            '  "evidence_refs": [\n'
+            "    {\n"
+            '      "kind": "file",\n'
+            '      "path": "repo/path.py",\n'
+            '      "line_range": [10, 20],\n'
+            '      "quote": "short excerpt"\n'
+            "    }\n"
+            "  ],\n"
+            '  "risk_flags": [],\n'
+            '  "open_questions": [],\n'
+            '  "round_index": 1,\n'
+            '  "latency_ms": 0,\n'
+            '  "cost_usd": 0.0\n'
+            "}\n"
+            "If you do not see a concrete defect, return one validation or bounded-green finding "
+            "instead of an empty findings array. Ground all claims in the diff or changed files."
+        )
+
+    def _extract_reviewer_payload(self, raw_text: str) -> dict[str, Any]:
+        text = str(raw_text or "").strip()
+        if text.startswith("```"):
+            lines = text.splitlines()
+            if lines and lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            text = "\n".join(lines).strip()
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            start = text.find("{")
+            end = text.rfind("}")
+            if start == -1 or end == -1 or end <= start:
+                raise ValueError("reviewer output did not contain a JSON object") from None
+            payload = json.loads(text[start : end + 1])
+        if not isinstance(payload, dict):
+            raise ValueError("reviewer output JSON must be an object")
+        return payload
+
     def _confidence_for(
         self,
         *,
@@ -333,8 +934,11 @@ def default_pr_review_protocol() -> PRReviewProtocol:
 
 
 __all__ = [
+    "EXECUTED_PROTOCOL_STATUS",
+    "FALLBACK_PROTOCOL_STATUS",
     "PRReviewBinding",
     "PRReviewFinding",
+    "PRReviewerExecutionFailure",
     "PRReviewProtocol",
     "PRReviewProtocolPacket",
     "ProviderSlotAvailabilitySummary",

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -33,6 +33,16 @@ from aragora.cli.commands.review_queue import (
     add_review_queue_parser,
     cmd_review_queue,
 )
+from aragora.review import (
+    EvidenceKind,
+    EvidenceRef,
+    FindingCategory,
+    FindingSeverity,
+    Recommendation,
+    ReviewerFinding,
+    ReviewerOutput,
+)
+from aragora.swarm.pr_review_protocol import EXECUTED_PROTOCOL_STATUS
 
 
 # --- Synthetic PR payload builder ------------------------------------------
@@ -75,6 +85,47 @@ def _make_pr(
         "files": [{"path": p} for p in (files or [])],
         "body": body,
     }
+
+
+def _make_reviewer_output(
+    *,
+    slot_id: str,
+    provider: str,
+    family: str,
+    recommendation: Recommendation,
+) -> ReviewerOutput:
+    return ReviewerOutput(
+        reviewer_id=f"{provider}:{slot_id}",
+        slot_id=slot_id,
+        provider=provider,
+        lens="core" if slot_id in {"logic", "security"} else "heterodox",
+        family=family,
+        recommendation_class=recommendation,
+        confidence=0.63,
+        summary=f"{slot_id} summary",
+        top_findings=(
+            ReviewerFinding(
+                category=FindingCategory.VALIDATION,
+                severity=FindingSeverity.MEDIUM,
+                claim=f"{slot_id} reviewed the diff",
+                evidence=(f"{slot_id} evidence",),
+                files=(),
+            ),
+        ),
+        evidence_refs=(
+            EvidenceRef(
+                kind=EvidenceKind.FILE,
+                path=f"aragora/{slot_id}.py",
+                line_range=(1, 2),
+                quote="example",
+            ),
+        ),
+        risk_flags=(),
+        open_questions=(),
+        round_index=1,
+        latency_ms=100,
+        cost_usd=0.2,
+    )
 
 
 # --- _summarize_checks -----------------------------------------------------
@@ -547,6 +598,50 @@ class TestBuildQueueAndPacket:
         with pytest.raises(_GhError, match="not found"):
             _build_packet("9999", repo_override=None)
 
+    def test_build_packet_can_execute_live_reviewers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pr_payload = _make_pr(
+            number=6280,
+            files=["aragora/cli/commands/review_pr.py"],
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_json",
+            lambda args: pr_payload,
+        )
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._gh_text",
+            lambda args: "diff --git a/aragora/cli/commands/review_pr.py b/aragora/cli/commands/review_pr.py",
+        )
+        outputs = [
+            _make_reviewer_output(
+                slot_id="logic",
+                provider="claude",
+                family="claude",
+                recommendation=Recommendation.APPROVE_CANDIDATE,
+            ),
+            _make_reviewer_output(
+                slot_id="security",
+                provider="openai-api",
+                family="gpt",
+                recommendation=Recommendation.REPAIR_FIRST,
+            ),
+            _make_reviewer_output(
+                slot_id="maintainability",
+                provider="gemini-cli",
+                family="gemini",
+                recommendation=Recommendation.APPROVE_CANDIDATE,
+            ),
+        ]
+        monkeypatch.setattr(
+            "aragora.swarm.pr_review_protocol.PRReviewProtocol.execute_live_reviewers",
+            lambda self, **kwargs: (outputs, []),
+        )
+
+        packet = _build_packet("6280", repo_override=None, execute_reviewers=True)
+
+        assert packet.protocol["status"] == EXECUTED_PROTOCOL_STATUS
+        assert packet.protocol["validation_summary"]["reviewer_execution"]["reviewer_count"] == 3
+        assert len(packet.protocol["dissenting_views"]) == 1
+
 
 # --- JSON output schema ----------------------------------------------------
 
@@ -636,9 +731,12 @@ class TestCommandDispatch:
         assert ns_build.limit == 5
         assert ns_build.json is True
         # packet invocation parses
-        ns_packet = root.parse_args(["review-queue", "packet", "6280", "--json"])
+        ns_packet = root.parse_args(
+            ["review-queue", "packet", "6280", "--execute-reviewers", "--json"]
+        )
         assert ns_packet.review_queue_command == "packet"
         assert ns_packet.pr == "6280"
+        assert ns_packet.execute_reviewers is True
         # run invocation parses
         ns_run = root.parse_args(["review-queue", "run", "--limit", "3", "--ready-only"])
         assert ns_run.review_queue_command == "run"

--- a/tests/swarm/test_pr_review_protocol.py
+++ b/tests/swarm/test_pr_review_protocol.py
@@ -4,14 +4,72 @@ import json
 
 import pytest
 
+from aragora.review import (
+    EvidenceKind,
+    EvidenceRef,
+    FindingCategory,
+    FindingSeverity,
+    Recommendation,
+    ReviewerFinding,
+    ReviewerOutput,
+)
+from aragora.review.provider_slots import ProviderSlotResolution
 from aragora.swarm.pr_review_protocol import (
+    EXECUTED_PROTOCOL_STATUS,
+    FALLBACK_PROTOCOL_STATUS,
     PROTOCOL_STATUS,
     PROTOCOL_VERSION,
+    PRReviewerExecutionFailure,
     RECOMMEND_APPROVE,
     RECOMMEND_ATTENTION,
     RECOMMEND_REPAIR,
     default_pr_review_protocol,
 )
+
+
+def _reviewer_output(
+    *,
+    slot_id: str,
+    provider: str,
+    family: str,
+    recommendation: Recommendation,
+    confidence: float,
+    summary: str,
+    claim: str,
+    category: FindingCategory,
+) -> ReviewerOutput:
+    return ReviewerOutput(
+        reviewer_id=f"{provider}:{slot_id}",
+        slot_id=slot_id,
+        provider=provider,
+        lens="core" if slot_id in {"logic", "security"} else "heterodox",
+        family=family,
+        recommendation_class=recommendation,
+        confidence=confidence,
+        summary=summary,
+        top_findings=(
+            ReviewerFinding(
+                category=category,
+                severity=FindingSeverity.MEDIUM,
+                claim=claim,
+                evidence=(f"evidence for {slot_id}",),
+                files=(f"aragora/{slot_id}.py",),
+            ),
+        ),
+        evidence_refs=(
+            EvidenceRef(
+                kind=EvidenceKind.FILE,
+                path=f"aragora/{slot_id}.py",
+                line_range=(10, 18),
+                quote=f"quoted evidence for {slot_id}",
+            ),
+        ),
+        risk_flags=(f"{slot_id}_flag",),
+        open_questions=(),
+        round_index=1,
+        latency_ms=1200,
+        cost_usd=0.25,
+    )
 
 
 def test_resolve_provider_slots_prefers_available_candidates(
@@ -177,3 +235,248 @@ def test_packet_to_dict_round_trips_to_json() -> None:
     assert roundtrip["availability_summary"]["total_slots"] == 5
     assert "candidate_checks" not in roundtrip["provider_slots"][0]
     assert "selected_allowlisted" not in roundtrip["provider_slots"][0]
+
+
+def test_build_packet_upgrades_to_executed_status_and_preserves_dissent() -> None:
+    protocol = default_pr_review_protocol()
+    packet = protocol.build_packet(
+        repo="synaptent/aragora",
+        pr_number=77,
+        title="Executed protocol",
+        base_sha="base",
+        head_sha="head",
+        mergeable="MERGEABLE",
+        review_decision="",
+        checks_summary="5/5 green",
+        has_failures=False,
+        has_pending=False,
+        additions=42,
+        deletions=7,
+        changed_files=3,
+        labels=[],
+        high_risk_paths=[],
+        validation_commands=["pytest -q tests/swarm/test_pr_review_protocol.py"],
+        machine_recommendation=RECOMMEND_APPROVE,
+        machine_recommendation_reason="all green, bounded diff, no high-risk paths",
+        reviewer_outputs=[
+            _reviewer_output(
+                slot_id="logic",
+                provider="claude",
+                family="claude",
+                recommendation=Recommendation.APPROVE_CANDIDATE,
+                confidence=0.72,
+                summary="Logic review sees a bounded change.",
+                claim="Logic path remains bounded.",
+                category=FindingCategory.LOGIC,
+            ),
+            _reviewer_output(
+                slot_id="security",
+                provider="openai-api",
+                family="gpt",
+                recommendation=Recommendation.REPAIR_FIRST,
+                confidence=0.44,
+                summary="Security wants a tighter guard before merge.",
+                claim="One auth boundary still needs direct review.",
+                category=FindingCategory.SECURITY,
+            ),
+            _reviewer_output(
+                slot_id="maintainability",
+                provider="gemini-cli",
+                family="gemini",
+                recommendation=Recommendation.APPROVE_CANDIDATE,
+                confidence=0.66,
+                summary="Maintainability review is comfortable with the diff.",
+                claim="Naming and structure stay within existing patterns.",
+                category=FindingCategory.MAINTAINABILITY,
+            ),
+        ],
+    )
+
+    assert packet.status == EXECUTED_PROTOCOL_STATUS
+    assert packet.recommendation_class == RECOMMEND_APPROVE
+    assert packet.confidence_basis == EXECUTED_PROTOCOL_STATUS
+    assert len(packet.dissenting_views) == 1
+    assert packet.dissenting_views[0]["position"] == "request_changes"
+    assert packet.validation_summary["reviewer_execution"]["reviewer_count"] == 3
+    assert packet.top_findings[0].source in {
+        "claude:logic",
+        "openai-api:security",
+        "gemini-cli:maintainability",
+    }
+    assert packet.cost_estimate["low"] == pytest.approx(0.75)
+    assert packet.cost_estimate["high"] == pytest.approx(0.75)
+
+
+def test_build_packet_falls_back_when_live_reviews_are_incomplete() -> None:
+    protocol = default_pr_review_protocol()
+    packet = protocol.build_packet(
+        repo="synaptent/aragora",
+        pr_number=78,
+        title="Fallback protocol",
+        base_sha="base",
+        head_sha="head",
+        mergeable="MERGEABLE",
+        review_decision="",
+        checks_summary="5/5 green",
+        has_failures=False,
+        has_pending=False,
+        additions=18,
+        deletions=4,
+        changed_files=2,
+        labels=[],
+        high_risk_paths=[],
+        validation_commands=[],
+        machine_recommendation=RECOMMEND_APPROVE,
+        machine_recommendation_reason="all green, bounded diff, no high-risk paths",
+        reviewer_outputs=[
+            _reviewer_output(
+                slot_id="logic",
+                provider="claude",
+                family="claude",
+                recommendation=Recommendation.APPROVE_CANDIDATE,
+                confidence=0.7,
+                summary="Logic is comfortable with the patch.",
+                claim="Logic path is bounded.",
+                category=FindingCategory.LOGIC,
+            ),
+            _reviewer_output(
+                slot_id="security",
+                provider="openai-api",
+                family="gpt",
+                recommendation=Recommendation.NEEDS_HUMAN_ATTENTION,
+                confidence=0.5,
+                summary="Security wants a human to verify one edge.",
+                claim="Auth-adjacent change still needs human eyes.",
+                category=FindingCategory.SECURITY,
+            ),
+        ],
+        execution_failures=[
+            PRReviewerExecutionFailure(
+                slot_id="maintainability",
+                review_role="maintainability_reviewer",
+                provider="gemini-cli",
+                reason="timed out",
+            )
+        ],
+    )
+
+    assert packet.status == f"{FALLBACK_PROTOCOL_STATUS}_insufficient_live_reviews"
+    assert packet.recommendation_class == RECOMMEND_APPROVE
+    assert packet.validation_summary["reviewer_execution"]["failure_count"] == 1
+    assert len(packet.dissenting_views) == 1
+    assert (
+        "falling back" in packet.dissent_summary.lower()
+        or "partial live reviewer" in packet.dissent_summary.lower()
+    )
+
+
+def test_execute_live_reviewers_parses_structured_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    protocol = default_pr_review_protocol()
+    monkeypatch.setattr(
+        "aragora.swarm.pr_review_protocol.PRReviewProtocol.resolve_provider_slots",
+        lambda self: [
+            ProviderSlotResolution(
+                slot_id="logic",
+                review_role="logic_reviewer",
+                lens="core",
+                family="claude",
+                selected_provider="claude",
+                status="available",
+                detail="ready",
+                candidates=["claude"],
+            ),
+            ProviderSlotResolution(
+                slot_id="security",
+                review_role="security_reviewer",
+                lens="core",
+                family="gpt",
+                selected_provider="openai-api",
+                status="available",
+                detail="ready",
+                candidates=["openai-api"],
+            ),
+            ProviderSlotResolution(
+                slot_id="maintainability",
+                review_role="maintainability_reviewer",
+                lens="heterodox",
+                family="gemini",
+                selected_provider="gemini-cli",
+                status="available",
+                detail="ready",
+                candidates=["gemini-cli"],
+            ),
+        ],
+    )
+
+    class _FakeAgent:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def generate(self, prompt: str, context=None) -> str:
+            recommendation = "approve_candidate"
+            if "security" in self.name:
+                recommendation = "repair_first"
+            return json.dumps(
+                {
+                    "schema_version": "reviewer_output.v1",
+                    "reviewer_id": "placeholder",
+                    "slot_id": "placeholder",
+                    "provider": "placeholder",
+                    "lens": "placeholder",
+                    "family": "placeholder",
+                    "recommendation_class": recommendation,
+                    "confidence": 0.64,
+                    "summary": f"review from {self.name}",
+                    "top_findings": [
+                        {
+                            "category": "validation",
+                            "severity": "medium",
+                            "claim": f"{self.name} reviewed the diff",
+                            "evidence": ["diff excerpt present"],
+                        }
+                    ],
+                    "evidence_refs": [
+                        {
+                            "kind": "file",
+                            "path": "aragora/example.py",
+                            "line_range": [1, 2],
+                            "quote": "example",
+                        }
+                    ],
+                    "risk_flags": [],
+                    "open_questions": [],
+                    "round_index": 1,
+                    "latency_ms": 0,
+                    "cost_usd": 0.15,
+                }
+            )
+
+    monkeypatch.setattr(
+        "aragora.swarm.pr_review_protocol.create_agent",
+        lambda model_type, name=None, role="critic", timeout=None: _FakeAgent(
+            name or str(model_type)
+        ),
+    )
+
+    outputs, failures = protocol.execute_live_reviewers(
+        repo="synaptent/aragora",
+        pr_number=88,
+        title="Live execution",
+        base_sha="base",
+        head_sha="head",
+        checks_summary="5/5 green",
+        changed_files=["aragora/example.py"],
+        diff_text="diff --git a/aragora/example.py b/aragora/example.py\n+print('hi')\n",
+        machine_recommendation=RECOMMEND_APPROVE,
+        machine_recommendation_reason="all green, bounded diff, no high-risk paths",
+    )
+
+    assert failures == []
+    assert [output.reviewer_id for output in outputs] == [
+        "claude:logic",
+        "openai-api:security",
+        "gemini-cli:maintainability",
+    ]
+    assert outputs[1].recommendation_class is Recommendation.REPAIR_FIRST


### PR DESCRIPTION
## Summary
- add an opt-in bounded live reviewer execution path to `review-queue packet`
- upgrade `pr_review_protocol` packets to emit `heterogeneous_ensemble_v1` with real dissent when enough structured reviewer outputs are available
- preserve honest metadata fallback status and validation details when live reviewer execution is incomplete

## Validation
- `pytest -q tests/swarm/test_pr_review_protocol.py tests/cli/commands/test_review_queue.py`
- `pytest -q tests/swarm/test_pr_review_protocol.py tests/cli/commands/test_review_queue.py tests/review/test_reviewer_output.py`
- `ruff check aragora/swarm/pr_review_protocol.py aragora/cli/commands/review_queue.py tests/swarm/test_pr_review_protocol.py tests/cli/commands/test_review_queue.py`
- `ruff format --check aragora/swarm/pr_review_protocol.py aragora/cli/commands/review_queue.py tests/swarm/test_pr_review_protocol.py tests/cli/commands/test_review_queue.py`
- `mypy --follow-imports=silent aragora/swarm/pr_review_protocol.py aragora/cli/commands/review_queue.py tests/swarm/test_pr_review_protocol.py tests/cli/commands/test_review_queue.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Refs #6374