### PR TITLE
ci(security): replace gitleaks action with trufflehog (resolves GITLEAKS_LICENSE gate)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -735,8 +735,9 @@ jobs:
       # actually-live credentials (no false positives). Local pre-commit
       # still runs gitleaks (the binary) which remains free for individual use.
       - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.95.2
         with:
+          version: v3.95.2
           extra_args: --only-verified
 
   helm-lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -691,8 +691,6 @@ jobs:
     timeout-minutes: 10
     name: Secret Scanning
     if: github.event_name != 'pull_request'
-    env:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
     steps:
       - name: Checkout
@@ -731,18 +729,15 @@ jobs:
             exit 1
           fi
 
-      - name: Skip Gitleaks when license is missing
-        if: env.GITLEAKS_LICENSE == ''
-        run: |
-          echo "::warning::GITLEAKS_LICENSE is not configured; skipping gitleaks action."
-
-      - name: Run Gitleaks
-        if: env.GITLEAKS_LICENSE != ''
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_COMMENTS: false
-          GITLEAKS_LICENSE: ${{ env.GITLEAKS_LICENSE }}
+      # Gitleaks removed: gitleaks-action@v2 requires a paid GITLEAKS_LICENSE
+      # for organization accounts. TruffleHog provides equivalent secret-
+      # scanning coverage for free, with --only-verified filtering to
+      # actually-live credentials (no false positives). Local pre-commit
+      # still runs gitleaks (the binary) which remains free for individual use.
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified
 
   helm-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -423,6 +423,7 @@ jobs:
       # and is free + actively maintained. Local pre-commit still uses
       # gitleaks/gitleaks (the binary, not the action) which is free.
       - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.95.2
         with:
+          version: v3.95.2
           extra_args: --only-verified

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -417,21 +417,12 @@ jobs:
             exit 1
           fi
 
-      - name: Run Gitleaks
-        # gitleaks-action@v2 introduced a paid-license requirement for
-        # organization accounts ("missing GITLEAKS_LICENSE secret"). Until
-        # either a license is provisioned, this step is allowed to fail
-        # without blocking the workflow. TruffleHog (next step) provides
-        # redundant secret-scanning coverage during the transition.
-        # Decision tracked separately: license vs pin-to-v1 vs migrate.
-        continue-on-error: true
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_COMMENTS: false
-          GITLEAKS_CONFIG: .gitleaks.toml
-
-      - name: Run TruffleHog (additional scan)
+      # Gitleaks removed: gitleaks-action@v2 requires a paid GITLEAKS_LICENSE
+      # for organization accounts. TruffleHog (below) provides equivalent
+      # secret-scanning coverage with --only-verified (no false positives)
+      # and is free + actively maintained. Local pre-commit still uses
+      # gitleaks/gitleaks (the binary, not the action) which is free.
+      - name: Run TruffleHog
         uses: trufflesecurity/trufflehog@main
         with:
           extra_args: --only-verified


### PR DESCRIPTION
Addresses the `gitleaks-action@v2 requires paid GITLEAKS_LICENSE` CI failure.

## Context

gitleaks-action@v2 introduced an organization-license requirement in early 2024. Without `GITLEAKS_LICENSE` configured, both CI workflows have been failing (security.yml: hard-fail guarded with `continue-on-error: true`; lint.yml: silently skipped).

## Why TruffleHog

- **Free and open source** (trufflesecurity/trufflehog)
- **--only-verified** mode filters to actively-valid credentials only — effectively zero false positives, so we don't need to port the gitleaks allowlist
- **Actively maintained** (monthly releases)
- **Broader provider coverage** than gitleaks across modern SaaS/cloud APIs
- Was already running as a redundant step in security.yml; this PR consolidates onto it

## Changes

- `security.yml` — remove the gitleaks step (kept TruffleHog)
- `lint.yml` — remove the gitleaks step + GITLEAKS_LICENSE env guard, add TruffleHog

## What we kept

- `.gitleaks.toml` — unchanged; still used by local pre-commit (`gitleaks/gitleaks` binary, not the paid action)
- Pre-commit hook — unchanged; developers still scan locally before every commit

## Cost

- Before: gitleaks-action failing silently; could incur organization license cost if we wanted it working (reports: hundreds–thousands USD/year)
- After: $0 recurring; CI gate is actually running in both workflows

## Companion PRs (chronic-red sweep — all merged)

- **#6554** Load Tests → ubuntu-latest
- **#6555** bandit dev extra
- **#6556** Coverage Gate timeout 30→90 min
- **#6557** trivy-action 0.28.0→0.35.0 (CRITICAL)
- **#6558** npm overrides (17 vulns)
- **#6559** pip-audit ignore-list refresh
- **#6562** Integration C.1/C.2 (MockAgent + route)
- **#6563** E2E Python deps install
- **#6575** Integration C.3 webhook_configs schema