### PR TITLE
fix(devops): align service catalog contract

### DIFF
--- a/aragora/server/handlers/features/devops/__init__.py
+++ b/aragora/server/handlers/features/devops/__init__.py
@@ -100,6 +100,7 @@ class DevOpsHandler(BaseHandler):
         "/api/v1/oncall",
         "/api/v1/oncall/*",
         "/api/v1/services",
+        "/api/v1/services/{service_id}",
         "/api/v1/services/*",
         "/api/v1/webhooks/pagerduty",
         "/api/v1/devops/status",

--- a/aragora/server/openapi/endpoints/sdk_missing.py
+++ b/aragora/server/openapi/endpoints/sdk_missing.py
@@ -164,43 +164,6 @@ SDK_MISSING_ENDPOINTS: dict = {
             "responses": {"200": _ok_response("Calibration history", _arr_obj)},
         },
     },
-    # --- services ---
-    "/api/services/{service_id}/health": {
-        "get": {
-            "tags": ["Services"],
-            "summary": "Get service health",
-            "description": "Return health information for an external or internal service registered with Aragora.",
-            "operationId": "getServiceHealth",
-            "parameters": [
-                {
-                    "name": "service_id",
-                    "in": "path",
-                    "required": True,
-                    "description": "Unique service identifier.",
-                    "schema": _str,
-                }
-            ],
-            "responses": {"200": _ok_response("Service health", _obj)},
-        },
-    },
-    "/api/services/{service_id}/metrics": {
-        "get": {
-            "tags": ["Services"],
-            "summary": "Get service metrics",
-            "description": "Return operational metrics for a registered service.",
-            "operationId": "getServiceMetrics",
-            "parameters": [
-                {
-                    "name": "service_id",
-                    "in": "path",
-                    "required": True,
-                    "description": "Unique service identifier.",
-                    "schema": _str,
-                }
-            ],
-            "responses": {"200": _ok_response("Service metrics", _obj)},
-        },
-    },
     # --- flips ---
     "/api/flips/{flip_id}": {
         "get": {

--- a/sdk/python/aragora_sdk/namespaces/services.py
+++ b/sdk/python/aragora_sdk/namespaces/services.py
@@ -1,10 +1,9 @@
 """
 Services Namespace API
 
-Provides methods for service management:
+Provides methods for service discovery:
 - Service discovery and listing
-- Individual service health monitoring
-- Service configuration and details
+- Service details
 """
 
 from __future__ import annotations
@@ -19,7 +18,7 @@ class ServicesAPI:
     """
     Synchronous Services API.
 
-    Provides methods for DevOps service discovery and health monitoring.
+    Provides methods for DevOps service discovery.
 
     Example:
         >>> client = AragoraClient(base_url="https://api.aragora.ai")
@@ -61,56 +60,6 @@ class ServicesAPI:
         """
         return self._client.request("GET", f"/api/v1/services/{service_id}")
 
-    def get_health(self, service_id: str) -> dict[str, Any]:
-        """
-        Get health status for a specific service.
-
-        Args:
-            service_id: Service identifier.
-
-        Returns:
-            Dict with service health including latency, error rate,
-            and uptime metrics.
-        """
-        return self._client.request("GET", f"/api/v1/services/{service_id}/health")
-
-    def get_metrics(self, service_id: str) -> dict[str, Any]:
-        """
-        Get metrics for a specific service.
-
-        Args:
-            service_id: Service identifier.
-
-        Returns:
-            Dict with service metrics including request rates,
-            latency percentiles, and error counts.
-        """
-        return self._client.request("GET", f"/api/v1/services/{service_id}/metrics")
-
-    def register(
-        self,
-        name: str,
-        version: str,
-        endpoint: str,
-        tags: list[str] | None = None,
-        metadata: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Register a new service."""
-        body: dict[str, Any] = {"name": name, "version": version, "endpoint": endpoint}
-        if tags:
-            body["tags"] = tags
-        if metadata:
-            body["metadata"] = metadata
-        return self._client.request("POST", "/api/v1/services", json=body)
-
-    def deregister(self, service_id: str) -> dict[str, Any]:
-        """Deregister a service."""
-        return self._client.request("DELETE", f"/api/v1/services/{service_id}")
-
-    def get_dependencies(self, service_id: str) -> dict[str, Any]:
-        """Get service dependencies."""
-        return self._client.request("GET", f"/api/v1/services/{service_id}/dependencies")
-
 
 class AsyncServicesAPI:
     """
@@ -135,35 +84,3 @@ class AsyncServicesAPI:
     async def get(self, service_id: str) -> dict[str, Any]:
         """Get detailed information for a specific service."""
         return await self._client.request("GET", f"/api/v1/services/{service_id}")
-
-    async def get_health(self, service_id: str) -> dict[str, Any]:
-        """Get health status for a specific service."""
-        return await self._client.request("GET", f"/api/v1/services/{service_id}/health")
-
-    async def get_metrics(self, service_id: str) -> dict[str, Any]:
-        """Get metrics for a specific service."""
-        return await self._client.request("GET", f"/api/v1/services/{service_id}/metrics")
-
-    async def register(
-        self,
-        name: str,
-        version: str,
-        endpoint: str,
-        tags: list[str] | None = None,
-        metadata: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Register a new service."""
-        body: dict[str, Any] = {"name": name, "version": version, "endpoint": endpoint}
-        if tags:
-            body["tags"] = tags
-        if metadata:
-            body["metadata"] = metadata
-        return await self._client.request("POST", "/api/v1/services", json=body)
-
-    async def deregister(self, service_id: str) -> dict[str, Any]:
-        """Deregister a service."""
-        return await self._client.request("DELETE", f"/api/v1/services/{service_id}")
-
-    async def get_dependencies(self, service_id: str) -> dict[str, Any]:
-        """Get service dependencies."""
-        return await self._client.request("GET", f"/api/v1/services/{service_id}/dependencies")

--- a/sdk/python/tests/test_services.py
+++ b/sdk/python/tests/test_services.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from aragora_sdk.client import AragoraAsyncClient, AragoraClient
+from aragora_sdk.namespaces.services import AsyncServicesAPI, ServicesAPI
+
+
+class TestServicesWiring:
+    def test_sync_client_has_services(self) -> None:
+        client = AragoraClient(base_url="http://localhost")
+        assert isinstance(client.services, ServicesAPI)
+        client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_client_has_services(self) -> None:
+        async with AragoraAsyncClient(base_url="http://localhost") as client:
+            assert isinstance(client.services, AsyncServicesAPI)
+
+
+class TestServicesNamespace:
+    def test_list_services(self) -> None:
+        with patch.object(AragoraClient, "request") as mock_request:
+            mock_request.return_value = {"services": [{"id": "svc-1"}], "count": 1}
+
+            client = AragoraClient(base_url="http://localhost")
+            result = client.services.list(status="healthy")
+
+            mock_request.assert_called_once_with(
+                "GET",
+                "/api/v1/services",
+                params={"status": "healthy"},
+            )
+            assert result["count"] == 1
+            client.close()
+
+    def test_get_service(self) -> None:
+        with patch.object(AragoraClient, "request") as mock_request:
+            mock_request.return_value = {"service": {"id": "svc-1", "name": "API"}}
+
+            client = AragoraClient(base_url="http://localhost")
+            result = client.services.get("svc-1")
+
+            mock_request.assert_called_once_with("GET", "/api/v1/services/svc-1")
+            assert result["service"]["id"] == "svc-1"
+            client.close()
+
+    def test_namespace_no_longer_exposes_unimplemented_service_operations(self) -> None:
+        client = AragoraClient(base_url="http://localhost")
+
+        assert not hasattr(client.services, "get_health")
+        assert not hasattr(client.services, "get_metrics")
+        assert not hasattr(client.services, "register")
+        assert not hasattr(client.services, "deregister")
+        assert not hasattr(client.services, "get_dependencies")
+
+        client.close()

--- a/sdk/typescript/src/namespaces/__tests__/services.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/services.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+
+import { ServicesNamespace } from '../services';
+
+interface MockClient {
+  request: Mock;
+}
+
+describe('ServicesNamespace', () => {
+  let api: ServicesNamespace;
+  let mockClient: MockClient;
+
+  beforeEach(() => {
+    mockClient = {
+      request: vi.fn(),
+    };
+    api = new ServicesNamespace(mockClient as any);
+  });
+
+  it('lists services', async () => {
+    mockClient.request.mockResolvedValue({
+      services: [{ id: 'svc-1', name: 'API', status: 'healthy' }],
+    });
+
+    const result = await api.list({ status: 'healthy' });
+
+    expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/services', {
+      params: { status: 'healthy' },
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  it('gets service details', async () => {
+    mockClient.request.mockResolvedValue({ id: 'svc-1', name: 'API', status: 'healthy' });
+
+    const result = await api.get('svc-1');
+
+    expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/services/svc-1');
+    expect(result.id).toBe('svc-1');
+  });
+
+  it('does not expose unsupported service helper methods', () => {
+    expect('getHealth' in api).toBe(false);
+    expect('getMetrics' in api).toBe(false);
+    expect('register' in api).toBe(false);
+    expect('deregister' in api).toBe(false);
+    expect('getDependencies' in api).toBe(false);
+  });
+});

--- a/sdk/typescript/src/namespaces/index.ts
+++ b/sdk/typescript/src/namespaces/index.ts
@@ -1725,8 +1725,6 @@ export {
   ServicesNamespace,
   type ServiceHealthStatus,
   type Service as DiscoveredService,
-  type ServiceDependency,
-  type RegisterServiceRequest,
 } from './services';
 
 // E-commerce (Product & Order Management)

--- a/sdk/typescript/src/namespaces/services.ts
+++ b/sdk/typescript/src/namespaces/services.ts
@@ -1,8 +1,7 @@
 /**
  * Services Namespace API
  *
- * Provides endpoints for service discovery including
- * service registration, health checks, and dependency mapping.
+ * Provides endpoints for service discovery and detail lookup.
  */
 
 import type { AragoraClient } from '../client';
@@ -23,25 +22,8 @@ export interface Service {
   registered_at: string;
 }
 
-/** Service dependency */
-export interface ServiceDependency {
-  service_id: string;
-  depends_on: string;
-  type: 'required' | 'optional';
-  health: ServiceHealthStatus;
-}
-
-/** Service registration request */
-export interface RegisterServiceRequest {
-  name: string;
-  version: string;
-  endpoint: string;
-  tags?: string[];
-  metadata?: Record<string, unknown>;
-}
-
 /**
- * Services namespace for service discovery and registration.
+ * Services namespace for service discovery.
  *
  * @example
  * ```typescript
@@ -68,39 +50,5 @@ export class ServicesNamespace {
       'GET',
       `/api/v1/services/${encodeURIComponent(serviceId)}`
     );
-  }
-
-  /** Register a new service. */
-  async register(request: RegisterServiceRequest): Promise<Service> {
-    return this.client.request<Service>('POST', '/api/v1/services', {
-      body: request,
-    });
-  }
-
-  /** Deregister a service. */
-  async deregister(serviceId: string): Promise<{ success: boolean }> {
-    return this.client.request<{ success: boolean }>(
-      'DELETE',
-      `/api/v1/services/${encodeURIComponent(serviceId)}`
-    );
-  }
-
-  /** Get service dependencies. */
-  async getDependencies(serviceId: string): Promise<ServiceDependency[]> {
-    const response = await this.client.request<{ dependencies: ServiceDependency[] }>(
-      'GET',
-      `/api/v1/services/${encodeURIComponent(serviceId)}/dependencies`
-    );
-    return response.dependencies;
-  }
-
-  /** Get health status for a specific service. */
-  async getHealth(serviceId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/services/${encodeURIComponent(serviceId)}/health`);
-  }
-
-  /** Get metrics for a specific service. */
-  async getMetrics(serviceId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/services/${encodeURIComponent(serviceId)}/metrics`);
   }
 }

--- a/tests/server/openapi/test_devops_service_catalog_route_exports.py
+++ b/tests/server/openapi/test_devops_service_catalog_route_exports.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from aragora.server.handlers import ALL_HANDLERS
+from aragora.server.handlers.features.devops import DevOpsHandler
+from aragora.server.openapi import generate_openapi_schema
+
+
+HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options"}
+
+
+def _operation_methods(path_spec: dict[str, object]) -> set[str]:
+    return {method for method in path_spec if method in HTTP_METHODS}
+
+
+def test_devops_handler_participates_in_all_handlers() -> None:
+    assert DevOpsHandler in set(ALL_HANDLERS)
+
+
+def test_service_catalog_routes_match_live_devops_handler_contract() -> None:
+    paths = generate_openapi_schema()["paths"]
+
+    assert "/api/v1/services" in paths
+    assert "/api/v1/services/{service_id}" in paths
+    assert _operation_methods(paths["/api/v1/services"]) == {"get"}
+    assert _operation_methods(paths["/api/v1/services/{service_id}"]) == {"get"}
+    assert "/api/v1/services/{service_id}/health" not in paths
+    assert "/api/v1/services/{service_id}/metrics" not in paths


### PR DESCRIPTION
## Summary
- export the live `/api/v1/services/{service_id}` contract from the DevOps handler surface
- remove unsupported service health/metrics placeholder routes from OpenAPI fallback stubs
- trim unsupported services SDK helpers and add direct Python/TypeScript contract tests

## Validation
- `python -m pytest tests/server/openapi/test_devops_service_catalog_route_exports.py sdk/python/tests/test_services.py tests/handlers/features/devops/test_handler.py -q`
- `python -m ruff check aragora/server/handlers/features/devops/__init__.py aragora/server/openapi/endpoints/sdk_missing.py sdk/python/aragora_sdk/namespaces/services.py sdk/python/tests/test_services.py tests/server/openapi/test_devops_service_catalog_route_exports.py`
- `cd sdk/typescript && NODE_PATH=/Users/armand/Development/aragora/sdk/typescript/node_modules /Users/armand/Development/aragora/sdk/typescript/node_modules/.bin/vitest run src/namespaces/__tests__/services.test.ts`
- `python3 scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
