### PR TITLE
test(rbac): align system role expectation with shipped defaults

### DIFF
--- a/tests/rbac/test_rbac_v2.py
+++ b/tests/rbac/test_rbac_v2.py
@@ -456,6 +456,8 @@ class TestSystemRoles:
             "debate_creator",
             "team_lead",
             "analyst",
+            "developer",
+            "ops_reviewer",
             "viewer",
             "member",
         }


### PR DESCRIPTION
## Summary
- update `TestSystemRoles.test_all_system_roles_exist` to match the shipped RBAC system-role catalog
- include the `developer` and `ops_reviewer` roles that already exist in `aragora/rbac/defaults/roles.py`
- repair the baseline-red RBAC expectation drift that was blocking downstream PR reads

## Validation
- `pytest -q tests/rbac/test_rbac_v2.py::TestSystemRoles::test_all_system_roles_exist tests/handlers/oauth/test_handler.py::TestValidateRedirectUrl::test_subdomain_of_allowed_host tests/handlers/oauth/test_handler.py::TestReExportIdentity::test_validate_redirect_url_identity`
- `pytest -q tests/rbac/test_rbac_v2.py`
- `ruff check tests/rbac/test_rbac_v2.py`
- `ruff format --check tests/rbac/test_rbac_v2.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Refs #6374