### PR TITLE
ci(load-tests): switch runner aragora → ubuntu-latest

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -35,7 +35,7 @@ jobs:
   load-test:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Load Test Suite
-    runs-on: aragora
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     services:
@@ -421,7 +421,8 @@ jobs:
   memory-stress:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Memory Stress Test
-    runs-on: aragora
+    # Match load-test runner choice above.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: load-test
 


### PR DESCRIPTION
## Summary

Fixes the chronic-red Load Tests nightly workflow (4+ consecutive failed runs) by switching both jobs from self-hosted `aragora` to `ubuntu-latest`.

## Root cause

The `aragora` self-hosted runner image lacks Docker. The workflow's `services: redis:7-alpine` block requires Docker to start the redis sidecar. Every scheduled nightly run has failed at setup with:

```
##[error]docker: command not found
```

## Fix

Two line changes — `runs-on: aragora` → `runs-on: ubuntu-latest` for both `load-test` and `memory-stress` jobs. `ubuntu-latest` includes Docker by default.

## Why ubuntu-latest is safe here

- Load tests don't use any self-hosted-runner-specific resources (no private network, no local cache)
- Target API is started in-process on the runner itself
- Redis service block works unchanged

## Test plan

- [ ] Workflow passes on `ubuntu-latest` (will confirm via workflow_dispatch after merge)
- [x] `docker: command not found` failure eliminated by using a runner with Docker

Part of the chronic-red nightly cleanup identified during the 48h soak-compression for v2.9.0-rc.1. Addresses one of the 6 workflows listed in #6493 as blocking meaningful soak signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)