### PR TITLE
ci(coverage): bump coverage gate timeout 30→90 min

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,11 @@ jobs:
   coverage:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 30 min was not enough to complete the full test suite under coverage
+    # instrumentation — every nightly cancelled at ~0% pytest progress
+    # (chronic-red since 2026-04-22). Bumping to 90 to give headroom; if
+    # this still cancels, the next move is sharding the coverage run.
+    timeout-minutes: 90
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Fix F of the chronic-red soak compression sweep.

## What

`coverage.yml` has a `timeout-minutes: 30` ceiling. The full test suite under coverage instrumentation can't complete in 30 min — every scheduled nightly since 2026-04-22 has cancelled at ~0% pytest progress. Bumping to 90.

## Evidence

```
2026-04-24T05:19  schedule :: cancelled
2026-04-23T05:14  schedule :: cancelled
2026-04-22T05:10  schedule :: cancelled
```

Cancellation log shows pytest at `....[ 0%]` when the runner kills the job.

## Why this is the minimal fix

The workflow already excludes `slow/load/e2e` markers — the cancellation isn't due to bad scope. It's the suite size + coverage overhead that exceeds 30 min. Sharding is the next-step fallback if 90 min also cancels.

## Scope

- 1 file changed, 5 insertions(+), 1 deletion(-)
- No code/test changes
- Comment explains the chronic-red history so future readers don't relitigate

## Related

- Soak compression diagnosis from 2026-04-24 — chronic-red workflows on main
- Other parallel quick-wins in flight: Load Tests runner switch + bandit dep