### PR TITLE
fix(sdk): cover agent bridge runs route

### DIFF
--- a/sdk/python/aragora_sdk/client.py
+++ b/sdk/python/aragora_sdk/client.py
@@ -161,6 +161,7 @@ class AragoraClient:
         from .namespaces.actions import ActionsAPI
         from .namespaces.admin import AdminAPI
         from .namespaces.advertising import AdvertisingAPI
+        from .namespaces.agent_bridge import AgentBridgeAPI
         from .namespaces.agent_dashboard import AgentDashboardAPI
         from .namespaces.agent_selection import AgentSelectionAPI
         from .namespaces.agents import AgentsAPI
@@ -350,6 +351,7 @@ class AragoraClient:
         self.accounting = AccountingAPI(self)
         self.actions = ActionsAPI(self)
         self.admin = AdminAPI(self)
+        self.agent_bridge = AgentBridgeAPI(self)
         self.advertising = AdvertisingAPI(self)
         self.agent_dashboard = AgentDashboardAPI(self)
         self.agent_selection = AgentSelectionAPI(self)
@@ -823,6 +825,7 @@ class AragoraAsyncClient:
         from .namespaces.actions import AsyncActionsAPI
         from .namespaces.admin import AsyncAdminAPI
         from .namespaces.advertising import AsyncAdvertisingAPI
+        from .namespaces.agent_bridge import AsyncAgentBridgeAPI
         from .namespaces.agent_dashboard import AsyncAgentDashboardAPI
         from .namespaces.agent_selection import AsyncAgentSelectionAPI
         from .namespaces.agents import AsyncAgentsAPI
@@ -999,6 +1002,7 @@ class AragoraAsyncClient:
         self.accounting = AsyncAccountingAPI(self)
         self.actions = AsyncActionsAPI(self)
         self.admin = AsyncAdminAPI(self)
+        self.agent_bridge = AsyncAgentBridgeAPI(self)
         self.advertising = AsyncAdvertisingAPI(self)
         self.agent_dashboard = AsyncAgentDashboardAPI(self)
         self.agent_selection = AsyncAgentSelectionAPI(self)

--- a/sdk/python/aragora_sdk/namespaces/__init__.py
+++ b/sdk/python/aragora_sdk/namespaces/__init__.py
@@ -9,6 +9,7 @@ from .accounting import AccountingAPI, AsyncAccountingAPI
 from .actions import ActionsAPI, AsyncActionsAPI
 from .admin import AdminAPI, AsyncAdminAPI
 from .advertising import AdvertisingAPI, AsyncAdvertisingAPI
+from .agent_bridge import AgentBridgeAPI, AsyncAgentBridgeAPI
 from .agent_dashboard import AgentDashboardAPI, AsyncAgentDashboardAPI
 from .agent_selection import AgentSelectionAPI, AsyncAgentSelectionAPI
 from .agents import AgentsAPI, AsyncAgentsAPI
@@ -192,6 +193,8 @@ __all__ = [
     "AsyncAccountingAPI",
     "AgentDashboardAPI",
     "AsyncAgentDashboardAPI",
+    "AgentBridgeAPI",
+    "AsyncAgentBridgeAPI",
     "ActionsAPI",
     "AsyncActionsAPI",
     "AdvertisingAPI",

--- a/sdk/python/aragora_sdk/namespaces/agent_bridge.py
+++ b/sdk/python/aragora_sdk/namespaces/agent_bridge.py
@@ -1,0 +1,56 @@
+"""Agent Bridge namespace API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..client import AragoraAsyncClient, AragoraClient
+
+
+class AgentBridgeAPI:
+    """Synchronous Agent Bridge API."""
+
+    def __init__(self, client: AragoraClient) -> None:
+        self._client = client
+
+    def list_runs(
+        self,
+        *,
+        status: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any]:
+        """List recorded agent-bridge runs."""
+        params: dict[str, Any] = {}
+        if status is not None:
+            params["status"] = status
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        return self._client.request("GET", "/api/v1/agent-bridge/runs", params=params)
+
+
+class AsyncAgentBridgeAPI:
+    """Asynchronous Agent Bridge API."""
+
+    def __init__(self, client: AragoraAsyncClient) -> None:
+        self._client = client
+
+    async def list_runs(
+        self,
+        *,
+        status: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any]:
+        """List recorded agent-bridge runs."""
+        params: dict[str, Any] = {}
+        if status is not None:
+            params["status"] = status
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        return await self._client.request("GET", "/api/v1/agent-bridge/runs", params=params)

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -207,6 +207,7 @@ import {
   PaymentsAPI,
   TrainingAPI,
   AdminAPI,
+  AgentBridgeAPI,
   // Additional namespaces (SDK Parity Sprint)
   AccountingAPI,
   APAutomationAPI,
@@ -901,6 +902,9 @@ export class AragoraClient {
   /** Review Queue API - Browser-based PR settlement triage for PDB briefs. */
   readonly reviewQueue: ReviewQueueAPI;
 
+  /** Agent Bridge API - Recorded agent-bridge run visibility. */
+  readonly agentBridge: AgentBridgeAPI;
+
   /** Checkpoints API - Debate checkpoint and pause/resume management. */
   readonly checkpoints: CheckpointsAPI;
 
@@ -1165,6 +1169,7 @@ export class AragoraClient {
     this.security = new SecurityAPI(this);
     this.reviews = new ReviewsAPI(this);
     this.reviewQueue = new ReviewQueueAPI(this);
+    this.agentBridge = new AgentBridgeAPI(this);
     this.checkpoints = new CheckpointsAPI(this);
     this.uncertainty = new UncertaintyAPI(this);
     this.audio = new AudioAPI(this);

--- a/sdk/typescript/src/namespaces/agent-bridge.ts
+++ b/sdk/typescript/src/namespaces/agent-bridge.ts
@@ -1,0 +1,46 @@
+/**
+ * Agent Bridge Namespace API
+ *
+ * Provides access to recorded agent-bridge runs.
+ */
+
+import type { AragoraClient } from '../client';
+
+export interface AgentBridgeRun {
+  run_id?: string;
+  status?: string;
+  created_at?: string;
+  updated_at?: string;
+  [key: string]: unknown;
+}
+
+export interface ListAgentBridgeRunsOptions {
+  status?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export class AgentBridgeAPI {
+  constructor(private client: AragoraClient) {}
+
+  /** List recorded agent-bridge runs. */
+  async listRuns(
+    options?: ListAgentBridgeRunsOptions
+  ): Promise<{ runs: AgentBridgeRun[]; total?: number }> {
+    const params: Record<string, unknown> = {};
+    if (options?.status !== undefined) {
+      params.status = options.status;
+    }
+    if (options?.limit !== undefined) {
+      params.limit = options.limit;
+    }
+    if (options?.offset !== undefined) {
+      params.offset = options.offset;
+    }
+    return this.client.request<{ runs: AgentBridgeRun[]; total?: number }>(
+      'GET',
+      '/api/v1/agent-bridge/runs',
+      { params }
+    );
+  }
+}

--- a/sdk/typescript/src/namespaces/index.ts
+++ b/sdk/typescript/src/namespaces/index.ts
@@ -24,6 +24,11 @@ export {
   type MatrixComparison,
 } from './debates';
 export { AgentDashboardAPI } from './agent-dashboard';
+export {
+  AgentBridgeAPI,
+  type AgentBridgeRun,
+  type ListAgentBridgeRunsOptions,
+} from './agent-bridge';
 export { AgentsAPI } from './agents';
 export { WorkflowsAPI } from './workflows';
 export { SMEAPI } from './sme';


### PR DESCRIPTION
## Summary
- add Python and TypeScript SDK Agent Bridge namespaces for `GET /api/v1/agent-bridge/runs`
- expose the namespace from the Python and TypeScript SDK clients/barrels
- clear the SDK parity regression that surfaced after the agent-bridge route landed on main

## Validation
- `python3 scripts/check_sdk_parity.py`
- `python3 scripts/check_sdk_namespace_parity.py`
- `python3 scripts/check_cross_sdk_parity.py`
- `python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py sdk/python/aragora_sdk/namespaces/agent_bridge.py sdk/python/aragora_sdk/namespaces/__init__.py sdk/python/aragora_sdk/client.py`
- `python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py sdk/python/aragora_sdk/namespaces/agent_bridge.py sdk/python/aragora_sdk/namespaces/__init__.py sdk/python/aragora_sdk/client.py`
- `python3 -m py_compile sdk/python/aragora_sdk/client.py sdk/python/aragora_sdk/namespaces/__init__.py sdk/python/aragora_sdk/namespaces/agent_bridge.py`
- `python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py`

Note: `npm --prefix sdk/typescript run typecheck` currently stops before project checking with `TS5103: Invalid value for --ignoreDeprecations` in `tsconfig.json`.