### PR TITLE
fix(automation): relax in-flight PR backpressure

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -40,19 +40,14 @@ VERIFY_AUTOMATION_GIT_PUSH_ENV = "ARAGORA_AUTOMATION_GIT_PUSH_VERIFY"
 UNHEALTHY_OPEN_PR_MERGE_STATES = {"BLOCKED", "DIRTY"}
 UNHEALTHY_CHECK_STATES = {
     "ACTION_REQUIRED",
-    "CANCELLED",
     "ERROR",
     "FAILURE",
     "FAILED",
     "TIMED_OUT",
 }
-PENDING_CHECK_STATES = {
-    "EXPECTED",
-    "IN_PROGRESS",
-    "PENDING",
-    "QUEUED",
-    "REQUESTED",
-    "WAITING",
+CANCELLED_ADVISORY_WORKFLOWS = {
+    "Metrics Drift",
+    "Module Tier Drift",
 }
 STOPWORDS = {
     "and",
@@ -394,6 +389,17 @@ def _rollup_state(item: dict[str, Any]) -> str:
     return ""
 
 
+def _check_rollup_is_unhealthy(item: dict[str, Any]) -> bool:
+    state = _rollup_state(item)
+    if state in UNHEALTHY_CHECK_STATES:
+        return True
+    if state != "CANCELLED":
+        return False
+
+    workflow_name = str(item.get("workflowName") or "")
+    return workflow_name not in CANCELLED_ADVISORY_WORKFLOWS
+
+
 def _open_codex_pr_is_unhealthy(item: dict[str, Any]) -> bool:
     """Return true only for PR states that should pause more automation publishing.
 
@@ -413,10 +419,9 @@ def _open_codex_pr_is_unhealthy(item: dict[str, Any]) -> bool:
 
     check_rollup = item.get("statusCheckRollup") or []
     if isinstance(check_rollup, list):
-        states = [_rollup_state(check) for check in check_rollup if isinstance(check, dict)]
-        if any(state in UNHEALTHY_CHECK_STATES for state in states):
-            return True
-        if any(state in PENDING_CHECK_STATES for state in states):
+        if any(
+            _check_rollup_is_unhealthy(check) for check in check_rollup if isinstance(check, dict)
+        ):
             return True
 
     review_decision = str(item.get("reviewDecision") or "").upper()

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -760,3 +760,54 @@ def test_main_does_not_pause_for_green_review_required_codex_pr(
     out = capsys.readouterr().out
     assert '"publish_paused_reason"' not in out
     assert '"unhealthy_open_pr_count": 0' in out
+
+
+def test_review_required_inflight_pr_does_not_pause_for_pending_or_advisory_cancelled() -> None:
+    assert (
+        mod._open_codex_pr_is_unhealthy(
+            {
+                "headRefName": "codex/inflight",
+                "isDraft": False,
+                "mergeStateStatus": "BLOCKED",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "statusCheckRollup": [
+                    {"conclusion": "CANCELLED", "workflowName": "Metrics Drift"},
+                    {"conclusion": "CANCELLED", "workflowName": "Module Tier Drift"},
+                    {"status": "IN_PROGRESS", "workflowName": "Tests"},
+                    {"status": "QUEUED", "workflowName": "Aragora Code Review"},
+                ],
+            }
+        )
+        is False
+    )
+
+
+def test_review_required_pr_still_pauses_for_hard_failures_or_non_advisory_cancels() -> None:
+    assert (
+        mod._open_codex_pr_is_unhealthy(
+            {
+                "headRefName": "codex/failing",
+                "isDraft": False,
+                "mergeStateStatus": "BLOCKED",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "statusCheckRollup": [
+                    {"conclusion": "FAILURE", "workflowName": "Tests"},
+                ],
+            }
+        )
+        is True
+    )
+    assert (
+        mod._open_codex_pr_is_unhealthy(
+            {
+                "headRefName": "codex/cancelled-required",
+                "isDraft": False,
+                "mergeStateStatus": "BLOCKED",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "statusCheckRollup": [
+                    {"conclusion": "CANCELLED", "workflowName": "Tests"},
+                ],
+            }
+        )
+        is True
+    )


### PR DESCRIPTION
## Summary
- Keep dirty, draft, changes-requested, hard-failed checks, and non-advisory cancellations as publisher backpressure
- Stop treating ordinary pending CI as unhealthy backpressure
- Treat cancelled Metrics Drift and Module Tier Drift checks as advisory noise instead of publisher-blocking failures

## Validation
- python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py
- python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- python3 scripts/publish_codex_automation_branches.py --base origin/main --json --limit 5 --scan-limit 80 --max-open-prs 12