### PR TITLE
test(admin): make dashboard today counts UTC-stable

### DIFF
--- a/tests/server/handlers/admin/test_dashboard.py
+++ b/tests/server/handlers/admin/test_dashboard.py
@@ -1056,12 +1056,12 @@ class TestDashboardStats:
         handler.get_elo_system = MagicMock(return_value=None)
         handler.ctx = {}
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
         records = [
             _dashboard_record(
                 "d1",
                 "tech",
-                created_at=now - timedelta(hours=1),
+                created_at=now,
                 confidence=0.9,
                 total_tokens=120,
                 artifact_bytes=200,
@@ -1322,12 +1322,12 @@ class TestOverviewWired:
         handler.get_storage = MagicMock(return_value=storage)
         handler.get_elo_system = MagicMock(return_value=None)
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
         records = [
             _dashboard_record(
                 "d1",
                 "tech",
-                created_at=now - timedelta(hours=1),
+                created_at=now,
                 confidence=0.9,
                 rounds_used=3,
                 duration_seconds=2.5,


### PR DESCRIPTION
## Summary
- Make admin dashboard tests use a timestamp inside the current UTC day instead of `now - 1 hour`.
- Fixes the first-hour-after-UTC-midnight failure where `today` counts dropped to zero.

## Validation
- `python -m pytest tests/server/handlers/admin/test_dashboard.py::TestOverviewWired::test_overview_with_storage tests/server/handlers/admin/test_dashboard.py::TestDashboardStats::test_returns_stats_from_storage -q` → 2 passed
- `python -m pytest tests/server/handlers/admin/test_dashboard.py -q` → 57 passed
- `ruff check tests/server/handlers/admin/test_dashboard.py`
- `ruff format --check tests/server/handlers/admin/test_dashboard.py`
- commit/push hooks passed

## Context
This unblocks the shared `test-fast (server)` failure currently showing on unrelated PRs such as #6468 and #6465.