### PR TITLE
ci(coverage): parallelize Coverage Gate with -n auto + bump timeout 30→45

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
   coverage:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -63,6 +63,9 @@ jobs:
 
       - name: Run tests with coverage
         run: |
+          # -n auto: parallel execution via pytest-xdist (~4-8x speedup on CI runners
+          # with multiple cores). Coverage is collected per-worker and merged
+          # automatically by pytest-cov when COV_CORE_SOURCE is set, which xdist does.
           python -m pytest tests/ \
             -m "not slow and not load and not e2e" \
             --cov=aragora \
@@ -70,6 +73,7 @@ jobs:
             --cov-report=xml:coverage.xml \
             --cov-report=term-missing \
             --timeout=120 \
+            -n auto \
             -q \
             --cov-fail-under=70
 


### PR DESCRIPTION
## Summary

Closes the chronic-cancel pattern on Coverage Gate (10+ consecutive nights cancelled, including both today's dispatched runs which hit the 30:17 mark). Root cause: pytest --cov over the full suite runs serially and exceeds the 30-minute timeout.

## Fix

1. Add \`-n auto\` to pytest invocation. pytest-xdist is already installed via \`ci_install_project.sh\`. On ubuntu-latest 4-vCPU runners, this typically yields 3-4x speedup. Coverage collection integrates with xdist correctly via standard pytest-cov.

2. Bump \`timeout-minutes: 30 → 45\` as safety margin while measuring the actual parallel runtime. Can tune back down once we see how long it takes.

## Why this is the right shape

- pytest-xdist is already in the install pattern (verified in passing workflows like nightly-full-matrix)
- Coverage Gate currently runs ~30+ min serial; expect 8-15 min parallel
- 45-min cap gives margin without locking in a bigger budget
- Doesn't touch the underlying test suite or coverage thresholds

## Out of scope

- Sharding the test suite by category (larger play, not needed yet)
- Reducing coverage scope (\`--cov-fail-under=70\` stays)
- Refactoring slow individual tests

## Test plan

- [ ] Workflow_dispatch after merge to confirm it actually completes
- [ ] First nightly run hits success/failure (terminal state) instead of cancelled
- [ ] If runtime is well under 30 min in parallel, can revert timeout bump in a follow-up

Refs #6493 (release prep checklist) and the chronic-red repair sweep that started with #6554, #6555, #6560, #6564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)