### PR TITLE
docs(architecture): reconcile ARCHITECTURE.md with current code (Q2 2026)

### DIFF
--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -5,7 +5,9 @@ description: Aragora Architecture
 
 # Aragora Architecture
 
-> **Last Updated:** 2026-01-21
+> **Last Updated:** 2026-04-24
+>
+> **Scope:** This document is a hand-curated overview of the **core debate-engine subsystems** (agents, debate, reasoning, verification, memory, evolution, connectors, server, RLM, ops, persistence) — about 13 of the ~169 packages in `aragora/`. For the **full module index** (every package, with one-line descriptions), see [`CLAUDE.md`](../contributing/claude). For per-track deep dives, see the other documents in `docs/architecture/`.
 
 
 This document describes the high-level architecture of Aragora, the control plane for multi-agent vetted decisionmaking across organizational knowledge and channels. The multi-agent debate system is the engine that powers adversarial validation and decision assurance.
@@ -88,12 +90,12 @@ aragora/
 ├── agents/                 # Agent implementations
 │   ├── base.py            # Abstract Agent class
 │   ├── cli_agents.py      # CLI tool wrappers (Claude, Codex, etc.)
-│   ├── api_agents.py      # API-based agents (Anthropic, OpenAI, etc.)
+│   ├── api_agents/        # API-based agents (Anthropic, OpenAI, Mistral, Grok, OpenRouter)
 │   ├── fallback.py        # QuotaFallbackMixin for provider failover
 │   ├── streaming.py       # StreamingMixin for SSE parsing
-│   ├── personas.py        # PersonaManager for agent traits
+│   ├── personas/          # PersonaManager for agent traits
 │   ├── laboratory.py      # PersonaLaboratory for A/B testing
-│   ├── prober.py          # CapabilityProber for quality assurance
+│   ├── calibration.py     # CalibrationTracker for prediction-accuracy scoring
 │   ├── grounded.py        # GroundedPersona (truth-based personas)
 │   ├── relationships.py   # RelationshipTracker (agent relationships)
 │   └── positions.py       # PositionTracker (position history)
@@ -177,13 +179,13 @@ aragora/
 │   └── public/            # Static assets
 │
 ├── server/                 # WebSocket/HTTP server
-│   ├── unified_server.py  # Unified server (3,000+ API operations)
+│   ├── unified_server.py  # Unified server (3,100+ API operations across 2,900+ paths)
 │   ├── handlers/          # Request handlers by domain
 │   │   ├── base.py        # BaseHandler, ttl_cache decorator
 │   │   ├── debates.py     # Debate CRUD and exports
 │   │   ├── agents.py      # Agent profiles and rankings
 │   │   ├── analytics.py   # System analytics
-│   │   └── ...            # 41 handler modules
+│   │   └── ...            # 700+ handler modules across handler_registry/
 │   └── stream/            # Streaming infrastructure (refactored)
 │       ├── servers.py     # WebSocket server classes
 │       ├── broadcaster.py # Event broadcasting
@@ -753,7 +755,10 @@ Critical operations use explicit transactions:
 
 - **Debate latency**: 2-5 seconds per round (depends on agent response time)
 - **Memory tiers**: Fast (1min TTL), Medium (1hr), Slow (1day), Glacial (1week)
-- **Test coverage**: 38,000+ test functions across 1,100+ test files
+- **Test coverage**: 210,000+ tests across 5,000+ test files
 - **Type safety**: 250+ modules in strict mypy mode
-- **Source LOC**: 495,713 lines across 1,203 modules
-- **Storage tests**: 468 tests covering all backends
+- **Source modules**: 3,800+ Python modules
+- **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
+- **API surface**: 3,100+ API operations across 2,900+ paths
+- **SDK breadth**: 185 Python / 183 TypeScript SDK namespaces
+- **KM adapters**: 42 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,6 +1,8 @@
 # Aragora Architecture
 
-> **Last Updated:** 2026-01-21
+> **Last Updated:** 2026-04-24
+>
+> **Scope:** This document is a hand-curated overview of the **core debate-engine subsystems** (agents, debate, reasoning, verification, memory, evolution, connectors, server, RLM, ops, persistence) — about 13 of the ~169 packages in `aragora/`. For the **full module index** (every package, with one-line descriptions), see [`CLAUDE.md`](../../CLAUDE.md). For per-track deep dives, see the other documents in `docs/architecture/`.
 
 
 This document describes the high-level architecture of Aragora, the control plane for multi-agent vetted decisionmaking across organizational knowledge and channels. The multi-agent debate system is the engine that powers adversarial validation and decision assurance.
@@ -83,12 +85,12 @@ aragora/
 ├── agents/                 # Agent implementations
 │   ├── base.py            # Abstract Agent class
 │   ├── cli_agents.py      # CLI tool wrappers (Claude, Codex, etc.)
-│   ├── api_agents.py      # API-based agents (Anthropic, OpenAI, etc.)
+│   ├── api_agents/        # API-based agents (Anthropic, OpenAI, Mistral, Grok, OpenRouter)
 │   ├── fallback.py        # QuotaFallbackMixin for provider failover
 │   ├── streaming.py       # StreamingMixin for SSE parsing
-│   ├── personas.py        # PersonaManager for agent traits
+│   ├── personas/          # PersonaManager for agent traits
 │   ├── laboratory.py      # PersonaLaboratory for A/B testing
-│   ├── prober.py          # CapabilityProber for quality assurance
+│   ├── calibration.py     # CalibrationTracker for prediction-accuracy scoring
 │   ├── grounded.py        # GroundedPersona (truth-based personas)
 │   ├── relationships.py   # RelationshipTracker (agent relationships)
 │   └── positions.py       # PositionTracker (position history)
@@ -172,13 +174,13 @@ aragora/
 │   └── public/            # Static assets
 │
 ├── server/                 # WebSocket/HTTP server
-│   ├── unified_server.py  # Unified server (3,000+ API operations)
+│   ├── unified_server.py  # Unified server (3,100+ API operations across 2,900+ paths)
 │   ├── handlers/          # Request handlers by domain
 │   │   ├── base.py        # BaseHandler, ttl_cache decorator
 │   │   ├── debates.py     # Debate CRUD and exports
 │   │   ├── agents.py      # Agent profiles and rankings
 │   │   ├── analytics.py   # System analytics
-│   │   └── ...            # 41 handler modules
+│   │   └── ...            # 700+ handler modules across handler_registry/
 │   └── stream/            # Streaming infrastructure (refactored)
 │       ├── servers.py     # WebSocket server classes
 │       ├── broadcaster.py # Event broadcasting
@@ -748,7 +750,10 @@ Critical operations use explicit transactions:
 
 - **Debate latency**: 2-5 seconds per round (depends on agent response time)
 - **Memory tiers**: Fast (1min TTL), Medium (1hr), Slow (1day), Glacial (1week)
-- **Test coverage**: 38,000+ test functions across 1,100+ test files
+- **Test coverage**: 210,000+ tests across 5,000+ test files
 - **Type safety**: 250+ modules in strict mypy mode
-- **Source LOC**: 495,713 lines across 1,203 modules
-- **Storage tests**: 468 tests covering all backends
+- **Source modules**: 3,800+ Python modules
+- **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
+- **API surface**: 3,100+ API operations across 2,900+ paths
+- **SDK breadth**: 185 Python / 183 TypeScript SDK namespaces
+- **KM adapters**: 42 registered adapters (see `aragora/knowledge/mound/adapters/`)


### PR DESCRIPTION
## Background

`docs/architecture/ARCHITECTURE.md` was last updated 2026-01-21 and accumulated stale claims through Q1 2026 as the codebase grew. This PR corrects file references and statistics that drifted during the Phase 8 GA hardening burst, without restructuring the doc.

## Stale references corrected

| Field | Before | After |
|---|---|---|
| File | `api_agents.py` | `api_agents/` (directory) |
| File | `personas.py` | `personas/` (directory) |
| File | `prober.py` (deleted) | `calibration.py` (the surviving tracker) |
| API ops | 3,000+ | 3,100+ across 2,900+ paths |
| Handlers | 41 modules | 700+ across handler_registry/ |
| Tests | 38,000+ across 1,100+ files | 210,000+ across 5,000+ files |
| Source | 495,713 LOC across 1,203 modules | 3,800+ Python modules |
| Storage tests | 468 | 4,300+ including KM |
| Last updated | 2026-01-21 | 2026-04-24 |

## Scope clarification added

ARCHITECTURE.md should NOT become a 169-package wall. Added a scope note at the top making clear that:
- This document is a hand-curated overview of the **13 core debate-engine subsystems**
- For the **full module index** (every package, with one-line descriptions), readers should consult `CLAUDE.md`
- For per-track deep dives, readers should consult the other documents in `docs/architecture/`

## New performance bullets

Q1 2026 platform-breadth metrics that didn't exist when the doc was last updated:
- API surface: 3,100+ operations / 2,900+ paths
- SDK breadth: 185 Python / 183 TypeScript namespaces
- KM adapters: 42 registered

## What this PR does NOT do

- Does NOT add any of the ~155 packages absent from the directory tree (audience, blockchain, canvas, gauntlet, genesis, marketplace, swarm, etc.). Adding all of them would defeat the doc's purpose as a focused engine overview. Refer readers to CLAUDE.md instead.
- Does NOT touch other documents in `docs/architecture/` — they're per-track and should be reconciled in their own sweeps.
- Does NOT update the SVG (no SVG exists in `docs/architecture/` — only mermaid-flavored diagrams in markdown).

## No code changes

Pure documentation reconciliation. Companion to the v2.9.0 release polish (#6578).