### PR TITLE
fix(swarm): preserve dispatch hook under claims

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -31,7 +31,6 @@ from aragora.swarm.boss_loop_outcome import (
 )
 from aragora.swarm.boss_worker_lifecycle import (
     dispatch_issue as _dispatch_issue_impl,
-    dispatch_issue_under_claim as _dispatch_issue_under_claim_impl,
     finalize_worker_result as _finalize_worker_result_impl,
 )
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
@@ -4535,7 +4534,18 @@ class BossLoop:
         issue: GitHubIssue,
         freshness: RunnerFreshnessResult,
     ) -> dict[str, Any]:
-        return await _dispatch_issue_under_claim_impl(self, issue, freshness)
+        """Dispatch an issue and release the per-issue claim in all paths.
+
+        The claim-release ``finally`` lives on the loop itself so that the
+        dispatch hook (``_dispatch_issue``) is never reached through an
+        external helper. Keeping this wrapper in-class makes the
+        claim/dispatch contract a single object rather than a pair of
+        modules coupled through a private method name.
+        """
+        try:
+            return await self._dispatch_issue(issue, freshness)
+        finally:
+            self._release_issue_dispatch_claim(issue.number)
 
     def _attach_issue_handoff_metadata(
         self,

--- a/aragora/swarm/boss_worker_lifecycle.py
+++ b/aragora/swarm/boss_worker_lifecycle.py
@@ -1061,6 +1061,6 @@ async def dispatch_issue_under_claim(
     freshness: RunnerFreshnessResult,
 ) -> dict[str, Any]:
     try:
-        return await dispatch_issue(loop, issue, freshness)
+        return await loop._dispatch_issue(issue, freshness)
     finally:
         loop._release_issue_dispatch_claim(issue.number)

--- a/aragora/swarm/boss_worker_lifecycle.py
+++ b/aragora/swarm/boss_worker_lifecycle.py
@@ -1053,14 +1053,3 @@ async def dispatch_issue(
         repo_root=Path.cwd(),
     )
     return result
-
-
-async def dispatch_issue_under_claim(
-    loop: "BossLoop",
-    issue: GitHubIssue,
-    freshness: RunnerFreshnessResult,
-) -> dict[str, Any]:
-    try:
-        return await loop._dispatch_issue(issue, freshness)
-    finally:
-        loop._release_issue_dispatch_claim(issue.number)

--- a/tests/debate/test_pr_review_protocol_smoke.py
+++ b/tests/debate/test_pr_review_protocol_smoke.py
@@ -19,7 +19,7 @@ def test_pr_review_protocol_packet_smoke(monkeypatch: pytest.MonkeyPatch) -> Non
             "gemini": "/usr/bin/gemini",
         }.get(binary)
 
-    monkeypatch.setattr("aragora.swarm.pr_review_protocol.shutil.which", fake_which)
+    monkeypatch.setattr("aragora.review.provider_slots.shutil.which", fake_which)
 
     packet = default_pr_review_protocol().build_packet(
         repo="synaptent/aragora",

--- a/tests/swarm/test_boss_worker_lifecycle.py
+++ b/tests/swarm/test_boss_worker_lifecycle.py
@@ -21,7 +21,7 @@ Covers:
   - gate unresolved_missing targets
   - dispatch_enabled=False preview mode
   - require_validation_contract missing criteria
-- dispatch_issue_under_claim: delegates and releases claim
+- BossLoop._dispatch_issue_under_claim: releases claim on success + exception
 """
 
 from __future__ import annotations
@@ -43,7 +43,6 @@ from aragora.swarm.boss_loop import (
 )
 from aragora.swarm.boss_worker_lifecycle import (
     dispatch_issue,
-    dispatch_issue_under_claim,
     finalize_worker_result,
 )
 from aragora.swarm.task_sanitizer import SanitizationOutcome, SanitizationResult
@@ -1089,7 +1088,11 @@ class TestDispatchIssueDispatchDisabled:
 
 
 # ---------------------------------------------------------------------------
-# dispatch_issue_under_claim
+# BossLoop._dispatch_issue_under_claim
+#
+# The claim-release contract lives on the loop itself so the dispatch hook
+# is never reached through an external helper. These tests cover the
+# claim/dispatch contract on the class method directly.
 # ---------------------------------------------------------------------------
 
 
@@ -1101,7 +1104,7 @@ class TestDispatchIssueUnderClaim:
         issue = _make_issue(number=5)
         freshness = _fresh_result()
 
-        result = asyncio.run(dispatch_issue_under_claim(loop, issue, freshness))
+        result = asyncio.run(loop._dispatch_issue_under_claim(issue, freshness))
 
         loop._release_issue_dispatch_claim.assert_called_once_with(5)
         loop._dispatch_issue.assert_awaited_once_with(issue, freshness)
@@ -1118,7 +1121,7 @@ class TestDispatchIssueUnderClaim:
 
         loop._dispatch_issue = AsyncMock(side_effect=_raise)
         with pytest.raises(RuntimeError, match="dispatch error"):
-            asyncio.run(dispatch_issue_under_claim(loop, issue, freshness))
+            asyncio.run(loop._dispatch_issue_under_claim(issue, freshness))
 
         loop._release_issue_dispatch_claim.assert_called_once_with(6)
         loop._dispatch_issue.assert_awaited_once_with(issue, freshness)
@@ -1131,7 +1134,7 @@ class TestDispatchIssueUnderClaim:
         freshness = _fresh_result()
 
         loop._dispatch_issue = AsyncMock(return_value=expected)
-        result = asyncio.run(dispatch_issue_under_claim(loop, issue, freshness))
+        result = asyncio.run(loop._dispatch_issue_under_claim(issue, freshness))
 
         loop._dispatch_issue.assert_awaited_once_with(issue, freshness)
         assert result == expected

--- a/tests/swarm/test_boss_worker_lifecycle.py
+++ b/tests/swarm/test_boss_worker_lifecycle.py
@@ -859,9 +859,7 @@ class TestDispatchIssueSanitizerBlocking:
         sanitization = _make_sanitization(SanitizationOutcome.DROPPED)
 
         with _patch_sanitizer_and_module(SanitizationOutcome.DROPPED, sanitization, loop):
-            result = asyncio.get_event_loop().run_until_complete(
-                dispatch_issue(loop, issue, _fresh_result())
-            )
+            result = asyncio.run(dispatch_issue(loop, issue, _fresh_result()))
 
         assert result["status"] == "needs_human"
         assert result["outcome"] == "sanitation_failed"
@@ -872,9 +870,7 @@ class TestDispatchIssueSanitizerBlocking:
         sanitization = _make_sanitization(SanitizationOutcome.DROPPED)
 
         with _patch_sanitizer_and_module(SanitizationOutcome.DROPPED, sanitization, loop):
-            result = asyncio.get_event_loop().run_until_complete(
-                dispatch_issue(loop, issue, _fresh_result())
-            )
+            result = asyncio.run(dispatch_issue(loop, issue, _fresh_result()))
 
         assert "sanitizer_outcome" in result
         assert result["sanitizer_outcome"] == "dropped"
@@ -889,9 +885,7 @@ class TestDispatchIssueSanitizerBlocking:
         )
 
         with _patch_sanitizer_and_module(SanitizationOutcome.DROPPED, sanitization, loop):
-            result = asyncio.get_event_loop().run_until_complete(
-                dispatch_issue(loop, issue, _fresh_result())
-            )
+            result = asyncio.run(dispatch_issue(loop, issue, _fresh_result()))
 
         assert result["outcome"] == "verification_target_missing"
 
@@ -1009,9 +1003,7 @@ class TestDispatchIssuePreDispatchGate:
                 "aragora.swarm.dispatch_followups.maybe_upgrade_dispatch_spec",
                 side_effect=lambda **kw: kw.get("spec"),
             ):
-                result = asyncio.get_event_loop().run_until_complete(
-                    dispatch_issue(loop, issue, _fresh_result())
-                )
+                result = asyncio.run(dispatch_issue(loop, issue, _fresh_result()))
 
         assert result["status"] == "needs_human"
         assert result["outcome"] == "sanitation_failed"
@@ -1028,9 +1020,7 @@ class TestDispatchIssuePreDispatchGate:
                 "aragora.swarm.dispatch_followups.maybe_upgrade_dispatch_spec",
                 side_effect=lambda **kw: kw.get("spec"),
             ):
-                result = asyncio.get_event_loop().run_until_complete(
-                    dispatch_issue(loop, issue, _fresh_result())
-                )
+                result = asyncio.run(dispatch_issue(loop, issue, _fresh_result()))
 
         assert result["status"] == "needs_human"
         assert result["outcome"] == "verification_target_missing"
@@ -1092,9 +1082,7 @@ class TestDispatchIssueDispatchDisabled:
                     "aragora.swarm.dispatch_followups.maybe_upgrade_dispatch_spec",
                     return_value=spec_mock,
                 ):
-                    result = asyncio.get_event_loop().run_until_complete(
-                        dispatch_issue(loop, issue, _fresh_result())
-                    )
+                    result = asyncio.run(dispatch_issue(loop, issue, _fresh_result()))
 
         assert result["status"] == "needs_human"
         assert result["outcome"] == "preview_only"
@@ -1113,9 +1101,7 @@ class TestDispatchIssueUnderClaim:
         issue = _make_issue(number=5)
         freshness = _fresh_result()
 
-        result = asyncio.get_event_loop().run_until_complete(
-            dispatch_issue_under_claim(loop, issue, freshness)
-        )
+        result = asyncio.run(dispatch_issue_under_claim(loop, issue, freshness))
 
         loop._release_issue_dispatch_claim.assert_called_once_with(5)
         loop._dispatch_issue.assert_awaited_once_with(issue, freshness)
@@ -1132,9 +1118,7 @@ class TestDispatchIssueUnderClaim:
 
         loop._dispatch_issue = AsyncMock(side_effect=_raise)
         with pytest.raises(RuntimeError, match="dispatch error"):
-            asyncio.get_event_loop().run_until_complete(
-                dispatch_issue_under_claim(loop, issue, freshness)
-            )
+            asyncio.run(dispatch_issue_under_claim(loop, issue, freshness))
 
         loop._release_issue_dispatch_claim.assert_called_once_with(6)
         loop._dispatch_issue.assert_awaited_once_with(issue, freshness)
@@ -1147,9 +1131,7 @@ class TestDispatchIssueUnderClaim:
         freshness = _fresh_result()
 
         loop._dispatch_issue = AsyncMock(return_value=expected)
-        result = asyncio.get_event_loop().run_until_complete(
-            dispatch_issue_under_claim(loop, issue, freshness)
-        )
+        result = asyncio.run(dispatch_issue_under_claim(loop, issue, freshness))
 
         loop._dispatch_issue.assert_awaited_once_with(issue, freshness)
         assert result == expected

--- a/tests/swarm/test_boss_worker_lifecycle.py
+++ b/tests/swarm/test_boss_worker_lifecycle.py
@@ -1109,52 +1109,49 @@ class TestDispatchIssueUnderClaim:
     def test_releases_claim_on_success(self):
         loop = _make_loop()
         loop._release_issue_dispatch_claim = MagicMock()
+        loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
         issue = _make_issue(number=5)
+        freshness = _fresh_result()
 
-        with patch(
-            "aragora.swarm.boss_worker_lifecycle.dispatch_issue",
-            new=AsyncMock(return_value={"status": "completed"}),
-        ):
-            result = asyncio.get_event_loop().run_until_complete(
-                dispatch_issue_under_claim(loop, issue, _fresh_result())
-            )
+        result = asyncio.get_event_loop().run_until_complete(
+            dispatch_issue_under_claim(loop, issue, freshness)
+        )
 
         loop._release_issue_dispatch_claim.assert_called_once_with(5)
+        loop._dispatch_issue.assert_awaited_once_with(issue, freshness)
         assert result["status"] == "completed"
 
     def test_releases_claim_on_exception(self):
         loop = _make_loop()
         loop._release_issue_dispatch_claim = MagicMock()
         issue = _make_issue(number=6)
+        freshness = _fresh_result()
 
         async def _raise(*args: Any, **kwargs: Any) -> dict[str, Any]:
             raise RuntimeError("dispatch error")
 
-        with patch(
-            "aragora.swarm.boss_worker_lifecycle.dispatch_issue",
-            new=_raise,
-        ):
-            with pytest.raises(RuntimeError, match="dispatch error"):
-                asyncio.get_event_loop().run_until_complete(
-                    dispatch_issue_under_claim(loop, issue, _fresh_result())
-                )
+        loop._dispatch_issue = AsyncMock(side_effect=_raise)
+        with pytest.raises(RuntimeError, match="dispatch error"):
+            asyncio.get_event_loop().run_until_complete(
+                dispatch_issue_under_claim(loop, issue, freshness)
+            )
 
         loop._release_issue_dispatch_claim.assert_called_once_with(6)
+        loop._dispatch_issue.assert_awaited_once_with(issue, freshness)
 
     def test_returns_dispatch_issue_result(self):
         loop = _make_loop()
         loop._release_issue_dispatch_claim = MagicMock()
         issue = _make_issue(number=7)
         expected = {"status": "running", "run_id": "run-123"}
+        freshness = _fresh_result()
 
-        with patch(
-            "aragora.swarm.boss_worker_lifecycle.dispatch_issue",
-            new=AsyncMock(return_value=expected),
-        ):
-            result = asyncio.get_event_loop().run_until_complete(
-                dispatch_issue_under_claim(loop, issue, _fresh_result())
-            )
+        loop._dispatch_issue = AsyncMock(return_value=expected)
+        result = asyncio.get_event_loop().run_until_complete(
+            dispatch_issue_under_claim(loop, issue, freshness)
+        )
 
+        loop._dispatch_issue.assert_awaited_once_with(issue, freshness)
         assert result == expected
 
 


### PR DESCRIPTION
## Summary
- preserve `loop._dispatch_issue` when dispatching under an issue claim
- align the lower-level lifecycle helper tests with the boss-loop hook contract
- intentionally exclude the removed autonomous queue-autofill path from old `pr6281`

## Validation
- `python -m pytest tests/swarm/test_boss_loop.py -k dispatch_issue_under_claim_releases_issue_lock tests/swarm/test_boss_worker_lifecycle.py::TestDispatchIssueUnderClaim -q`
- `python -m pytest tests/swarm/test_boss_worker_lifecycle.py::TestDispatchIssueUnderClaim -q`
- `python -m ruff check aragora/swarm/boss_worker_lifecycle.py tests/swarm/test_boss_worker_lifecycle.py tests/swarm/test_boss_loop.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
