### PR TITLE
fix(automation): protect superseded outbox branches

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -252,6 +252,45 @@ def _outbox_payload_branch(payload: dict[str, Any]) -> str:
     return str(payload.get("branch") or "").strip()
 
 
+def _add_branch_reference(branches: set[str], value: Any) -> None:
+    if isinstance(value, str):
+        branch = value.strip()
+        if branch:
+            branches.add(branch)
+    elif isinstance(value, dict):
+        branch = str(value.get("branch") or "").strip()
+        if branch:
+            branches.add(branch)
+
+
+def _outbox_payload_branches(payload: dict[str, Any]) -> set[str]:
+    """Return primary and explicitly superseded branch references from a handoff."""
+
+    branches: set[str] = set()
+    _add_branch_reference(branches, _outbox_payload_branch(payload))
+
+    containers: list[dict[str, Any]] = [payload]
+    local_evidence = payload.get("local_evidence")
+    if isinstance(local_evidence, dict):
+        containers.insert(0, local_evidence)
+
+    for container in containers:
+        _add_branch_reference(branches, container.get("supersedes_branch"))
+        supersedes_branches = container.get("supersedes_branches")
+        if isinstance(supersedes_branches, list):
+            for item in supersedes_branches:
+                _add_branch_reference(branches, item)
+
+        supersedes = container.get("supersedes")
+        if isinstance(supersedes, list):
+            for item in supersedes:
+                _add_branch_reference(branches, item)
+        else:
+            _add_branch_reference(branches, supersedes)
+
+    return branches
+
+
 def terminal_receipted_handoff_branches(
     root: Path,
     *,
@@ -277,9 +316,7 @@ def terminal_receipted_handoff_branches(
         idempotency_key = str(payload.get("idempotency_key") or "").strip()
         if idempotency_key not in terminal_keys:
             continue
-        branch = _outbox_payload_branch(payload)
-        if branch:
-            branches.add(branch)
+        branches.update(_outbox_payload_branches(payload))
     return branches
 
 
@@ -305,9 +342,7 @@ def unresolved_outbox_handoff_branches(
         idempotency_key = str(payload.get("idempotency_key") or "").strip()
         if not idempotency_key or idempotency_key in terminal_keys:
             continue
-        branch = _outbox_payload_branch(payload)
-        if branch:
-            branches.add(branch)
+        branches.update(_outbox_payload_branches(payload))
     return branches
 
 

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -295,6 +295,134 @@ def test_audit_excludes_unresolved_outbox_handoffs_from_publishable_backlog(
     assert handed_off["category"] == "protected_handoff_outbox"
 
 
+def test_audit_treats_superseded_branch_as_unresolved_handoff(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    now = datetime.now(timezone.utc)
+    rows = [
+        _branch_row("codex/stale-original", committed_at=now),
+        _branch_row("codex/new-work", committed_at=now),
+    ]
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "refresh.json").write_text(
+        json.dumps(
+            {
+                "task": "Publish refreshed branch",
+                "requires_github": True,
+                "requested_action": "open_pr",
+                "repo": "synaptent/aragora",
+                "local_evidence": {
+                    "branch": "codex/stale-original-refresh",
+                    "head": "def456",
+                    "supersedes_branch": "codex/stale-original",
+                },
+                "validation": ["pytest tests/example.py -q"],
+                "idempotency_key": "open-pr-codex-stale-original-refresh-def456",
+                "created_at": "2026-04-24T16:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "local_branches", lambda _root, _prefix, _base: rows)
+    monkeypatch.setattr(mod, "remote_branch_names", lambda _root, _prefix: set())
+    monkeypatch.setattr(mod, "merged_branch_names", lambda _root, _base, _prefix: set())
+    monkeypatch.setattr(mod, "worktree_map", lambda _root: {})
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=2,
+    )
+
+    assert payload["summary"]["handoff_outbox_branches"] == 1
+    assert payload["summary"]["publishable_branch_backlog"] == 1
+    original = next(
+        record for record in payload["records"] if record["name"] == "codex/stale-original"
+    )
+    assert original["handoff_outbox_exists"] is True
+    assert original["category"] == "protected_handoff_outbox"
+
+
+def test_audit_treats_superseded_branch_as_terminal_receipt(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-stale-original-refresh-def456"
+    (outbox / "refresh.json").write_text(
+        json.dumps(
+            {
+                "task": "Publish refreshed branch",
+                "requires_github": True,
+                "requested_action": "open_pr",
+                "repo": "synaptent/aragora",
+                "local_evidence": {
+                    "branch": "codex/stale-original-refresh",
+                    "head": "def456",
+                    "supersedes": {"branch": "codex/stale-original", "head_sha": "abc123"},
+                },
+                "validation": ["pytest tests/example.py -q"],
+                "idempotency_key": key,
+                "created_at": "2026-04-24T16:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / f"{key}.json").write_text(
+        json.dumps({"idempotency_key": key, "status": "published"}),
+        encoding="utf-8",
+    )
+    _stub_git_inventory(monkeypatch, _branch_row("codex/stale-original"))
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=1,
+    )
+
+    assert payload["summary"]["handoff_receipted_branches"] == 1
+    assert payload["summary"]["publishable_branch_backlog"] == 0
+    assert payload["records"][0]["handoff_receipt_exists"] is True
+    assert payload["records"][0]["category"] == "protected_handoff_receipt"
+
+
 def test_audit_reads_top_level_branch_for_terminal_outbox_receipts(
     tmp_path: Path, monkeypatch: Any
 ) -> None:


### PR DESCRIPTION
## Summary

Backlog-audit protection for superseded automation handoffs:

- Reads explicit supersession references from unresolved outbox files and terminal receipts.
- Treats superseded branches as protected so cleanup does not discard older branches while a refreshed handoff still depends on them.
- Supports `supersedes_branch`, `supersedes_branches`, and structured `supersedes` entries from both top-level payload and `local_evidence`.

## Validation

- `python3 -m pytest tests/scripts/test_audit_codex_branch_backlog.py -q` -> 15 passed
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> pass

## Safety

Classification/protection only. No branch deletion, no worktree cleanup, no outbox mutation.
