### PR TITLE
fix(docs-site): upgrade uuid to 14.0.0 via overrides

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -19494,12 +19494,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate.io-array": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -40,6 +40,7 @@
     "minimatch": "10.2.4",
     "qs": "6.15.0",
     "serialize-javascript": "7.0.4",
+    "uuid": "^14.0.0",
     "openapi-to-postmanv2": {
       "js-yaml": "4.1.1",
       "lodash": "4.17.23"


### PR DESCRIPTION
## Summary

- Upgrades transitive `uuid@8.3.2` → `uuid@14.0.0` in `docs-site/` via `overrides` in `package.json`
- Unblocks the Dependabot Updates workflow (currently failing 7+ times daily on the affected advisory)
- Chose upgrade over ignoring the advisory per maintainer direction

## Root cause (from #6491)

The GHSA advisory on `uuid < 14.0.0` has an empty `patched-versions` array. Dependabot reads this and concludes "nothing to upgrade to" even though `uuid@14.0.0` is on npm. Forcing the upgrade via `overrides` resolves it properly.

## Transitive consumers affected

- `postman-collection@5.3.0` — exact pin to `8.3.2`, used by `docusaurus-plugin-openapi-docs` at build time
- `sockjs@0.3.24` — `^8.3.2`, dev-server HMR only

## Risk

uuid v9+ dropped the CJS default export pattern. Both consumers do named-export destructuring, not default imports, so the v8 → v14 jump is safe for them at the API surface.

## Test plan

- [x] `npm install` in `docs-site/` regenerates lockfile with `uuid@14.0.0`
- [x] `docusaurus build` succeeds end-to-end (exercises postman-collection via API docs generation); no uuid-related errors
- [ ] Dependabot Updates workflow stops failing on next scheduled run

Fixes #6491

🤖 Generated with [Claude Code](https://claude.com/claude-code)