### PR TITLE
[DIC-23] Dialectical Runtime Loop orchestrator (report-only skeleton)

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -1,4 +1,4 @@
-"""Epistemic CI and crux-engine helpers (DIC-13..22 + DIC-25/26 tranche).
+"""Epistemic CI and crux-engine helpers (DIC-13..22 + DIC-23..28 tranche).
 
 Exposes:
 - DIC-13: typed ExecutableClaim manifest model (:class:`ExecutableClaim`,
@@ -29,6 +29,10 @@ Exposes:
   :func:`load_proof_unit_from_yaml`, :func:`load_proof_units_from_dir`)
   Flag gate: ``ARAGORA_PROOF_UNIT_SCAN_ENABLED`` (default off; dataclasses
   are always importable).
+- DIC-23: dialectical runtime loop orchestrator (:class:`DialecticalEvent`,
+  :class:`DialecticalRuntimeError`, :func:`run_dialectical_loop`,
+  :func:`dialectical_runtime_enabled`, :func:`enable_dialectical_runtime`)
+  Flag gate: ``ARAGORA_DIALECTICAL_RUNTIME_ENABLED`` (default off).
 - DIC-26: belief coherence monitor (:class:`BeliefEntry`,
   :class:`CoherenceReport`, :func:`scan_coherence`)
 - DIC-28: proactive crux gardening (:class:`GardeningConfig`,
@@ -45,6 +49,13 @@ from __future__ import annotations
 
 import os
 
+from .runtime_loop import (
+    DialecticalEvent,
+    DialecticalRuntimeError,
+    dialectical_runtime_enabled,
+    enable_dialectical_runtime,
+    run_dialectical_loop,
+)
 from .arbitration import (
     PERSISTENT_CRUX_MIN_CONSECUTIVE,
     PERSISTENT_CRUX_MIN_SCORE,
@@ -142,6 +153,11 @@ from .truth_map import (
 )
 
 __all__ = [
+    "DialecticalEvent",
+    "DialecticalRuntimeError",
+    "dialectical_runtime_enabled",
+    "enable_dialectical_runtime",
+    "run_dialectical_loop",
     "ArbitrationSide",
     "BeliefEntry",
     "ClaimConfidence",

--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -31,7 +31,7 @@ Exposes:
   are always importable).
 - DIC-23: dialectical runtime loop orchestrator (:class:`DialecticalEvent`,
   :class:`DialecticalRuntimeError`, :func:`run_dialectical_loop`,
-  :func:`dialectical_runtime_enabled`, :func:`enable_dialectical_runtime`)
+  :func:`dialectical_runtime_enabled`)
   Flag gate: ``ARAGORA_DIALECTICAL_RUNTIME_ENABLED`` (default off).
 - DIC-26: belief coherence monitor (:class:`BeliefEntry`,
   :class:`CoherenceReport`, :func:`scan_coherence`)
@@ -53,7 +53,6 @@ from .runtime_loop import (
     DialecticalEvent,
     DialecticalRuntimeError,
     dialectical_runtime_enabled,
-    enable_dialectical_runtime,
     run_dialectical_loop,
 )
 from .arbitration import (
@@ -156,7 +155,6 @@ __all__ = [
     "DialecticalEvent",
     "DialecticalRuntimeError",
     "dialectical_runtime_enabled",
-    "enable_dialectical_runtime",
     "run_dialectical_loop",
     "ArbitrationSide",
     "BeliefEntry",

--- a/aragora/epistemic/genealogy.py
+++ b/aragora/epistemic/genealogy.py
@@ -11,6 +11,8 @@ wiring to receipt/KM stores is deferred to the DIC-23..28 activation gate.
 Flag: ``ARAGORA_GENEALOGY_ENABLED`` (default False).  The data classes and
 store implementations are always importable; only ``get_genealogy`` checks
 the flag when ``require_enabled=True`` (the default for production callers).
+Tests and demos should set the flag at the process boundary; this module does
+not mutate ``os.environ``.
 """
 
 from __future__ import annotations
@@ -31,11 +33,6 @@ _ENTRY_KINDS: frozenset[str] = frozenset(get_args(EntryKind))
 def _genealogy_enabled() -> bool:
     raw = str(os.environ.get("ARAGORA_GENEALOGY_ENABLED") or "").strip().lower()
     return raw in {"1", "true", "yes", "on"}
-
-
-def enable_genealogy() -> None:
-    """Enable genealogy actions for the current process (tests/demo)."""
-    os.environ["ARAGORA_GENEALOGY_ENABLED"] = "1"
 
 
 # ---------------------------------------------------------------------------
@@ -181,7 +178,7 @@ def get_genealogy(
 
     When *require_enabled* is True (default), raises ``RuntimeError`` if
     ``ARAGORA_GENEALOGY_ENABLED`` is not set.  Tests can pass
-    ``require_enabled=False`` or set the env var via ``enable_genealogy()``.
+    ``require_enabled=False`` or set the env var with ``monkeypatch``.
     """
     if not code_unit_id:
         raise ValueError("code_unit_id must be non-empty")

--- a/aragora/epistemic/runtime_loop.py
+++ b/aragora/epistemic/runtime_loop.py
@@ -16,7 +16,9 @@ follow-on PR and will clear the ``crux_probe_skipped`` field.
 Flag: ``ARAGORA_DIALECTICAL_RUNTIME_ENABLED`` (default off).
 Dataclasses and ``run_dialectical_loop`` are always importable; the
 flag is checked only when ``require_enabled=True`` (the default for
-production callers) to avoid silent no-ops.
+production callers) to avoid silent no-ops. Tests and demos should set
+the flag at the process boundary; this module does not mutate
+``os.environ``.
 
 Advances: #6217 (DIC-23)
 See also: ``docs/plans/2026-04-18-dialectical-runtime-synthesis.md``
@@ -47,11 +49,6 @@ def dialectical_runtime_enabled() -> bool:
     """Return True if the DIC-23 runtime loop is enabled for this process."""
     raw = str(os.environ.get(_FLAG) or "").strip().lower()
     return raw in {"1", "true", "yes", "on"}
-
-
-def enable_dialectical_runtime() -> None:
-    """Enable the DIC-23 runtime loop for the current process (tests/demo)."""
-    os.environ[_FLAG] = "1"
 
 
 def _utc_now_iso() -> str:
@@ -160,8 +157,7 @@ def run_dialectical_loop(
     if require_enabled and not dialectical_runtime_enabled():
         raise DialecticalRuntimeError(
             "DIC-23 dialectical runtime is disabled; "
-            "set ARAGORA_DIALECTICAL_RUNTIME_ENABLED=1 "
-            "or call enable_dialectical_runtime()"
+            "set ARAGORA_DIALECTICAL_RUNTIME_ENABLED=1 at the process boundary"
         )
 
     resolved_policy = policy or DEFAULT_POLICIES.get(code_unit_class, DEFAULT_POLICIES["default"])
@@ -192,6 +188,5 @@ __all__ = [
     "DialecticalEvent",
     "DialecticalRuntimeError",
     "dialectical_runtime_enabled",
-    "enable_dialectical_runtime",
     "run_dialectical_loop",
 ]

--- a/aragora/epistemic/runtime_loop.py
+++ b/aragora/epistemic/runtime_loop.py
@@ -70,9 +70,11 @@ class DialecticalEvent:
     a repair spec.  ``crux_probe_skipped`` is always ``True`` in this
     slice; crux-finder integration (DIC-15) updates it in a follow-on PR.
 
-    ``prior_receipt_ids`` is the caller-supplied ancestry chain, allowing
-    the event to be linked to the decision receipts that originally
-    justified the code unit.
+    ``prior_receipt_ids`` is the caller-supplied ancestry chain stored as
+    an immutable tuple.  ``metadata`` is a shallow-frozen dict copy: the
+    outer reference is immutable but nested mutable values are not
+    deep-copied.  Callers must not store references to mutable nested
+    objects in metadata when receipt-chain immutability matters.
     """
 
     event_id: str
@@ -82,7 +84,7 @@ class DialecticalEvent:
     quarantine_action: str
     crux_probe_skipped: bool
     repair_spec: RepairSpec | None
-    prior_receipt_ids: list[str]
+    prior_receipt_ids: tuple[str, ...]
     created_at: str
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -175,7 +177,7 @@ def run_dialectical_loop(
         quarantine_action=quarantine.policy_action,
         crux_probe_skipped=True,
         repair_spec=repair_spec,
-        prior_receipt_ids=list(prior_receipt_ids or []),
+        prior_receipt_ids=tuple(prior_receipt_ids or []),
         created_at=ts,
         metadata=dict(metadata or {}),
     )

--- a/aragora/epistemic/runtime_loop.py
+++ b/aragora/epistemic/runtime_loop.py
@@ -28,7 +28,7 @@ import hashlib
 import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 from aragora.epistemic.decay_monitor import DecaySignal
 from aragora.epistemic.quarantine_policy import (
@@ -37,9 +37,6 @@ from aragora.epistemic.quarantine_policy import (
     apply_quarantine_policy,
 )
 from aragora.epistemic.repair import RepairSpec, propose_repair
-
-if TYPE_CHECKING:
-    pass
 
 _FLAG = "ARAGORA_DIALECTICAL_RUNTIME_ENABLED"
 

--- a/aragora/epistemic/runtime_loop.py
+++ b/aragora/epistemic/runtime_loop.py
@@ -26,8 +26,10 @@ from __future__ import annotations
 
 import hashlib
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from types import MappingProxyType
 from typing import Any
 
 from aragora.epistemic.decay_monitor import DecaySignal
@@ -71,8 +73,8 @@ class DialecticalEvent:
     slice; crux-finder integration (DIC-15) updates it in a follow-on PR.
 
     ``prior_receipt_ids`` is the caller-supplied ancestry chain stored as
-    an immutable tuple.  ``metadata`` is a shallow-frozen dict copy: the
-    outer reference is immutable but nested mutable values are not
+    an immutable tuple.  ``metadata`` is stored as a shallow-frozen mapping:
+    the outer mapping is immutable but nested mutable values are not
     deep-copied.  Callers must not store references to mutable nested
     objects in metadata when receipt-chain immutability matters.
     """
@@ -86,7 +88,10 @@ class DialecticalEvent:
     repair_spec: RepairSpec | None
     prior_receipt_ids: tuple[str, ...]
     created_at: str
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/aragora/epistemic/runtime_loop.py
+++ b/aragora/epistemic/runtime_loop.py
@@ -1,0 +1,193 @@
+"""DIC-23 Dialectical Runtime Loop orchestrator.
+
+Connects the decay monitor (DIC-20), quarantine policy (DIC-21), and
+repair pipeline (DIC-22) into a single, observable, receipt-carrying trace:
+
+    DecaySignal
+        → apply_quarantine_policy          (DIC-21)
+        → propose_repair (optional)        (DIC-22)
+        → DialecticalEvent                 (this module)
+
+Default posture is *report-only*: no state is mutated, no issues are
+created, and nothing is routed to the live queue.  Crux probing
+(DIC-15 / crux-finder consensus mode integration) is deferred to a
+follow-on PR and will clear the ``crux_probe_skipped`` field.
+
+Flag: ``ARAGORA_DIALECTICAL_RUNTIME_ENABLED`` (default off).
+Dataclasses and ``run_dialectical_loop`` are always importable; the
+flag is checked only when ``require_enabled=True`` (the default for
+production callers) to avoid silent no-ops.
+
+Advances: #6217 (DIC-23)
+See also: ``docs/plans/2026-04-18-dialectical-runtime-synthesis.md``
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, TYPE_CHECKING
+
+from aragora.epistemic.decay_monitor import DecaySignal
+from aragora.epistemic.quarantine_policy import (
+    DEFAULT_POLICIES,
+    QuarantinePolicy,
+    apply_quarantine_policy,
+)
+from aragora.epistemic.repair import RepairSpec, propose_repair
+
+if TYPE_CHECKING:
+    pass
+
+_FLAG = "ARAGORA_DIALECTICAL_RUNTIME_ENABLED"
+
+
+def dialectical_runtime_enabled() -> bool:
+    """Return True if the DIC-23 runtime loop is enabled for this process."""
+    raw = str(os.environ.get(_FLAG) or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def enable_dialectical_runtime() -> None:
+    """Enable the DIC-23 runtime loop for the current process (tests/demo)."""
+    os.environ[_FLAG] = "1"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _event_id(unit_id: str, recommended_action: str, ts: str) -> str:
+    material = f"drt|{unit_id}|{recommended_action}|{ts}"
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"drt_{digest}"
+
+
+@dataclass(frozen=True)
+class DialecticalEvent:
+    """Canonical trace record for one DIC-23 orchestration pass.
+
+    Carries the decay summary, the quarantine decision, and (optionally)
+    a repair spec.  ``crux_probe_skipped`` is always ``True`` in this
+    slice; crux-finder integration (DIC-15) updates it in a follow-on PR.
+
+    ``prior_receipt_ids`` is the caller-supplied ancestry chain, allowing
+    the event to be linked to the decision receipts that originally
+    justified the code unit.
+    """
+
+    event_id: str
+    code_unit_id: str
+    integrity_score: float
+    recommended_action: str
+    quarantine_action: str
+    crux_probe_skipped: bool
+    repair_spec: RepairSpec | None
+    prior_receipt_ids: list[str]
+    created_at: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "code_unit_id": self.code_unit_id,
+            "integrity_score": round(self.integrity_score, 4),
+            "recommended_action": self.recommended_action,
+            "quarantine_action": self.quarantine_action,
+            "crux_probe_skipped": self.crux_probe_skipped,
+            "repair_spec": self.repair_spec.to_dict() if self.repair_spec else None,
+            "prior_receipt_ids": list(self.prior_receipt_ids),
+            "created_at": self.created_at,
+            "metadata": dict(self.metadata),
+        }
+
+
+class DialecticalRuntimeError(RuntimeError):
+    """Raised when the loop is invoked but the feature flag is off."""
+
+
+def run_dialectical_loop(
+    signal: DecaySignal,
+    *,
+    policy: QuarantinePolicy | None = None,
+    code_unit_class: str = "default",
+    enable_repair_proposal: bool = False,
+    prior_receipt_ids: list[str] | None = None,
+    metadata: dict[str, Any] | None = None,
+    require_enabled: bool = True,
+) -> DialecticalEvent:
+    """Run one DIC-23 orchestration pass and return a :class:`DialecticalEvent`.
+
+    Parameters
+    ----------
+    signal:
+        The :class:`~aragora.epistemic.decay_monitor.DecaySignal` to act on.
+    policy:
+        Explicit :class:`~aragora.epistemic.quarantine_policy.QuarantinePolicy`.
+        When ``None``, resolves from
+        :data:`~aragora.epistemic.quarantine_policy.DEFAULT_POLICIES` using
+        ``code_unit_class``.
+    code_unit_class:
+        Policy class key used when ``policy`` is ``None``.
+    enable_repair_proposal:
+        When ``True`` *and* the quarantine decision is
+        ``"repair_required"``, calls
+        :func:`~aragora.epistemic.repair.propose_repair` to produce a
+        ``report_only`` :class:`~aragora.epistemic.repair.RepairSpec`.
+        Defaults to ``False`` — pure report-only trace with no spec.
+    prior_receipt_ids:
+        Receipt IDs to attach to the event's ancestry chain.
+    metadata:
+        Arbitrary pass-through payload stored in the event.
+    require_enabled:
+        When ``True`` (default), raises :class:`DialecticalRuntimeError`
+        if ``ARAGORA_DIALECTICAL_RUNTIME_ENABLED`` is not set.  Pass
+        ``False`` in unit tests to build events without touching the
+        environment.
+
+    Returns
+    -------
+    DialecticalEvent
+        Immutable trace record.  Never mutates claim manifests, never
+        creates issues, never routes to the live queue.
+    """
+    if require_enabled and not dialectical_runtime_enabled():
+        raise DialecticalRuntimeError(
+            "DIC-23 dialectical runtime is disabled; "
+            "set ARAGORA_DIALECTICAL_RUNTIME_ENABLED=1 "
+            "or call enable_dialectical_runtime()"
+        )
+
+    resolved_policy = policy or DEFAULT_POLICIES.get(code_unit_class, DEFAULT_POLICIES["default"])
+    quarantine = apply_quarantine_policy(signal, resolved_policy)
+
+    repair_spec: RepairSpec | None = None
+    if enable_repair_proposal and quarantine.policy_action == "repair_required":
+        repair_spec = propose_repair(signal)
+
+    ts = _utc_now_iso()
+    event_id = _event_id(signal.code_unit_id, signal.recommended_action, ts)
+
+    return DialecticalEvent(
+        event_id=event_id,
+        code_unit_id=signal.code_unit_id,
+        integrity_score=signal.integrity_score,
+        recommended_action=signal.recommended_action,
+        quarantine_action=quarantine.policy_action,
+        crux_probe_skipped=True,
+        repair_spec=repair_spec,
+        prior_receipt_ids=list(prior_receipt_ids or []),
+        created_at=ts,
+        metadata=dict(metadata or {}),
+    )
+
+
+__all__ = [
+    "DialecticalEvent",
+    "DialecticalRuntimeError",
+    "dialectical_runtime_enabled",
+    "enable_dialectical_runtime",
+    "run_dialectical_loop",
+]

--- a/tests/epistemic/test_genealogy.py
+++ b/tests/epistemic/test_genealogy.py
@@ -10,7 +10,6 @@ from aragora.epistemic.genealogy import (
     GenealogyStore,
     InMemoryGenealogyStore,
     _chain_checksum,
-    enable_genealogy,
     get_genealogy,
 )
 
@@ -297,13 +296,6 @@ class TestGetGenealogy:
 
     def test_flag_enabled_via_true_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ARAGORA_GENEALOGY_ENABLED", "true")
-        store = InMemoryGenealogyStore()
-        g = get_genealogy("unit.x", store)
-        assert g.code_unit_id == "unit.x"
-
-    def test_enable_genealogy_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("ARAGORA_GENEALOGY_ENABLED", raising=False)
-        enable_genealogy()
         store = InMemoryGenealogyStore()
         g = get_genealogy("unit.x", store)
         assert g.code_unit_id == "unit.x"

--- a/tests/epistemic/test_runtime_loop.py
+++ b/tests/epistemic/test_runtime_loop.py
@@ -106,6 +106,12 @@ class TestReportOnlyTrace:
         event = run_dialectical_loop(_signal(), metadata={"source": "test"}, require_enabled=False)
         assert event.metadata == {"source": "test"}
 
+    def test_metadata_outer_mapping_is_immutable(self):
+        event = run_dialectical_loop(_signal(), metadata={"source": "test"}, require_enabled=False)
+
+        with pytest.raises(TypeError):
+            event.metadata["source"] = "mutated"  # type: ignore[index]
+
     def test_to_dict_is_json_friendly(self):
         import json
 

--- a/tests/epistemic/test_runtime_loop.py
+++ b/tests/epistemic/test_runtime_loop.py
@@ -20,6 +20,7 @@ from aragora.epistemic.runtime_loop import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _signal(
     *,
     unit_id: str = "unit.test",
@@ -38,6 +39,7 @@ def _signal(
 # ---------------------------------------------------------------------------
 # Feature flag
 # ---------------------------------------------------------------------------
+
 
 class TestFeatureFlag:
     def setup_method(self):
@@ -71,6 +73,7 @@ class TestFeatureFlag:
 # Report-only (default) trace
 # ---------------------------------------------------------------------------
 
+
 class TestReportOnlyTrace:
     def test_event_fields_populated(self):
         sig = _signal(unit_id="unit.alpha", integrity_score=0.75)
@@ -96,19 +99,16 @@ class TestReportOnlyTrace:
 
     def test_prior_receipt_ids_preserved(self):
         receipts = ["rcpt-001", "rcpt-002"]
-        event = run_dialectical_loop(
-            _signal(), prior_receipt_ids=receipts, require_enabled=False
-        )
+        event = run_dialectical_loop(_signal(), prior_receipt_ids=receipts, require_enabled=False)
         assert event.prior_receipt_ids == receipts
 
     def test_metadata_preserved(self):
-        event = run_dialectical_loop(
-            _signal(), metadata={"source": "test"}, require_enabled=False
-        )
+        event = run_dialectical_loop(_signal(), metadata={"source": "test"}, require_enabled=False)
         assert event.metadata == {"source": "test"}
 
     def test_to_dict_is_json_friendly(self):
         import json
+
         event = run_dialectical_loop(_signal(), require_enabled=False)
         d = event.to_dict()
         serialized = json.dumps(d)
@@ -124,12 +124,11 @@ class TestReportOnlyTrace:
 # Repair-proposal path
 # ---------------------------------------------------------------------------
 
+
 class TestRepairProposal:
     def test_repair_spec_none_when_flag_false(self):
         sig = _signal(integrity_score=0.1, recommended_action="repair_required")
-        event = run_dialectical_loop(
-            sig, enable_repair_proposal=False, require_enabled=False
-        )
+        event = run_dialectical_loop(sig, enable_repair_proposal=False, require_enabled=False)
         assert event.repair_spec is None
 
     def test_repair_spec_produced_when_action_repair_required(self):
@@ -150,6 +149,7 @@ class TestRepairProposal:
 
     def test_repair_spec_produced_with_custom_policy(self):
         from aragora.epistemic.quarantine_policy import EscalationMap
+
         sig = _signal(integrity_score=0.5, recommended_action="repair_required")
         # Custom policy: repair_required stays repair_required, threshold=0.3
         policy = QuarantinePolicy(
@@ -174,9 +174,11 @@ class TestRepairProposal:
 # Policy resolution
 # ---------------------------------------------------------------------------
 
+
 class TestPolicyResolution:
     def test_explicit_policy_overrides_class(self):
         from aragora.epistemic.quarantine_policy import EscalationMap
+
         sig = _signal(integrity_score=0.9, recommended_action="report_only")
         policy = QuarantinePolicy(
             code_unit_class="strict",
@@ -189,23 +191,20 @@ class TestPolicyResolution:
     def test_code_unit_class_live_dispatch(self):
         # live_dispatch policy has fail_closed_threshold=0.6; score=0.5 → fail_closed
         sig = _signal(integrity_score=0.5, recommended_action="report_only")
-        event = run_dialectical_loop(
-            sig, code_unit_class="live_dispatch", require_enabled=False
-        )
+        event = run_dialectical_loop(sig, code_unit_class="live_dispatch", require_enabled=False)
         assert event.quarantine_action == "fail_closed"
 
     def test_code_unit_class_report_surface(self):
         # report_surface policy has fail_closed_threshold=0.3; score=0.5 → degrade
         sig = _signal(integrity_score=0.5, recommended_action="repair_required")
-        event = run_dialectical_loop(
-            sig, code_unit_class="report_surface", require_enabled=False
-        )
+        event = run_dialectical_loop(sig, code_unit_class="report_surface", require_enabled=False)
         assert event.quarantine_action in {"degrade", "repair_required", "report_only"}
 
 
 # ---------------------------------------------------------------------------
 # Serialization round-trip
 # ---------------------------------------------------------------------------
+
 
 class TestSerialization:
     def test_to_dict_keys(self):
@@ -233,9 +232,7 @@ class TestSerialization:
 
     def test_prior_receipt_ids_is_list_copy(self):
         receipts = ["r1", "r2"]
-        event = run_dialectical_loop(
-            _signal(), prior_receipt_ids=receipts, require_enabled=False
-        )
+        event = run_dialectical_loop(_signal(), prior_receipt_ids=receipts, require_enabled=False)
         d = event.to_dict()
         assert d["prior_receipt_ids"] == ["r1", "r2"]
         # Mutation of original list does not affect the event
@@ -244,6 +241,7 @@ class TestSerialization:
 
     def test_with_repair_spec_in_dict(self):
         from aragora.epistemic.quarantine_policy import EscalationMap
+
         sig = _signal(integrity_score=0.5, recommended_action="repair_required")
         policy = QuarantinePolicy(
             code_unit_class="custom",

--- a/tests/epistemic/test_runtime_loop.py
+++ b/tests/epistemic/test_runtime_loop.py
@@ -84,7 +84,7 @@ class TestReportOnlyTrace:
         assert event.recommended_action == "report_only"
         assert event.repair_spec is None
         assert event.crux_probe_skipped is True
-        assert event.prior_receipt_ids == []
+        assert event.prior_receipt_ids == ()
         assert event.created_at  # non-empty timestamp
 
     def test_event_id_has_drt_prefix(self):
@@ -100,7 +100,7 @@ class TestReportOnlyTrace:
     def test_prior_receipt_ids_preserved(self):
         receipts = ["rcpt-001", "rcpt-002"]
         event = run_dialectical_loop(_signal(), prior_receipt_ids=receipts, require_enabled=False)
-        assert event.prior_receipt_ids == receipts
+        assert event.prior_receipt_ids == tuple(receipts)
 
     def test_metadata_preserved(self):
         event = run_dialectical_loop(_signal(), metadata={"source": "test"}, require_enabled=False)
@@ -131,21 +131,19 @@ class TestRepairProposal:
         event = run_dialectical_loop(sig, enable_repair_proposal=False, require_enabled=False)
         assert event.repair_spec is None
 
-    def test_repair_spec_produced_when_action_repair_required(self):
-        # Use a policy that maps repair_required → repair_required
+    def test_repair_spec_absent_when_policy_escalates_to_fail_closed(self):
+        # score=0.1 is below default fail_closed_threshold=0.4, so the policy
+        # escalates to fail_closed — NOT repair_required.  repair_spec must stay
+        # None even when enable_repair_proposal=True.
         sig = _signal(integrity_score=0.1, recommended_action="repair_required")
-        # Default policy with score=0.1 is below fail_closed_threshold=0.4 → fail_closed
-        # Use the "pure_policy" class which has a default escalation map
         event = run_dialectical_loop(
             sig,
             code_unit_class="default",
             enable_repair_proposal=True,
             require_enabled=False,
         )
-        # With integrity_score=0.1, default policy produces fail_closed, not repair_required,
-        # so repair_spec stays None (correct: spec is only produced for repair_required).
-        # We test the repair path explicitly via a relaxed-threshold policy.
-        assert event.repair_spec is None  # fail_closed branch, not repair_required
+        assert event.quarantine_action == "fail_closed"
+        assert event.repair_spec is None
 
     def test_repair_spec_produced_with_custom_policy(self):
         from aragora.epistemic.quarantine_policy import EscalationMap
@@ -230,14 +228,18 @@ class TestSerialization:
         d = event.to_dict()
         assert d["integrity_score"] == round(0.123456789, 4)
 
-    def test_prior_receipt_ids_is_list_copy(self):
+    def test_prior_receipt_ids_is_immutable_tuple(self):
         receipts = ["r1", "r2"]
         event = run_dialectical_loop(_signal(), prior_receipt_ids=receipts, require_enabled=False)
+        # Stored as an immutable tuple
+        assert isinstance(event.prior_receipt_ids, tuple)
+        assert event.prior_receipt_ids == ("r1", "r2")
+        # to_dict() returns a list for JSON-serializability
         d = event.to_dict()
         assert d["prior_receipt_ids"] == ["r1", "r2"]
-        # Mutation of original list does not affect the event
+        # Mutation of the original list does not affect the event
         receipts.append("r3")
-        assert event.prior_receipt_ids == ["r1", "r2"]
+        assert event.prior_receipt_ids == ("r1", "r2")
 
     def test_with_repair_spec_in_dict(self):
         from aragora.epistemic.quarantine_policy import EscalationMap

--- a/tests/epistemic/test_runtime_loop.py
+++ b/tests/epistemic/test_runtime_loop.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import pytest
 
 from aragora.epistemic.decay_monitor import DecayReason, DecaySignal
@@ -11,7 +10,6 @@ from aragora.epistemic.runtime_loop import (
     DialecticalEvent,
     DialecticalRuntimeError,
     dialectical_runtime_enabled,
-    enable_dialectical_runtime,
     run_dialectical_loop,
 )
 
@@ -42,20 +40,17 @@ def _signal(
 
 
 class TestFeatureFlag:
-    def setup_method(self):
-        os.environ.pop("ARAGORA_DIALECTICAL_RUNTIME_ENABLED", None)
-
-    def teardown_method(self):
-        os.environ.pop("ARAGORA_DIALECTICAL_RUNTIME_ENABLED", None)
-
-    def test_disabled_by_default(self):
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARAGORA_DIALECTICAL_RUNTIME_ENABLED", raising=False)
         assert not dialectical_runtime_enabled()
 
-    def test_enable_sets_flag(self):
-        enable_dialectical_runtime()
-        assert dialectical_runtime_enabled()
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+    def test_truthy_values_enable_runtime(self, monkeypatch: pytest.MonkeyPatch, value: str):
+        monkeypatch.setenv("ARAGORA_DIALECTICAL_RUNTIME_ENABLED", value)
+        assert dialectical_runtime_enabled() is True
 
-    def test_raises_when_flag_off_and_require_enabled(self):
+    def test_raises_when_flag_off_and_require_enabled(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARAGORA_DIALECTICAL_RUNTIME_ENABLED", raising=False)
         with pytest.raises(DialecticalRuntimeError, match="ARAGORA_DIALECTICAL_RUNTIME_ENABLED"):
             run_dialectical_loop(_signal())
 
@@ -63,8 +58,8 @@ class TestFeatureFlag:
         event = run_dialectical_loop(_signal(), require_enabled=False)
         assert isinstance(event, DialecticalEvent)
 
-    def test_flag_on_allows_call(self):
-        enable_dialectical_runtime()
+    def test_flag_on_allows_call(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("ARAGORA_DIALECTICAL_RUNTIME_ENABLED", "1")
         event = run_dialectical_loop(_signal())
         assert isinstance(event, DialecticalEvent)
 

--- a/tests/epistemic/test_runtime_loop.py
+++ b/tests/epistemic/test_runtime_loop.py
@@ -1,0 +1,263 @@
+"""Unit tests for DIC-23 Dialectical Runtime Loop (aragora.epistemic.runtime_loop)."""
+
+from __future__ import annotations
+
+import os
+import pytest
+
+from aragora.epistemic.decay_monitor import DecayReason, DecaySignal
+from aragora.epistemic.quarantine_policy import QuarantinePolicy
+from aragora.epistemic.runtime_loop import (
+    DialecticalEvent,
+    DialecticalRuntimeError,
+    dialectical_runtime_enabled,
+    enable_dialectical_runtime,
+    run_dialectical_loop,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _signal(
+    *,
+    unit_id: str = "unit.test",
+    integrity_score: float = 0.8,
+    recommended_action: str = "report_only",
+    reasons: list[DecayReason] | None = None,
+) -> DecaySignal:
+    return DecaySignal(
+        code_unit_id=unit_id,
+        integrity_score=integrity_score,
+        reasons=reasons or [],
+        recommended_action=recommended_action,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+class TestFeatureFlag:
+    def setup_method(self):
+        os.environ.pop("ARAGORA_DIALECTICAL_RUNTIME_ENABLED", None)
+
+    def teardown_method(self):
+        os.environ.pop("ARAGORA_DIALECTICAL_RUNTIME_ENABLED", None)
+
+    def test_disabled_by_default(self):
+        assert not dialectical_runtime_enabled()
+
+    def test_enable_sets_flag(self):
+        enable_dialectical_runtime()
+        assert dialectical_runtime_enabled()
+
+    def test_raises_when_flag_off_and_require_enabled(self):
+        with pytest.raises(DialecticalRuntimeError, match="ARAGORA_DIALECTICAL_RUNTIME_ENABLED"):
+            run_dialectical_loop(_signal())
+
+    def test_require_enabled_false_bypasses_flag(self):
+        event = run_dialectical_loop(_signal(), require_enabled=False)
+        assert isinstance(event, DialecticalEvent)
+
+    def test_flag_on_allows_call(self):
+        enable_dialectical_runtime()
+        event = run_dialectical_loop(_signal())
+        assert isinstance(event, DialecticalEvent)
+
+
+# ---------------------------------------------------------------------------
+# Report-only (default) trace
+# ---------------------------------------------------------------------------
+
+class TestReportOnlyTrace:
+    def test_event_fields_populated(self):
+        sig = _signal(unit_id="unit.alpha", integrity_score=0.75)
+        event = run_dialectical_loop(sig, require_enabled=False)
+
+        assert event.code_unit_id == "unit.alpha"
+        assert event.integrity_score == 0.75
+        assert event.recommended_action == "report_only"
+        assert event.repair_spec is None
+        assert event.crux_probe_skipped is True
+        assert event.prior_receipt_ids == []
+        assert event.created_at  # non-empty timestamp
+
+    def test_event_id_has_drt_prefix(self):
+        event = run_dialectical_loop(_signal(), require_enabled=False)
+        assert event.event_id.startswith("drt_")
+
+    def test_quarantine_action_for_healthy_unit(self):
+        # integrity_score=0.8 → above default fail_closed_threshold (0.4)
+        # recommended_action="report_only" → policy resolves to report_only
+        event = run_dialectical_loop(_signal(integrity_score=0.8), require_enabled=False)
+        assert event.quarantine_action == "report_only"
+
+    def test_prior_receipt_ids_preserved(self):
+        receipts = ["rcpt-001", "rcpt-002"]
+        event = run_dialectical_loop(
+            _signal(), prior_receipt_ids=receipts, require_enabled=False
+        )
+        assert event.prior_receipt_ids == receipts
+
+    def test_metadata_preserved(self):
+        event = run_dialectical_loop(
+            _signal(), metadata={"source": "test"}, require_enabled=False
+        )
+        assert event.metadata == {"source": "test"}
+
+    def test_to_dict_is_json_friendly(self):
+        import json
+        event = run_dialectical_loop(_signal(), require_enabled=False)
+        d = event.to_dict()
+        serialized = json.dumps(d)
+        assert "drt_" in serialized
+        assert "report_only" in serialized
+
+    def test_to_dict_repair_spec_is_none(self):
+        event = run_dialectical_loop(_signal(), require_enabled=False)
+        assert event.to_dict()["repair_spec"] is None
+
+
+# ---------------------------------------------------------------------------
+# Repair-proposal path
+# ---------------------------------------------------------------------------
+
+class TestRepairProposal:
+    def test_repair_spec_none_when_flag_false(self):
+        sig = _signal(integrity_score=0.1, recommended_action="repair_required")
+        event = run_dialectical_loop(
+            sig, enable_repair_proposal=False, require_enabled=False
+        )
+        assert event.repair_spec is None
+
+    def test_repair_spec_produced_when_action_repair_required(self):
+        # Use a policy that maps repair_required → repair_required
+        sig = _signal(integrity_score=0.1, recommended_action="repair_required")
+        # Default policy with score=0.1 is below fail_closed_threshold=0.4 → fail_closed
+        # Use the "pure_policy" class which has a default escalation map
+        event = run_dialectical_loop(
+            sig,
+            code_unit_class="default",
+            enable_repair_proposal=True,
+            require_enabled=False,
+        )
+        # With integrity_score=0.1, default policy produces fail_closed, not repair_required,
+        # so repair_spec stays None (correct: spec is only produced for repair_required).
+        # We test the repair path explicitly via a relaxed-threshold policy.
+        assert event.repair_spec is None  # fail_closed branch, not repair_required
+
+    def test_repair_spec_produced_with_custom_policy(self):
+        from aragora.epistemic.quarantine_policy import EscalationMap
+        sig = _signal(integrity_score=0.5, recommended_action="repair_required")
+        # Custom policy: repair_required stays repair_required, threshold=0.3
+        policy = QuarantinePolicy(
+            code_unit_class="custom",
+            escalation_map=EscalationMap(
+                report_only="report_only",
+                repair_required="repair_required",
+                fail_closed="fail_closed",
+            ),
+            fail_closed_threshold=0.3,
+        )
+        event = run_dialectical_loop(
+            sig, policy=policy, enable_repair_proposal=True, require_enabled=False
+        )
+        assert event.repair_spec is not None
+        assert event.repair_spec.code_unit_id == "unit.test"
+        assert event.repair_spec.repair_kind == "report_only"
+        assert event.quarantine_action == "repair_required"
+
+
+# ---------------------------------------------------------------------------
+# Policy resolution
+# ---------------------------------------------------------------------------
+
+class TestPolicyResolution:
+    def test_explicit_policy_overrides_class(self):
+        from aragora.epistemic.quarantine_policy import EscalationMap
+        sig = _signal(integrity_score=0.9, recommended_action="report_only")
+        policy = QuarantinePolicy(
+            code_unit_class="strict",
+            escalation_map=EscalationMap(),
+            fail_closed_threshold=0.95,  # very strict: 0.9 → fail_closed
+        )
+        event = run_dialectical_loop(sig, policy=policy, require_enabled=False)
+        assert event.quarantine_action == "fail_closed"
+
+    def test_code_unit_class_live_dispatch(self):
+        # live_dispatch policy has fail_closed_threshold=0.6; score=0.5 → fail_closed
+        sig = _signal(integrity_score=0.5, recommended_action="report_only")
+        event = run_dialectical_loop(
+            sig, code_unit_class="live_dispatch", require_enabled=False
+        )
+        assert event.quarantine_action == "fail_closed"
+
+    def test_code_unit_class_report_surface(self):
+        # report_surface policy has fail_closed_threshold=0.3; score=0.5 → degrade
+        sig = _signal(integrity_score=0.5, recommended_action="repair_required")
+        event = run_dialectical_loop(
+            sig, code_unit_class="report_surface", require_enabled=False
+        )
+        assert event.quarantine_action in {"degrade", "repair_required", "report_only"}
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+
+class TestSerialization:
+    def test_to_dict_keys(self):
+        event = run_dialectical_loop(_signal(), require_enabled=False)
+        d = event.to_dict()
+        expected_keys = {
+            "event_id",
+            "code_unit_id",
+            "integrity_score",
+            "recommended_action",
+            "quarantine_action",
+            "crux_probe_skipped",
+            "repair_spec",
+            "prior_receipt_ids",
+            "created_at",
+            "metadata",
+        }
+        assert set(d.keys()) == expected_keys
+
+    def test_integrity_score_rounded(self):
+        sig = _signal(integrity_score=0.123456789)
+        event = run_dialectical_loop(sig, require_enabled=False)
+        d = event.to_dict()
+        assert d["integrity_score"] == round(0.123456789, 4)
+
+    def test_prior_receipt_ids_is_list_copy(self):
+        receipts = ["r1", "r2"]
+        event = run_dialectical_loop(
+            _signal(), prior_receipt_ids=receipts, require_enabled=False
+        )
+        d = event.to_dict()
+        assert d["prior_receipt_ids"] == ["r1", "r2"]
+        # Mutation of original list does not affect the event
+        receipts.append("r3")
+        assert event.prior_receipt_ids == ["r1", "r2"]
+
+    def test_with_repair_spec_in_dict(self):
+        from aragora.epistemic.quarantine_policy import EscalationMap
+        sig = _signal(integrity_score=0.5, recommended_action="repair_required")
+        policy = QuarantinePolicy(
+            code_unit_class="custom",
+            escalation_map=EscalationMap(
+                report_only="report_only",
+                repair_required="repair_required",
+                fail_closed="fail_closed",
+            ),
+            fail_closed_threshold=0.3,
+        )
+        event = run_dialectical_loop(
+            sig, policy=policy, enable_repair_proposal=True, require_enabled=False
+        )
+        d = event.to_dict()
+        assert d["repair_spec"] is not None
+        assert isinstance(d["repair_spec"], dict)
+        assert "spec_id" in d["repair_spec"]


### PR DESCRIPTION
## Slice
Adds `aragora/epistemic/runtime_loop.py` — the DIC-23 orchestration layer that connects the decay monitor (DIC-20), quarantine policy (DIC-21), and repair pipeline (DIC-22) into a single `DialecticalEvent` trace record. Default posture is report-only; crux probing (DIC-15 crux-finder integration) is explicitly deferred with a `crux_probe_skipped=True` flag cleared by a follow-on PR.

## Gating
- Default: OFF (flag: `ARAGORA_DIALECTICAL_RUNTIME_ENABLED`)
- Live queue effect: none — no state mutated, no issues created, no routing to dispatch
- Advances issue: #6217 (DIC-23)
- Per `docs/status/NEXT_STEPS_CANONICAL.md`: AGT/DIC tranche is planning truth only; `boss-ready` must not be applied until the proof-first Foreman gate opens

## Tests
- `TestFeatureFlag` — verifies flag default-off, `enable_dialectical_runtime()`, and `DialecticalRuntimeError` guard
- `TestReportOnlyTrace` — event fields, `event_id` prefix, quarantine action for healthy unit, `prior_receipt_ids` and `metadata` passthrough, `to_dict()` JSON shape
- `TestRepairProposal` — repair spec absent when `enable_repair_proposal=False`; spec produced when action is `repair_required` via custom policy; fail_closed branch leaves spec None
- `TestPolicyResolution` — explicit policy overrides class; `live_dispatch` and `report_surface` policy classes resolve expected actions
- `TestSerialization` — `to_dict()` key set, score rounding, list copy immutability, repair spec embedded dict

## Validation
- `uv run --with numpy pytest tests/epistemic/test_runtime_loop.py -v` — **22 passed**
- `ruff check aragora/epistemic/runtime_loop.py tests/epistemic/test_runtime_loop.py` — **clean**
- `mypy aragora/epistemic/runtime_loop.py --ignore-missing-imports` — **exit 0**

## Out of scope
- Crux-finder integration (`enable_crux_probe` param, DIC-15 Arena call) — `crux_probe_skipped=True` placeholder marks the slot; follow-on PR wires `crux_mode.run_crux_finder` once crux-finder consensus mode is stable in production
- Async `handle_decay` variant described in the design doc — synchronous `run_dialectical_loop` ships first; async wrapper added when Arena integration needs it
- Issue creation / live dispatch routing — permanently out of scope for this module; flows only through DIC-17 bridge
- DIC-24 genealogy `__init__` wiring — `genealogy.py` exists but is not yet exported; trivial follow-on, kept out of this slice to stay bounded

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cp498VtroQ1V9bPdNwVops)_