### PR TITLE
fix(pyproject): add bandit to dev extra for nightly security gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "mypy>=1.19.0,<2.0",
     "types-PyYAML>=6.0,<7.0",
     "types-croniter>=2.0,<6.0",
+    "bandit>=1.7,<2.0",
 ]
 all = [
     "fastapi>=0.135.3,<1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -270,6 +270,7 @@ connectors = [
     { name = "aiokafka" },
 ]
 dev = [
+    { name = "bandit" },
     { name = "mypy" },
     { name = "types-croniter" },
     { name = "types-pyyaml" },
@@ -304,6 +305,7 @@ requires-dist = [
     { name = "aiokafka", marker = "extra == 'connectors'", specifier = ">=0.10,<1.0" },
     { name = "asyncpg", marker = "extra == 'all'", specifier = ">=0.31.0,<1.0" },
     { name = "asyncpg", marker = "extra == 'enterprise'", specifier = ">=0.31.0,<1.0" },
+    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
     { name = "build", marker = "extra == 'test'", specifier = ">=1.2,<2.0" },
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.135.3,<1.0" },
     { name = "fastapi", marker = "extra == 'gateway'", specifier = ">=0.135.3,<1.0" },
@@ -421,6 +423,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181 },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741 },
 ]
 
 [[package]]
@@ -3154,6 +3171,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651 },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `bandit>=1.7,<2.0` to the `dev` optional-dependency extra in `pyproject.toml`. Fixes the chronic-red Nightly Full Matrix / Pre-release Gates security step (4+ consecutive failed runs).

## Root cause

The security gate step runs:
```yaml
run: python scripts/pre_release_check.py --category security
```

…which invokes `bandit`. But `bandit` wasn't declared in any extra. The workflow installs:
```bash
python -m pip install -e ".[dev,research,code-intel,test,monitoring]"
```

Only `dev` and `test` actually exist (others silently install nothing). Adding `bandit` to `dev` makes the existing install pattern pick it up.

Failure log:
```
[-] bandit: FAIL  (/home/runner/work/_temp/hostedtoolcache/Python/3.11.15/x64/bin/python: No module named bandit)
```

## Fix

One line added to `pyproject.toml` `[project.optional-dependencies].dev`.

## Scope

This PR closes ONE of the 4 failing steps in Nightly Full Matrix. The other 3 failing steps are the Regression Matrix sub-jobs (`sdk-openapi-observability`, `server-integration-memory`, `debate-workflow-handlers`), which have distinct root causes and will be addressed in follow-up PRs.

## Test plan

- [ ] Nightly Full Matrix Pre-release Gates security step passes (will confirm via workflow_dispatch after merge)
- [x] `bandit` now available in the dev environment (verified locally: `pip install -e ".[dev]" && python -m bandit --version` works)

Part of the chronic-red nightly cleanup identified during the 48h soak-compression for v2.9.0-rc.1. Addresses one of the 6 workflows listed in #6493 as blocking meaningful soak signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)