### PR TITLE
ci(e2e): align Python deps install with integration/load-tests (fixes ModuleNotFoundError pydantic)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -241,10 +241,14 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Python dependencies
+        # NOTE: pyproject.toml's [dev] extra only contains type stubs
+        # (mypy, types-*); it does NOT pull pydantic, aiohttp, fastapi or
+        # any of the actual control-plane deps. Use ci_install_project.sh
+        # (same script used by integration.yml + load-tests.yml) so the
+        # E2E job runs against the real dep set including pydantic.
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
-          python -m pip install pytest pytest-asyncio pytest-timeout aiohttp
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run Python E2E tests
         run: |


### PR DESCRIPTION
Closes the chronic-red **Python E2E Tests** failure on main.

## What

`e2e.yml` was running `pip install -e ".[dev]"` to pull the project for the Python E2E job. But pyproject.toml's `[dev]` extra only contains type stubs:

```toml
dev = [
    "mypy>=1.19.0,<2.0",
    "types-PyYAML>=6.0,<7.0",
    "types-croniter>=2.0,<6.0",
]
```

No pydantic, no aiohttp, no fastapi — none of the actual runtime deps that `tests/conftest.py` needs to import.

This PR replaces it with the same `bash scripts/ci_install_project.sh --extras dev,test` that **integration.yml** and **load-tests.yml** already use, which sources the proper `LEGACY_CONTROL_PLANE_BASE_DEPS` array.

## Evidence

```
2026-04-24T21:32:40.7615319Z ImportError while loading conftest '/home/runner/work/aragora/aragora/tests/conftest.py'.
2026-04-24T21:32:40.8277450Z E   ModuleNotFoundError: No module named 'pydantic'
2026-04-24T21:32:40.8631696Z ##[error]Process completed with exit code 4.
```

## Scope

- 1 file changed: `.github/workflows/e2e.yml`
- Replaces 2 `pip install` lines with 1 `bash scripts/ci_install_project.sh` line
- Adds an inline comment explaining the gotcha (dev extra is only type stubs)

## Companion PRs (chronic-red sweep)

- **#6562** Integration tests fix (MockAgent + route bound)
- **#6557** trivy-action 0.28.0→0.35.0 (CRITICAL)
- **#6558** chore(deps): patch 17 npm vulns via overrides
- **#6559** ci(security): pip-audit ignore-list refresh
- **#6556** ci(coverage): timeout 30→90 min