### PR TITLE
fix(integration C.3): align webhook_configs schema with INITIAL_SCHEMA (closes last chronic-red Integration)

### DIFF
--- a/aragora/db/schema/postgres_schema.sql
+++ b/aragora/db/schema/postgres_schema.sql
@@ -265,20 +265,27 @@ CREATE TABLE IF NOT EXISTS integrations (
     sync_status TEXT
 );
 
+-- Must stay in sync with PostgresWebhookConfigStore.INITIAL_SCHEMA
+-- in aragora/storage/webhook_config_store.py. When the store's initialize()
+-- runs CREATE TABLE IF NOT EXISTS + CREATE INDEX ON webhook_configs(user_id),
+-- the CREATE INDEX fails with UndefinedColumnError if the CREATE TABLE is a
+-- noop against an older, drifted shape of this table.
 CREATE TABLE IF NOT EXISTS webhook_configs (
     id TEXT PRIMARY KEY,
-    name TEXT NOT NULL,
     url TEXT NOT NULL,
-    events JSONB DEFAULT '[]',
-    secret TEXT,
-    headers JSONB DEFAULT '{}',
-    is_active BOOLEAN DEFAULT TRUE,
-    org_id TEXT,
-    created_at TIMESTAMPTZ DEFAULT NOW(),
-    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    events_json JSONB NOT NULL,
+    secret TEXT NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    name TEXT,
+    description TEXT,
+    last_delivery_at TIMESTAMPTZ,
+    last_delivery_status INTEGER,
+    delivery_count INTEGER DEFAULT 0,
     failure_count INTEGER DEFAULT 0,
-    last_failure_at TIMESTAMPTZ,
-    last_success_at TIMESTAMPTZ
+    user_id TEXT,
+    workspace_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS webhook_deliveries (
@@ -309,7 +316,11 @@ CREATE TABLE IF NOT EXISTS gmail_tokens (
 
 CREATE INDEX IF NOT EXISTS idx_integrations_org ON integrations(org_id);
 CREATE INDEX IF NOT EXISTS idx_integrations_type ON integrations(type);
-CREATE INDEX IF NOT EXISTS idx_webhook_configs_org ON webhook_configs(org_id);
+-- Indexes on webhook_configs must match
+-- PostgresWebhookConfigStore.INITIAL_SCHEMA (see aragora/storage/webhook_config_store.py).
+CREATE INDEX IF NOT EXISTS idx_webhook_configs_user ON webhook_configs(user_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_configs_workspace ON webhook_configs(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_configs_active ON webhook_configs(active);
 CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON webhook_deliveries(status);
 
 -- ============================================================================

--- a/aragora/migrations/versions/v20260424000000_align_webhook_configs_schema.py
+++ b/aragora/migrations/versions/v20260424000000_align_webhook_configs_schema.py
@@ -43,7 +43,10 @@ Zero-Downtime Strategy
   (PostgreSQL only updates the catalog, no table rewrite).
 - ADD COLUMN with a default is fast on modern Postgres (11+).
 - DROP COLUMN is metadata-only until next VACUUM.
-- CREATE INDEX uses CONCURRENTLY via ``safe_create_index``.
+- CREATE INDEX intentionally avoids CONCURRENTLY because the current
+  ``PostgreSQLBackend.execute_write`` helper wraps each statement in a
+  transaction, and PostgreSQL rejects ``CREATE INDEX CONCURRENTLY`` inside
+  transaction blocks.
 """
 
 import logging
@@ -157,21 +160,21 @@ def up_fn(backend: DatabaseBackend) -> None:
             "idx_webhook_configs_user",
             "webhook_configs",
             ["user_id"],
-            concurrently=True,
+            concurrently=False,
         )
         safe_create_index(
             backend,
             "idx_webhook_configs_workspace",
             "webhook_configs",
             ["workspace_id"],
-            concurrently=True,
+            concurrently=False,
         )
         safe_create_index(
             backend,
             "idx_webhook_configs_active",
             "webhook_configs",
             ["active"],
-            concurrently=True,
+            concurrently=False,
         )
 
         logger.info("webhook_configs schema aligned with INITIAL_SCHEMA")

--- a/aragora/migrations/versions/v20260424000000_align_webhook_configs_schema.py
+++ b/aragora/migrations/versions/v20260424000000_align_webhook_configs_schema.py
@@ -1,0 +1,254 @@
+"""
+Align webhook_configs schema with PostgresWebhookConfigStore.INITIAL_SCHEMA.
+
+Migration created: 2026-04-24
+
+Background
+----------
+The canonical schema in ``aragora/db/schema/postgres_schema.sql`` had a
+``webhook_configs`` table definition that drifted from
+``PostgresWebhookConfigStore.INITIAL_SCHEMA`` in
+``aragora/storage/webhook_config_store.py``. The store is the source of
+truth; the schema file had the old shape (``org_id``, ``is_active``,
+``events JSONB``, ``headers JSONB``, ``last_failure_at``, ``last_success_at``),
+while the store uses ``user_id``, ``workspace_id``, ``active``, ``events_json``,
+``description``, ``last_delivery_at``, ``last_delivery_status``,
+``delivery_count``.
+
+When integration tests ran ``psql -f postgres_schema.sql`` first and then
+``store.initialize()`` executed, the store's ``CREATE TABLE IF NOT EXISTS``
+was a noop against the stale table, and the subsequent
+``CREATE INDEX ... ON webhook_configs(user_id)`` failed with
+``UndefinedColumnError``.
+
+This migration brings existing production databases up to the canonical
+shape without data loss for rows already written with the old schema. It
+is idempotent.
+
+Column mapping
+--------------
+- ``org_id`` → ``workspace_id`` (rename; same concept in the new model)
+- ``is_active`` → ``active``       (rename)
+- ``events``   → ``events_json``   (rename; same JSONB type)
+- ``headers``  → dropped           (no longer tracked by the store)
+- ``last_failure_at`` → dropped    (replaced by ``last_delivery_at`` + ``last_delivery_status``)
+- ``last_success_at`` → dropped    (replaced by ``last_delivery_at`` + ``last_delivery_status``)
+
+New columns added: ``user_id``, ``description``, ``last_delivery_at``,
+``last_delivery_status``, ``delivery_count``.
+
+Zero-Downtime Strategy
+----------------------
+- RENAME COLUMN takes a brief exclusive lock but finishes instantly
+  (PostgreSQL only updates the catalog, no table rewrite).
+- ADD COLUMN with a default is fast on modern Postgres (11+).
+- DROP COLUMN is metadata-only until next VACUUM.
+- CREATE INDEX uses CONCURRENTLY via ``safe_create_index``.
+"""
+
+import logging
+
+from aragora.migrations.patterns import safe_create_index, safe_drop_index
+from aragora.migrations.runner import Migration
+from aragora.storage.backends import DatabaseBackend, PostgreSQLBackend
+
+logger = logging.getLogger(__name__)
+
+
+def _table_exists(backend: DatabaseBackend, table: str) -> bool:
+    try:
+        if isinstance(backend, PostgreSQLBackend):
+            rows = backend.fetch_all(
+                """
+                SELECT table_name FROM information_schema.tables
+                WHERE table_name = %s
+                """,
+                (table,),
+            )
+        else:
+            rows = backend.fetch_all(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                (table,),
+            )
+        return len(rows) > 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _column_exists(backend: DatabaseBackend, table: str, column: str) -> bool:
+    try:
+        if isinstance(backend, PostgreSQLBackend):
+            rows = backend.fetch_all(
+                """
+                SELECT column_name FROM information_schema.columns
+                WHERE table_name = %s AND column_name = %s
+                """,
+                (table, column),
+            )
+        else:
+            rows = backend.fetch_all(f"PRAGMA table_info({table})")
+            return any(r[1] == column for r in rows)
+        return len(rows) > 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def up_fn(backend: DatabaseBackend) -> None:
+    """Align webhook_configs to the canonical shape."""
+    if not _table_exists(backend, "webhook_configs"):
+        logger.info("webhook_configs table not present; nothing to migrate")
+        return
+
+    is_postgres = isinstance(backend, PostgreSQLBackend)
+
+    if is_postgres:
+        # --------------------------------------------------------------
+        # Rename legacy columns (preserves data)
+        # --------------------------------------------------------------
+        if _column_exists(backend, "webhook_configs", "org_id") and not _column_exists(
+            backend, "webhook_configs", "workspace_id"
+        ):
+            backend.execute_write(
+                "ALTER TABLE webhook_configs RENAME COLUMN org_id TO workspace_id"
+            )
+            logger.info("Renamed webhook_configs.org_id -> workspace_id")
+
+        if _column_exists(backend, "webhook_configs", "is_active") and not _column_exists(
+            backend, "webhook_configs", "active"
+        ):
+            backend.execute_write("ALTER TABLE webhook_configs RENAME COLUMN is_active TO active")
+            logger.info("Renamed webhook_configs.is_active -> active")
+
+        if _column_exists(backend, "webhook_configs", "events") and not _column_exists(
+            backend, "webhook_configs", "events_json"
+        ):
+            backend.execute_write("ALTER TABLE webhook_configs RENAME COLUMN events TO events_json")
+            logger.info("Renamed webhook_configs.events -> events_json")
+
+        # --------------------------------------------------------------
+        # Add new columns (idempotent)
+        # --------------------------------------------------------------
+        for column, ddl in (
+            ("user_id", "TEXT"),
+            ("description", "TEXT"),
+            ("last_delivery_at", "TIMESTAMPTZ"),
+            ("last_delivery_status", "INTEGER"),
+            ("delivery_count", "INTEGER DEFAULT 0"),
+        ):
+            backend.execute_write(
+                f"ALTER TABLE webhook_configs ADD COLUMN IF NOT EXISTS {column} {ddl}"
+            )
+            logger.debug("Ensured webhook_configs.%s exists (%s)", column, ddl)
+
+        # --------------------------------------------------------------
+        # Drop removed columns (idempotent)
+        # --------------------------------------------------------------
+        # Drop any indexes on those columns first so DROP COLUMN succeeds.
+        safe_drop_index(backend, "idx_webhook_configs_org", concurrently=False)
+        for column in ("headers", "last_failure_at", "last_success_at"):
+            backend.execute_write(f"ALTER TABLE webhook_configs DROP COLUMN IF EXISTS {column}")
+            logger.debug("Ensured webhook_configs.%s is dropped", column)
+
+        # --------------------------------------------------------------
+        # Indexes on new columns (idempotent)
+        # --------------------------------------------------------------
+        safe_create_index(
+            backend,
+            "idx_webhook_configs_user",
+            "webhook_configs",
+            ["user_id"],
+            concurrently=True,
+        )
+        safe_create_index(
+            backend,
+            "idx_webhook_configs_workspace",
+            "webhook_configs",
+            ["workspace_id"],
+            concurrently=True,
+        )
+        safe_create_index(
+            backend,
+            "idx_webhook_configs_active",
+            "webhook_configs",
+            ["active"],
+            concurrently=True,
+        )
+
+        logger.info("webhook_configs schema aligned with INITIAL_SCHEMA")
+    else:
+        # SQLite: PostgresWebhookConfigStore is not used for SQLite backends;
+        # the SQLite WebhookConfigStore manages its own table. Nothing to do.
+        logger.info("SQLite backend: webhook_configs is managed by the sync store; skipping")
+
+
+def down_fn(backend: DatabaseBackend) -> None:
+    """Revert to the legacy webhook_configs shape.
+
+    Note: rollback re-creates the old shape but cannot recover data from
+    columns that were dropped (``headers``, ``last_failure_at``,
+    ``last_success_at``). Use only for schema compatibility emergencies.
+    """
+    if not _table_exists(backend, "webhook_configs"):
+        return
+
+    is_postgres = isinstance(backend, PostgreSQLBackend)
+    if not is_postgres:
+        logger.info("SQLite backend: nothing to roll back")
+        return
+
+    # Drop new indexes
+    safe_drop_index(backend, "idx_webhook_configs_user", concurrently=False)
+    safe_drop_index(backend, "idx_webhook_configs_workspace", concurrently=False)
+    safe_drop_index(backend, "idx_webhook_configs_active", concurrently=False)
+
+    # Drop columns we added (lossy for user_id / description / delivery_* data)
+    for column in (
+        "user_id",
+        "description",
+        "last_delivery_at",
+        "last_delivery_status",
+        "delivery_count",
+    ):
+        backend.execute_write(f"ALTER TABLE webhook_configs DROP COLUMN IF EXISTS {column}")
+
+    # Rename back to legacy column names if they exist in new form
+    if _column_exists(backend, "webhook_configs", "workspace_id") and not _column_exists(
+        backend, "webhook_configs", "org_id"
+    ):
+        backend.execute_write("ALTER TABLE webhook_configs RENAME COLUMN workspace_id TO org_id")
+    if _column_exists(backend, "webhook_configs", "active") and not _column_exists(
+        backend, "webhook_configs", "is_active"
+    ):
+        backend.execute_write("ALTER TABLE webhook_configs RENAME COLUMN active TO is_active")
+    if _column_exists(backend, "webhook_configs", "events_json") and not _column_exists(
+        backend, "webhook_configs", "events"
+    ):
+        backend.execute_write("ALTER TABLE webhook_configs RENAME COLUMN events_json TO events")
+
+    # Re-add legacy columns (without data)
+    backend.execute_write(
+        "ALTER TABLE webhook_configs ADD COLUMN IF NOT EXISTS headers JSONB DEFAULT '{}'"
+    )
+    backend.execute_write(
+        "ALTER TABLE webhook_configs ADD COLUMN IF NOT EXISTS last_failure_at TIMESTAMPTZ"
+    )
+    backend.execute_write(
+        "ALTER TABLE webhook_configs ADD COLUMN IF NOT EXISTS last_success_at TIMESTAMPTZ"
+    )
+
+    # Restore legacy index
+    safe_create_index(
+        backend,
+        "idx_webhook_configs_org",
+        "webhook_configs",
+        ["org_id"],
+        concurrently=False,
+    )
+
+
+migration = Migration(
+    version=20260424000000,
+    name="Align webhook_configs schema with INITIAL_SCHEMA",
+    up_fn=up_fn,
+    down_fn=down_fn,
+)

--- a/tests/migrations/test_webhook_configs_schema_alignment.py
+++ b/tests/migrations/test_webhook_configs_schema_alignment.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import re
+
+from aragora.migrations.versions import (
+    v20260424000000_align_webhook_configs_schema as migration_module,
+)
+
+
+class PostgreSQLBackend:
+    """Tiny fake that exercises the migration's PostgreSQL branch."""
+
+    def __init__(self) -> None:
+        self.columns = {
+            "id",
+            "name",
+            "url",
+            "events",
+            "secret",
+            "headers",
+            "is_active",
+            "org_id",
+            "created_at",
+            "updated_at",
+            "failure_count",
+            "last_failure_at",
+            "last_success_at",
+        }
+        self.indexes = {"idx_webhook_configs_org"}
+        self.statements: list[str] = []
+
+    def fetch_all(self, sql: str, params: tuple = ()) -> list[tuple[str]]:
+        if "information_schema.tables" in sql:
+            return [("webhook_configs",)] if params == ("webhook_configs",) else []
+        if "information_schema.columns" in sql:
+            column = params[1]
+            return [(column,)] if column in self.columns else []
+        return []
+
+    def execute_write(self, sql: str, params: tuple = ()) -> None:
+        del params
+        if "CONCURRENTLY" in sql:
+            raise AssertionError("migration must not use CONCURRENTLY inside execute_write")
+        self.statements.append(sql)
+
+        if match := re.search(r"RENAME COLUMN (\w+) TO (\w+)", sql):
+            old, new = match.groups()
+            self.columns.remove(old)
+            self.columns.add(new)
+            return
+
+        if match := re.search(r"ADD COLUMN IF NOT EXISTS (\w+)", sql):
+            self.columns.add(match.group(1))
+            return
+
+        if match := re.search(r"DROP COLUMN IF EXISTS (\w+)", sql):
+            self.columns.discard(match.group(1))
+            return
+
+        if match := re.search(r'DROP INDEX IF EXISTS "(\w+)"', sql):
+            self.indexes.discard(match.group(1))
+            return
+
+        if match := re.search(r'CREATE INDEX IF NOT EXISTS "(\w+)"', sql):
+            self.indexes.add(match.group(1))
+
+
+def test_webhook_configs_alignment_migration_avoids_concurrent_indexes(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(migration_module, "PostgreSQLBackend", PostgreSQLBackend)
+    backend = PostgreSQLBackend()
+
+    migration_module.up_fn(backend)
+
+    assert {
+        "workspace_id",
+        "active",
+        "events_json",
+        "user_id",
+        "description",
+        "last_delivery_at",
+        "last_delivery_status",
+        "delivery_count",
+    } <= backend.columns
+    assert (
+        not {
+            "org_id",
+            "is_active",
+            "events",
+            "headers",
+            "last_failure_at",
+            "last_success_at",
+        }
+        & backend.columns
+    )
+    assert {
+        "idx_webhook_configs_user",
+        "idx_webhook_configs_workspace",
+        "idx_webhook_configs_active",
+    } <= backend.indexes
+    assert "idx_webhook_configs_org" not in backend.indexes
+    assert not any("CONCURRENTLY" in statement for statement in backend.statements)


### PR DESCRIPTION
Closes the final chronic-red **Integration Tests** failure — 4 tests in `TestPostgresWebhookConfigStore` all failing at fixture setup with:

```
asyncpg.exceptions.UndefinedColumnError: column "user_id" does not exist
```

## Root cause

Two sources of truth for the `webhook_configs` table had drifted:

| File | Shape |
|---|---|
| `aragora/db/schema/postgres_schema.sql` (stale) | id, name, url, **events**, secret, **headers**, **is_active**, **org_id**, ..., **last_failure_at**, **last_success_at** |
| `aragora/storage/webhook_config_store.py` `PostgresWebhookConfigStore.INITIAL_SCHEMA` (canonical) | id, url, **events_json**, secret, **active**, ..., name, **description**, **last_delivery_at**, **last_delivery_status**, **delivery_count**, failure_count, **user_id**, **workspace_id** |

CI flow:
1. `psql -f postgres_schema.sql` creates stale table.
2. `clean_test_tables` fixture drops + recreates via `INITIAL_SCHEMA` — OK.
3. `store` fixture calls `store.initialize()` which runs `CREATE TABLE IF NOT EXISTS ... ; CREATE INDEX ... ON webhook_configs(user_id);`.
4. Depending on fixture order (pytest resolves function-scoped fixtures in signature order, and pytest may traverse `store` first):
   - `CREATE TABLE IF NOT EXISTS` is a noop against the stale table
   - `CREATE INDEX ... (user_id)` fails → `UndefinedColumnError` → **fixture setup errors out 4 tests**

## Fix

### 1. Align `postgres_schema.sql` with `INITIAL_SCHEMA`

- Replace the stale `webhook_configs` DDL with the canonical shape (user_id, workspace_id, active, events_json, description, last_delivery_at, last_delivery_status, delivery_count)
- Replace `idx_webhook_configs_org` with `idx_webhook_configs_user`, `idx_webhook_configs_workspace`, `idx_webhook_configs_active`
- Add cross-reference comments at both sites so future drift is caught

### 2. Migration `v20260424000000_align_webhook_configs_schema.py`

For production databases that may already have the stale shape. Idempotent; preserves data via RENAME COLUMN where possible:

| Action | Column | Data |
|---|---|---|
| RENAME | `org_id` → `workspace_id` | preserved |
| RENAME | `is_active` → `active` | preserved |
| RENAME | `events` → `events_json` | preserved |
| ADD | `user_id`, `description`, `last_delivery_at`, `last_delivery_status`, `delivery_count` | NULL / 0 |
| DROP | `headers`, `last_failure_at`, `last_success_at` | lost (not read by any code path) |
| INDEX | drop `idx_webhook_configs_org`; add user/workspace/active | — |

Rollback (`down_fn`) is provided for emergency schema compatibility, but reverses add/drop asymmetrically (can't recover data from dropped columns).

## Verification

- No live code reads `headers` / `last_failure_at` / `last_success_at` / `org_id` / `is_active` / `events` from webhook_configs (grep-verified).
- SQLite backend is unaffected — its own `WebhookConfigStore._init_schema` already has the canonical shape.
- `ruff`, `ruff-format`, and mypy (baseline-filtered) all pass locally.

## Companion PRs (chronic-red sweep — merged)

- **#6554** (Lane 1) Load Tests → ubuntu-latest
- **#6555** (Lane 1) bandit dev extra
- **#6556** Coverage Gate timeout 30→90 min
- **#6557** trivy-action 0.28.0→0.35.0 (CRITICAL)
- **#6558** chore(deps): patch 7 npm vulns via overrides
- **#6559** ci(security): pip-audit ignore-list refresh
- **#6562** Integration C.1+C.2 (MockAgent + route bound)
- **#6563** E2E Python deps install