### PR TITLE
feat(runners): TIME_WAIT monitor for Mac runners (#6478)

### DIFF
--- a/.github/workflows/mac-runner-health-poll.yml
+++ b/.github/workflows/mac-runner-health-poll.yml
@@ -70,7 +70,7 @@ jobs:
           set +e
           declare -a alerts=()
 
-          echo "$HOSTS_JSON" | jq -c '.[]' | while read -r entry; do
+          while read -r entry; do
             name=$(echo "$entry" | jq -r '.name')
             host=$(echo "$entry" | jq -r '.host')
 
@@ -114,7 +114,7 @@ jobs:
                 alerts+=("$name: log stale by ${HOURS_STALE}h > $STALE_HOURS")
               fi
             fi
-          done
+          done < <(echo "$HOSTS_JSON" | jq -c '.[]')
 
           if [ ${#alerts[@]} -gt 0 ]; then
             {
@@ -156,6 +156,11 @@ jobs:
           [Run log]($SERVER_URL/$REPO/actions/runs/$RUN_ID)
           BODY_END
           )
+
+          gh label create runner-health \
+            --description "Mac runner health and TIME_WAIT alerts" \
+            --color "B60205" \
+            2>/dev/null || true
 
           EXISTING=$(gh issue list --label runner-health --state open --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then

--- a/.github/workflows/mac-runner-health-poll.yml
+++ b/.github/workflows/mac-runner-health-poll.yml
@@ -1,0 +1,169 @@
+name: Mac Runner Health Poll
+
+# Weekly SSH into each Mac runner to read the TIME_WAIT / health log.
+# Alerts via a runner-health labeled issue if:
+#   (a) any host's latest log line shows TIME_WAIT > threshold, or
+#   (b) any host's log hasn't been appended to in >48h (indicates the
+#       launchd job itself is stuck — the condition we CAN'T detect
+#       from the host's own alerting path).
+#
+# Survives the failure mode from issue #6474: the host's outbound TCP
+# was broken, so a host-initiated alert would not have reached GH.
+# This workflow runs on GH-hosted ubuntu and SSHes IN to the Macs.
+
+on:
+  schedule:
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  issues: write
+  contents: read
+
+concurrency:
+  group: mac-runner-health-poll
+  cancel-in-progress: false
+
+env:
+  THRESHOLD: "5000"
+  STALE_HOURS: "48"
+
+jobs:
+  poll:
+    name: Poll Mac runner TIME_WAIT logs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ssh client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq openssh-client
+
+      - name: Setup SSH key
+        env:
+          MAC_RUNNER_SSH_KEY: ${{ secrets.MAC_RUNNER_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          if [ -n "${MAC_RUNNER_SSH_KEY:-}" ]; then
+            echo "$MAC_RUNNER_SSH_KEY" > ~/.ssh/mac_runner
+            chmod 600 ~/.ssh/mac_runner
+            echo "KEY_READY=1" >> "$GITHUB_ENV"
+          else
+            echo "::warning::MAC_RUNNER_SSH_KEY secret not set; poll will be skipped"
+          fi
+
+      - name: Poll each Mac
+        id: poll
+        if: env.KEY_READY == '1'
+        env:
+          HOSTS_JSON: |
+            [
+              {"name": "mac-studio-m3ultra", "host": "mac-studio.aragora.ts.net"},
+              {"name": "macbook-m1-16gb", "host": "macbook-pro16gb.aragora.ts.net"},
+              {"name": "macbook-intel-64gb", "host": "macbook-pro-3.aragora.ts.net"}
+            ]
+        run: |
+          set +e
+          declare -a alerts=()
+
+          echo "$HOSTS_JSON" | jq -c '.[]' | while read -r entry; do
+            name=$(echo "$entry" | jq -r '.name')
+            host=$(echo "$entry" | jq -r '.host')
+
+            echo "=== Polling $name ($host) ==="
+
+            LAST_LINE=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+                           -i ~/.ssh/mac_runner \
+                           armand@"$host" \
+                           'tail -n 1 ~/Library/Logs/aragora-runner-health.log 2>/dev/null || echo no-log' \
+                           2>/dev/null || echo "ssh-failed")
+
+            echo "  last: $LAST_LINE"
+
+            if [ "$LAST_LINE" = "ssh-failed" ]; then
+              alerts+=("$name: SSH unreachable")
+              continue
+            fi
+
+            if [ "$LAST_LINE" = "no-log" ]; then
+              alerts+=("$name: health log missing")
+              continue
+            fi
+
+            TS=$(echo "$LAST_LINE" | grep -oE 'ts=[^ ]+' | cut -d= -f2 | head -1)
+            TW=$(echo "$LAST_LINE" | grep -oE 'timewait=[0-9]+' | cut -d= -f2 | head -1)
+
+            if [ -z "$TW" ]; then
+              alerts+=("$name: could not parse timewait from: $LAST_LINE")
+              continue
+            fi
+
+            if [ "$TW" -gt "$THRESHOLD" ]; then
+              alerts+=("$name: TIME_WAIT=$TW > threshold $THRESHOLD (at $TS)")
+            fi
+
+            if [ -n "$TS" ]; then
+              NOW_EPOCH=$(date -u +%s)
+              LAST_EPOCH=$(date -u -d "$TS" +%s 2>/dev/null || echo 0)
+              HOURS_STALE=$(( (NOW_EPOCH - LAST_EPOCH) / 3600 ))
+              if [ "$HOURS_STALE" -gt "$STALE_HOURS" ]; then
+                alerts+=("$name: log stale by ${HOURS_STALE}h > $STALE_HOURS")
+              fi
+            fi
+          done
+
+          if [ ${#alerts[@]} -gt 0 ]; then
+            {
+              echo "alerts<<EOF"
+              printf '%s\n' "${alerts[@]}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "drift=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open alert issue
+        if: steps.poll.outputs.drift == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALERTS: ${{ steps.poll.outputs.alerts }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TITLE="runners: Mac health alert $(date -u +%Y-%m-%d)"
+          BODY=$(cat <<BODY_END
+          ## Mac runner health alert
+
+          Weekly poll detected one or more issues:
+
+          \`\`\`
+          $ALERTS
+          \`\`\`
+
+          ### What to check
+
+          - **TIME_WAIT > threshold**: reboot the affected host. See docs/runners/FLEET.md "Past incidents" section for the #6474 playbook.
+          - **Health log missing or stale**: SSH in and verify the \`com.aragora.runner-health\` launchd job is loaded: \`launchctl list | grep runner-health\`.
+          - **SSH unreachable**: host may be off, on a different network, or have SSH disabled.
+
+          [Run log]($SERVER_URL/$REPO/actions/runs/$RUN_ID)
+          BODY_END
+          )
+
+          EXISTING=$(gh issue list --label runner-health --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label runner-health
+          fi
+
+      - name: Report clean
+        if: steps.poll.outputs.drift != '1' && env.KEY_READY == '1'
+        run: echo "::notice::All Mac runners healthy — TIME_WAIT within threshold, logs fresh."

--- a/scripts/runners/README.md
+++ b/scripts/runners/README.md
@@ -14,15 +14,15 @@ Per-host daily monitoring for Mac self-hosted runners. Addresses issue #6478 fol
 
 # 1. Copy the check script + plist
 mkdir -p ~/actions-runner/runner-health
-scp scripts/runners/mac_timewait_check.sh armand@<host>.local:~/actions-runner/runner-health/
-scp scripts/runners/com.aragora.runner-health.plist armand@<host>.local:~/Library/LaunchAgents/
-ssh armand@<host>.local "chmod +x ~/actions-runner/runner-health/mac_timewait_check.sh"
+scp scripts/runners/mac_timewait_check.sh armand@<magicdns-host>:~/actions-runner/runner-health/
+scp scripts/runners/com.aragora.runner-health.plist armand@<magicdns-host>:~/Library/LaunchAgents/
+ssh armand@<magicdns-host> "chmod +x ~/actions-runner/runner-health/mac_timewait_check.sh"
 
 # 2. Load the LaunchAgent
-ssh armand@<host>.local "launchctl load ~/Library/LaunchAgents/com.aragora.runner-health.plist"
+ssh armand@<magicdns-host> "launchctl load ~/Library/LaunchAgents/com.aragora.runner-health.plist"
 
 # 3. Verify first run produced a log line
-ssh armand@<host>.local "tail -1 ~/Library/Logs/aragora-runner-health.log"
+ssh armand@<magicdns-host> "tail -1 ~/Library/Logs/aragora-runner-health.log"
 # Expected: ts=... host=... uptime=... tcp_total=... timewait=... established=... threshold=5000
 ```
 

--- a/scripts/runners/README.md
+++ b/scripts/runners/README.md
@@ -1,0 +1,56 @@
+# Runner health monitoring
+
+Per-host daily monitoring for Mac self-hosted runners. Addresses issue #6478 following the incident post-mortem in `docs/runners/FLEET.md` "Past incidents".
+
+## Files
+
+- `mac_timewait_check.sh` — bash script that counts TIME_WAIT TCP entries and writes a structured log line. Alerts via a flag file when count exceeds threshold.
+- `com.aragora.runner-health.plist` — LaunchAgent that runs the check daily at 06:00 local. Writes to `~/Library/Logs/aragora-runner-health.log`.
+
+## Installation (per Mac runner)
+
+```bash
+# One-time on each Mac (mac-studio, macbook-m1-16gb, macbook-intel-64gb):
+
+# 1. Copy the check script + plist
+mkdir -p ~/actions-runner/runner-health
+scp scripts/runners/mac_timewait_check.sh armand@<host>.local:~/actions-runner/runner-health/
+scp scripts/runners/com.aragora.runner-health.plist armand@<host>.local:~/Library/LaunchAgents/
+ssh armand@<host>.local "chmod +x ~/actions-runner/runner-health/mac_timewait_check.sh"
+
+# 2. Load the LaunchAgent
+ssh armand@<host>.local "launchctl load ~/Library/LaunchAgents/com.aragora.runner-health.plist"
+
+# 3. Verify first run produced a log line
+ssh armand@<host>.local "tail -1 ~/Library/Logs/aragora-runner-health.log"
+# Expected: ts=... host=... uptime=... tcp_total=... timewait=... established=... threshold=5000
+```
+
+## Alert paths
+
+**Local (always works, even if network is broken):**
+- Structured line appended to `~/Library/Logs/aragora-runner-health.log` daily
+- Alert flag file at `~/Library/Logs/aragora-runner-health.alert` when threshold crossed
+- Review with `tail -f ~/Library/Logs/aragora-runner-health.log` after any mysterious runner downtime
+
+**Remote (GH Actions weekly poll):**
+- `.github/workflows/mac-runner-health-poll.yml` runs Mondays 14:00 UTC
+- SSHes into each Mac via `secrets.MAC_RUNNER_SSH_KEY`
+- Reads the last log line; alerts if `timewait > 5000` or log is > 48h stale
+- Opens / comments on a `runner-health`-labeled issue on drift
+
+## Threshold rationale
+
+- macOS ephemeral port range: 49152–65535 (16,384 ports)
+- 5,000 = ~30% of the pool — well before exhaustion at ~15K, leaving headroom to investigate
+- Actual exhaustion in #6474 was at 31,857 (~200% of the pool, kernel cycling)
+
+## Secrets setup (one-time)
+
+Add a GH secret `MAC_RUNNER_SSH_KEY` containing the SSH private key that can reach the Macs. For this repo's setup, the Tailscale ACL lets a GH-hosted runner SSH to MagicDNS names; adjust the workflow's host list if routing differs.
+
+## Related
+
+- Incident: #6474 (TIME_WAIT exhaustion locked 2 Mac runners for 2 months)
+- Issue: #6478 (this monitor's tracking issue)
+- Runbook: `docs/runners/FLEET.md` "Past incidents" section

--- a/scripts/runners/com.aragora.runner-health.plist
+++ b/scripts/runners/com.aragora.runner-health.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.aragora.runner-health</string>
+
+    <!-- Run daily at 06:00 local time. Runs as the logged-in user;
+         sudo calls inside the script will prompt (must be in sudoers
+         NOPASSWD for the netstat+tee paths or the plist adjusted to
+         run as root). For the initial deploy we prefer user-context
+         and write to a user-owned log instead. -->
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/armand/actions-runner/runner-health/mac_timewait_check.sh</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>THRESHOLD</key>
+        <string>5000</string>
+        <key>LOG_FILE</key>
+        <string>/Users/armand/Library/Logs/aragora-runner-health.log</string>
+        <key>ALERT_FILE</key>
+        <string>/Users/armand/Library/Logs/aragora-runner-health.alert</string>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>6</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <!-- Also run once right after load so we have a fresh data point
+         without waiting 24 hours for the first tick. -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/armand/Library/Logs/aragora-runner-health.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/armand/Library/Logs/aragora-runner-health.stderr.log</string>
+</dict>
+</plist>

--- a/scripts/runners/mac_timewait_check.sh
+++ b/scripts/runners/mac_timewait_check.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# TIME_WAIT monitor for Mac runners.
+#
+# Counts TCP connections in TIME_WAIT state and emits a single line of
+# structured log output. Alerts via a flag file when the count exceeds
+# the threshold so the weekly GH Actions check can detect it.
+#
+# Intended to run under launchd daily. Writes to a persistent log so a
+# human SSHing in later sees the forensic trail, even if the alert
+# path (which depends on outbound TCP) itself is what's broken.
+#
+# Background: issue #6474 traced two Mac runners offline for 2 months
+# due to TIME_WAIT exhaustion (31K+ entries filled the ephemeral port
+# range). This monitor catches that condition early.
+
+set -euo pipefail
+
+THRESHOLD="${THRESHOLD:-5000}"
+LOG_FILE="${LOG_FILE:-/var/log/aragora-runner-health.log}"
+ALERT_FILE="${ALERT_FILE:-/var/log/aragora-runner-health.alert}"
+
+# Count TIME_WAIT entries. Use -p tcp so we don't include unix sockets.
+TIMEWAIT_COUNT=$(netstat -an -p tcp 2>/dev/null | awk '$NF == "TIME_WAIT"' | wc -l | tr -d ' ')
+
+# Also count totals for context.
+TCP_TOTAL=$(netstat -an -p tcp 2>/dev/null | wc -l | tr -d ' ')
+ESTABLISHED=$(netstat -an -p tcp 2>/dev/null | awk '$NF == "ESTABLISHED"' | wc -l | tr -d ' ')
+UPTIME=$(uptime | awk -F'up ' '{print $2}' | awk -F',' '{print $1}' | tr -d ' ')
+HOST=$(hostname)
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Single structured log line (parse-friendly).
+LINE="ts=$TS host=$HOST uptime=$UPTIME tcp_total=$TCP_TOTAL timewait=$TIMEWAIT_COUNT established=$ESTABLISHED threshold=$THRESHOLD"
+
+# Append to log (create if missing).
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+echo "$LINE" | sudo tee -a "$LOG_FILE" >/dev/null 2>&1 || echo "$LINE" >&2
+
+# Write alert flag if we're over threshold.
+if [ "$TIMEWAIT_COUNT" -gt "$THRESHOLD" ]; then
+    sudo tee "$ALERT_FILE" >/dev/null 2>&1 <<ALERT || echo "ALERT: $LINE" >&2
+host=$HOST
+ts=$TS
+timewait=$TIMEWAIT_COUNT
+threshold=$THRESHOLD
+uptime=$UPTIME
+message=TIME_WAIT count exceeded threshold; reboot likely needed (see docs/runners/FLEET.md).
+ALERT
+    echo "ALERT: $LINE" >&2
+else
+    # Clear any stale alert file if we've recovered.
+    sudo rm -f "$ALERT_FILE" 2>/dev/null || true
+fi
+
+# Emit the line to stdout too so interactive runs show it.
+echo "$LINE"

--- a/scripts/runners/mac_timewait_check.sh
+++ b/scripts/runners/mac_timewait_check.sh
@@ -16,8 +16,8 @@
 set -euo pipefail
 
 THRESHOLD="${THRESHOLD:-5000}"
-LOG_FILE="${LOG_FILE:-/var/log/aragora-runner-health.log}"
-ALERT_FILE="${ALERT_FILE:-/var/log/aragora-runner-health.alert}"
+LOG_FILE="${LOG_FILE:-$HOME/Library/Logs/aragora-runner-health.log}"
+ALERT_FILE="${ALERT_FILE:-$HOME/Library/Logs/aragora-runner-health.alert}"
 
 # Count TIME_WAIT entries. Use -p tcp so we don't include unix sockets.
 TIMEWAIT_COUNT=$(netstat -an -p tcp 2>/dev/null | awk '$NF == "TIME_WAIT"' | wc -l | tr -d ' ')
@@ -32,13 +32,15 @@ TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 # Single structured log line (parse-friendly).
 LINE="ts=$TS host=$HOST uptime=$UPTIME tcp_total=$TCP_TOTAL timewait=$TIMEWAIT_COUNT established=$ESTABLISHED threshold=$THRESHOLD"
 
-# Append to log (create if missing).
+# Append to log (create if missing). This runs as a LaunchAgent in user
+# context, so avoid sudo: a password prompt under launchd would drop the
+# forensic trail this script exists to preserve.
 mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
-echo "$LINE" | sudo tee -a "$LOG_FILE" >/dev/null 2>&1 || echo "$LINE" >&2
+printf '%s\n' "$LINE" >> "$LOG_FILE" 2>/dev/null || echo "$LINE" >&2
 
 # Write alert flag if we're over threshold.
 if [ "$TIMEWAIT_COUNT" -gt "$THRESHOLD" ]; then
-    sudo tee "$ALERT_FILE" >/dev/null 2>&1 <<ALERT || echo "ALERT: $LINE" >&2
+    cat > "$ALERT_FILE" <<ALERT || echo "ALERT: $LINE" >&2
 host=$HOST
 ts=$TS
 timewait=$TIMEWAIT_COUNT
@@ -49,7 +51,7 @@ ALERT
     echo "ALERT: $LINE" >&2
 else
     # Clear any stale alert file if we've recovered.
-    sudo rm -f "$ALERT_FILE" 2>/dev/null || true
+    rm -f "$ALERT_FILE" 2>/dev/null || true
 fi
 
 # Emit the line to stdout too so interactive runs show it.


### PR DESCRIPTION
## Summary

Implements the hybrid monitor per #6478. Catches the failure class that hid 2 Mac runners offline for ~2 months in #6474 (kernel ephemeral-port exhaustion via 31K+ TIME_WAIT accumulation).

## Files

- **\`scripts/runners/mac_timewait_check.sh\`** — counts TIME_WAIT entries, writes structured log line, raises local alert flag. Runs in user context.
- **\`scripts/runners/com.aragora.runner-health.plist\`** — LaunchAgent, daily 06:00 local + RunAtLoad.
- **\`.github/workflows/mac-runner-health-poll.yml\`** — weekly remote poll via SSH; alerts on TIME_WAIT > 5000 OR log >48h stale.
- **\`scripts/runners/README.md\`** — deployment + operational docs.

## Why two paths (local + remote)?

The #6474 failure mode was "outbound TCP broken." A host-side monitor that only alerts via network wouldn't have raised the alarm — it couldn't phone out. So:

- **Local** (always works): structured line to \`~/Library/Logs/aragora-runner-health.log\`. Gives a forensic trail for any human who SSHes in later.
- **Remote** (GH Actions SSHes IN): catches the condition even if the host can't phone out. Also catches the "launchd job itself is stuck" case via staleness detection on the log.

## Threshold

5,000 TIME_WAITs = ~30% of the 16,384-port ephemeral pool. Fires well before the ~15K exhaustion floor. #6474's actual number was 31,857.

## Deployment

Not auto-deployed in this PR. Each Mac needs 3 commands (see README). The plist references user-specific paths; easier to document than to auto-detect. After deployment, bump the runner-headcount-monitor baseline to whatever matches the fleet.

## Acceptance criteria (from #6478)

- [x] launchd job installable on Macs
- [x] Local log emits one line per day
- [x] GH workflow opens runner-health issue on drift
- [x] Runbook in README links to FLEET.md "Past incidents" playbook

## After this lands

- Deploy to \`mac-studio-m3ultra\`, \`macbook-m1-16gb\`, \`macbook-intel-64gb\`
- Add \`MAC_RUNNER_SSH_KEY\` repo secret
- Verify first workflow run (manual-dispatch) against a healthy fleet reports "clean"

## Related

- #6478 — this PR's tracking issue (closes on deployment)
- #6474 — the incident this guards against
- \`docs/runners/FLEET.md\` — "Past incidents" runbook referenced from the alert text

🤖 Generated with [Claude Code](https://claude.com/claude-code)