### PR TITLE
ci: opt load tests into Node 24 actions runtime

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -25,6 +25,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.11'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   K6_DOCKER_IMAGE: grafana/k6:0.57.0
   K6_NO_USAGE_REPORT: "true"
   LOAD_HTTP_PORT: '18080'


### PR DESCRIPTION
## Summary

Opts the load-test workflow into GitHub's Node 24 JavaScript actions runtime before GitHub forces the migration.

## Changes

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to the load-test workflow environment.
- Keeps scope limited to the workflow that emitted the Node 20 deprecation warning.

## Validation

- Parsed `.github/workflows/load-tests.yml` with PyYAML and asserted the env flag.
- `actionlint .github/workflows/load-tests.yml`
- `git diff --check`
- commit hooks and pre-push hooks passed.
