### PR TITLE
docs(releases): honest nightly status note in v2.9.0 release notes

### DIFF
--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -33,12 +33,12 @@ Important qualifier:
 - the newer `aragora/pdb/` execution path is shipping alongside it
 - so the canonical PR packet path is not yet fully upgraded to the thesis's heterogeneous-ensemble standard
 
-The current bounded queue is:
+The current bounded queue (updated 2026-04-25):
 
-1. close [#6374](https://github.com/synaptent/aragora/issues/6374) on the canonical PR-review path
-2. close [#6373](https://github.com/synaptent/aragora/issues/6373) with rolling-window triage metrics
-3. close [#6372](https://github.com/synaptent/aragora/issues/6372) with auto-handle calibration + drift gating
-4. close [#6375](https://github.com/synaptent/aragora/issues/6375) with empirical threshold grounding
+1. ~~close [#6374](https://github.com/synaptent/aragora/issues/6374) on the canonical PR-review path~~ — **CLOSED**
+2. ~~close [#6373](https://github.com/synaptent/aragora/issues/6373) with rolling-window triage metrics~~ — **CLOSED**
+3. ~~close [#6372](https://github.com/synaptent/aragora/issues/6372) with auto-handle calibration + drift gating~~ — **CLOSED**
+4. close [#6375](https://github.com/synaptent/aragora/issues/6375) with empirical threshold grounding — **OPEN, sole remaining H1 gap**
 
 For the full current-status narrative, use the canonical doc:
 

--- a/docs/releases/v2.9.0.md
+++ b/docs/releases/v2.9.0.md
@@ -81,8 +81,13 @@ If you depend on `aragora/live` or any of the npm projects (`sdk/typescript`, `e
 - **Implementation gaps remaining:** #6371 (PDB UI auth), #6375 (5% threshold empirical grounding) — both non-blocking for v2.9.0; carried into v2.10.
 - **Solo-founder bus factor:** still an honest concern. Co-maintainer call drafted but not yet published.
 
-<!-- VALIDATE_AGAINST_NIGHTLY -->
-**Pending nightly confirmation (final pass before tag):** all 6 chronic-red workflows producing honest terminal pass/fail signal in tomorrow's scheduled run. If the next nightly observation shows clean state, this section can be removed; if any workflow still reports `cancelled` or fails for an unexpected reason, that becomes a known issue here.
+### Nightly status at tag-cut time (honest update, 2026-04-25)
+
+The pre-tag plan was to wait for a clean nightly-full-matrix run before publishing the tag. The tag was published at 2026-04-25 09:17 UTC; the most recent nightly-full-matrix at the time (2026-04-25 06:04 UTC) had `Pre-release Gates` and `Nightly Matrix Summary` failing. Prior nights (04-22, 04-23, 04-24) also failed.
+
+This is acknowledged here rather than retroactively scrubbed: the chronic-red sweep (#6554 – #6567 + #6577) cleared the directly-required checks, but the larger `nightly-full-matrix` workflow has additional jobs that did not fully stabilise before the tag. Tracked separately in #6495 (cross-platform Tests workflow) and the in-flight CI hygiene work.
+
+The tag itself ships against the directly-required check set (lint, typecheck, sdk-parity, OpenAPI generate/validate, TS SDK type check) — all green at the tagged commit. The nightly-matrix gap is an operator-visibility fire, not a release-content defect.
 
 ## Receipts and validation
 


### PR DESCRIPTION
## Summary

The published v2.9.0 release notes (\`docs/releases/v2.9.0.md\`) still contain the pre-tag VALIDATE_AGAINST_NIGHTLY placeholder. The placeholder asks the reader to delete it once a clean nightly is observed; the tag was published before that ever happened, and the most recent nightly-full-matrix at the time (2026-04-25 06:04 UTC) was failing.

This PR replaces the placeholder with an honest acknowledgment of the actual state at tag-cut time, rather than retroactively scrubbing the placeholder as if the validation had succeeded.

## What the new note says

- Tag was published 2026-04-25 09:17 UTC.
- Most recent nightly-full-matrix at that time had \`Pre-release Gates\` and \`Nightly Matrix Summary\` failing.
- Prior nights (04-22, 04-23, 04-24) also failed.
- The chronic-red sweep (#6554 – #6567 + #6577) cleared the directly-required check set; the larger \`nightly-full-matrix\` workflow has additional jobs that did not stabilise before the tag.
- Tracked separately in #6495 (cross-platform Tests workflow).
- The tag itself ships against the directly-required check set (lint, typecheck, sdk-parity, OpenAPI generate/validate, TS SDK type check) — all green at the tagged commit. The nightly-matrix gap is an operator-visibility fire, not a release-content defect.

## Risk

Docs-only. No code, workflow, release-tag, or branch-protection changes. Updates the published release notes to match what actually shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)