### PR TITLE
fix(pdb): raise slot timeout default 90s→300s (follow-up to #6462)

### DIFF
--- a/aragora/pdb/real_invoker.py
+++ b/aragora/pdb/real_invoker.py
@@ -84,7 +84,22 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 _SLOT_TIMEOUT_ENV = "ARAGORA_PDB_SLOT_TIMEOUT_SECONDS"
-_DEFAULT_SLOT_TIMEOUT_SECONDS = 90.0
+# Default per-slot provider-call timeout.
+#
+# Deliberately generous (5 minutes). The goal of this timeout is to
+# surface a genuinely-hung provider — never to cap a legitimately
+# slow reasoning response. Empirically:
+#   - Haiku:     typical 5-15s, worst ~30s
+#   - Sonnet:    typical 20-45s, worst ~90s
+#   - Opus:      typical 60s, worst 120-180s on large diffs
+#   - Gemini / Grok / DeepSeek / Kimi / Qwen via OpenRouter: wide variance
+#
+# Earlier iterations set this to 20s and then 90s, both of which
+# false-positive tripped on legitimately-long Opus reviews during
+# Mode 3 dogfood. 300s ensures timeout is only a last-resort safety
+# net, not a review-blocking heuristic. Operators who want tighter
+# bounds (e.g. CI) can override via ARAGORA_PDB_SLOT_TIMEOUT_SECONDS.
+_DEFAULT_SLOT_TIMEOUT_SECONDS = 300.0
 
 FAMILY_CLAUDE = "claude"
 FAMILY_GPT = "gpt"

--- a/tests/pdb/test_real_invoker.py
+++ b/tests/pdb/test_real_invoker.py
@@ -468,6 +468,24 @@ class TestFindings:
         with pytest.raises(TimeoutError, match="provider call timed out after 0.1s"):
             invoker.findings(slot=slot, provider="claude", prompt="p", binding=_binding())
 
+    def test_agent_timeout_catches_asyncio_timeout_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent = MagicMock()
+        agent.model = "claude-sonnet-4-6"
+        agent.last_tokens_in = 0
+        agent.last_tokens_out = 0
+
+        monkeypatch.setattr(
+            "aragora.pdb.real_invoker._run_sync",
+            lambda _coro, *, timeout_seconds: (_ for _ in ()).throw(asyncio.TimeoutError()),
+        )
+
+        invoker = RealProviderInvoker(claude=agent, gpt=_make_mock_agent())
+        slot = _slot("claude_core", family=FAMILY_CLAUDE, required=True)
+        with pytest.raises(TimeoutError, match=r"provider call timed out after \d+\.\d+s"):
+            invoker.findings(slot=slot, provider="claude", prompt="p", binding=_binding())
+
 
 # ---------------------------------------------------------------------------
 # Critique


### PR DESCRIPTION
## Summary

Extracts `dd56163e63` (the squash-merge of PR #6452, which was previously targeted at the #6448 branch, not main) — raises the per-slot timeout default from 90s to 300s so reasoning passes don't get cut off.

## Why separate from #6462

Per codex's stricter scoping: the mechanism (bounded calls, 90s default) lands in #6462. This PR tunes the default upward. Two logical units, independently reviewable and revertible.

## Base branch

Based on `fix/pdb-slot-timeout-extraction` (the #6462 branch). Once #6462 merges to main, GitHub will automatically retarget this PR to main and the diff will be clean.

## Files

- `aragora/pdb/real_invoker.py`: `_DEFAULT_SLOT_TIMEOUT_SECONDS = 90.0` → `300.0`
- `tests/pdb/test_real_invoker.py`: adds `test_agent_timeout_catches_asyncio_timeout_error` coverage

## Test plan

- [x] 38/38 tests pass
- [x] ruff + format clean

## Authorship

Original commit authored by @an0mium; cherry-pick preserves authorship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)