### PR TITLE
[DIC-24] Epistemic Genealogy ledger — read-only lineage view for proof-carrying code units

### DIFF
--- a/aragora/epistemic/genealogy.py
+++ b/aragora/epistemic/genealogy.py
@@ -1,0 +1,174 @@
+"""Epistemic Genealogy ledger — lineage view for proof-carrying code units (DIC-24 / #6218).
+
+Read-only ancestry view.  Given a *code_unit_id*, returns an ordered chain of
+evidence nodes (decision receipts, decay signals, crux receipts, and repair
+proposals) that explains why a code path looks the way it does today.
+
+No new persistence model is introduced.  ``GenealogyStore`` is a simple
+protocol whose :class:`InMemoryGenealogyStore` is used in tests; production
+wiring to receipt/KM stores is deferred to the DIC-23..28 activation gate.
+
+Flag: ``ARAGORA_GENEALOGY_ENABLED`` (default False).  The data classes and
+store implementations are always importable; only ``get_genealogy`` checks
+the flag when ``require_enabled=True`` (the default for production callers).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal, Protocol, runtime_checkable
+
+EntryKind = Literal["decision_receipt", "decay_signal", "crux_receipt", "repair_proposal"]
+
+_ENTRY_KINDS: frozenset[str] = frozenset(
+    {"decision_receipt", "decay_signal", "crux_receipt", "repair_proposal"}
+)
+
+
+def _genealogy_enabled() -> bool:
+    raw = str(os.environ.get("ARAGORA_GENEALOGY_ENABLED") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_genealogy() -> None:
+    """Enable genealogy actions for the current process (tests/demo)."""
+    os.environ["ARAGORA_GENEALOGY_ENABLED"] = "1"
+
+
+# ---------------------------------------------------------------------------
+# Core data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GenealogyEntry:
+    """One node in a code unit's lineage chain.
+
+    ``entry_kind`` classifies the artifact source.  ``entry_id`` is the
+    artifact's own stable identifier.  ``checksum`` is the SHA-256 supplied
+    by the artifact (or computed by the caller from its canonical JSON).
+    ``timestamp`` is ISO-8601 UTC.
+    """
+
+    entry_kind: EntryKind
+    entry_id: str
+    checksum: str
+    timestamp: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.entry_kind not in _ENTRY_KINDS:
+            raise ValueError(f"unknown entry_kind: {self.entry_kind!r}")
+        if not self.entry_id:
+            raise ValueError("entry_id must be non-empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "entry_kind": self.entry_kind,
+            "entry_id": self.entry_id,
+            "checksum": self.checksum,
+            "timestamp": self.timestamp,
+        }
+        if self.metadata:
+            d["metadata"] = self.metadata
+        return d
+
+
+def _chain_checksum(entries: list[GenealogyEntry]) -> str:
+    """SHA-256 over canonical-sorted ancestry JSON.  Order-independent."""
+    payload = sorted(
+        [e.to_dict() for e in entries],
+        key=lambda d: (d["timestamp"], d["entry_id"]),
+    )
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+@dataclass
+class CodeUnitGenealogy:
+    """Full lineage view for one proof-carrying code unit.
+
+    ``entries`` are ordered oldest-first by timestamp then entry_id.
+    ``chain_checksum`` is SHA-256 of the canonical-sorted entries JSON.
+    """
+
+    code_unit_id: str
+    entries: list[GenealogyEntry]
+    chain_checksum: str
+    generated_at: str
+
+    @classmethod
+    def build(cls, code_unit_id: str, entries: list[GenealogyEntry]) -> CodeUnitGenealogy:
+        sorted_entries = sorted(entries, key=lambda e: (e.timestamp, e.entry_id))
+        return cls(
+            code_unit_id=code_unit_id,
+            entries=sorted_entries,
+            chain_checksum=_chain_checksum(sorted_entries),
+            generated_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code_unit_id": self.code_unit_id,
+            "entries": [e.to_dict() for e in self.entries],
+            "chain_checksum": self.chain_checksum,
+            "generated_at": self.generated_at,
+            "entry_count": len(self.entries),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Store protocol and in-memory implementation
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class GenealogyStore(Protocol):
+    """Read-only ancestry source for one or more code units."""
+
+    def get_entries(self, code_unit_id: str) -> list[GenealogyEntry]:
+        """Return all lineage entries for *code_unit_id* in any order."""
+        ...
+
+
+@dataclass
+class InMemoryGenealogyStore:
+    """Simple dict-backed store for tests and demos."""
+
+    _entries: dict[str, list[GenealogyEntry]] = field(default_factory=dict)
+
+    def add(self, code_unit_id: str, entry: GenealogyEntry) -> None:
+        self._entries.setdefault(code_unit_id, []).append(entry)
+
+    def get_entries(self, code_unit_id: str) -> list[GenealogyEntry]:
+        return list(self._entries.get(code_unit_id, []))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_genealogy(
+    code_unit_id: str,
+    store: GenealogyStore,
+    *,
+    require_enabled: bool = True,
+) -> CodeUnitGenealogy:
+    """Return the lineage view for *code_unit_id*.
+
+    When *require_enabled* is True (default), raises ``RuntimeError`` if
+    ``ARAGORA_GENEALOGY_ENABLED`` is not set.  Tests can pass
+    ``require_enabled=False`` or set the env var via ``enable_genealogy()``.
+    """
+    if require_enabled and not _genealogy_enabled():
+        raise RuntimeError(
+            "ARAGORA_GENEALOGY_ENABLED is not set; "
+            "set it to '1' or pass require_enabled=False in tests"
+        )
+    entries = store.get_entries(code_unit_id)
+    return CodeUnitGenealogy.build(code_unit_id, entries)

--- a/aragora/epistemic/genealogy.py
+++ b/aragora/epistemic/genealogy.py
@@ -20,13 +20,11 @@ import json
 import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, get_args, runtime_checkable
 
 EntryKind = Literal["decision_receipt", "decay_signal", "crux_receipt", "repair_proposal"]
 
-_ENTRY_KINDS: frozenset[str] = frozenset(
-    {"decision_receipt", "decay_signal", "crux_receipt", "repair_proposal"}
-)
+_ENTRY_KINDS: frozenset[str] = frozenset(get_args(EntryKind))
 
 
 def _genealogy_enabled() -> bool:
@@ -65,6 +63,16 @@ class GenealogyEntry:
             raise ValueError(f"unknown entry_kind: {self.entry_kind!r}")
         if not self.entry_id:
             raise ValueError("entry_id must be non-empty")
+        # Q2: validate and normalize timestamp to canonical UTC form so that
+        # lex-sort is safe even when producers use mixed ISO-8601 representations.
+        try:
+            dt = datetime.fromisoformat(self.timestamp.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            raise ValueError(f"timestamp must be ISO-8601 UTC: {self.timestamp!r}")
+        normalized = dt.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+        object.__setattr__(self, "timestamp", normalized)
+        # Q10: defensive copy so caller mutations don't reach inside frozen entry.
+        object.__setattr__(self, "metadata", dict(self.metadata))
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -74,7 +82,7 @@ class GenealogyEntry:
             "timestamp": self.timestamp,
         }
         if self.metadata:
-            d["metadata"] = self.metadata
+            d["metadata"] = dict(self.metadata)  # Q10: copy on serialization
         return d
 
 
@@ -94,6 +102,9 @@ class CodeUnitGenealogy:
 
     ``entries`` are ordered oldest-first by timestamp then entry_id.
     ``chain_checksum`` is SHA-256 of the canonical-sorted entries JSON.
+    It proves set membership (same entries regardless of insertion order),
+    not historical sequence — two genealogies are equal iff they contain the
+    same set of entries.
     """
 
     code_unit_id: str
@@ -108,7 +119,9 @@ class CodeUnitGenealogy:
             code_unit_id=code_unit_id,
             entries=sorted_entries,
             chain_checksum=_chain_checksum(sorted_entries),
-            generated_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            generated_at=datetime.now(UTC)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -165,6 +178,8 @@ def get_genealogy(
     ``ARAGORA_GENEALOGY_ENABLED`` is not set.  Tests can pass
     ``require_enabled=False`` or set the env var via ``enable_genealogy()``.
     """
+    if not code_unit_id:
+        raise ValueError("code_unit_id must be non-empty")
     if require_enabled and not _genealogy_enabled():
         raise RuntimeError(
             "ARAGORA_GENEALOGY_ENABLED is not set; "

--- a/aragora/epistemic/genealogy.py
+++ b/aragora/epistemic/genealogy.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Literal, Protocol, get_args, runtime_checkable
@@ -69,10 +70,12 @@ class GenealogyEntry:
             dt = datetime.fromisoformat(self.timestamp.replace("Z", "+00:00"))
         except (ValueError, AttributeError):
             raise ValueError(f"timestamp must be ISO-8601 UTC: {self.timestamp!r}")
+        if dt.tzinfo is None or dt.utcoffset() is None:
+            raise ValueError(f"timestamp must include timezone: {self.timestamp!r}")
         normalized = dt.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
-        object.__setattr__(self, "timestamp", normalized)
         # Q10: defensive copy so caller mutations don't reach inside frozen entry.
-        object.__setattr__(self, "metadata", dict(self.metadata))
+        object.__setattr__(self, "timestamp", normalized)
+        object.__setattr__(self, "metadata", deepcopy(self.metadata))
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -82,7 +85,7 @@ class GenealogyEntry:
             "timestamp": self.timestamp,
         }
         if self.metadata:
-            d["metadata"] = dict(self.metadata)  # Q10: copy on serialization
+            d["metadata"] = deepcopy(self.metadata)  # Q10: copy on serialization
         return d
 
 
@@ -114,6 +117,8 @@ class CodeUnitGenealogy:
 
     @classmethod
     def build(cls, code_unit_id: str, entries: list[GenealogyEntry]) -> CodeUnitGenealogy:
+        if not code_unit_id:
+            raise ValueError("code_unit_id must be non-empty")
         sorted_entries = sorted(entries, key=lambda e: (e.timestamp, e.entry_id))
         return cls(
             code_unit_id=code_unit_id,

--- a/tests/epistemic/test_genealogy.py
+++ b/tests/epistemic/test_genealogy.py
@@ -151,9 +151,7 @@ class TestCodeUnitGenealogy:
         assert len(d["chain_checksum"]) == 64
 
     def test_chain_checksum_stable_regardless_of_input_order(self) -> None:
-        entries = [
-            _entry("decay_signal", f"e{i}", f"2026-04-25T0{i}:00:00Z") for i in range(1, 4)
-        ]
+        entries = [_entry("decay_signal", f"e{i}", f"2026-04-25T0{i}:00:00Z") for i in range(1, 4)]
         g1 = CodeUnitGenealogy.build("unit.foo", entries)
         g2 = CodeUnitGenealogy.build("unit.foo", list(reversed(entries)))
         assert g1.chain_checksum == g2.chain_checksum

--- a/tests/epistemic/test_genealogy.py
+++ b/tests/epistemic/test_genealogy.py
@@ -58,7 +58,7 @@ class TestGenealogyEntry:
         assert e.to_dict()["metadata"]["repair_kind"] == "pr_candidate"
 
     def test_metadata_defensive_copy_on_construction(self) -> None:
-        caller_dict = {"key": "original"}
+        caller_dict = {"key": "original", "nested": {"inner": "original"}}
         e = GenealogyEntry(
             entry_kind="decay_signal",
             entry_id="e1",
@@ -67,7 +67,9 @@ class TestGenealogyEntry:
             metadata=caller_dict,
         )
         caller_dict["key"] = "mutated"
+        caller_dict["nested"]["inner"] = "mutated"
         assert e.metadata["key"] == "original"
+        assert e.metadata["nested"]["inner"] == "original"
 
     def test_metadata_defensive_copy_on_to_dict(self) -> None:
         e = GenealogyEntry(
@@ -75,11 +77,13 @@ class TestGenealogyEntry:
             entry_id="e1",
             checksum="abc",
             timestamp="2026-04-25T00:00:00Z",
-            metadata={"key": "original"},
+            metadata={"key": "original", "nested": {"inner": "original"}},
         )
         d = e.to_dict()
         d["metadata"]["key"] = "mutated"
+        d["metadata"]["nested"]["inner"] = "mutated"
         assert e.metadata["key"] == "original"
+        assert e.metadata["nested"]["inner"] == "original"
 
     def test_invalid_kind_raises(self) -> None:
         with pytest.raises(ValueError, match="entry_kind"):
@@ -121,6 +125,15 @@ class TestGenealogyEntry:
     def test_timestamp_z_suffix_accepted(self) -> None:
         e = _entry(ts="2026-04-25T00:00:00Z")
         assert e.timestamp == "2026-04-25T00:00:00.000Z"
+
+    def test_naive_timestamp_raises(self) -> None:
+        with pytest.raises(ValueError, match="timezone"):
+            GenealogyEntry(
+                entry_kind="decay_signal",
+                entry_id="e1",
+                checksum="abc",
+                timestamp="2026-04-25T00:00:00",
+            )
 
     def test_all_valid_kinds_accepted(self) -> None:
         for kind in ("decision_receipt", "decay_signal", "crux_receipt", "repair_proposal"):
@@ -167,6 +180,10 @@ class TestChainChecksum:
 
 
 class TestCodeUnitGenealogy:
+    def test_build_empty_code_unit_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="code_unit_id"):
+            CodeUnitGenealogy.build("", [])
+
     def test_build_sorts_by_timestamp(self) -> None:
         e1 = _entry("decay_signal", "e1", "2026-04-25T03:00:00Z")
         e2 = _entry("decision_receipt", "e2", "2026-04-25T01:00:00Z")

--- a/tests/epistemic/test_genealogy.py
+++ b/tests/epistemic/test_genealogy.py
@@ -57,6 +57,30 @@ class TestGenealogyEntry:
         )
         assert e.to_dict()["metadata"]["repair_kind"] == "pr_candidate"
 
+    def test_metadata_defensive_copy_on_construction(self) -> None:
+        caller_dict = {"key": "original"}
+        e = GenealogyEntry(
+            entry_kind="decay_signal",
+            entry_id="e1",
+            checksum="abc",
+            timestamp="2026-04-25T00:00:00Z",
+            metadata=caller_dict,
+        )
+        caller_dict["key"] = "mutated"
+        assert e.metadata["key"] == "original"
+
+    def test_metadata_defensive_copy_on_to_dict(self) -> None:
+        e = GenealogyEntry(
+            entry_kind="decay_signal",
+            entry_id="e1",
+            checksum="abc",
+            timestamp="2026-04-25T00:00:00Z",
+            metadata={"key": "original"},
+        )
+        d = e.to_dict()
+        d["metadata"]["key"] = "mutated"
+        assert e.metadata["key"] == "original"
+
     def test_invalid_kind_raises(self) -> None:
         with pytest.raises(ValueError, match="entry_kind"):
             GenealogyEntry(
@@ -74,6 +98,29 @@ class TestGenealogyEntry:
                 checksum="",
                 timestamp="2026-04-25T00:00:00Z",
             )
+
+    def test_invalid_timestamp_raises(self) -> None:
+        with pytest.raises(ValueError, match="timestamp"):
+            GenealogyEntry(
+                entry_kind="decay_signal",
+                entry_id="e1",
+                checksum="abc",
+                timestamp="not-a-date",
+            )
+
+    def test_timestamp_normalized_to_canonical_form(self) -> None:
+        # +00:00 offset form → Z suffix; millisecond precision enforced
+        e = GenealogyEntry(
+            entry_kind="decay_signal",
+            entry_id="e1",
+            checksum="abc",
+            timestamp="2026-04-25T12:00:00+00:00",
+        )
+        assert e.timestamp == "2026-04-25T12:00:00.000Z"
+
+    def test_timestamp_z_suffix_accepted(self) -> None:
+        e = _entry(ts="2026-04-25T00:00:00Z")
+        assert e.timestamp == "2026-04-25T00:00:00.000Z"
 
     def test_all_valid_kinds_accepted(self) -> None:
         for kind in ("decision_receipt", "decay_signal", "crux_receipt", "repair_proposal"):
@@ -205,6 +252,11 @@ class TestInMemoryGenealogyStore:
 
 
 class TestGetGenealogy:
+    def test_empty_code_unit_id_raises(self) -> None:
+        store = InMemoryGenealogyStore()
+        with pytest.raises(ValueError, match="code_unit_id"):
+            get_genealogy("", store, require_enabled=False)
+
     def test_flag_off_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ARAGORA_GENEALOGY_ENABLED", raising=False)
         store = InMemoryGenealogyStore()

--- a/tests/epistemic/test_genealogy.py
+++ b/tests/epistemic/test_genealogy.py
@@ -1,0 +1,255 @@
+"""Unit tests for aragora.epistemic.genealogy (DIC-24 / #6218)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.genealogy import (
+    CodeUnitGenealogy,
+    GenealogyEntry,
+    GenealogyStore,
+    InMemoryGenealogyStore,
+    _chain_checksum,
+    enable_genealogy,
+    get_genealogy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entry(
+    kind: str = "decay_signal",
+    entry_id: str = "test-entry-1",
+    ts: str = "2026-04-25T00:00:00Z",
+    checksum: str = "abc123",
+) -> GenealogyEntry:
+    return GenealogyEntry(
+        entry_kind=kind,  # type: ignore[arg-type]
+        entry_id=entry_id,
+        checksum=checksum,
+        timestamp=ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GenealogyEntry
+# ---------------------------------------------------------------------------
+
+
+class TestGenealogyEntry:
+    def test_roundtrip_excludes_empty_metadata(self) -> None:
+        e = _entry("decision_receipt", "dr-1", "2026-04-25T10:00:00Z")
+        d = e.to_dict()
+        assert d["entry_kind"] == "decision_receipt"
+        assert d["entry_id"] == "dr-1"
+        assert "metadata" not in d
+
+    def test_metadata_included_when_present(self) -> None:
+        e = GenealogyEntry(
+            entry_kind="repair_proposal",
+            entry_id="rp-1",
+            checksum="deadbeef",
+            timestamp="2026-04-25T00:00:00Z",
+            metadata={"repair_kind": "pr_candidate"},
+        )
+        assert e.to_dict()["metadata"]["repair_kind"] == "pr_candidate"
+
+    def test_invalid_kind_raises(self) -> None:
+        with pytest.raises(ValueError, match="entry_kind"):
+            GenealogyEntry(
+                entry_kind="unknown_kind",  # type: ignore[arg-type]
+                entry_id="x",
+                checksum="",
+                timestamp="2026-04-25T00:00:00Z",
+            )
+
+    def test_empty_entry_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="entry_id"):
+            GenealogyEntry(
+                entry_kind="decay_signal",
+                entry_id="",
+                checksum="",
+                timestamp="2026-04-25T00:00:00Z",
+            )
+
+    def test_all_valid_kinds_accepted(self) -> None:
+        for kind in ("decision_receipt", "decay_signal", "crux_receipt", "repair_proposal"):
+            e = GenealogyEntry(
+                entry_kind=kind,  # type: ignore[arg-type]
+                entry_id="eid",
+                checksum="c",
+                timestamp="2026-04-25T00:00:00Z",
+            )
+            assert e.entry_kind == kind
+
+
+# ---------------------------------------------------------------------------
+# _chain_checksum
+# ---------------------------------------------------------------------------
+
+
+class TestChainChecksum:
+    def test_empty_entries_is_deterministic(self) -> None:
+        c1 = _chain_checksum([])
+        c2 = _chain_checksum([])
+        assert c1 == c2
+        assert len(c1) == 64  # SHA-256 hex
+
+    def test_order_independent(self) -> None:
+        e1 = _entry("decay_signal", "e1", "2026-04-25T01:00:00Z")
+        e2 = _entry("crux_receipt", "e2", "2026-04-25T02:00:00Z")
+        assert _chain_checksum([e1, e2]) == _chain_checksum([e2, e1])
+
+    def test_different_entries_give_different_checksums(self) -> None:
+        e1 = _entry("decay_signal", "e1", "2026-04-25T01:00:00Z")
+        e2 = _entry("crux_receipt", "e2", "2026-04-25T01:00:00Z")
+        assert _chain_checksum([e1]) != _chain_checksum([e2])
+
+    def test_checksum_changes_when_content_changes(self) -> None:
+        e1 = _entry("decay_signal", "e1", "2026-04-25T01:00:00Z", checksum="aaa")
+        e2 = _entry("decay_signal", "e1", "2026-04-25T01:00:00Z", checksum="bbb")
+        assert _chain_checksum([e1]) != _chain_checksum([e2])
+
+
+# ---------------------------------------------------------------------------
+# CodeUnitGenealogy
+# ---------------------------------------------------------------------------
+
+
+class TestCodeUnitGenealogy:
+    def test_build_sorts_by_timestamp(self) -> None:
+        e1 = _entry("decay_signal", "e1", "2026-04-25T03:00:00Z")
+        e2 = _entry("decision_receipt", "e2", "2026-04-25T01:00:00Z")
+        e3 = _entry("crux_receipt", "e3", "2026-04-25T02:00:00Z")
+        g = CodeUnitGenealogy.build("unit.foo", [e1, e2, e3])
+        assert [e.entry_id for e in g.entries] == ["e2", "e3", "e1"]
+
+    def test_build_secondary_sort_by_entry_id(self) -> None:
+        # Same timestamp — should sort by entry_id
+        e1 = _entry("decay_signal", "z-first", "2026-04-25T01:00:00Z")
+        e2 = _entry("crux_receipt", "a-second", "2026-04-25T01:00:00Z")
+        g = CodeUnitGenealogy.build("unit.foo", [e1, e2])
+        assert g.entries[0].entry_id == "a-second"
+        assert g.entries[1].entry_id == "z-first"
+
+    def test_to_dict_has_all_keys(self) -> None:
+        g = CodeUnitGenealogy.build("unit.foo", [_entry()])
+        d = g.to_dict()
+        for key in ("code_unit_id", "entries", "chain_checksum", "generated_at", "entry_count"):
+            assert key in d
+        assert d["entry_count"] == 1
+        assert d["code_unit_id"] == "unit.foo"
+
+    def test_empty_genealogy_to_dict(self) -> None:
+        g = CodeUnitGenealogy.build("unit.empty", [])
+        d = g.to_dict()
+        assert d["entry_count"] == 0
+        assert d["entries"] == []
+        assert len(d["chain_checksum"]) == 64
+
+    def test_chain_checksum_stable_regardless_of_input_order(self) -> None:
+        entries = [
+            _entry("decay_signal", f"e{i}", f"2026-04-25T0{i}:00:00Z") for i in range(1, 4)
+        ]
+        g1 = CodeUnitGenealogy.build("unit.foo", entries)
+        g2 = CodeUnitGenealogy.build("unit.foo", list(reversed(entries)))
+        assert g1.chain_checksum == g2.chain_checksum
+
+    def test_chain_checksum_differs_for_different_entries(self) -> None:
+        g1 = CodeUnitGenealogy.build("unit.foo", [_entry("decay_signal", "e1")])
+        g2 = CodeUnitGenealogy.build("unit.foo", [_entry("crux_receipt", "e2")])
+        assert g1.chain_checksum != g2.chain_checksum
+
+
+# ---------------------------------------------------------------------------
+# InMemoryGenealogyStore
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryGenealogyStore:
+    def test_get_entries_empty(self) -> None:
+        store = InMemoryGenealogyStore()
+        assert store.get_entries("unit.missing") == []
+
+    def test_add_and_retrieve(self) -> None:
+        store = InMemoryGenealogyStore()
+        e = _entry("repair_proposal", "rp-1")
+        store.add("unit.foo", e)
+        assert store.get_entries("unit.foo") == [e]
+        assert store.get_entries("unit.bar") == []
+
+    def test_multiple_entries_for_same_unit(self) -> None:
+        store = InMemoryGenealogyStore()
+        e1 = _entry("decay_signal", "e1")
+        e2 = _entry("crux_receipt", "e2")
+        store.add("unit.foo", e1)
+        store.add("unit.foo", e2)
+        assert len(store.get_entries("unit.foo")) == 2
+
+    def test_returns_copy_not_reference(self) -> None:
+        store = InMemoryGenealogyStore()
+        store.add("unit.foo", _entry())
+        result = store.get_entries("unit.foo")
+        result.clear()
+        assert len(store.get_entries("unit.foo")) == 1
+
+    def test_implements_protocol(self) -> None:
+        store = InMemoryGenealogyStore()
+        assert isinstance(store, GenealogyStore)
+
+
+# ---------------------------------------------------------------------------
+# get_genealogy
+# ---------------------------------------------------------------------------
+
+
+class TestGetGenealogy:
+    def test_flag_off_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_GENEALOGY_ENABLED", raising=False)
+        store = InMemoryGenealogyStore()
+        with pytest.raises(RuntimeError, match="ARAGORA_GENEALOGY_ENABLED"):
+            get_genealogy("unit.foo", store)
+
+    def test_require_enabled_false_bypasses_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_GENEALOGY_ENABLED", raising=False)
+        store = InMemoryGenealogyStore()
+        g = get_genealogy("unit.foo", store, require_enabled=False)
+        assert g.code_unit_id == "unit.foo"
+        assert g.entries == []
+
+    def test_flag_enabled_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_GENEALOGY_ENABLED", "1")
+        store = InMemoryGenealogyStore()
+        store.add("unit.bar", _entry("decision_receipt", "dr-1"))
+        g = get_genealogy("unit.bar", store)
+        assert len(g.entries) == 1
+        assert g.entries[0].entry_id == "dr-1"
+
+    def test_flag_enabled_via_true_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_GENEALOGY_ENABLED", "true")
+        store = InMemoryGenealogyStore()
+        g = get_genealogy("unit.x", store)
+        assert g.code_unit_id == "unit.x"
+
+    def test_enable_genealogy_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_GENEALOGY_ENABLED", raising=False)
+        enable_genealogy()
+        store = InMemoryGenealogyStore()
+        g = get_genealogy("unit.x", store)
+        assert g.code_unit_id == "unit.x"
+
+    def test_returns_genealogy_with_sorted_entries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_GENEALOGY_ENABLED", "1")
+        store = InMemoryGenealogyStore()
+        store.add("unit.chain", _entry("repair_proposal", "rp-1", "2026-04-25T05:00:00Z"))
+        store.add("unit.chain", _entry("decision_receipt", "dr-1", "2026-04-25T01:00:00Z"))
+        store.add("unit.chain", _entry("decay_signal", "ds-1", "2026-04-25T03:00:00Z"))
+        g = get_genealogy("unit.chain", store)
+        assert [e.entry_kind for e in g.entries] == [
+            "decision_receipt",
+            "decay_signal",
+            "repair_proposal",
+        ]


### PR DESCRIPTION
## Slice

Adds `aragora/epistemic/genealogy.py` — a read-only ancestry view over existing artifact stores (decision receipts, decay signals, crux receipts, and repair proposals) that answers "why does this code unit look the way it does today?" No new persistence model; ancestry is a derived view. Chain checksum is SHA-256 over canonical-sorted entries JSON, deterministic and order-independent.

## Gating

- Default: OFF (flag: `ARAGORA_GENEALOGY_ENABLED`; or pass `require_enabled=False` in tests)
- Live queue effect: none
- Advances issue: #6218

## Tests

- `TestGenealogyEntry` — roundtrip serialization, metadata inclusion, invalid-kind and empty-id guards, all four valid entry kinds accepted
- `TestChainChecksum` — deterministic on empty input, order-independent, changes when content changes
- `TestCodeUnitGenealogy` — build sorts by (timestamp, entry_id), to_dict keys, empty genealogy, chain checksum stability across input order
- `TestInMemoryGenealogyStore` — empty get, add/retrieve, multiple entries, returns copy not reference, implements GenealogyStore protocol
- `TestGetGenealogy` — flag-off raises RuntimeError, require_enabled=False bypasses flag, env "1" and "true" both enable, enable_genealogy() helper, sorted entries returned correctly

## Validation

- `pytest tests/epistemic/test_genealogy.py` — **26 passed**
- `ruff check aragora/epistemic/genealogy.py tests/epistemic/test_genealogy.py` — clean
- `mypy aragora/epistemic/genealogy.py --ignore-missing-imports --strict` — **0 errors in touched file** (pre-existing errors in unrelated modules are not introduced by this change)

## Out of scope

- Production wiring to receipt/KM stores (deferred to DIC-23..28 activation gate per NEXT_STEPS_CANONICAL)
- Integration into DIC-18 truth map drill-down (next slice once this lands)
- DIC-23 `runtime_loop.py` orchestrator (separate issue #6217, depends on DIC-20/21/22 production-green)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QU8uR2uxwTWAmiLHE5xGps)_