### PR TITLE
feat(review): add APPROVE_WITH_FOLLOWUPS verdict + severity gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ _Changes landing on `main` after the v2.9.0-rc.1 tag will be collected here unti
 
 ### Added
 - **Mode 3 brief severity counts (#6505):** `ReviewBrief` now carries `findings_severity_counts` — aggregate `{high, medium, low}` counts derived from each slot's top findings — and surfaces it in the stored brief JSON. Operators can now distinguish "1 high-severity blocker" from "5 low-severity editorial comments" without reading every finding. Legacy callers that omit the new `build_brief` kwarg get an empty map rather than a crash.
+- **`Recommendation.APPROVE_WITH_FOLLOWUPS` verdict class (#6505):** Fourth brief recommendation for the "real findings but none are blockers" case. `ReviewBrief.recommendation` can now emit `approve_with_followups` (string value); downstream triage classifies it in the approve family.
+
+### Changed
+- **Mode 3 verdict severity gate (#6505):** `REPAIR_FIRST` is now downgraded to `APPROVE_WITH_FOLLOWUPS` when the aggregated severity map reports zero `high` findings. Fixes the calibration bias identified in `docs/status/2026-04-24-mode3-rc1-calibration.md` where 8 skeptical lenses all looking for problems always produced `REPAIR_FIRST` regardless of severity. Legacy callers without severity data preserve the old three-class behavior. `APPROVE_CANDIDATE` and `NEEDS_HUMAN_ATTENTION` paths are untouched.
 
 
 ## [v2.9.0-rc.1] - 2026-04-24

--- a/aragora/brief_engine/protocol.py
+++ b/aragora/brief_engine/protocol.py
@@ -96,6 +96,7 @@ STATUS_FAILED_CLOSED = "failed_closed"
 
 _RECOMMENDATION_CLASS_BY_DECISION: Mapping[Recommendation, str] = {
     Recommendation.APPROVE_CANDIDATE: "approve_candidate",
+    Recommendation.APPROVE_WITH_FOLLOWUPS: "approve_with_followups",
     Recommendation.REPAIR_FIRST: "repair_first",
     Recommendation.NEEDS_HUMAN_ATTENTION: "needs_human_attention",
 }

--- a/aragora/review/builder.py
+++ b/aragora/review/builder.py
@@ -117,13 +117,17 @@ def build_brief(
     if output_roles is not None:
         _validate_output_role_coverage(votes_tuple, output_roles)
 
-    recommendation = _resolve_recommendation(votes_tuple, synthesis_policy)
+    recommendation = _resolve_recommendation(
+        votes_tuple,
+        synthesis_policy,
+        findings_severity_counts=findings_severity_counts,
+    )
     dissent = _build_dissent(votes_tuple, recommendation)
     overall_confidence = _aggregate_confidence(votes_tuple)
     disagreement_score = _disagreement_score(votes_tuple)
     role_findings = tuple(v.finding for v in votes_tuple)
     agent_roster = tuple(v.finding.agent for v in votes_tuple)
-    severity_counts = dict(findings_severity_counts) if findings_severity_counts else {}
+    severity_counts = dict(findings_severity_counts) if findings_severity_counts is not None else {}
 
     def _make(packet_sha: str) -> ReviewBrief:
         return ReviewBrief(
@@ -172,6 +176,16 @@ def compute_packet_sha(brief: ReviewBrief) -> str:
 def _resolve_recommendation(
     votes: tuple[PanelVote, ...],
     policy: SynthesisPolicy,
+    *,
+    findings_severity_counts: Mapping[str, int] | None = None,
+) -> Recommendation:
+    primary = _primary_verdict(votes, policy)
+    return _apply_severity_gate(primary, findings_severity_counts)
+
+
+def _primary_verdict(
+    votes: tuple[PanelVote, ...],
+    policy: SynthesisPolicy,
 ) -> Recommendation:
     if policy is SynthesisPolicy.MAJORITY:
         return _majority(votes)
@@ -182,6 +196,44 @@ def _resolve_recommendation(
     if policy is SynthesisPolicy.UNANIMOUS_OR_ESCALATE:
         return _unanimous(votes)
     raise ValueError(f"unsupported synthesis policy: {policy!r}")
+
+
+def _apply_severity_gate(
+    primary: Recommendation,
+    findings_severity_counts: Mapping[str, int] | None,
+) -> Recommendation:
+    """Downgrade ``REPAIR_FIRST`` to ``APPROVE_WITH_FOLLOWUPS`` when no high.
+
+    Added under #6505 to address the calibration bias where 8 skeptical
+    lenses all looking for problems produce ``REPAIR_FIRST`` on every
+    non-trivial diff. The gate only touches ``REPAIR_FIRST``; every
+    other verdict passes through unchanged.
+
+    Semantics:
+
+    - ``None`` (legacy caller, no aggregator run) → preserve ``REPAIR_FIRST``
+      so briefs built without severity data keep the old three-class
+      behavior.
+    - Dict missing the ``high`` key (malformed input) → preserve
+      ``REPAIR_FIRST``; do not guess.
+    - ``high`` key present and value > 0 → at least one slot flagged a
+      hard blocker; preserve ``REPAIR_FIRST``.
+    - ``high`` key present and value == 0 → real findings exist but none
+      are blockers; downgrade to ``APPROVE_WITH_FOLLOWUPS``.
+
+    The gate currently operates on the total high-severity count across
+    all lenses, not the narrower "high from a CORE lens" rule proposed
+    in the epic. That refinement is a follow-up; restricting to core
+    lenses needs a per-lens count field, not yet plumbed.
+    """
+    if primary is not Recommendation.REPAIR_FIRST:
+        return primary
+    if findings_severity_counts is None:
+        return primary
+    high = findings_severity_counts.get("high")
+    if high is None or high > 0:
+        return primary
+    return Recommendation.APPROVE_WITH_FOLLOWUPS
 
 
 def _majority(votes: tuple[PanelVote, ...]) -> Recommendation:

--- a/aragora/review/protocol.py
+++ b/aragora/review/protocol.py
@@ -51,12 +51,22 @@ class ReviewRole(str, Enum):
 class Recommendation(str, Enum):
     """Top-line recommendation classes a brief can produce.
 
-    Same three classes used by ``aragora.cli.commands.review_queue.ReviewPacket``
-    so downstream consumers (queue, UI, ledger) can treat brief and packet
-    outputs uniformly when both are present.
+    Four classes, originally three. The ``APPROVE_WITH_FOLLOWUPS`` class
+    was added under #6505 to separate "the panel surfaced real issues
+    but none are hard blockers" from "the panel found a real blocker."
+    The verdict rule downgrades ``REPAIR_FIRST`` to
+    ``APPROVE_WITH_FOLLOWUPS`` when no slot reports a ``high``-severity
+    finding, so the sharp-end class (``REPAIR_FIRST``) is reserved for
+    cases where at least one lens flags a high-severity issue.
+
+    Same class strings are used by
+    ``aragora.cli.commands.review_queue.ReviewPacket`` so downstream
+    consumers (queue, UI, ledger) can treat brief and packet outputs
+    uniformly when both are present.
     """
 
     APPROVE_CANDIDATE = "approve_candidate"
+    APPROVE_WITH_FOLLOWUPS = "approve_with_followups"
     NEEDS_HUMAN_ATTENTION = "needs_human_attention"
     REPAIR_FIRST = "repair_first"
 

--- a/aragora/swarm/pr_review_protocol.py
+++ b/aragora/swarm/pr_review_protocol.py
@@ -65,6 +65,7 @@ EXECUTED_PROTOCOL_STATUS = "heterogeneous_ensemble_v1"
 FALLBACK_PROTOCOL_STATUS = "metadata_heuristic_fallback"
 
 RECOMMEND_APPROVE = "approve_candidate"
+RECOMMEND_APPROVE_WITH_FOLLOWUPS = "approve_with_followups"
 RECOMMEND_ATTENTION = "needs_human_attention"
 RECOMMEND_REPAIR = "repair_first"
 
@@ -901,7 +902,7 @@ class PRReviewProtocol:
             '  "provider": "set to any non-empty placeholder; caller will overwrite",\n'
             '  "lens": "set to any non-empty placeholder; caller will overwrite",\n'
             '  "family": "set to any non-empty placeholder; caller will overwrite",\n'
-            '  "recommendation_class": "approve_candidate | needs_human_attention | repair_first",\n'
+            '  "recommendation_class": "approve_candidate | approve_with_followups | needs_human_attention | repair_first",\n'
             '  "confidence": 0.0,\n'
             '  "summary": "1-2 sentence reviewer summary",\n'
             '  "top_findings": [\n'

--- a/aragora/triage/event_source.py
+++ b/aragora/triage/event_source.py
@@ -95,7 +95,14 @@ _ESCALATION_RECOMMENDATIONS = frozenset(
 # ``defer`` is neither an agreement nor an override — it's a "come back
 # later" signal. We record it as non-override.
 _APPROVE_RECS = frozenset(
-    {"approve", "approve_candidate", "approve_now", "ready_now", "safe_to_merge"}
+    {
+        "approve",
+        "approve_candidate",
+        "approve_with_followups",
+        "approve_now",
+        "ready_now",
+        "safe_to_merge",
+    }
 )
 _REJECT_RECS = frozenset(
     {"reject", "request_changes", "needs_human_attention", "needs_human_review", "block"}

--- a/aragora/triage/metrics.py
+++ b/aragora/triage/metrics.py
@@ -437,6 +437,7 @@ _APPROVE_RECOMMENDATIONS = frozenset(
     {
         "approve",
         "approve_candidate",
+        "approve_with_followups",
         "approve_now",
         "ready_now",
         "safe_to_merge",

--- a/tests/review/test_builder.py
+++ b/tests/review/test_builder.py
@@ -64,6 +64,7 @@ def _build(
     policy: SynthesisPolicy = SynthesisPolicy.MAJORITY,
     head_sha: str = "deadbeef",
     base_sha: str = "feedface",
+    findings_severity_counts: dict[str, int] | None = None,
 ) -> ReviewBrief:
     return build_brief(
         votes=votes,
@@ -75,6 +76,7 @@ def _build(
         validation_summary="checks green",
         generated_at="2026-04-20T12:00:00+00:00",
         synthesis_policy=policy,
+        findings_severity_counts=findings_severity_counts,
     )
 
 
@@ -615,3 +617,87 @@ class TestConfidenceClamping:
         ]
         brief = _build(votes)
         assert brief.overall_confidence == pytest.approx(0.6)
+
+
+# --- Severity-gated verdict (#6505) --------------------------------------
+
+
+class TestSeverityGate:
+    """Gate downgrades REPAIR_FIRST → APPROVE_WITH_FOLLOWUPS when no high findings.
+
+    Core behavioral fix from the Mode 3 rubric calibration epic. The
+    primary verdict logic is unchanged; only the specific
+    ``REPAIR_FIRST`` → ``APPROVE_WITH_FOLLOWUPS`` downgrade is added.
+    """
+
+    def _request_changes_votes(self) -> list[PanelVote]:
+        # Majority request_changes → primary verdict is REPAIR_FIRST.
+        return [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.REQUEST_CHANGES),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.REQUEST_CHANGES),
+            _vote(
+                role=ReviewRole.MAINTAINABILITY,
+                agent="a3",
+                position=DissentPosition.REQUEST_CHANGES,
+            ),
+        ]
+
+    def test_no_high_severity_downgrades_to_approve_with_followups(self) -> None:
+        votes = self._request_changes_votes()
+        brief = _build(
+            votes,
+            findings_severity_counts={"high": 0, "medium": 2, "low": 5},
+        )
+        assert brief.recommendation is Recommendation.APPROVE_WITH_FOLLOWUPS
+
+    def test_high_severity_preserves_repair_first(self) -> None:
+        votes = self._request_changes_votes()
+        brief = _build(
+            votes,
+            findings_severity_counts={"high": 1, "medium": 0, "low": 0},
+        )
+        assert brief.recommendation is Recommendation.REPAIR_FIRST
+
+    def test_legacy_caller_without_severity_preserves_repair_first(self) -> None:
+        # Backwards compatibility: briefs built without severity counts
+        # (legacy path, degraded runs, older callers) must keep the old
+        # three-class behavior.
+        votes = self._request_changes_votes()
+        brief = _build(votes)  # no findings_severity_counts passed
+        assert brief.recommendation is Recommendation.REPAIR_FIRST
+
+    def test_malformed_severity_map_missing_high_key_preserves_repair_first(self) -> None:
+        # Defensive: if upstream ever emits a counts dict without the
+        # canonical key, do not guess. Preserve the conservative verdict.
+        votes = self._request_changes_votes()
+        brief = _build(
+            votes,
+            findings_severity_counts={"medium": 3, "low": 1},
+        )
+        assert brief.recommendation is Recommendation.REPAIR_FIRST
+
+    def test_approve_primary_unchanged_by_gate(self) -> None:
+        # The gate only ever fires on REPAIR_FIRST. APPROVE_CANDIDATE
+        # cannot be downgraded (and should not be). Confirm regardless
+        # of severity input.
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.APPROVE),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.APPROVE),
+        ]
+        for counts in (None, {"high": 0, "medium": 0, "low": 0}, {"high": 5}):
+            brief = _build(votes, findings_severity_counts=counts)
+            assert brief.recommendation is Recommendation.APPROVE_CANDIDATE
+
+    def test_defer_primary_unchanged_by_gate(self) -> None:
+        # DEFER → NEEDS_HUMAN_ATTENTION is never downgraded; operator
+        # attention is a signal in its own right, not a symptom of
+        # finding severity.
+        votes = [
+            _vote(role=ReviewRole.LOGIC, agent="a1", position=DissentPosition.DEFER),
+            _vote(role=ReviewRole.SECURITY, agent="a2", position=DissentPosition.DEFER),
+        ]
+        brief = _build(
+            votes,
+            findings_severity_counts={"high": 0, "medium": 0, "low": 0},
+        )
+        assert brief.recommendation is Recommendation.NEEDS_HUMAN_ATTENTION

--- a/tests/review/test_protocol.py
+++ b/tests/review/test_protocol.py
@@ -458,10 +458,19 @@ class TestContractCoherence:
         # ReviewBrief.recommendation values must match ReviewPacket
         # machine_recommendation values, since downstream consumers (queue,
         # UI, ledger) may receive either output kind.
-        from aragora.cli.commands.review_queue import ReviewPacket
+        from aragora.cli.commands.review_queue import ReviewPacket  # noqa: F401
 
         # Build a minimal ReviewPacket and confirm its machine_recommendation
         # field accepts the same strings ReviewBrief.recommendation produces.
-        packet_recommendations = {"approve_candidate", "needs_human_attention", "repair_first"}
+        # ``approve_with_followups`` was added under #6505; the CLI
+        # heuristic path still emits only the three classic strings, but
+        # the downstream type must know about all four so brief-driven
+        # consumers can render the extra class.
+        packet_recommendations = {
+            "approve_candidate",
+            "approve_with_followups",
+            "needs_human_attention",
+            "repair_first",
+        }
         brief_recommendations = {r.value for r in Recommendation}
         assert packet_recommendations == brief_recommendations


### PR DESCRIPTION
## Summary

Implements fix #2 of the Mode 3 rubric-calibration epic (#6505). Extends the `Recommendation` enum with `APPROVE_WITH_FOLLOWUPS` and gates the `REPAIR_FIRST` path on the aggregated high-severity count.

**Depends on #6506** (severity-counts surfacing). That PR adds the data this one consumes.

## Root cause (from #6505 investigation)

The rc.1 calibration sample returned `repair_first` on 15/15 merged PRs. Root cause: the panel runs 8 skeptical lenses explicitly asked to find problems; with weighted voting, at least one always finds something plausible. The 3-class verdict then flattens "real but non-blocking" findings into the same bucket as "hard blockers."

## Fix

- **New enum class:** `Recommendation.APPROVE_WITH_FOLLOWUPS` (string: `approve_with_followups`)
- **New rule** in `_resolve_recommendation`:
  - Primary verdict is not `REPAIR_FIRST` → unchanged
  - `findings_severity_counts` is `None` (legacy caller) → unchanged
  - `"high"` key missing from map (malformed) → unchanged
  - `high > 0` → unchanged (real blocker)
  - `high == 0` → downgrade to `APPROVE_WITH_FOLLOWUPS`
- **Triage classifies** `APPROVE_WITH_FOLLOWUPS` in the approve family
- **Reviewer prompt contract** lists the new class as a valid `recommendation_class` value

`APPROVE_CANDIDATE` and `NEEDS_HUMAN_ATTENTION` paths never touched.

## What's NOT in this PR (still under #6505)

- Advocate-lens slot (fix #3 — adds a 9th lens that argues FOR the PR)
- CORE-only high-severity refinement (current gate counts high across all lenses)

## Test plan

- [x] `tests/review/test_builder.py::TestSeverityGate` — 6 new tests for downgrade, preserve-on-high, legacy-None, malformed-map, approve/defer primaries untouched
- [x] `tests/review/test_protocol.py` contract-coherence assertion updated to include the new string
- [x] Full `tests/review/` + `tests/brief_engine/` pass (212 total, 1 pre-existing env-dependent failure on `origin/main`)
- [x] Full `tests/pdb/` + `tests/triage/` pass (375 total)

Refs #6505, #6492

🤖 Generated with [Claude Code](https://claude.com/claude-code)