### PR TITLE
docs(pr-review-protocol): clarify two-state status model

### DIFF
--- a/aragora/swarm/pr_review_protocol.py
+++ b/aragora/swarm/pr_review_protocol.py
@@ -1,3 +1,43 @@
+"""PR review protocol schema + types.
+
+This module defines the packet shape and role catalog for PR reviews
+(:class:`PRReviewProtocolPacket`, :class:`PRReviewBinding`,
+:data:`REVIEW_ROLES`, slot catalog). It is a **schema module** — it
+does not itself invoke reviewers or produce the active ensemble state.
+
+Two-state model
+---------------
+The protocol now operates with two distinct status values:
+
+* :data:`PROTOCOL_STATUS` (module-level) — the *fallback default* for
+  packets constructed without explicit status. Remains
+  ``"metadata_heuristic"`` to accurately label packets that emerge
+  from this schema module alone without an active ensemble run.
+
+* Per-packet ``status`` field — set by the **active realization** when
+  real reviewers execute. The :mod:`aragora.pdb` path (worker +
+  real_invoker + invoker_factory + response_parser + protocol)
+  invokes Claude, GPT, Gemini, Grok, DeepSeek, Kimi, Qwen, and
+  Mistral, populates ``dissenting_views`` with per-lens votes, and
+  emits packets with status reflecting the real heterogeneous
+  ensemble execution.
+
+The test contract (:mod:`tests.pdb.test_protocol`) explicitly verifies
+this distinction: when PDB runs, the resulting packet's status is
+*different* from :data:`PROTOCOL_STATUS`, precisely so that callers
+can tell a fallback/heuristic packet apart from a real
+heterogeneous-ensemble run.
+
+Active realization status (as of 2026-04-22):
+    PR #6404 wired Claude + GPT ProviderInvoker; PR #6425 completed
+    Phase B with gemini/grok/deepseek/kimi/qwen/mistral slots; PR #6421
+    shipped the single-PR dogfood CLI. Packets emitted via
+    :mod:`aragora.pdb.protocol` carry a status reflecting the real
+    ensemble run, not the fallback.
+
+See also: ``docs/THESIS.md`` § Implementation gaps, issue #6374.
+"""
+
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
@@ -11,6 +51,9 @@ from aragora.review.provider_slots import (
 )
 
 PROTOCOL_VERSION = "pr_review_protocol.v1"
+# Fallback default for packets constructed without explicit status.
+# Packets produced by the active aragora.pdb ensemble path carry their
+# own status that differs from this value — see module docstring.
 PROTOCOL_STATUS = "metadata_heuristic"
 
 RECOMMEND_APPROVE = "approve_candidate"


### PR DESCRIPTION
## Summary

Updates \`aragora/swarm/pr_review_protocol.py\` module docstring to document the two-state status model honestly. No constant change, no API change.

## Background

Gap issue #6374 asked to flip \`PROTOCOL_STATUS\` from \`metadata_heuristic\` to \`heterogeneous_ensemble_v1\`. Closer reading of the existing test contract (\`tests/pdb/test_protocol.py:727-728\`) revealed the intended design is two states, not a single constant flip:

- **Module-level \`PROTOCOL_STATUS\`** = fallback default when no active ensemble runs
- **Per-packet \`status\` field** = set by active realization (PDB path) when reviewers actually execute

The test \`assert result.packet.status != PROTOCOL_STATUS\` explicitly verifies this distinction — the constant MUST stay as fallback so callers can tell real runs from fallbacks.

## What changed

- Added comprehensive module docstring documenting the two-state model
- Cross-referenced the \`aragora.pdb\` active realization (worker + real_invoker + invoker_factory + response_parser + protocol)
- Recorded the active-realization status landmarks: PR #6404 (Claude+GPT), #6425 (Phase B: gemini/grok/deepseek/kimi/qwen/mistral), #6421 (dogfood CLI)
- Cross-referenced \`docs/THESIS.md\` § Implementation gaps and issue #6374

## What did NOT change

- \`PROTOCOL_STATUS\` constant value (remains \`"metadata_heuristic"\` as fallback)
- Any packet construction logic
- Any tests

## Why this is the right close of gap #6374's documentation side

The substantive gap — "replace metadata_heuristic with real heterogeneous ensemble" — is **already done** in the code. 8 providers wired. Dissent populated. CLI ships. Tests cover real_invoker, invoker_factory, response_parser. The issue's literal "flip the constant" criterion was based on a misreading of the design intent. The honest close is: document the two-state model, and let the constant keep representing what it actually represents (the fallback).

Gap #6374 also asks for end-to-end PR review validation on a live PR. That remains a separate follow-up and is NOT claimed closed by this PR.

## Refs

- Gap issue: #6374
- Thesis: \`docs/THESIS.md\` § Implementation gaps
- Active realization: #6404, #6425, #6421

🤖 Generated with [Claude Code](https://claude.com/claude-code)