### PR TITLE
ci: extend debate test shard timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -582,7 +582,11 @@ jobs:
             timeout: 30
           - name: debate
             path: tests/debate
-            timeout: 30
+            # The debate shard currently exceeds the generic 30-minute cap on
+            # GitHub-hosted runners: #6579 reached 54% before cancellation.
+            # Keep the suite required, but give it a realistic envelope while
+            # longer-term sharding work splits tests/debate into smaller lanes.
+            timeout: 60
           - name: reasoning
             path: tests/rlm tests/reasoning
             timeout: 30


### PR DESCRIPTION
## Summary
- Extends only the `test-fast (debate, tests/debate, 30)` job timeout from 30 to 60 minutes.
- Keeps the debate shard required; this does not skip or weaken coverage.
- Documents the immediate evidence: PR #6579 reached 54% completion before GitHub cancelled the shard at the 30-minute job cap.

## Why
The debate shard is currently larger than the generic 30-minute envelope on GitHub-hosted runners. This is blocking queue drain for unrelated PRs (#6579, #6581, #6578) with timeout cancellations rather than assertion failures. The durable follow-up is to split `tests/debate` into smaller lanes, but the immediate high-quality unblock is a realistic timeout while keeping the check required.

## Validation
- `git diff --check`
- Parsed `.github/workflows/test.yml` with PyYAML.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
