### PR TITLE
ci: unify install pattern to ci_install_project.sh in 2 chronic-red workflows

### DIFF
--- a/.github/workflows/nightly-full-matrix.yml
+++ b/.github/workflows/nightly-full-matrix.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,research,code-intel,test,monitoring]"
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Security gates
         run: python scripts/pre_release_check.py --category security
@@ -133,7 +133,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,research,code-intel,test,monitoring]"
+          bash scripts/ci_install_project.sh --extras dev,test
           python -m pip install pytest-timeout
 
       - name: Run shard

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -158,7 +158,9 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: python -m pip install -e ".[dev]" 2>/dev/null || python -m pip install -e . || true
+        run: |
+          python -m pip install --upgrade pip
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run Aragora Security Scanner
         id: security-scan


### PR DESCRIPTION
## Summary

Closes the install-pattern issue across `security.yml` and `nightly-full-matrix.yml` (chronic-red since 2026-04-21). e2e.yml was originally in this PR but is now covered by Factory's parallel #6563; this PR has been rebased to drop the e2e.yml hunk.

## Root cause

`pyproject.toml` has `dependencies = []` — the canonical install path is `scripts/ci_install_project.sh`, which has the full dep list hard-coded. Workflows using `pip install -e \".[dev]\"` or `pip install -e \".[dev,research,code-intel,test,monitoring]\"` get an empty install of the package and miss core deps (httpx, pydantic, fastapi, etc.).

## Fix

Switch install to `bash scripts/ci_install_project.sh --extras dev,test` — the pattern that `core-suites.yml`, `migration-tests.yml`, and `nightly-integration.yml` use successfully.

## Workflows changed (this PR)

- `.github/workflows/security.yml` (Aragora Security Scanner — silent-failure install replaced)
- `.github/workflows/nightly-full-matrix.yml` (Pre-release Gates + Regression Matrix shards)

## Workflows NOT in this PR

- `.github/workflows/e2e.yml` — covered by **#6563** (Factory). Original scope of this PR included e2e.yml; rebased away to avoid merge conflict.

## What this closes

- Aragora Security Scanner (Security: Pentest Findings Gate)
- Pre-release Gates Security step (combined with #6555 bandit fix)
- Regression Matrix shards (3): debate-workflow-handlers, server-integration-memory, sdk-openapi-observability

## Validation

- [x] All install lines updated in security.yml + nightly-full-matrix.yml
- [x] `ci_install_project.sh` proven correct by passing workflows
- [ ] Workflow_dispatch confirmation post-merge
- [ ] Next nightly run shows green imports

Refs #6493 (release prep checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)