### PR TITLE
fix(swarm): report scope-overlap over missing-labels in target_issue_miss_guidance (#6591)

### DIFF
--- a/aragora/swarm/boss_loop_selection.py
+++ b/aragora/swarm/boss_loop_selection.py
@@ -277,19 +277,10 @@ def target_issue_miss_guidance(
             ],
         )
 
-    required = set(require_labels or set())
-    missing_labels = sorted(required - labels)
-    if missing_labels:
-        return (
-            [
-                f"Target issue #{issue_number} is missing required labels: {', '.join(missing_labels)}."
-            ],
-            [
-                f"Add the required labels to issue #{issue_number} or adjust --require-label settings.",
-                "Remove --boss-issue-number to return to feed-driven selection.",
-            ],
-        )
-
+    # Scope-overlap is checked before required-labels because the proof-first
+    # filter (filter_noncanonical_boss_ready_issues) mutates issue.labels to
+    # strip `boss-ready` for non-canonical issues. Reporting "missing labels"
+    # in that path masks the more actionable root cause when both apply.
     overlapping_scopes = sorted(
         {
             entry
@@ -310,6 +301,19 @@ def target_issue_miss_guidance(
             ],
             [
                 f"Merge, close, or retarget the overlapping work before redispatching issue #{issue_number}.",
+                "Remove --boss-issue-number to return to feed-driven selection.",
+            ],
+        )
+
+    required = set(require_labels or set())
+    missing_labels = sorted(required - labels)
+    if missing_labels:
+        return (
+            [
+                f"Target issue #{issue_number} is missing required labels: {', '.join(missing_labels)}."
+            ],
+            [
+                f"Add the required labels to issue #{issue_number} or adjust --require-label settings.",
                 "Remove --boss-issue-number to return to feed-driven selection.",
             ],
         )


### PR DESCRIPTION
## Summary

Closes #6591. Surfaced by the verify-then-restock one-shot report (#6590).

## Bug

\`tests/swarm/test_boss_loop.py::TestBossLoop::test_specific_issue_number_scope_conflict_reports_overlap_reason\` was failing on main.

The test sets up issue #873 with all required labels (\`boss-ready\`, \`priority:critical\`, \`autonomous\`) and a scope conflict with in-flight work, then expects \`needs_human_reasons[0]\` to surface the **scope-overlap** reason. The loop instead reported \"missing required labels: boss-ready.\"

## Root cause

\`filter_noncanonical_boss_ready_issues\` (in \`aragora/swarm/proof_first_queue.py\`) **intentionally mutates** \`issue.labels\` to strip \`boss-ready\` for non-canonical issues — a documented contract enforced by \`test_filter_noncanonical_boss_ready_issues_strips_label_and_excludes_issue\` (line 3160: \`assert \"boss-ready\" not in generic.labels\`).

That mutation lands BEFORE \`target_issue_miss_guidance\` is called. The function then sees an issue without \`boss-ready\` and correctly reports \"missing required labels.\" The message is technically true in the mutated in-memory state, but it masks the actual operator-actionable blocker (scope overlap with in-flight work).

## Fix

Reorder the gates in \`target_issue_miss_guidance\`: check **scope-overlap before required-labels**. When both apply, the more actionable diagnostic is surfaced. When only labels are genuinely missing, the labels message still fires.

The proof-first mutation contract is preserved — no change to \`filter_noncanonical_boss_ready_issues\`.

## Verification

All six tests touching this code path pass on the fix branch:

\`\`\`
tests/swarm/test_boss_loop.py::test_filter_noncanonical_boss_ready_issues_strips_label_and_excludes_issue PASSED
tests/swarm/test_boss_loop.py::TestBossLoop::test_specific_issue_number_seeds_explicit_feed_issue_numbers PASSED
tests/swarm/test_boss_loop.py::TestBossLoop::test_specific_issue_number_scope_conflict_reports_overlap_reason PASSED
tests/swarm/test_boss_loop.py::TestBossLoop::test_specific_issue_number_missing_stops_truthfully PASSED
tests/swarm/test_boss_loop.py::TestBossLoop::test_specific_issue_number_closed_stops_with_closed_reason PASSED
tests/swarm/test_boss_loop.py::TestBossLoop::test_specific_issue_number_selects_target_issue PASSED
\`\`\`

Wider swarm-suite failures observed are pre-existing on \`main\` (same positions/counts on baseline). Not caused by this PR.

## Risk

Bounded. One file changed, 17 insertions / 13 deletions, all in the same function. Ordering change only — no new behavior; existing \"missing labels\" diagnostic still fires when scope is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)