### PR TITLE
ci(security): bump trivy-action 0.28.0→0.35.0 (CVE-2026-33634, 2× CRITICAL)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
           done
 
       - name: Run Trivy vulnerability scanner (config)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         continue-on-error: true  # Findings uploaded to GitHub Security tab via SARIF
         with:
           scan-type: 'config'
@@ -194,7 +194,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (Image)
         if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         continue-on-error: true  # Findings uploaded to GitHub Security tab via SARIF
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,7 +104,7 @@ jobs:
           docker run --rm test-backend:latest python -c "import aragora; print('Aragora imported successfully')"
 
       - name: Run Trivy vulnerability scanner (backend)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'test-backend:latest'
           format: 'sarif'
@@ -203,7 +203,7 @@ jobs:
           docker build -f deploy/Dockerfile.frontend -t test-frontend:latest .
 
       - name: Run Trivy vulnerability scanner (frontend)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'test-frontend:latest'
           format: 'sarif'
@@ -302,7 +302,7 @@ jobs:
           docker build -f aragora-operator/Dockerfile -t test-operator:latest aragora-operator/
 
       - name: Run Trivy vulnerability scanner (operator)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'test-operator:latest'
           format: 'sarif'


### PR DESCRIPTION
Closes the **only CRITICAL-severity** open Dependabot alerts on main.

## What

Bumps `aquasecurity/trivy-action` from `0.28.0` → `0.35.0` across 5 references in 2 workflow files.

## Why

Dependabot alerts #119 and #120 flag `aquasecurity/trivy-action < 0.35.0` as vulnerable to **CVE-2026-33634** (CRITICAL). Fix is available in `0.35.0`.

## Changes

- `.github/workflows/docker.yml`: 3 × `@0.28.0` → `@0.35.0`
- `.github/workflows/build.yml`: 2 × `@0.28.0` → `@0.35.0`

## Compat check

Aragora uses the following action inputs: `scan-type`, `scan-ref`, `severity`, `exit-code`, `format`, `output`, `ignore-unfixed`. All of these are backwards-compatible between 0.28.0 and 0.35.0 per the action's release notes.

## Scope

Zero code changes. Just action version pin updates.

## Part of

Upgrade-first security posture sweep on main — converting ignore-list entries into actual fixes where upstream has shipped patches. This PR handles 2 of 19 open Dependabot alerts (both CRITICAL). Follow-up PRs for HIGH (lodash, picomatch) and MEDIUM (postcss, vite, yaml, uuid, serialize-javascript, cookie).