### PR TITLE
ci(status): hand off benchmark publication when PR creation is blocked

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -349,6 +349,8 @@ jobs:
           branch="benchmark-truth-publication/${GITHUB_RUN_ID}"
           title="docs(status): refresh recurring trust-loop surfaces"
           body_file="$RUNNER_TEMP/benchmark-truth-publication-pr.md"
+          compare_url="https://github.com/${GITHUB_REPOSITORY}/compare/main...${branch}?expand=1"
+          permission_blocked=0
 
           find_draft_pr() {
             gh pr list \
@@ -399,6 +401,10 @@ jobs:
             set -e
             if [[ $create_status -ne 0 ]]; then
               echo "$create_output"
+              if grep -Fq "GitHub Actions is not permitted to create or approve pull requests" <<<"$create_output"; then
+                permission_blocked=1
+                echo "::notice::GitHub Actions token cannot create draft PRs in this repository; leaving a branch-backed handoff instead."
+              fi
             fi
           fi
 
@@ -411,6 +417,16 @@ jobs:
           done
 
           if [[ -z "$pr_url" ]]; then
+            if [[ $permission_blocked -eq 1 ]]; then
+              {
+                echo "Published automation branch: \`$branch\`"
+                echo ""
+                echo "Draft PR auto-creation is blocked for GitHub Actions in this repository."
+                echo "Open draft PR manually: $compare_url"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+
             echo "::error::Benchmark publication branch was pushed but no draft PR exists for $branch"
             exit 1
           fi

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -5,9 +5,11 @@ description: Aragora Project Status
 
 # Aragora Project Status
 
-*Last updated: April 21, 2026*
+*Last updated: April 23, 2026*
 
 > Compatibility mirror for older links. The canonical current-status document is [status/STATUS.md](./status).
+> The thesis settlement ledger lives at [status/2026-04-21-thesis-settlement-session.md](status/2026-04-21-thesis-settlement-session.md).
+> Historical sections below are retained for continuity, but the active source of truth for current project status is `docs/status/STATUS.md`.
 > See [README](../analysis/adr) for the five pillars framework. See [Documentation Index](./documentation-index) for the curated technical reference map.
 
 ## April 21, 2026 — Canonical Reality Moved to Thesis + PDB Execution

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,10 @@
 # Aragora Project Status
 
-*Last updated: April 21, 2026*
+*Last updated: April 23, 2026*
 
 > Compatibility mirror for older links. The canonical current-status document is [status/STATUS.md](status/STATUS.md).
+> The thesis settlement ledger lives at [status/2026-04-21-thesis-settlement-session.md](status/2026-04-21-thesis-settlement-session.md).
+> Historical sections below are retained for continuity, but the active source of truth for current project status is `docs/status/STATUS.md`.
 > See [README](../README.md) for the five pillars framework. See [Documentation Index](INDEX.md) for the curated technical reference map.
 
 ## April 21, 2026 — Canonical Reality Moved to Thesis + PDB Execution


### PR DESCRIPTION
## Summary
When the Benchmark Truth Publication workflow successfully pushes its branch but the GitHub Actions token is forbidden from creating a draft PR, treat that as a branch-backed handoff instead of a hard workflow failure. This keeps main health honest by failing on real publication problems, not repository-policy restrictions.

Also refresh the legacy `docs/STATUS.md` compatibility mirror timestamp and pointer so it stops lagging the canonical status surface.

## Verification
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/benchmark-truth-publication.yml", encoding="utf-8").read())'`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: PASS (notes source/config changes without tests; workflow YAML parsed cleanly)

## Non-goals
- No change to the benchmark truth generation logic itself
- No attempt to grant broader PR-creation permissions to GitHub Actions
- No rewrite of the canonical `docs/status/STATUS.md` document
