### PR TITLE
fix(automation): gate backlog audit PR lookup on gh health

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -12,11 +12,17 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import sys
 from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.github_cli_health import check_github_cli_health
 
 ACTIVE_SESSION_FILES = (
     ".claude-session-active",
@@ -265,7 +271,8 @@ def audit(
     remotes = remote_branch_names(root, prefix)
     merged_branches = merged_branch_names(root, base, prefix)
     worktrees = worktree_map(root)
-    prs = open_pr_heads(root, repo, prefix)
+    github_health = check_github_cli_health(root)
+    prs = open_pr_heads(root, repo, prefix) if github_health.ready else {}
 
     records: list[BranchRecord] = []
     for row in rows:
@@ -331,6 +338,8 @@ def audit(
         "prefix": prefix,
         "recent_hours": recent_hours,
         "include_patch_equivalence": include_patch_equivalence,
+        "github_health": github_health.to_dict(),
+        "open_pr_lookup_skipped": not github_health.ready,
         "branch_count": len(records),
         "summary": {
             "safe_cleanup_candidates": safe_cleanup,

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts.github_cli_health import GitHubCLIHealth
+
+import scripts.audit_codex_branch_backlog as mod
+
+
+def _branch_row(name: str = "codex/example") -> dict[str, str]:
+    return {
+        "name": name,
+        "upstream": "",
+        "head_sha": "abc1234",
+        "committed_at": datetime.now(timezone.utc).isoformat(),
+        "ahead_count": "1",
+        "subject": "test branch",
+    }
+
+
+def _stub_git_inventory(monkeypatch: Any, row: dict[str, str]) -> None:
+    monkeypatch.setattr(mod, "local_branches", lambda _root, _prefix, _base: [row])
+    monkeypatch.setattr(mod, "remote_branch_names", lambda _root, _prefix: set())
+    monkeypatch.setattr(mod, "merged_branch_names", lambda _root, _base, _prefix: set())
+    monkeypatch.setattr(mod, "worktree_map", lambda _root: {})
+
+
+def test_audit_skips_open_pr_lookup_when_github_health_degraded(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    _stub_git_inventory(monkeypatch, _branch_row())
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    def fail_open_pr_lookup(*_args: Any, **_kwargs: Any) -> dict[str, int]:
+        raise AssertionError("open PR lookup should be skipped when GitHub is unhealthy")
+
+    monkeypatch.setattr(mod, "open_pr_heads", fail_open_pr_lookup)
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+    )
+
+    assert payload["github_health"]["mode"] == "connectivity_failed"
+    assert payload["open_pr_lookup_skipped"] is True
+    assert payload["records"][0]["open_pr"] is None
+    assert payload["records"][0]["category"] == "salvage_recent_unique"
+
+
+def test_audit_uses_open_pr_lookup_when_github_health_is_ready(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    row = _branch_row("codex/has-pr")
+    _stub_git_inventory(monkeypatch, row)
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(mod, "open_pr_heads", lambda _root, _repo, _prefix: {"codex/has-pr": 6500})
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+    )
+
+    assert payload["github_health"]["ready"] is True
+    assert payload["open_pr_lookup_skipped"] is False
+    assert payload["records"][0]["open_pr"] == 6500
+    assert payload["records"][0]["category"] == "protected_open_pr"


### PR DESCRIPTION
## Summary

- Makes `scripts/audit_codex_branch_backlog.py` respect the GitHub health gate before open-PR lookup.
- Reports `github_health` and `open_pr_lookup_skipped` in audit JSON so degraded automation contexts still get useful local branch classification.
- Adds regression tests for degraded and healthy GitHub modes.

## Why

Primary Writer runs can have degraded `gh` connectivity while local git is still usable. The backlog audit should not fail or loop on GitHub just to classify local branch state.

## Validation

- `python -m pytest tests/scripts/test_audit_codex_branch_backlog.py tests/scripts/test_publish_codex_automation_branches.py -q`
- `python -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py`
- `python scripts/audit_codex_branch_backlog.py --max-branches 3 --json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
