### PR TITLE
[AGT-05] ReputationStore — per-agent JSONL-backed reputation ledger

### DIFF
--- a/aragora/reputation/__init__.py
+++ b/aragora/reputation/__init__.py
@@ -30,6 +30,13 @@ from aragora.reputation.anchor import (
 )
 from aragora.reputation.bridge import bridge_from_market_position
 from aragora.reputation.settlement import settle_claim
+from aragora.reputation.store import (
+    AgentScore,
+    ReputationStore,
+    ReputationStoreError,
+    enable_store,
+    store_enabled,
+)
 from aragora.reputation.types import (
     DOMAIN_CODE_PR,
     DOMAIN_CRUX_RESOLUTION,
@@ -60,6 +67,12 @@ __all__ = [
     "enable_reputation_flow",
     "reputation_flow_enabled",
     "settle_claim",
+    # store
+    "AgentScore",
+    "ReputationStore",
+    "ReputationStoreError",
+    "enable_store",
+    "store_enabled",
 ]
 
 

--- a/aragora/reputation/store.py
+++ b/aragora/reputation/store.py
@@ -124,16 +124,18 @@ class ReputationStore:
         """
         if not str(delta.agent_id).strip():
             raise ReputationStoreError("delta.agent_id must be non-empty")
-        self._deltas[delta.agent_id].append(delta)
         if self._path is not None:
             self._append_to_file(delta)
+        self._deltas[delta.agent_id].append(delta)
 
     def _append_to_file(self, delta: ReputationDelta) -> None:
         try:
             with self._path.open("a", encoding="utf-8") as fh:  # type: ignore[union-attr]
                 fh.write(json.dumps(delta.to_json(), sort_keys=True) + "\n")
         except OSError as exc:
-            logger.warning("ReputationStore: could not write to %s: %s", self._path, exc)
+            raise ReputationStoreError(
+                f"could not persist reputation delta to {self._path}: {exc}"
+            ) from exc
 
     # ------------------------------------------------------------------
     # Query

--- a/aragora/reputation/store.py
+++ b/aragora/reputation/store.py
@@ -85,9 +85,7 @@ def _decay_weight(delta: ReputationDelta, now: datetime) -> float:
     if delta.decay_half_life_days is None:
         return 1.0
     try:
-        applied = datetime.fromisoformat(
-            delta.applied_at.replace("Z", "+00:00")
-        ).astimezone(UTC)
+        applied = datetime.fromisoformat(delta.applied_at.replace("Z", "+00:00")).astimezone(UTC)
     except (ValueError, TypeError):
         return 1.0
     age_days = max(0.0, (now - applied).total_seconds() / 86_400.0)
@@ -177,9 +175,7 @@ class ReputationStore:
 
     def all_scores(self, *, apply_decay: bool = True) -> list[AgentScore]:
         """Return per-agent score summaries, sorted descending by score."""
-        scores = [
-            self.agent_score(aid, apply_decay=apply_decay) for aid in self._deltas
-        ]
+        scores = [self.agent_score(aid, apply_decay=apply_decay) for aid in self._deltas]
         return sorted(scores, key=lambda s: s.running_score, reverse=True)
 
     def __len__(self) -> int:

--- a/aragora/reputation/store.py
+++ b/aragora/reputation/store.py
@@ -1,0 +1,228 @@
+"""AGT-05 reputation store — per-agent ledger of ReputationDeltas.
+
+This module is the in-memory accumulation layer that sits between the
+settlement function (:func:`aragora.reputation.settlement.settle_claim`)
+and downstream consumers such as the team_selector dispatch-eligibility
+filter (wired in a follow-on PR).
+
+Persistence: an optional append-only JSONL path.  When ``path`` is
+supplied, each recorded delta is written as one JSON line immediately
+after it is added to the in-memory index.  The store can be rebuilt from
+that file at startup via :meth:`ReputationStore.load_from_file`.
+
+Decay: when a :class:`~aragora.reputation.types.ReputationDelta` was
+created with a ``decay_half_life_days`` value, :meth:`get_score` applies
+exponential decay so that older deltas contribute less.  Callers that
+want raw un-decayed sums can pass ``apply_decay=False``.
+
+Gating: the store is always constructable, but :func:`store_enabled`
+checks ``ARAGORA_REPUTATION_FLOW_ENABLED`` so callers that respect the
+AGT-05 feature flag have a single check point.
+
+Out of scope for this PR:
+- Team-selector wiring (follow-on: ``enable_agt05_reputation_selection``
+  flag on TeamSelectorConfig).
+- On-chain anchoring (lives in :mod:`aragora.reputation.anchor`).
+- CruxSet resolution bridge (deferred to DIC-17 landing).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from aragora.reputation.types import ReputationDelta
+
+logger = logging.getLogger(__name__)
+
+
+def store_enabled() -> bool:
+    """Return True when the AGT-05 reputation-flow flag is set."""
+    raw = str(os.environ.get("ARAGORA_REPUTATION_FLOW_ENABLED") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_store() -> None:
+    """Enable the AGT-05 reputation flow for the current process."""
+    os.environ["ARAGORA_REPUTATION_FLOW_ENABLED"] = "1"
+
+
+class ReputationStoreError(RuntimeError):
+    """Raised when a delta cannot be recorded."""
+
+
+@dataclass
+class AgentScore:
+    """Aggregated reputation summary for one agent."""
+
+    agent_id: str
+    running_score: float
+    delta_count: int
+    domains: list[str] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "running_score": round(self.running_score, 6),
+            "delta_count": self.delta_count,
+            "domains": self.domains,
+        }
+
+
+def _decay_weight(delta: ReputationDelta, now: datetime) -> float:
+    """Compute the time-decay multiplier for *delta*.
+
+    Returns 1.0 when ``decay_half_life_days`` is None (no decay).
+    Uses exponential half-life: ``weight = 2 ** (-age_days / half_life)``.
+    """
+    if delta.decay_half_life_days is None:
+        return 1.0
+    try:
+        applied = datetime.fromisoformat(
+            delta.applied_at.replace("Z", "+00:00")
+        ).astimezone(UTC)
+    except (ValueError, TypeError):
+        return 1.0
+    age_days = max(0.0, (now - applied).total_seconds() / 86_400.0)
+    return math.exp(-math.log(2.0) * age_days / delta.decay_half_life_days)
+
+
+class ReputationStore:
+    """In-memory per-agent reputation ledger with optional JSONL persistence.
+
+    Thread-safety: not thread-safe; wrap with a lock for concurrent use.
+
+    Typical usage::
+
+        store = ReputationStore()
+        delta = settle_claim(claim, resolved)
+        store.record_delta(delta)
+        score = store.get_score("agent-id")
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._deltas: dict[str, list[ReputationDelta]] = defaultdict(list)
+        self._path = path
+        if path is not None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def record_delta(self, delta: ReputationDelta) -> None:
+        """Record a settled reputation delta.
+
+        Raises :class:`ReputationStoreError` when ``delta.agent_id`` is
+        empty; all other validation has already been applied by
+        :func:`~aragora.reputation.settlement.settle_claim`.
+        """
+        if not str(delta.agent_id).strip():
+            raise ReputationStoreError("delta.agent_id must be non-empty")
+        self._deltas[delta.agent_id].append(delta)
+        if self._path is not None:
+            self._append_to_file(delta)
+
+    def _append_to_file(self, delta: ReputationDelta) -> None:
+        try:
+            with self._path.open("a", encoding="utf-8") as fh:  # type: ignore[union-attr]
+                fh.write(json.dumps(delta.to_json(), sort_keys=True) + "\n")
+        except OSError as exc:
+            logger.warning("ReputationStore: could not write to %s: %s", self._path, exc)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def get_score(self, agent_id: str, *, apply_decay: bool = True) -> float:
+        """Return the running reputation score for *agent_id*.
+
+        Score is the sum of all recorded deltas, optionally weighted by
+        exponential time-decay.  Agents with no recorded deltas return 0.0.
+        The score is unbounded; callers normalise it for dispatch-eligibility.
+        """
+        deltas = self._deltas.get(agent_id, [])
+        if not deltas:
+            return 0.0
+        if not apply_decay:
+            return sum(d.delta for d in deltas)
+        now = datetime.now(tz=UTC)
+        return sum(d.delta * _decay_weight(d, now) for d in deltas)
+
+    def agent_ids(self) -> list[str]:
+        """Return sorted list of agent IDs that have at least one delta."""
+        return sorted(self._deltas.keys())
+
+    def deltas_for(self, agent_id: str) -> list[ReputationDelta]:
+        """Return a copy of the delta history for *agent_id*."""
+        return list(self._deltas.get(agent_id, []))
+
+    def agent_score(self, agent_id: str, *, apply_decay: bool = True) -> AgentScore:
+        """Return a structured score summary for *agent_id*."""
+        deltas = self._deltas.get(agent_id, [])
+        domains = sorted({d.domain for d in deltas})
+        return AgentScore(
+            agent_id=agent_id,
+            running_score=self.get_score(agent_id, apply_decay=apply_decay),
+            delta_count=len(deltas),
+            domains=domains,
+        )
+
+    def all_scores(self, *, apply_decay: bool = True) -> list[AgentScore]:
+        """Return per-agent score summaries, sorted descending by score."""
+        scores = [
+            self.agent_score(aid, apply_decay=apply_decay) for aid in self._deltas
+        ]
+        return sorted(scores, key=lambda s: s.running_score, reverse=True)
+
+    def __len__(self) -> int:
+        """Return the total number of recorded deltas across all agents."""
+        return sum(len(v) for v in self._deltas.values())
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def load_from_file(cls, path: Path) -> "ReputationStore":
+        """Reconstruct a store from an existing JSONL file.
+
+        Lines that cannot be parsed are skipped with a warning so a
+        corrupt tail does not discard earlier good records.
+        """
+        store = cls(path=path)
+        if not path.exists():
+            return store
+        with path.open(encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, 1):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    payload = json.loads(raw)
+                    delta = ReputationDelta.from_json(payload)
+                    store._deltas[delta.agent_id].append(delta)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "ReputationStore: skipping invalid line %d in %s: %s",
+                        lineno,
+                        path,
+                        exc,
+                    )
+        return store
+
+
+__all__ = [
+    "AgentScore",
+    "ReputationStore",
+    "ReputationStoreError",
+    "enable_store",
+    "store_enabled",
+]

--- a/tests/reputation/test_store.py
+++ b/tests/reputation/test_store.py
@@ -191,12 +191,8 @@ class TestRecordAndQuery:
 class TestAgentScore:
     def test_agent_score_structure(self) -> None:
         store = ReputationStore()
-        store.record_delta(
-            _delta(agent_id="alice", delta=30.0, domain=DOMAIN_PREDICTION_MARKET)
-        )
-        store.record_delta(
-            _delta(agent_id="alice", delta=10.0, domain=DOMAIN_DEBATE_POSITION)
-        )
+        store.record_delta(_delta(agent_id="alice", delta=30.0, domain=DOMAIN_PREDICTION_MARKET))
+        store.record_delta(_delta(agent_id="alice", delta=10.0, domain=DOMAIN_DEBATE_POSITION))
         score = store.agent_score("alice", apply_decay=False)
         assert score.agent_id == "alice"
         assert score.delta_count == 2
@@ -256,8 +252,8 @@ class TestDecay:
     def test_one_half_life_old_delta_halves(self) -> None:
         store = ReputationStore()
         thirty_days_ago = (
-            datetime.now(tz=UTC) - timedelta(days=30)
-        ).isoformat().replace("+00:00", "Z")
+            (datetime.now(tz=UTC) - timedelta(days=30)).isoformat().replace("+00:00", "Z")
+        )
         d = _delta(delta=100.0, decay_half_life_days=30.0, applied_at=thirty_days_ago)
         store.record_delta(d)
         score = store.get_score("alice", apply_decay=True)
@@ -265,9 +261,7 @@ class TestDecay:
 
     def test_very_old_delta_decays_near_zero(self) -> None:
         store = ReputationStore()
-        old = (datetime.now(tz=UTC) - timedelta(days=365)).isoformat().replace(
-            "+00:00", "Z"
-        )
+        old = (datetime.now(tz=UTC) - timedelta(days=365)).isoformat().replace("+00:00", "Z")
         d = _delta(delta=100.0, decay_half_life_days=30.0, applied_at=old)
         store.record_delta(d)
         score = store.get_score("alice", apply_decay=True)

--- a/tests/reputation/test_store.py
+++ b/tests/reputation/test_store.py
@@ -6,6 +6,7 @@ import json
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -317,3 +318,12 @@ class TestPersistence:
         store = ReputationStore(path=None)
         store.record_delta(_delta(delta=10.0))
         assert not any(tmp_path.iterdir())
+
+    def test_write_failure_raises_without_mutating_memory(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "rep.jsonl"
+        store = ReputationStore(path=ledger)
+        with patch.object(Path, "open", side_effect=OSError("disk full")):
+            with pytest.raises(ReputationStoreError, match="could not persist"):
+                store.record_delta(_delta(delta=10.0))
+        assert len(store) == 0
+        assert store.get_score("alice", apply_decay=False) == 0.0

--- a/tests/reputation/test_store.py
+++ b/tests/reputation/test_store.py
@@ -1,0 +1,325 @@
+"""Tests for aragora.reputation.store (AGT-05 ReputationStore)."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.reputation.settlement import settle_claim
+from aragora.reputation.store import (
+    AgentScore,
+    ReputationStore,
+    ReputationStoreError,
+    enable_store,
+    store_enabled,
+)
+from aragora.reputation.types import (
+    DOMAIN_DEBATE_POSITION,
+    DOMAIN_PREDICTION_MARKET,
+    ReputationDelta,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _claim(
+    *,
+    agent_id: str = "alice",
+    probability: float | None = 0.8,
+    position: str = "yes",
+    stake: int = 100,
+    domain: str = DOMAIN_PREDICTION_MARKET,
+    resolution_id: str = "mkt_abc",
+) -> StakeableClaim:
+    return StakeableClaim.create(
+        agent_id=agent_id,
+        domain=domain,
+        statement="PR #42 will be merged within 30 days",
+        position=position,
+        stake_units=stake,
+        resolution_source="synthetic_github",
+        resolution_id=resolution_id,
+        predicted_probability=probability,
+    )
+
+
+def _resolved(claim: StakeableClaim, outcome: str = "yes") -> ResolvedClaim:
+    return ResolvedClaim(
+        claim_id=claim.claim_id,
+        outcome=outcome,  # type: ignore[arg-type]
+        resolved_at="2026-04-24T12:00:00Z",
+        resolution_source="synthetic_github",
+    )
+
+
+def _delta(
+    *,
+    agent_id: str = "alice",
+    delta: float = 50.0,
+    domain: str = DOMAIN_PREDICTION_MARKET,
+    decay_half_life_days: float | None = None,
+    applied_at: str | None = None,
+    resolution_id: str = "mkt_abc",
+) -> ReputationDelta:
+    claim = _claim(agent_id=agent_id, domain=domain, resolution_id=resolution_id)
+    resolved = _resolved(claim, "yes")
+    d = settle_claim(claim, resolved, decay_half_life_days=decay_half_life_days)
+    # Return a patched version with the desired delta value for determinism.
+    return ReputationDelta(
+        delta_id=d.delta_id,
+        agent_id=agent_id,
+        domain=domain,
+        claim_id=d.claim_id,
+        resolution_id=d.resolution_id,
+        delta=delta,
+        scoring_rule=d.scoring_rule,
+        applied_at=applied_at or d.applied_at,
+        decay_half_life_days=decay_half_life_days,
+        reason=d.reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFlagHelpers:
+    def test_store_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+        assert store_enabled() is False
+
+    def test_enable_store_sets_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+        enable_store()
+        assert store_enabled() is True
+
+    def test_store_enabled_via_env_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+        assert store_enabled() is True
+
+    def test_store_enabled_via_true_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "true")
+        assert store_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# record_delta and basic queries
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAndQuery:
+    def test_empty_store_len_zero(self) -> None:
+        store = ReputationStore()
+        assert len(store) == 0
+
+    def test_empty_agent_score_zero(self) -> None:
+        store = ReputationStore()
+        assert store.get_score("ghost") == 0.0
+
+    def test_record_single_delta(self) -> None:
+        store = ReputationStore()
+        d = _delta(delta=60.0)
+        store.record_delta(d)
+        assert len(store) == 1
+        assert store.get_score("alice") == pytest.approx(60.0)
+
+    def test_record_multiple_deltas_accumulate(self) -> None:
+        store = ReputationStore()
+        store.record_delta(_delta(agent_id="alice", delta=40.0, resolution_id="r1"))
+        store.record_delta(_delta(agent_id="alice", delta=-20.0, resolution_id="r2"))
+        assert len(store) == 2
+        assert store.get_score("alice") == pytest.approx(20.0)
+
+    def test_multiple_agents_isolated(self) -> None:
+        store = ReputationStore()
+        store.record_delta(_delta(agent_id="alice", delta=80.0))
+        store.record_delta(_delta(agent_id="bob", delta=30.0))
+        assert store.get_score("alice") == pytest.approx(80.0)
+        assert store.get_score("bob") == pytest.approx(30.0)
+
+    def test_agent_ids_sorted(self) -> None:
+        store = ReputationStore()
+        store.record_delta(_delta(agent_id="charlie", delta=10.0))
+        store.record_delta(_delta(agent_id="alice", delta=10.0))
+        store.record_delta(_delta(agent_id="bob", delta=10.0))
+        assert store.agent_ids() == ["alice", "bob", "charlie"]
+
+    def test_deltas_for_returns_copy(self) -> None:
+        store = ReputationStore()
+        d = _delta(delta=50.0)
+        store.record_delta(d)
+        history = store.deltas_for("alice")
+        assert len(history) == 1
+        history.clear()  # mutating the copy must not affect the store
+        assert len(store.deltas_for("alice")) == 1
+
+    def test_empty_agent_rejects(self) -> None:
+        store = ReputationStore()
+        d = _delta()
+        # Craft a delta with empty agent_id by bypassing the factory
+        bad = ReputationDelta(
+            delta_id=d.delta_id,
+            agent_id="  ",  # whitespace only
+            domain=d.domain,
+            claim_id=d.claim_id,
+            resolution_id=d.resolution_id,
+            delta=d.delta,
+            scoring_rule=d.scoring_rule,
+            applied_at=d.applied_at,
+            decay_half_life_days=d.decay_half_life_days,
+            reason=d.reason,
+        )
+        with pytest.raises(ReputationStoreError, match="agent_id"):
+            store.record_delta(bad)
+
+
+# ---------------------------------------------------------------------------
+# AgentScore
+# ---------------------------------------------------------------------------
+
+
+class TestAgentScore:
+    def test_agent_score_structure(self) -> None:
+        store = ReputationStore()
+        store.record_delta(
+            _delta(agent_id="alice", delta=30.0, domain=DOMAIN_PREDICTION_MARKET)
+        )
+        store.record_delta(
+            _delta(agent_id="alice", delta=10.0, domain=DOMAIN_DEBATE_POSITION)
+        )
+        score = store.agent_score("alice", apply_decay=False)
+        assert score.agent_id == "alice"
+        assert score.delta_count == 2
+        assert score.running_score == pytest.approx(40.0)
+        assert sorted(score.domains) == [DOMAIN_DEBATE_POSITION, DOMAIN_PREDICTION_MARKET]
+
+    def test_all_scores_sorted_descending(self) -> None:
+        store = ReputationStore()
+        store.record_delta(_delta(agent_id="charlie", delta=10.0))
+        store.record_delta(_delta(agent_id="alice", delta=80.0))
+        store.record_delta(_delta(agent_id="bob", delta=40.0))
+        scores = store.all_scores(apply_decay=False)
+        assert [s.agent_id for s in scores] == ["alice", "bob", "charlie"]
+        assert scores[0].running_score == pytest.approx(80.0)
+
+    def test_agent_score_to_json(self) -> None:
+        score = AgentScore(
+            agent_id="alice",
+            running_score=42.5,
+            delta_count=3,
+            domains=["prediction_market"],
+        )
+        j = score.to_json()
+        assert j["agent_id"] == "alice"
+        assert j["running_score"] == pytest.approx(42.5)
+        assert j["delta_count"] == 3
+        assert j["domains"] == ["prediction_market"]
+
+
+# ---------------------------------------------------------------------------
+# Decay
+# ---------------------------------------------------------------------------
+
+
+class TestDecay:
+    def test_no_decay_when_half_life_none(self) -> None:
+        store = ReputationStore()
+        d = _delta(delta=100.0, decay_half_life_days=None)
+        store.record_delta(d)
+        assert store.get_score("alice", apply_decay=True) == pytest.approx(100.0)
+
+    def test_apply_decay_false_returns_raw_sum(self) -> None:
+        store = ReputationStore()
+        store.record_delta(_delta(delta=100.0, decay_half_life_days=30.0))
+        # Raw sum ignores decay
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(100.0)
+
+    def test_fresh_delta_barely_decays(self) -> None:
+        store = ReputationStore()
+        now_iso = datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+        d = _delta(delta=100.0, decay_half_life_days=30.0, applied_at=now_iso)
+        store.record_delta(d)
+        score = store.get_score("alice", apply_decay=True)
+        # Should be very close to 100 since it was just applied
+        assert score == pytest.approx(100.0, rel=0.01)
+
+    def test_one_half_life_old_delta_halves(self) -> None:
+        store = ReputationStore()
+        thirty_days_ago = (
+            datetime.now(tz=UTC) - timedelta(days=30)
+        ).isoformat().replace("+00:00", "Z")
+        d = _delta(delta=100.0, decay_half_life_days=30.0, applied_at=thirty_days_ago)
+        store.record_delta(d)
+        score = store.get_score("alice", apply_decay=True)
+        assert score == pytest.approx(50.0, rel=0.02)
+
+    def test_very_old_delta_decays_near_zero(self) -> None:
+        store = ReputationStore()
+        old = (datetime.now(tz=UTC) - timedelta(days=365)).isoformat().replace(
+            "+00:00", "Z"
+        )
+        d = _delta(delta=100.0, decay_half_life_days=30.0, applied_at=old)
+        store.record_delta(d)
+        score = store.get_score("alice", apply_decay=True)
+        assert score < 1.0  # ~100 * 2^(-365/30) ≈ 0.00032
+
+
+# ---------------------------------------------------------------------------
+# Persistence (JSONL round-trip)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_file_created_on_record(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "rep.jsonl"
+        store = ReputationStore(path=ledger)
+        store.record_delta(_delta(delta=50.0))
+        assert ledger.exists()
+
+    def test_file_has_one_line_per_delta(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "rep.jsonl"
+        store = ReputationStore(path=ledger)
+        store.record_delta(_delta(delta=50.0, resolution_id="r1"))
+        store.record_delta(_delta(delta=30.0, resolution_id="r2"))
+        lines = [l for l in ledger.read_text().splitlines() if l.strip()]
+        assert len(lines) == 2
+
+    def test_load_from_file_round_trip(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "rep.jsonl"
+        store = ReputationStore(path=ledger)
+        store.record_delta(_delta(agent_id="alice", delta=70.0))
+        store.record_delta(_delta(agent_id="bob", delta=20.0))
+
+        reloaded = ReputationStore.load_from_file(ledger)
+        assert reloaded.get_score("alice", apply_decay=False) == pytest.approx(70.0)
+        assert reloaded.get_score("bob", apply_decay=False) == pytest.approx(20.0)
+
+    def test_load_from_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        store = ReputationStore.load_from_file(tmp_path / "ghost.jsonl")
+        assert len(store) == 0
+
+    def test_load_skips_corrupt_lines(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "rep.jsonl"
+        # Write one valid line and one invalid line
+        good = _delta(delta=55.0)
+        with ledger.open("w", encoding="utf-8") as fh:
+            fh.write(json.dumps(good.to_json(), sort_keys=True) + "\n")
+            fh.write("not valid json\n")
+        store = ReputationStore.load_from_file(ledger)
+        assert len(store) == 1
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(55.0)
+
+    def test_no_path_no_file_written(self, tmp_path: Path) -> None:
+        store = ReputationStore(path=None)
+        store.record_delta(_delta(delta=10.0))
+        assert not any(tmp_path.iterdir())


### PR DESCRIPTION
## Slice
Adds `aragora/reputation/store.py` — an in-memory, append-only JSONL-backed per-agent reputation ledger. It accumulates `ReputationDelta` objects (from `settle_claim`), computes running scores with optional exponential time-decay, and persists to a JSONL file for audit. This closes the gap between the settlement layer (which produces deltas) and the team-selector dispatch-eligibility wiring (next slice).

## Gating
- Default: **OFF** (flag: `ARAGORA_REPUTATION_FLOW_ENABLED`, shared with existing `reputation_flow_enabled()`)
- Store is always constructable — only opt-in callers check the flag
- Live queue effect: **none** — pure data layer, no team-selector, no dispatch, no queue mutation
- Advances issue: #6066

## Tests
- `test_store_disabled_by_default` — flag absent → `store_enabled()` returns False
- `test_enable_store_sets_env` — `enable_store()` sets env; flag reads True
- `test_store_enabled_via_env_one` / `test_store_enabled_via_true_string` — string variants accepted
- `test_empty_store_len_zero` — fresh store has length 0
- `test_empty_agent_score_zero` — unknown agent returns 0.0
- `test_record_single_delta` — one delta → `get_score` returns its value
- `test_record_multiple_deltas_accumulate` — signed accumulation across two deltas
- `test_multiple_agents_isolated` — two agents don't bleed into each other
- `test_agent_ids_sorted` — `agent_ids()` returns lexicographic sort
- `test_deltas_for_returns_copy` — mutating the returned list doesn't affect the store
- `test_empty_agent_rejects` — whitespace-only `agent_id` raises `ReputationStoreError`
- `test_agent_score_structure` — `delta_count`, `domains`, `running_score` populated correctly
- `test_all_scores_sorted_descending` — `all_scores()` orders by score descending
- `test_agent_score_to_json` — serialization round-trip
- `test_no_decay_when_half_life_none` — no decay when `decay_half_life_days` is None
- `test_apply_decay_false_returns_raw_sum` — `apply_decay=False` bypasses decay
- `test_fresh_delta_barely_decays` — just-applied delta loses <1% score
- `test_one_half_life_old_delta_halves` — 30-day-old delta with 30-day half-life → ~50% score
- `test_very_old_delta_decays_near_zero` — 365-day-old delta with 30-day half-life → <1.0
- `test_file_created_on_record` — JSONL file created after first `record_delta`
- `test_file_has_one_line_per_delta` — two deltas → two JSONL lines
- `test_load_from_file_round_trip` — file written by store → loaded store has same scores
- `test_load_from_missing_file_returns_empty` — missing path → empty store, no error
- `test_load_skips_corrupt_lines` — bad JSONL line skipped with warning; good line survives
- `test_no_path_no_file_written` — `path=None` → nothing written to disk

## Validation
- `uv tool run pytest tests/reputation/test_store.py --noconftest` — **26 passed**
- `uv tool run ruff check aragora/reputation/store.py aragora/reputation/__init__.py tests/reputation/test_store.py` — **clean**
- `uv tool run mypy aragora/reputation/store.py aragora/reputation/__init__.py --ignore-missing-imports` — **clean**

## Out of scope
- Team-selector wiring (`enable_agt05_reputation_selection` flag on `TeamSelectorConfig`) — follow-on slice once the Foreman gate opens
- On-chain anchoring via `ReputationRegistryContract` — lives in `aragora/reputation/anchor.py` (already exists); no change here
- CruxSet resolution bridge (domain `crux_resolution`) — deferred to DIC-17 landing
- Scheduled rolling-window eviction — callers apply decay via `get_score(apply_decay=True)`; no background thread

> **Gate note:** Per `docs/status/NEXT_STEPS_CANONICAL.md`, AGT-05 is in the **Delay** lane until BC-12/Foreman reliability is proven. This PR is planning-truth work only. Do NOT apply `boss-ready` or `autonomous` labels.

---
_Generated by [Claude Code](https://claude.ai/code/session_018eyJZAwPzydnssmYKYvR2u)_