### PR TITLE
fix(automation): skip empty PR diff branches

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -249,6 +249,15 @@ def _branch_patch_equivalent_to_base(repo_root: Path, base: str, branch: str) ->
     return bool(statuses) and all(status == "-" for status in statuses)
 
 
+def _branch_has_pr_diff(repo_root: Path, base: str, branch: str) -> bool:
+    proc = _run(["git", "diff", "--quiet", f"{base}...{branch}", "--"], cwd=repo_root)
+    if proc.returncode == 0:
+        return False
+    if proc.returncode == 1:
+        return True
+    return False
+
+
 def _local_codex_branches(repo_root: Path) -> list[BranchSnapshot]:
     proc = _run(
         [
@@ -567,6 +576,7 @@ def select_publishable_branches(
     historical_pr_branches: set[str] | None = None,
     resolved_related_branches: set[str] | None = None,
     remote_head_lookup: dict[str, str | None] | None = None,
+    has_pr_diff: dict[str, bool] | None = None,
 ) -> list[PublishDecision]:
     worktrees_by_branch: dict[str, list[WorktreeSnapshot]] = {}
     for worktree in worktrees:
@@ -578,6 +588,7 @@ def select_publishable_branches(
     historical_lookup = historical_pr_branches or set()
     resolved_related_lookup = resolved_related_branches or set()
     remote_lookup = remote_head_lookup or {}
+    pr_diff_lookup = has_pr_diff or {}
     decisions: list[PublishDecision] = []
 
     for branch in sorted(branches, key=lambda item: item.committed_at, reverse=True):
@@ -592,6 +603,8 @@ def select_publishable_branches(
             reason = "related_resolved_work_exists"
         elif branch.unique_commit_count <= 0:
             reason = "no_unique_commits"
+        elif pr_diff_lookup.get(branch.branch, True) is False:
+            reason = "empty_pr_diff"
         elif branch.committed_at < cutoff:
             reason = "older_than_cutoff"
         elif branch.branch in open_pr_heads:
@@ -926,6 +939,11 @@ def main(argv: list[str] | None = None) -> int:
         for branch in branches
         if not merged_lookup.get(branch.branch, False)
     }
+    pr_diff_lookup = {
+        branch.branch: _branch_has_pr_diff(repo_root, args.base, branch.branch)
+        for branch in branches
+        if not merged_lookup.get(branch.branch, False)
+    }
     hydrated_branches = [
         BranchSnapshot(
             branch=branch.branch,
@@ -983,6 +1001,7 @@ def main(argv: list[str] | None = None) -> int:
             branch.branch: _branch_remote_head(repo_root, branch.branch)
             for branch in hydrated_branches
         },
+        has_pr_diff=pr_diff_lookup,
     )
     merge_state_counts: dict[str, int] = {}
     for item in open_codex_prs:

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -86,6 +86,7 @@ def test_select_publishable_branches_skips_open_pr_and_old_or_merged_branches() 
             _branch("codex/cherry-picked"),
             _branch("codex/related-resolved"),
             _branch("codex/no-unique", unique_commit_count=0),
+            _branch("codex/empty-diff", unique_commit_count=2),
         ],
         [],
         {"codex/already-open"},
@@ -98,8 +99,10 @@ def test_select_publishable_branches_skips_open_pr_and_old_or_merged_branches() 
             "codex/cherry-picked": False,
             "codex/related-resolved": False,
             "codex/no-unique": False,
+            "codex/empty-diff": False,
         },
         is_patch_equivalent={"codex/cherry-picked": True},
+        has_pr_diff={"codex/empty-diff": False},
         historical_pr_branches=set(),
         resolved_related_branches={"codex/related-resolved"},
     )
@@ -111,6 +114,7 @@ def test_select_publishable_branches_skips_open_pr_and_old_or_merged_branches() 
     assert by_branch["codex/cherry-picked"].reason == "patch_equivalent_to_base"
     assert by_branch["codex/related-resolved"].reason == "related_resolved_work_exists"
     assert by_branch["codex/no-unique"].reason == "no_unique_commits"
+    assert by_branch["codex/empty-diff"].reason == "empty_pr_diff"
 
 
 def test_select_publishable_branches_skips_dirty_and_active_worktrees() -> None:


### PR DESCRIPTION
## Summary
- Skip automation branches with an empty GitHub-style PR diff, even when they still contain unique historical commits
- Prevent the publisher bridge from opening stale/superseded no-op PRs after queue drain
- Cover the new empty_pr_diff classifier reason in publisher tests

## Validation
- python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py
- python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- python3 scripts/publish_codex_automation_branches.py --base origin/main --json --limit 5 --scan-limit 80 --max-open-prs 12