### PR TITLE
docs: add cold reviewer proof surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ receipts, provenance, and truthful gates.
 ### Govern AI-Assisted Work With Receipts, Review, and Truthful Gates
 
 [![PyPI](https://img.shields.io/pypi/v/aragora)](https://pypi.org/project/aragora/)
-[![Tests](https://github.com/an0mium/aragora/actions/workflows/test.yml/badge.svg)](https://github.com/an0mium/aragora/actions/workflows/test.yml)
-[![Smoke Tests](https://github.com/an0mium/aragora/actions/workflows/smoke.yml/badge.svg)](https://github.com/an0mium/aragora/actions/workflows/smoke.yml)
-[![Docker Build](https://github.com/an0mium/aragora/actions/workflows/docker.yml/badge.svg)](https://github.com/an0mium/aragora/actions/workflows/docker.yml)
-[![Deploy](https://github.com/an0mium/aragora/actions/workflows/deploy-lightsail.yml/badge.svg)](https://github.com/an0mium/aragora/actions/workflows/deploy-lightsail.yml)
+[![Tests](https://github.com/synaptent/aragora/actions/workflows/test.yml/badge.svg)](https://github.com/synaptent/aragora/actions/workflows/test.yml)
+[![Smoke Tests](https://github.com/synaptent/aragora/actions/workflows/smoke.yml/badge.svg)](https://github.com/synaptent/aragora/actions/workflows/smoke.yml)
+[![Docker Build](https://github.com/synaptent/aragora/actions/workflows/docker.yml/badge.svg)](https://github.com/synaptent/aragora/actions/workflows/docker.yml)
+[![Deploy](https://github.com/synaptent/aragora/actions/workflows/deploy-lightsail.yml/badge.svg)](https://github.com/synaptent/aragora/actions/workflows/deploy-lightsail.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**New here?** Start with the [Quickstart Guide](docs/quickstart.md) -- you'll have a working debate in under a minute. For a deeper overview, see [Start Here](docs/START_HERE.md). For strategic framing, see [Positioning And Messaging](docs/strategy/POSITIONING_AND_MESSAGING.md) (includes competitive positioning), [Boundaries And Scope](docs/strategy/BOUNDARIES_AND_SCOPE.md) (includes when-to-use-Aragora-vs-execution-substrates), and [Precision And Terms](docs/strategy/PRECISION_AND_TERMS.md) (includes the terminology glossary). The consolidation of earlier-dated strategy files is tracked in [STRATEGY_INDEX.md](docs/STRATEGY_INDEX.md).
+**New here?** Start with the [Quickstart Guide](docs/quickstart.md) -- you'll have a working debate in under a minute. For a cold reviewer or auditor path, start with [Cold Reviewer Guide](docs/COLD_REVIEWER_GUIDE.md). For a deeper overview, see [Start Here](docs/START_HERE.md). For strategic framing, see [Positioning And Messaging](docs/strategy/POSITIONING_AND_MESSAGING.md) (includes competitive positioning), [Boundaries And Scope](docs/strategy/BOUNDARIES_AND_SCOPE.md) (includes when-to-use-Aragora-vs-execution-substrates), and [Precision And Terms](docs/strategy/PRECISION_AND_TERMS.md) (includes the terminology glossary). The consolidation of earlier-dated strategy files is tracked in [STRATEGY_INDEX.md](docs/STRATEGY_INDEX.md).
 
 | I want to... | Install |
 |--------------|---------|
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: an0mium/aragora@main
+      - uses: synaptent/aragora@main
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -313,7 +313,7 @@ See [docs/guides/GETTING_STARTED.md](docs/guides/GETTING_STARTED.md) for the com
 
 ```bash
 # Clone and deploy
-git clone https://github.com/an0mium/aragora && cd aragora
+git clone https://github.com/synaptent/aragora && cd aragora
 
 # Production deployment (secrets from AWS Secrets Manager)
 cd deploy/liftmode && ./setup.sh

--- a/docs-site/docs/api/supported-surface.md
+++ b/docs-site/docs/api/supported-surface.md
@@ -1,0 +1,51 @@
+---
+title: Supported API Surface
+description: Stability tiers for Aragora's API, SDK, and generated OpenAPI surface.
+sidebar_position: 2
+---
+
+# Supported API Surface
+
+Last updated: 2026-04-24
+
+Aragora has a large generated API catalog because the platform includes debates,
+agents, memory, workflows, integrations, autonomy controls, and operational
+surfaces. That catalog is useful for discovery, but it is not a blanket promise
+that every route is equally stable.
+
+## Stability Tiers
+
+| Tier | Meaning | Change Policy |
+|------|---------|---------------|
+| Supported | Intended for external use and source-compatible across patch releases | Breaking changes require migration notes and versioning |
+| Beta | Useful and documented, but still hardening | Breaking changes are allowed with release notes |
+| Internal | Used by Aragora operators, automations, or generated tools | No external stability promise |
+| Experimental | Research, roadmap, or proof-of-concept surface | May change or disappear without migration |
+
+## Supported Today
+
+- Core debate package install path: `pip install aragora-debate`.
+- Python SDK package: `aragora-sdk`.
+- TypeScript SDK package: `@aragora/sdk`.
+- [GitHub PR Review API](/docs/api/github-pr-review).
+- Receipt-backed review, decision, and merge-readiness surfaces covered by tests
+  and canonical status docs.
+- Published OpenAPI reference as a discovery surface, with this document acting
+  as the stability boundary.
+
+## Beta / Productizing
+
+- Autonomous execution and worker-contract control-plane APIs.
+- Benchmark truth and rescue-productization publication surfaces.
+- Decision Integrity Core slices such as executable claims, crux analysis,
+  coherence checks, and gardening passes.
+- Operator inbox and non-code action loops.
+
+## Promotion Checklist
+
+An API moves into the supported tier only when it has clear documentation,
+examples, auth and failure semantics, focused tests, SDK or CLI coverage, and a
+receipt, audit event, or provenance hook for consequential actions.
+
+If the tier is unclear, the API should remain beta or internal until the
+contract is explicit.

--- a/docs-site/docs/contributing/cold-reviewer-guide.md
+++ b/docs-site/docs/contributing/cold-reviewer-guide.md
@@ -1,0 +1,64 @@
+---
+title: Cold Reviewer Guide
+description: Fast path for reviewing Aragora's thesis, proof surfaces, and shipped boundary.
+sidebar_position: 2
+---
+
+# Cold Reviewer Guide
+
+Last updated: 2026-04-24
+
+Aragora is an auditable execution control plane for consequential AI-assisted
+work. It coordinates heterogeneous agents, requires evidence-backed review,
+preserves receipts and provenance, and stops truthfully when a task lacks enough
+support to proceed.
+
+## What It Is Good For Today
+
+- PR review and merge settlement where multiple agents inspect the same diff,
+  dissent is preserved, and merge readiness is tied to evidence.
+- Autonomous or semi-autonomous software execution where work orders, validation
+  plans, receipts, and stop states matter more than raw coding speed.
+- Decision records that need provenance, claims, disagreement, and later
+  reassessment instead of ephemeral chat transcripts.
+- Calibration loops that compare agent recommendations against later outcomes.
+- Fail-closed automation where admin-scoped approvals and truth surfaces are
+  required before high-impact actions advance.
+
+## What Is Still Aspirational
+
+The long-term roadmap is larger than the current wedge: an organization substrate
+for the full `idea -> goal -> plan -> action -> receipt -> later settlement`
+loop. Reviewers should treat future-facing documents as roadmap material unless
+the capability has tests, receipts, and proof surfaces.
+
+## Inspect These First
+
+- [Supported API Surface](/docs/api/supported-surface)
+- [Canonical Goals](/docs/contributing/canonical-goals)
+- [Evolution Roadmap](/docs/contributing/aragora-evolution-roadmap)
+- [Next Steps Canonical](/docs/contributing/next-steps-canonical)
+- [Benchmark Truth Status](/docs/contributing/b0-benchmark-truth-status)
+- [Rescue Productization Status](/docs/contributing/tw03-rescue-productization-status)
+- [GitHub PR Review API](/docs/api/github-pr-review)
+
+## Fast Verification
+
+Run these from the repository root:
+
+```bash
+python scripts/inspect_cold_review_surface.py
+python scripts/check_version_alignment.py
+npm run build --prefix docs-site
+```
+
+The cold-review inspector checks public framing, docs-site announcement drift,
+reviewer/auditor entry points, supported-surface documentation, live queue
+alignment, and OpenAPI scale summary.
+
+## Bottom Line
+
+Aragora is valuable if it keeps tightening the gap between AI-generated work and
+auditable organizational trust. The next phase should bias toward fewer,
+better-proofed surfaces: PR settlement, receipts, calibration, review gates,
+proof-carrying code, and cold-reviewable documentation.

--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -5,7 +5,7 @@
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Aragora Documentation',
-  tagline: 'Control plane for multi-agent vetted decisionmaking across org knowledge and channels',
+  tagline: 'Auditable execution control plane for consequential AI-assisted work',
   favicon: 'img/favicon.ico',
 
   // Production URL
@@ -13,7 +13,7 @@ const config = {
   baseUrl: '/',
 
   // GitHub Pages deployment config (if using)
-  organizationName: 'aragora',
+  organizationName: 'synaptent',
   projectName: 'aragora',
 
   onBrokenLinks: 'warn',
@@ -39,7 +39,7 @@ const config = {
       ({
         docs: {
           sidebarPath: './sidebars.js',
-          editUrl: 'https://github.com/aragora/aragora/tree/main/docs/',
+          editUrl: 'https://github.com/synaptent/aragora/tree/main/docs/',
           showLastUpdateTime: true,
           showLastUpdateAuthor: true,
         },
@@ -121,7 +121,7 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://github.com/aragora/aragora',
+            href: 'https://github.com/synaptent/aragora',
             label: 'GitHub',
             position: 'right',
           },
@@ -159,7 +159,7 @@ const config = {
             items: [
               {
                 label: 'GitHub Discussions',
-                href: 'https://github.com/aragora/aragora/discussions',
+                href: 'https://github.com/synaptent/aragora/discussions',
               },
               {
                 label: 'Discord',
@@ -209,9 +209,9 @@ const config = {
 
       // Announcement bar
       announcementBar: {
-        id: 'v2_4_release',
+        id: 'proof_first_rc1',
         content:
-          'Aragora v2.4 is out! Expanded Python SDK with 10+ new resource namespaces. <a href="/docs/changelog">See what\'s new</a>.',
+          'Aragora v2.9.0-rc.1 is out: proof-first PR settlement, calibration gates, and Decision Integrity Core slices. <a href="/docs/contributing/b0-benchmark-truth-status">See the proof surfaces</a>.',
         backgroundColor: '#4F46E5',
         textColor: '#FFFFFF',
         isCloseable: true,

--- a/docs-site/src/pages/index.md
+++ b/docs-site/src/pages/index.md
@@ -1,16 +1,42 @@
 ---
 title: Aragora Docs
-description: Control plane for multi-agent vetted decisionmaking across org knowledge and channels.
+description: Auditable execution control plane for consequential AI-assisted work.
 ---
 
 # Aragora Documentation
 
-Aragora is the control plane for multi-agent vetted decisionmaking across organizational
-knowledge and channels. This site is the published view of the canonical docs in
-`docs/`.
+Aragora is an auditable execution control plane for consequential AI-assisted
+work. It uses multi-model review, receipts, provenance, and truthful gates so
+software and organizational decisions can be inspected instead of merely trusted.
 
-## Quick Links
+This site is the published view of the canonical docs in `docs/`. If you are
+reviewing the project cold, start with the proof path below before diving into
+the full API surface.
+
+## Review Path
+
+- [Cold Reviewer Guide](/docs/contributing/cold-reviewer-guide) explains what
+  Aragora is good for today, what is aspirational, and how to verify the serious
+  surfaces quickly.
+- [Supported API Surface](/docs/api/supported-surface) separates stable,
+  beta, internal, and experimental contracts so the generated API catalog is not
+  mistaken for a blanket stability promise.
+- [Benchmark Truth Status](/docs/contributing/b0-benchmark-truth-status) and
+  [Rescue Productization Status](/docs/contributing/tw03-rescue-productization-status)
+  are the recurring proof surfaces for the current reliability wedge.
+
+## Build Path
 
 - [Getting Started](/docs/getting-started/overview)
-- [Guides](/docs/guides)
+- [GitHub PR Review API](/docs/api/github-pr-review)
 - [API Reference](/docs/api/reference)
+- [Canonical Goals](/docs/contributing/canonical-goals)
+- [Evolution Roadmap](/docs/contributing/aragora-evolution-roadmap)
+
+## Current Boundary
+
+Today, Aragora is strongest as a proof-first review and execution governance
+layer for bounded AI-assisted software work. The maximalist direction is larger:
+an organization substrate for the full idea-to-goal-to-plan-to-action-to-receipt
+loop. The roadmap is valuable only when each stage keeps the same fail-closed
+contract: explicit evidence, review, receipts, and truthful stops.

--- a/docs/COLD_REVIEWER_GUIDE.md
+++ b/docs/COLD_REVIEWER_GUIDE.md
@@ -1,0 +1,111 @@
+# Cold Reviewer Guide
+
+Last updated: 2026-04-24
+
+This guide is the shortest serious path for a reviewer, auditor, investor, or
+new maintainer who is inspecting Aragora without prior context.
+
+## One-Sentence Thesis
+
+Aragora is an auditable execution control plane for consequential AI-assisted
+work: it coordinates heterogeneous agents, requires evidence-backed review,
+preserves receipts and provenance, and stops truthfully when a task lacks enough
+support to proceed.
+
+## What Aragora Is Good For Today
+
+Aragora is strongest when the work is too consequential for a single model
+answer but still bounded enough to verify:
+
+- PR review and merge settlement where multiple agents inspect the same diff,
+  dissent is preserved, and merge readiness is tied to evidence.
+- Autonomous or semi-autonomous software execution where work orders, validation
+  plans, receipts, and stop states matter more than raw coding speed.
+- Decision records that need provenance, claims, disagreement, and later
+  reassessment instead of ephemeral chat transcripts.
+- Calibration loops that compare agent recommendations against later outcomes.
+- Fail-closed automation where admin-scoped approvals and truth surfaces are
+  required before high-impact actions advance.
+
+## What Is Still Aspirational
+
+The long-term roadmap is larger than the current wedge: an organization substrate
+for the full `idea -> goal -> plan -> action -> receipt -> later settlement`
+loop. The repo contains real building blocks for that direction, but reviewers
+should not judge every future-facing document as a shipped product claim.
+
+The near-term discipline is proof-first: every stage should add a smaller,
+inspectable capability with tests, receipts, and clear stop/go semantics before
+the project expands the surface area.
+
+## Why This Is Not Just Another Agent Framework
+
+Generic orchestration, chat UX, and coding-agent execution are likely to be
+replicated by large model providers and workflow frameworks. Aragora's more
+defensible layer is the governance substrate around those executors:
+
+- vendor-neutral review and dissent across heterogeneous agents
+- durable receipts, claims, and provenance
+- calibrated trust based on observed outcomes
+- explicit admin approvals and bounded delegation
+- executable claims and stale-evidence repair loops
+- API and SDK contracts separated from internal experimental machinery
+
+## Inspect These First
+
+1. [README](../README.md) for product framing and install paths.
+2. [Supported API Surface](api/SUPPORTED_SURFACE.md) for what is stable, beta,
+   internal, or experimental.
+3. [Canonical Goals](CANONICAL_GOALS.md) and
+   [Evolution Roadmap](plans/ARAGORA_EVOLUTION_ROADMAP.md) for the staged
+   maximalist thesis.
+4. [Next Steps Canonical](status/NEXT_STEPS_CANONICAL.md) for current execution
+   priorities.
+5. [B0 Benchmark Truth Status](status/B0_BENCHMARK_TRUTH_STATUS.md) and
+   [TW03 Rescue Productization Status](status/TW03_RESCUE_PRODUCTIZATION_STATUS.md)
+   for recurring proof surfaces.
+6. [GitHub PR Review API](integrations/GITHUB_PR_REVIEW.md) for the current practical
+   control-plane wedge.
+
+## Fast Verification
+
+Run these from the repository root:
+
+```bash
+python scripts/inspect_cold_review_surface.py
+python scripts/check_version_alignment.py
+npm run build --prefix docs-site
+```
+
+The cold-review inspector checks the public framing, docs-site announcement,
+reviewer/auditor entry points, supported-surface document, live queue alignment,
+and OpenAPI scale summary. It is intentionally small and dependency-free so it
+can run in local review, CI, or branch preflight.
+
+## Quality Bar For New Work
+
+New capabilities should be easy for a cold reviewer to classify:
+
+- The user-visible promise is explicit.
+- The supported API or CLI contract is documented.
+- The validation command is listed and reproducible.
+- The receipt, audit, or provenance surface is inspectable.
+- Failure modes stop truthfully instead of silently degrading.
+- Experimental pieces are labeled experimental and kept out of the stable
+  contract until they have proof.
+
+## Red Flags To Avoid
+
+- Treating the generated OpenAPI catalog as a stability promise for every route.
+- Adding broad agent/provider support without stronger receipts or verification.
+- Letting stale roadmap docs override current proof surfaces.
+- Claiming organization-scale autonomy when the shipped wedge is bounded
+  software execution and review governance.
+- Hiding missing evidence behind `healthy`, `success`, or `green` labels.
+
+## Bottom Line
+
+The project is valuable if it keeps tightening the gap between AI-generated work
+and auditable organizational trust. The next phase should bias toward fewer,
+better-proofed surfaces: PR settlement, receipts, calibration, review gates,
+proof-carrying code, and cold-reviewable documentation.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,6 +6,7 @@ This index intentionally links to actively maintained docs with validated paths.
 
 ## Getting Started
 
+- [Cold Reviewer Guide](COLD_REVIEWER_GUIDE.md)
 - [Getting Started](guides/GETTING_STARTED.md)
 - [SDK Guide (Python)](SDK_GUIDE.md)
 - [CLI Reference (generated)](reference/CLI_REFERENCE.md)
@@ -13,6 +14,7 @@ This index intentionally links to actively maintained docs with validated paths.
 ## API
 
 - [API Reference](api/API_REFERENCE.md)
+- [Supported API Surface](api/SUPPORTED_SURFACE.md)
 - [API Endpoint Catalog](api/API_ENDPOINTS.md)
 - [API Examples](api/API_EXAMPLES.md)
 - [API Versioning](api/API_VERSIONING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,15 +4,19 @@ Welcome to Aragora's documentation. The `docs/` directory is the canonical
 source. The published site in `docs-site/` is synced from these files via
 `docs-site/scripts/sync-docs.js`.
 
-Aragora is the **control plane for multi-agent vetted decisionmaking across
-organizational knowledge and channels**.
+Aragora is an **auditable execution control plane for consequential
+AI-assisted work**. It uses multi-model review, receipts, provenance, and
+truthful gates so consequential work can be inspected instead of merely
+trusted.
 
 ## What Are You Trying To Do?
 
 | Goal | Document |
 |------|----------|
+| Review or audit the project quickly | [Cold Reviewer Guide](./COLD_REVIEWER_GUIDE.md) |
 | **Run your first debate in 5 minutes** | [Quickstart](./guides/QUICKSTART.md) |
 | Full onboarding guide | [Getting Started](./guides/GETTING_STARTED.md) |
+| Understand the supported API contract | [Supported API Surface](./api/SUPPORTED_SURFACE.md) |
 | See 20 runnable code examples | [API Cookbook](./guides/API_COOKBOOK.md) |
 | Build a Python integration | [SDK Guide](./SDK_GUIDE.md) |
 | Build a TypeScript integration | [TypeScript SDK](./guides/SDK_TYPESCRIPT.md) |

--- a/docs/api/SUPPORTED_SURFACE.md
+++ b/docs/api/SUPPORTED_SURFACE.md
@@ -1,0 +1,83 @@
+# Supported API Surface
+
+Last updated: 2026-04-24
+
+Aragora has a large generated API catalog because the platform includes debates,
+agents, memory, workflows, integrations, autonomy controls, and operational
+surfaces. That catalog is useful for discovery, but it is not a blanket promise
+that every route is equally stable.
+
+This document defines the contract a cold reviewer should use when judging API
+quality and maintainability.
+
+## Stability Tiers
+
+| Tier | Meaning | Change Policy |
+|------|---------|---------------|
+| Supported | Intended for external use and should remain source-compatible across patch releases | Breaking changes require migration notes and versioning |
+| Beta | Useful and documented, but still subject to shape changes | Breaking changes are allowed with release notes |
+| Internal | Used by Aragora operators, automations, or generated tools | No external stability promise |
+| Experimental | Research, roadmap, or proof-of-concept surface | May change or disappear without migration |
+
+## Supported Today
+
+These surfaces should meet the highest documentation and regression bar:
+
+- Core debate package install path: `pip install aragora-debate`.
+- Python SDK package: `aragora-sdk`.
+- TypeScript SDK package: `@aragora/sdk`.
+- GitHub PR review and settlement APIs documented in
+  [GitHub PR Review API](../integrations/GITHUB_PR_REVIEW.md).
+- Receipt-backed review, decision, and merge-readiness surfaces that are covered
+  by tests and canonical status docs.
+- Published OpenAPI reference as a discovery surface, with this document acting
+  as the stability boundary.
+
+## Beta / Productizing
+
+These surfaces are valuable but should be described as still hardening:
+
+- Autonomous execution and worker-contract control-plane APIs.
+- Benchmark truth and rescue-productization publication surfaces.
+- Decision Integrity Core slices such as executable claims, crux analysis,
+  coherence checks, and gardening passes.
+- Operator inbox and non-code action loops.
+
+## Internal Or Experimental
+
+These should not be sold as stable external contracts without a promotion pass:
+
+- Large generated route families that lack public docs, SDK coverage, or
+  explicit stability notes.
+- Provider-specific agent plumbing and local runner internals.
+- Broad DAG workbench and multi-host expansion routes that are not yet backed by
+  repeated green proof surfaces.
+- Research-oriented persona, ranking, and nomic-loop internals that are still
+  evolving.
+
+## Promotion Checklist
+
+An API moves into the supported tier only when it has:
+
+- A clear user story and owner-facing documentation.
+- Request and response examples.
+- Auth, permissions, and failure semantics.
+- At least one SDK or CLI path, or a documented reason why HTTP is the only
+  contract.
+- Focused tests that cover success, validation failure, and authorization or
+  admission failure where applicable.
+- A receipt, audit event, or provenance hook for consequential actions.
+- Versioning or migration notes for breaking changes.
+
+## Reviewer Guidance
+
+When inspecting a PR that adds API surface, ask three questions:
+
+1. Is this route part of the supported external contract, a beta surface, or an
+   internal helper?
+2. Does the documentation make that tier obvious to a new integrator?
+3. Does the implementation fail closed when evidence, authorization, or
+   validation is missing?
+
+If the answer is unclear, the API should remain beta or internal until the
+contract is explicit.

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -44,11 +44,12 @@ Status note: use `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW0
 
 Source of truth: [Next Steps (Canonical)](NEXT_STEPS_CANONICAL.md).
 
-- Do now: `BC-07..09`, `RS-11..12`
+- Do now: `CS-01..03`, observer truth, and benchmark publication freshness/completeness
+- Conditional/reopen only on fresh evidence: `BC-07..09`, `RS-11..12`
 - Delay: `TW-07..09`, `UDW-01..06`, `MCF-01..03`
 - Future decision-integrity planning: `DIC-13..22` is tracked but delayed until proof-first Foreman reliability is stable; these issues must not be added to `boss-ready` during the current tranche
 - Avoid in this tranche: `UDW-07..12`, `MCF-04..12`, `CS-04..12`, broad provider-surface expansion, heavy DAG workbench work that is not backed by live runtime truth
-- Queue rule: only **Do now** roadmap codes may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
+- Queue rule: only **Do now** roadmap codes, recurring proof-surface regressions, or freshly evidenced BC/RS regressions may be created or preserved as `boss-ready`; delayed-track issues may remain open, but restock and decomposition must keep them out of the live boss queue
 - Live boss-ready queue: no dedicated open trust-loop issue right now; `TW-01`, `TW-02`, and `TW-03` now publish through `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` and `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md`, and the recurring surfaces should keep the queue empty unless they expose a fresh bounded regression or repeated rescue class
 - `RS-07`, `BC-01`, `BC-02`, and `BC-03` are already on `main`; the live queue should not recycle them as active blockers unless a concrete regression appears
 

--- a/scripts/inspect_cold_review_surface.py
+++ b/scripts/inspect_cold_review_surface.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Inspect the public proof surface a cold reviewer sees first.
+
+This is intentionally dependency-free. It is a fast drift check for framing,
+reviewer entry points, API stability boundaries, and current execution truth.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HTTP_METHODS = {"delete", "get", "head", "options", "patch", "post", "put", "trace"}
+
+
+def read_text(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def count_openapi_operations(relative_path: str) -> tuple[int, int] | None:
+    path = ROOT / relative_path
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    paths = data.get("paths", {})
+    if not isinstance(paths, dict):
+        return None
+    operation_count = 0
+    for path_item in paths.values():
+        if not isinstance(path_item, dict):
+            continue
+        operation_count += sum(1 for method in path_item if method.lower() in HTTP_METHODS)
+    return len(paths), operation_count
+
+
+def main() -> int:
+    failures: list[str] = []
+    facts: list[str] = []
+
+    def require_file(relative_path: str) -> None:
+        if not (ROOT / relative_path).is_file():
+            failures.append(f"missing required file: {relative_path}")
+
+    def require_contains(relative_path: str, needle: str) -> None:
+        try:
+            content = read_text(relative_path)
+        except FileNotFoundError:
+            failures.append(f"cannot inspect missing file: {relative_path}")
+            return
+        if needle not in content:
+            failures.append(f"{relative_path} must contain: {needle!r}")
+
+    def require_not_contains(relative_path: str, needle: str) -> None:
+        try:
+            content = read_text(relative_path)
+        except FileNotFoundError:
+            failures.append(f"cannot inspect missing file: {relative_path}")
+            return
+        if needle in content:
+            failures.append(f"{relative_path} still contains stale text: {needle!r}")
+
+    required_files = [
+        "README.md",
+        "docs/README.md",
+        "docs/COLD_REVIEWER_GUIDE.md",
+        "docs/api/SUPPORTED_SURFACE.md",
+        "docs/CANONICAL_GOALS.md",
+        "docs/THESIS.md",
+        "docs/status/NEXT_STEPS_CANONICAL.md",
+        "docs/status/ACTIVE_EXECUTION_ISSUES.md",
+        "docs/status/B0_BENCHMARK_TRUTH_STATUS.md",
+        "docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md",
+        "docs-site/docusaurus.config.js",
+        "docs-site/src/pages/index.md",
+        "docs-site/docs/contributing/cold-reviewer-guide.md",
+        "docs-site/docs/api/supported-surface.md",
+    ]
+    for relative_path in required_files:
+        require_file(relative_path)
+
+    require_contains("README.md", "auditable execution control plane")
+    require_contains("README.md", "docs/COLD_REVIEWER_GUIDE.md")
+    require_not_contains("README.md", "github.com/an0mium/aragora")
+
+    require_contains(
+        "docs/README.md",
+        "auditable execution control plane for consequential",
+    )
+    require_contains("docs/README.md", "Cold Reviewer Guide")
+    require_contains("docs/README.md", "Supported API Surface")
+
+    require_contains("docs/COLD_REVIEWER_GUIDE.md", "What Aragora Is Good For Today")
+    require_contains("docs/COLD_REVIEWER_GUIDE.md", "What Is Still Aspirational")
+    require_contains("docs/COLD_REVIEWER_GUIDE.md", "Fast Verification")
+    require_contains("docs/api/SUPPORTED_SURFACE.md", "Stability Tiers")
+    require_contains("docs/api/SUPPORTED_SURFACE.md", "Promotion Checklist")
+
+    require_contains("docs/status/ACTIVE_EXECUTION_ISSUES.md", "Do now: `CS-01..03`")
+    require_contains(
+        "docs/status/ACTIVE_EXECUTION_ISSUES.md",
+        "Conditional/reopen only on fresh evidence",
+    )
+    require_not_contains(
+        "docs/status/ACTIVE_EXECUTION_ISSUES.md",
+        "Do now: `BC-07..09`, `RS-11..12`",
+    )
+
+    require_contains(
+        "docs-site/docusaurus.config.js",
+        "Auditable execution control plane for consequential AI-assisted work",
+    )
+    require_contains("docs-site/docusaurus.config.js", "github.com/synaptent/aragora")
+    require_not_contains("docs-site/docusaurus.config.js", "github.com/aragora/aragora")
+    require_not_contains("docs-site/docusaurus.config.js", "v2_4_release")
+    require_not_contains("docs-site/docusaurus.config.js", "Aragora v2.4")
+
+    require_contains("docs-site/src/pages/index.md", "Cold Reviewer Guide")
+    require_contains("docs-site/src/pages/index.md", "Supported API Surface")
+    require_contains("docs-site/src/pages/index.md", "Current Boundary")
+
+    for openapi_path in ("docs/api/openapi.json", "docs/openapi.json"):
+        summary = count_openapi_operations(openapi_path)
+        if summary is None:
+            continue
+        path_count, operation_count = summary
+        facts.append(f"{openapi_path}: {path_count} paths, {operation_count} operations")
+        if path_count < 10 or operation_count < 10:
+            failures.append(f"{openapi_path} looks unexpectedly small")
+
+    print("Cold-review surface inspection")
+    print("=" * 30)
+    for fact in facts:
+        print(f"- {fact}")
+
+    if failures:
+        print("\nFailures:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("\nOK: public proof surface is present and internally aligned.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a cold-review proof surface so a third-party reviewer can quickly understand what Aragora is good for today, what is aspirational, and which API surfaces are supported versus beta/internal/experimental.

## Changes

- Add `docs/COLD_REVIEWER_GUIDE.md` and docs-site mirror.
- Add `docs/api/SUPPORTED_SURFACE.md` and docs-site mirror.
- Refresh README/docs-site framing around Aragora as an auditable execution control plane.
- Remove stale public GitHub owner links from the touched entry points.
- Replace the stale v2.4 docs-site announcement with the proof-first RC proof-surface link.
- Reconcile `ACTIVE_EXECUTION_ISSUES.md` with `NEXT_STEPS_CANONICAL.md` for current do-now work.
- Add `scripts/inspect_cold_review_surface.py` as a dependency-free drift check.

## Validation

- `python scripts/inspect_cold_review_surface.py`
- `python scripts/check_version_alignment.py`
- `ruff format --check scripts/inspect_cold_review_surface.py`
- `ruff check scripts/inspect_cold_review_surface.py`
- `git diff --check`
- `npm run build --prefix docs-site` succeeds; Docusaurus still warns on pre-existing broken links in older mirrored docs, but no new cold-review/homepage links are in the broken-link list.
- `python scripts/validate_doc_links.py` now reports only 3 pre-existing archive broken links after fixing the new root-doc links.
