### PR TITLE
feat(review): on-disk adapter for InvalidatedDecision (gap #6375 step A)

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -32,6 +32,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from aragora.review.invalidation import (
+    BaselineMeasurement,
+    DEFAULT_BASELINE_WINDOW_DAYS,
+    DEFAULT_MIN_BASELINE_SAMPLES,
+    DEFAULT_MINIMUM_MEANINGFUL_RATE,
+    DEFAULT_SAFETY_MARGIN,
+    ThresholdProposal,
+    derive_threshold,
+)
+from aragora.review.invalidation_event_source import measure_baseline_from_stores
 from aragora.review.reviewer_output import ReviewerOutput
 from aragora.swarm.pr_review_protocol import (
     PRReviewerExecutionFailure,
@@ -250,6 +260,86 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     act_p.add_argument("--json", action="store_true", help="Output settlement receipt as JSON")
 
+    baseline_p = sub.add_parser(
+        "baseline",
+        help="Measure empirical invalidation baseline from on-disk stores (#6375)",
+        description=(
+            "Read the auto-handle calibration store (failure outcomes) and the\n"
+            "settlement-receipt tree (denominator for human-settled decisions),\n"
+            "compute the empirical invalidation baseline, and propose an auto-\n"
+            "handle invalidation threshold.\n\n"
+            "Read-only: this command does NOT mutate the calibration store, the\n"
+            "receipt tree, or any threshold configuration. It is the operator-\n"
+            "facing surface for the empirical-threshold framework that landed\n"
+            "in #6602 (phase 1) and #6615 (phase 2 adapter)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    baseline_p.add_argument(
+        "--window-days",
+        type=int,
+        default=DEFAULT_BASELINE_WINDOW_DAYS,
+        help=(f"Measurement-window width in days (default: {DEFAULT_BASELINE_WINDOW_DAYS})."),
+    )
+    baseline_p.add_argument(
+        "--min-samples",
+        type=int,
+        default=DEFAULT_MIN_BASELINE_SAMPLES,
+        help=(
+            "Minimum human-settled sample size before the baseline is "
+            f"considered usable for non-placeholder threshold derivation "
+            f"(default: {DEFAULT_MIN_BASELINE_SAMPLES})."
+        ),
+    )
+    baseline_p.add_argument(
+        "--safety-margin",
+        type=float,
+        default=DEFAULT_SAFETY_MARGIN,
+        help=(
+            "Multiplier applied to the baseline when deriving the threshold "
+            f"(default: {DEFAULT_SAFETY_MARGIN}). Must be in (0, 1]."
+        ),
+    )
+    baseline_p.add_argument(
+        "--minimum-meaningful-rate",
+        type=float,
+        default=DEFAULT_MINIMUM_MEANINGFUL_RATE,
+        help=(
+            "Floor below which threshold drift is indistinguishable from "
+            f"sample noise (default: {DEFAULT_MINIMUM_MEANINGFUL_RATE})."
+        ),
+    )
+    baseline_p.add_argument(
+        "--placeholder-value",
+        type=float,
+        default=0.05,
+        help=(
+            "Threshold to use when the baseline is below the sample-size "
+            "floor (default: 0.05, matching the THESIS Commitment 3 placeholder)."
+        ),
+    )
+    baseline_p.add_argument(
+        "--calibration-db",
+        default=None,
+        help=(
+            "Override the auto-handle calibration store path. Defaults to "
+            "the canonical store under aragora's data dir."
+        ),
+    )
+    baseline_p.add_argument(
+        "--review-queue-root",
+        default=None,
+        help=(
+            "Override the review-queue store root used for settlement "
+            "receipts. Defaults to <repo>/.aragora/review-queue."
+        ),
+    )
+    baseline_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the BaselineMeasurement + ThresholdProposal as JSON.",
+    )
+
     parser.set_defaults(func=cmd_review_queue)
 
 
@@ -264,8 +354,10 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
         return _cmd_run(args)
     if command == "act":
         return _cmd_act(args)
+    if command == "baseline":
+        return _cmd_baseline(args)
     print(
-        "Usage: aragora review-queue {build,packet,run,act} [...]\n"
+        "Usage: aragora review-queue {build,packet,run,act,baseline} [...]\n"
         "Run 'aragora review-queue run --help' for the human settlement loop.",
         file=sys.stderr,
     )
@@ -441,6 +533,74 @@ def _cmd_act(args: argparse.Namespace) -> int:
         print(json.dumps(receipt.to_dict(), indent=2))
     else:
         _render_settlement_receipt(receipt)
+    return 0
+
+
+def _cmd_baseline(args: argparse.Namespace) -> int:
+    """Measure the empirical invalidation baseline + propose a threshold.
+
+    Read-only against the calibration store and the settlement-receipt
+    tree. Does not mutate either; does not write a receipt; does not
+    apply the proposed threshold anywhere. The recalibration receipt
+    flow is #6375 step B (codex).
+    """
+    if args.window_days <= 0:
+        print("error: --window-days must be positive", file=sys.stderr)
+        return 2
+    if args.min_samples <= 0:
+        print("error: --min-samples must be positive", file=sys.stderr)
+        return 2
+    if not 0 < args.safety_margin <= 1:
+        print("error: --safety-margin must be in (0, 1]", file=sys.stderr)
+        return 2
+    if args.minimum_meaningful_rate <= 0:
+        print("error: --minimum-meaningful-rate must be positive", file=sys.stderr)
+        return 2
+    if not 0 < args.placeholder_value < 1:
+        print("error: --placeholder-value must be in (0, 1)", file=sys.stderr)
+        return 2
+
+    json_output = bool(getattr(args, "json", False))
+
+    try:
+        store = AutoHandleCalibrationStore(db_path=args.calibration_db)
+    except (OSError, RuntimeError, sqlite3.Error, ValueError, TypeError) as exc:
+        print(f"error: cannot open calibration store: {exc}", file=sys.stderr)
+        return 1
+
+    window_end = datetime.now(UTC)
+    try:
+        measurement = measure_baseline_from_stores(
+            calibration_store=store,
+            review_queue_root=args.review_queue_root,
+            window_end=window_end,
+            window_days=args.window_days,
+            min_samples=args.min_samples,
+        )
+    except (OSError, RuntimeError, sqlite3.Error, ValueError) as exc:
+        print(f"error: baseline measurement failed: {exc}", file=sys.stderr)
+        return 1
+
+    proposal = derive_threshold(
+        measurement,
+        safety_margin=args.safety_margin,
+        minimum_meaningful_rate=args.minimum_meaningful_rate,
+        measured_at=window_end,
+        placeholder_value=args.placeholder_value,
+    )
+
+    if json_output:
+        print(
+            json.dumps(
+                {
+                    "measurement": measurement.to_dict(),
+                    "proposal": proposal.to_dict(),
+                },
+                indent=2,
+            )
+        )
+    else:
+        _render_baseline_report(measurement=measurement, proposal=proposal)
     return 0
 
 
@@ -1214,6 +1374,83 @@ def _render_settlement_receipt(receipt: SettlementReceipt) -> None:
     if receipt.elapsed_seconds is not None:
         print(f"  elapsed:      {receipt.elapsed_seconds:.3f}s")
     print(f"  receipt:      {receipt.receipt_path}")
+
+
+def _render_baseline_report(
+    *,
+    measurement: BaselineMeasurement,
+    proposal: ThresholdProposal,
+) -> None:
+    """Print a human-readable empirical-threshold baseline report."""
+    print("# Empirical invalidation baseline (gap #6375)")
+    print()
+    print(f"window:       {measurement.window_start.isoformat()}")
+    print(f"           -> {measurement.window_end.isoformat()}")
+    print(f"              ({measurement.window_days}d)")
+    print()
+    print("samples:")
+    print(
+        f"  human-settled:   {measurement.invalidated_human_settled} invalidated "
+        f"/ {measurement.total_human_settled} total"
+    )
+    print(
+        f"  auto-handled:    {measurement.invalidated_auto_handled} invalidated "
+        f"/ {measurement.total_auto_handled} total"
+    )
+    print(
+        f"  min required:    {measurement.min_samples_required}  "
+        f"(acceptable: {measurement.sample_size_acceptable})"
+    )
+    print()
+    print("rates (with Wilson 95% CI):")
+    print(
+        "  human baseline:  "
+        f"{_fmt_rate(measurement.baseline_human_rate)}  "
+        f"[{_fmt_rate(measurement.baseline_human_rate_ci_low)}, "
+        f"{_fmt_rate(measurement.baseline_human_rate_ci_high)}]"
+    )
+    print(
+        "  auto-handle:     "
+        f"{_fmt_rate(measurement.auto_handle_rate)}  "
+        f"[{_fmt_rate(measurement.auto_handle_rate_ci_low)}, "
+        f"{_fmt_rate(measurement.auto_handle_rate_ci_high)}]"
+    )
+    print()
+    if measurement.per_class_human:
+        print("per-class human breakdown (invalidated/total):")
+        for cls, (inv, tot) in sorted(measurement.per_class_human.items()):
+            print(f"  - {cls}: {inv}/{tot}")
+        print()
+    if measurement.per_class_auto:
+        print("per-class auto-handle breakdown (invalidated/total):")
+        for cls, (inv, tot) in sorted(measurement.per_class_auto.items()):
+            print(f"  - {cls}: {inv}/{tot}")
+        print()
+    if measurement.notes:
+        print("notes (data-availability caveats):")
+        for key, note in sorted(measurement.notes.items()):
+            print(f"  - {key}: {note}")
+        print()
+    print("proposed threshold:")
+    print(f"  value:         {_fmt_rate(proposal.threshold)}")
+    print(f"  baseline:      {_fmt_rate(proposal.baseline)}")
+    print(f"  safety margin: {proposal.safety_margin:.2f}")
+    print(f"  min meaningful rate: {proposal.minimum_meaningful_rate:.4f}")
+    print(f"  placeholder:   {proposal.is_placeholder}")
+    print(f"  rationale:     {proposal.rationale}")
+    print(f"  measured at:   {proposal.measured_at.isoformat()}")
+    print()
+    print(
+        "Note: this command is read-only and advisory. Applying the proposed "
+        "threshold or persisting a recalibration receipt is the recalibration "
+        "scheduler's job (#6375 step B), not this CLI."
+    )
+
+
+def _fmt_rate(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.4f} ({value:.2%})"
 
 
 def _render_active_auto_handle_alerts() -> None:

--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -81,6 +81,13 @@ from aragora.review.invalidation import (
     derive_threshold,
     is_invalidated,
 )
+from aragora.review.invalidation_event_source import (
+    count_decisions_from_settlement_receipts,
+    iter_invalidations_from_calibration_store,
+    iter_invalidations_from_settlement_receipts,
+    measure_baseline_from_stores,
+    resolve_review_queue_root,
+)
 
 __all__ = [
     "ADVISORY_NOTE",
@@ -138,7 +145,12 @@ __all__ = [
     "classify_invalidation",
     "compute_baseline",
     "compute_packet_sha",
+    "count_decisions_from_settlement_receipts",
     "derive_threshold",
     "is_invalidated",
+    "iter_invalidations_from_calibration_store",
+    "iter_invalidations_from_settlement_receipts",
+    "measure_baseline_from_stores",
+    "resolve_review_queue_root",
     "validate_reviewer_outputs",
 ]

--- a/aragora/review/invalidation_event_source.py
+++ b/aragora/review/invalidation_event_source.py
@@ -1,0 +1,617 @@
+"""Adapter from on-disk auto-handle calibration + settlement receipts to
+:class:`aragora.review.invalidation.InvalidatedDecision` (gap #6375 phase 2).
+
+This module wires the empirical-threshold framework that landed in
+phase 1 (#6602) to the data already on disk:
+
+  - :class:`aragora.triage.auto_handle_calibration.AutoHandleCalibrationStore`
+    rows whose ``outcome`` is one of the failure constants
+    (:data:`OUTCOME_REVERT`, :data:`OUTCOME_INCIDENT`,
+    :data:`OUTCOME_HUMAN_OVERRIDE`) — these are *auto-handled*
+    invalidations.
+  - settlement-receipt JSON files under
+    ``<store_root>/receipts/`` — used as the *denominator* for
+    human-settled decisions (the per-window total against which the
+    baseline rate is computed).
+
+Both surfaces are read-only here; the adapter does not mutate either
+store. Connection lifecycle on the calibration store mirrors that
+module's contract (file-backed stores open/close per call;
+``:memory:`` stores reuse the persistent connection).
+
+Honest caveats
+--------------
+
+The settlement-receipt schema does not yet record *post-settlement*
+invalidation signals (revert, incident, follow-up redo). That means:
+
+- Human-settled decisions can be *counted* (denominator) but not yet
+  *classified* as invalidated from receipts alone. Until receipts grow
+  outcome fields, the human-side numerator is 0; the corresponding
+  note is added to the :class:`BaselineMeasurement` so consumers can
+  tell "no invalidations" apart from "no signal source".
+- Auto-handled decisions DO carry outcomes (the calibration store's
+  whole purpose) so they classify cleanly.
+
+This is the same shape #6373 / #6440 chose for the rolling-window
+metrics: emit ``None`` honestly when an upstream signal is missing,
+and surface the gap in ``notes`` so callers cannot silently
+mistake suppressed metrics for measured zero rates.
+
+Phase boundaries
+----------------
+
+Phase 1 (#6602): pure-function classification + baseline + threshold.
+Phase 2 (this PR): on-disk adapters reading existing stores.
+Phase 3 (codex, #6375 step B): recalibration scheduler + ``ThresholdUpdateReceipt``.
+Phase 4 (separate PR): CLI surfacing — ``aragora review-queue baseline``.
+Phase 5 (separate PR, requires real data): replace the literal ``5%``
+in ``docs/THESIS.md`` Commitment 3.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+from aragora.review.invalidation import (
+    BaselineMeasurement,
+    DEFAULT_BASELINE_WINDOW_DAYS,
+    DEFAULT_MIN_BASELINE_SAMPLES,
+    DEFAULT_REVERT_WINDOW_DAYS,
+    INVALIDATION_HUMAN_OVERRIDE_REDO,
+    INVALIDATION_POST_MERGE_INCIDENT,
+    INVALIDATION_REVERT_WITHIN_WINDOW,
+    InvalidatedDecision,
+    compute_baseline,
+)
+from aragora.triage.auto_handle_calibration import (
+    AutoHandleCalibrationStore,
+    OUTCOME_HUMAN_OVERRIDE,
+    OUTCOME_INCIDENT,
+    OUTCOME_REVERT,
+    OUTCOME_SUCCESS,
+)
+
+__all__ = [
+    "DEFAULT_REVIEW_QUEUE_SUBDIR",
+    "RECEIPTS_SUBDIR",
+    "iter_invalidations_from_calibration_store",
+    "iter_invalidations_from_settlement_receipts",
+    "count_decisions_from_settlement_receipts",
+    "measure_baseline_from_stores",
+    "resolve_review_queue_root",
+]
+
+UTC = timezone.utc
+logger = logging.getLogger(__name__)
+
+DEFAULT_REVIEW_QUEUE_SUBDIR = ".aragora/review-queue"
+RECEIPTS_SUBDIR = "receipts"
+
+# Map calibration-store outcomes to invalidation signals.
+# OUTCOME_SUCCESS does not produce an invalidation signal; the other
+# three failure outcomes each map to one canonical signal.
+_OUTCOME_TO_SIGNAL: dict[str, str] = {
+    OUTCOME_REVERT: INVALIDATION_REVERT_WITHIN_WINDOW,
+    OUTCOME_INCIDENT: INVALIDATION_POST_MERGE_INCIDENT,
+    OUTCOME_HUMAN_OVERRIDE: INVALIDATION_HUMAN_OVERRIDE_REDO,
+}
+
+_FAILURE_OUTCOMES = frozenset(_OUTCOME_TO_SIGNAL.keys())
+
+
+# ---------------------------------------------------------------------------
+# Public API — settlement-receipt side (human-settled denominators)
+# ---------------------------------------------------------------------------
+
+
+def resolve_review_queue_root(override: str | Path | None = None) -> Path:
+    """Resolve the canonical review-queue store root.
+
+    Mirrors the resolution order used by
+    :func:`aragora.triage.event_source.resolve_store_root` so this
+    adapter and the metrics adapter read from the same tree:
+
+    1. Explicit ``override`` argument.
+    2. ``ARAGORA_REVIEW_QUEUE_ROOT`` environment variable.
+    3. Walk up from cwd looking for ``.aragora/`` or ``.git/``; return
+       ``<found>/.aragora/review-queue``.
+    4. Fallback: ``cwd/.aragora/review-queue``.
+    """
+    if override is not None:
+        return Path(override)
+    env = os.environ.get("ARAGORA_REVIEW_QUEUE_ROOT")
+    if env:
+        return Path(env)
+    cwd = Path.cwd()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / ".aragora").exists() or (candidate / ".git").exists():
+            return candidate / ".aragora" / "review-queue"
+    return cwd / ".aragora" / "review-queue"
+
+
+def count_decisions_from_settlement_receipts(
+    *,
+    store_root: str | Path | None = None,
+    window_end: datetime,
+    window_days: int = DEFAULT_BASELINE_WINDOW_DAYS,
+) -> int:
+    """Return the count of human-settled decisions in the window.
+
+    Each settlement receipt corresponds to exactly one human-settled
+    decision (the writer in
+    :mod:`aragora.cli.commands.review_queue` emits one per
+    ``review-queue act``). Receipts whose ``reviewed_at`` cannot be
+    parsed are skipped with a WARNING log; this matches the resilience
+    posture of :mod:`aragora.triage.event_source`.
+
+    Args:
+        store_root: Path to the review-queue store; resolved via
+            :func:`resolve_review_queue_root` when ``None``.
+        window_end: Right edge of the measurement window (inclusive).
+        window_days: Width of the window in days. Defaults to
+            :data:`DEFAULT_BASELINE_WINDOW_DAYS`.
+    """
+    if window_days <= 0:
+        raise ValueError("window_days must be positive")
+    window_end = _ensure_utc(window_end)
+    window_start = window_end - timedelta(days=window_days)
+
+    receipts_dir = resolve_review_queue_root(store_root) / RECEIPTS_SUBDIR
+    if not receipts_dir.exists():
+        return 0
+
+    try:
+        candidates = [p for p in receipts_dir.iterdir() if p.is_file() and p.suffix == ".json"]
+    except OSError as exc:
+        logger.warning("review.invalidation_event_source: cannot list %s: %s", receipts_dir, exc)
+        return 0
+
+    total = 0
+    for path in candidates:
+        payload = _safe_read_json(path)
+        if payload is None:
+            continue
+        reviewed_raw = payload.get("reviewed_at")
+        if not reviewed_raw:
+            continue
+        try:
+            reviewed_at = _parse_iso(str(reviewed_raw))
+        except ValueError:
+            logger.warning(
+                "review.invalidation_event_source: receipt %s has invalid reviewed_at=%r",
+                path,
+                reviewed_raw,
+            )
+            continue
+        if window_start <= reviewed_at <= window_end:
+            total += 1
+    return total
+
+
+def iter_invalidations_from_settlement_receipts(
+    *,
+    store_root: str | Path | None = None,
+    revert_window_days: int = DEFAULT_REVERT_WINDOW_DAYS,
+) -> Iterator[InvalidatedDecision]:
+    """Yield :class:`InvalidatedDecision` for receipts that already
+    record invalidation signals.
+
+    Today's settlement-receipt schema does not carry post-settlement
+    invalidation fields (revert/incident/redo). When future schema
+    extensions add them, this iterator will start yielding events
+    without consumer changes — the dispatch table here is the only
+    place that needs to grow.
+
+    Until then this iterator yields nothing for almost every receipt,
+    by design. Callers should treat the human-settled invalidation
+    *numerator* as ``0`` and rely on the per-field ``notes`` map on
+    :class:`BaselineMeasurement` to surface the gap.
+
+    The ``revert_window_days`` argument is reserved for the future
+    schema; current code does not consult it.
+    """
+    receipts_dir = resolve_review_queue_root(store_root) / RECEIPTS_SUBDIR
+    if not receipts_dir.exists():
+        return
+    try:
+        candidates = sorted(
+            (p for p in receipts_dir.iterdir() if p.is_file() and p.suffix == ".json"),
+            key=lambda p: p.name,
+        )
+    except OSError as exc:
+        logger.warning("review.invalidation_event_source: cannot list %s: %s", receipts_dir, exc)
+        return
+    for path in candidates:
+        payload = _safe_read_json(path)
+        if payload is None:
+            continue
+        decision = _invalidation_from_settlement_receipt(
+            payload,
+            source_path=path,
+            revert_window_days=revert_window_days,
+        )
+        if decision is not None:
+            yield decision
+
+
+# ---------------------------------------------------------------------------
+# Public API — calibration-store side (auto-handled invalidations)
+# ---------------------------------------------------------------------------
+
+
+def iter_invalidations_from_calibration_store(
+    store: AutoHandleCalibrationStore,
+    *,
+    window_end: datetime | None = None,
+    window_days: int = DEFAULT_BASELINE_WINDOW_DAYS,
+) -> Iterator[InvalidatedDecision]:
+    """Yield one :class:`InvalidatedDecision` per failure-outcome row
+    in the auto-handle calibration store.
+
+    Pulls directly from the store's underlying SQLite. Read-only —
+    does not open a write transaction.
+
+    Args:
+        store: An :class:`AutoHandleCalibrationStore` instance.
+        window_end: Optional right edge for filtering rows. ``None``
+            yields every failure-outcome row regardless of date.
+        window_days: When ``window_end`` is provided, restricts to
+            rows whose ``decided_at`` is within
+            ``[window_end - window_days, window_end]``.
+    """
+    if window_days <= 0:
+        raise ValueError("window_days must be positive")
+
+    end_ts: float | None = None
+    start_ts: float | None = None
+    if window_end is not None:
+        window_end = _ensure_utc(window_end)
+        end_ts = window_end.timestamp()
+        start_ts = end_ts - (window_days * 86400)
+
+    query = (
+        "SELECT decision_id, auto_handle_path, decision_class, pr_url, pr_number, "
+        "outcome, decided_at, metadata_json "
+        "FROM auto_handle_decisions "
+        "WHERE outcome IN (?, ?, ?) "
+        + ("AND decided_at >= ? AND decided_at <= ? " if end_ts is not None else "")
+        + "ORDER BY decided_at ASC"
+    )
+    params: list[Any] = [OUTCOME_REVERT, OUTCOME_INCIDENT, OUTCOME_HUMAN_OVERRIDE]
+    if end_ts is not None and start_ts is not None:
+        params.extend([float(start_ts), float(end_ts)])
+
+    rows = _read_rows(store, query, params)
+    for row in rows:
+        decision = _invalidation_from_calibration_row(row)
+        if decision is not None:
+            yield decision
+
+
+# ---------------------------------------------------------------------------
+# Public API — top-level: full baseline measurement from the live stores
+# ---------------------------------------------------------------------------
+
+
+def measure_baseline_from_stores(
+    *,
+    calibration_store: AutoHandleCalibrationStore,
+    review_queue_root: str | Path | None = None,
+    window_end: datetime,
+    window_days: int = DEFAULT_BASELINE_WINDOW_DAYS,
+    min_samples: int = DEFAULT_MIN_BASELINE_SAMPLES,
+    revert_window_days: int = DEFAULT_REVERT_WINDOW_DAYS,
+) -> BaselineMeasurement:
+    """Measure the empirical invalidation baseline from on-disk stores.
+
+    Combines:
+
+      - Auto-handled invalidations from the calibration store
+        (numerator + denominator both queryable from there).
+      - Human-settled invalidations from settlement receipts
+        (numerator typically 0 today; denominator from receipt count).
+
+    Returns a :class:`BaselineMeasurement` whose ``notes`` map names
+    the fields that are unmeasurable from current schemas. The
+    ``BaselineMeasurement`` is *not* persisted here — callers that
+    want a signed receipt should pass it to the recalibration
+    scheduler (#6375 step B, codex).
+
+    Args:
+        calibration_store: An :class:`AutoHandleCalibrationStore`
+            instance pointing at the live store path.
+        review_queue_root: Optional override for the review-queue store
+            location; resolved via :func:`resolve_review_queue_root`.
+        window_end: Right edge of the measurement window.
+        window_days: Width of the window in days.
+        min_samples: Minimum sample size before the baseline is
+            considered usable for non-placeholder threshold derivation.
+        revert_window_days: Days within which a revert counts as
+            invalidation; reserved for future settlement-receipt
+            schema use.
+    """
+    if window_days <= 0:
+        raise ValueError("window_days must be positive")
+    window_end = _ensure_utc(window_end)
+
+    # Auto-handle side --------------------------------------------------
+    auto_invalidations = list(
+        iter_invalidations_from_calibration_store(
+            calibration_store,
+            window_end=window_end,
+            window_days=window_days,
+        )
+    )
+    auto_total = _count_calibration_decisions_in_window(
+        calibration_store,
+        window_end=window_end,
+        window_days=window_days,
+    )
+
+    # Human-settled side ------------------------------------------------
+    human_invalidations = list(
+        iter_invalidations_from_settlement_receipts(
+            store_root=review_queue_root,
+            revert_window_days=revert_window_days,
+        )
+    )
+    # Only count human invalidations whose settled_at falls in the
+    # window; iter_invalidations_from_settlement_receipts() emits all
+    # of them regardless of date because the schema does not yet have
+    # post-settlement signals to filter on.
+    window_start = window_end - timedelta(days=window_days)
+    human_invalidations_in_window = [
+        d for d in human_invalidations if window_start <= d.settled_at <= window_end
+    ]
+
+    human_total = count_decisions_from_settlement_receipts(
+        store_root=review_queue_root,
+        window_end=window_end,
+        window_days=window_days,
+    )
+
+    measurement = compute_baseline(
+        list(auto_invalidations) + human_invalidations_in_window,
+        total_human_settled=human_total,
+        total_auto_handled=auto_total,
+        window_end=window_end,
+        window_days=window_days,
+        min_samples=min_samples,
+    )
+
+    # Tag the gap explicitly so downstream consumers don't mistake a
+    # zero numerator for a measured zero rate.
+    extra_notes = dict(measurement.notes)
+    if not human_invalidations_in_window:
+        extra_notes.setdefault(
+            "human_invalidations_source",
+            "settlement-receipt schema does not yet record post-settlement "
+            "invalidation signals (revert/incident/redo); human-side numerator "
+            "is 0 by data availability, not by measurement. Tracked as a "
+            "follow-up to #6375 step A.",
+        )
+
+    # Re-pack to attach the additional note while keeping the
+    # measurement immutable in spirit. BaselineMeasurement is frozen,
+    # so we re-construct rather than mutating.
+    return BaselineMeasurement(
+        window_start=measurement.window_start,
+        window_end=measurement.window_end,
+        window_days=measurement.window_days,
+        total_human_settled=measurement.total_human_settled,
+        invalidated_human_settled=measurement.invalidated_human_settled,
+        total_auto_handled=measurement.total_auto_handled,
+        invalidated_auto_handled=measurement.invalidated_auto_handled,
+        baseline_human_rate=measurement.baseline_human_rate,
+        baseline_human_rate_ci_low=measurement.baseline_human_rate_ci_low,
+        baseline_human_rate_ci_high=measurement.baseline_human_rate_ci_high,
+        auto_handle_rate=measurement.auto_handle_rate,
+        auto_handle_rate_ci_low=measurement.auto_handle_rate_ci_low,
+        auto_handle_rate_ci_high=measurement.auto_handle_rate_ci_high,
+        per_class_human=measurement.per_class_human,
+        per_class_auto=measurement.per_class_auto,
+        min_samples_required=measurement.min_samples_required,
+        sample_size_acceptable=measurement.sample_size_acceptable,
+        notes=extra_notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_rows(
+    store: AutoHandleCalibrationStore,
+    query: str,
+    params: Iterable[Any],
+) -> list[sqlite3.Row]:
+    """Run ``query`` against the store's connection and return all rows.
+
+    Read-only; does not open a write transaction. Uses the store's
+    ``_connection`` context manager so the file-vs-memory connection
+    lifecycle stays consistent with the rest of the calibration code.
+    """
+    # ``_connection`` is module-private but documented as the
+    # canonical way to get a configured connection within the
+    # calibration package; using it here keeps WAL / busy-timeout /
+    # row-factory configuration identical to writers and avoids the
+    # journal-mode mismatch flagged in the calibration module
+    # docstring.
+    with store._connection() as conn:  # noqa: SLF001 — intentional in-package read
+        rows = conn.execute(query, tuple(params)).fetchall()
+    return list(rows)
+
+
+def _count_calibration_decisions_in_window(
+    store: AutoHandleCalibrationStore,
+    *,
+    window_end: datetime,
+    window_days: int,
+) -> int:
+    """Count auto-handled decisions in the window (success + failures)."""
+    end_ts = window_end.timestamp()
+    start_ts = end_ts - (window_days * 86400)
+    rows = _read_rows(
+        store,
+        "SELECT COUNT(*) AS n FROM auto_handle_decisions "
+        "WHERE outcome IN (?, ?, ?, ?) AND decided_at >= ? AND decided_at <= ?",
+        [
+            OUTCOME_SUCCESS,
+            OUTCOME_REVERT,
+            OUTCOME_INCIDENT,
+            OUTCOME_HUMAN_OVERRIDE,
+            float(start_ts),
+            float(end_ts),
+        ],
+    )
+    if not rows:
+        return 0
+    return int(rows[0]["n"] or 0)
+
+
+def _invalidation_from_calibration_row(row: sqlite3.Row) -> InvalidatedDecision | None:
+    """Build an :class:`InvalidatedDecision` from one calibration-store row.
+
+    Returns ``None`` when the outcome string is not recognized as a
+    failure (for example, a future-schema outcome we don't yet know
+    how to map). The caller will see the row simply skipped.
+    """
+    outcome = str(row["outcome"] or "")
+    if outcome not in _FAILURE_OUTCOMES:
+        return None
+    signal = _OUTCOME_TO_SIGNAL[outcome]
+    decided_at = float(row["decided_at"] or 0.0)
+    settled_at = datetime.fromtimestamp(decided_at, tz=UTC)
+    pr_url = str(row["pr_url"] or "").strip()
+    decision_class = str(row["decision_class"] or "").strip()
+    rationale = (
+        f"calibration-store outcome={outcome!r} (class={decision_class!r}, pr_url={pr_url!r})"
+    )
+    return InvalidatedDecision(
+        decision_id=str(row["decision_id"] or ""),
+        settled_at=settled_at,
+        signals=(signal,),
+        rationales=(rationale,),
+        was_human_settled=False,
+        was_auto_handled=True,
+    )
+
+
+def _invalidation_from_settlement_receipt(
+    payload: dict[str, Any],
+    *,
+    source_path: Path | None = None,
+    revert_window_days: int = DEFAULT_REVERT_WINDOW_DAYS,
+) -> InvalidatedDecision | None:
+    """Build an :class:`InvalidatedDecision` from one settlement-receipt dict.
+
+    Today's schema does not carry post-settlement signals, so this
+    function returns ``None`` for almost every receipt. It is structured
+    so that adding new fields (e.g. ``reverted_at``,
+    ``post_merge_incident``, ``redo_pr``) becomes a small additive
+    change inside this function rather than reshaping every caller.
+
+    Args:
+        payload: Parsed JSON of one settlement-receipt file.
+        source_path: Optional path for logging diagnostics.
+        revert_window_days: Days within which a recorded revert counts.
+    """
+    reviewed_at_raw = payload.get("reviewed_at")
+    pr_number = payload.get("pr_number")
+    action = payload.get("action")
+    if not reviewed_at_raw or pr_number is None or not action:
+        return None
+    try:
+        settled_at = _parse_iso(str(reviewed_at_raw))
+    except ValueError:
+        logger.warning(
+            "review.invalidation_event_source: receipt %s has invalid reviewed_at=%r",
+            source_path,
+            reviewed_at_raw,
+        )
+        return None
+
+    signals: list[str] = []
+    rationales: list[str] = []
+
+    # Future schema fields — defensive lookups so this function keeps
+    # working when receipt schemas grow without breaking.
+    reverted_at_raw = payload.get("reverted_at")
+    incident_attributed = bool(payload.get("post_merge_incident"))
+    redo_pr = payload.get("redo_pr") or payload.get("human_override_redo_pr")
+
+    if reverted_at_raw:
+        try:
+            reverted_at = _parse_iso(str(reverted_at_raw))
+        except ValueError:
+            reverted_at = None
+        if reverted_at is not None:
+            delta = reverted_at - settled_at
+            if timedelta(0) <= delta <= timedelta(days=revert_window_days):
+                signals.append(INVALIDATION_REVERT_WITHIN_WINDOW)
+                rationales.append(
+                    f"settlement-receipt records revert {delta.days}d after settlement "
+                    f"(window={revert_window_days}d)"
+                )
+
+    if incident_attributed:
+        signals.append(INVALIDATION_POST_MERGE_INCIDENT)
+        rationales.append("settlement-receipt records post_merge_incident attributed to this PR")
+
+    if redo_pr:
+        signals.append(INVALIDATION_HUMAN_OVERRIDE_REDO)
+        rationales.append(f"settlement-receipt references follow-up redo PR {redo_pr!r}")
+
+    if not signals:
+        return None
+
+    session_id = str(payload.get("session_id") or "")
+    decision_id = f"pr-{pr_number}-{session_id}-{action}"
+
+    return InvalidatedDecision(
+        decision_id=decision_id,
+        settled_at=settled_at,
+        signals=tuple(signals),
+        rationales=tuple(rationales),
+        was_human_settled=True,
+        was_auto_handled=False,
+    )
+
+
+def _safe_read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("review.invalidation_event_source: could not read %s: %s", path, exc)
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("review.invalidation_event_source: malformed JSON in %s: %s", path, exc)
+        return None
+    if not isinstance(data, dict):
+        logger.warning("review.invalidation_event_source: non-dict payload in %s", path)
+        return None
+    return data
+
+
+def _ensure_utc(ts: datetime) -> datetime:
+    return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts
+
+
+def _parse_iso(raw: str) -> datetime:
+    text = raw.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    dt = datetime.fromisoformat(text)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)

--- a/tests/cli/commands/test_review_queue_baseline.py
+++ b/tests/cli/commands/test_review_queue_baseline.py
@@ -1,0 +1,471 @@
+"""Unit tests for `aragora review-queue baseline` subcommand (#6375 step C).
+
+The subcommand is the operator-facing surface for the empirical-
+threshold framework that landed in #6602 (phase 1) and #6615 (phase 2
+adapter). Tests cover argument validation, json/text output, default-
+empty-stores behavior, the placeholder-vs-derived branch, and graceful
+failure when the calibration store cannot be opened.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora.cli.commands.review_queue import (
+    _cmd_baseline,
+    _fmt_rate,
+    _render_baseline_report,
+    add_review_queue_parser,
+    cmd_review_queue,
+)
+from aragora.review.invalidation import (
+    BaselineMeasurement,
+    DEFAULT_BASELINE_WINDOW_DAYS,
+    DEFAULT_MIN_BASELINE_SAMPLES,
+    DEFAULT_MINIMUM_MEANINGFUL_RATE,
+    DEFAULT_SAFETY_MARGIN,
+    ThresholdProposal,
+)
+from aragora.triage.auto_handle_calibration import (
+    AUTO_HANDLE_PATH_FIRE_AND_FORGET,
+    OUTCOME_REVERT,
+    OUTCOME_SUCCESS,
+    AutoHandleCalibrationStore,
+)
+
+UTC = timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def calibration_db(tmp_path: Path) -> str:
+    """A file-backed calibration store path; the CLI cannot use ``:memory:``
+    because it constructs the store itself."""
+    return str(tmp_path / "auto_handle_calibration.db")
+
+
+def _seed_calibration(db_path: str, *, success: int = 0, revert: int = 0) -> None:
+    store = AutoHandleCalibrationStore(db_path=db_path)
+    counter = 0
+    for outcome, n in ((OUTCOME_SUCCESS, success), (OUTCOME_REVERT, revert)):
+        for _ in range(n):
+            counter += 1
+            store.record_outcome(
+                decision_id=f"d-{counter}-{outcome}",
+                auto_handle_path=AUTO_HANDLE_PATH_FIRE_AND_FORGET,
+                decision_class="low_risk:scope=tests:size=S",
+                outcome=outcome,
+                pr_number=counter,
+            )
+
+
+def _write_receipt(receipts_dir: Path, *, pr_number: int) -> None:
+    receipts_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "pr_number": pr_number,
+        "action": "approve",
+        "reviewed_at": datetime.now(UTC).isoformat(),
+        "session_id": f"sess-{pr_number}",
+    }
+    (receipts_dir / f"pr-{pr_number}-sess-{pr_number}-approve.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _baseline_args(**overrides: Any) -> argparse.Namespace:
+    """Build a Namespace mirroring the parser defaults."""
+    defaults: dict[str, Any] = {
+        "review_queue_command": "baseline",
+        "window_days": DEFAULT_BASELINE_WINDOW_DAYS,
+        "min_samples": DEFAULT_MIN_BASELINE_SAMPLES,
+        "safety_margin": DEFAULT_SAFETY_MARGIN,
+        "minimum_meaningful_rate": DEFAULT_MINIMUM_MEANINGFUL_RATE,
+        "placeholder_value": 0.05,
+        "calibration_db": None,
+        "review_queue_root": None,
+        "json": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Parser registration
+# ---------------------------------------------------------------------------
+
+
+def test_parser_registers_baseline_subcommand() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_review_queue_parser(sub)
+    args = parser.parse_args(["review-queue", "baseline"])
+    assert args.review_queue_command == "baseline"
+    assert args.window_days == DEFAULT_BASELINE_WINDOW_DAYS
+    assert args.min_samples == DEFAULT_MIN_BASELINE_SAMPLES
+    assert args.safety_margin == DEFAULT_SAFETY_MARGIN
+    assert args.json is False
+
+
+def test_parser_passes_through_overrides() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    add_review_queue_parser(sub)
+    args = parser.parse_args(
+        [
+            "review-queue",
+            "baseline",
+            "--window-days",
+            "60",
+            "--min-samples",
+            "100",
+            "--safety-margin",
+            "0.4",
+            "--minimum-meaningful-rate",
+            "0.005",
+            "--placeholder-value",
+            "0.07",
+            "--calibration-db",
+            "/tmp/x.db",
+            "--review-queue-root",
+            "/tmp/rq",
+            "--json",
+        ]
+    )
+    assert args.window_days == 60
+    assert args.min_samples == 100
+    assert args.safety_margin == pytest.approx(0.4)
+    assert args.minimum_meaningful_rate == pytest.approx(0.005)
+    assert args.placeholder_value == pytest.approx(0.07)
+    assert args.calibration_db == "/tmp/x.db"
+    assert args.review_queue_root == "/tmp/rq"
+    assert args.json is True
+
+
+def test_dispatcher_routes_baseline_to_handler(tmp_path: Path) -> None:
+    # cmd_review_queue routes review_queue_command="baseline" to _cmd_baseline.
+    args = _baseline_args(
+        calibration_db=str(tmp_path / "x.db"),
+        review_queue_root=tmp_path,
+    )
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = cmd_review_queue(args)
+    assert rc == 0
+    assert "Empirical invalidation baseline" in out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_baseline_rejects_zero_window_days() -> None:
+    args = _baseline_args(window_days=0)
+    err = io.StringIO()
+    with redirect_stderr(err):
+        rc = _cmd_baseline(args)
+    assert rc == 2
+    assert "--window-days must be positive" in err.getvalue()
+
+
+def test_cmd_baseline_rejects_negative_min_samples() -> None:
+    args = _baseline_args(min_samples=-1)
+    err = io.StringIO()
+    with redirect_stderr(err):
+        rc = _cmd_baseline(args)
+    assert rc == 2
+    assert "--min-samples must be positive" in err.getvalue()
+
+
+def test_cmd_baseline_rejects_safety_margin_above_one() -> None:
+    args = _baseline_args(safety_margin=1.5)
+    err = io.StringIO()
+    with redirect_stderr(err):
+        rc = _cmd_baseline(args)
+    assert rc == 2
+    assert "--safety-margin must be in (0, 1]" in err.getvalue()
+
+
+def test_cmd_baseline_rejects_safety_margin_zero() -> None:
+    args = _baseline_args(safety_margin=0.0)
+    err = io.StringIO()
+    with redirect_stderr(err):
+        rc = _cmd_baseline(args)
+    assert rc == 2
+
+
+def test_cmd_baseline_rejects_zero_minimum_meaningful_rate() -> None:
+    args = _baseline_args(minimum_meaningful_rate=0.0)
+    err = io.StringIO()
+    with redirect_stderr(err):
+        rc = _cmd_baseline(args)
+    assert rc == 2
+    assert "--minimum-meaningful-rate must be positive" in err.getvalue()
+
+
+def test_cmd_baseline_rejects_placeholder_outside_unit_interval() -> None:
+    args = _baseline_args(placeholder_value=1.5)
+    err = io.StringIO()
+    with redirect_stderr(err):
+        rc = _cmd_baseline(args)
+    assert rc == 2
+    assert "--placeholder-value must be in (0, 1)" in err.getvalue()
+
+
+def test_cmd_baseline_rejects_placeholder_zero() -> None:
+    args = _baseline_args(placeholder_value=0.0)
+    err = io.StringIO()
+    with redirect_stderr(err):
+        rc = _cmd_baseline(args)
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# Empty-store path: no data anywhere
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_baseline_no_data_emits_placeholder_text(tmp_path: Path, calibration_db: str) -> None:
+    args = _baseline_args(
+        calibration_db=calibration_db,
+        review_queue_root=tmp_path,
+    )
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = _cmd_baseline(args)
+    assert rc == 0
+    text = out.getvalue()
+    assert "Empirical invalidation baseline" in text
+    assert "human-settled:   0 invalidated / 0 total" in text
+    assert "placeholder:   True" in text
+    # Default placeholder is 5%
+    assert "0.0500 (5.00%)" in text
+    assert err.getvalue() == ""
+
+
+def test_cmd_baseline_no_data_emits_placeholder_json(tmp_path: Path, calibration_db: str) -> None:
+    args = _baseline_args(
+        calibration_db=calibration_db,
+        review_queue_root=tmp_path,
+        json=True,
+    )
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = _cmd_baseline(args)
+    assert rc == 0
+    payload = json.loads(out.getvalue())
+    assert "measurement" in payload
+    assert "proposal" in payload
+    proposal = payload["proposal"]
+    assert proposal["is_placeholder"] is True
+    assert proposal["threshold"] == pytest.approx(0.05)
+    assert proposal["sample_size"] == 0
+    measurement = payload["measurement"]
+    assert measurement["total_human_settled"] == 0
+    assert measurement["total_auto_handled"] == 0
+
+
+# ---------------------------------------------------------------------------
+# With calibration data + receipts
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_baseline_with_data_text_output(tmp_path: Path, calibration_db: str) -> None:
+    _seed_calibration(calibration_db, success=50, revert=5)
+
+    receipts_dir = tmp_path / ".aragora" / "review-queue" / "receipts"
+    for i in range(60):
+        _write_receipt(receipts_dir, pr_number=i)
+
+    args = _baseline_args(
+        calibration_db=calibration_db,
+        review_queue_root=tmp_path / ".aragora" / "review-queue",
+    )
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = _cmd_baseline(args)
+    assert rc == 0
+    text = out.getvalue()
+    # Auto-handle side has 5/55
+    assert "auto-handled:    5 invalidated / 55 total" in text
+    # Human side denominator from receipts
+    assert "human-settled:   0 invalidated / 60 total" in text
+    # Sample-size acceptable since 60 >= 50 default
+    assert "acceptable: True" in text
+    # Threshold derived not placeholder (baseline = 0/60 = 0; floor kicks in)
+    assert "placeholder:   False" in text
+    # Note: human invalidation source gap surfaced
+    assert "human_invalidations_source" in text
+
+
+def test_cmd_baseline_with_data_json_output(tmp_path: Path, calibration_db: str) -> None:
+    _seed_calibration(calibration_db, success=50, revert=5)
+    receipts_dir = tmp_path / ".aragora" / "review-queue" / "receipts"
+    for i in range(60):
+        _write_receipt(receipts_dir, pr_number=i)
+
+    args = _baseline_args(
+        calibration_db=calibration_db,
+        review_queue_root=tmp_path / ".aragora" / "review-queue",
+        json=True,
+    )
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = _cmd_baseline(args)
+    assert rc == 0
+    payload = json.loads(out.getvalue())
+    measurement = payload["measurement"]
+    proposal = payload["proposal"]
+    assert measurement["total_human_settled"] == 60
+    assert measurement["total_auto_handled"] == 55
+    assert measurement["invalidated_auto_handled"] == 5
+    assert measurement["invalidated_human_settled"] == 0
+    assert proposal["is_placeholder"] is False
+    assert proposal["threshold"] == pytest.approx(
+        DEFAULT_MINIMUM_MEANINGFUL_RATE
+    )  # baseline 0 * margin → floor
+
+
+def test_cmd_baseline_below_min_samples_falls_back_to_placeholder(
+    tmp_path: Path, calibration_db: str
+) -> None:
+    receipts_dir = tmp_path / ".aragora" / "review-queue" / "receipts"
+    for i in range(10):  # below default min 50
+        _write_receipt(receipts_dir, pr_number=i)
+    args = _baseline_args(
+        calibration_db=calibration_db,
+        review_queue_root=tmp_path / ".aragora" / "review-queue",
+        json=True,
+    )
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = _cmd_baseline(args)
+    assert rc == 0
+    payload = json.loads(out.getvalue())
+    assert payload["proposal"]["is_placeholder"] is True
+    assert payload["measurement"]["sample_size_acceptable"] is False
+
+
+def test_cmd_baseline_custom_safety_margin(tmp_path: Path, calibration_db: str) -> None:
+    args = _baseline_args(
+        calibration_db=calibration_db,
+        review_queue_root=tmp_path,
+        safety_margin=0.25,
+        json=True,
+    )
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = _cmd_baseline(args)
+    assert rc == 0
+    payload = json.loads(out.getvalue())
+    assert payload["proposal"]["safety_margin"] == pytest.approx(0.25)
+
+
+def test_cmd_baseline_custom_placeholder_value(tmp_path: Path, calibration_db: str) -> None:
+    args = _baseline_args(
+        calibration_db=calibration_db,
+        review_queue_root=tmp_path,
+        placeholder_value=0.07,
+        json=True,
+    )
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = _cmd_baseline(args)
+    assert rc == 0
+    payload = json.loads(out.getvalue())
+    proposal = payload["proposal"]
+    assert proposal["is_placeholder"] is True
+    assert proposal["threshold"] == pytest.approx(0.07)
+
+
+# ---------------------------------------------------------------------------
+# Defensive paths
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_baseline_handles_unreadable_calibration_db(tmp_path: Path) -> None:
+    # Pass a path under a non-existent parent so SQLite cannot create the file
+    bad = tmp_path / "no" / "such" / "dir" / "x.db"
+    args = _baseline_args(calibration_db=str(bad), review_queue_root=tmp_path)
+    err = io.StringIO()
+    out = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = _cmd_baseline(args)
+    # SQLite raises OperationalError for unable-to-open; the CLI should
+    # return an error exit and emit a single-line message.
+    assert rc == 1
+    assert "calibration store" in err.getvalue() or "error" in err.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_fmt_rate_handles_none() -> None:
+    assert _fmt_rate(None) == "n/a"
+
+
+def test_fmt_rate_formats_value() -> None:
+    out = _fmt_rate(0.0123)
+    assert "0.0123" in out
+    assert "1.23%" in out
+
+
+def test_render_baseline_report_smoke(capsys: pytest.CaptureFixture[str]) -> None:
+    """Sanity-check the renderer prints without error for a synthetic
+    measurement + proposal."""
+    now = datetime.now(UTC)
+    measurement = BaselineMeasurement(
+        window_start=now - timedelta(days=30),
+        window_end=now,
+        window_days=30,
+        total_human_settled=60,
+        invalidated_human_settled=2,
+        total_auto_handled=55,
+        invalidated_auto_handled=5,
+        baseline_human_rate=2 / 60,
+        baseline_human_rate_ci_low=0.005,
+        baseline_human_rate_ci_high=0.10,
+        auto_handle_rate=5 / 55,
+        auto_handle_rate_ci_low=0.04,
+        auto_handle_rate_ci_high=0.18,
+        per_class_human={"low_risk": (2, 60)},
+        per_class_auto={"low_risk": (5, 55)},
+        min_samples_required=50,
+        sample_size_acceptable=True,
+        notes={"caveat": "synthetic"},
+    )
+    proposal = ThresholdProposal(
+        threshold=0.0167,
+        baseline=2 / 60,
+        sample_size=60,
+        safety_margin=0.5,
+        minimum_meaningful_rate=0.01,
+        is_placeholder=False,
+        rationale="threshold derived from sample",
+        measured_at=now,
+        measurement_window_days=30,
+    )
+    _render_baseline_report(measurement=measurement, proposal=proposal)
+    captured = capsys.readouterr()
+    assert "Empirical invalidation baseline" in captured.out
+    assert "per-class human breakdown" in captured.out
+    assert "per-class auto-handle breakdown" in captured.out
+    assert "caveat: synthetic" in captured.out
+    assert "threshold derived from sample" in captured.out
+    assert "advisory" in captured.out.lower() or "read-only" in captured.out.lower()

--- a/tests/review/test_invalidation_event_source.py
+++ b/tests/review/test_invalidation_event_source.py
@@ -1,0 +1,571 @@
+"""Unit tests for aragora.review.invalidation_event_source (#6375 phase 2).
+
+Covers the on-disk adapter that translates auto-handle calibration
+rows + settlement receipts into :class:`InvalidatedDecision`. Uses a
+``:memory:`` calibration store + a tmp-path receipts directory; no
+real network, no real disk outside ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora.review import (
+    INVALIDATION_HUMAN_OVERRIDE_REDO,
+    INVALIDATION_POST_MERGE_INCIDENT,
+    INVALIDATION_REVERT_WITHIN_WINDOW,
+    InvalidatedDecision,
+)
+from aragora.review.invalidation_event_source import (
+    count_decisions_from_settlement_receipts,
+    iter_invalidations_from_calibration_store,
+    iter_invalidations_from_settlement_receipts,
+    measure_baseline_from_stores,
+    resolve_review_queue_root,
+)
+from aragora.triage.auto_handle_calibration import (
+    AUTO_HANDLE_PATH_FIRE_AND_FORGET,
+    OUTCOME_HUMAN_OVERRIDE,
+    OUTCOME_INCIDENT,
+    OUTCOME_REVERT,
+    OUTCOME_SUCCESS,
+    AutoHandleCalibrationStore,
+)
+
+UTC = timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# Calibration-store side
+# ---------------------------------------------------------------------------
+
+
+def _seed_calibration_store(
+    store: AutoHandleCalibrationStore,
+    *,
+    success: int = 0,
+    revert: int = 0,
+    incident: int = 0,
+    human_override: int = 0,
+    decision_class: str = "low_risk:scope=tests:size=S",
+    pr_offset: int = 0,
+) -> None:
+    """Seed N decisions of each outcome class into the calibration store."""
+    counter = pr_offset
+    for outcome, n in (
+        (OUTCOME_SUCCESS, success),
+        (OUTCOME_REVERT, revert),
+        (OUTCOME_INCIDENT, incident),
+        (OUTCOME_HUMAN_OVERRIDE, human_override),
+    ):
+        for _ in range(n):
+            counter += 1
+            store.record_outcome(
+                decision_id=f"d-{counter}-{outcome}",
+                auto_handle_path=AUTO_HANDLE_PATH_FIRE_AND_FORGET,
+                decision_class=decision_class,
+                outcome=outcome,
+                pr_number=counter,
+            )
+
+
+def test_iter_calibration_store_yields_only_failures() -> None:
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    _seed_calibration_store(store, success=5, revert=2, incident=1, human_override=1)
+    invalidations = list(iter_invalidations_from_calibration_store(store))
+    assert len(invalidations) == 4
+    signals = sorted(d.signals[0] for d in invalidations)
+    assert signals == sorted(
+        [
+            INVALIDATION_HUMAN_OVERRIDE_REDO,
+            INVALIDATION_POST_MERGE_INCIDENT,
+            INVALIDATION_REVERT_WITHIN_WINDOW,
+            INVALIDATION_REVERT_WITHIN_WINDOW,
+        ]
+    )
+    for d in invalidations:
+        assert d.was_auto_handled is True
+        assert d.was_human_settled is False
+        assert len(d.rationales) == 1
+        assert "calibration-store outcome" in d.rationales[0]
+
+
+def test_iter_calibration_store_outcome_to_signal_mapping() -> None:
+    """Each failure outcome maps to a distinct invalidation signal."""
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    _seed_calibration_store(store, revert=1, incident=1, human_override=1)
+    invalidations = list(iter_invalidations_from_calibration_store(store))
+    by_signal = {d.signals[0] for d in invalidations}
+    assert by_signal == {
+        INVALIDATION_REVERT_WITHIN_WINDOW,
+        INVALIDATION_POST_MERGE_INCIDENT,
+        INVALIDATION_HUMAN_OVERRIDE_REDO,
+    }
+
+
+def test_iter_calibration_store_empty_yields_nothing() -> None:
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    invalidations = list(iter_invalidations_from_calibration_store(store))
+    assert invalidations == []
+
+
+def test_iter_calibration_store_window_filter() -> None:
+    """When a window is provided, rows outside it are excluded."""
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    _seed_calibration_store(store, revert=3)
+    # Row decided_at is "now" (record_outcome calls time.time()), so a
+    # window ending well in the past must yield 0 rows.
+    long_ago = datetime(2000, 1, 1, tzinfo=UTC)
+    invalidations = list(
+        iter_invalidations_from_calibration_store(store, window_end=long_ago, window_days=30)
+    )
+    assert invalidations == []
+
+
+def test_iter_calibration_store_window_includes_current_rows() -> None:
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    _seed_calibration_store(store, revert=2)
+    # A window ending now should include the just-inserted rows
+    now = datetime.now(UTC)
+    invalidations = list(
+        iter_invalidations_from_calibration_store(store, window_end=now, window_days=30)
+    )
+    assert len(invalidations) == 2
+
+
+def test_iter_calibration_store_rejects_zero_window_days() -> None:
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    with pytest.raises(ValueError, match="window_days must be positive"):
+        list(iter_invalidations_from_calibration_store(store, window_days=0))
+
+
+# ---------------------------------------------------------------------------
+# Settlement-receipt side
+# ---------------------------------------------------------------------------
+
+
+def _write_receipt(
+    receipts_dir: Path,
+    *,
+    pr_number: int,
+    action: str = "approve",
+    reviewed_at: datetime | None = None,
+    extra: dict[str, Any] | None = None,
+) -> Path:
+    """Write a synthetic settlement-receipt JSON file."""
+    if reviewed_at is None:
+        reviewed_at = datetime.now(UTC)
+    payload: dict[str, Any] = {
+        "pr_number": pr_number,
+        "action": action,
+        "reviewed_at": reviewed_at.isoformat(),
+        "session_id": f"sess-{pr_number}",
+    }
+    if extra:
+        payload.update(extra)
+    path = receipts_dir / f"pr-{pr_number}-sess-{pr_number}-{action}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_count_decisions_from_receipts_basic(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    _write_receipt(receipts, pr_number=1, reviewed_at=now - timedelta(days=1))
+    _write_receipt(receipts, pr_number=2, reviewed_at=now - timedelta(days=10))
+    _write_receipt(receipts, pr_number=3, reviewed_at=now - timedelta(days=29))
+
+    total = count_decisions_from_settlement_receipts(
+        store_root=tmp_path / ".aragora" / "review-queue",
+        window_end=now,
+        window_days=30,
+    )
+    assert total == 3
+
+
+def test_count_decisions_from_receipts_window_excludes_old(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    _write_receipt(receipts, pr_number=1, reviewed_at=now - timedelta(days=1))
+    _write_receipt(receipts, pr_number=2, reviewed_at=now - timedelta(days=100))
+
+    total = count_decisions_from_settlement_receipts(
+        store_root=tmp_path / ".aragora" / "review-queue",
+        window_end=now,
+        window_days=30,
+    )
+    assert total == 1
+
+
+def test_count_decisions_from_receipts_handles_missing_dir(tmp_path: Path) -> None:
+    # The receipts dir does not exist yet
+    total = count_decisions_from_settlement_receipts(
+        store_root=tmp_path / "does-not-exist",
+        window_end=datetime.now(UTC),
+        window_days=30,
+    )
+    assert total == 0
+
+
+def test_count_decisions_skips_invalid_reviewed_at(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    _write_receipt(receipts, pr_number=1, reviewed_at=now)
+    bad_path = receipts / "pr-bad-sess-bad-approve.json"
+    bad_path.write_text(
+        json.dumps(
+            {
+                "pr_number": 99,
+                "action": "approve",
+                "reviewed_at": "not-a-real-iso-string",
+                "session_id": "x",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    total = count_decisions_from_settlement_receipts(
+        store_root=tmp_path / ".aragora" / "review-queue",
+        window_end=now,
+        window_days=30,
+    )
+    assert total == 1
+
+
+def test_count_decisions_skips_malformed_json(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    _write_receipt(receipts, pr_number=1, reviewed_at=now)
+    (receipts / "garbage.json").write_text("not json {", encoding="utf-8")
+
+    total = count_decisions_from_settlement_receipts(
+        store_root=tmp_path / ".aragora" / "review-queue",
+        window_end=now,
+        window_days=30,
+    )
+    assert total == 1
+
+
+def test_count_decisions_rejects_zero_window_days() -> None:
+    with pytest.raises(ValueError, match="window_days must be positive"):
+        count_decisions_from_settlement_receipts(
+            store_root=Path("/tmp"),
+            window_end=datetime.now(UTC),
+            window_days=0,
+        )
+
+
+def test_iter_settlement_receipts_yields_when_revert_recorded(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    settled = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    _write_receipt(
+        receipts,
+        pr_number=42,
+        reviewed_at=settled,
+        extra={"reverted_at": (settled + timedelta(days=3)).isoformat()},
+    )
+
+    invalidations = list(
+        iter_invalidations_from_settlement_receipts(
+            store_root=tmp_path / ".aragora" / "review-queue"
+        )
+    )
+    assert len(invalidations) == 1
+    inv = invalidations[0]
+    assert inv.was_human_settled is True
+    assert inv.was_auto_handled is False
+    assert INVALIDATION_REVERT_WITHIN_WINDOW in inv.signals
+
+
+def test_iter_settlement_receipts_yields_when_incident_recorded(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    _write_receipt(
+        receipts,
+        pr_number=43,
+        extra={"post_merge_incident": True},
+    )
+    invalidations = list(
+        iter_invalidations_from_settlement_receipts(
+            store_root=tmp_path / ".aragora" / "review-queue"
+        )
+    )
+    assert len(invalidations) == 1
+    assert invalidations[0].signals == (INVALIDATION_POST_MERGE_INCIDENT,)
+
+
+def test_iter_settlement_receipts_yields_when_redo_pr_recorded(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    _write_receipt(
+        receipts,
+        pr_number=44,
+        extra={"redo_pr": "synaptent/aragora#1234"},
+    )
+    invalidations = list(
+        iter_invalidations_from_settlement_receipts(
+            store_root=tmp_path / ".aragora" / "review-queue"
+        )
+    )
+    assert len(invalidations) == 1
+    inv = invalidations[0]
+    assert inv.signals == (INVALIDATION_HUMAN_OVERRIDE_REDO,)
+    assert "1234" in inv.rationales[0]
+
+
+def test_iter_settlement_receipts_no_signals_yields_nothing(tmp_path: Path) -> None:
+    """Plain receipts (no future-schema fields) yield no invalidations."""
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    for i in range(5):
+        _write_receipt(receipts, pr_number=100 + i)
+    invalidations = list(
+        iter_invalidations_from_settlement_receipts(
+            store_root=tmp_path / ".aragora" / "review-queue"
+        )
+    )
+    assert invalidations == []
+
+
+def test_iter_settlement_receipts_revert_outside_window_excluded(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    settled = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    _write_receipt(
+        receipts,
+        pr_number=200,
+        reviewed_at=settled,
+        # 30 days post-settlement is outside the 14-day default window
+        extra={"reverted_at": (settled + timedelta(days=30)).isoformat()},
+    )
+    invalidations = list(
+        iter_invalidations_from_settlement_receipts(
+            store_root=tmp_path / ".aragora" / "review-queue"
+        )
+    )
+    assert invalidations == []
+
+
+def test_iter_settlement_receipts_handles_missing_dir(tmp_path: Path) -> None:
+    invalidations = list(
+        iter_invalidations_from_settlement_receipts(store_root=tmp_path / "does-not-exist")
+    )
+    assert invalidations == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_review_queue_root
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_review_queue_root_explicit_override() -> None:
+    out = resolve_review_queue_root("/explicit/path")
+    assert out == Path("/explicit/path")
+
+
+def test_resolve_review_queue_root_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARAGORA_REVIEW_QUEUE_ROOT", "/from/env")
+    monkeypatch.delenv("ARAGORA_REVIEW_QUEUE_ROOT", raising=False)
+    monkeypatch.setenv("ARAGORA_REVIEW_QUEUE_ROOT", "/from/env")
+    out = resolve_review_queue_root()
+    assert out == Path("/from/env")
+
+
+def test_resolve_review_queue_root_walk_finds_aragora(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ARAGORA_REVIEW_QUEUE_ROOT", raising=False)
+    (tmp_path / ".aragora").mkdir()
+    nested = tmp_path / "nested" / "deeper"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    out = resolve_review_queue_root()
+    assert out == tmp_path / ".aragora" / "review-queue"
+
+
+# ---------------------------------------------------------------------------
+# measure_baseline_from_stores — integration of both sides
+# ---------------------------------------------------------------------------
+
+
+def test_measure_baseline_combines_calibration_and_receipts(tmp_path: Path) -> None:
+    # Auto-handle side: 50 success, 5 revert → 5/55 = 9.09%
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    _seed_calibration_store(store, success=50, revert=5)
+
+    # Human-settled side: 60 receipts (denominator); 0 numerator
+    # because plain receipts don't have invalidation fields
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    now = datetime.now(UTC)
+    for i in range(60):
+        _write_receipt(receipts, pr_number=i, reviewed_at=now - timedelta(days=1))
+
+    measurement = measure_baseline_from_stores(
+        calibration_store=store,
+        review_queue_root=tmp_path / ".aragora" / "review-queue",
+        window_end=now,
+        window_days=30,
+    )
+    assert measurement.total_human_settled == 60
+    # Auto-handle counts include success + failures
+    assert measurement.total_auto_handled == 55
+    assert measurement.invalidated_human_settled == 0
+    assert measurement.invalidated_auto_handled == 5
+
+    # Auto-handle rate is computed
+    assert measurement.auto_handle_rate == pytest.approx(5 / 55)
+    # Human baseline rate is 0 (no human invalidations yet) but sample
+    # size is acceptable
+    assert measurement.baseline_human_rate == pytest.approx(0.0)
+    assert measurement.sample_size_acceptable is True
+
+    # Note explicitly flags the schema gap so downstream consumers
+    # don't conflate "0 invalidations" with "0 measured rate"
+    assert "human_invalidations_source" in measurement.notes
+
+
+def test_measure_baseline_below_min_samples_marks_unacceptable(tmp_path: Path) -> None:
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    _seed_calibration_store(store, success=10, revert=1)
+
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    now = datetime.now(UTC)
+    for i in range(10):  # below default min 50
+        _write_receipt(receipts, pr_number=i, reviewed_at=now)
+
+    measurement = measure_baseline_from_stores(
+        calibration_store=store,
+        review_queue_root=tmp_path / ".aragora" / "review-queue",
+        window_end=now,
+        window_days=30,
+    )
+    assert measurement.sample_size_acceptable is False
+    assert "sample_size_acceptable" in measurement.notes
+
+
+def test_measure_baseline_no_data_returns_none_rates(tmp_path: Path) -> None:
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    measurement = measure_baseline_from_stores(
+        calibration_store=store,
+        review_queue_root=tmp_path / ".aragora" / "review-queue",
+        window_end=datetime.now(UTC),
+        window_days=30,
+    )
+    assert measurement.total_human_settled == 0
+    assert measurement.total_auto_handled == 0
+    assert measurement.baseline_human_rate is None
+    assert measurement.auto_handle_rate is None
+
+
+def test_measure_baseline_human_invalidation_picks_up_when_recorded(
+    tmp_path: Path,
+) -> None:
+    """When receipts grow invalidation fields, the numerator activates
+    without changing the public API."""
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    # 49 plain receipts + 3 with invalidation signals = 52 total
+    for i in range(49):
+        _write_receipt(receipts, pr_number=i, reviewed_at=now - timedelta(days=1))
+    settled = now - timedelta(days=2)
+    _write_receipt(
+        receipts,
+        pr_number=1001,
+        reviewed_at=settled,
+        extra={"reverted_at": (settled + timedelta(days=2)).isoformat()},
+    )
+    _write_receipt(receipts, pr_number=1002, reviewed_at=now, extra={"post_merge_incident": True})
+    _write_receipt(receipts, pr_number=1003, reviewed_at=now, extra={"redo_pr": "x/y#9"})
+
+    measurement = measure_baseline_from_stores(
+        calibration_store=store,
+        review_queue_root=tmp_path / ".aragora" / "review-queue",
+        window_end=now,
+        window_days=30,
+    )
+    assert measurement.total_human_settled == 52
+    assert measurement.invalidated_human_settled == 3
+    assert measurement.sample_size_acceptable is True
+    # 3/52 ≈ 5.77%
+    assert measurement.baseline_human_rate == pytest.approx(3 / 52)
+    # When the numerator is non-zero, the schema-gap note must NOT
+    # claim the source is missing
+    assert "human_invalidations_source" not in measurement.notes
+
+
+def test_measure_baseline_rejects_zero_window_days(tmp_path: Path) -> None:
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    with pytest.raises(ValueError, match="window_days must be positive"):
+        measure_baseline_from_stores(
+            calibration_store=store,
+            review_queue_root=tmp_path,
+            window_end=datetime.now(UTC),
+            window_days=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Schema-stability sanity
+# ---------------------------------------------------------------------------
+
+
+def test_invalidated_decisions_from_calibration_round_trip_to_dict() -> None:
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    _seed_calibration_store(store, revert=1)
+    invalidations = list(iter_invalidations_from_calibration_store(store))
+    assert len(invalidations) == 1
+    payload = invalidations[0].to_dict()
+    assert payload["was_auto_handled"] is True
+    assert payload["was_human_settled"] is False
+    assert payload["signals"] == [INVALIDATION_REVERT_WITHIN_WINDOW]
+    assert isinstance(payload["rationales"], list)
+
+
+def test_invalidated_decisions_from_receipt_round_trip_to_dict(tmp_path: Path) -> None:
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    settled = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    _write_receipt(
+        receipts,
+        pr_number=99,
+        reviewed_at=settled,
+        extra={"reverted_at": (settled + timedelta(days=2)).isoformat()},
+    )
+    invalidations = list(
+        iter_invalidations_from_settlement_receipts(
+            store_root=tmp_path / ".aragora" / "review-queue"
+        )
+    )
+    payload = invalidations[0].to_dict()
+    assert payload["was_human_settled"] is True
+    assert payload["was_auto_handled"] is False
+    assert payload["signals"] == [INVALIDATION_REVERT_WITHIN_WINDOW]
+    assert "decision_id" in payload
+    assert "settled_at" in payload
+
+
+def test_validates_inputs_consistently_with_phase_1() -> None:
+    """Spot-check that constructed InvalidatedDecision instances
+    satisfy the phase-1 validation rules."""
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    _seed_calibration_store(store, revert=1, incident=1, human_override=1)
+    for inv in iter_invalidations_from_calibration_store(store):
+        # phase-1 InvalidatedDecision constructor enforces both:
+        # (a) signals subset of INVALIDATION_SIGNALS
+        # (b) signals/rationales same length
+        assert isinstance(inv, InvalidatedDecision)


### PR DESCRIPTION
Phase 2 of #6375 (empirical threshold grounding). Phase 1 (#6602) landed the pure-function module; this PR connects it to the data already on disk.

## What lands

**`aragora/review/invalidation_event_source.py`** — read-only adapter:
- `iter_invalidations_from_calibration_store()` — yields one `InvalidatedDecision` per failure-outcome row in the auto-handle calibration store. Maps `OUTCOME_REVERT → INVALIDATION_REVERT_WITHIN_WINDOW`, `OUTCOME_INCIDENT → INVALIDATION_POST_MERGE_INCIDENT`, `OUTCOME_HUMAN_OVERRIDE → INVALIDATION_HUMAN_OVERRIDE_REDO`. Reuses the store's `_connection()` context manager for WAL/busy-timeout/row-factory consistency.
- `count_decisions_from_settlement_receipts()` — window-filtered receipt count (denominator for the human-settled rate). Skips malformed JSON / invalid `reviewed_at` with WARNING logs rather than poisoning the rolling-window query.
- `iter_invalidations_from_settlement_receipts()` — defensive lookups for future schema fields (`reverted_at`, `post_merge_incident`, `redo_pr`). Today's schema doesn't carry them, so this iterator yields nothing for plain receipts; growing the receipt schema is purely additive.
- `measure_baseline_from_stores()` — top-level glue. Combines both sides into one `BaselineMeasurement`; attaches `notes['human_invalidations_source']` when the human-side numerator is 0 by data availability so consumers can tell that apart from a measured zero rate.
- `resolve_review_queue_root()` — mirrors the metrics adapter's resolution order (override → env → walk-up → cwd).

**`tests/review/test_invalidation_event_source.py`** — 29 unit tests covering outcome-to-signal mapping, window filtering, malformed-JSON resilience, env-var resolution, future-schema activation, no-data and below-min-samples paths, and `to_dict()` round-trip.

**`aragora/review/__init__.py`** — re-exports the 5 new public symbols.

## Honest caveats

- Settlement-receipt schema does NOT yet carry post-settlement invalidation signals. Until it does, the human-side numerator is 0 by data availability, not by measurement. The notes map says so explicitly.
- Auto-handled outcomes DO carry the data (the calibration store's whole purpose) so they classify cleanly.

## What does NOT land here (deferred, by design)

- Step B (recalibration scheduler + `ThresholdUpdateReceipt`) — **codex owns**
- Step C (\`aragora review-queue baseline\` CLI) — separate PR after this lands
- Step D (replace the 5% literal in \`docs/THESIS.md\`) — needs real data first

## Validation

- \`pytest tests/review/\` → 237 passed (29 new + 208 existing, no regressions)
- \`pytest tests/triage/\` → 70 passed (this adapter touches `AutoHandleCalibrationStore` via `_connection`; no triage-side regressions)
- \`ruff check\` → clean
- \`mypy aragora/review/invalidation_event_source.py\` → no issues
- \`scripts/automation_pr_preflight.sh\` → ok

Refs gap #6375 step A; builds on #6602.