### PR TITLE
[AGT-05] CruxSet→reputation bridge for DOMAIN_CRUX_RESOLUTION

### DIFF
--- a/aragora/reputation/__init__.py
+++ b/aragora/reputation/__init__.py
@@ -2,10 +2,10 @@
 
 This package is the in-memory Python layer of the AGT-05 spec in
 ``docs/plans/SKIN_IN_THE_GAME_REPUTATION.md``. It unifies the AGT-04
-synthetic-market resolution stream and (in a later PR) the AGT-01
-CruxSet resolution stream into a single shape — :class:`StakeableClaim`
-plus :class:`ResolvedClaim` — from which :func:`settle_claim` computes
-a :class:`ReputationDelta` using a proper scoring rule.
+synthetic-market resolution stream and the AGT-01 CruxSet resolution
+stream into a single shape — :class:`StakeableClaim` plus
+:class:`ResolvedClaim` — from which :func:`settle_claim` computes a
+:class:`ReputationDelta` using a proper scoring rule.
 
 The on-chain anchoring via
 :class:`aragora.blockchain.contracts.reputation.ReputationRegistry`
@@ -29,6 +29,11 @@ from aragora.reputation.anchor import (
     enable_anchoring,
 )
 from aragora.reputation.bridge import bridge_from_market_position
+from aragora.reputation.crux_bridge import (
+    CruxPositionRecord,
+    CruxResolutionEvent,
+    bridge_from_crux_position,
+)
 from aragora.reputation.settlement import settle_claim
 from aragora.reputation.store import (
     AgentScore,
@@ -62,6 +67,9 @@ __all__ = [
     "anchor_delta",
     "anchoring_enabled",
     "bridge_from_market_position",
+    "CruxPositionRecord",
+    "CruxResolutionEvent",
+    "bridge_from_crux_position",
     "delta_to_feedback_args",
     "enable_anchoring",
     "enable_reputation_flow",

--- a/aragora/reputation/crux_bridge.py
+++ b/aragora/reputation/crux_bridge.py
@@ -1,0 +1,311 @@
+"""Bridge from AGT-01 CruxSet positions to AGT-05 reputation types.
+
+When a crux that appeared in a :class:`~aragora.reasoning.cruxset.CruxSet`
+is later resolved — by debate consensus, an operator decision, or an
+external oracle — each agent that staked a position on that crux deserves
+a reputation delta.  This module provides:
+
+* :class:`CruxPositionRecord` — an agent's staked position on one crux.
+* :class:`CruxResolutionEvent` — the oracle's determination of which
+  crux side won (or that the crux is inconclusive).
+* :func:`bridge_from_crux_position` — converts the pair into a
+  (:class:`~aragora.reputation.types.StakeableClaim`,
+  :class:`~aragora.reputation.types.ResolvedClaim`) pair that feeds
+  directly into :func:`~aragora.reputation.settlement.settle_claim`.
+
+Feature-gating: this module is part of the ``DOMAIN_CRUX_RESOLUTION``
+reputation flow.  It does **not** wire into any live debate or dispatch
+path.  The connection from CruxDetector → CruxSet emission → position
+recording → resolution → settlement is dormant until the AGT-* upper-layer
+gate opens per ``docs/status/NEXT_STEPS_CANONICAL.md``.
+
+Prior art: :mod:`aragora.reputation.bridge` handles
+``DOMAIN_PREDICTION_MARKET``; this module adds ``DOMAIN_CRUX_RESOLUTION``
+using the same (position, event) → (StakeableClaim, ResolvedClaim) pattern.
+The comment in :mod:`aragora.reputation.bridge` notes that "the CruxSet
+bridge lives in a follow-up PR once DIC-17 is wired" — DIC-17 is now
+shipped in :mod:`aragora.epistemic.followup`, so this is that PR.
+
+Scoring note: callers should pass ``scoring_rule="binary"`` to
+:func:`~aragora.reputation.settlement.settle_claim`.  Every staker's
+``claim.position`` is normalised to ``"yes"`` (they claim their side will
+prevail); ``resolved.outcome`` carries the per-agent verdict so the binary
+rule rewards correct stakers and penalises incorrect ones symmetrically.
+
+Advances: AGT-05 (#6066).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from aragora.reputation.types import (
+    DOMAIN_CRUX_RESOLUTION,
+    ClaimOutcome,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+if TYPE_CHECKING:
+    from aragora.reasoning.cruxset import Crux
+
+# Sentinel for an inconclusive resolution — no side was validated.
+_INCONCLUSIVE_SIDE = ""
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _position_id(agent_id: str, crux_id: str, cruxset_id: str, side: str) -> str:
+    material = json.dumps(
+        {
+            "agent_id": agent_id,
+            "crux_id": crux_id,
+            "cruxset_id": cruxset_id,
+            "side": side,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"cp_{digest}"
+
+
+@dataclass(frozen=True)
+class CruxPositionRecord:
+    """An agent's staked position on a single crux in a CruxSet.
+
+    Analogous to :class:`~aragora.markets.types.MarketPosition` for
+    synthetic GitHub markets.  The agent commits ``stake_units`` of
+    compute-credit to the claim that their chosen ``side`` is the correct
+    resolution of ``crux_id`` within ``cruxset_id``.
+
+    Use :meth:`create` to build instances with a content-addressed
+    ``position_id``.
+    """
+
+    position_id: str
+    agent_id: str
+    crux_id: str
+    cruxset_id: str
+    side: str
+    stake_units: int
+    submitted_at: str
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not str(self.agent_id).strip():
+            raise ValueError("agent_id must be non-empty")
+        if not str(self.crux_id).strip():
+            raise ValueError("crux_id must be non-empty")
+        if not str(self.cruxset_id).strip():
+            raise ValueError("cruxset_id must be non-empty")
+        if not str(self.side).strip():
+            raise ValueError("side must be non-empty")
+        if self.stake_units < 1:
+            raise ValueError(f"stake_units must be >= 1, got {self.stake_units}")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        agent_id: str,
+        crux_id: str,
+        cruxset_id: str,
+        side: str,
+        stake_units: int,
+        submitted_at: str | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> "CruxPositionRecord":
+        """Build a CruxPositionRecord with a content-addressed position_id."""
+        position_id = _position_id(agent_id, crux_id, cruxset_id, side)
+        return cls(
+            position_id=position_id,
+            agent_id=agent_id,
+            crux_id=crux_id,
+            cruxset_id=cruxset_id,
+            side=side,
+            stake_units=stake_units,
+            submitted_at=submitted_at or _utc_now_iso(),
+            provenance=dict(provenance or {}),
+        )
+
+
+@dataclass(frozen=True)
+class CruxResolutionEvent:
+    """Oracle determination of which side of a crux won.
+
+    Analogous to :class:`~aragora.markets.types.ResolutionEvent` for
+    synthetic GitHub markets.  The oracle declares a ``winning_side``
+    (e.g. ``"for"`` or ``"against"``) or leaves it empty to signal that
+    the crux is inconclusive.
+
+    Per-agent outcomes are computed in :func:`bridge_from_crux_position`:
+    agents on the winning side receive ``"yes"``, others ``"no"``, and all
+    agents receive ``"inconclusive"`` when ``winning_side`` is empty.
+
+    Use :meth:`resolved` or :meth:`inconclusive` factory methods.
+    """
+
+    crux_id: str
+    cruxset_id: str
+    winning_side: str
+    resolution_source: str
+    resolved_at: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not str(self.crux_id).strip():
+            raise ValueError("crux_id must be non-empty")
+        if not str(self.cruxset_id).strip():
+            raise ValueError("cruxset_id must be non-empty")
+        if not str(self.resolution_source).strip():
+            raise ValueError("resolution_source must be non-empty")
+
+    @property
+    def is_inconclusive(self) -> bool:
+        """True when no winning side was determined."""
+        return self.winning_side == _INCONCLUSIVE_SIDE
+
+    @classmethod
+    def resolved(
+        cls,
+        *,
+        crux_id: str,
+        cruxset_id: str,
+        winning_side: str,
+        resolution_source: str,
+        resolved_at: str | None = None,
+        evidence: dict[str, Any] | None = None,
+    ) -> "CruxResolutionEvent":
+        """Build a resolution event with a specific winning side."""
+        if not str(winning_side).strip():
+            raise ValueError(
+                "winning_side must be non-empty for a resolved event; "
+                "use .inconclusive() for no-winner outcomes"
+            )
+        return cls(
+            crux_id=crux_id,
+            cruxset_id=cruxset_id,
+            winning_side=winning_side,
+            resolution_source=resolution_source,
+            resolved_at=resolved_at or _utc_now_iso(),
+            evidence=dict(evidence or {}),
+        )
+
+    @classmethod
+    def inconclusive(
+        cls,
+        *,
+        crux_id: str,
+        cruxset_id: str,
+        resolution_source: str,
+        resolved_at: str | None = None,
+        evidence: dict[str, Any] | None = None,
+    ) -> "CruxResolutionEvent":
+        """Build an inconclusive resolution event (no winning side)."""
+        return cls(
+            crux_id=crux_id,
+            cruxset_id=cruxset_id,
+            winning_side=_INCONCLUSIVE_SIDE,
+            resolution_source=resolution_source,
+            resolved_at=resolved_at or _utc_now_iso(),
+            evidence=dict(evidence or {}),
+        )
+
+
+def bridge_from_crux_position(
+    position: "CruxPositionRecord",
+    crux: "Crux",
+    resolution: "CruxResolutionEvent",
+) -> tuple[StakeableClaim, ResolvedClaim]:
+    """Convert a crux position + resolution into an AGT-05 claim/resolved pair.
+
+    The returned tuple feeds directly into
+    :func:`aragora.reputation.settlement.settle_claim` with
+    ``scoring_rule="binary"``.
+
+    Scoring convention: ``claim.position`` is always ``"yes"`` because
+    every staker is claiming "my side will prevail."  The per-agent verdict
+    lives in ``resolved.outcome``:
+
+    * ``"yes"``         — agent was on the winning side
+    * ``"no"``          — agent was on the losing side
+    * ``"inconclusive"`` — resolution declared no winner
+
+    This mirrors :func:`aragora.reputation.bridge.bridge_from_market_position`,
+    which normalises a continuous probability to ``"yes"``/``"no"`` via the
+    0.5 threshold.
+
+    Cross-checks:
+
+    * ``position.crux_id`` must equal ``crux.crux_id``
+    * ``position.crux_id`` / ``position.cruxset_id`` must equal
+      ``resolution.crux_id`` / ``resolution.cruxset_id``
+    """
+    if position.crux_id != crux.crux_id:
+        raise ValueError(
+            f"position.crux_id={position.crux_id!r} does not match "
+            f"crux.crux_id={crux.crux_id!r}"
+        )
+    if position.crux_id != resolution.crux_id:
+        raise ValueError(
+            f"position.crux_id={position.crux_id!r} does not match "
+            f"resolution.crux_id={resolution.crux_id!r}"
+        )
+    if position.cruxset_id != resolution.cruxset_id:
+        raise ValueError(
+            f"position.cruxset_id={position.cruxset_id!r} does not match "
+            f"resolution.cruxset_id={resolution.cruxset_id!r}"
+        )
+
+    if resolution.is_inconclusive:
+        agent_outcome: ClaimOutcome = "inconclusive"
+    elif position.side == resolution.winning_side:
+        agent_outcome = "yes"
+    else:
+        agent_outcome = "no"
+
+    resolution_id = f"{resolution.cruxset_id}:{resolution.crux_id}"
+
+    claim = StakeableClaim.create(
+        agent_id=position.agent_id,
+        domain=DOMAIN_CRUX_RESOLUTION,
+        statement=crux.statement,
+        position="yes",  # normalised: staker claims their side will prevail
+        predicted_probability=None,  # binary stance — use scoring_rule="binary"
+        stake_units=position.stake_units,
+        stake_policy="forfeit_on_loss",
+        resolution_source=resolution.resolution_source,
+        resolution_id=resolution_id,
+        provenance={
+            "position_id": position.position_id,
+            "crux_id": position.crux_id,
+            "cruxset_id": position.cruxset_id,
+            "agent_side": position.side,
+            "winning_side": resolution.winning_side,
+            "load_bearing_score": crux.load_bearing_score,
+        },
+        created_at=position.submitted_at,
+    )
+
+    resolved = ResolvedClaim(
+        claim_id=claim.claim_id,
+        outcome=agent_outcome,
+        resolved_at=resolution.resolved_at,
+        resolution_source=resolution.resolution_source,
+        evidence=dict(resolution.evidence),
+    )
+    return claim, resolved
+
+
+__all__ = [
+    "CruxPositionRecord",
+    "CruxResolutionEvent",
+    "bridge_from_crux_position",
+]

--- a/aragora/reputation/crux_bridge.py
+++ b/aragora/reputation/crux_bridge.py
@@ -250,8 +250,7 @@ def bridge_from_crux_position(
     """
     if position.crux_id != crux.crux_id:
         raise ValueError(
-            f"position.crux_id={position.crux_id!r} does not match "
-            f"crux.crux_id={crux.crux_id!r}"
+            f"position.crux_id={position.crux_id!r} does not match crux.crux_id={crux.crux_id!r}"
         )
     if position.crux_id != resolution.crux_id:
         raise ValueError(

--- a/tests/reputation/test_crux_bridge.py
+++ b/tests/reputation/test_crux_bridge.py
@@ -1,0 +1,438 @@
+"""Tests for aragora.reputation.crux_bridge — AGT-05 CruxSet resolution bridge.
+
+Verifies:
+- CruxPositionRecord content-addressing and validation
+- CruxResolutionEvent factory methods and inconclusive sentinel
+- bridge_from_crux_position outcome derivation and cross-checks
+- Full pipeline: bridge → settle_claim → ReputationDelta (binary scoring)
+
+Note: ``Crux`` is accessed via duck-typing in the bridge (TYPE_CHECKING-only
+import).  Tests use a ``SimpleNamespace`` stub carrying the three fields the
+bridge reads (``crux_id``, ``statement``, ``load_bearing_score``) to avoid
+pulling the full ``aragora.reasoning`` package initialisation chain, which
+requires optional heavy dependencies not present in this CI environment.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aragora.reputation.crux_bridge import (
+    CruxPositionRecord,
+    CruxResolutionEvent,
+    bridge_from_crux_position,
+)
+from aragora.reputation.settlement import settle_claim
+from aragora.reputation.types import DOMAIN_CRUX_RESOLUTION
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_crux(
+    crux_id: str = "c1",
+    statement: str = "X is the load-bearing constraint",
+    score: float = 0.75,
+) -> SimpleNamespace:
+    # Minimal duck-typed stub: bridge only reads crux_id, statement,
+    # and load_bearing_score — no need for the full Crux dataclass.
+    return SimpleNamespace(
+        crux_id=crux_id,
+        statement=statement,
+        load_bearing_score=score,
+    )
+
+
+def _make_position(
+    *,
+    agent_id: str = "alice",
+    crux_id: str = "c1",
+    cruxset_id: str = "cs_abc",
+    side: str = "for",
+    stake_units: int = 20,
+    submitted_at: str = "2026-04-25T08:00:00Z",
+) -> CruxPositionRecord:
+    return CruxPositionRecord.create(
+        agent_id=agent_id,
+        crux_id=crux_id,
+        cruxset_id=cruxset_id,
+        side=side,
+        stake_units=stake_units,
+        submitted_at=submitted_at,
+    )
+
+
+def _make_resolution(
+    winning_side: str,
+    *,
+    crux_id: str = "c1",
+    cruxset_id: str = "cs_abc",
+    resolution_source: str = "debate_consensus",
+    resolved_at: str = "2026-04-25T12:00:00Z",
+) -> CruxResolutionEvent:
+    return CruxResolutionEvent.resolved(
+        crux_id=crux_id,
+        cruxset_id=cruxset_id,
+        winning_side=winning_side,
+        resolution_source=resolution_source,
+        resolved_at=resolved_at,
+        evidence={"rounds": 3, "consensus_mode": "crux_finder"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# CruxPositionRecord
+# ---------------------------------------------------------------------------
+
+
+class TestCruxPositionRecord:
+    def test_create_produces_content_addressed_id(self) -> None:
+        p1 = CruxPositionRecord.create(
+            agent_id="alice", crux_id="c1", cruxset_id="cs1", side="for", stake_units=10
+        )
+        p2 = CruxPositionRecord.create(
+            agent_id="alice", crux_id="c1", cruxset_id="cs1", side="for", stake_units=10
+        )
+        assert p1.position_id == p2.position_id
+        assert p1.position_id.startswith("cp_")
+
+    def test_different_sides_produce_different_ids(self) -> None:
+        p_for = CruxPositionRecord.create(
+            agent_id="alice", crux_id="c1", cruxset_id="cs1", side="for", stake_units=10
+        )
+        p_against = CruxPositionRecord.create(
+            agent_id="alice", crux_id="c1", cruxset_id="cs1", side="against", stake_units=10
+        )
+        assert p_for.position_id != p_against.position_id
+
+    def test_different_agents_produce_different_ids(self) -> None:
+        pa = CruxPositionRecord.create(
+            agent_id="alice", crux_id="c1", cruxset_id="cs1", side="for", stake_units=10
+        )
+        pb = CruxPositionRecord.create(
+            agent_id="bob", crux_id="c1", cruxset_id="cs1", side="for", stake_units=10
+        )
+        assert pa.position_id != pb.position_id
+
+    def test_rejects_zero_stake(self) -> None:
+        with pytest.raises(ValueError, match="stake_units must be >= 1"):
+            CruxPositionRecord.create(
+                agent_id="alice", crux_id="c1", cruxset_id="cs1", side="for", stake_units=0
+            )
+
+    def test_rejects_negative_stake(self) -> None:
+        with pytest.raises(ValueError, match="stake_units must be >= 1"):
+            CruxPositionRecord.create(
+                agent_id="alice", crux_id="c1", cruxset_id="cs1", side="for", stake_units=-5
+            )
+
+    def test_rejects_empty_agent_id(self) -> None:
+        with pytest.raises(ValueError, match="agent_id"):
+            CruxPositionRecord.create(
+                agent_id="  ", crux_id="c1", cruxset_id="cs1", side="for", stake_units=5
+            )
+
+    def test_rejects_empty_side(self) -> None:
+        with pytest.raises(ValueError, match="side"):
+            CruxPositionRecord.create(
+                agent_id="alice", crux_id="c1", cruxset_id="cs1", side="", stake_units=5
+            )
+
+    def test_rejects_empty_crux_id(self) -> None:
+        with pytest.raises(ValueError, match="crux_id"):
+            CruxPositionRecord.create(
+                agent_id="alice", crux_id="", cruxset_id="cs1", side="for", stake_units=5
+            )
+
+    def test_provenance_defaults_to_empty_dict(self) -> None:
+        p = CruxPositionRecord.create(
+            agent_id="alice", crux_id="c1", cruxset_id="cs1", side="for", stake_units=1
+        )
+        assert p.provenance == {}
+
+    def test_custom_provenance_is_copied(self) -> None:
+        prov = {"source": "arena_round_2"}
+        p = CruxPositionRecord.create(
+            agent_id="alice",
+            crux_id="c1",
+            cruxset_id="cs1",
+            side="for",
+            stake_units=1,
+            provenance=prov,
+        )
+        assert p.provenance == prov
+        prov["source"] = "mutated"
+        assert p.provenance["source"] == "arena_round_2"  # copy not reference
+
+
+# ---------------------------------------------------------------------------
+# CruxResolutionEvent
+# ---------------------------------------------------------------------------
+
+
+class TestCruxResolutionEvent:
+    def test_resolved_factory_preserves_fields(self) -> None:
+        ev = CruxResolutionEvent.resolved(
+            crux_id="c1",
+            cruxset_id="cs1",
+            winning_side="for",
+            resolution_source="debate",
+            resolved_at="2026-04-25T10:00:00Z",
+            evidence={"k": "v"},
+        )
+        assert ev.crux_id == "c1"
+        assert ev.winning_side == "for"
+        assert not ev.is_inconclusive
+        assert ev.evidence == {"k": "v"}
+
+    def test_resolved_requires_nonempty_winning_side(self) -> None:
+        with pytest.raises(ValueError, match="winning_side must be non-empty"):
+            CruxResolutionEvent.resolved(
+                crux_id="c1",
+                cruxset_id="cs1",
+                winning_side="  ",
+                resolution_source="debate",
+            )
+
+    def test_inconclusive_factory_sets_empty_winning_side(self) -> None:
+        ev = CruxResolutionEvent.inconclusive(
+            crux_id="c1",
+            cruxset_id="cs1",
+            resolution_source="oracle",
+        )
+        assert ev.is_inconclusive
+        assert ev.winning_side == ""
+
+    def test_resolved_is_not_inconclusive(self) -> None:
+        ev = CruxResolutionEvent.resolved(
+            crux_id="c1",
+            cruxset_id="cs1",
+            winning_side="for",
+            resolution_source="debate",
+        )
+        assert not ev.is_inconclusive
+
+    def test_rejects_empty_crux_id(self) -> None:
+        with pytest.raises(ValueError, match="crux_id"):
+            CruxResolutionEvent.resolved(
+                crux_id="",
+                cruxset_id="cs1",
+                winning_side="for",
+                resolution_source="debate",
+            )
+
+    def test_rejects_empty_resolution_source(self) -> None:
+        with pytest.raises(ValueError, match="resolution_source"):
+            CruxResolutionEvent.resolved(
+                crux_id="c1",
+                cruxset_id="cs1",
+                winning_side="for",
+                resolution_source="",
+            )
+
+
+# ---------------------------------------------------------------------------
+# bridge_from_crux_position — outcome derivation
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeOutcomeDerivation:
+    def test_winner_gets_yes(self) -> None:
+        position = _make_position(side="for")
+        crux = _make_crux()
+        resolution = _make_resolution("for")
+        _, resolved = bridge_from_crux_position(position, crux, resolution)
+        assert resolved.outcome == "yes"
+
+    def test_loser_gets_no(self) -> None:
+        position = _make_position(side="for")
+        crux = _make_crux()
+        resolution = _make_resolution("against")
+        _, resolved = bridge_from_crux_position(position, crux, resolution)
+        assert resolved.outcome == "no"
+
+    def test_inconclusive_resolution_yields_inconclusive(self) -> None:
+        position = _make_position()
+        crux = _make_crux()
+        ev = CruxResolutionEvent.inconclusive(
+            crux_id="c1",
+            cruxset_id="cs_abc",
+            resolution_source="oracle",
+            resolved_at="2026-04-25T12:00:00Z",
+        )
+        _, resolved = bridge_from_crux_position(position, crux, ev)
+        assert resolved.outcome == "inconclusive"
+
+    def test_against_side_wins(self) -> None:
+        position = _make_position(side="against")
+        crux = _make_crux()
+        resolution = _make_resolution("against")
+        _, resolved = bridge_from_crux_position(position, crux, resolution)
+        assert resolved.outcome == "yes"
+
+    def test_against_side_loses(self) -> None:
+        position = _make_position(side="against")
+        crux = _make_crux()
+        resolution = _make_resolution("for")
+        _, resolved = bridge_from_crux_position(position, crux, resolution)
+        assert resolved.outcome == "no"
+
+
+# ---------------------------------------------------------------------------
+# bridge_from_crux_position — claim shape
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeClaimShape:
+    def test_domain_is_crux_resolution(self) -> None:
+        claim, _ = bridge_from_crux_position(
+            _make_position(), _make_crux(), _make_resolution("for")
+        )
+        assert claim.domain == DOMAIN_CRUX_RESOLUTION
+
+    def test_predicted_probability_is_none(self) -> None:
+        claim, _ = bridge_from_crux_position(
+            _make_position(), _make_crux(), _make_resolution("for")
+        )
+        assert claim.predicted_probability is None
+
+    def test_position_is_normalised_to_yes(self) -> None:
+        claim, _ = bridge_from_crux_position(
+            _make_position(side="for"), _make_crux(), _make_resolution("for")
+        )
+        assert claim.position == "yes"
+
+    def test_statement_carried_from_crux(self) -> None:
+        crux = _make_crux(statement="The deployment window is safe")
+        claim, _ = bridge_from_crux_position(
+            _make_position(), crux, _make_resolution("for")
+        )
+        assert claim.statement == "The deployment window is safe"
+
+    def test_provenance_contains_agent_side(self) -> None:
+        claim, _ = bridge_from_crux_position(
+            _make_position(side="for"), _make_crux(), _make_resolution("for")
+        )
+        assert claim.provenance["agent_side"] == "for"
+
+    def test_provenance_contains_winning_side(self) -> None:
+        claim, _ = bridge_from_crux_position(
+            _make_position(), _make_crux(), _make_resolution("against")
+        )
+        assert claim.provenance["winning_side"] == "against"
+
+    def test_provenance_contains_load_bearing_score(self) -> None:
+        crux = _make_crux(score=0.88)
+        claim, _ = bridge_from_crux_position(
+            _make_position(), crux, _make_resolution("for")
+        )
+        assert claim.provenance["load_bearing_score"] == pytest.approx(0.88)
+
+    def test_resolution_id_encodes_cruxset_and_crux(self) -> None:
+        claim, _ = bridge_from_crux_position(
+            _make_position(cruxset_id="cs_abc", crux_id="c1"),
+            _make_crux(crux_id="c1"),
+            _make_resolution("for", cruxset_id="cs_abc", crux_id="c1"),
+        )
+        assert claim.resolution_id == "cs_abc:c1"
+
+    def test_resolved_carries_evidence(self) -> None:
+        _, resolved = bridge_from_crux_position(
+            _make_position(), _make_crux(), _make_resolution("for")
+        )
+        assert resolved.evidence == {"rounds": 3, "consensus_mode": "crux_finder"}
+
+
+# ---------------------------------------------------------------------------
+# bridge_from_crux_position — cross-checks
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeCrossChecks:
+    def test_rejects_crux_id_mismatch_position_vs_crux(self) -> None:
+        position = _make_position(crux_id="c1")
+        crux = _make_crux(crux_id="c2")
+        resolution = _make_resolution("for", crux_id="c1")
+        with pytest.raises(ValueError, match="crux_id"):
+            bridge_from_crux_position(position, crux, resolution)
+
+    def test_rejects_crux_id_mismatch_position_vs_resolution(self) -> None:
+        position = _make_position(crux_id="c1")
+        crux = _make_crux(crux_id="c1")
+        resolution = _make_resolution("for", crux_id="c99")
+        with pytest.raises(ValueError, match="crux_id"):
+            bridge_from_crux_position(position, crux, resolution)
+
+    def test_rejects_cruxset_id_mismatch(self) -> None:
+        position = _make_position(cruxset_id="cs_abc")
+        crux = _make_crux()
+        resolution = _make_resolution("for", cruxset_id="cs_xyz")
+        with pytest.raises(ValueError, match="cruxset_id"):
+            bridge_from_crux_position(position, crux, resolution)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end settlement pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestSettlementPipeline:
+    def test_winner_gains_stake(self) -> None:
+        position = _make_position(side="for", stake_units=30)
+        crux = _make_crux()
+        resolution = _make_resolution("for")
+        claim, resolved = bridge_from_crux_position(position, crux, resolution)
+        delta = settle_claim(claim, resolved, scoring_rule="binary")
+        assert delta.delta == pytest.approx(30.0)
+        assert delta.domain == DOMAIN_CRUX_RESOLUTION
+        assert delta.agent_id == "alice"
+
+    def test_loser_loses_stake(self) -> None:
+        position = _make_position(side="for", stake_units=30)
+        crux = _make_crux()
+        resolution = _make_resolution("against")
+        claim, resolved = bridge_from_crux_position(position, crux, resolution)
+        delta = settle_claim(claim, resolved, scoring_rule="binary")
+        assert delta.delta == pytest.approx(-30.0)
+
+    def test_inconclusive_yields_zero_delta(self) -> None:
+        position = _make_position(side="for", stake_units=50)
+        crux = _make_crux()
+        ev = CruxResolutionEvent.inconclusive(
+            crux_id="c1",
+            cruxset_id="cs_abc",
+            resolution_source="oracle",
+            resolved_at="2026-04-25T12:00:00Z",
+        )
+        claim, resolved = bridge_from_crux_position(position, crux, ev)
+        delta = settle_claim(claim, resolved, scoring_rule="binary")
+        assert delta.delta == pytest.approx(0.0)
+
+    def test_two_agents_on_opposing_sides(self) -> None:
+        crux = _make_crux()
+        resolution = _make_resolution("for")
+
+        pos_alice = _make_position(agent_id="alice", side="for", stake_units=40)
+        pos_bob = _make_position(agent_id="bob", side="against", stake_units=40)
+
+        claim_alice, resolved_alice = bridge_from_crux_position(pos_alice, crux, resolution)
+        claim_bob, resolved_bob = bridge_from_crux_position(pos_bob, crux, resolution)
+
+        delta_alice = settle_claim(claim_alice, resolved_alice, scoring_rule="binary")
+        delta_bob = settle_claim(claim_bob, resolved_bob, scoring_rule="binary")
+
+        assert delta_alice.delta == pytest.approx(40.0)
+        assert delta_bob.delta == pytest.approx(-40.0)
+
+    def test_claim_ids_differ_across_agents(self) -> None:
+        crux = _make_crux()
+        resolution = _make_resolution("for")
+        pos_alice = _make_position(agent_id="alice", side="for")
+        pos_bob = _make_position(agent_id="bob", side="against")
+        claim_alice, _ = bridge_from_crux_position(pos_alice, crux, resolution)
+        claim_bob, _ = bridge_from_crux_position(pos_bob, crux, resolution)
+        assert claim_alice.claim_id != claim_bob.claim_id

--- a/tests/reputation/test_crux_bridge.py
+++ b/tests/reputation/test_crux_bridge.py
@@ -308,9 +308,7 @@ class TestBridgeClaimShape:
 
     def test_statement_carried_from_crux(self) -> None:
         crux = _make_crux(statement="The deployment window is safe")
-        claim, _ = bridge_from_crux_position(
-            _make_position(), crux, _make_resolution("for")
-        )
+        claim, _ = bridge_from_crux_position(_make_position(), crux, _make_resolution("for"))
         assert claim.statement == "The deployment window is safe"
 
     def test_provenance_contains_agent_side(self) -> None:
@@ -327,9 +325,7 @@ class TestBridgeClaimShape:
 
     def test_provenance_contains_load_bearing_score(self) -> None:
         crux = _make_crux(score=0.88)
-        claim, _ = bridge_from_crux_position(
-            _make_position(), crux, _make_resolution("for")
-        )
+        claim, _ = bridge_from_crux_position(_make_position(), crux, _make_resolution("for"))
         assert claim.provenance["load_bearing_score"] == pytest.approx(0.88)
 
     def test_resolution_id_encodes_cruxset_and_crux(self) -> None:


### PR DESCRIPTION
## Slice

Adds `CruxPositionRecord`, `CruxResolutionEvent`, and `bridge_from_crux_position()` in `aragora/reputation/crux_bridge.py` — the "follow-up PR" explicitly deferred in `aragora/reputation/bridge.py` ("The CruxSet bridge lives in a follow-up PR once DIC-17 is wired"). DIC-17 (`aragora/epistemic/followup.py`) shipped earlier; this is that PR. It fills in the `DOMAIN_CRUX_RESOLUTION` gap so crux-resolution events can flow through the same `StakeableClaim → settle_claim → ReputationDelta` pipeline that AGT-04 synthetic-market positions already use.

## Gating

- Default: **OFF** — no live debate, dispatch, or boss-loop path imports this module; dormant until the AGT-* upper-layer gate opens per `docs/status/NEXT_STEPS_CANONICAL.md`
- Live queue effect: **none**
- Advances issue: #6066 (AGT-05 skin-in-the-game reputation flow)

## Tests

- `TestCruxPositionRecord` (10 tests) — content-addressed ID, validation of stake/agent/side/crux fields, provenance copy semantics
- `TestCruxResolutionEvent` (6 tests) — `.resolved()` and `.inconclusive()` factories, sentinel, field validation
- `TestBridgeOutcomeDerivation` (5 tests) — `"yes"`/`"no"`/`"inconclusive"` per agent × winning-side combinations
- `TestBridgeClaimShape` (9 tests) — domain, statement, normalised position, provenance fields, resolution_id encoding
- `TestBridgeCrossChecks` (3 tests) — crux_id mismatch (position vs crux), crux_id mismatch (position vs resolution), cruxset_id mismatch
- `TestSettlementPipeline` (5 tests) — winner gains stake, loser loses stake, inconclusive → zero delta, two opposing agents, claim-ID uniqueness

## Validation

- `pytest tests/reputation/test_crux_bridge.py` — **38 passed**
- `pytest tests/reputation/` — **130 passed** (no regressions in existing suite)
- `ruff check aragora/reputation/crux_bridge.py tests/reputation/test_crux_bridge.py aragora/reputation/__init__.py` — **clean**
- `mypy aragora/reputation/crux_bridge.py aragora/reputation/__init__.py --ignore-missing-imports` — **clean**

## Out of scope

- Wiring `bridge_from_crux_position` into the live Arena debate path or CruxDetector emission — deferred until the AGT-* substrate gate opens
- On-chain anchoring via `ReputationRegistry` — downstream PR per existing `__init__.py` note
- Crux resolution oracle (Manifold/Metaculus/debate consensus) that would actually produce `CruxResolutionEvent` instances at runtime — AGT-03/AGT-04 track
- `DOMAIN_DEBATE_POSITION` and `DOMAIN_CODE_PR` bridges — separate future slices

---
_Generated by [Claude Code](https://claude.ai/code/session_018o4BtjEQigFSU1dcuESyd4)_