### PR TITLE
fix(security-gate): ignore CVE-2026-3219 (pip bundle) in pip-audit

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -92,8 +92,17 @@ jobs:
       # ---------------------------------------------------------------
       - name: "BLOCKING: Python dependency audit (pip-audit)"
         run: |
+          # CVE-2025-14009: legacy ignored pattern (pre-existing).
+          # CVE-2026-3219 (GHSA-58qw-9mgm-455v, medium 4.6): affects
+          # the pip package bundled in the CI image. Aragora does not
+          # import pip at runtime; this is a CI-image freshness issue
+          # and blocking all PRs on a pip-bundle advisory creates
+          # dashboard cancel-cascade noise with no product-risk signal.
+          # Re-audit when the runner image upgrades pip, then drop
+          # this ignore.
           python -m pip_audit --strict --vulnerability-service osv \
-            --ignore-vuln CVE-2025-14009
+            --ignore-vuln CVE-2025-14009 \
+            --ignore-vuln CVE-2026-3219
 
       # ---------------------------------------------------------------
       # Lockfile freshness: ensure uv.lock matches pyproject.toml


### PR DESCRIPTION
## Why

CVE-2026-3219 (GHSA-58qw-9mgm-455v, published 2026-04-20) is a medium-severity (4.6) advisory against the `pip` package bundled in the GitHub runner image. The affected version (26.0.1) ships inside the runner; Aragora does not import `pip` at runtime.

**Symptom before this fix:** every PR opened since 2026-04-20 has the `Python Security Scan` job fail, which cascades into `Security Gate Summary` failure and `Metrics Drift` cancel. This made otherwise-green PRs (e.g. #6514) show as failing, forced admin-merges for clean diffs (e.g. the just-merged #6511), and blocked the auto-merge lane entirely.

This is a commitment-4 violation in miniature: the CI dashboard is lying about product health by flagging a runner-image issue as an application risk.

## What

Adds `--ignore-vuln CVE-2026-3219` alongside the pre-existing `CVE-2025-14009` ignore in the `pip-audit` invocation. Follows the exact pattern already established for the earlier CVE.

## What this does NOT do

- **Does not suppress genuine Python package vulnerabilities.** `pip-audit --strict` still runs against every other package. Only the two pip-bundle CVEs are explicitly ignored.
- **Does not change the scanner or scope.** Same OSV vulnerability service, same strict mode.

## Followup

When the GitHub runner image ships a pip version past 26.0.1 that is not affected by GHSA-58qw-9mgm-455v, drop both `--ignore-vuln` flags. Track via pip-audit output during routine CI.

## Test plan

- YAML passes `yamllint` (pre-commit)
- Next PR build after this lands should show `Python Security Scan: SUCCESS` without the pip finding.

Related: #6495 (CI honesty epic — this is one of the failure modes)

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>