### PR TITLE
fix(automation): exclude diverged branches from publishable backlog

### DIFF
--- a/docs/briefs/automation-merge-contract.md
+++ b/docs/briefs/automation-merge-contract.md
@@ -81,7 +81,7 @@ The bridge intentionally does not use browser fallback. Browser profiles can be 
 
 The publisher bridge now has an explicit GitHub health probe at `scripts/github_cli_health.py`. Sandboxed coding automations should treat a failed probe as a hard boundary and switch into handoff-only mode immediately instead of retrying `gh issue create`, `gh pr create`, `gh workflow run`, or merge-watch commands from inside the sandbox.
 
-Do not use a raw local `git branch --list 'codex/*'` count as the unpublished-work backlog gate. Local developer machines can retain thousands of stale historical `codex/*` refs that are already merged, patch-equivalent, or local-only archaeology. Use `python3 scripts/audit_codex_branch_backlog.py --json` and gate on `summary.publishable_branch_backlog` instead. That metric counts recent unique local work and stale unique remote branches, but intentionally excludes stale local-only refs so writer automations keep producing useful local code when GitHub is sandboxed.
+Do not use a raw local `git branch --list 'codex/*'` count as the unpublished-work backlog gate. Local developer machines can retain thousands of stale historical `codex/*` refs that are already merged, patch-equivalent, diverged from the current base, or local-only archaeology. Use `python3 scripts/audit_codex_branch_backlog.py --json` and gate on `summary.publishable_branch_backlog` instead. That metric counts recent unique local work and stale unique remote branches that are not behind the base, but intentionally excludes stale local-only refs and diverged repair candidates so writer automations keep producing useful local code when GitHub is sandboxed.
 
 For steady local operation, install the publisher bridge as a LaunchAgent from a normal user shell:
 

--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -43,6 +43,7 @@ class BranchRecord:
     committed_at: str
     subject: str
     ahead_count: int
+    behind_count: int
     merged_to_base: bool
     patch_equivalent_to_base: bool
     remote_branch_exists: bool
@@ -106,14 +107,15 @@ def local_branches(root: Path, prefix: str, base: str) -> list[dict[str, str]]:
         if not line.strip():
             continue
         name, upstream, head_sha, committed_at, ahead_behind, subject = line.split("|", 5)
-        ahead_count = ahead_behind.split(" ", 1)[0] or "0"
+        ahead_count, _, behind_count = ahead_behind.partition(" ")
         rows.append(
             {
                 "name": name,
                 "upstream": upstream,
                 "head_sha": head_sha,
                 "committed_at": committed_at,
-                "ahead_count": ahead_count,
+                "ahead_count": ahead_count or "0",
+                "behind_count": behind_count or "0",
                 "subject": subject,
             }
         )
@@ -378,6 +380,7 @@ def classify(
     active_paths: list[str],
     dirty_paths: list[str],
     ahead_count: int,
+    behind_count: int,
     merged_to_base: bool,
     patch_equivalent_to_base: bool,
     handoff_receipt_exists: bool,
@@ -400,6 +403,12 @@ def classify(
         return "protected_handoff_receipt"
     if handoff_outbox_exists:
         return "protected_handoff_outbox"
+    if behind_count > 0:
+        if committed_at >= recent_cutoff:
+            return "salvage_diverged_recent"
+        if remote_branch_exists:
+            return "salvage_diverged_remote"
+        return "salvage_diverged_local"
     if committed_at >= recent_cutoff:
         return "salvage_recent_unique"
     if remote_branch_exists:
@@ -455,6 +464,10 @@ def audit(
             ahead_count = int(row["ahead_count"])
         except ValueError:
             ahead_count = count_ahead(root, base, branch)
+        try:
+            behind_count = int(row.get("behind_count", "0"))
+        except ValueError:
+            behind_count = 0
         merged_to_base = branch in merged_branches
         patch_equivalent = False
         if include_patch_equivalence and ahead_count > 0 and not merged_to_base:
@@ -467,6 +480,7 @@ def audit(
             active_paths=active_paths,
             dirty_paths=dirty_paths,
             ahead_count=ahead_count,
+            behind_count=behind_count,
             merged_to_base=merged_to_base,
             patch_equivalent_to_base=patch_equivalent,
             handoff_receipt_exists=handoff_receipted,
@@ -483,6 +497,7 @@ def audit(
                 committed_at=committed_at.isoformat(),
                 subject=row["subject"],
                 ahead_count=ahead_count,
+                behind_count=behind_count,
                 merged_to_base=merged_to_base,
                 patch_equivalent_to_base=patch_equivalent,
                 remote_branch_exists=remote_exists,
@@ -509,6 +524,14 @@ def audit(
         counts["salvage_recent_unique"]
         + counts["salvage_stale_remote_unique"]
         + counts["salvage_stale_local_unique"]
+        + counts["salvage_diverged_recent"]
+        + counts["salvage_diverged_remote"]
+        + counts["salvage_diverged_local"]
+    )
+    diverged_salvage = (
+        counts["salvage_diverged_recent"]
+        + counts["salvage_diverged_remote"]
+        + counts["salvage_diverged_local"]
     )
     publishable_branch_backlog = (
         counts["salvage_recent_unique"] + counts["salvage_stale_remote_unique"]
@@ -530,6 +553,7 @@ def audit(
             "protected": protected,
             "salvage_candidates": salvage,
             "publishable_branch_backlog": publishable_branch_backlog,
+            "diverged_salvage_candidates": diverged_salvage,
             "stale_local_only_salvage_candidates": counts["salvage_stale_local_unique"],
             "handoff_receipted_branches": counts["protected_handoff_receipt"],
             "handoff_outbox_branches": counts["protected_handoff_outbox"],
@@ -551,6 +575,7 @@ def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
     print(f"- Safe cleanup candidates: `{summary['safe_cleanup_candidates']}`")
     print(f"- Salvage candidates: `{summary['salvage_candidates']}`")
     print(f"- Publishable branch backlog: `{summary['publishable_branch_backlog']}`")
+    print(f"- Diverged salvage candidates: `{summary['diverged_salvage_candidates']}`")
     print(f"- Handoff-receipted branches: `{summary['handoff_receipted_branches']}`")
     print(f"- Handoff-outbox branches: `{summary['handoff_outbox_branches']}`")
     print(
@@ -567,6 +592,9 @@ def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
         "salvage_recent_unique",
         "salvage_stale_remote_unique",
         "salvage_stale_local_unique",
+        "salvage_diverged_recent",
+        "salvage_diverged_remote",
+        "salvage_diverged_local",
         "cleanup_local_merged",
         "cleanup_patch_equivalent",
         "protected_open_pr",
@@ -583,6 +611,7 @@ def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
             print(
                 f"- `{record['name']}` "
                 f"ahead={record['ahead_count']} "
+                f"behind={record['behind_count']} "
                 f"sha={record['head_sha']} "
                 f"subject={record['subject']}"
             )

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -15,13 +15,16 @@ def _branch_row(
     name: str = "codex/example",
     *,
     committed_at: datetime | None = None,
+    ahead_count: str = "1",
+    behind_count: str = "0",
 ) -> dict[str, str]:
     return {
         "name": name,
         "upstream": "",
         "head_sha": "abc1234",
         "committed_at": (committed_at or datetime.now(timezone.utc)).isoformat(),
-        "ahead_count": "1",
+        "ahead_count": ahead_count,
+        "behind_count": behind_count,
         "subject": "test branch",
     }
 
@@ -154,6 +157,64 @@ def test_audit_publishable_backlog_excludes_stale_local_only_branches(
     assert payload["summary"]["publishable_branch_backlog"] == 2
     assert payload["summary"]["stale_local_only_salvage_candidates"] == 1
     assert payload["summary"]["writer_should_pause_for_branch_backlog"] is False
+
+
+def test_audit_excludes_diverged_branches_from_publishable_backlog(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    now = datetime.now(timezone.utc)
+    rows = [
+        _branch_row("codex/recent-ready", committed_at=now),
+        _branch_row("codex/recent-diverged", committed_at=now, behind_count="12"),
+        _branch_row(
+            "codex/stale-remote-diverged",
+            committed_at=now.replace(year=now.year - 1),
+            behind_count="4",
+        ),
+    ]
+    monkeypatch.setattr(mod, "local_branches", lambda _root, _prefix, _base: rows)
+    monkeypatch.setattr(
+        mod, "remote_branch_names", lambda _root, _prefix: {"codex/stale-remote-diverged"}
+    )
+    monkeypatch.setattr(mod, "merged_branch_names", lambda _root, _base, _prefix: set())
+    monkeypatch.setattr(mod, "worktree_map", lambda _root: {})
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=2,
+    )
+
+    by_category = payload["summary"]["by_category"]
+    assert by_category["salvage_recent_unique"] == 1
+    assert by_category["salvage_diverged_recent"] == 1
+    assert by_category["salvage_diverged_remote"] == 1
+    assert payload["summary"]["salvage_candidates"] == 3
+    assert payload["summary"]["publishable_branch_backlog"] == 1
+    assert payload["summary"]["diverged_salvage_candidates"] == 2
+    assert payload["summary"]["writer_should_pause_for_branch_backlog"] is False
+    diverged = next(
+        record for record in payload["records"] if record["name"] == "codex/recent-diverged"
+    )
+    assert diverged["behind_count"] == 12
+    assert diverged["category"] == "salvage_diverged_recent"
 
 
 def test_audit_excludes_terminal_outbox_receipts_from_publishable_backlog(


### PR DESCRIPTION
## Summary

Backlog-audit correction for branch/worktree drain:

- Tracks both ahead and behind counts for `codex/*` branches.
- Classifies behind/diverged branches separately as `salvage_diverged_*`.
- Keeps diverged repair candidates visible as salvage, but excludes them from `publishable_branch_backlog` so writer automations do not pause solely because stale/diverged local work exists.
- Updates the automation merge contract to document the distinction.

## Validation

- `python3 -m pytest tests/scripts/test_audit_codex_branch_backlog.py -q` -> 13 passed
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> pass

## Safety

Classification-only. No branch deletion, no worktree cleanup, no outbox mutation.
