### PR TITLE
fix(pdb): raise slot timeout to 300s

### DIFF
--- a/aragora/pdb/real_invoker.py
+++ b/aragora/pdb/real_invoker.py
@@ -84,7 +84,22 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 _SLOT_TIMEOUT_ENV = "ARAGORA_PDB_SLOT_TIMEOUT_SECONDS"
-_DEFAULT_SLOT_TIMEOUT_SECONDS = 90.0
+# Default per-slot provider-call timeout.
+#
+# Deliberately generous (5 minutes). The goal of this timeout is to
+# surface a genuinely-hung provider — never to cap a legitimately
+# slow reasoning response. Empirically:
+#   - Haiku:     typical 5-15s, worst ~30s
+#   - Sonnet:    typical 20-45s, worst ~90s
+#   - Opus:      typical 60s, worst 120-180s on large diffs
+#   - Gemini / Grok / DeepSeek / Kimi / Qwen via OpenRouter: wide variance
+#
+# Earlier iterations set this to 20s and then 90s, both of which
+# false-positive tripped on legitimately-long Opus reviews during
+# Mode 3 dogfood. 300s ensures timeout is only a last-resort safety
+# net, not a review-blocking heuristic. Operators who want tighter
+# bounds (e.g. CI) can override via ARAGORA_PDB_SLOT_TIMEOUT_SECONDS.
+_DEFAULT_SLOT_TIMEOUT_SECONDS = 300.0
 
 FAMILY_CLAUDE = "claude"
 FAMILY_GPT = "gpt"

--- a/tests/pdb/test_real_invoker.py
+++ b/tests/pdb/test_real_invoker.py
@@ -483,7 +483,7 @@ class TestFindings:
 
         invoker = RealProviderInvoker(claude=agent, gpt=_make_mock_agent())
         slot = _slot("claude_core", family=FAMILY_CLAUDE, required=True)
-        with pytest.raises(TimeoutError, match="provider call timed out after 90.0s"):
+        with pytest.raises(TimeoutError, match=r"provider call timed out after \d+\.\d+s"):
             invoker.findings(slot=slot, provider="claude", prompt="p", binding=_binding())
 
 


### PR DESCRIPTION
## Summary

Raises \`_DEFAULT_SLOT_TIMEOUT_SECONDS\` from 90s → 300s to eliminate timeout false-positives that tripped on legitimately-long Opus reasoning passes during Mode 3 dogfood.

## Context

Stacked on top of #6448's timeout infrastructure. Codex added the per-slot timeout (originally 20s, bumped to 90s in-flight). Dogfood showed Opus on complex reviews takes 60-180s, so 90s still false-positives. 300s makes timeout a last-resort safety net for genuinely hung providers, not a review-blocking heuristic.

## Evidence

Real-world latencies observed during this week's Mode 3 dogfood:
- Haiku: 5-15s typical, worst ~30s
- Sonnet: 20-45s typical, worst ~90s  
- **Opus: 60s typical, worst 120-180s on large diffs**
- OpenRouter families (DeepSeek/Kimi/Qwen): wide variance

## Override

Operators who want tighter bounds (e.g. CI time budgets) can still override via \`ARAGORA_PDB_SLOT_TIMEOUT_SECONDS\`.

## Base branch

Targeted at \`codex/codex-20260422-191638-6ae8cc24\` (#6448) so this lands together with the rest of codex's repair pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)