### PR TITLE
test(server): isolate security debate coroutine warning assertion

### DIFF
--- a/tests/server/handlers/test_security_debate.py
+++ b/tests/server/handlers/test_security_debate.py
@@ -392,7 +392,11 @@ class TestPostSecurityDebate:
                             del result
                             gc.collect()
 
-        leaked = [warning for warning in caught if "was never awaited" in str(warning.message)]
+        leaked = [
+            warning
+            for warning in caught
+            if "was never awaited" in str(warning.message) and "_run_debate" in str(warning.message)
+        ]
         assert leaked == []
 
 


### PR DESCRIPTION
## Summary

Fixes the shared `test-fast (server)` failure currently blocking thesis-critical PRs such as #6471, #6468, #6462, and #6465.

The regression test `test_post_success_does_not_leak_coroutine_when_run_async_short_circuits` intentionally records RuntimeWarnings while forcing `gc.collect()`. In the full server shard, unrelated unawaited-coroutine warnings from earlier tests in the same worker can be emitted during that collection and incorrectly fail this test.

This keeps the test's intended guard intact by only failing on leaked `_run_debate` coroutines from the security-debate handler path.

## Validation

- `python -m pytest tests/server/handlers/test_security_debate.py::TestPostSecurityDebate::test_post_success_does_not_leak_coroutine_when_run_async_short_circuits -q -W always::RuntimeWarning`
- `python -m pytest tests/server/handlers/test_security_debate.py -q`
- `python -m pytest tests/server/handlers/test_security_debate.py::TestPostSecurityDebate::test_post_success_does_not_leak_coroutine_when_run_async_short_circuits tests/server/handlers/test_security_debate.py -q`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Queue impact

Expected to clear the repeated server-shard failure seen in:

- #6471
- #6468
- #6462
- #6465