### PR TITLE
ci(security): refresh pip-audit ignore-list (forced-ignore pip CVE-2026-3219, drop stale nltk)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -228,10 +228,20 @@ jobs:
         run: |
           # Audit installed packages against the OSV vulnerability database.
           # --strict exits non-zero on any known vulnerability.
-          # CVE-2025-14009: nltk Zip Slip in downloader — transitive dep, no fix version,
-          # and we never call nltk.download() in production code.
+          #
+          # Forced ignores (no upstream fix available — verified against OSV
+          # at the date in the comment):
+          #
+          # CVE-2026-3219 (2026-04-24): pip 26.0.1 itself — pip 26.0.1 is the
+          #   latest published pip; the runner toolcache is locked to it. No
+          #   patched pip release exists yet. pip is a dev tool, not shipped
+          #   to end users, so production exposure is nil. Re-evaluate when
+          #   pip 26.0.2 (or later) ships with a fix.
+          #
+          # Removed: CVE-2025-14009 (nltk Zip Slip) — confirmed clean in
+          #   nltk 3.9.4 (current latest) per OSV; the ignore is stale.
           pip-audit --strict --vulnerability-service osv \
-            --ignore-vuln CVE-2025-14009
+            --ignore-vuln CVE-2026-3219
 
       - name: Report Python dependency status
         if: always() && (steps.safety.outcome == 'failure' || steps.pip-audit.outcome == 'failure')


### PR DESCRIPTION
Unblocks the Security: Pentest Findings Gate (chronic-red since 2026-04-22).

## What

Two changes to `security.yml` pip-audit step:

1. **Add** `--ignore-vuln CVE-2026-3219` (pip 26.0.1 itself)
2. **Remove** `--ignore-vuln CVE-2025-14009` (nltk Zip Slip — now stale)

## Why pip CVE-2026-3219 is forced-ignore

`pip` 26.0.1 IS the latest published pip. Verified:
```
$ python3 -m pip index versions pip
pip (26.0.1)
  INSTALLED: 26.0.1
  LATEST:    26.0.1
```

There is no patched pip version to upgrade to. The runner toolcache is locked to 26.0.1. `pip` is a dev/build tool, not shipped to end users, so production exposure is nil.

Same forced-ignore pattern as the previously-merged #6525 (the original CVE-2025-14009 nltk ignore that's now being removed because the situation changed).

## Why nltk CVE-2025-14009 ignore is stale

Verified directly against OSV:
```
$ pip-audit --vulnerability-service osv --requirement <(echo "nltk==3.9.4")
No known vulnerabilities found
```

`nltk` 3.9.4 (current latest) is clean per OSV. The ignore was added when an older 3.9.x was current and the CVE was active there. Since the project now resolves to nltk 3.9.4 transitively, the ignore is dead code.

## Re-evaluation

When pip 26.0.2+ ships with a fix for CVE-2026-3219, this ignore should be removed.

## Companion PRs (upgrade-first sweep)

- **#6557** trivy-action 0.28.0→0.35.0 (CVE-2026-33634 CRITICAL, 2 alerts)
- **#6558** chore(deps): patch 17 npm vulns via overrides + sveltekit bump (6 projects, 0 vulns post-fix)
- **#6556** Coverage Gate timeout 30→90 min