### PR TITLE
fix(automation): distinguish publishable codex backlog

### DIFF
--- a/docs/briefs/automation-merge-contract.md
+++ b/docs/briefs/automation-merge-contract.md
@@ -81,6 +81,8 @@ The bridge intentionally does not use browser fallback. Browser profiles can be 
 
 The publisher bridge now has an explicit GitHub health probe at `scripts/github_cli_health.py`. Sandboxed coding automations should treat a failed probe as a hard boundary and switch into handoff-only mode immediately instead of retrying `gh issue create`, `gh pr create`, `gh workflow run`, or merge-watch commands from inside the sandbox.
 
+Do not use a raw local `git branch --list 'codex/*'` count as the unpublished-work backlog gate. Local developer machines can retain thousands of stale historical `codex/*` refs that are already merged, patch-equivalent, or local-only archaeology. Use `python3 scripts/audit_codex_branch_backlog.py --json` and gate on `summary.publishable_branch_backlog` instead. That metric counts recent unique local work and stale unique remote branches, but intentionally excludes stale local-only refs so writer automations keep producing useful local code when GitHub is sandboxed.
+
 For steady local operation, install the publisher bridge as a LaunchAgent from a normal user shell:
 
 ```bash

--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -261,6 +261,7 @@ def audit(
     recent_hours: int,
     max_branches: int | None,
     include_patch_equivalence: bool,
+    publisher_backlog_limit: int,
 ) -> dict[str, Any]:
     rows = local_branches(root, prefix, base)
     rows.sort(key=lambda row: parse_dt(row["committed_at"]), reverse=True)
@@ -332,11 +333,15 @@ def audit(
         + counts["salvage_stale_remote_unique"]
         + counts["salvage_stale_local_unique"]
     )
+    publishable_branch_backlog = (
+        counts["salvage_recent_unique"] + counts["salvage_stale_remote_unique"]
+    )
     return {
         "repo": str(root),
         "base": base,
         "prefix": prefix,
         "recent_hours": recent_hours,
+        "publisher_backlog_limit": publisher_backlog_limit,
         "include_patch_equivalence": include_patch_equivalence,
         "github_health": github_health.to_dict(),
         "open_pr_lookup_skipped": not github_health.ready,
@@ -345,6 +350,11 @@ def audit(
             "safe_cleanup_candidates": safe_cleanup,
             "protected": protected,
             "salvage_candidates": salvage,
+            "publishable_branch_backlog": publishable_branch_backlog,
+            "stale_local_only_salvage_candidates": counts["salvage_stale_local_unique"],
+            "writer_should_pause_for_branch_backlog": (
+                publishable_branch_backlog >= publisher_backlog_limit
+            ),
             "by_category": dict(sorted(counts.items())),
         },
         "records": [asdict(record) for record in records],
@@ -359,6 +369,11 @@ def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
     print(f"- Branches audited: `{payload['branch_count']}`")
     print(f"- Safe cleanup candidates: `{summary['safe_cleanup_candidates']}`")
     print(f"- Salvage candidates: `{summary['salvage_candidates']}`")
+    print(f"- Publishable branch backlog: `{summary['publishable_branch_backlog']}`")
+    print(
+        "- Writer should pause for branch backlog: "
+        f"`{summary['writer_should_pause_for_branch_backlog']}`"
+    )
     print(f"- Protected branches: `{summary['protected']}`\n")
     print("## Counts\n")
     for category, count in summary["by_category"].items():
@@ -415,6 +430,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Run git cherry per non-merged branch to identify patch-equivalent cleanup candidates.",
     )
+    parser.add_argument(
+        "--publisher-backlog-limit",
+        type=int,
+        default=12,
+        help=(
+            "Threshold for publishable branch backlog. This intentionally excludes "
+            "stale local-only codex/* branches so writer automations do not pause "
+            "on historical local ref cache."
+        ),
+    )
     parser.add_argument("--examples", type=int, default=10, help="Examples per Markdown category")
     return parser
 
@@ -430,6 +455,7 @@ def main(argv: list[str] | None = None) -> int:
         recent_hours=args.recent_hours,
         max_branches=args.max_branches,
         include_patch_equivalence=args.include_patch_equivalence,
+        publisher_backlog_limit=args.publisher_backlog_limit,
     )
     if args.markdown:
         print_markdown(payload, examples=args.examples)

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -9,12 +9,16 @@ from scripts.github_cli_health import GitHubCLIHealth
 import scripts.audit_codex_branch_backlog as mod
 
 
-def _branch_row(name: str = "codex/example") -> dict[str, str]:
+def _branch_row(
+    name: str = "codex/example",
+    *,
+    committed_at: datetime | None = None,
+) -> dict[str, str]:
     return {
         "name": name,
         "upstream": "",
         "head_sha": "abc1234",
-        "committed_at": datetime.now(timezone.utc).isoformat(),
+        "committed_at": (committed_at or datetime.now(timezone.utc)).isoformat(),
         "ahead_count": "1",
         "subject": "test branch",
     }
@@ -57,6 +61,7 @@ def test_audit_skips_open_pr_lookup_when_github_health_degraded(
         recent_hours=72,
         max_branches=None,
         include_patch_equivalence=False,
+        publisher_backlog_limit=12,
     )
 
     assert payload["github_health"]["mode"] == "connectivity_failed"
@@ -92,9 +97,58 @@ def test_audit_uses_open_pr_lookup_when_github_health_is_ready(
         recent_hours=72,
         max_branches=None,
         include_patch_equivalence=False,
+        publisher_backlog_limit=12,
     )
 
     assert payload["github_health"]["ready"] is True
     assert payload["open_pr_lookup_skipped"] is False
     assert payload["records"][0]["open_pr"] == 6500
     assert payload["records"][0]["category"] == "protected_open_pr"
+
+
+def test_audit_publishable_backlog_excludes_stale_local_only_branches(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    now = datetime.now(timezone.utc)
+    rows = [
+        _branch_row("codex/recent-local", committed_at=now),
+        _branch_row("codex/stale-local", committed_at=now.replace(year=now.year - 1)),
+        _branch_row("codex/stale-remote", committed_at=now.replace(year=now.year - 1)),
+    ]
+    monkeypatch.setattr(mod, "local_branches", lambda _root, _prefix, _base: rows)
+    monkeypatch.setattr(mod, "remote_branch_names", lambda _root, _prefix: {"codex/stale-remote"})
+    monkeypatch.setattr(mod, "merged_branch_names", lambda _root, _base, _prefix: set())
+    monkeypatch.setattr(mod, "worktree_map", lambda _root: {})
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ready",
+            error="",
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(mod, "open_pr_heads", lambda _root, _repo, _prefix: {})
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=3,
+    )
+
+    by_category = payload["summary"]["by_category"]
+    assert by_category["salvage_recent_unique"] == 1
+    assert by_category["salvage_stale_remote_unique"] == 1
+    assert by_category["salvage_stale_local_unique"] == 1
+    assert payload["summary"]["salvage_candidates"] == 3
+    assert payload["summary"]["publishable_branch_backlog"] == 2
+    assert payload["summary"]["stale_local_only_salvage_candidates"] == 1
+    assert payload["summary"]["writer_should_pause_for_branch_backlog"] is False


### PR DESCRIPTION
## Summary

Prevents writer automations from treating raw local `codex/*` branch volume as a publish-blocking backlog.

Local developer machines can retain thousands of stale historical `codex/*` refs. This change adds an explicit `summary.publishable_branch_backlog` metric to `scripts/audit_codex_branch_backlog.py` that counts recent unique work plus stale unique remote branches, while excluding stale local-only archaeology from the writer pause gate.

Also updates the automation merge contract and Primary Writer memory guidance to use this metric instead of raw local branch counts.

## Validation

- `python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py tests/scripts/test_publish_codex_automation_branches.py` — 26 passed
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` — passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` — passed
- `python3 scripts/audit_codex_branch_backlog.py --repo . --base origin/main --max-branches 50 --json` — emits `summary.publishable_branch_backlog`