### PR TITLE
feat(review): surface findings_severity_counts in Mode 3 briefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 _Changes landing on `main` after the v2.9.0-rc.1 tag will be collected here until promotion to v2.9.0 stable._
 
+### Added
+- **Mode 3 brief severity counts (#6505):** `ReviewBrief` now carries `findings_severity_counts` — aggregate `{high, medium, low}` counts derived from each slot's top findings — and surfaces it in the stored brief JSON. Operators can now distinguish "1 high-severity blocker" from "5 low-severity editorial comments" without reading every finding. Legacy callers that omit the new `build_brief` kwarg get an empty map rather than a crash.
+
 
 ## [v2.9.0-rc.1] - 2026-04-24
 

--- a/aragora/brief_engine/protocol.py
+++ b/aragora/brief_engine/protocol.py
@@ -620,6 +620,7 @@ def run_brief_protocol_b(
     # own SYNTHESIZER-role vote as an extra, which the builder permits.
     synthesizer_vote = _synthesizer_panel_vote(synthesizer_slot, synthesis)
     votes_for_brief = panel_votes + (synthesizer_vote,)
+    severity_counts = _severity_counts_from_slot_findings(findings_by_slot)
     brief = build_brief(
         votes=votes_for_brief,
         pr_number=input.binding.pr_number,
@@ -635,6 +636,7 @@ def run_brief_protocol_b(
         total_wall_clock_ms=sum(resp.latency_ms for resp in findings_by_slot.values())
         + sum(resp.latency_ms for resp in critiques_by_slot.values())
         + synthesis.latency_ms,
+        findings_severity_counts=severity_counts,
     )
 
     # packet-facing projection
@@ -780,6 +782,29 @@ def _position_to_recommendation(position: DissentPosition) -> Recommendation:
     if position is DissentPosition.REQUEST_CHANGES:
         return Recommendation.REPAIR_FIRST
     return Recommendation.NEEDS_HUMAN_ATTENTION
+
+
+_VALID_SEVERITIES: tuple[str, ...] = ("high", "medium", "low")
+
+
+def _severity_counts_from_slot_findings(
+    findings_by_slot: Mapping[str, SlotFindingsResponse],
+) -> dict[str, int]:
+    """Aggregate severity counts across every slot's top_findings.
+
+    Returned dict always has the three canonical severity keys (``high``,
+    ``medium``, ``low``) so downstream consumers can index without a
+    default-get dance. Unknown severity strings are silently dropped
+    rather than counted — the input is LLM-parsed and we never want
+    ``{"high": 0, "medium": 0, "low": 0, "???": 3}`` polluting the UI.
+    """
+    counts: dict[str, int] = {sev: 0 for sev in _VALID_SEVERITIES}
+    for resp in findings_by_slot.values():
+        for finding in resp.top_findings:
+            sev = (finding.severity or "").strip().lower()
+            if sev in counts:
+                counts[sev] += 1
+    return counts
 
 
 def _aggregate_top_findings(

--- a/aragora/review/builder.py
+++ b/aragora/review/builder.py
@@ -88,6 +88,7 @@ def build_brief(
     output_roles: tuple[ReviewRole, ...] | None = None,
     total_cost_usd: float = 0.0,
     total_wall_clock_ms: int = 0,
+    findings_severity_counts: Mapping[str, int] | None = None,
 ) -> ReviewBrief:
     """Build a deterministic ReviewBrief from panel votes.
 
@@ -122,6 +123,7 @@ def build_brief(
     disagreement_score = _disagreement_score(votes_tuple)
     role_findings = tuple(v.finding for v in votes_tuple)
     agent_roster = tuple(v.finding.agent for v in votes_tuple)
+    severity_counts = dict(findings_severity_counts) if findings_severity_counts else {}
 
     def _make(packet_sha: str) -> ReviewBrief:
         return ReviewBrief(
@@ -141,6 +143,7 @@ def build_brief(
             total_wall_clock_ms=total_wall_clock_ms,
             agent_roster=agent_roster,
             generated_at=generated_at,
+            findings_severity_counts=severity_counts,
         )
 
     return _make(compute_packet_sha(_make("")))

--- a/aragora/review/protocol.py
+++ b/aragora/review/protocol.py
@@ -21,10 +21,10 @@ trusting prose.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import timezone
 from enum import Enum
-from typing import Any
+from typing import Any, Mapping
 
 UTC = timezone.utc
 
@@ -188,6 +188,11 @@ class ReviewBrief:
     generated_at: str  # ISO-8601 with timezone
     advisory_only: bool = True
     settlement_note: str = ADVISORY_NOTE
+    # Aggregate severity counts across the panel's top findings. Keys are
+    # "high" | "medium" | "low"; values are ints. Empty when no structured
+    # severity signal was supplied (legacy/degraded briefs). Exposed at the
+    # brief level so operators can triage without reading every finding.
+    findings_severity_counts: Mapping[str, int] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
@@ -195,6 +200,7 @@ class ReviewBrief:
         d["role_findings"] = [f.to_dict() for f in self.role_findings]
         d["dissent"] = [v.to_dict() for v in self.dissent]
         d["agent_roster"] = list(self.agent_roster)
+        d["findings_severity_counts"] = dict(self.findings_severity_counts)
         return d
 
 

--- a/tests/brief_engine/test_severity_surfacing.py
+++ b/tests/brief_engine/test_severity_surfacing.py
@@ -1,0 +1,170 @@
+"""Tests for the severity-count surfacing (#6505 fix #1).
+
+The brief-engine pipeline computes severity info on every ``top_finding``
+but drops it when the brief is persisted as JSON. This module pins the
+behavior introduced to expose aggregate counts at the brief level so
+operators can triage without reading every finding.
+
+Scope is narrow on purpose: the aggregator, the degraded-input
+behavior, and the pass-through from ``build_brief``. The weighted-vote
+policy is unchanged in this PR and keeps its own tests in
+``tests/review/test_builder.py``.
+"""
+
+from __future__ import annotations
+
+from aragora.brief_engine.protocol import (
+    SlotFindingsResponse,
+    _severity_counts_from_slot_findings,
+)
+from aragora.review.builder import PanelVote, build_brief
+from aragora.review.protocol import (
+    DissentPosition,
+    Recommendation,
+    ReviewRole,
+    RoleFinding,
+    SynthesisPolicy,
+)
+from aragora.swarm.pr_review_protocol import PRReviewFinding
+
+
+def _finding(fid: str, severity: str) -> PRReviewFinding:
+    return PRReviewFinding(
+        finding_id=fid,
+        category="correctness",
+        severity=severity,
+        summary="test finding",
+        evidence=[],
+    )
+
+
+def _slot_response(
+    slot_id: str,
+    top_findings: tuple[PRReviewFinding, ...],
+) -> SlotFindingsResponse:
+    return SlotFindingsResponse(
+        slot_id=slot_id,
+        provider="mock",
+        model="mock-model",
+        position=DissentPosition.REQUEST_CHANGES,
+        confidence=0.8,
+        summary="s",
+        top_findings=top_findings,
+        contested_finding_ids=(),
+        reason="r",
+    )
+
+
+class TestSeverityCountsAggregator:
+    def test_empty_inputs_return_zero_counts(self) -> None:
+        assert _severity_counts_from_slot_findings({}) == {
+            "high": 0,
+            "medium": 0,
+            "low": 0,
+        }
+
+    def test_counts_aggregated_across_slots(self) -> None:
+        findings_by_slot = {
+            "s1": _slot_response(
+                "s1",
+                top_findings=(_finding("f1", "high"), _finding("f2", "low")),
+            ),
+            "s2": _slot_response(
+                "s2",
+                top_findings=(_finding("f3", "medium"), _finding("f4", "high")),
+            ),
+        }
+        assert _severity_counts_from_slot_findings(findings_by_slot) == {
+            "high": 2,
+            "medium": 1,
+            "low": 1,
+        }
+
+    def test_unknown_severity_strings_are_dropped_not_counted(self) -> None:
+        # The severity field is LLM-parsed; defensive coercion drops
+        # unknowns rather than spraying junk keys into the counts dict.
+        findings_by_slot = {
+            "s1": _slot_response(
+                "s1",
+                top_findings=(
+                    _finding("f1", "critical"),
+                    _finding("f2", ""),
+                    _finding("f3", "MEDIUM"),
+                ),
+            ),
+        }
+        counts = _severity_counts_from_slot_findings(findings_by_slot)
+        assert counts == {"high": 0, "medium": 1, "low": 0}
+        assert "critical" not in counts
+
+    def test_case_insensitive_severity_matching(self) -> None:
+        findings_by_slot = {
+            "s1": _slot_response(
+                "s1",
+                top_findings=(
+                    _finding("f1", "HIGH"),
+                    _finding("f2", " Medium "),
+                    _finding("f3", "low"),
+                ),
+            ),
+        }
+        assert _severity_counts_from_slot_findings(findings_by_slot) == {
+            "high": 1,
+            "medium": 1,
+            "low": 1,
+        }
+
+
+class TestBuildBriefSeverityPassThrough:
+    def _votes(self) -> tuple[PanelVote, ...]:
+        finding = RoleFinding(
+            role=ReviewRole.LOGIC,
+            agent="slot-a:claude",
+            model="mock",
+            confidence=0.9,
+            finding_text="ok",
+        )
+        return (
+            PanelVote(
+                finding=finding,
+                position=DissentPosition.APPROVE,
+                reason="fine",
+            ),
+        )
+
+    def test_build_brief_passes_severity_counts_through(self) -> None:
+        counts = {"high": 1, "medium": 2, "low": 0}
+        brief = build_brief(
+            votes=self._votes(),
+            pr_number=1,
+            repo="o/r",
+            head_sha="head",
+            base_sha="base",
+            top_line="t",
+            validation_summary="v",
+            generated_at="2026-04-24T00:00:00+00:00",
+            synthesis_policy=SynthesisPolicy.MAJORITY,
+            findings_severity_counts=counts,
+        )
+        assert brief.findings_severity_counts == counts
+        assert brief.to_dict()["findings_severity_counts"] == counts
+        # Recommendation path is unchanged by this field — confirm.
+        assert brief.recommendation is Recommendation.APPROVE_CANDIDATE
+
+    def test_build_brief_omits_severity_counts_defaults_to_empty(self) -> None:
+        # Backwards compatibility: callers that don't supply the new
+        # param (legacy, degraded, partial test fixtures) must still
+        # produce a valid brief with an empty severity map.
+        brief = build_brief(
+            votes=self._votes(),
+            pr_number=1,
+            repo="o/r",
+            head_sha="head",
+            base_sha="base",
+            top_line="t",
+            validation_summary="v",
+            generated_at="2026-04-24T00:00:00+00:00",
+            synthesis_policy=SynthesisPolicy.MAJORITY,
+        )
+        assert brief.findings_severity_counts == {}
+        assert brief.to_dict()["findings_severity_counts"] == {}

--- a/tests/review/test_protocol.py
+++ b/tests/review/test_protocol.py
@@ -168,6 +168,22 @@ class TestReviewBrief:
         assert d["overall_confidence"] == 0.72
         assert d["disagreement_score"] == 0.41
 
+    def test_findings_severity_counts_defaults_to_empty(self) -> None:
+        # Briefs built without structured severity input (legacy callers,
+        # degraded paths) must not crash; the field carries an empty dict.
+        brief = self._brief()
+        assert brief.findings_severity_counts == {}
+        assert brief.to_dict()["findings_severity_counts"] == {}
+
+    def test_findings_severity_counts_round_trip(self) -> None:
+        # First-class operator triage signal per #6505: "1 high finding"
+        # and "5 low-severity editorial comments" must be mechanically
+        # distinguishable without reading every finding's prose.
+        counts = {"high": 1, "medium": 2, "low": 5}
+        brief = self._brief(findings_severity_counts=counts)
+        assert brief.findings_severity_counts == counts
+        assert brief.to_dict()["findings_severity_counts"] == counts
+
     def test_advisory_only_default_is_true(self) -> None:
         # SAFETY INVARIANT: a brief is never an approval.
         brief = self._brief()


### PR DESCRIPTION
## Summary

Adds `findings_severity_counts` — an aggregate `{high, medium, low}` map — to every Mode 3 `ReviewBrief` and surfaces it in the persisted JSON.

Addresses fix #1 of the Mode 3 rubric calibration epic (#6505). The panel already computes severity on every `top_finding`, but the data was dropped during brief persistence. This PR plumbs it through without changing any verdict behavior.

## What changes

- `ReviewBrief`: new optional field `findings_severity_counts: Mapping[str, int]`, empty dict by default
- `build_brief`: new kwarg passes counts through; absent callers get an empty map (backwards-compat)
- `brief_engine.protocol`: new `_severity_counts_from_slot_findings` aggregator. Unknown severity strings dropped; case-insensitive match
- JSON schema: new `findings_severity_counts` key appears on future briefs (empty dict on degraded paths)

## Why this matters

From the #6505 investigation: the 15-brief rc.1 calibration sample returned `repair_first` on 100 % of post-merge PRs. Spot-checks showed the panel is catching real things — but operators have no mechanical way to sort "1 high-severity blocker" from "5 low-severity editorial comments" without reading every finding.

Surfacing the aggregate counts is the cheapest triage unlock, prerequisite for the follow-on verdict-class and severity-gated-rule PRs.

## What's NOT in this PR (tracked under #6505)

- `approve_with_followups` verdict class
- Severity-gated verdict rule
- Advocate lens

## Test plan

- [x] `tests/brief_engine/test_severity_surfacing.py` — new file, covers aggregator (empty input, multi-slot sum, unknown severity drop, case variation) and `build_brief` pass-through
- [x] `tests/review/test_protocol.py` — 2 new tests for round-trip through `to_dict()`
- [x] Full `tests/review/`, `tests/pdb/`, `tests/brief_engine/` — 511 passed, 1 pre-existing env-dependent failure reproduces on `origin/main` (unrelated to this PR: `test_provider_slot_resolver_explains_unavailable_slot` leaks `XAI_API_KEY` from dev env)

Refs #6505, #6492

🤖 Generated with [Claude Code](https://claude.com/claude-code)