### PR TITLE
ci(docs): run cold-review surface inspector

### DIFF
--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -6,8 +6,10 @@ on:
     paths:
       - "docs/**"
       - "README.md"
+      - "docs-site/**"
       - "Makefile"
       - "scripts/check_docs_consistency.py"
+      - "scripts/inspect_cold_review_surface.py"
       - "tests/scripts/test_check_docs_consistency.py"
       - ".github/workflows/docs-consistency.yml"
   pull_request:
@@ -15,8 +17,10 @@ on:
     paths:
       - "docs/**"
       - "README.md"
+      - "docs-site/**"
       - "Makefile"
       - "scripts/check_docs_consistency.py"
+      - "scripts/inspect_cold_review_surface.py"
       - "tests/scripts/test_check_docs_consistency.py"
       - ".github/workflows/docs-consistency.yml"
 
@@ -40,3 +44,6 @@ jobs:
 
       - name: Run docs consistency lint
         run: python3 scripts/check_docs_consistency.py
+
+      - name: Inspect cold-review proof surface
+        run: python3 scripts/inspect_cold_review_surface.py


### PR DESCRIPTION
## Summary

Wires the new cold-review proof-surface inspector into the Docs Consistency workflow so docs-site framing, reviewer entry points, supported API boundary docs, queue-truth alignment, and stale announcement strings stay protected in CI.

## Changes

- Trigger Docs Consistency when `docs-site/**` or `scripts/inspect_cold_review_surface.py` changes.
- Run `python3 scripts/inspect_cold_review_surface.py` after the existing docs consistency lint.

## Validation

- `python3 scripts/check_docs_consistency.py`
- `python3 scripts/inspect_cold_review_surface.py`
- `git diff --check`
