### PR TITLE
chore(deps): align ci_install_project.sh floors with pyproject.toml (Wave 1A)

### DIFF
--- a/scripts/ci_install_project.sh
+++ b/scripts/ci_install_project.sh
@@ -9,11 +9,16 @@ INSTALL_SCOPE="system"
 readonly LEGACY_CONTROL_PLANE_PACKAGE_NAME="aragora-debate"
 readonly LEGACY_CONTROL_PLANE_MARKER_PATH="aragora/server"
 
+# Floor pins below are kept in lockstep with `pyproject.toml`'s
+# `[project.optional-dependencies]` (test/gateway/enterprise/dev/all). The
+# constraint solver enforces the higher floor at install time — having the
+# two files disagree creates noise and confusion. If pyproject.toml raises
+# any floor, mirror it here.
 LEGACY_CONTROL_PLANE_BASE_DEPS=(
   "aiohttp>=3.13.3,<4.0"
   "websockets>=13.0,<15.1"
   "pyyaml>=6.0.3,<7.0"
-  "pydantic>=2.0,<3.0"
+  "pydantic>=2.13.2,<3.0"            # aligned to pyproject [test]
   "pydantic-settings>=2.0,<3.0"
   "bcrypt>=4.0,<6.0"
   "cryptography>=46.0,<48.0"
@@ -27,14 +32,14 @@ LEGACY_CONTROL_PLANE_BASE_DEPS=(
   "watchfiles>=0.21,<2.0"
   "boto3>=1.34,<2.0"
   "PyJWT>=2.8,<3.0"
-  "fastapi>=0.109.0,<1.0"
-  "uvicorn[standard]>=0.27.0,<1.0"
+  "fastapi>=0.135.3,<1.0"            # aligned to pyproject [gateway]/[all]
+  "uvicorn[standard]>=0.44.0,<1.0"   # aligned to pyproject [gateway]/[all]
   "python-multipart>=0.0.22"
   "mcp>=1.0,<2.0"
 )
 
 LEGACY_CONTROL_PLANE_DEV_DEPS=(
-  "pytest>=7.0,<10.0"
+  "pytest>=9.0.3,<10.0"              # aligned to pyproject [test]
   "pytest-asyncio>=0.21,<2.0"
   "pytest-benchmark>=4.0,<6.0"
   "pytest-cov>=4.0,<8.0"
@@ -45,14 +50,14 @@ LEGACY_CONTROL_PLANE_DEV_DEPS=(
   "black>=23.0,<27.0"
   "ruff>=0.1,<1.0"
   "bandit>=1.7,<2.0"
-  "mypy>=1.8,<2.0"
+  "mypy>=1.19.0,<2.0"                # aligned to pyproject [dev]
   "types-jsonschema"
   "types-PyYAML"
   "mutmut>=3.0,<4.0"
   "pre-commit>=3.6,<5.0"
   "datamodel-code-generator==0.54.0"
   "async-timeout>=4.0,<6.0"
-  "python3-saml>=1.15,<2.0"
+  "python3-saml>=1.16.0,<2.0"        # aligned to pyproject [enterprise]/[all]
   "tiktoken>=0.5,<1.0"
 )
 
@@ -60,7 +65,7 @@ LEGACY_CONTROL_PLANE_TEST_EXTRA_DEPS=(
   "aiosqlite>=0.19,<1.0"
   "supabase>=2.0,<3.0"
   "redis>=5.0.0,<8.0"
-  "asyncpg>=0.29.0,<1.0"
+  "asyncpg>=0.31.0,<1.0"             # aligned to pyproject [enterprise]/[all]
   "yt-dlp>=2024.1,<2027.0"
   "openai>=2.0,<3.0"
   "twilio>=8.0,<10.0"


### PR DESCRIPTION
## Wave 1A: dep floor reconciliation (paperwork PR)

Pure paperwork: `ci_install_project.sh` stated dep floors that were strictly less restrictive than `pyproject.toml`'s. The constraint solver was **already enforcing** the higher pyproject floors at install time, so this change has **zero behavioral impact**. But having the two files disagree creates noise (pip-audit reports, dependabot reasoning) and makes future bumps confusing.

## Aligned floors

| Package | Old floor | New floor | pyproject extra |
|---|---|---|---|
| `pydantic` | `>=2.0` | `>=2.13.2` | [test] |
| `fastapi` | `>=0.109.0` | `>=0.135.3` | [gateway]/[all] |
| `uvicorn[standard]` | `>=0.27.0` | `>=0.44.0` | [gateway]/[all] |
| `pytest` | `>=7.0` | `>=9.0.3` | [test] |
| `mypy` | `>=1.8` | `>=1.19.0` | [dev] |
| `asyncpg` | `>=0.29.0` | `>=0.31.0` | [enterprise]/[all] |
| `python3-saml` | `>=1.15` | `>=1.16.0` | [enterprise]/[all] |

## Verification

Clean venv install with the aligned floors resolved cleanly:

```
pydantic           2.13.3
fastapi            0.136.1
uvicorn            0.46.0
pytest             9.0.3
mypy               1.20.2
asyncpg            0.31.0
```

All real PyPI versions exist at the new floors.

## Why this is a paperwork PR

For each pin, pip's resolver takes the **maximum** of all stated floors. With `pyproject.toml` saying `>=2.13.2` and `ci_install_project.sh` saying `>=2.0`, the resolver was already pulling `>=2.13.2`. So:

- No version actually changes in CI
- No new behavior gets exercised
- The script just stops lying about what its floors are

This is the safest possible change.

## Roadmap context

This is **Wave 1A** of the foundation-hardening roadmap (12-week plan). Subsequent waves:

- **Wave 1B**: Batched security-libs floor bumps (cryptography, urllib3, PyJWT, bcrypt, pyotp, python-multipart) — single PR
- **Wave 1C**: pip-audit ignore list audit
- **Wave 2**: Each of FastAPI/httpx/aiohttp/uvicorn/boto3/websockets minor bumps in **isolated** PRs (per Codex review feedback)
- **Wave 3**: Heavy-eco bumps (langchain, OpenAI, MCP, supabase, weaviate, redis) — also isolated