### PR TITLE
fix(sdk): align agent bridge runs namespace contract

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -16,15 +16,15 @@
 | Python lines of code under aragora/ | `1915385` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `135` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5077` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `216002` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `216007` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `643` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `60` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2928` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3386` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1363` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
 | Unique permission strings | `424` | `aragora/` | `git grep -h -o -E "@require_permission\(['\"][^'\"]+['\"]\)" -- aragora \| sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/" \| sort -u \| wc -l` |
-| Python SDK modules | `197` | `sdk/python/` | `git ls-files sdk/python/aragora_sdk \| grep -E '\.py$' \| grep -v '/__' \| awk -F/ 'NF<=5' \| wc -l` |
-| TypeScript SDK modules | `214` | `sdk/typescript/` | `git ls-files sdk/typescript/src \| grep -E '\.ts$' \| awk -F/ 'NF<=5' \| wc -l` |
+| Python SDK modules | `198` | `sdk/python/` | `git ls-files sdk/python/aragora_sdk \| grep -E '\.py$' \| grep -v '/__' \| awk -F/ 'NF<=5' \| wc -l` |
+| TypeScript SDK modules | `215` | `sdk/typescript/` | `git ls-files sdk/typescript/src \| grep -E '\.ts$' \| awk -F/ 'NF<=5' \| wc -l` |
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `45` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |

--- a/sdk/python/aragora_sdk/namespaces/agent_bridge.py
+++ b/sdk/python/aragora_sdk/namespaces/agent_bridge.py
@@ -17,18 +17,15 @@ class AgentBridgeAPI:
     def list_runs(
         self,
         *,
-        status: str | None = None,
         limit: int | None = None,
-        offset: int | None = None,
+        cursor: str | None = None,
     ) -> dict[str, Any]:
         """List recorded agent-bridge runs."""
         params: dict[str, Any] = {}
-        if status is not None:
-            params["status"] = status
         if limit is not None:
             params["limit"] = limit
-        if offset is not None:
-            params["offset"] = offset
+        if cursor is not None:
+            params["cursor"] = cursor
         return self._client.request("GET", "/api/v1/agent-bridge/runs", params=params)
 
 
@@ -41,16 +38,13 @@ class AsyncAgentBridgeAPI:
     async def list_runs(
         self,
         *,
-        status: str | None = None,
         limit: int | None = None,
-        offset: int | None = None,
+        cursor: str | None = None,
     ) -> dict[str, Any]:
         """List recorded agent-bridge runs."""
         params: dict[str, Any] = {}
-        if status is not None:
-            params["status"] = status
         if limit is not None:
             params["limit"] = limit
-        if offset is not None:
-            params["offset"] = offset
+        if cursor is not None:
+            params["cursor"] = cursor
         return await self._client.request("GET", "/api/v1/agent-bridge/runs", params=params)

--- a/sdk/python/tests/test_agent_bridge.py
+++ b/sdk/python/tests/test_agent_bridge.py
@@ -1,0 +1,44 @@
+"""Tests for agent-bridge namespace route mappings."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from aragora_sdk.client import AragoraAsyncClient, AragoraClient
+from aragora_sdk.namespaces.agent_bridge import AgentBridgeAPI, AsyncAgentBridgeAPI
+
+
+def test_agent_bridge_list_runs_uses_cursor_contract() -> None:
+    with patch.object(AragoraClient, "request") as mock_request:
+        mock_request.return_value = {"schema_version": 1, "runs": []}
+        client = AragoraClient(base_url="https://api.aragora.ai", api_key="test-key")
+        agent_bridge = AgentBridgeAPI(client)
+
+        agent_bridge.list_runs(limit=10, cursor="run:abc")
+
+        mock_request.assert_called_once_with(
+            "GET",
+            "/api/v1/agent-bridge/runs",
+            params={"limit": 10, "cursor": "run:abc"},
+        )
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_agent_bridge_list_runs_uses_cursor_contract() -> None:
+    with patch.object(AragoraAsyncClient, "request") as mock_request:
+        mock_request.return_value = {"schema_version": 1, "runs": []}
+        async with AragoraAsyncClient(
+            base_url="https://api.aragora.ai", api_key="test-key"
+        ) as client:
+            agent_bridge = AsyncAgentBridgeAPI(client)
+
+            await agent_bridge.list_runs(limit=20, cursor="run:def")
+
+            mock_request.assert_called_once_with(
+                "GET",
+                "/api/v1/agent-bridge/runs",
+                params={"limit": 20, "cursor": "run:def"},
+            )

--- a/sdk/typescript/src/namespaces/__tests__/agent-bridge.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/agent-bridge.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { AgentBridgeAPI } from '../agent-bridge';
+
+interface MockClient {
+  request: Mock;
+}
+
+describe('AgentBridgeAPI', () => {
+  let api: AgentBridgeAPI;
+  let mockClient: MockClient;
+
+  beforeEach(() => {
+    mockClient = {
+      request: vi.fn(),
+    };
+    api = new AgentBridgeAPI(mockClient as any);
+  });
+
+  it('maps listRuns to the cursor-paginated agent-bridge route', async () => {
+    mockClient.request.mockResolvedValue({
+      schema_version: 1,
+      runs: [],
+      next_cursor: 'run:next',
+    });
+
+    await api.listRuns({ limit: 10, cursor: 'run:first' });
+
+    expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/agent-bridge/runs', {
+      params: { limit: 10, cursor: 'run:first' },
+    });
+  });
+});

--- a/sdk/typescript/src/namespaces/agent-bridge.ts
+++ b/sdk/typescript/src/namespaces/agent-bridge.ts
@@ -7,40 +7,51 @@
 import type { AragoraClient } from '../client';
 
 export interface AgentBridgeRun {
-  run_id?: string;
-  status?: string;
-  created_at?: string;
-  updated_at?: string;
-  [key: string]: unknown;
+  schema_version: 1;
+  run_id: string;
+  task: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  last_turn_index: number;
+  next_actor: string | null;
+  repair_budget_per_turn: number;
+  footer_mode: string;
+  worktree_cleanup_mode: string;
+  participants: Array<{
+    role: string;
+    harness: string;
+    model: string;
+  }>;
+  last_event_id: string | null;
 }
 
 export interface ListAgentBridgeRunsOptions {
-  status?: string;
   limit?: number;
-  offset?: number;
+  cursor?: string;
+}
+
+export interface AgentBridgeRunListResponse {
+  schema_version: 1;
+  runs: AgentBridgeRun[];
+  next_cursor?: string | null;
 }
 
 export class AgentBridgeAPI {
   constructor(private client: AragoraClient) {}
 
   /** List recorded agent-bridge runs. */
-  async listRuns(
-    options?: ListAgentBridgeRunsOptions
-  ): Promise<{ runs: AgentBridgeRun[]; total?: number }> {
+  async listRuns(options?: ListAgentBridgeRunsOptions): Promise<AgentBridgeRunListResponse> {
     const params: Record<string, unknown> = {};
-    if (options?.status !== undefined) {
-      params.status = options.status;
-    }
     if (options?.limit !== undefined) {
       params.limit = options.limit;
     }
-    if (options?.offset !== undefined) {
-      params.offset = options.offset;
+    if (options?.cursor !== undefined) {
+      params.cursor = options.cursor;
     }
-    return this.client.request<{ runs: AgentBridgeRun[]; total?: number }>(
-      'GET',
-      '/api/v1/agent-bridge/runs',
-      { params }
-    );
+    return this.client.request<AgentBridgeRunListResponse>('GET', '/api/v1/agent-bridge/runs', {
+      params,
+    });
   }
 }

--- a/sdk/typescript/src/namespaces/index.ts
+++ b/sdk/typescript/src/namespaces/index.ts
@@ -26,6 +26,7 @@ export {
 export { AgentDashboardAPI } from './agent-dashboard';
 export {
   AgentBridgeAPI,
+  type AgentBridgeRunListResponse,
   type AgentBridgeRun,
   type ListAgentBridgeRunsOptions,
 } from './agent-bridge';


### PR DESCRIPTION
## Summary
- repair the just-merged Agent Bridge SDK namespace to match the actual `/api/v1/agent-bridge/runs` contract
- replace unsupported `status` / `offset` query parameters with supported `limit` / `cursor`
- type the TypeScript response as `{ schema_version, runs, next_cursor }` and export that response type
- add focused Python and TypeScript route-mapping tests
- refresh canonical metrics for the added SDK modules/tests

## Root cause
PR #6527 merged while local review was still in progress. The merged SDK wrappers were shaped like older offset/status list APIs, but the agent-bridge handler and OpenAPI endpoint are cursor-paginated and do not support `status` or `offset`.

## Validation
- `python3 -m pytest sdk/python/tests/test_agent_bridge.py -q`
- `python3 -m pytest sdk/python/tests/test_agent_bridge.py tests/openapi/test_agent_bridge_endpoints.py tests/handlers/test_agent_bridge_handler.py -q`
- `python3 scripts/check_sdk_parity.py`
- `python3 scripts/check_sdk_namespace_parity.py`
- `python3 scripts/check_cross_sdk_parity.py`
- `ruff check ...` / `ruff format --check ...`
- `python3 -m py_compile sdk/python/aragora_sdk/client.py sdk/python/aragora_sdk/namespaces/__init__.py sdk/python/aragora_sdk/namespaces/agent_bridge.py`
- `npm --prefix sdk/typescript ci --ignore-scripts`
- `npm --prefix sdk/typescript test -- agent-bridge.test.ts`
- `npm --prefix sdk/typescript test`
- `npm --prefix sdk/typescript run typecheck`
- `npm --prefix sdk/typescript run build`
- `npm --prefix sdk/typescript run lint -- --quiet`
- `npm --prefix sdk/typescript audit --omit=dev --audit-level=high`
- `python3 scripts/check_docs_consistency.py`
- `python3 scripts/regenerate_metrics.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
