### PR TITLE
[DIC-14] Add scripts/verify_claims.py CLI runner

### DIFF
--- a/scripts/verify_claims.py
+++ b/scripts/verify_claims.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Executable claim verification CLI (DIC-14 / #6024).
+
+Scans *.yaml manifests in a claims directory, verifies each claim via
+ClaimVerifier, and emits a JSON report.  Explicit invocation is always
+permitted; automatic production-path loading via
+``load_claims_from_dir`` is separately gated behind
+``ARAGORA_EPISTEMIC_CLAIMS_ENABLED`` (default off).
+
+Exit codes: 0 = ok/skipped, 1 = fail/stale/error (with --exit-code), 2 = fatal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_UNHEALTHY = frozenset({"fail", "stale", "error"})
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Verify DIC-14 executable claim manifests.")
+    p.add_argument("--claims-dir", type=Path,
+                   default=_REPO_ROOT / "docs" / "status" / "claims", metavar="DIR")
+    p.add_argument("--repo-root", type=Path, default=_REPO_ROOT, metavar="DIR")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Skip command execution; return UNSUPPORTED for command claims.")
+    p.add_argument("--output", type=Path, default=None, metavar="FILE")
+    p.add_argument("--exit-code", action="store_true",
+                   help="Exit 1 when any claim is fail, stale, or error.")
+    return p.parse_args(argv)
+
+
+def _emit(payload: dict[str, Any], output: Path | None) -> None:
+    text = json.dumps(payload, indent=2)
+    if output is not None:
+        output.write_text(text, encoding="utf-8")
+    else:
+        print(text)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    try:
+        from aragora.epistemic.claim_verifier import ClaimStatus, ClaimVerifier
+    except ImportError as exc:
+        print(f"error: cannot import aragora.epistemic.claim_verifier: {exc}", file=sys.stderr)
+        return 2
+
+    claims_dir: Path = args.claims_dir
+    if not claims_dir.is_dir():
+        print(f"error: claims directory not found: {claims_dir}", file=sys.stderr)
+        return 2
+
+    manifest_paths = sorted(claims_dir.glob("*.yaml"))
+    empty_summary = {s.value: 0 for s in ClaimStatus}
+
+    if not manifest_paths:
+        print(f"warning: no *.yaml manifests found in {claims_dir}", file=sys.stderr)
+        _emit({"schema_version": 1, "manifests_scanned": 0, "results": [],
+               "summary": empty_summary}, args.output)
+        return 0
+
+    verifier = ClaimVerifier(repo_root=args.repo_root, dry_run=args.dry_run)
+    result_dicts: list[dict[str, Any]] = []
+    summary = dict(empty_summary)
+
+    for path in manifest_paths:
+        try:
+            results = verifier.verify_manifest(path)
+        except Exception as exc:  # noqa: BLE001
+            result_dicts.append({"claim_id": f"<manifest:{path.name}>", "status": "error",
+                                  "message": f"failed to load manifest: {exc}",
+                                  "severity": "warning", "allowed_action": "report_only",
+                                  "elapsed_ms": 0.0, "detail": {}})
+            summary["error"] += 1
+            continue
+        for r in results:
+            result_dicts.append(r.to_dict())
+            summary[r.status.value] += 1
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "manifests_scanned": len(manifest_paths),
+        "results": result_dicts,
+        "summary": summary,
+    }
+    _emit(payload, args.output)
+
+    if args.exit_code and any(summary.get(s, 0) > 0 for s in _UNHEALTHY):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_claims.py
+++ b/scripts/verify_claims.py
@@ -24,14 +24,19 @@ _UNHEALTHY = frozenset({"fail", "stale", "error"})
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Verify DIC-14 executable claim manifests.")
-    p.add_argument("--claims-dir", type=Path,
-                   default=_REPO_ROOT / "docs" / "status" / "claims", metavar="DIR")
+    p.add_argument(
+        "--claims-dir", type=Path, default=_REPO_ROOT / "docs" / "status" / "claims", metavar="DIR"
+    )
     p.add_argument("--repo-root", type=Path, default=_REPO_ROOT, metavar="DIR")
-    p.add_argument("--dry-run", action="store_true",
-                   help="Skip command execution; return UNSUPPORTED for command claims.")
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip command execution; return UNSUPPORTED for command claims.",
+    )
     p.add_argument("--output", type=Path, default=None, metavar="FILE")
-    p.add_argument("--exit-code", action="store_true",
-                   help="Exit 1 when any claim is fail, stale, or error.")
+    p.add_argument(
+        "--exit-code", action="store_true", help="Exit 1 when any claim is fail, stale, or error."
+    )
     return p.parse_args(argv)
 
 
@@ -62,8 +67,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if not manifest_paths:
         print(f"warning: no *.yaml manifests found in {claims_dir}", file=sys.stderr)
-        _emit({"schema_version": 1, "manifests_scanned": 0, "results": [],
-               "summary": empty_summary}, args.output)
+        _emit(
+            {"schema_version": 1, "manifests_scanned": 0, "results": [], "summary": empty_summary},
+            args.output,
+        )
         return 0
 
     verifier = ClaimVerifier(repo_root=args.repo_root, dry_run=args.dry_run)
@@ -74,10 +81,17 @@ def main(argv: list[str] | None = None) -> int:
         try:
             results = verifier.verify_manifest(path)
         except Exception as exc:  # noqa: BLE001
-            result_dicts.append({"claim_id": f"<manifest:{path.name}>", "status": "error",
-                                  "message": f"failed to load manifest: {exc}",
-                                  "severity": "warning", "allowed_action": "report_only",
-                                  "elapsed_ms": 0.0, "detail": {}})
+            result_dicts.append(
+                {
+                    "claim_id": f"<manifest:{path.name}>",
+                    "status": "error",
+                    "message": f"failed to load manifest: {exc}",
+                    "severity": "warning",
+                    "allowed_action": "report_only",
+                    "elapsed_ms": 0.0,
+                    "detail": {},
+                }
+            )
             summary["error"] += 1
             continue
         for r in results:

--- a/tests/scripts/test_verify_claims.py
+++ b/tests/scripts/test_verify_claims.py
@@ -41,15 +41,21 @@ claims:
       - type: test
 """
 
-_CMD_DRY = _MANUAL.replace("kind: manual", "kind: command").replace(
-    'command: ""', 'command: "true"'
-).replace("manifest_id: test_manual", "manifest_id: test_cmd")
+_CMD_DRY = (
+    _MANUAL.replace("kind: manual", "kind: command")
+    .replace('command: ""', 'command: "true"')
+    .replace("manifest_id: test_manual", "manifest_id: test_cmd")
+)
 
 
 def _available() -> bool:
     try:
-        return subprocess.run([_PYTHON, str(_SCRIPT), "--help"],
-                              capture_output=True, timeout=15).returncode == 0
+        return (
+            subprocess.run(
+                [_PYTHON, str(_SCRIPT), "--help"], capture_output=True, timeout=15
+            ).returncode
+            == 0
+        )
     except Exception:
         return False
 
@@ -93,7 +99,8 @@ class TestBasic:
         multi = _MANUAL
         for i in range(1, 3):
             extra = _MANUAL.replace("test.manual.claim", f"test.claim.{i}").replace(
-                "manifest_id: test_manual", f"manifest_id: test_{i}")
+                "manifest_id: test_manual", f"manifest_id: test_{i}"
+            )
             _write(tmp_path, f"m{i}.yaml", extra)
         _write(tmp_path, "m0.yaml", multi)
         rc, payload, _ = _run(tmp_path)

--- a/tests/scripts/test_verify_claims.py
+++ b/tests/scripts/test_verify_claims.py
@@ -1,0 +1,143 @@
+"""Tests for scripts/verify_claims.py (DIC-14 / #6024).
+
+Invokes the script via subprocess (system python3 which has aragora
+installed).  Tests are skipped if the script is unavailable.
+No network access; all manifests use ``kind: manual`` or ``--dry-run``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "verify_claims.py"
+_PYTHON = shutil.which("python3") or sys.executable
+
+_MANUAL = """\
+schema_version: 1
+manifest_id: test_manual
+claims:
+  - claim_id: test.manual.claim
+    statement: Test.
+    owner: test
+    scope: repo
+    confidence: high
+    freshness_sla_hours: 24
+    evidence:
+      - note: present
+    verification:
+      kind: manual
+      command: ""
+    failure:
+      severity: info
+      allowed_action: report_only
+    receipts:
+      - type: test
+"""
+
+_CMD_DRY = _MANUAL.replace("kind: manual", "kind: command").replace(
+    'command: ""', 'command: "true"'
+).replace("manifest_id: test_manual", "manifest_id: test_cmd")
+
+
+def _available() -> bool:
+    try:
+        return subprocess.run([_PYTHON, str(_SCRIPT), "--help"],
+                              capture_output=True, timeout=15).returncode == 0
+    except Exception:
+        return False
+
+
+skip_if_unavailable = pytest.mark.skipif(
+    not _available(), reason="script unavailable in this environment"
+)
+
+
+def _run(claims_dir: Path, extra: list[str] | None = None) -> tuple[int, Any, str]:
+    cmd = [_PYTHON, str(_SCRIPT), "--claims-dir", str(claims_dir), *(extra or [])]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    payload = json.loads(r.stdout.strip()) if r.stdout.strip() else None
+    return r.returncode, payload, r.stderr
+
+
+def _write(tmp_path: Path, name: str, body: str) -> None:
+    (tmp_path / name).write_text(body, encoding="utf-8")
+
+
+@skip_if_unavailable
+class TestBasic:
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        rc, payload, _ = _run(tmp_path)
+        assert rc == 0 and payload["manifests_scanned"] == 0
+
+    def test_manual_claim_unsupported(self, tmp_path: Path) -> None:
+        _write(tmp_path, "m.yaml", _MANUAL)
+        rc, payload, _ = _run(tmp_path)
+        assert rc == 0
+        assert payload["results"][0]["status"] == "unsupported"
+        assert payload["results"][0]["claim_id"] == "test.manual.claim"
+
+    def test_dry_run_skips_command(self, tmp_path: Path) -> None:
+        _write(tmp_path, "m.yaml", _CMD_DRY)
+        rc, payload, _ = _run(tmp_path, ["--dry-run"])
+        assert rc == 0
+        assert payload["results"][0]["status"] == "unsupported"
+
+    def test_summary_counts_results(self, tmp_path: Path) -> None:
+        multi = _MANUAL
+        for i in range(1, 3):
+            extra = _MANUAL.replace("test.manual.claim", f"test.claim.{i}").replace(
+                "manifest_id: test_manual", f"manifest_id: test_{i}")
+            _write(tmp_path, f"m{i}.yaml", extra)
+        _write(tmp_path, "m0.yaml", multi)
+        rc, payload, _ = _run(tmp_path)
+        assert rc == 0
+        assert payload["manifests_scanned"] == 3
+        assert sum(payload["summary"].values()) == 3
+
+    def test_output_has_schema_version(self, tmp_path: Path) -> None:
+        _write(tmp_path, "m.yaml", _MANUAL)
+        _, payload, _ = _run(tmp_path)
+        assert payload["schema_version"] == 1
+        assert {"schema_version", "manifests_scanned", "results", "summary"} <= payload.keys()
+
+
+@skip_if_unavailable
+class TestOutputFile:
+    def test_file_written_not_stdout(self, tmp_path: Path) -> None:
+        _write(tmp_path, "m.yaml", _MANUAL)
+        out = tmp_path / "out.json"
+        rc, payload, _ = _run(tmp_path, ["--output", str(out)])
+        assert rc == 0 and payload is None
+        data = json.loads(out.read_text())
+        assert data["results"][0]["claim_id"] == "test.manual.claim"
+
+
+@skip_if_unavailable
+class TestExitCode:
+    def test_unsupported_is_healthy(self, tmp_path: Path) -> None:
+        _write(tmp_path, "m.yaml", _MANUAL)
+        rc, _, _ = _run(tmp_path, ["--exit-code"])
+        assert rc == 0
+
+    def test_missing_dir_is_fatal(self, tmp_path: Path) -> None:
+        rc, _, stderr = _run(tmp_path / "nope")
+        assert rc == 2
+        assert "not found" in stderr
+
+
+@skip_if_unavailable
+class TestMultiManifest:
+    def test_malformed_produces_error(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.yaml").write_text("not: a: valid: [", encoding="utf-8")
+        _write(tmp_path, "good.yaml", _MANUAL)
+        rc, payload, _ = _run(tmp_path)
+        assert rc == 0
+        statuses = {r["status"] for r in payload["results"]}
+        assert "error" in statuses and "unsupported" in statuses


### PR DESCRIPTION
## Slice

Adds the `scripts/verify_claims.py` operator CLI called for in DIC-14 (#6024). The `ClaimVerifier` Python class in `aragora/epistemic/claim_verifier.py` already existed; this provides the missing command-line entry point so operators and CI steps can run explicit claim verification without writing Python.

## Gating

- Default: OFF — automatic production-path loading is gated behind `ARAGORA_EPISTEMIC_CLAIMS_ENABLED` (unchanged). This script is an explicit CLI tool; it has no auto-load behavior.
- Live queue effect: **none**
- Advances issue: #6024 (DIC-14)

## Tests

- `tests/scripts/test_verify_claims.py` — 9 tests covering:
  - empty claims directory → zero exit, empty result list
  - `kind: manual` claim → `unsupported` status (no subprocess)
  - `--dry-run` on a command claim → `unsupported`, no subprocess
  - multi-manifest scanning → counts and summary correct
  - `--output FILE` → JSON written to file, nothing on stdout
  - `--exit-code` with no unhealthy claims → exit 0
  - missing directory → exit 2 with error message
  - malformed YAML manifest → synthetic `error` result, healthy manifests still processed

## Validation

- `uv run pytest tests/scripts/test_verify_claims.py -v --noconftest` — **9 passed**
- `ruff check scripts/verify_claims.py tests/scripts/test_verify_claims.py` — **clean**
- `mypy scripts/verify_claims.py --ignore-missing-imports` — **clean**
- Net diff: 244 LOC (101 script + 143 tests)

## Out of scope

- Claim-to-boss-queue bridge (DIC-17): script never creates issues or modifies labels
- Receipt ingestion of verification results (DIC-16): no receipt output in this slice
- Scheduled/CI invocation wiring: that belongs in a future CI-lane PR once the gate opens
- `--watch` or live-reload mode: not needed; operator invocation is explicit

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5qvxA6LCmk3DhNsBxGt11)_