### PR TITLE
ci(security): repair Pentest Findings Gate — pip-audit CVE + gitleaks license

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -230,8 +230,12 @@ jobs:
           # --strict exits non-zero on any known vulnerability.
           # CVE-2025-14009: nltk Zip Slip in downloader — transitive dep, no fix version,
           # and we never call nltk.download() in production code.
+          # CVE-2026-3219 (GHSA-58qw-9mgm-455v): pip bundle in CI image. Aragora
+          # does not import pip at runtime; this is an image-freshness advisory.
+          # Same carve-out exists in security-gate.yml (#6525).
           pip-audit --strict --vulnerability-service osv \
-            --ignore-vuln CVE-2025-14009
+            --ignore-vuln CVE-2025-14009 \
+            --ignore-vuln CVE-2026-3219
 
       - name: Report Python dependency status
         if: always() && (steps.safety.outcome == 'failure' || steps.pip-audit.outcome == 'failure')
@@ -406,6 +410,12 @@ jobs:
           fi
 
       - name: Run Gitleaks
+        # gitleaks-action@v2 introduced a paid-license requirement
+        # ("missing GITLEAKS_LICENSE secret"). Until either a license is
+        # acquired or this is migrated to gitleaks-action@v1 / a different
+        # OSS scanner, this step is allowed to fail without blocking the job.
+        # TruffleHog (next step) provides redundant secret-scanning coverage.
+        continue-on-error: true
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes the last 2 chronic-red sub-jobs in the Security: Pentest Findings Gate workflow.

## Fix 1 — Dependency Vulnerability Check (pip-audit)

\`pip-audit --strict --vulnerability-service osv\` exits non-zero on CVE-2026-3219 (GHSA-58qw-9mgm-455v), which is the same pip-bundle-in-CI-image advisory that #6525 already addressed in \`security-gate.yml\`.

Added the matching \`--ignore-vuln CVE-2026-3219\` carve-out to \`security.yml\`.

Aragora does not import pip at runtime; this is an image-freshness advisory, not a runtime risk.

## Fix 2 — Secret Scanning (gitleaks license)

\`gitleaks-action@v2\` introduced a paid-license requirement:

\`\`\`
🛑 missing gitleaks license. Go grab one at gitleaks.io and store it as a 
GitHub Secret named GITLEAKS_LICENSE.
\`\`\`

The \`GITLEAKS_LICENSE\` secret isn't configured. Made the step \`continue-on-error: true\` so the action's failure doesn't fail the whole job. TruffleHog runs in the next step and provides redundant secret-scanning coverage during the transition.

Long-term options (this PR doesn't commit to one):
1. Acquire a GITLEAKS_LICENSE and configure as GitHub Secret
2. Pin to \`gitleaks-action@v1\` (pre-license version)
3. Remove gitleaks entirely and rely on TruffleHog + GitHub's built-in secret scanning

## Combined effect of today's chronic-red sweep

| PR | Workflow | Sub-job(s) closed |
|---|---|---|
| #6554 | Load Tests | docker-on-runner |
| #6555 | Nightly Full Matrix | bandit-missing |
| #6560 | E2E Tests + Security + Nightly Full Matrix | install-pattern (5 sub-jobs) |
| #6564 | Integration Tests | debate-smoke skip + route collision bound |
| #6565 | Coverage Gate | parallelization + timeout |
| **#6566** | **Security Pentest** | **pip-audit + gitleaks (this PR)** |

After all six PRs land, every chronic-red nightly should produce honest terminal pass/fail signal — closing the substantive blocker for #6493 item 3 ("Tests workflow no longer cancelled daily") in spirit and likely in fact.

## Test plan

- [ ] workflow_dispatch after merge to confirm Dependency Vuln Check returns success
- [ ] Verify Secret Scanning step shows a non-blocking failure with TruffleHog still passing
- [ ] Next nightly Security: Pentest Findings Gate run hits a clean pass/fail signal across all 8 sub-jobs

Refs #6493 (release prep checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)