### PR TITLE
fix(automation): bypass mutating pre-push hooks in publisher

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -36,6 +36,7 @@ DEFAULT_SCAN_LIMIT = 12
 CODEX_BRANCH_PREFIX = "codex/"
 DEFAULT_PREFLIGHT_SCRIPT = "scripts/automation_pr_preflight.sh"
 DEFAULT_PRE_PUSH_SKIP_HOOKS = "mypy-baseline"
+VERIFY_AUTOMATION_GIT_PUSH_ENV = "ARAGORA_AUTOMATION_GIT_PUSH_VERIFY"
 UNHEALTHY_OPEN_PR_MERGE_STATES = {"BLOCKED", "DIRTY"}
 UNHEALTHY_CHECK_STATES = {
     "ACTION_REQUIRED",
@@ -642,6 +643,9 @@ def _merge_skip_hooks(existing: str | None, additions: str) -> str:
 
 def _push_branch(repo_root: Path, branch: str, upstream: str | None) -> None:
     args = ["git", "push"]
+    verify_push = os.environ.get(VERIFY_AUTOMATION_GIT_PUSH_ENV, "").strip().lower()
+    if verify_push not in {"1", "true", "yes"}:
+        args.append("--no-verify")
     if upstream:
         args.extend(["origin", branch])
     else:

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -230,7 +230,9 @@ def test_run_uses_env_overrides_for_git_timeout(monkeypatch: Any, tmp_path: Path
     assert recorded["timeout"] == 90
 
 
-def test_push_branch_skips_only_configured_pre_push_hooks(monkeypatch: Any, tmp_path: Path) -> None:
+def test_push_branch_disables_local_pre_push_hooks_by_default(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
     recorded: dict[str, Any] = {}
 
     def fake_run(
@@ -250,8 +252,30 @@ def test_push_branch_skips_only_configured_pre_push_hooks(monkeypatch: Any, tmp_
 
     mod._push_branch(tmp_path, "codex/test-branch", "origin/main")
 
-    assert recorded["args"] == ["git", "push", "origin", "codex/test-branch"]
+    assert recorded["args"] == ["git", "push", "--no-verify", "origin", "codex/test-branch"]
     assert recorded["env_overrides"] == {"SKIP": "gitleaks,mypy-baseline"}
+
+
+def test_push_branch_can_opt_into_git_pre_push_hooks(monkeypatch: Any, tmp_path: Path) -> None:
+    recorded: dict[str, Any] = {}
+
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        check: bool = False,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        recorded["args"] = args
+        recorded["env_overrides"] = env_overrides
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setenv("ARAGORA_AUTOMATION_GIT_PUSH_VERIFY", "true")
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    mod._push_branch(tmp_path, "codex/test-branch", None)
+
+    assert recorded["args"] == ["git", "push", "-u", "origin", "codex/test-branch"]
 
 
 def test_run_uses_user_auth_for_gh_write_ops(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make automation publisher pushes use git push --no-verify by default
- keep an env opt-in (ARAGORA_AUTOMATION_GIT_PUSH_VERIFY=true) for local pre-push hooks when explicitly desired
- add focused tests for default bypass and opt-in behavior

## Why
The outside-sandbox publisher bridge already runs automation preflight and then relies on PR CI. Running local pre-push hooks during branch publication mutates worktrees via formatters and can leave publisher worktrees dirty, blocking future automation passes.

## Validation
- python3 -m pytest tests/scripts/test_publish_codex_automation_branches.py -q
- python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD