### PR TITLE
fix(automation): skip patch-equivalent outbox handoffs

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -38,6 +38,7 @@ MAX_ISSUE_BODY_CHARS = 60_000
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_BASE_REF = "origin/main"
+PR_OPEN_REQUEST_ACTIONS = {"open_pr", "push_branch_and_open_pr"}
 REQUIRED_OUTBOX_KEYS = (
     "task",
     "requires_github",
@@ -523,7 +524,7 @@ def _git_patch_equivalent(repo_root: Path, base: str, candidate: str) -> bool:
 
 def _outbox_branch_already_merged(repo_root: Path, payload: dict[str, Any]) -> bool:
     requested_action = str(payload.get("requested_action") or "").strip()
-    if requested_action != "open_pr":
+    if requested_action not in PR_OPEN_REQUEST_ACTIONS:
         return False
 
     base_ref = _outbox_evidence_value(payload, "base") or DEFAULT_BASE_REF
@@ -544,7 +545,7 @@ def _outbox_branch_already_merged(repo_root: Path, payload: dict[str, Any]) -> b
 
 def _outbox_branch_patch_equivalent(repo_root: Path, payload: dict[str, Any]) -> bool:
     requested_action = str(payload.get("requested_action") or "").strip()
-    if requested_action != "open_pr":
+    if requested_action not in PR_OPEN_REQUEST_ACTIONS:
         return False
 
     base_ref = _outbox_evidence_value(payload, "base") or DEFAULT_BASE_REF

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -507,6 +507,20 @@ def _git_is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
     return proc.returncode == 0
 
 
+def _git_patch_equivalent(repo_root: Path, base: str, candidate: str) -> bool:
+    diff_proc = _run(["git", "diff", "--quiet", f"{base}...{candidate}"], cwd=repo_root)
+    if diff_proc.returncode == 0:
+        return True
+    if diff_proc.returncode != 1:
+        return False
+
+    proc = _run(["git", "cherry", base, candidate], cwd=repo_root)
+    if proc.returncode != 0:
+        return False
+    statuses = [line[:1] for line in proc.stdout.splitlines() if line.strip()]
+    return bool(statuses) and all(status == "-" for status in statuses)
+
+
 def _outbox_branch_already_merged(repo_root: Path, payload: dict[str, Any]) -> bool:
     requested_action = str(payload.get("requested_action") or "").strip()
     if requested_action != "open_pr":
@@ -524,6 +538,27 @@ def _outbox_branch_already_merged(repo_root: Path, payload: dict[str, Any]) -> b
     ]
     for candidate in dict.fromkeys(item for item in candidates if item):
         if _git_is_ancestor(repo_root, candidate, base_ref):
+            return True
+    return False
+
+
+def _outbox_branch_patch_equivalent(repo_root: Path, payload: dict[str, Any]) -> bool:
+    requested_action = str(payload.get("requested_action") or "").strip()
+    if requested_action != "open_pr":
+        return False
+
+    base_ref = _outbox_evidence_value(payload, "base") or DEFAULT_BASE_REF
+    if not base_ref:
+        return False
+
+    candidates = [
+        _outbox_evidence_value(payload, "branch"),
+        _outbox_evidence_value(payload, "head"),
+        _outbox_evidence_value(payload, "head_sha"),
+        _outbox_evidence_value(payload, "commit"),
+    ]
+    for candidate in dict.fromkeys(item for item in candidates if item):
+        if _git_patch_equivalent(repo_root, base_ref, candidate):
             return True
     return False
 
@@ -644,6 +679,8 @@ def load_outbox_handoffs(
         if branch_fingerprint and branch_fingerprint in terminal_fingerprints:
             continue
         if _outbox_branch_already_merged(repo_root, payload):
+            continue
+        if _outbox_branch_patch_equivalent(repo_root, payload):
             continue
         handoff = Handoff(
             source_file=str(source_file),

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -85,6 +85,37 @@ def _repo_with_merged_codex_branch(tmp_path: Path) -> tuple[Path, str]:
     return repo, head
 
 
+def _repo_with_patch_equivalent_codex_branch(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return proc.stdout.strip()
+
+    git("init")
+    git("checkout", "-b", "main")
+    git("config", "user.email", "codex@example.com")
+    git("config", "user.name", "Codex")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    git("add", "README.md")
+    git("commit", "-m", "base")
+    git("checkout", "-b", "codex/example")
+    (repo / "README.md").write_text("base\nbranch change\n", encoding="utf-8")
+    git("commit", "-am", "change from branch")
+    head = git("rev-parse", "HEAD")
+    git("checkout", "main")
+    (repo / "README.md").write_text("base\nbranch change\n", encoding="utf-8")
+    git("commit", "-am", "same change from main")
+    return repo, head
+
+
 def test_load_handoffs_parses_structured_memory(tmp_path: Path) -> None:
     _memory(tmp_path, "founder-review", _handoff())
 
@@ -360,6 +391,28 @@ def test_load_outbox_handoffs_skips_already_merged_top_level_head(tmp_path: Path
                 branch="codex/example",
                 head_sha=head,
                 base="main",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert mod.load_outbox_handoffs(repo) == []
+
+
+def test_load_outbox_handoffs_skips_patch_equivalent_branch(tmp_path: Path) -> None:
+    repo, head = _repo_with_patch_equivalent_codex_branch(tmp_path)
+    outbox = repo / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "patch-equivalent.json").write_text(
+        json.dumps(
+            _outbox_payload(
+                repo="synaptent/aragora",
+                idempotency_key="open-pr-codex-example-patch-equivalent",
+                local_evidence={
+                    "branch": "codex/example",
+                    "head_sha": head,
+                    "base": "main",
+                },
             )
         ),
         encoding="utf-8",

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -421,6 +421,29 @@ def test_load_outbox_handoffs_skips_patch_equivalent_branch(tmp_path: Path) -> N
     assert mod.load_outbox_handoffs(repo) == []
 
 
+def test_load_outbox_handoffs_skips_merged_push_branch_request(tmp_path: Path) -> None:
+    repo, head = _repo_with_merged_codex_branch(tmp_path)
+    outbox = repo / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "merged-push.json").write_text(
+        json.dumps(
+            _outbox_payload(
+                repo="synaptent/aragora",
+                requested_action="push_branch_and_open_pr",
+                idempotency_key="open-pr-codex-example-merged-push",
+                local_evidence={
+                    "branch": "codex/example",
+                    "head_sha": head,
+                    "base": "main",
+                },
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert mod.load_outbox_handoffs(repo) == []
+
+
 def test_load_outbox_handoffs_skips_non_github_and_expired(tmp_path: Path) -> None:
     outbox = tmp_path / ".aragora" / "automation-outbox"
     outbox.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Queue-drain publisher hardening for automation outbox handoffs:

- Skips outbox handoffs whose branch is patch-equivalent to the base branch, preventing duplicate publication after equivalent work already landed.
- Treats both `open_pr` and `push_branch_and_open_pr` as PR-opening actions for merged/patch-equivalent skip logic.
- Supersedes #6611 by including its `push_branch_and_open_pr` merged-branch regression test in this branch.

## Validation

- `python3 -m pytest tests/scripts/test_publish_automation_handoffs.py -q` -> 30 passed
- `python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` -> pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok
- `git diff --check` -> pass

## Safety

No branch deletion, no outbox mutation, no GitHub publication side effects. This only filters stale handoffs before publication.
