### PR TITLE
docs: align public scale claims with canonical metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,800+ Python modules | 210,000+ tests | 5,000+ test files | 210+ debate modules | 3,100+ API operations across 2,900+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 4,069 tracked Python files | 135 top-level modules | 216,000+ test functions | 5,078 test files | 3,386 API operations across 2,928 paths | canonical counts in `docs/METRICS.md`
 
 ## Architecture
 
@@ -225,7 +225,7 @@ aragora/
 │           ├── kafka.py    # Apache Kafka consumer
 │           └── rabbitmq.py # RabbitMQ consumer/publisher
 ├── server/           # HTTP/WebSocket API
-│   ├── unified_server.py   # Main server (3,100+ API operations)
+│   ├── unified_server.py   # Main server (3,386 API operations)
 │   ├── startup.py          # Server startup sequence
 │   ├── debate_origin.py    # Bidirectional chat result routing
 │   ├── handlers/           # HTTP endpoint handlers (700+ modules)
@@ -432,7 +432,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-**Test Suite:** 210,000+ tests across 5,000+ test files
+**Test Suite:** 216,000+ test functions across 5,078 test files (canonical counts in `docs/METRICS.md`)
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)
@@ -500,7 +500,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 **Integrated:**
 - Knowledge Mound - STABLE Phase A2 (100% integrated, 4,300+ tests passing)
-  - 42 adapters (Belief, CalibrationFusion, ClaudeMem, Codebase, Compliance, ComputerUse, Confluence, Consensus, Continuum, ControlPlane, Cost, Critique, Culture, Debate, DecisionPlan, ELO, Email, ERC8004, Evidence, Explainability, Extraction, Fabric, Gateway, Genesis, GoalCanvas, IdeaCanvas, Insights, Jira, LangExtract, NomicCycle, Obsidian, OpenClaw, Outcome, Performance, Pipeline, Provenance, Pulse, Ranking, Receipt, RLM, RLMContext, Supermemory, Trickster, Workflow, Workspace)
+  - Knowledge Mound adapters (canonical adapter counts live in `docs/METRICS.md`)
   - Visibility, sharing, federation, global knowledge
   - Semantic search, validation feedback, cross-debate learning
   - SLO alerting with Prometheus metrics

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Individual LLMs exhibit persona instability -- their outputs shift based on fram
 
 ### 5. Self-Healing and Self-Extending
 
-The Nomic Loop is Aragora's autonomous self-improvement system: agents debate improvements to the codebase, design solutions, implement code, run tests, and verify changes -- with human approval gates and automatic rollback on failure. This is how Aragora grew from a debate engine to 3,800+ modules. Red-team mode stress-tests the platform's own specs. The Gauntlet runs adversarial attacks against proposed changes. The system hardens itself.
+The Nomic Loop is Aragora's autonomous self-improvement system: agents debate improvements to the codebase, design solutions, implement code, run tests, and verify changes -- with human approval gates and automatic rollback on failure. This is how Aragora grew from a debate engine into a broad governed platform. Current scale is tracked in the auto-regenerated [canonical metrics](docs/METRICS.md). Red-team mode stress-tests the platform's own specs. The Gauntlet runs adversarial attacks against proposed changes. The system hardens itself.
 
 ---
 
@@ -397,7 +397,7 @@ aragora/
 ├── gauntlet/       # Adversarial stress testing
 ├── knowledge/      # Knowledge Mound with 42 registered adapter specs
 ├── memory/         # 4-tier memory (fast/medium/slow/glacial)
-├── server/         # 3,100+ API operations, 270+ WebSocket event types
+├── server/         # 3,386 API operations, 270+ WebSocket event types
 ├── pipeline/       # Decision-to-PR generation
 ├── genesis/        # Fractal debates, agent evolution
 ├── sandbox/        # Docker-based safe execution
@@ -406,7 +406,7 @@ aragora/
 └── workflow/       # DAG-based automation engine
 ```
 
-**Scale:** 3,800+ Python modules | 210,000+ tests across 5,000+ test files
+**Scale:** 4,069 tracked Python files | 135 top-level modules | 216,000+ test functions across 5,078 test files
 (canonical, auto-regenerated numbers: [`docs/METRICS.md`](docs/METRICS.md))
 
 ### Performance and Costs

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -10,19 +10,21 @@ description: "Aragora: Canonical Goals & Foundational Thesis"
 **The [3-Horizon Execution Roadmap](plans/2026-04-18-3-horizon-roadmap.md) operationalizes the next 30/90/365 days of concrete deliverables.**
 **Last updated: April 18, 2026**
 
-## Canonical Metrics (March 2026 baseline)
+## Canonical Metrics
 
-These are the current baseline numbers used across docs until the next explicit refresh.
+Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.md). If a numeric claim in this document or any other doc disagrees with `docs/METRICS.md`, the generated metrics doc wins.
 
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.8.0 | `pyproject.toml` |
-| Python modules | 3,800+ | `aragora/` file count |
-| Lines of code | 1,490,000 | LOC count |
-| Automated tests | 210,000+ | repo-wide `def test_` count |
-| Test files | 5,000+ | `tests/` file count |
-| API operations | 3,100+ across 2,600+ paths | OpenAPI spec |
-| Knowledge Mound adapters | 42 registered adapter specs | adapter factory registry |
+| Python files under `aragora/` | 4,069 | `docs/METRICS.md` |
+| Python modules | 135 top-level package directories | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,915,420 | `docs/METRICS.md` |
+| Automated tests | 216,016 test functions | `docs/METRICS.md` |
+| Test files | 5,078 | `docs/METRICS.md` |
+| API operations | 3,386 across 2,928 paths | `docs/METRICS.md` |
+| API paths | 2,928 | `docs/METRICS.md` |
+| Knowledge Mound adapters | 41 registered specs / 45 adapter files | `docs/METRICS.md` |
 | Agent types | 43 across 6+ LLM providers | agent registry |
 | Workflow templates | 50+ across 6 categories | template registry |
 | Handler modules | 580+ | handlers directory |

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -189,7 +189,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,800+ Python modules | 210,000+ tests | 5,000+ test files | 210+ debate modules | 3,100+ API operations across 2,900+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 4,069 tracked Python files | 135 top-level modules | 216,000+ test functions | 5,078 test files | 3,386 API operations across 2,928 paths | canonical counts in `docs/METRICS.md`
 
 ## Architecture
 
@@ -230,7 +230,7 @@ aragora/
 │           ├── kafka.py    # Apache Kafka consumer
 │           └── rabbitmq.py # RabbitMQ consumer/publisher
 ├── server/           # HTTP/WebSocket API
-│   ├── unified_server.py   # Main server (3,100+ API operations)
+│   ├── unified_server.py   # Main server (3,386 API operations)
 │   ├── startup.py          # Server startup sequence
 │   ├── debate_origin.py    # Bidirectional chat result routing
 │   ├── handlers/           # HTTP endpoint handlers (700+ modules)
@@ -437,7 +437,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-**Test Suite:** 210,000+ tests across 5,000+ test files
+**Test Suite:** 216,000+ test functions across 5,078 test files (canonical counts in `docs/METRICS.md`)
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)
@@ -505,7 +505,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 **Integrated:**
 - Knowledge Mound - STABLE Phase A2 (100% integrated, 4,300+ tests passing)
-  - 42 adapters (Belief, CalibrationFusion, ClaudeMem, Codebase, Compliance, ComputerUse, Confluence, Consensus, Continuum, ControlPlane, Cost, Critique, Culture, Debate, DecisionPlan, ELO, Email, ERC8004, Evidence, Explainability, Extraction, Fabric, Gateway, Genesis, GoalCanvas, IdeaCanvas, Insights, Jira, LangExtract, NomicCycle, Obsidian, OpenClaw, Outcome, Performance, Pipeline, Provenance, Pulse, Ranking, Receipt, RLM, RLMContext, Supermemory, Trickster, Workflow, Workspace)
+  - Knowledge Mound adapters (canonical adapter counts live in `docs/METRICS.md`)
   - Visibility, sharing, federation, global knowledge
   - Semantic search, validation feedback, cross-debate learning
   - SLO alerting with Prometheus metrics

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -16,7 +16,7 @@ description: Aragora -- Extended Reference
 - [Core Workflows](#core-workflows)
 - [Architecture](#architecture)
 - [Programmatic Usage](#programmatic-usage)
-- [Implemented Features (3,700+ Modules)](#implemented-features-3700-modules)
+- [Implemented Features](#implemented-features)
 - [Prerequisites](#prerequisites)
 - [Deployment](#deployment)
 - [API Endpoints](#api-endpoints)
@@ -36,11 +36,11 @@ Aragora works for a 5-person startup on day one and scales to regulated enterpri
 
 ### 2. Leading-Edge Memory and Context
 
-Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / slow / glacial) and Knowledge Mound with 42 registered adapters give every debate access to institutional history, cross-session learning, and evidence provenance. The RLM (Recursive Language Models) system compresses and structures context to reduce prompt bloat, enabling debates that sustain coherence across long multi-round sessions and large document sets where individual models would degrade.
+Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / slow / glacial) and Knowledge Mound with 41 registered adapters give every debate access to institutional history, cross-session learning, and evidence provenance. The RLM (Recursive Language Models) system compresses and structures context to reduce prompt bloat, enabling debates that sustain coherence across long multi-round sessions and large document sets where individual models would degrade.
 
 ### 3. Extensible and Modular
 
-Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,100+ API operations across 2,900+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
+Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,386 API operations across 2,928 paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
 
 ### 4. Multi-Agent Robustness
 
@@ -235,7 +235,7 @@ print(f"Consensus: {result.consensus_reached} ({result.confidence:.0%})")
 │  │  • Belief networks with Bayesian propagation              │   │
 │  │  • Claims kernel with typed relationships                 │   │
 │  │  • Evidence provenance with hash chains                   │   │
-│  │  • Knowledge Mound (42 registered adapters) + Semantic search  │   │
+│  │  • Knowledge Mound (41 registered adapters) + Semantic search  │   │
 │  └───────────────────────────┬──────────────────────────────┘   │
 │                               ▼                                  │
 │  ┌──────────────────────────────────────────────────────────┐   │
@@ -290,7 +290,7 @@ aragora/
 │   └── embeddings.py       # Semantic embedding for retrieval
 ├── knowledge/        # Unified knowledge management
 │   ├── bridges.py          # KnowledgeBridgeHub, MetaLearner, Evidence bridges
-│   └── mound/              # KnowledgeMound (42 registered adapters, 4,300+ tests)
+│   └── mound/              # KnowledgeMound (41 registered adapters, 4,300+ tests)
 │       ├── adapters/       # Belief, Consensus, ELO, Evidence, OpenClaw, etc.
 │       ├── semantic.py     # Vector embedding-based search
 │       ├── federation.py   # Multi-region sync
@@ -341,7 +341,7 @@ aragora/
 └── cli/              # Command-line interface
 ```
 
-**Scale:** 3,800+ Python modules | 210,000+ tests across 5,000+ test files | 185 Python / 191 TypeScript SDK namespaces
+**Scale:** 4,069 tracked Python files | 135 top-level modules | 216,000+ test functions across 5,078 test files | canonical counts in [METRICS.md](METRICS.md)
 
 ---
 
@@ -482,7 +482,7 @@ See [SDK_COMPARISON.md](SDK_COMPARISON.md) for detailed feature comparison.
 
 ---
 
-## Implemented Features (3,700+ Modules)
+## Implemented Features
 
 Aragora has evolved through 21+ phases of self-improvement, with the Nomic Loop debating and implementing each feature.
 
@@ -686,7 +686,7 @@ aragora serve --api-port 8080 --ws-port 8765
 
 ## API Endpoints
 
-The server exposes 3,100+ API operations across 2,900+ paths. Key categories:
+The server exposes 3,386 API operations across 2,928 paths. Key categories:
 
 | Category | Description |
 |----------|-------------|

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -5,19 +5,20 @@
 **The [3-Horizon Execution Roadmap](plans/2026-04-18-3-horizon-roadmap.md) operationalizes the next 30/90/365 days of concrete deliverables.**
 **Last updated: April 18, 2026**
 
-## Canonical Metrics (March 2026 baseline)
+## Canonical Metrics
 
-These are the current baseline numbers used across docs until the next explicit refresh.
+Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.md). If a numeric claim in this document or any other doc disagrees with `docs/METRICS.md`, the generated metrics doc wins.
 
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.8.0 | `pyproject.toml` |
-| Python modules | 3,800+ | `aragora/` file count |
-| Lines of code | 1,490,000 | LOC count |
-| Automated tests | 210,000+ | repo-wide `def test_` count |
-| Test files | 5,000+ | `tests/` file count |
-| API operations | 3,100+ across 2,600+ paths | OpenAPI spec |
-| Knowledge Mound adapters | 42 registered adapter specs | adapter factory registry |
+| Python files under `aragora/` | 4,069 | `docs/METRICS.md` |
+| Python modules | 135 top-level package directories | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,915,420 | `docs/METRICS.md` |
+| Automated tests | 216,016 test functions | `docs/METRICS.md` |
+| Test files | 5,078 | `docs/METRICS.md` |
+| API operations | 3,386 across 2,928 paths | `docs/METRICS.md` |
+| Knowledge Mound adapters | 41 registered specs / 45 adapter files | `docs/METRICS.md` |
 | Agent types | 43 across 6+ LLM providers | agent registry |
 | Workflow templates | 50+ across 6 categories | template registry |
 | Handler modules | 580+ | handlers directory |

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -18,6 +18,7 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Automated tests | 216,016 test functions | `docs/METRICS.md` |
 | Test files | 5,078 | `docs/METRICS.md` |
 | API operations | 3,386 across 2,928 paths | `docs/METRICS.md` |
+| API paths | 2,928 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 41 registered specs / 45 adapter files | `docs/METRICS.md` |
 | Agent types | 43 across 6+ LLM providers | agent registry |
 | Workflow templates | 50+ across 6 categories | template registry |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -11,7 +11,7 @@
 - [Core Workflows](#core-workflows)
 - [Architecture](#architecture)
 - [Programmatic Usage](#programmatic-usage)
-- [Implemented Features (3,700+ Modules)](#implemented-features-3700-modules)
+- [Implemented Features](#implemented-features)
 - [Prerequisites](#prerequisites)
 - [Deployment](#deployment)
 - [API Endpoints](#api-endpoints)
@@ -35,7 +35,7 @@ Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / s
 
 ### 3. Extensible and Modular
 
-Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,100+ API operations across 2,900+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
+Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,386 API operations across 2,928 paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
 
 ### 4. Multi-Agent Robustness
 
@@ -336,7 +336,7 @@ aragora/
 └── cli/              # Command-line interface
 ```
 
-**Scale:** 3,800+ Python modules | 210,000+ tests across 5,000+ test files | 185 Python / 191 TypeScript SDK namespaces
+**Scale:** 4,069 tracked Python files | 135 top-level modules | 216,000+ test functions across 5,078 test files | canonical counts in [METRICS.md](METRICS.md)
 
 ---
 
@@ -477,7 +477,7 @@ See [SDK_COMPARISON.md](SDK_COMPARISON.md) for detailed feature comparison.
 
 ---
 
-## Implemented Features (3,700+ Modules)
+## Implemented Features
 
 Aragora has evolved through 21+ phases of self-improvement, with the Nomic Loop debating and implementing each feature.
 
@@ -681,7 +681,7 @@ aragora serve --api-port 8080 --ws-port 8765
 
 ## API Endpoints
 
-The server exposes 3,100+ API operations across 2,900+ paths. Key categories:
+The server exposes 3,386 API operations across 2,928 paths. Key categories:
 
 | Category | Description |
 |----------|-------------|

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -31,7 +31,7 @@ Aragora works for a 5-person startup on day one and scales to regulated enterpri
 
 ### 2. Leading-Edge Memory and Context
 
-Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / slow / glacial) and Knowledge Mound with 42 registered adapters give every debate access to institutional history, cross-session learning, and evidence provenance. The RLM (Recursive Language Models) system compresses and structures context to reduce prompt bloat, enabling debates that sustain coherence across long multi-round sessions and large document sets where individual models would degrade.
+Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / slow / glacial) and Knowledge Mound with 41 registered adapters give every debate access to institutional history, cross-session learning, and evidence provenance. The RLM (Recursive Language Models) system compresses and structures context to reduce prompt bloat, enabling debates that sustain coherence across long multi-round sessions and large document sets where individual models would degrade.
 
 ### 3. Extensible and Modular
 
@@ -230,7 +230,7 @@ print(f"Consensus: {result.consensus_reached} ({result.confidence:.0%})")
 │  │  • Belief networks with Bayesian propagation              │   │
 │  │  • Claims kernel with typed relationships                 │   │
 │  │  • Evidence provenance with hash chains                   │   │
-│  │  • Knowledge Mound (42 registered adapters) + Semantic search  │   │
+│  │  • Knowledge Mound (41 registered adapters) + Semantic search  │   │
 │  └───────────────────────────┬──────────────────────────────┘   │
 │                               ▼                                  │
 │  ┌──────────────────────────────────────────────────────────┐   │
@@ -285,7 +285,7 @@ aragora/
 │   └── embeddings.py       # Semantic embedding for retrieval
 ├── knowledge/        # Unified knowledge management
 │   ├── bridges.py          # KnowledgeBridgeHub, MetaLearner, Evidence bridges
-│   └── mound/              # KnowledgeMound (42 registered adapters, 4,300+ tests)
+│   └── mound/              # KnowledgeMound (41 registered adapters, 4,300+ tests)
 │       ├── adapters/       # Belief, Consensus, ELO, Evidence, OpenClaw, etc.
 │       ├── semantic.py     # Vector embedding-based search
 │       ├── federation.py   # Multi-region sync

--- a/docs/HONEST_ASSESSMENT.md
+++ b/docs/HONEST_ASSESSMENT.md
@@ -5,6 +5,10 @@
 >
 > **Written:** Early March 2026 (Run 001-003 era). **March 5 update:** Several blockers
 > described below have since been resolved — see update notes inline.
+>
+> **Metrics note:** This document is a historical assessment. Current live scale
+> numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.md), and that file
+> wins over any stale numeric snapshot below.
 
 ---
 
@@ -43,7 +47,7 @@ The debate engine is real, functional, and battle-tested.
 | ELO rankings | Domain-specific ratings, Brier score calibration, persistent leaderboards |
 | Demo mode | Works end-to-end with no API keys required |
 | CLI | `aragora review`, `aragora gauntlet` work in both live and demo modes |
-| Test coverage | 208,000+ automated tests, 0 mypy type errors |
+| Test coverage | Historical snapshot; current test-function and mypy-baseline counts live in [`docs/METRICS.md`](METRICS.md) |
 
 ### Idea-to-Execution Pipeline (90% Working)
 
@@ -189,7 +193,7 @@ Why it resists commoditization:
 
 - It is architecturally different from cooperative frameworks. Adversarial vs. cooperative is a design philosophy, not a feature toggle.
 - The receipt format, dissent tracking, and evidence chains create a document standard that represents years of domain expertise.
-- 210+ debate modules encode deep knowledge of structured argumentation that cannot be bolted onto a cooperative framework.
+- The debate subsystem encodes deep knowledge of structured argumentation that cannot be bolted onto a cooperative framework.
 
 #### 2. Heterogeneous Model Consensus as Bias Countermeasure
 
@@ -285,7 +289,7 @@ Aragora's core value proposition is **real and defensible**: multi-agent adversa
 - The CLI works.
 - The API works.
 - The enterprise security works.
-- 210,000+ tests prove it.
+- A large, auto-counted test suite and the quality gates support it; see [`docs/METRICS.md`](METRICS.md) for current counts.
 
 This combination is unique. No funded competitor does it. It represents a new category -- Decision Integrity -- not a feature added to an existing category.
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -15,8 +15,8 @@
      my Python code            REST API           contribute
               |                   |                   |
     pip install aragora-debate  Python or TS SDK    Clone the repo
-       (zero dependencies,     (API client for      (3,700+ modules,
-        works offline)         a running server)    full platform)
+       (zero dependencies,     (API client for      (full platform;
+        works offline)         a running server)    see METRICS.md)
 ```
 
 | Goal | Package | Install |

--- a/docs/landing/pricing.md
+++ b/docs/landing/pricing.md
@@ -34,7 +34,7 @@ For teams shipping high-stakes software.
 - CI/CD integration (GitHub Actions, GitLab CI)
 - Channel delivery (Slack, Teams, Discord, email)
 - 4-tier Continuum Memory
-- Knowledge Mound (42 adapters)
+- Knowledge Mound (41 registered adapter specs)
 - ELO rankings + Brier calibration
 - Workflow engine (50+ templates)
 - Python SDK (185 namespaces) + TypeScript SDK (183 namespaces)

--- a/docs/outreach/BUYER_AND_PRODUCT_STORY.md
+++ b/docs/outreach/BUYER_AND_PRODUCT_STORY.md
@@ -322,7 +322,7 @@ undocumented operator rescue, we treat that as a blocker, not a success.
 
 ### Supporting Facts, Not Opening Claims
 
-- **210,000+ tests** across 4,700+ test files
+- **216,016 automated tests** across 5,078 test files
 - **Receipt-gated repo improvement** validated on the benchmark path
 - **Inbox trust wedge** shipped from debate to signed receipt to action
 - **Heterogeneous provider support** across CLI, API, and local-model workers

--- a/docs/outreach/DESIGN_PARTNER_ONEPAGER.md
+++ b/docs/outreach/DESIGN_PARTNER_ONEPAGER.md
@@ -204,7 +204,7 @@ business development leaders, and recruiting-heavy operators who already feel th
 
 ## Supporting Facts, Not Opening Claims
 
-- **210,000+ tests** across 4,700+ test files
+- **216,016 automated tests** across 5,078 test files
 - **Receipt-gated repo improvement** validated on the benchmark path
 - **Inbox trust wedge** shipped from debate to signed receipt to action
 - **Heterogeneous provider support** across CLI, API, and local-model workers

--- a/docs/security/PENTEST_REQUIREMENTS.md
+++ b/docs/security/PENTEST_REQUIREMENTS.md
@@ -245,6 +245,6 @@ Based on expertise in API security and enterprise platforms:
 ### API Documentation
 
 - OpenAPI 3.1 specification available
-- 3,100+ API operations across 2,600+ paths (OpenAPI documented)
+- 3,386 API operations across 2,928 paths (OpenAPI documented)
 - Request/response schemas
 - Authentication requirements per endpoint

--- a/docs/security/PENTEST_RFP.md
+++ b/docs/security/PENTEST_RFP.md
@@ -16,8 +16,8 @@ Aragora Inc. is seeking proposals from qualified penetration testing firms to co
 Aragora is a multi-agent debate framework that orchestrates 43 agent types to deliver defensible decisions across enterprise knowledge and channels. Our platform serves enterprise customers across regulated industries including finance, healthcare, and government.
 
 **Platform Scale:**
-- 3,100+ API operations across 2,600+ paths
-- 130,000+ automated tests
+- 3,386 API operations across 2,928 paths
+- 216,016 automated tests
 - Multi-tenant SaaS architecture
 - WebSocket real-time communication
 - Integration with major AI providers
@@ -36,7 +36,7 @@ Aragora is a multi-agent debate framework that orchestrates 43 agent types to de
 
 | Component | Priority | Notes |
 |-----------|----------|-------|
-| API Gateway (api.aragora.ai) | Critical | 3,100+ API operations |
+| API Gateway (api.aragora.ai) | Critical | 3,386 API operations |
 | Live Dashboard (live.aragora.ai) | High | React SPA |
 | WebSocket Server | High | Real-time updates |
 | Authentication/Authorization | Critical | JWT, OAuth, RBAC |
@@ -77,7 +77,7 @@ Full scope details: See attached `PENTEST_SCOPE.md`
 **Preferred:**
 - Experience with AI/ML platforms
 - Experience with real-time WebSocket applications
-- Previous work with similar-scale platforms (3,100+ API operations)
+- Previous work with similar-scale platforms (3,386 API operations)
 
 ### 3.2 Insurance Requirements
 

--- a/docs/security/PENTEST_SCOPE.md
+++ b/docs/security/PENTEST_SCOPE.md
@@ -80,7 +80,7 @@ specification (see `docs/api/openapi.json`). Handlers are organized across 240+ 
 | Debates | `/api/v2/debates/*` | High | Core business logic, multi-agent orchestration |
 | Users / Tenancy | `/api/v2/users/*`, `/api/v2/workspaces/*` | High | User PII, tenant boundaries |
 | OpenClaw Gateway | `/api/gateway/openclaw/*` | High | Computer-use agent actions, credential store |
-| Knowledge Mound | `/api/v2/knowledge/*` | Medium | Organizational knowledge, 42 adapters |
+| Knowledge Mound | `/api/v2/knowledge/*` | Medium | Organizational knowledge, 41 registered adapter specs |
 | Workflows | `/api/v2/workflows/*` | Medium | DAG-based automation execution |
 | Pipeline | `/api/v2/pipeline/*` | Medium | Idea-to-execution 4-stage pipeline |
 | Privacy / Consent | `/api/v2/privacy/*` | Medium | GDPR consent, data deletion, retention |

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -26,7 +26,7 @@
 | RBAC role assignments and permissions | Integrity-critical | PostgreSQL | Platform admin |
 | Tenant configuration and quotas | Confidential | PostgreSQL via `aragora/tenancy/quotas.py` | Tenant admin |
 | Audit logs (security events, authorization decisions) | Integrity-critical | PostgreSQL + in-memory (10K cap per F11) | Platform |
-| Knowledge Mound data (42 adapters, semantic search indices) | Confidential | PostgreSQL + file storage | Per-tenant |
+| Knowledge Mound data (41 registered adapter specs, semantic search indices) | Confidential | PostgreSQL + file storage | Per-tenant |
 | Skill definitions and marketplace content | Internal | SQLite / PostgreSQL via `aragora/skills/` | Platform |
 
 ### 1.2 Supporting Assets

--- a/docs/strategy/POSITIONING_AND_MESSAGING.md
+++ b/docs/strategy/POSITIONING_AND_MESSAGING.md
@@ -450,7 +450,7 @@ Use selectively. These are evidence atoms to support the wedge, not hero copy.
 - production debate engine with heterogeneous agent support
 - decision receipts and provenance already wired into real flows
 - bounded autonomous repo-improvement path with receipt gates
-- heavy automated test coverage and broad knowledge-adapter surface (exact counts in [../CANONICAL_GOALS.md](../CANONICAL_GOALS.md#canonical-metrics-march-2026-baseline) — this doc should not drift from the canonical baseline)
+- heavy automated test coverage and broad knowledge-adapter surface (exact counts in [../CANONICAL_GOALS.md](../CANONICAL_GOALS.md#canonical-metrics) — this doc should not drift from the canonical baseline)
 
 ### Proof Points That Fit The Story
 

--- a/scripts/doc_stats.py
+++ b/scripts/doc_stats.py
@@ -50,7 +50,9 @@ def _canonical_metrics() -> dict[str, CanonicalMetric]:
     key_for = {
         "python modules": "modules",
         "automated tests": "tests",
+        "test files": "test_files",
         "api operations": "api_operations",
+        "api paths": "api_paths",
         "knowledge mound adapters": "adapters",
         "agent types": "agent_types",
     }
@@ -256,11 +258,19 @@ def patch_docs(stats: Stats, write: bool) -> int:
     canonical = _canonical_metrics()
     modules_approx = _canonical_count(canonical, "modules", _approx(stats.python_modules, 1000))
     tests_approx = _canonical_count(canonical, "tests", _approx(stats.test_count, 1000))
-    test_files_approx = _approx(stats.test_files, 1000)
+    test_files_approx = _canonical_count(
+        canonical,
+        "test_files",
+        _approx(stats.test_files, 1000),
+    )
     api_ops_approx = _canonical_count(
         canonical, "api_operations", _approx(stats.api_operations, 1000)
     )
-    api_paths_approx = _approx(stats.api_paths, 100)
+    api_paths_approx = _canonical_count(
+        canonical,
+        "api_paths",
+        _approx(stats.api_paths, 100),
+    )
     ws_events_approx = _approx(stats.ws_event_types, 10)
     templates_approx = _approx(stats.workflow_templates, 10)
     agent_types_approx = _canonical_count(


### PR DESCRIPTION
## Summary

Align public scale claims with the auto-regenerated canonical metrics surface.

Changes:
- Replace stale `3,700+` / `3,800+ modules` framing with tracked Python-file and top-level-module counts.
- Replace stale API/test/adapter counts in README, extended README, buyer/security docs, and agent guidance.
- Update the old `#canonical-metrics-march-2026-baseline` anchor to the current `#canonical-metrics` section.
- Preserve historical framing in `docs/HONEST_ASSESSMENT.md` while explicitly pointing live counts at `docs/METRICS.md`.

## Validation

- `python scripts/check_docs_consistency.py`
- `python scripts/regenerate_metrics.py --check`
- `python scripts/inspect_cold_review_surface.py`
- `python scripts/check_version_alignment.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
