### PR TITLE
fix(automation): fail open on PR diff probe errors

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -255,7 +255,9 @@ def _branch_has_pr_diff(repo_root: Path, base: str, branch: str) -> bool:
         return False
     if proc.returncode == 1:
         return True
-    return False
+    # Fail open on unexpected git errors: a missing ref or transient git
+    # failure should not silently suppress a branch as "empty_pr_diff".
+    return True
 
 
 def _local_codex_branches(repo_root: Path) -> list[BranchSnapshot]:

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -194,6 +194,21 @@ def test_github_base_ref_strips_remote_tracking_prefix() -> None:
     assert mod._github_base_ref("main") == "main"
 
 
+def test_branch_has_pr_diff_fails_open_on_git_errors(monkeypatch: Any, tmp_path: Path) -> None:
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        check: bool = False,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=args, returncode=128, stdout="", stderr="bad ref")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    assert mod._branch_has_pr_diff(tmp_path, "origin/main", "codex/broken-ref") is True
+
+
 def test_open_pr_heads_counts_only_codex_branches(monkeypatch: Any, tmp_path: Path) -> None:
     payload = """
     [


### PR DESCRIPTION
## Summary
- Follow-up to #6536 after it merged before this review fix landed.
- Treat unexpected `git diff --quiet base...branch` errors as `has_pr_diff=True` instead of classifying the branch as `empty_pr_diff`.
- Adds a regression test so missing refs/transient git errors do not silently suppress publishable automation branches.

## Validation
- python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py
- ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- ruff format --check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD