### PR TITLE
ci(test): harden zero-coverage gate for unmapped modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -540,6 +540,9 @@ jobs:
           PY
 
       - name: Check for new zero-coverage files
+        env:
+          SELECTOR_STATUS: ${{ steps.selected.outputs.status }}
+          CHANGED_PYTHON_COUNT: ${{ steps.selected.outputs.changed_python_count || 0 }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             if [ "${{ steps.selected.outputs.status }}" = "skipped" ]; then
@@ -558,40 +561,11 @@ jobs:
               -m "not slow and not load and not e2e" --timeout=60 -x || true
           fi
 
-          # Check for new zero-coverage files not in baseline
-          python -c "
-          import json
-          import sys
-          from pathlib import Path
-
-          baseline_file = Path('tests/.zero_coverage_baseline')
-          baseline = set()
-          if baseline_file.exists():
-              baseline = set(line.strip() for line in baseline_file.read_text().splitlines() if line.strip())
-
-          try:
-              with open('cov.json') as f:
-                  data = json.load(f)
-          except (FileNotFoundError, json.JSONDecodeError):
-              print('Coverage data not available, skipping check')
-              sys.exit(0)
-
-          zero_cov = []
-          for file, info in data.get('files', {}).items():
-              if info.get('summary', {}).get('percent_covered', 100) == 0:
-                  if file not in baseline:
-                      zero_cov.append(file)
-
-          if zero_cov:
-              print('::error::New zero-coverage files detected:')
-              for f in sorted(zero_cov)[:20]:
-                  print(f'  - {f}')
-              if len(zero_cov) > 20:
-                  print(f'  ... and {len(zero_cov) - 20} more')
-              print('Add to tests/.zero_coverage_baseline if intentional')
-              sys.exit(1)
-          print('No new zero-coverage files detected')
-          "
+          python scripts/check_zero_coverage_gate.py \
+            --coverage-path cov.json \
+            --baseline-path tests/.zero_coverage_baseline \
+            --selector-status "${SELECTOR_STATUS}" \
+            --changed-python-count "${CHANGED_PYTHON_COUNT}"
 
   # Fast parallel tests by category (Ubuntu only, primary Python)
   test-fast:

--- a/scripts/check_zero_coverage_gate.py
+++ b/scripts/check_zero_coverage_gate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Evaluate the PR-scoped zero-coverage gate.
+
+The zero-coverage workflow currently has two distinct signal sources:
+
+1. ``scripts/nomic_ci_test_selector.py`` decides whether a PR changed any
+   Python modules and whether those modules map to tests.
+2. ``pytest --cov`` emits ``cov.json`` for the selected tests.
+
+This script joins those signals into one explicit decision:
+
+- selector status ``skipped`` is the only case where missing coverage is OK
+- selector status ``unmapped_python_changes`` is a hard failure
+- missing or invalid ``cov.json`` is a hard failure in every non-skipped case
+- newly zero-covered files not present in the baseline are a hard failure
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_baseline(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {line.strip() for line in path.read_text().splitlines() if line.strip()}
+
+
+def _new_zero_coverage_files(coverage: dict[str, Any], baseline: set[str]) -> list[str]:
+    zero_cov: list[str] = []
+    for file, info in coverage.get("files", {}).items():
+        percent = info.get("summary", {}).get("percent_covered", 100)
+        if percent == 0 and file not in baseline:
+            zero_cov.append(file)
+    return sorted(zero_cov)
+
+
+def evaluate_zero_coverage_gate(
+    *,
+    coverage_path: Path,
+    baseline_path: Path,
+    selector_status: str,
+    changed_python_count: int,
+) -> tuple[bool, list[str]]:
+    if selector_status == "skipped":
+        return True, ["No changed Python files required PR-scoped zero-coverage probing; skipping."]
+
+    if selector_status == "unmapped_python_changes":
+        count_msg = (
+            f" for {changed_python_count} changed Python file(s)"
+            if changed_python_count > 0
+            else ""
+        )
+        return False, [
+            f"::error::PR-scoped coverage selector reported unmapped Python changes{count_msg}",
+            "::error::Changed Python modules without mapped tests must fail the zero-coverage gate",
+        ]
+
+    if not coverage_path.exists():
+        return False, [
+            f"::error::Coverage data not available at {coverage_path}; zero-coverage gate cannot verify this change",
+        ]
+
+    try:
+        coverage = json.loads(coverage_path.read_text())
+    except json.JSONDecodeError:
+        return False, [
+            f"::error::Coverage data at {coverage_path} is invalid JSON; zero-coverage gate cannot verify this change",
+        ]
+
+    baseline = _load_baseline(baseline_path)
+    zero_cov = _new_zero_coverage_files(coverage, baseline)
+    if zero_cov:
+        messages = ["::error::New zero-coverage files detected:"]
+        messages.extend(f"  - {path}" for path in zero_cov[:20])
+        if len(zero_cov) > 20:
+            messages.append(f"  ... and {len(zero_cov) - 20} more")
+        messages.append("Add to tests/.zero_coverage_baseline if intentional")
+        return False, messages
+
+    return True, ["No new zero-coverage files detected"]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--coverage-path",
+        type=Path,
+        default=Path("cov.json"),
+        help="Path to the JSON coverage report emitted by pytest-cov.",
+    )
+    parser.add_argument(
+        "--baseline-path",
+        type=Path,
+        default=Path("tests/.zero_coverage_baseline"),
+        help="Path to the committed zero-coverage baseline file.",
+    )
+    parser.add_argument(
+        "--selector-status",
+        default="",
+        help="Status emitted by scripts/nomic_ci_test_selector.py.",
+    )
+    parser.add_argument(
+        "--changed-python-count",
+        type=int,
+        default=0,
+        help="Count of changed Python files from the selector result.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    ok, messages = evaluate_zero_coverage_gate(
+        coverage_path=args.coverage_path,
+        baseline_path=args.baseline_path,
+        selector_status=args.selector_status,
+        changed_python_count=args.changed_python_count,
+    )
+    for message in messages:
+        print(message)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_zero_coverage_gate.py
+++ b/tests/scripts/test_check_zero_coverage_gate.py
@@ -1,0 +1,146 @@
+"""Tests for scripts/check_zero_coverage_gate.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check_zero_coverage_gate.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_zero_coverage_gate", str(SCRIPT))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_zero_coverage_gate"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skipped_selector_status_allows_missing_coverage(tmp_path):
+    mod = _load_module()
+    ok, messages = mod.evaluate_zero_coverage_gate(
+        coverage_path=tmp_path / "cov.json",
+        baseline_path=tmp_path / "baseline",
+        selector_status="skipped",
+        changed_python_count=0,
+    )
+    assert ok is True
+    assert messages == [
+        "No changed Python files required PR-scoped zero-coverage probing; skipping."
+    ]
+
+
+def test_unmapped_python_changes_fail_even_without_coverage(tmp_path):
+    mod = _load_module()
+    ok, messages = mod.evaluate_zero_coverage_gate(
+        coverage_path=tmp_path / "cov.json",
+        baseline_path=tmp_path / "baseline",
+        selector_status="unmapped_python_changes",
+        changed_python_count=1,
+    )
+    assert ok is False
+    assert "unmapped Python changes" in messages[0]
+    assert "must fail the zero-coverage gate" in messages[1]
+
+
+def test_missing_coverage_fails_for_non_skipped_selector(tmp_path):
+    mod = _load_module()
+    ok, messages = mod.evaluate_zero_coverage_gate(
+        coverage_path=tmp_path / "cov.json",
+        baseline_path=tmp_path / "baseline",
+        selector_status="dry_run",
+        changed_python_count=1,
+    )
+    assert ok is False
+    assert messages == [
+        "::error::Coverage data not available at "
+        f"{tmp_path / 'cov.json'}; zero-coverage gate cannot verify this change"
+    ]
+
+
+def test_invalid_coverage_json_fails(tmp_path):
+    mod = _load_module()
+    coverage_path = tmp_path / "cov.json"
+    coverage_path.write_text("{not-json")
+    ok, messages = mod.evaluate_zero_coverage_gate(
+        coverage_path=coverage_path,
+        baseline_path=tmp_path / "baseline",
+        selector_status="dry_run",
+        changed_python_count=1,
+    )
+    assert ok is False
+    assert "invalid JSON" in messages[0]
+
+
+def test_new_zero_coverage_file_fails(tmp_path):
+    mod = _load_module()
+    coverage_path = tmp_path / "cov.json"
+    coverage_path.write_text(
+        json.dumps(
+            {
+                "files": {
+                    "aragora/foo/new_module.py": {
+                        "summary": {"percent_covered": 0},
+                    }
+                }
+            }
+        )
+    )
+    ok, messages = mod.evaluate_zero_coverage_gate(
+        coverage_path=coverage_path,
+        baseline_path=tmp_path / "baseline",
+        selector_status="dry_run",
+        changed_python_count=1,
+    )
+    assert ok is False
+    assert messages[0] == "::error::New zero-coverage files detected:"
+    assert "aragora/foo/new_module.py" in messages[1]
+
+
+def test_baselined_zero_coverage_file_passes(tmp_path):
+    mod = _load_module()
+    coverage_path = tmp_path / "cov.json"
+    coverage_path.write_text(
+        json.dumps(
+            {
+                "files": {
+                    "aragora/foo/legacy_module.py": {
+                        "summary": {"percent_covered": 0},
+                    }
+                }
+            }
+        )
+    )
+    baseline_path = tmp_path / "baseline"
+    baseline_path.write_text("aragora/foo/legacy_module.py\n")
+    ok, messages = mod.evaluate_zero_coverage_gate(
+        coverage_path=coverage_path,
+        baseline_path=baseline_path,
+        selector_status="dry_run",
+        changed_python_count=1,
+    )
+    assert ok is True
+    assert messages == ["No new zero-coverage files detected"]
+
+
+def test_main_cli_returns_failure_for_missing_coverage(monkeypatch, tmp_path, capsys):
+    mod = _load_module()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_zero_coverage_gate.py",
+            "--coverage-path",
+            "cov.json",
+            "--changed-python-count",
+            "1",
+        ],
+    )
+    exit_code = mod.main()
+    assert exit_code == 1
+    assert "Coverage data not available" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- extract the zero-coverage decision into a dedicated script
- fail explicitly when PR-scoped coverage cannot be verified for changed Python files
- add regression tests for unmapped-module, missing-cov.json, invalid-cov.json, and baseline behavior

## Why
Finding 1 identified a real gap in the inline workflow logic: when PR-scoped selection found no mapped tests, coverage collection could be skipped and the downstream `cov.json` read would exit 0. Current selector behavior already rejects unmapped Python changes, but the workflow still encoded the `missing cov.json => success` branch. This patch makes the gate explicit and testable.

## Scope
- `.github/workflows/test.yml`
- `scripts/check_zero_coverage_gate.py`
- `tests/scripts/test_check_zero_coverage_gate.py`

## Verification
- `python3 -m pytest tests/scripts/test_check_zero_coverage_gate.py tests/nomic/test_ci_feedback.py -q`
- `python3 -m ruff check scripts/check_zero_coverage_gate.py tests/scripts/test_check_zero_coverage_gate.py`
- `python3 - <<'PY' ... yaml.safe_load(Path('.github/workflows/test.yml').read_text()) ... PY`

## Review-note reconciliation
- Finding 2 is already fixed on current `main` in `aragora/review/reviewer_output.py` and covered by `tests/review/test_reviewer_output.py`.
- Finding 3 is already fixed on current `main` in `aragora/review/builder.py` and covered by `tests/review/test_builder.py`.
