### PR TITLE
ci(tests): harden test analytics summary and merge-base detection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2269,12 +2269,17 @@ jobs:
           bash scripts/ci_install_project.sh --extras dev
 
       - name: Fetch base ref
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+        run: git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
 
       - name: Get changed Python files
         id: changed
         run: |
-          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- 'aragora/**/*.py' 'tests/**/*.py' | tr '\n' ' ')
+          if git merge-base "origin/${{ github.base_ref }}" HEAD >/dev/null 2>&1; then
+            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- 'aragora/**/*.py' 'tests/**/*.py' | tr '\n' ' ')
+          else
+            echo "::warning::No merge base found with origin/${{ github.base_ref }}; continuing with an empty changed-file set"
+            CHANGED=""
+          fi
           echo "files=$CHANGED" >> "$GITHUB_OUTPUT"
 
       - name: Select relevant tests
@@ -2335,6 +2340,7 @@ jobs:
           {
             echo "summary<<$SUMMARY_DELIM"
             cat test-summary.md
+            printf '\n'
             echo "$SUMMARY_DELIM"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- fetch a deeper base branch for test-analytics diffing and fall back cleanly when no merge base is available
- ensure the generated test analytics summary always writes a newline before the closing GITHUB_OUTPUT delimiter
- keep the change scoped to the test workflow so blocked PRs can rerun without branch-local debugging

## Why
Recent PRs including #6462 and #6468 hit two workflow-level failures:
- shallow base fetches produced "no merge base" during changed-file detection
- test analytics summary publication could fail with "Matching delimiter not found" when test-summary.md lacked a trailing newline

This patch hardens both paths without changing product code.