### PR TITLE
codex/docs safe hints salvage

### DIFF
--- a/aragora/docs_only.py
+++ b/aragora/docs_only.py
@@ -54,7 +54,7 @@ def is_docs_safe_path(path: Any) -> bool:
 def infer_docs_safe_hints(text: str) -> list[str]:
     hints: list[str] = []
     for raw in re.split(r"\s+", text or ""):
-        token = raw.strip().strip("`'\".,;:()[]{}<>")
+        token = raw.strip().lstrip("`'\",;:()[]{}<>").rstrip("`'\".,;:()[]{}<>")
         normalized = normalize_docs_path(token)
         if not is_docs_safe_path(normalized):
             continue

--- a/tests/test_docs_only.py
+++ b/tests/test_docs_only.py
@@ -1,0 +1,78 @@
+"""Unit tests for docs-only scope helpers."""
+
+from pathlib import Path
+
+from aragora.docs_only import (
+    canonical_docs_container_scope,
+    infer_docs_safe_hints,
+    is_docs_safe_path,
+    is_docs_safe_top_level_file,
+    normalize_docs_path,
+)
+
+
+def test_normalize_docs_path_normalizes_slashes_and_relative_prefixes():
+    assert normalize_docs_path(r" .\docs\guide\intro.md/ ") == "docs/guide/intro.md"
+
+
+def test_normalize_docs_path_accepts_pathlike_inputs():
+    assert normalize_docs_path(Path("./docs-site/reference/")) == "docs-site/reference"
+
+
+def test_canonical_docs_container_scope_recognizes_docs_variants():
+    assert canonical_docs_container_scope("docs") == "docs"
+    assert canonical_docs_container_scope("./docs/**/") == "docs"
+
+
+def test_canonical_docs_container_scope_recognizes_docs_site_variants():
+    assert canonical_docs_container_scope("docs-site") == "docs-site"
+    assert canonical_docs_container_scope("./docs-site/**") == "docs-site"
+
+
+def test_canonical_docs_container_scope_rejects_non_container_paths():
+    assert canonical_docs_container_scope("docs/guide.md") is None
+    assert canonical_docs_container_scope("docs-site-assets") is None
+
+
+def test_is_docs_safe_top_level_file_accepts_allowlisted_filenames():
+    assert is_docs_safe_top_level_file("CHANGELOG.md") is True
+    assert is_docs_safe_top_level_file("LICENSE") is True
+
+
+def test_is_docs_safe_top_level_file_rejects_nested_or_unlisted_files():
+    assert is_docs_safe_top_level_file("README.md") is False
+    assert is_docs_safe_top_level_file("docs/CHANGELOG.md") is False
+
+
+def test_is_docs_safe_path_accepts_docs_containers_prefixes_and_top_level_files():
+    assert is_docs_safe_path("docs") is True
+    assert is_docs_safe_path("./docs-site/guides/getting-started.md") is True
+    assert is_docs_safe_path("CONTRIBUTING.md") is True
+
+
+def test_is_docs_safe_path_rejects_non_docs_paths_and_partial_prefixes():
+    assert is_docs_safe_path("") is False
+    assert is_docs_safe_path("src/docs_only.py") is False
+    assert is_docs_safe_path("docs-site-assets/logo.svg") is False
+
+
+def test_infer_docs_safe_hints_extracts_normalized_docs_tokens_from_text():
+    text = "Touch `./docs/guide.md`, (docs-site/reference/), CHANGELOG.md, and src/app.py."
+
+    assert infer_docs_safe_hints(text) == [
+        "docs/guide.md",
+        "docs-site/reference",
+        "CHANGELOG.md",
+    ]
+
+
+def test_infer_docs_safe_hints_deduplicates_preserving_first_seen_order():
+    text = "docs/guide.md `./docs/guide.md` docs-site/reference docs-site/reference/"
+
+    assert infer_docs_safe_hints(text) == ["docs/guide.md", "docs-site/reference"]
+
+
+def test_infer_docs_safe_hints_ignores_non_docs_tokens():
+    text = "src/app.py README.md docs-site-assets/logo.svg"
+
+    assert infer_docs_safe_hints(text) == []


### PR DESCRIPTION
## Summary

Small docs-only scope helper salvage:

- Fixes `infer_docs_safe_hints()` so leading punctuation is stripped without dropping a trailing `.` from relative docs paths before normalization.
- Adds focused coverage for docs path normalization, docs-safe containers, top-level allowlist behavior, and hint extraction/deduplication.

## Validation

- `python3 -m pytest tests/test_docs_only.py -q` -> 12 passed
- `python3 -m ruff check aragora/docs_only.py tests/test_docs_only.py` -> pass
- `git diff --check origin/main...HEAD -- aragora/docs_only.py tests/test_docs_only.py` -> pass

## Safety

Small parser/test change only. No workflow, publisher, branch, or cleanup side effects.
