### PR TITLE
ci(security): make gitleaks step soft-fail until license is provisioned

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -406,6 +406,13 @@ jobs:
           fi
 
       - name: Run Gitleaks
+        # gitleaks-action@v2 introduced a paid-license requirement for
+        # organization accounts ("missing GITLEAKS_LICENSE secret"). Until
+        # either a license is provisioned, this step is allowed to fail
+        # without blocking the workflow. TruffleHog (next step) provides
+        # redundant secret-scanning coverage during the transition.
+        # Decision tracked separately: license vs pin-to-v1 vs migrate.
+        continue-on-error: true
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes the **last remaining chronic-red sub-job** in Security: Pentest Findings Gate — Secret Scanning, which has been failing on every nightly run because gitleaks-action@v2 requires a paid license now.

## Root cause

\`\`\`
🛑 missing gitleaks license. Go grab one at gitleaks.io and store it as a 
GitHub Secret named GITLEAKS_LICENSE.
\`\`\`

\`gitleaks-action@v2\` introduced a paid-license requirement for organization accounts. The \`GITLEAKS_LICENSE\` GitHub Secret isn't configured, so the action exits at startup. **No leaked secret was found** — the scanner never ran.

## Fix

Single change: add \`continue-on-error: true\` to the Run Gitleaks step.

- TruffleHog runs in the next step and provides redundant secret-scanning coverage during the transition
- Pre-commit hooks also run gitleaks locally (different mode, license-free)
- GitHub's native secret scanning provides additional defense-in-depth

## Long-term decision (tracked separately, not this PR)

1. **Provision GITLEAKS_LICENSE** as a GitHub Secret (paid)
2. **Pin to gitleaks-action@v1** (free, pre-license-requirement version)
3. **Remove gitleaks** entirely; rely on TruffleHog + GitHub native + pre-commit

## Test plan

- [x] Single-line workflow change; YAML syntax verified
- [ ] workflow_dispatch confirms Secret Scanning step shows non-blocking failure
- [ ] Other sub-jobs in Security: Pentest Findings Gate still report their own pass/fail (no longer masked by gitleaks failure)

## Why this is narrow

Originally part of #6566 (now closed) which also addressed the pip-audit CVE. Factory's #6559 covers the pip-audit half; this PR is the gitleaks half on its own to avoid merge conflict. Touches a different file region (line 409 area) than #6559 (line 230 area), so they should land in any order without collision.

Refs the chronic-red repair sweep: #6554, #6555, #6557, #6558, #6559, #6560, #6562, #6563. With this PR, every chronic-red sub-job has an associated fix in the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)