### PR TITLE
fix(pdb-cli): use current DissentingView attrs in generate_one_brief

### DIFF
--- a/scripts/generate_one_brief.py
+++ b/scripts/generate_one_brief.py
@@ -179,9 +179,12 @@ def _summarize_result(result: PDBExecutionResult, *, quiet: bool) -> None:
     if brief.dissent:
         print(f"\ndissent ({len(brief.dissent)} view(s)):")
         for view in brief.dissent:
-            dissent_conf = _format_confidence(view.confidence, include_raw=False)
-            print(f"  - {view.slot_id}: {view.position.value} ({dissent_conf})")
-            print(f"    {view.reason[:200]}")
+            position = getattr(view.position, "value", view.position)
+            agent = getattr(view, "agent", getattr(view, "slot_id", "?"))
+            print(f"  - {agent}: {position}")
+            reason = getattr(view, "reason", "")
+            if reason:
+                print(f"    {reason[:200]}")
 
     if quiet:
         return


### PR DESCRIPTION
## Summary
- Panel from #6450 returned first non-zero dissent during dogfood, which crashed the CLI summarizer with `AttributeError: 'DissentingView' object has no attribute 'confidence'`.
- Switched `scripts/generate_one_brief.py` to read the current `DissentingView` fields (`agent`, `position`, `reason`) via `getattr`, with a `slot_id` fallback for views from older executors.
- Guarded the reason line so views without a reason don't emit a blank indented print.

## Why this is separate from #6454
This is a CLI-only print-path fix discovered during dogfooding — unrelated to the server-side secrets hydration in #6454. Keeping it separate so the two PRs can be reviewed and merged independently.

## Test plan
- [x] Re-run `python scripts/generate_one_brief.py synaptent/aragora <pr-with-dissent>` — prints the dissenting view without crashing.
- [ ] Let CI exercise the script path if any test covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)