### PR TITLE
fix(sdk): cover legacy marketplace listings aliases

### DIFF
--- a/sdk/python/aragora_sdk/namespaces/marketplace.py
+++ b/sdk/python/aragora_sdk/namespaces/marketplace.py
@@ -214,6 +214,30 @@ class MarketplaceAPI:
         """
         return self._client.request("GET", "/api/v1/marketplace/featured")
 
+    def list_listing_templates_legacy(
+        self,
+        category: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List templates through the legacy marketplace listings alias."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if category:
+            params["category"] = category
+        return self._client.request("GET", "/api/marketplace/listings", params=params)
+
+    def get_featured_listings_legacy(self) -> dict[str, Any]:
+        """Get featured templates through the legacy marketplace listings alias."""
+        return self._client.request("GET", "/api/marketplace/listings/featured")
+
+    def get_listing_stats_legacy(self) -> dict[str, Any]:
+        """Get marketplace listing stats through the legacy alias."""
+        return self._client.request("GET", "/api/marketplace/listings/stats")
+
+    def get_listing_legacy(self, listing_id: str) -> dict[str, Any]:
+        """Get a marketplace listing by ID through the legacy alias."""
+        return self._client.request("GET", f"/api/marketplace/listings/{listing_id}")
+
     def submit_review(
         self,
         template_id: str,
@@ -434,6 +458,30 @@ class AsyncMarketplaceAPI:
     async def get_featured(self) -> dict[str, Any]:
         """Get featured templates."""
         return await self._client.request("GET", "/api/v1/marketplace/featured")
+
+    async def list_listing_templates_legacy(
+        self,
+        category: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List templates through the legacy marketplace listings alias."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if category:
+            params["category"] = category
+        return await self._client.request("GET", "/api/marketplace/listings", params=params)
+
+    async def get_featured_listings_legacy(self) -> dict[str, Any]:
+        """Get featured templates through the legacy marketplace listings alias."""
+        return await self._client.request("GET", "/api/marketplace/listings/featured")
+
+    async def get_listing_stats_legacy(self) -> dict[str, Any]:
+        """Get marketplace listing stats through the legacy alias."""
+        return await self._client.request("GET", "/api/marketplace/listings/stats")
+
+    async def get_listing_legacy(self, listing_id: str) -> dict[str, Any]:
+        """Get a marketplace listing by ID through the legacy alias."""
+        return await self._client.request("GET", f"/api/marketplace/listings/{listing_id}")
 
     async def submit_review(
         self,

--- a/sdk/python/tests/test_cross_sdk_parity_routes.py
+++ b/sdk/python/tests/test_cross_sdk_parity_routes.py
@@ -45,9 +45,13 @@ class TestSyncParityRoutes:
             client.orchestration.get_status_v1_compat("req_legacy")
             client.orchestration.list_templates_v1_compat()
             client.marketplace.list_templates(category="ops", limit=5, offset=2)
+            client.marketplace.list_listing_templates_legacy(category="ops", limit=5, offset=2)
             client.marketplace.search_templates("risk", limit=3, offset=1)
             client.marketplace.get_template("tpl_123")
+            client.marketplace.get_listing_legacy("tpl_123")
             client.marketplace.get_template_reviews("tpl_123", limit=10, offset=0)
+            client.marketplace.get_featured_listings_legacy()
+            client.marketplace.get_listing_stats_legacy()
             client.marketplace.list_categories()
             client.marketplace.submit_review("tpl_123", 5, "Great template")
             client.marketplace.star_template("tpl_123")
@@ -117,15 +121,23 @@ class TestSyncParityRoutes:
                 ),
                 call(
                     "GET",
+                    "/api/marketplace/listings",
+                    params={"limit": 5, "offset": 2, "category": "ops"},
+                ),
+                call(
+                    "GET",
                     "/api/v2/marketplace/templates",
                     params={"q": "risk", "limit": 3, "offset": 1},
                 ),
                 call("GET", "/api/v2/marketplace/templates/tpl_123"),
+                call("GET", "/api/marketplace/listings/tpl_123"),
                 call(
                     "GET",
                     "/api/v2/marketplace/templates/tpl_123/ratings",
                     params={"limit": 10, "offset": 0},
                 ),
+                call("GET", "/api/marketplace/listings/featured"),
+                call("GET", "/api/marketplace/listings/stats"),
                 call("GET", "/api/v2/marketplace/categories"),
                 call(
                     "POST",
@@ -207,9 +219,13 @@ class TestAsyncParityRoutes:
                 await orchestration.get_status_v1_compat("req_legacy")
                 await orchestration.list_templates_v1_compat()
                 await marketplace.list_templates(category="ops", limit=5, offset=2)
+                await marketplace.list_listing_templates_legacy(category="ops", limit=5, offset=2)
                 await marketplace.search_templates("risk", limit=3, offset=1)
                 await marketplace.get_template("tpl_123")
+                await marketplace.get_listing_legacy("tpl_123")
                 await marketplace.get_template_reviews("tpl_123", limit=10, offset=0)
+                await marketplace.get_featured_listings_legacy()
+                await marketplace.get_listing_stats_legacy()
                 await marketplace.list_categories()
                 await marketplace.submit_review("tpl_123", 5, "Great template")
                 await marketplace.star_template("tpl_123")
@@ -282,15 +298,23 @@ class TestAsyncParityRoutes:
                     ),
                     call(
                         "GET",
+                        "/api/marketplace/listings",
+                        params={"limit": 5, "offset": 2, "category": "ops"},
+                    ),
+                    call(
+                        "GET",
                         "/api/v2/marketplace/templates",
                         params={"q": "risk", "limit": 3, "offset": 1},
                     ),
                     call("GET", "/api/v2/marketplace/templates/tpl_123"),
+                    call("GET", "/api/marketplace/listings/tpl_123"),
                     call(
                         "GET",
                         "/api/v2/marketplace/templates/tpl_123/ratings",
                         params={"limit": 10, "offset": 0},
                     ),
+                    call("GET", "/api/marketplace/listings/featured"),
+                    call("GET", "/api/marketplace/listings/stats"),
                     call("GET", "/api/v2/marketplace/categories"),
                     call(
                         "POST",

--- a/sdk/typescript/src/__tests__/core-namespaces.test.ts
+++ b/sdk/typescript/src/__tests__/core-namespaces.test.ts
@@ -629,6 +629,41 @@ describe('Core Namespace APIs', () => {
       expect(result.templates).toHaveLength(1);
     });
 
+    it('should call legacy marketplace listing aliases via namespace', async () => {
+      const client = createClient({ baseUrl: 'https://api.example.com' });
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ templates: [] })),
+      });
+
+      await client.marketplace.listListingsLegacy({ category: 'ops', limit: 5, offset: 2 });
+      await client.marketplace.getFeaturedListingsLegacy();
+      await client.marketplace.getListingStatsLegacy();
+      await client.marketplace.getListingLegacy('template-123');
+
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://api.example.com/api/marketplace/listings?category=ops&limit=5&offset=2',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://api.example.com/api/marketplace/listings/featured',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        3,
+        'https://api.example.com/api/marketplace/listings/stats',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        4,
+        'https://api.example.com/api/marketplace/listings/template-123',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
     it('should get template via namespace', async () => {
       const client = createClient({ baseUrl: 'https://api.example.com' });
 

--- a/sdk/typescript/src/namespaces/marketplace.ts
+++ b/sdk/typescript/src/namespaces/marketplace.ts
@@ -204,6 +204,49 @@ export class MarketplaceAPI {
   }
 
   /**
+   * List marketplace templates through the legacy listings alias.
+   *
+   * @param params - Filter and pagination options
+   * @returns List of templates matching the criteria
+   */
+  async listListingsLegacy(params?: MarketplaceListParams): Promise<{ templates: MarketplaceTemplate[] }> {
+    return this.client.request<{ templates: MarketplaceTemplate[] }>('GET', '/api/marketplace/listings', {
+      params: {
+        category: params?.category,
+        limit: params?.limit,
+        offset: params?.offset,
+      },
+    });
+  }
+
+  /**
+   * Get featured templates through the legacy listings alias.
+   */
+  async getFeaturedListingsLegacy(): Promise<{ templates: MarketplaceTemplate[] }> {
+    return this.client.request<{ templates: MarketplaceTemplate[] }>('GET', '/api/marketplace/listings/featured');
+  }
+
+  /**
+   * Get marketplace listing stats through the legacy listings alias.
+   */
+  async getListingStatsLegacy(): Promise<Record<string, unknown>> {
+    return this.client.request<Record<string, unknown>>('GET', '/api/marketplace/listings/stats');
+  }
+
+  /**
+   * Get a marketplace listing by ID through the legacy listings alias.
+   *
+   * @param listingId - The listing ID
+   * @returns The template details
+   */
+  async getListingLegacy(listingId: string): Promise<MarketplaceTemplate> {
+    return this.client.request<MarketplaceTemplate>(
+      'GET',
+      `/api/marketplace/listings/${encodeURIComponent(listingId)}`
+    );
+  }
+
+  /**
    * Get trending templates based on recent activity.
    *
    * @returns List of trending templates


### PR DESCRIPTION
## Summary

SDK parity salvage for legacy marketplace listing aliases:

- Adds Python sync/async namespace methods for `/api/marketplace/listings*` legacy aliases.
- Adds TypeScript namespace methods for the same legacy listing aliases.
- Extends Python parity and TypeScript namespace tests so the legacy endpoints stay covered.

## Validation

- `python3 -m pytest sdk/python/tests/test_cross_sdk_parity_routes.py -q` -> 2 passed
- `python3 -m ruff check sdk/python/aragora_sdk/namespaces/marketplace.py sdk/python/tests/test_cross_sdk_parity_routes.py` -> pass
- `git diff --check` -> pass
- GitHub checks are green/no pending at review time.

## Local TypeScript Note

Local TS validation could not be completed in this worktree: `vitest` was not installed, and local `npm --prefix sdk/typescript run typecheck` used an incompatible/global TypeScript surface (`TS5103: Invalid value for --ignoreDeprecations`). The PR's GitHub TypeScript SDK checks are green.
