### PR TITLE
ci(test-fast): sub-shard heavy lanes + scope-aware path filter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -567,49 +567,260 @@ jobs:
             --selector-status "${SELECTOR_STATUS}" \
             --changed-python-count "${CHANGED_PYTHON_COUNT}"
 
-  # Fast parallel tests by category (Ubuntu only, primary Python)
-  test-fast:
+  # ==========================================================================
+  # test-shard-scope (NEW): classify which test-fast shards must run for this
+  # change. Heavy shards (debate, server-handlers, handlers) skip when no
+  # relevant code/test paths changed; their job still reports success so the
+  # `needs: test-fast` downstream gates remain satisfied.
+  #
+  # Triggered always on push/schedule; scope-filtered only on pull_request.
+  # The `core` filter, when matched, forces ALL shards to run (covers
+  # workflow/script/dependency/version edits that touch the whole repo).
+  # ==========================================================================
+  test-shard-scope:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: Classify test-fast Shard Scope
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ matrix.category.timeout }}
-    needs: baseline-determinism
-    strategy:
-      fail-fast: false
-      matrix:
-        category:
-          - name: agents
-            path: tests/agents
-            timeout: 30
-          - name: debate
-            path: tests/debate
-            timeout: 30
-          - name: reasoning
-            path: tests/rlm tests/reasoning
-            timeout: 30
-          - name: workflow-client
-            path: tests/workflow tests/client
-            timeout: 30
-          - name: server
-            path: tests/server
-            timeout: 30
-          - name: handlers
-            path: tests/handlers
-            timeout: 30
-          - name: knowledge
-            path: tests/knowledge tests/evidence tests/memory
-            timeout: 30
-          - name: storage
-            path: tests/storage tests/ranking tests/persistence tests/billing
-            timeout: 30
-          - name: infra
-            path: tests/nomic tests/control_plane tests/rbac tests/events tests/observability tests/compliance tests/gauntlet tests/cli
-            timeout: 30
-
+    timeout-minutes: 3
+    outputs:
+      scopes_changed: ${{ steps.filter.outputs.changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect scopes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            core:
+              - 'pyproject.toml'
+              - 'requirements*.txt'
+              - 'scripts/ci_install_project.sh'
+              - '.github/workflows/test.yml'
+              - '.github/actions/setup-python-safe/**'
+              - 'aragora/__init__.py'
+              - 'aragora/__version__.py'
+              - 'aragora/_version.py'
+              - 'aragora/core.py'
+              - 'aragora/config/**'
+              - 'aragora/protocols/**'
+              - 'tests/conftest.py'
+              - 'conftest.py'
+            agents:
+              - 'aragora/agents/**'
+              - 'tests/agents/**'
+            debate:
+              - 'aragora/debate/**'
+              - 'tests/debate/**'
+              - 'aragora/agents/**'
+              - 'aragora/memory/**'
+              - 'aragora/reasoning/**'
+            reasoning:
+              - 'aragora/rlm/**'
+              - 'aragora/reasoning/**'
+              - 'tests/rlm/**'
+              - 'tests/reasoning/**'
+            workflow_client:
+              - 'aragora/workflow/**'
+              - 'aragora/client/**'
+              - 'tests/workflow/**'
+              - 'tests/client/**'
+            server_handlers:
+              - 'aragora/server/handlers/**'
+              - 'tests/server/handlers/**'
+              - 'aragora/server/handler_registry/**'
+              - 'aragora/server/openapi/**'
+              - 'aragora/server/openapi_impl.py'
+            server_rest:
+              - 'aragora/server/**'
+              - 'tests/server/**'
+            handlers:
+              - 'aragora/server/handlers/**'
+              - 'tests/handlers/**'
+              - 'aragora/control_plane/**'
+            knowledge:
+              - 'aragora/knowledge/**'
+              - 'aragora/memory/**'
+              - 'aragora/evidence/**'
+              - 'tests/knowledge/**'
+              - 'tests/evidence/**'
+              - 'tests/memory/**'
+            storage:
+              - 'aragora/storage/**'
+              - 'aragora/persistence/**'
+              - 'aragora/billing/**'
+              - 'aragora/ranking/**'
+              - 'tests/storage/**'
+              - 'tests/persistence/**'
+              - 'tests/billing/**'
+              - 'tests/ranking/**'
+            infra:
+              - 'aragora/nomic/**'
+              - 'aragora/control_plane/**'
+              - 'aragora/rbac/**'
+              - 'aragora/events/**'
+              - 'aragora/observability/**'
+              - 'aragora/compliance/**'
+              - 'aragora/gauntlet/**'
+              - 'aragora/cli/**'
+              - 'tests/nomic/**'
+              - 'tests/control_plane/**'
+              - 'tests/rbac/**'
+              - 'tests/events/**'
+              - 'tests/observability/**'
+              - 'tests/compliance/**'
+              - 'tests/gauntlet/**'
+              - 'tests/cli/**'
+
+      - name: Report scopes
+        run: |
+          echo "Scopes changed: ${{ steps.filter.outputs.changes }}"
+
+  # ==========================================================================
+  # Fast parallel tests by category (Ubuntu only, primary Python)
+  #
+  # Sub-sharding history:
+  #   2026-04-25: Heavy shards split to fit within 30-min runner cap.
+  #     - debate (1 shard, 30+ min) -> debate-am, debate-nz, debate-phases
+  #     - server (1 shard, 23 min)  -> server-handlers-am, server-handlers-nz, server-rest
+  #     - handlers (1 shard, 26 min) -> handlers-features, handlers-amk-no-features, handlers-lz
+  #   Path-filter (test-shard-scope) added: PRs touching only docs/CI/integration
+  #     tests skip irrelevant heavy shards entirely.
+  # ==========================================================================
+  test-fast:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.category.timeout }}
+    needs: [baseline-determinism, test-shard-scope]
+    strategy:
+      fail-fast: false
+      matrix:
+        category:
+          # Light shards (unchanged from prior 9-shard layout)
+          - name: agents
+            pytest_args: tests/agents
+            scope: agents
+            timeout: 30
+          - name: reasoning
+            pytest_args: tests/rlm tests/reasoning
+            scope: reasoning
+            timeout: 30
+          - name: workflow-client
+            pytest_args: tests/workflow tests/client
+            scope: workflow_client
+            timeout: 30
+          - name: knowledge
+            pytest_args: tests/knowledge tests/evidence tests/memory
+            scope: knowledge
+            timeout: 30
+          - name: storage
+            pytest_args: tests/storage tests/ranking tests/persistence tests/billing
+            scope: storage
+            timeout: 30
+          - name: infra
+            pytest_args: tests/nomic tests/control_plane tests/rbac tests/events tests/observability tests/compliance tests/gauntlet tests/cli
+            scope: infra
+            timeout: 30
+
+          # debate (was 1 shard hitting 30-min cap, now 3 sub-shards by alphabet)
+          # Top-level debate test files a-m (~5500 tests)
+          - name: debate-am
+            pytest_args: ""
+            resolver: debate-am
+            scope: debate
+            timeout: 30
+          # Top-level debate test files n-z (~5600 tests)
+          - name: debate-nz
+            pytest_args: ""
+            resolver: debate-nz
+            scope: debate
+            timeout: 30
+          # Subdirectories under tests/debate/ (~3000 tests)
+          - name: debate-phases
+            pytest_args: ""
+            resolver: debate-phases
+            scope: debate
+            timeout: 30
+
+          # server (was 1 shard at 23 min, now 3 sub-shards)
+          # tests/server/handlers/ a-m subdirs + files (~16K tests)
+          - name: server-handlers-am
+            pytest_args: ""
+            resolver: server-handlers-am
+            scope: server_handlers
+            timeout: 30
+          # tests/server/handlers/ n-z subdirs + files (~8K tests)
+          - name: server-handlers-nz
+            pytest_args: ""
+            resolver: server-handlers-nz
+            scope: server_handlers
+            timeout: 30
+          # tests/server/ minus tests/server/handlers/ (~7500 tests)
+          - name: server-rest
+            pytest_args: ""
+            resolver: server-rest
+            scope: server_rest
+            timeout: 30
+
+          # handlers (was 1 shard at 26 min, now 3 sub-shards)
+          # tests/handlers/features/ alone (~7700 tests, biggest single subdir)
+          - name: handlers-features
+            pytest_args: ""
+            resolver: handlers-features
+            scope: handlers
+            timeout: 30
+          # tests/handlers/ A-K subdirs (incl. underscore-prefixed) + A-K files,
+          # excluding ``features``. Mutually-exclusive with handlers-lz.
+          - name: handlers-amk-no-features
+            pytest_args: ""
+            resolver: handlers-amk-no-features
+            scope: handlers
+            timeout: 30
+          # tests/handlers/ L-Z subdirs + L-Z files. Mutually-exclusive with
+          # handlers-amk-no-features. See scripts/ci_resolve_test_shard.py.
+          - name: handlers-lz
+            pytest_args: ""
+            resolver: handlers-lz
+            scope: handlers
+            timeout: 30
+
+    steps:
+      - name: Resolve shard relevance
+        id: relevance
+        shell: bash
+        env:
+          SCOPES: ${{ needs.test-shard-scope.outputs.scopes_changed }}
+          MY_SCOPE: ${{ matrix.category.scope }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          # Always run on push/schedule/dispatch (non-PR)
+          if [[ "$EVENT" != "pull_request" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Reason: not a pull_request"
+            exit 0
+          fi
+          # If 'core' (workflow/dependency/version) changed, all shards run
+          if echo "$SCOPES" | grep -q '"core"'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Reason: core scope matched (deps/workflow/version)"
+            exit 0
+          fi
+          # If our scope matched, run
+          if echo "$SCOPES" | grep -q "\"$MY_SCOPE\""; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Reason: scope '$MY_SCOPE' matched"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Shard ${{ matrix.category.name }} skipped (scope '$MY_SCOPE' not in changes: $SCOPES)"
+          fi
+
+      - name: Checkout
+        if: steps.relevance.outputs.should_run == 'true'
+        uses: actions/checkout@v4
+
       - name: Verify checkout integrity
+        if: steps.relevance.outputs.should_run == 'true'
         shell: bash
         run: |
           if [[ ! -f pyproject.toml ]]; then
@@ -632,6 +843,7 @@ jobs:
           fi
 
       - name: Set up Python
+        if: steps.relevance.outputs.should_run == 'true'
         uses: ./.github/actions/setup-python-safe
         with:
           python-version: "3.11"
@@ -639,14 +851,37 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
+        if: steps.relevance.outputs.should_run == 'true'
         run: |
           python -m pip install --upgrade pip
           bash scripts/ci_install_project.sh --extras test
           python -m pip install pytest-timeout pytest-xdist
 
-      - name: Run ${{ matrix.category.name }} tests
+      - name: Resolve shard test paths
+        id: shard_paths
+        if: steps.relevance.outputs.should_run == 'true'
+        shell: bash
+        env:
+          RESOLVER: ${{ matrix.category.resolver }}
+          INLINE_ARGS: ${{ matrix.category.pytest_args }}
         run: |
-          pytest ${{ matrix.category.path }} \
+          # Light shards encode their paths inline via pytest_args. Heavy
+          # shards delegate to scripts/ci_resolve_test_shard.py so the
+          # alphabetic partitioning lives in versioned Python rather than
+          # 5KB of fragile YAML --ignore-glob soup. See script header for
+          # rationale.
+          if [[ -n "$RESOLVER" ]]; then
+            args=$(python3 scripts/ci_resolve_test_shard.py "$RESOLVER" --check)
+          else
+            args="$INLINE_ARGS"
+          fi
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+          echo "Resolved pytest args: $args"
+
+      - name: Run ${{ matrix.category.name }} tests
+        if: steps.relevance.outputs.should_run == 'true'
+        run: |
+          pytest ${{ steps.shard_paths.outputs.args }} \
             -m "not slow and not load and not e2e and not integration and not integration_minimal and not benchmark and not performance" \
             --timeout=120 \
             -n auto \
@@ -657,6 +892,11 @@ jobs:
             --durations-min=1.0
         env:
           PYTHONPATH: .:aragora-debate/src
+
+      - name: Mark shard as skipped (no-op success)
+        if: steps.relevance.outputs.should_run != 'true'
+        run: |
+          echo "::notice::Shard ${{ matrix.category.name }} skipped: scope '${{ matrix.category.scope }}' not in changed scopes"
 
   epistemic-settlement-gate:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft

--- a/scripts/ci_resolve_test_shard.py
+++ b/scripts/ci_resolve_test_shard.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Resolve concrete pytest path arguments for a CI test shard.
+
+Why this exists:
+Pytest's `--ignore-glob` matcher uses ``fnmatch`` against absolute paths,
+which makes mutually-exclusive alphabetic shards extremely tricky to
+express purely in YAML. Stacking many ``--ignore-glob`` patterns also
+leaves the resulting argv hard to audit at a glance.
+
+This helper translates a logical shard name (``handlers-amk-no-features``,
+``debate-am`` and friends) into a concrete list of test files / dirs that
+pytest can be invoked with directly, leaving collection itself simple,
+deterministic, and easy to verify locally.
+
+Usage::
+
+    python3 scripts/ci_resolve_test_shard.py debate-am
+    python3 scripts/ci_resolve_test_shard.py handlers-lz --check
+
+Each shard prints a single line with the test paths to stdout. The
+``--check`` flag additionally prints partition diagnostics on stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Callable, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TESTS_ROOT = REPO_ROOT / "tests"
+
+
+# ---------------------------------------------------------------------------
+# Generic helpers
+# ---------------------------------------------------------------------------
+
+
+def _entries(parent: Path) -> tuple[list[str], list[str]]:
+    """Return (subdirs, top_level_test_files) under ``parent``.
+
+    Both sorted alphabetically. ``__pycache__`` and ``__init__.py`` are
+    filtered out so they never end up in a shard partition.
+    """
+    if not parent.exists():
+        return [], []
+    subdirs: list[str] = []
+    files: list[str] = []
+    for entry in sorted(parent.iterdir()):
+        if entry.name.startswith("__pycache__"):
+            continue
+        if entry.is_dir():
+            subdirs.append(entry.name)
+        elif entry.is_file() and entry.name.startswith("test_") and entry.name.endswith(".py"):
+            files.append(entry.name)
+    return subdirs, files
+
+
+def _starts_in(name: str, predicate: Callable[[str], bool]) -> bool:
+    return bool(name) and predicate(name[0].lower())
+
+
+def _alpha_range(low: str, high: str) -> Callable[[str], bool]:
+    return lambda c: low <= c <= high
+
+
+# Top-level test file alphabet uses the leading char of the *suffix* after
+# the ``test_`` prefix (so ``test_admin.py`` is "a", not "t").
+def _file_letter(name: str) -> str:
+    suffix = name[len("test_") :] if name.startswith("test_") else name
+    return suffix[0].lower() if suffix else ""
+
+
+# ---------------------------------------------------------------------------
+# Per-shard resolvers
+# ---------------------------------------------------------------------------
+
+
+def _under(parent: Path, names: Iterable[str]) -> list[str]:
+    return [str((parent / name).relative_to(REPO_ROOT)) for name in names]
+
+
+def shard_debate_am() -> list[str]:
+    """Top-level debate test files starting a-m, no subdir tests."""
+    parent = TESTS_ROOT / "debate"
+    _, files = _entries(parent)
+    in_am = _alpha_range("a", "m")
+    return _under(parent, [f for f in files if in_am(_file_letter(f))])
+
+
+def shard_debate_nz() -> list[str]:
+    """Top-level debate test files starting n-z, no subdir tests."""
+    parent = TESTS_ROOT / "debate"
+    _, files = _entries(parent)
+    in_nz = _alpha_range("n", "z")
+    return _under(parent, [f for f in files if in_nz(_file_letter(f))])
+
+
+def shard_debate_phases() -> list[str]:
+    """All subdirectories under tests/debate/."""
+    parent = TESTS_ROOT / "debate"
+    subdirs, _ = _entries(parent)
+    return _under(parent, subdirs)
+
+
+def _server_handlers_root() -> Path:
+    return TESTS_ROOT / "server" / "handlers"
+
+
+def shard_server_handlers_am() -> list[str]:
+    parent = _server_handlers_root()
+    subdirs, files = _entries(parent)
+    in_am = _alpha_range("a", "m")
+    chosen = [s for s in subdirs if _starts_in(s.lstrip("_"), in_am)]
+    chosen += [f for f in files if in_am(_file_letter(f))]
+    return _under(parent, chosen)
+
+
+def shard_server_handlers_nz() -> list[str]:
+    parent = _server_handlers_root()
+    subdirs, files = _entries(parent)
+    in_nz = _alpha_range("n", "z")
+    chosen = [s for s in subdirs if _starts_in(s.lstrip("_"), in_nz)]
+    chosen += [f for f in files if in_nz(_file_letter(f))]
+    return _under(parent, chosen)
+
+
+def shard_server_rest() -> list[str]:
+    """Everything under tests/server/ except tests/server/handlers/."""
+    return ["tests/server", "--ignore=tests/server/handlers"]
+
+
+def _handlers_root() -> Path:
+    return TESTS_ROOT / "handlers"
+
+
+def shard_handlers_features() -> list[str]:
+    """Single largest subdir of tests/handlers/."""
+    return ["tests/handlers/features"]
+
+
+def shard_handlers_amk_no_features() -> list[str]:
+    """A-K subdirs (excluding ``features``) + A-K top-level files.
+
+    Underscore-prefixed subdirs (e.g. ``_oauth``) are grouped here so that
+    every test in tests/handlers/ runs in exactly one shard.
+    """
+    parent = _handlers_root()
+    subdirs, files = _entries(parent)
+    in_ak = _alpha_range("a", "k")
+    chosen_subdirs = [
+        s for s in subdirs if s != "features" and (s.startswith("_") or _starts_in(s, in_ak))
+    ]
+    chosen_files = [f for f in files if in_ak(_file_letter(f))]
+    return _under(parent, chosen_subdirs + chosen_files)
+
+
+def shard_handlers_lz() -> list[str]:
+    """L-Z subdirs + L-Z top-level files (no underscore-prefixed dirs)."""
+    parent = _handlers_root()
+    subdirs, files = _entries(parent)
+    in_lz = _alpha_range("l", "z")
+    chosen_subdirs = [s for s in subdirs if not s.startswith("_") and _starts_in(s, in_lz)]
+    chosen_files = [f for f in files if in_lz(_file_letter(f))]
+    return _under(parent, chosen_subdirs + chosen_files)
+
+
+SHARDS: dict[str, Callable[[], list[str]]] = {
+    "debate-am": shard_debate_am,
+    "debate-nz": shard_debate_nz,
+    "debate-phases": shard_debate_phases,
+    "server-handlers-am": shard_server_handlers_am,
+    "server-handlers-nz": shard_server_handlers_nz,
+    "server-rest": shard_server_rest,
+    "handlers-features": shard_handlers_features,
+    "handlers-amk-no-features": shard_handlers_amk_no_features,
+    "handlers-lz": shard_handlers_lz,
+}
+
+
+# ---------------------------------------------------------------------------
+# Self-check (used by tests/CI sanity)
+# ---------------------------------------------------------------------------
+
+
+def _print_diagnostics(name: str, paths: list[str]) -> None:
+    print(f"shard: {name}", file=sys.stderr)
+    print(f"  resolved {len(paths)} entries", file=sys.stderr)
+    for p in paths[:5]:
+        print(f"  - {p}", file=sys.stderr)
+    if len(paths) > 5:
+        print(f"  ... and {len(paths) - 5} more", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("shard", choices=sorted(SHARDS), help="logical shard name")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="print partition diagnostics on stderr",
+    )
+    args = parser.parse_args(argv)
+
+    paths = SHARDS[args.shard]()
+    if args.check:
+        _print_diagnostics(args.shard, paths)
+    print(" ".join(paths))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_ci_resolve_test_shard.py
+++ b/tests/scripts/test_ci_resolve_test_shard.py
@@ -1,0 +1,114 @@
+"""Verify CI test shards partition tests/{handlers,debate,server} cleanly.
+
+The shard resolver in scripts/ci_resolve_test_shard.py drives the
+test-fast matrix in .github/workflows/test.yml. If sub-shards overlap
+or miss files we either run tests twice (wasted CI minutes) or skip
+them entirely (silent regressions). Both are bad, so guard with this
+test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ci_resolve_test_shard.py"
+
+spec = importlib.util.spec_from_file_location("ci_resolve_test_shard", SCRIPT_PATH)
+assert spec and spec.loader
+shard_mod = importlib.util.module_from_spec(spec)
+sys.modules["ci_resolve_test_shard"] = shard_mod
+spec.loader.exec_module(shard_mod)
+
+
+def _expand_to_files(paths: list[str]) -> set[str]:
+    """Recursively expand any directory entries in ``paths`` to test_*.py files.
+
+    Tokens starting with ``--`` (e.g. ``--ignore=tests/server/handlers``) are
+    interpreted as pytest options, not test paths, and the operand is removed
+    from the resulting set so we model what pytest will actually collect.
+    """
+    include: set[str] = set()
+    excludes: set[str] = set()
+    for raw in paths:
+        if raw.startswith("--ignore="):
+            excludes.add(raw.split("=", 1)[1])
+            continue
+        if raw.startswith("--"):
+            continue
+        path = REPO_ROOT / raw
+        if path.is_file():
+            include.add(str(path.relative_to(REPO_ROOT)))
+        elif path.is_dir():
+            for f in path.rglob("test_*.py"):
+                if "__pycache__" in f.parts:
+                    continue
+                include.add(str(f.relative_to(REPO_ROOT)))
+    for ex in excludes:
+        ex_path = REPO_ROOT / ex
+        include = {f for f in include if not Path(f).is_relative_to(ex_path.relative_to(REPO_ROOT))}
+    return include
+
+
+def _all_tests_under(rel_root: str) -> set[str]:
+    root = REPO_ROOT / rel_root
+    return {
+        str(p.relative_to(REPO_ROOT))
+        for p in root.rglob("test_*.py")
+        if "__pycache__" not in p.parts
+    }
+
+
+def _assert_partition(
+    expected_total_root: str,
+    shard_names: list[str],
+) -> None:
+    expected = _all_tests_under(expected_total_root)
+    expanded_per_shard = {name: _expand_to_files(shard_mod.SHARDS[name]()) for name in shard_names}
+    union: set[str] = set().union(*expanded_per_shard.values())
+
+    missing = expected - union
+    extras = union - expected
+    overlaps: set[str] = set()
+    items = list(expanded_per_shard.items())
+    for i in range(len(items)):
+        for j in range(i + 1, len(items)):
+            overlaps |= items[i][1] & items[j][1]
+
+    assert not missing, (
+        f"shards miss {len(missing)} files under {expected_total_root}: {sorted(missing)[:10]}"
+    )
+    assert not extras, f"shards include unexpected files: {sorted(extras)[:10]}"
+    assert not overlaps, f"shards overlap on {len(overlaps)} files: {sorted(overlaps)[:10]}"
+
+
+def test_handlers_partition_is_complete_and_disjoint() -> None:
+    _assert_partition(
+        "tests/handlers",
+        ["handlers-features", "handlers-amk-no-features", "handlers-lz"],
+    )
+
+
+def test_server_handlers_partition_is_complete_and_disjoint() -> None:
+    _assert_partition(
+        "tests/server/handlers",
+        ["server-handlers-am", "server-handlers-nz"],
+    )
+
+
+def test_debate_partition_is_complete_and_disjoint() -> None:
+    _assert_partition(
+        "tests/debate",
+        ["debate-am", "debate-nz", "debate-phases"],
+    )
+
+
+def test_resolver_emits_relative_paths() -> None:
+    """All resolver outputs are repo-relative paths that exist or are pytest options."""
+    for name, fn in shard_mod.SHARDS.items():
+        for token in fn():
+            if token.startswith("--"):
+                continue
+            assert (REPO_ROOT / token).exists(), f"shard {name} resolved nonexistent path: {token}"


### PR DESCRIPTION
## Why

The test-fast matrix has three shards regularly hitting the 30-min runner cap or running unnecessarily on every PR:

| Shard | Tests | Wall clock | Status |
|-------|-------|------------|--------|
| debate | ~14K | 28+ min | Cancelled at 54% in #6579 |
| server | ~31K | 22 min | Next at risk |
| handlers | ~58K | 26 min | Next at risk |

Branch protection only requires lint, typecheck, sdk-parity, openapi generate/validate, and ts-sdk-typecheck — so test-fast is informational but expensive. Sub-sharding within `ubuntu-latest` keeps the workflow free and wall-clock comparable; no infra upgrade needed.

## What changed

**1. Heavy shards split into 9 sub-shards (15 total, was 9):**
- `debate` → `debate-am` / `debate-nz` / `debate-phases`
- `server` → `server-handlers-am` / `server-handlers-nz` / `server-rest`
- `handlers` → `handlers-features` / `handlers-amk-no-features` / `handlers-lz`

All three partitions are mutually exclusive AND complete, verified by `tests/scripts/test_ci_resolve_test_shard.py` (4 tests, all passing locally).

**2. `scripts/ci_resolve_test_shard.py` resolver:**

The alphabetic partitioning lives in versioned Python rather than 5KB of YAML `--ignore-glob` soup. pytest's `--ignore-glob` uses `fnmatch` against absolute paths with subtle semantics that silently dropped 10K+ tests in earlier drafts (top-level `test_admin.py` got swept by `tests/handlers/l*`-style globs). The resolver script computes shards from real directory listings, so partitioning is auditable, locally reproducible, and unit-tested.

**3. Scope-aware path filter (`test-shard-scope` job):**

New `test-shard-scope` job uses `dorny/paths-filter@v3` with 10 per-area filters plus a `core` meta-filter (deps / workflow / version / config). Each test-fast shard reads its scope from the matrix entry; PRs that do not touch a shard's area cause that shard to short-circuit with a no-op success step. `push`, `schedule` and `workflow_dispatch` always run every shard. Touching anything in `core` forces every shard to run.

## Verified

```
debate-am: 5508 tests
debate-nz: 5644 tests
debate-phases: 3063 tests       sum = 14,215 = total
server-handlers-am: 15666 tests
server-handlers-nz: 8182 tests   sum = 23,848 = total
server-rest: 7591 tests
handlers-features: 7714 tests
handlers-amk-no-features: 31446 tests
handlers-lz: 19052 tests        sum = 58,212 = total
```

YAML parses (28 jobs total). Lint clean. Partition unit tests pass.

## Follow-ups (not in this PR)
- Promote heaviest shards to `ubuntu-latest-16cores` if even 3-way split is insufficient.
- `@pytest.mark.slow` triage script to push genuinely slow tests off the fast lane.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>