### PR TITLE
feat(review): per-class invalidation numerator (#6608 step D)

### DIFF
--- a/aragora/review/invalidation.py
+++ b/aragora/review/invalidation.py
@@ -169,6 +169,7 @@ class InvalidatedDecision:
     rationales: tuple[str, ...]  # parallel to signals
     was_human_settled: bool
     was_auto_handled: bool
+    decision_class: str | None = None  # optional taxonomy class for per-class breakdown
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "signals", tuple(self.signals))
@@ -202,6 +203,7 @@ class InvalidatedDecision:
             "rationales": list(self.rationales),
             "was_human_settled": bool(self.was_human_settled),
             "was_auto_handled": bool(self.was_auto_handled),
+            "decision_class": self.decision_class,
         }
 
 
@@ -339,6 +341,7 @@ def classify_invalidation(
     pr_reopened: bool = False,
     human_override_redo_pr: str | None = None,
     revert_window_days: int = DEFAULT_REVERT_WINDOW_DAYS,
+    decision_class: str | None = None,
 ) -> InvalidatedDecision | None:
     """Classify a settled decision against the invalidation vocabulary.
 
@@ -421,6 +424,7 @@ def classify_invalidation(
         rationales=tuple(rationales),
         was_human_settled=bool(was_human_settled),
         was_auto_handled=bool(was_auto_handled),
+        decision_class=decision_class,
     )
 
 
@@ -548,24 +552,82 @@ def compute_baseline(
     per_class_human_breakdown: dict[str, tuple[int, int]] = {}
     per_class_auto_breakdown: dict[str, tuple[int, int]] = {}
 
-    # Group classified invalidations by an implicit decision_class field.
-    # Since InvalidatedDecision does not carry class today, callers are
-    # expected to embed it via the decision_id prefix when needed; for
-    # this phase 1 module, per-class breakdown is populated only when
-    # the caller passes per-class denominators. The numerator side
-    # remains a follow-up (issue #6375 work breakdown step 2 sub-bullet
-    # "split by decision class where the sample supports it").
+    per_class_human_numerator: dict[str, int] = {}
+    per_class_auto_numerator: dict[str, int] = {}
+    untyped_human_invalidations = 0
+    untyped_auto_invalidations = 0
+    for d in invalidations:
+        if d.decision_class is None:
+            if d.was_human_settled:
+                untyped_human_invalidations += 1
+            else:
+                untyped_auto_invalidations += 1
+            continue
+        if d.was_human_settled:
+            per_class_human_numerator[d.decision_class] = (
+                per_class_human_numerator.get(d.decision_class, 0) + 1
+            )
+        else:
+            per_class_auto_numerator[d.decision_class] = (
+                per_class_auto_numerator.get(d.decision_class, 0) + 1
+            )
+
     if per_class_human:
         for cls, total in per_class_human.items():
-            per_class_human_breakdown[cls] = (0, int(total))
+            per_class_human_breakdown[cls] = (
+                per_class_human_numerator.get(cls, 0),
+                int(total),
+            )
     if per_class_auto:
         for cls, total in per_class_auto.items():
-            per_class_auto_breakdown[cls] = (0, int(total))
+            per_class_auto_breakdown[cls] = (
+                per_class_auto_numerator.get(cls, 0),
+                int(total),
+            )
 
-    if (per_class_human or per_class_auto) and "per_class_breakdown_numerator" not in notes:
+    typed_human_total = sum(per_class_human_numerator.values())
+    typed_auto_total = sum(per_class_auto_numerator.values())
+    if (per_class_human or per_class_auto) and (typed_human_total or typed_auto_total):
+        unmatched_human = (
+            sum(
+                count
+                for cls, count in per_class_human_numerator.items()
+                if cls not in (per_class_human or {})
+            )
+            if per_class_human
+            else typed_human_total
+        )
+        unmatched_auto = (
+            sum(
+                count
+                for cls, count in per_class_auto_numerator.items()
+                if cls not in (per_class_auto or {})
+            )
+            if per_class_auto
+            else typed_auto_total
+        )
+        if (
+            unmatched_human
+            or unmatched_auto
+            or untyped_human_invalidations
+            or untyped_auto_invalidations
+        ):
+            parts: list[str] = []
+            if untyped_human_invalidations or untyped_auto_invalidations:
+                parts.append(
+                    f"{untyped_human_invalidations} human + {untyped_auto_invalidations} auto "
+                    "invalidations carry no decision_class and are excluded from the breakdown"
+                )
+            if unmatched_human or unmatched_auto:
+                parts.append(
+                    f"{unmatched_human} human + {unmatched_auto} auto invalidations have classes "
+                    "absent from the per-class denominator inputs and are excluded"
+                )
+            notes["per_class_breakdown_coverage"] = "; ".join(parts)
+    elif (per_class_human or per_class_auto) and not (typed_human_total or typed_auto_total):
         notes["per_class_breakdown_numerator"] = (
-            "per-class invalidation numerators are 0 in phase 1; "
-            "follow-up PR will plumb decision_class through InvalidatedDecision"
+            "per-class denominators provided but no invalidation in window carries a "
+            "decision_class — pass decision_class to classify_invalidation to populate numerators"
         )
 
     if not sample_size_acceptable:
@@ -749,6 +811,11 @@ def _decision_from_dict(payload: dict[str, Any]) -> InvalidatedDecision:
             rationales=tuple(payload.get("rationales", ())),
             was_human_settled=bool(payload.get("was_human_settled", False)),
             was_auto_handled=bool(payload.get("was_auto_handled", False)),
+            decision_class=(
+                str(payload["decision_class"])
+                if payload.get("decision_class") is not None
+                else None
+            ),
         )
     except KeyError as exc:
         raise ValueError(

--- a/tests/review/test_invalidation.py
+++ b/tests/review/test_invalidation.py
@@ -667,3 +667,312 @@ def test_full_pipeline_auto_handled_path_below_baseline() -> None:
     # Auto-handle rate currently at threshold — borderline, would alert
     # in a realistic monitor.
     assert measurement.auto_handle_rate == pytest.approx(proposal.threshold)
+
+
+# --------------------------------------------------------------------------
+# Step D: per-class invalidation numerator (gap #6608 step D)
+# --------------------------------------------------------------------------
+
+
+def test_invalidated_decision_decision_class_defaults_to_none():
+    now = datetime.now(timezone.utc)
+    decision = InvalidatedDecision(
+        decision_id="d1",
+        settled_at=now,
+        signals=(INVALIDATION_REVERT_WITHIN_WINDOW,),
+        rationales=("test",),
+        was_human_settled=True,
+        was_auto_handled=False,
+    )
+    assert decision.decision_class is None
+
+
+def test_invalidated_decision_to_dict_includes_decision_class():
+    now = datetime.now(timezone.utc)
+    decision = InvalidatedDecision(
+        decision_id="d1",
+        settled_at=now,
+        signals=(INVALIDATION_REVERT_WITHIN_WINDOW,),
+        rationales=("test",),
+        was_human_settled=True,
+        was_auto_handled=False,
+        decision_class="small-bugfix",
+    )
+    payload = decision.to_dict()
+    assert payload["decision_class"] == "small-bugfix"
+
+
+def test_invalidated_decision_to_dict_serialises_none_decision_class():
+    now = datetime.now(timezone.utc)
+    decision = InvalidatedDecision(
+        decision_id="d1",
+        settled_at=now,
+        signals=(INVALIDATION_REVERT_WITHIN_WINDOW,),
+        rationales=("test",),
+        was_human_settled=True,
+        was_auto_handled=False,
+    )
+    assert "decision_class" in decision.to_dict()
+    assert decision.to_dict()["decision_class"] is None
+
+
+def test_classify_invalidation_propagates_decision_class():
+    now = datetime.now(timezone.utc)
+    decision = classify_invalidation(
+        decision_id="d1",
+        settled_at=now,
+        was_human_settled=True,
+        was_auto_handled=False,
+        reverted_at=now,
+        decision_class="big-refactor",
+    )
+    assert decision is not None
+    assert decision.decision_class == "big-refactor"
+
+
+def test_classify_invalidation_decision_class_remains_none_by_default():
+    now = datetime.now(timezone.utc)
+    decision = classify_invalidation(
+        decision_id="d1",
+        settled_at=now,
+        was_human_settled=True,
+        was_auto_handled=False,
+        reverted_at=now,
+    )
+    assert decision is not None
+    assert decision.decision_class is None
+
+
+def test_compute_baseline_populates_per_class_human_numerator_when_decisions_carry_class():
+    now = datetime.now(timezone.utc)
+    decisions = [
+        InvalidatedDecision(
+            "d1",
+            now,
+            (INVALIDATION_REVERT_WITHIN_WINDOW,),
+            ("r",),
+            True,
+            False,
+            decision_class="bugfix",
+        ),
+        InvalidatedDecision(
+            "d2",
+            now,
+            (INVALIDATION_REVERT_WITHIN_WINDOW,),
+            ("r",),
+            True,
+            False,
+            decision_class="bugfix",
+        ),
+        InvalidatedDecision(
+            "d3",
+            now,
+            (INVALIDATION_REVERT_WITHIN_WINDOW,),
+            ("r",),
+            True,
+            False,
+            decision_class="refactor",
+        ),
+    ]
+    measurement = compute_baseline(
+        decisions,
+        total_human_settled=200,
+        total_auto_handled=0,
+        window_end=now,
+        per_class_human={"bugfix": 100, "refactor": 60, "docs": 40},
+    )
+    assert measurement.per_class_human == {
+        "bugfix": (2, 100),
+        "refactor": (1, 60),
+        "docs": (0, 40),
+    }
+
+
+def test_compute_baseline_populates_per_class_auto_numerator_when_decisions_carry_class():
+    now = datetime.now(timezone.utc)
+    decisions = [
+        InvalidatedDecision(
+            "a1",
+            now,
+            (INVALIDATION_ROLLBACK,),
+            ("r",),
+            False,
+            True,
+            decision_class="auto-merge",
+        ),
+        InvalidatedDecision(
+            "a2",
+            now,
+            (INVALIDATION_ROLLBACK,),
+            ("r",),
+            False,
+            True,
+            decision_class="auto-merge",
+        ),
+    ]
+    measurement = compute_baseline(
+        decisions,
+        total_human_settled=DEFAULT_MIN_BASELINE_SAMPLES,
+        total_auto_handled=50,
+        window_end=now,
+        per_class_auto={"auto-merge": 30, "auto-decline": 20},
+    )
+    assert measurement.per_class_auto == {
+        "auto-merge": (2, 30),
+        "auto-decline": (0, 20),
+    }
+
+
+def test_compute_baseline_emits_coverage_note_when_invalidations_lack_decision_class():
+    now = datetime.now(timezone.utc)
+    decisions = [
+        InvalidatedDecision(
+            "typed",
+            now,
+            (INVALIDATION_REVERT_WITHIN_WINDOW,),
+            ("r",),
+            True,
+            False,
+            decision_class="bugfix",
+        ),
+        InvalidatedDecision(
+            "untyped",
+            now,
+            (INVALIDATION_REVERT_WITHIN_WINDOW,),
+            ("r",),
+            True,
+            False,
+        ),
+    ]
+    measurement = compute_baseline(
+        decisions,
+        total_human_settled=200,
+        total_auto_handled=0,
+        window_end=now,
+        per_class_human={"bugfix": 100},
+    )
+    assert "per_class_breakdown_coverage" in measurement.notes
+    assert (
+        "1 human + 0 auto invalidations carry no decision_class"
+        in (measurement.notes["per_class_breakdown_coverage"])
+    )
+
+
+def test_compute_baseline_emits_coverage_note_for_unmatched_classes():
+    now = datetime.now(timezone.utc)
+    decisions = [
+        InvalidatedDecision(
+            "d1",
+            now,
+            (INVALIDATION_REVERT_WITHIN_WINDOW,),
+            ("r",),
+            True,
+            False,
+            decision_class="ghost-class",
+        ),
+    ]
+    measurement = compute_baseline(
+        decisions,
+        total_human_settled=200,
+        total_auto_handled=0,
+        window_end=now,
+        per_class_human={"bugfix": 100},  # ghost-class is not here
+    )
+    assert "per_class_breakdown_coverage" in measurement.notes
+    assert (
+        "absent from the per-class denominator inputs"
+        in (measurement.notes["per_class_breakdown_coverage"])
+    )
+
+
+def test_compute_baseline_keeps_phase1_note_when_no_decisions_carry_class():
+    now = datetime.now(timezone.utc)
+    decisions = [
+        InvalidatedDecision(
+            "d1",
+            now,
+            (INVALIDATION_REVERT_WITHIN_WINDOW,),
+            ("r",),
+            True,
+            False,
+        ),
+    ]
+    measurement = compute_baseline(
+        decisions,
+        total_human_settled=200,
+        total_auto_handled=0,
+        window_end=now,
+        per_class_human={"bugfix": 100},
+    )
+    # When no invalidation carries decision_class, the original phase-1
+    # note still fires so callers know plumbing is incomplete on their side.
+    assert measurement.notes.get("per_class_breakdown_numerator", "").startswith(
+        "per-class denominators provided but no invalidation"
+    )
+
+
+def test_compute_baseline_no_per_class_inputs_skips_breakdown_entirely():
+    now = datetime.now(timezone.utc)
+    decisions = [
+        InvalidatedDecision(
+            "d1",
+            now,
+            (INVALIDATION_REVERT_WITHIN_WINDOW,),
+            ("r",),
+            True,
+            False,
+            decision_class="bugfix",
+        ),
+    ]
+    measurement = compute_baseline(
+        decisions,
+        total_human_settled=200,
+        total_auto_handled=0,
+        window_end=now,
+    )
+    assert measurement.per_class_human == {}
+    assert measurement.per_class_auto == {}
+    assert "per_class_breakdown_numerator" not in measurement.notes
+    assert "per_class_breakdown_coverage" not in measurement.notes
+
+
+def test_decision_from_dict_round_trips_decision_class():
+    now = datetime.now(timezone.utc)
+    original = InvalidatedDecision(
+        decision_id="d1",
+        settled_at=now,
+        signals=(INVALIDATION_REVERT_WITHIN_WINDOW,),
+        rationales=("test",),
+        was_human_settled=True,
+        was_auto_handled=False,
+        decision_class="big-refactor",
+    )
+    payload = original.to_dict()
+    measurement = compute_baseline(
+        [payload],
+        total_human_settled=200,
+        total_auto_handled=0,
+        window_end=now,
+        per_class_human={"big-refactor": 50},
+    )
+    assert measurement.per_class_human == {"big-refactor": (1, 50)}
+
+
+def test_decision_from_dict_round_trips_missing_decision_class_field():
+    now = datetime.now(timezone.utc)
+    payload = {
+        "decision_id": "d1",
+        "settled_at": now.isoformat(),
+        "signals": [INVALIDATION_REVERT_WITHIN_WINDOW],
+        "rationales": ["test"],
+        "was_human_settled": True,
+        "was_auto_handled": False,
+        # decision_class intentionally omitted to simulate legacy payload
+    }
+    measurement = compute_baseline(
+        [payload],
+        total_human_settled=200,
+        total_auto_handled=0,
+        window_end=now,
+    )
+    assert measurement.invalidated_human_settled == 1


### PR DESCRIPTION
## Summary

Closes step D of #6608 — the per-class invalidation breakdown numerator that #6602 explicitly deferred ("follow-up PR will plumb decision_class through InvalidatedDecision").

Pure additive change. Default \`decision_class=None\` preserves all existing behavior; opting into per-class breakdown is a single keyword argument at classification time.

## Changes

- \`InvalidatedDecision\` gains optional \`decision_class: str | None = None\` field.
- \`InvalidatedDecision.to_dict()\` round-trips the field.
- \`_decision_from_dict()\` reads the field tolerantly (legacy payloads without it still load — confirmed by test).
- \`classify_invalidation()\` accepts \`decision_class\` keyword arg and passes it through.
- \`compute_baseline()\` aggregates classified invalidations by \`decision_class\` and populates \`per_class_human\` / \`per_class_auto\` numerators when callers provide per-class denominators.
- Two new diagnostic notes in baseline output:
  - \`per_class_breakdown_coverage\` — fires when some invalidations lack a class or carry classes absent from the denominator inputs (so callers know what's excluded from the breakdown and why).
  - The legacy \`per_class_breakdown_numerator\` placeholder is kept only as a fallback when callers pass denominators but no invalidation in window has a class set (the \"plumbing-incomplete\" case).

## Verification

\`\`\`
tests/review/test_invalidation.py: 53 passed in 1.47s (was 40 before)
ruff check aragora/review/invalidation.py tests/review/test_invalidation.py: All checks passed!
mypy aragora/review/invalidation.py: Success: no issues found in 1 source file
\`\`\`

13 new tests cover:
- backward-compat default for \`decision_class\`
- \`to_dict()\` includes the field (None and string values)
- \`classify_invalidation()\` propagation
- per-class human numerator aggregation
- per-class auto numerator aggregation
- coverage note when invalidations lack a class
- coverage note when invalidations carry an unknown class
- phase-1 fallback note when no invalidation has a class
- skip per-class entirely when caller passes no denominators
- dict round-trip with \`decision_class\` set
- dict round-trip with \`decision_class\` field absent (legacy payload)

## Step D status in #6608

This is the smallest of the four deferred items (A: event source = #6615 merged, B: scheduler = #6616 merged, C: CLI surfacing = in flight, D: per-class numerator = this PR). Once D lands and step C lands, all #6608 code work is done; #6375 closure is then gated on real-data accumulation per the calendar-bound step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)