### PR TITLE
feat(agent-bridge): add write-gated ops plane

### DIFF
--- a/aragora/config/settings.py
+++ b/aragora/config/settings.py
@@ -688,6 +688,14 @@ class FeatureSettings(BaseSettings):
         alias="ARAGORA_FEATURE_AGENT_BRIDGE",
         description="Enable the experimental read-only Agent Bridge API and UI surface.",
     )
+    agent_bridge_write: bool = Field(
+        default=False,
+        alias="ARAGORA_FEATURE_AGENT_BRIDGE_WRITE",
+        description=(
+            "Enable operator-local Agent Bridge write endpoints that can spawn or resume "
+            "local model harness processes."
+        ),
+    )
 
     # Demo mode - when enabled, endpoints return mock data instead of requiring backend services
     # This is useful for frontend development and demos without full backend setup

--- a/aragora/live/src/app/(app)/autonomous/bridge/[run_id]/page.tsx
+++ b/aragora/live/src/app/(app)/autonomous/bridge/[run_id]/page.tsx
@@ -33,6 +33,10 @@ export default function AgentBridgeRunDetailPage() {
               <span className="text-white/50">Metadata</span>
               <span className="text-white/60">run.json + sessions.json</span>
             </div>
+            <div className="flex justify-between">
+              <span className="text-white/50">Actions</span>
+              <span className="text-amber-200">Write-gated</span>
+            </div>
           </div>
         </div>
       ),

--- a/aragora/live/src/app/(app)/autonomous/bridge/page.tsx
+++ b/aragora/live/src/app/(app)/autonomous/bridge/page.tsx
@@ -13,18 +13,22 @@ export default function AgentBridgeRunsPage() {
   useEffect(() => {
     setContext({
       title: 'Agent Bridge',
-      subtitle: 'Read-only broker state',
+      subtitle: 'Operator-gated broker state',
       statsContent: (
         <div className="space-y-4">
           <div className="text-xs uppercase tracking-wider text-white/40">Mode</div>
           <div className="space-y-2 text-sm">
             <div className="flex justify-between">
               <span className="text-white/50">Surface</span>
-              <span className="text-[var(--accent)]">Read only</span>
+              <span className="text-[var(--accent)]">Read + gated write</span>
             </div>
             <div className="flex justify-between">
               <span className="text-white/50">Transport</span>
               <span className="text-cyan-300">HTTP polling</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-white/50">Write gate</span>
+              <span className="text-amber-200">ARAGORA_FEATURE_AGENT_BRIDGE_WRITE</span>
             </div>
             <div className="flex justify-between">
               <span className="text-white/50">Broker store</span>
@@ -61,8 +65,8 @@ export default function AgentBridgeRunsPage() {
             </div>
             <h1 className="text-3xl font-bold text-white">Agent Bridge Runs</h1>
             <p className="mt-2 max-w-3xl text-sm text-white/55">
-              Inspect persistent bridge runs and role-keyed session state without mutation controls
-              or WebSocket transport.
+              Inspect persistent bridge runs, role-keyed session state, and operator-gated
+              one-step dispatch controls for local harness cross-check loops.
             </p>
           </div>
 

--- a/aragora/live/src/components/autonomous/bridge/BridgeOperatorActions.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeOperatorActions.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+
+import { apiFetch } from '@/lib/api';
+
+import type { AgentBridgeEvent, AgentBridgeRunDetail } from './types';
+
+interface BridgeOperatorActionsProps {
+  run: AgentBridgeRunDetail;
+  onDispatched: () => void;
+}
+
+function roleOptions(run: AgentBridgeRunDetail): string[] {
+  const ordered = run.participants.map((participant) => participant.role);
+  const extras = Object.keys(run.roles).filter((role) => !ordered.includes(role));
+  return [...ordered, ...extras];
+}
+
+export function BridgeOperatorActions({ run, onDispatched }: BridgeOperatorActionsProps) {
+  const roles = roleOptions(run);
+  const [role, setRole] = useState(run.next_actor ?? roles[0] ?? '');
+  const [prompt, setPrompt] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const isDispatchable = run.status === 'running' || run.status === 'awaiting_human';
+
+  const dispatch = (mode: 'auto-step' | 'dispatch') => {
+    setMessage(null);
+    startTransition(async () => {
+      try {
+        if (mode === 'auto-step') {
+          const event = await apiFetch<AgentBridgeEvent & { auto_step?: unknown }>(
+            `/api/v1/agent-bridge/runs/${encodeURIComponent(run.run_id)}/auto-step`,
+            {
+              method: 'POST',
+              body: JSON.stringify({}),
+            }
+          );
+          setMessage(`Auto-step dispatched ${event.role} turn ${event.turn_index}.`);
+        } else {
+          const trimmedPrompt = prompt.trim();
+          if (!trimmedPrompt) {
+            setMessage('Dispatch prompt is required.');
+            return;
+          }
+          const event = await apiFetch<AgentBridgeEvent>(
+            `/api/v1/agent-bridge/runs/${encodeURIComponent(run.run_id)}/dispatch`,
+            {
+              method: 'POST',
+              body: JSON.stringify({ role, prompt: trimmedPrompt }),
+            }
+          );
+          setPrompt('');
+          setMessage(`Dispatched ${event.role} turn ${event.turn_index}.`);
+        }
+        onDispatched();
+      } catch (error) {
+        setMessage(error instanceof Error ? error.message : 'Bridge write request failed.');
+      }
+    });
+  };
+
+  const curl = `curl -X POST "$ARAGORA_API_URL/api/v1/agent-bridge/runs/${run.run_id}/auto-step" \\
+  -H "Authorization: Bearer $ARAGORA_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{}'`;
+
+  return (
+    <section className="rounded-xl border border-amber-300/20 bg-amber-300/5 p-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="text-xs uppercase tracking-[0.25em] text-amber-200/60">
+            Operator actions
+          </div>
+          <p className="mt-2 max-w-3xl text-sm text-white/60">
+            Write actions are owner/admin gated and require ARAGORA_FEATURE_AGENT_BRIDGE_WRITE.
+            Use them for bounded handoffs, review loops, and one-step auto-baton validation.
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={!isDispatchable || isPending || !run.next_actor}
+          onClick={() => dispatch('auto-step')}
+          className="rounded border border-amber-200/30 bg-amber-200/10 px-3 py-2 text-sm text-amber-100 transition-colors hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Auto-step next actor
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-[14rem_1fr_auto]">
+        <select
+          value={role}
+          onChange={(event) => setRole(event.target.value)}
+          disabled={!isDispatchable || isPending}
+          className="rounded border border-white/10 bg-black/40 px-3 py-2 text-sm text-white"
+        >
+          {roles.map((item) => (
+            <option key={item} value={item}>
+              {item}
+            </option>
+          ))}
+        </select>
+        <input
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          disabled={!isDispatchable || isPending}
+          placeholder="Manual dispatch prompt"
+          className="rounded border border-white/10 bg-black/40 px-3 py-2 text-sm text-white placeholder:text-white/30"
+        />
+        <button
+          type="button"
+          disabled={!isDispatchable || isPending || !role}
+          onClick={() => dispatch('dispatch')}
+          className="rounded border border-cyan-200/30 bg-cyan-200/10 px-3 py-2 text-sm text-cyan-100 transition-colors hover:bg-cyan-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Dispatch turn
+        </button>
+      </div>
+
+      {message ? <div className="mt-3 text-sm text-white/65">{message}</div> : null}
+
+      <details className="mt-4 rounded border border-white/10 bg-black/20 p-3">
+        <summary className="cursor-pointer text-xs uppercase tracking-[0.2em] text-white/40">
+          Copy curl
+        </summary>
+        <pre className="mt-3 overflow-auto whitespace-pre-wrap break-all text-xs text-white/60">
+          {curl}
+        </pre>
+      </details>
+    </section>
+  );
+}

--- a/aragora/live/src/components/autonomous/bridge/BridgeOperatorActions.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeOperatorActions.tsx
@@ -23,7 +23,8 @@ export function BridgeOperatorActions({ run, onDispatched }: BridgeOperatorActio
   const [prompt, setPrompt] = useState('');
   const [message, setMessage] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-  const isDispatchable = run.status === 'running' || run.status === 'awaiting_human';
+  const canAutoStep = run.status === 'running';
+  const canManualDispatch = run.status === 'running' || run.status === 'awaiting_human';
 
   const dispatch = (mode: 'auto-step' | 'dispatch') => {
     setMessage(null);
@@ -80,7 +81,7 @@ export function BridgeOperatorActions({ run, onDispatched }: BridgeOperatorActio
         </div>
         <button
           type="button"
-          disabled={!isDispatchable || isPending || !run.next_actor}
+          disabled={!canAutoStep || isPending || !run.next_actor}
           onClick={() => dispatch('auto-step')}
           className="rounded border border-amber-200/30 bg-amber-200/10 px-3 py-2 text-sm text-amber-100 transition-colors hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
         >
@@ -92,7 +93,7 @@ export function BridgeOperatorActions({ run, onDispatched }: BridgeOperatorActio
         <select
           value={role}
           onChange={(event) => setRole(event.target.value)}
-          disabled={!isDispatchable || isPending}
+          disabled={!canManualDispatch || isPending}
           className="rounded border border-white/10 bg-black/40 px-3 py-2 text-sm text-white"
         >
           {roles.map((item) => (
@@ -104,13 +105,13 @@ export function BridgeOperatorActions({ run, onDispatched }: BridgeOperatorActio
         <input
           value={prompt}
           onChange={(event) => setPrompt(event.target.value)}
-          disabled={!isDispatchable || isPending}
+          disabled={!canManualDispatch || isPending}
           placeholder="Manual dispatch prompt"
           className="rounded border border-white/10 bg-black/40 px-3 py-2 text-sm text-white placeholder:text-white/30"
         />
         <button
           type="button"
-          disabled={!isDispatchable || isPending || !role}
+          disabled={!canManualDispatch || isPending || !role}
           onClick={() => dispatch('dispatch')}
           className="rounded border border-cyan-200/30 bg-cyan-200/10 px-3 py-2 text-sm text-cyan-100 transition-colors hover:bg-cyan-200/20 disabled:cursor-not-allowed disabled:opacity-40"
         >

--- a/aragora/live/src/components/autonomous/bridge/BridgeRunDetail.tsx
+++ b/aragora/live/src/components/autonomous/bridge/BridgeRunDetail.tsx
@@ -3,6 +3,7 @@
 import { TabPanel, Tabs } from '@/components/Tabs';
 import { StatusBadge } from '@/components/shared/StatusBadge';
 import { BridgeEventStream } from '@/components/autonomous/bridge/BridgeEventStream';
+import { BridgeOperatorActions } from '@/components/autonomous/bridge/BridgeOperatorActions';
 import { BridgeRoleCard } from '@/components/autonomous/bridge/BridgeRoleCard';
 import { BridgeTranscriptView } from '@/components/autonomous/bridge/BridgeTranscriptView';
 import { useAgentBridgeEvents } from '@/hooks/useAgentBridgeEvents';
@@ -153,6 +154,15 @@ export function BridgeRunDetail({ runId }: BridgeRunDetailProps) {
           <span>cleanup: {run.worktree_cleanup_mode}</span>
         </div>
       </section>
+
+      <BridgeOperatorActions
+        run={run}
+        onDispatched={() => {
+          runQuery.retry();
+          eventsQuery.retry();
+          transcriptQuery.retry();
+        }}
+      />
 
       <section className="space-y-3">
         <div className="text-xs uppercase tracking-[0.25em] text-white/35">Participant sessions</div>

--- a/aragora/rbac/defaults/permissions/__init__.py
+++ b/aragora/rbac/defaults/permissions/__init__.py
@@ -393,6 +393,7 @@ from .security import (
 # Route permissions (middleware-referenced resources)
 from .routes import (
     PERM_AGENT_BRIDGE_READ,
+    PERM_AGENT_BRIDGE_WRITE,
     PERM_AUDITING_CREATE,
     PERM_AUDITING_READ,
     PERM_BELIEF_READ,
@@ -886,6 +887,7 @@ __all__ = [
     "PERM_CVE_READ",
     # Route permissions (middleware-referenced resources)
     "PERM_AGENT_BRIDGE_READ",
+    "PERM_AGENT_BRIDGE_WRITE",
     "PERM_AUDITING_READ",
     "PERM_AUDITING_CREATE",
     "PERM_BELIEF_READ",

--- a/aragora/rbac/defaults/permissions/routes.py
+++ b/aragora/rbac/defaults/permissions/routes.py
@@ -21,6 +21,12 @@ PERM_AGENT_BRIDGE_READ = _permission(
     "View Agent Bridge Runs",
     "View persisted agent bridge runs, sessions, events, and transcripts",
 )
+PERM_AGENT_BRIDGE_WRITE = _permission(
+    ResourceType.AGENT_BRIDGE,
+    Action.WRITE,
+    "Operate Agent Bridge Runs",
+    "Start bridge runs and dispatch turns to local agent harnesses",
+)
 
 # ============================================================================
 # AUDITING PERMISSIONS (Red team operations)
@@ -221,6 +227,7 @@ PERM_EVOLUTION_WRITE = _permission(
 
 __all__ = [
     "PERM_AGENT_BRIDGE_READ",
+    "PERM_AGENT_BRIDGE_WRITE",
     "PERM_AUDITING_READ",
     "PERM_AUDITING_CREATE",
     "PERM_BELIEF_READ",

--- a/aragora/rbac/defaults/registry.py
+++ b/aragora/rbac/defaults/registry.py
@@ -464,6 +464,7 @@ from .permissions import (
     PERM_PLAN_REJECT,
     # Route permissions (middleware-referenced resources)
     PERM_AGENT_BRIDGE_READ,
+    PERM_AGENT_BRIDGE_WRITE,
     PERM_AUDITING_READ,
     PERM_AUDITING_CREATE,
     PERM_BELIEF_READ,
@@ -785,6 +786,7 @@ _ALL_PERMISSIONS = [
     PERM_SYSTEM_HEALTH_READ,
     # Verticals
     PERM_AGENT_BRIDGE_READ,
+    PERM_AGENT_BRIDGE_WRITE,
     PERM_VERTICALS_READ,
     PERM_VERTICALS_WRITE,
     # Canvas
@@ -962,6 +964,7 @@ _ALL_PERMISSIONS = [
     PERM_PLAN_REJECT,
     # Route permissions (middleware-referenced resources)
     PERM_AGENT_BRIDGE_READ,
+    PERM_AGENT_BRIDGE_WRITE,
     PERM_AUDITING_READ,
     PERM_AUDITING_CREATE,
     PERM_BELIEF_READ,

--- a/aragora/rbac/defaults/roles.py
+++ b/aragora/rbac/defaults/roles.py
@@ -261,6 +261,7 @@ from .permissions import (
     PERM_ALERTS_WRITE,
     PERM_ALERTS_ADMIN,
     PERM_AGENT_BRIDGE_READ,
+    PERM_AGENT_BRIDGE_WRITE,
 )
 
 
@@ -501,6 +502,8 @@ ROLE_ADMIN = Role(
         PERM_ALERTS_READ.key,
         PERM_ALERTS_WRITE.key,
         PERM_ALERTS_ADMIN.key,
+        PERM_AGENT_BRIDGE_READ.key,
+        PERM_AGENT_BRIDGE_WRITE.key,
     },
     parent_roles=[],
     priority=80,

--- a/aragora/server/handlers/agent_bridge.py
+++ b/aragora/server/handlers/agent_bridge.py
@@ -1,4 +1,4 @@
-"""Read-only HTTP handler for agent bridge run data."""
+"""HTTP handler for agent bridge run data and operator-gated dispatch."""
 
 from __future__ import annotations
 
@@ -6,17 +6,22 @@ __all__ = ["AgentBridgeHandler"]
 
 import base64
 import binascii
+import json
 import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from aragora.config.settings import get_settings
 from aragora.rbac.defaults.permissions import PERM_AGENT_BRIDGE_READ
+from aragora.rbac.defaults.permissions import PERM_AGENT_BRIDGE_WRITE
 from aragora.rbac.decorators import require_permission
 from aragora.server.http_caching import etag_matches
 from aragora.server.validation import validate_path_segment
 from aragora.server.versioning.compat import strip_version_prefix
+from aragora.swarm.agent_bridge.broker import AgentBridgeBroker
+from aragora.swarm.agent_bridge.exceptions import TransportError
 from aragora.swarm.agent_bridge.footer import extract_footer
 from aragora.swarm.agent_bridge.store import BridgeStore
 from aragora.swarm.agent_bridge.types import BridgeFooter
@@ -138,7 +143,7 @@ def _parse_limit(raw: Any) -> int:
 
 
 class AgentBridgeHandler(BaseHandler):
-    """Expose persisted agent-bridge run state through read-only HTTP endpoints."""
+    """Expose persisted agent-bridge state and feature-gated operator writes."""
 
     ROUTES = ["/api/v1/agent-bridge/runs"]
 
@@ -147,15 +152,31 @@ class AgentBridgeHandler(BaseHandler):
         self._store = BridgeStore(_bridge_repo_root(self.ctx))
 
     def can_handle(self, path: str, method: str = "GET") -> bool:
-        if method.upper() != "GET":
-            return False
+        method = method.upper()
         normalized = strip_version_prefix(path).rstrip("/")
-        return normalized == _RUNS_PATH or normalized.startswith(_RUNS_PREFIX)
+        if method == "GET":
+            return normalized == _RUNS_PATH or normalized.startswith(_RUNS_PREFIX)
+        if method == "POST":
+            if normalized == _RUNS_PATH:
+                return True
+            if not normalized.startswith(_RUNS_PREFIX):
+                return False
+            segments = [
+                segment for segment in normalized[len(_RUNS_PREFIX) :].split("/") if segment
+            ]
+            return len(segments) == 2 and segments[1] in {"dispatch", "auto-step"}
+        return False
 
     @handle_errors("agent bridge read API")  # type: ignore[untyped-decorator]
     @require_permission(PERM_AGENT_BRIDGE_READ.key)
     def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
+        method = str(getattr(handler, "command", "GET") or "GET").upper()
         normalized = strip_version_prefix(path).rstrip("/")
+        if method == "POST":
+            return self._handle_post(normalized, handler)
+        if method != "GET":
+            return error_response("Method not allowed", 405)
+
         if normalized == _RUNS_PATH:
             return self._handle_list_runs(query_params)
         if not normalized.startswith(_RUNS_PREFIX):
@@ -174,6 +195,240 @@ class AgentBridgeHandler(BaseHandler):
         if len(segments) == 2 and segments[1] == "transcript":
             return self._handle_get_transcript(run_id)
         return error_response("Not found", 404)
+
+    @require_permission(PERM_AGENT_BRIDGE_WRITE.key)
+    def _handle_post(self, normalized: str, handler: Any) -> HandlerResult:
+        if not self._write_enabled():
+            return error_response("Agent bridge write API is disabled", 403)
+
+        body, body_error = self.read_json_body_validated(handler)
+        if body_error:
+            return body_error
+        if body is None:
+            return error_response("Request body must be a JSON object", 400)
+
+        if normalized == _RUNS_PATH:
+            return self._handle_start_run(body)
+        if not normalized.startswith(_RUNS_PREFIX):
+            return error_response("Not found", 404)
+
+        segments = [segment for segment in normalized[len(_RUNS_PREFIX) :].split("/") if segment]
+        if len(segments) != 2:
+            return error_response("Not found", 404)
+        run_id, action = segments
+        if action == "dispatch":
+            return self._handle_dispatch_turn(run_id, body)
+        if action == "auto-step":
+            return self._handle_auto_step(run_id, body)
+        return error_response("Not found", 404)
+
+    def _write_enabled(self) -> bool:
+        override = self.ctx.get("agent_bridge_write_enabled")
+        if override is not None:
+            return bool(override)
+        try:
+            return bool(get_settings().features.agent_bridge_write)
+        except Exception:
+            logger.exception("Unable to read agent bridge write feature flag")
+            return False
+
+    def _broker(self) -> Any:
+        broker = self.ctx.get("agent_bridge_broker")
+        if broker is not None:
+            return broker
+        factory = self.ctx.get("agent_bridge_broker_factory", AgentBridgeBroker)
+        return factory(_bridge_repo_root(self.ctx), store=self._store)
+
+    def _handle_start_run(self, body: dict[str, Any]) -> HandlerResult:
+        task = str(body.get("task", "")).strip()
+        if not task:
+            return error_response("task is required", 400)
+
+        raw_actors = body.get("actors")
+        if not isinstance(raw_actors, list) or not raw_actors:
+            return error_response("actors must be a non-empty list", 400)
+
+        sessions: dict[str, BridgeSession] = {}
+        top_worktree_path = self._optional_string(body.get("worktree_path"))
+        top_worktree_agent_slug = str(body.get("worktree_agent_slug", "codex")).strip() or "codex"
+        for raw_actor in raw_actors:
+            if not isinstance(raw_actor, dict):
+                return error_response("each actor must be a JSON object", 400)
+            role = str(raw_actor.get("role", "")).strip()
+            harness = str(raw_actor.get("harness", "")).strip()
+            if not role or not harness:
+                return error_response("each actor requires role and harness", 400)
+            if not self._is_valid_slug(role):
+                return error_response(f"invalid actor role: {role}", 400)
+            if role in sessions:
+                return error_response(f"duplicate actor role: {role}", 400)
+            harness_options = raw_actor.get("harness_options", {})
+            if not isinstance(harness_options, dict):
+                return error_response("actor harness_options must be an object", 400)
+            sessions[role] = BridgeSession(
+                role=role,
+                harness=harness,
+                model=str(raw_actor.get("model", "") or ""),
+                session_id=self._optional_string(raw_actor.get("session_id")),
+                worktree_agent_slug=self._optional_string(raw_actor.get("worktree_agent_slug"))
+                or top_worktree_agent_slug,
+                worktree_path=self._optional_string(raw_actor.get("worktree_path"))
+                or top_worktree_path,
+                branch=self._optional_string(raw_actor.get("branch")),
+                session_status="not_started",
+                started_at=None,
+                last_turn_index=0,
+                last_completed_at=None,
+                harness_options=dict(harness_options),
+            )
+
+        run_id = self._optional_string(body.get("run_id"))
+        if run_id is not None and not self._is_valid_run_id(run_id):
+            return error_response("invalid run_id", 400)
+        if run_id is not None and self._load_run_or_none(run_id) is not None:
+            return error_response("Bridge run already exists", 409)
+
+        next_actor = self._optional_string(body.get("next_actor"))
+        if next_actor is not None and next_actor not in sessions:
+            return error_response("next_actor must match an actor role", 400)
+
+        repair_budget, repair_error = self._parse_nonnegative_int(
+            body.get("repair_budget_per_turn", 1),
+            "repair_budget_per_turn",
+        )
+        if repair_error:
+            return repair_error
+
+        broker = self._broker()
+        try:
+            run = broker.start_run(
+                task=task,
+                sessions=sessions,
+                next_actor=next_actor,
+                run_id=run_id,
+                worktree_path=top_worktree_path,
+                worktree_agent_slug=top_worktree_agent_slug,
+                repair_budget_per_turn=repair_budget,
+            )
+            registry = self._store.load_sessions(run.run_id)
+        except Exception as exc:
+            logger.exception("Agent bridge start-run failed")
+            return error_response(f"Agent bridge start-run failed: {exc}", 500)
+        return json_response(self._serialize_run_detail(run, registry), status=201)
+
+    def _handle_dispatch_turn(self, run_id: str, body: dict[str, Any]) -> HandlerResult:
+        run, registry, error = self._load_dispatchable_run(run_id)
+        if error is not None:
+            return error
+        if run is None or registry is None:
+            return self._not_found()
+
+        role = str(body.get("role", "")).strip()
+        prompt = str(body.get("prompt", "")).strip()
+        if not role:
+            return error_response("role is required", 400)
+        if not prompt:
+            return error_response("prompt is required", 400)
+        if role not in registry.sessions:
+            return error_response("Unknown role for bridge run", 400)
+
+        return self._dispatch_turn(run_id=run.run_id, role=role, prompt=prompt)
+
+    def _handle_auto_step(self, run_id: str, body: dict[str, Any]) -> HandlerResult:
+        run, registry, error = self._load_dispatchable_run(run_id)
+        if error is not None:
+            return error
+        if run is None or registry is None:
+            return self._not_found()
+
+        role = run.next_actor
+        if not role:
+            return error_response("Bridge run has no next_actor", 409)
+        if role not in registry.sessions:
+            return error_response("Bridge run next_actor is not a registered role", 409)
+
+        context_turns, turns_error = self._parse_nonnegative_int(
+            body.get("context_turns", 5),
+            "context_turns",
+        )
+        if turns_error:
+            return turns_error
+        context_turns = min(max(context_turns, 1), 20)
+
+        prompt = str(body.get("prompt", "")).strip()
+        if not prompt:
+            prompt = self._compose_auto_step_prompt(run, context_turns=context_turns)
+        result = self._dispatch_turn(run_id=run.run_id, role=role, prompt=prompt)
+        if result.status_code != 200:
+            return result
+        payload = _json_payload(result)
+        payload["auto_step"] = {"role": role, "context_turns": context_turns}
+        return json_response(payload)
+
+    def _load_dispatchable_run(
+        self,
+        run_id: str,
+    ) -> tuple[BridgeRun | None, SessionRegistry | None, HandlerResult | None]:
+        if not self._is_valid_run_id(run_id):
+            return None, None, self._not_found()
+        run = self._load_run_or_none(run_id)
+        if run is None:
+            return None, None, self._not_found()
+        if run.status in {"completed", "failed"}:
+            return None, None, error_response("Bridge run is not dispatchable", 409)
+        try:
+            registry = self._store.load_sessions(run_id)
+        except FileNotFoundError:
+            return None, None, self._not_found()
+        return run, registry, None
+
+    def _dispatch_turn(self, *, run_id: str, role: str, prompt: str) -> HandlerResult:
+        try:
+            event = self._broker().dispatch_turn(run_id=run_id, role=role, prompt=prompt)
+        except KeyError:
+            return error_response("Unknown role for bridge run", 400)
+        except FileNotFoundError:
+            return self._not_found()
+        except TransportError as exc:
+            logger.warning("Agent bridge transport failed for %s/%s: %s", run_id, role, exc)
+            return error_response(f"Agent bridge transport failed: {exc}", 502)
+        except Exception as exc:
+            logger.exception("Agent bridge dispatch failed")
+            return error_response(f"Agent bridge dispatch failed: {exc}", 500)
+        return json_response(event.to_dict())
+
+    def _compose_auto_step_prompt(self, run: BridgeRun, *, context_turns: int) -> str:
+        try:
+            events = self._store.load_events(run.run_id)
+            turns = self._reconstruct_transcript(run, events)[-context_turns:]
+        except Exception:
+            logger.exception("Unable to reconstruct bridge transcript for auto-step")
+            turns = []
+
+        recent_parts: list[str] = []
+        for turn in turns:
+            body = str(turn.get("body_markdown", "")).strip()
+            footer = turn.get("footer")
+            if len(body) > 2500:
+                body = body[:2500].rstrip() + "\n[truncated]"
+            recent_parts.append(
+                "\n".join(
+                    [
+                        f"Turn {turn.get('turn_index')} by {turn.get('author_role')}:",
+                        body or "[no body captured]",
+                        f"Footer: {footer if footer is not None else '[missing]'}",
+                    ]
+                )
+            )
+        recent = "\n\n".join(recent_parts) if recent_parts else "[no prior turns captured]"
+        return (
+            "Continue this agent-bridge run by taking the next useful step.\n\n"
+            f"Task:\n{run.task}\n\n"
+            f"Recent transcript:\n{recent}\n\n"
+            "Return a normal response followed by a valid bridge footer. "
+            "Set needs_human=true if blocked by missing authority, secrets, protected files, "
+            "conflicting ownership, or any irreversible action."
+        )
 
     def _handle_list_runs(self, query_params: dict[str, Any]) -> HandlerResult:
         limit = _parse_limit(query_params.get("limit"))
@@ -304,6 +559,25 @@ class AgentBridgeHandler(BaseHandler):
     def _is_valid_run_id(self, run_id: str) -> bool:
         ok, _ = validate_path_segment(run_id, "run_id", SAFE_SLUG_PATTERN)
         return ok
+
+    def _is_valid_slug(self, slug: str) -> bool:
+        ok, _ = validate_path_segment(slug, "slug", SAFE_SLUG_PATTERN)
+        return ok
+
+    def _optional_string(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _parse_nonnegative_int(self, value: Any, name: str) -> tuple[int, HandlerResult | None]:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return 0, error_response(f"{name} must be an integer", 400)
+        if parsed < 0:
+            return 0, error_response(f"{name} must be non-negative", 400)
+        return parsed, None
 
     def _serialize_run_summary(self, run: BridgeRun) -> dict[str, Any]:
         payload = run.to_dict()
@@ -449,3 +723,12 @@ class AgentBridgeHandler(BaseHandler):
     def _bridge_store_unavailable(self) -> HandlerResult:
         logger.exception("Agent bridge store unavailable")
         return error_response("bridge store unavailable", 500)
+
+
+def _json_payload(result: HandlerResult) -> dict[str, Any]:
+    raw = result.body.decode("utf-8") if isinstance(result.body, bytes) else str(result.body)
+    try:
+        payload = json.loads(raw) if raw else {}
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}

--- a/aragora/server/handlers/agent_bridge.py
+++ b/aragora/server/handlers/agent_bridge.py
@@ -335,7 +335,10 @@ class AgentBridgeHandler(BaseHandler):
         return self._dispatch_turn(run_id=run.run_id, role=role, prompt=prompt)
 
     def _handle_auto_step(self, run_id: str, body: dict[str, Any]) -> HandlerResult:
-        run, registry, error = self._load_dispatchable_run(run_id)
+        run, registry, error = self._load_dispatchable_run(
+            run_id,
+            allow_awaiting_human=False,
+        )
         if error is not None:
             return error
         if run is None or registry is None:
@@ -368,6 +371,8 @@ class AgentBridgeHandler(BaseHandler):
     def _load_dispatchable_run(
         self,
         run_id: str,
+        *,
+        allow_awaiting_human: bool = True,
     ) -> tuple[BridgeRun | None, SessionRegistry | None, HandlerResult | None]:
         if not self._is_valid_run_id(run_id):
             return None, None, self._not_found()
@@ -376,6 +381,8 @@ class AgentBridgeHandler(BaseHandler):
             return None, None, self._not_found()
         if run.status in {"completed", "failed"}:
             return None, None, error_response("Bridge run is not dispatchable", 409)
+        if run.status == "awaiting_human" and not allow_awaiting_human:
+            return None, None, error_response("Bridge run is awaiting human input", 409)
         try:
             registry = self._store.load_sessions(run_id)
         except FileNotFoundError:

--- a/aragora/server/handlers/control_plane/__init__.py
+++ b/aragora/server/handlers/control_plane/__init__.py
@@ -336,6 +336,10 @@ class ControlPlaneHandler(
         if path == "/api/v1/coordination/fleet/status":
             return self._handle_fleet_status(query_params)
 
+        # /api/v1/coordination/active-work
+        if path == "/api/v1/coordination/active-work":
+            return self._handle_active_work(query_params)
+
         # /api/v1/coordination/fleet/logs
         if path == "/api/v1/coordination/fleet/logs":
             return self._handle_fleet_logs(query_params)

--- a/aragora/server/handlers/control_plane/coordination.py
+++ b/aragora/server/handlers/control_plane/coordination.py
@@ -17,7 +17,7 @@ import sqlite3
 from datetime import UTC
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Awaitable, cast
 
 from aragora.server.handlers.base import (
     HandlerResult,
@@ -64,7 +64,7 @@ class CoordinationHandlerMixin:
         """Get the cross-workspace coordinator."""
         return self.ctx.get("coordination_coordinator")
 
-    def _require_coordination_coordinator(self) -> tuple[Any | None, HandlerResult | None]:
+    def _require_coordination_coordinator(self) -> tuple[Any, HandlerResult | None]:
         """Return coordinator and None, or None and error response if not available."""
         coord = self._get_coordination_coordinator()
         if not coord:
@@ -687,7 +687,11 @@ class CoordinationHandlerMixin:
         if bool(body.get("dispatch_workers", True)):
             dispatch_result = supervisor.dispatch_workers(run.run_id)
             if inspect.isawaitable(dispatch_result):
-                asyncio.run(dispatch_result)
+
+                async def await_dispatch_result(awaitable: Awaitable[Any]) -> Any:
+                    return await awaitable
+
+                asyncio.run(await_dispatch_result(dispatch_result))
             if bool(body.get("watch", False)):
                 run = asyncio.run(
                     SwarmReconciler(supervisor=supervisor).watch_run(
@@ -957,7 +961,7 @@ class CoordinationHandlerMixin:
             if entry is None:
                 return error_response(f"Branch not found: {branch}", 404)
             if is_dataclass(entry):
-                entry_payload = asdict(entry)
+                entry_payload = asdict(cast(Any, entry))
             elif isinstance(entry, dict):
                 entry_payload = dict(entry)
             else:

--- a/aragora/server/handlers/control_plane/coordination.py
+++ b/aragora/server/handlers/control_plane/coordination.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
+from datetime import UTC
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +31,7 @@ from aragora.server.handlers.utils.decorators import (
     require_permission,
 )
 from aragora.swarm.reporter import build_integrator_view
+from aragora.swarm.agent_bridge.store import BridgeStore
 from aragora.worktree.fleet import (
     FleetCoordinationStore,
     build_fleet_rows,
@@ -1040,6 +1043,243 @@ class CoordinationHandlerMixin:
                 "total": len(rows),
             }
         )
+
+    @api_endpoint(
+        method="GET",
+        path="/api/v1/coordination/active-work",
+        summary="Get compact active work snapshot for agent coordination",
+        tags=["Coordination"],
+    )
+    @require_permission("coordination:stats.read")
+    def _handle_active_work(self, query_params: dict[str, Any]) -> HandlerResult:
+        """Return one compact, agent-readable view of active ownership surfaces."""
+        base_branch = str(query_params.get("base", "main")).strip() or "main"
+        repo_root = self._fleet_repo_root()
+        source_errors: list[dict[str, str]] = []
+
+        try:
+            worktrees = build_fleet_rows(
+                repo_root,
+                base_branch=base_branch,
+                tail=0,
+                include_git_metrics=False,
+            )
+        except Exception as exc:
+            logger.exception("active-work worktree snapshot failed")
+            worktrees = []
+            source_errors.append({"source": "worktrees", "error": str(exc)})
+
+        try:
+            fleet_store = self._fleet_store(repo_root)
+            claims = fleet_store.list_claims()
+            merge_queue = fleet_store.list_merge_queue()
+        except Exception as exc:
+            logger.exception("active-work fleet snapshot failed")
+            claims = []
+            merge_queue = []
+            source_errors.append({"source": "fleet", "error": str(exc)})
+
+        try:
+            from aragora.nomic.dev_coordination import DevCoordinationStore
+
+            coordination = DevCoordinationStore(repo_root=repo_root).status_summary(
+                include_integrator_artifacts=True
+            )
+        except (ImportError, RuntimeError, OSError, ValueError, sqlite3.Error) as exc:
+            coordination = {"active_leases": [], "counts": {}, "error": str(exc)}
+            source_errors.append({"source": "dev_coordination", "error": str(exc)})
+
+        bridge_runs = self._active_bridge_runs(repo_root, source_errors)
+        active_owners = self._active_work_owners(
+            worktrees=worktrees,
+            claims=claims,
+            active_leases=coordination.get("active_leases", []),
+            bridge_runs=bridge_runs,
+        )
+        avoid_paths = self._active_work_avoid_paths(
+            claims=claims,
+            active_leases=coordination.get("active_leases", []),
+        )
+
+        return json_response(
+            {
+                "schema_version": 1,
+                "repo_root": str(repo_root),
+                "base_branch": base_branch,
+                "generated_at": datetime.now(UTC)
+                .replace(microsecond=0)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "active_owners": active_owners,
+                "claimed_paths": self._claim_paths(claims),
+                "avoid_paths": avoid_paths,
+                "avoid_path_hints": [
+                    {"path": path, "reason": "claimed_or_leased"} for path in avoid_paths
+                ],
+                "worktrees": worktrees,
+                "fleet_claims": claims,
+                "active_leases": coordination.get("active_leases", []),
+                "merge_queue": merge_queue,
+                "bridge_runs": bridge_runs,
+                "counts": {
+                    "worktrees": len(worktrees),
+                    "fleet_claims": len(claims),
+                    "active_leases": len(coordination.get("active_leases", []))
+                    if isinstance(coordination.get("active_leases"), list)
+                    else 0,
+                    "merge_queue": len(merge_queue),
+                    "bridge_runs": len(bridge_runs),
+                },
+                "source_errors": source_errors,
+            }
+        )
+
+    def _active_bridge_runs(
+        self,
+        repo_root: Path,
+        source_errors: list[dict[str, str]],
+    ) -> list[dict[str, Any]]:
+        try:
+            store = BridgeStore(repo_root)
+            runs = []
+            for run_path in store.runs_root().glob("*/run.json"):
+                run = store.load_run(run_path.parent.name)
+                if run.status not in {"running", "awaiting_human"}:
+                    continue
+                runs.append(
+                    {
+                        "run_id": run.run_id,
+                        "task": run.task,
+                        "status": run.status,
+                        "next_actor": run.next_actor,
+                        "updated_at": run.updated_at,
+                        "last_turn_index": run.last_turn_index,
+                        "worktree_path": run.worktree_path,
+                        "worktree_agent_slug": run.worktree_agent_slug,
+                        "participants": [participant.to_dict() for participant in run.participants],
+                    }
+                )
+            runs.sort(key=lambda item: str(item.get("updated_at", "")), reverse=True)
+            return runs
+        except Exception as exc:
+            logger.exception("active-work bridge snapshot failed")
+            source_errors.append({"source": "agent_bridge", "error": str(exc)})
+            return []
+
+    def _active_work_owners(
+        self,
+        *,
+        worktrees: list[dict[str, Any]],
+        claims: list[dict[str, Any]],
+        active_leases: Any,
+        bridge_runs: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        owners: dict[str, dict[str, Any]] = {}
+
+        def owner(session_id: str) -> dict[str, Any]:
+            key = session_id.strip() or "unknown"
+            return owners.setdefault(
+                key,
+                {
+                    "session_id": key,
+                    "agent": "",
+                    "branches": [],
+                    "worktree_paths": [],
+                    "claimed_paths": [],
+                    "lease_ids": [],
+                    "receipt_ids": [],
+                    "bridge_run_ids": [],
+                },
+            )
+
+        for row in worktrees:
+            session_id = str(row.get("session_id", "")).strip()
+            if not session_id:
+                continue
+            entry = owner(session_id)
+            entry["agent"] = entry["agent"] or str(row.get("agent", "")).strip()
+            self._append_unique(entry["branches"], str(row.get("branch", "")).strip())
+            self._append_unique(entry["worktree_paths"], str(row.get("path", "")).strip())
+
+        for claim in claims:
+            entry = owner(str(claim.get("session_id", "")).strip())
+            self._append_unique(entry["claimed_paths"], str(claim.get("path", "")).strip())
+            self._append_unique(entry["branches"], str(claim.get("branch", "")).strip())
+
+        if isinstance(active_leases, list):
+            for lease in active_leases:
+                if not isinstance(lease, dict):
+                    continue
+                entry = owner(str(lease.get("owner_session_id", "")).strip())
+                entry["agent"] = entry["agent"] or str(lease.get("owner_agent", "")).strip()
+                self._append_unique(entry["branches"], str(lease.get("branch", "")).strip())
+                self._append_unique(
+                    entry["worktree_paths"],
+                    str(lease.get("worktree_path", "")).strip(),
+                )
+                self._append_unique(entry["lease_ids"], str(lease.get("lease_id", "")).strip())
+                metadata = lease.get("metadata")
+                if isinstance(metadata, dict):
+                    self._append_unique(
+                        entry["receipt_ids"],
+                        str(metadata.get("receipt_id", "")).strip(),
+                    )
+                for path in self._lease_paths(lease):
+                    self._append_unique(entry["claimed_paths"], path)
+
+        for run in bridge_runs:
+            participants = run.get("participants")
+            if not isinstance(participants, list):
+                continue
+            for participant in participants:
+                if not isinstance(participant, dict):
+                    continue
+                role = str(participant.get("role", "")).strip()
+                if not role:
+                    continue
+                entry = owner(f"bridge:{run.get('run_id')}:{role}")
+                entry["agent"] = str(participant.get("harness", "")).strip()
+                self._append_unique(entry["bridge_run_ids"], str(run.get("run_id", "")).strip())
+                self._append_unique(
+                    entry["worktree_paths"], str(run.get("worktree_path", "")).strip()
+                )
+
+        return sorted(owners.values(), key=lambda item: str(item.get("session_id", "")))
+
+    def _active_work_avoid_paths(
+        self,
+        *,
+        claims: list[dict[str, Any]],
+        active_leases: Any,
+    ) -> list[str]:
+        paths = set(self._claim_paths(claims))
+        if isinstance(active_leases, list):
+            for lease in active_leases:
+                if isinstance(lease, dict):
+                    paths.update(self._lease_paths(lease))
+        return sorted(path for path in paths if path)
+
+    def _claim_paths(self, claims: list[dict[str, Any]]) -> list[str]:
+        return sorted(
+            {
+                str(claim.get("path", "")).strip()
+                for claim in claims
+                if str(claim.get("path", "")).strip()
+            }
+        )
+
+    def _lease_paths(self, lease: dict[str, Any]) -> list[str]:
+        paths: list[str] = []
+        for key in ("claimed_paths", "allowed_globs"):
+            raw = lease.get(key)
+            if not isinstance(raw, list):
+                continue
+            paths.extend(str(item).strip() for item in raw if str(item).strip())
+        return sorted(set(paths))
+
+    def _append_unique(self, values: list[Any], value: Any) -> None:
+        if value and value not in values:
+            values.append(value)
 
     @api_endpoint(
         method="GET",

--- a/aragora/server/openapi/endpoints/agent_bridge.py
+++ b/aragora/server/openapi/endpoints/agent_bridge.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from aragora.server.openapi.endpoints.response_schemas import (
     AGENT_BRIDGE_EVENTS_RESPONSE_SCHEMA,
+    AGENT_BRIDGE_EVENT_SCHEMA,
     AGENT_BRIDGE_RUN_DETAIL_SCHEMA,
     AGENT_BRIDGE_RUN_LIST_RESPONSE_SCHEMA,
     AGENT_BRIDGE_TRANSCRIPT_RESPONSE_SCHEMA,
@@ -71,6 +72,95 @@ def _secured_get(
     }
 
 
+def _secured_post(
+    *,
+    summary: str,
+    description: str,
+    operation_id: str,
+    request_schema: dict[str, Any],
+    responses: dict[str, Any],
+    parameters: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "tags": ["Agent Bridge"],
+        "summary": summary,
+        "description": description,
+        "operationId": operation_id,
+        "security": AUTH_REQUIREMENTS["required"]["security"],
+        "parameters": parameters or [],
+        "requestBody": {
+            "required": True,
+            "content": {"application/json": {"schema": request_schema}},
+        },
+        "responses": responses,
+    }
+
+
+_AGENT_BRIDGE_ACTOR_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["role", "harness"],
+    "additionalProperties": False,
+    "properties": {
+        "role": {"type": "string"},
+        "harness": {"type": "string"},
+        "model": {"type": "string"},
+        "session_id": {"type": "string"},
+        "worktree_path": {"type": "string"},
+        "worktree_agent_slug": {"type": "string"},
+        "branch": {"type": "string"},
+        "harness_options": {"type": "object", "additionalProperties": True},
+    },
+}
+
+_START_RUN_REQUEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["task", "actors"],
+    "additionalProperties": False,
+    "properties": {
+        "task": {"type": "string"},
+        "actors": {"type": "array", "items": _AGENT_BRIDGE_ACTOR_SCHEMA, "minItems": 1},
+        "run_id": {"type": "string"},
+        "next_actor": {"type": "string"},
+        "worktree_path": {"type": "string"},
+        "worktree_agent_slug": {"type": "string"},
+        "repair_budget_per_turn": {"type": "integer", "minimum": 0, "default": 1},
+    },
+}
+
+_DISPATCH_REQUEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["role", "prompt"],
+    "additionalProperties": False,
+    "properties": {"role": {"type": "string"}, "prompt": {"type": "string"}},
+}
+
+_AUTO_STEP_REQUEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "prompt": {"type": "string"},
+        "context_turns": {"type": "integer", "minimum": 1, "maximum": 20, "default": 5},
+    },
+}
+
+_AUTO_STEP_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": True,
+    "required": ["auto_step"],
+    "properties": {
+        **AGENT_BRIDGE_EVENT_SCHEMA["properties"],
+        "auto_step": {
+            "type": "object",
+            "required": ["role", "context_turns"],
+            "properties": {
+                "role": {"type": "string"},
+                "context_turns": {"type": "integer"},
+            },
+        },
+    },
+}
+
+
 AGENT_BRIDGE_ENDPOINTS: dict[str, dict[str, Any]] = {
     "/api/v1/agent-bridge/runs": {
         "get": _secured_get(
@@ -88,7 +178,25 @@ AGENT_BRIDGE_ENDPOINTS: dict[str, dict[str, Any]] = {
                 "403": STANDARD_ERRORS["403"],
                 "500": STANDARD_ERRORS["500"],
             },
-        )
+        ),
+        "post": _secured_post(
+            summary="Start agent bridge run",
+            description=(
+                "Start a persisted bridge run without dispatching a turn. "
+                "This operator-local write endpoint is separately feature-gated because "
+                "subsequent dispatch can spawn local model harness processes."
+            ),
+            operation_id="startAgentBridgeRun",
+            request_schema=_START_RUN_REQUEST_SCHEMA,
+            responses={
+                "201": _ok_response("Started agent bridge run", AGENT_BRIDGE_RUN_DETAIL_SCHEMA),
+                "400": STANDARD_ERRORS["400"],
+                "401": STANDARD_ERRORS["401"],
+                "403": STANDARD_ERRORS["403"],
+                "409": STANDARD_ERRORS["409"],
+                "500": STANDARD_ERRORS["500"],
+            },
+        ),
     },
     "/api/v1/agent-bridge/runs/{run_id}": {
         "get": _secured_get(
@@ -146,6 +254,45 @@ AGENT_BRIDGE_ENDPOINTS: dict[str, dict[str, Any]] = {
                 "401": STANDARD_ERRORS["401"],
                 "403": STANDARD_ERRORS["403"],
                 "404": STANDARD_ERRORS["404"],
+                "500": STANDARD_ERRORS["500"],
+            },
+        )
+    },
+    "/api/v1/agent-bridge/runs/{run_id}/dispatch": {
+        "post": _secured_post(
+            summary="Dispatch one bridge turn",
+            description="Dispatch one prompt to a registered role in an active bridge run.",
+            operation_id="dispatchAgentBridgeTurn",
+            parameters=[_RUN_ID_PARAM],
+            request_schema=_DISPATCH_REQUEST_SCHEMA,
+            responses={
+                "200": _ok_response("Agent bridge turn event", AGENT_BRIDGE_EVENT_SCHEMA),
+                "400": STANDARD_ERRORS["400"],
+                "401": STANDARD_ERRORS["401"],
+                "403": STANDARD_ERRORS["403"],
+                "404": STANDARD_ERRORS["404"],
+                "409": STANDARD_ERRORS["409"],
+                "500": STANDARD_ERRORS["500"],
+            },
+        )
+    },
+    "/api/v1/agent-bridge/runs/{run_id}/auto-step": {
+        "post": _secured_post(
+            summary="Auto-dispatch the next bridge actor",
+            description=(
+                "Compose a continuation prompt from the run task and recent transcript, "
+                "then dispatch one turn to next_actor. This is one-step automation, not a daemon."
+            ),
+            operation_id="autoStepAgentBridgeRun",
+            parameters=[_RUN_ID_PARAM],
+            request_schema=_AUTO_STEP_REQUEST_SCHEMA,
+            responses={
+                "200": _ok_response("Auto-step dispatch result", _AUTO_STEP_RESPONSE_SCHEMA),
+                "400": STANDARD_ERRORS["400"],
+                "401": STANDARD_ERRORS["401"],
+                "403": STANDARD_ERRORS["403"],
+                "404": STANDARD_ERRORS["404"],
+                "409": STANDARD_ERRORS["409"],
                 "500": STANDARD_ERRORS["500"],
             },
         )

--- a/aragora/server/openapi/endpoints/control_plane.py
+++ b/aragora/server/openapi/endpoints/control_plane.py
@@ -684,4 +684,70 @@ CONTROL_PLANE_ENDPOINTS = {
             },
         }
     },
+    "/api/v1/coordination/active-work": {
+        "get": {
+            "tags": ["Coordination"],
+            "summary": "Get active agent work snapshot",
+            "operationId": "getCoordinationActiveWork",
+            "description": (
+                "Return a compact, agent-readable snapshot over existing fleet claims, "
+                "developer leases, merge queue entries, worktree sessions, and active "
+                "agent bridge runs."
+            ),
+            "security": AUTH_REQUIREMENTS["required"]["security"],
+            "parameters": [
+                {
+                    "name": "base",
+                    "in": "query",
+                    "required": False,
+                    "description": "Base branch for worktree status.",
+                    "schema": {"type": "string", "default": "main"},
+                }
+            ],
+            "responses": {
+                "200": _ok_response(
+                    "Active work snapshot",
+                    {
+                        "type": "object",
+                        "required": [
+                            "schema_version",
+                            "repo_root",
+                            "base_branch",
+                            "generated_at",
+                            "active_owners",
+                            "claimed_paths",
+                            "avoid_paths",
+                            "worktrees",
+                            "fleet_claims",
+                            "active_leases",
+                            "merge_queue",
+                            "bridge_runs",
+                            "counts",
+                            "source_errors",
+                        ],
+                        "properties": {
+                            "schema_version": {"type": "integer", "enum": [1]},
+                            "repo_root": {"type": "string"},
+                            "base_branch": {"type": "string"},
+                            "generated_at": {"type": "string", "format": "date-time"},
+                            "active_owners": {"type": "array", "items": {"type": "object"}},
+                            "claimed_paths": {"type": "array", "items": {"type": "string"}},
+                            "avoid_paths": {"type": "array", "items": {"type": "string"}},
+                            "avoid_path_hints": {"type": "array", "items": {"type": "object"}},
+                            "worktrees": {"type": "array", "items": {"type": "object"}},
+                            "fleet_claims": {"type": "array", "items": {"type": "object"}},
+                            "active_leases": {"type": "array", "items": {"type": "object"}},
+                            "merge_queue": {"type": "array", "items": {"type": "object"}},
+                            "bridge_runs": {"type": "array", "items": {"type": "object"}},
+                            "counts": {"type": "object", "additionalProperties": True},
+                            "source_errors": {"type": "array", "items": {"type": "object"}},
+                        },
+                    },
+                ),
+                "401": STANDARD_ERRORS["401"],
+                "403": STANDARD_ERRORS["403"],
+                "500": STANDARD_ERRORS["500"],
+            },
+        }
+    },
 }

--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -555,6 +555,10 @@
       "description": "MCP operations"
     },
     {
+      "name": "Coordination",
+      "description": "Coordination operations"
+    },
+    {
       "name": "Mentions",
       "description": "Mentions operations"
     },
@@ -689,10 +693,6 @@
     {
       "name": "Activity",
       "description": "Activity operations"
-    },
-    {
-      "name": "Coordination",
-      "description": "Coordination operations"
     },
     {
       "name": "Debate Interventions",
@@ -70177,6 +70177,522 @@
           }
         },
         "x-aragora-stability": "experimental"
+      },
+      "post": {
+        "tags": [
+          "Agent Bridge"
+        ],
+        "summary": "Start agent bridge run",
+        "description": "Start a persisted bridge run without dispatching a turn. This operator-local write endpoint is separately feature-gated because subsequent dispatch can spawn local model harness processes.",
+        "operationId": "startAgentBridgeRun",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "task",
+                  "actors"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "task": {
+                    "type": "string"
+                  },
+                  "actors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "role",
+                        "harness"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "role": {
+                          "type": "string"
+                        },
+                        "harness": {
+                          "type": "string"
+                        },
+                        "model": {
+                          "type": "string"
+                        },
+                        "session_id": {
+                          "type": "string"
+                        },
+                        "worktree_path": {
+                          "type": "string"
+                        },
+                        "worktree_agent_slug": {
+                          "type": "string"
+                        },
+                        "branch": {
+                          "type": "string"
+                        },
+                        "harness_options": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    },
+                    "minItems": 1
+                  },
+                  "run_id": {
+                    "type": "string"
+                  },
+                  "next_actor": {
+                    "type": "string"
+                  },
+                  "worktree_path": {
+                    "type": "string"
+                  },
+                  "worktree_agent_slug": {
+                    "type": "string"
+                  },
+                  "repair_budget_per_turn": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Started agent bridge run",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "schema_version",
+                    "run_id",
+                    "task",
+                    "status",
+                    "created_at",
+                    "updated_at",
+                    "completed_at",
+                    "last_turn_index",
+                    "next_actor",
+                    "repair_budget_per_turn",
+                    "footer_mode",
+                    "worktree_cleanup_mode",
+                    "participants",
+                    "last_event_id",
+                    "roles",
+                    "worktree_path",
+                    "worktree_agent_slug"
+                  ],
+                  "properties": {
+                    "schema_version": {
+                      "type": "integer",
+                      "enum": [
+                        1
+                      ]
+                    },
+                    "run_id": {
+                      "type": "string"
+                    },
+                    "task": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "completed_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "last_turn_index": {
+                      "type": "integer"
+                    },
+                    "next_actor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "repair_budget_per_turn": {
+                      "type": "integer"
+                    },
+                    "footer_mode": {
+                      "type": "string"
+                    },
+                    "worktree_cleanup_mode": {
+                      "type": "string"
+                    },
+                    "participants": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "role",
+                          "harness",
+                          "model"
+                        ],
+                        "properties": {
+                          "role": {
+                            "type": "string"
+                          },
+                          "harness": {
+                            "type": "string"
+                          },
+                          "model": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "last_event_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "roles": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "role",
+                          "harness",
+                          "model",
+                          "session_id",
+                          "worktree_agent_slug",
+                          "worktree_path",
+                          "branch",
+                          "session_status",
+                          "started_at",
+                          "last_turn_index",
+                          "last_completed_at"
+                        ],
+                        "properties": {
+                          "role": {
+                            "type": "string"
+                          },
+                          "harness": {
+                            "type": "string"
+                          },
+                          "model": {
+                            "type": "string"
+                          },
+                          "session_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "worktree_agent_slug": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "worktree_path": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "branch": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "session_status": {
+                            "type": "string",
+                            "enum": [
+                              "not_started",
+                              "active",
+                              "completed",
+                              "failed"
+                            ]
+                          },
+                          "started_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          },
+                          "last_turn_index": {
+                            "type": "integer"
+                          },
+                          "last_completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          },
+                          "harness_options": {
+                            "type": "object",
+                            "additionalProperties": true
+                          }
+                        }
+                      }
+                    },
+                    "worktree_path": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "worktree_agent_slug": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or malformed JSON",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalid_json": {
+                    "summary": "Invalid JSON body",
+                    "value": {
+                      "error": "Invalid JSON in request body",
+                      "code": "INVALID_JSON",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "missing_field": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "error": "Missing required field: task",
+                      "code": "MISSING_FIELD",
+                      "field": "task",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_value": {
+                    "summary": "Invalid field value",
+                    "value": {
+                      "error": "Invalid value for 'rounds': must be between 1 and 12",
+                      "code": "INVALID_VALUE",
+                      "field": "rounds",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication required or token invalid",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "missing_token": {
+                    "summary": "No authentication token",
+                    "value": {
+                      "error": "Authentication required",
+                      "code": "AUTH_REQUIRED",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_token": {
+                    "summary": "Invalid or expired token",
+                    "value": {
+                      "error": "Invalid or expired authentication token",
+                      "code": "INVALID_TOKEN",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Insufficient permissions for this operation",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "insufficient_permissions": {
+                    "summary": "Insufficient permissions",
+                    "value": {
+                      "error": "You do not have permission to access this resource",
+                      "code": "FORBIDDEN",
+                      "required_role": "admin",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "resource_owner": {
+                    "summary": "Not resource owner",
+                    "value": {
+                      "error": "You do not have permission to modify this debate",
+                      "code": "NOT_OWNER",
+                      "resource_type": "debate",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict - The request could not be completed",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
       }
     },
     "/api/v1/agent-bridge/runs/{run_id}": {
@@ -70576,6 +71092,798 @@
                       "trace_id": "req_abc123xyz"
                     }
                   }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/agent-bridge/runs/{run_id}/auto-step": {
+      "post": {
+        "tags": [
+          "Agent Bridge"
+        ],
+        "summary": "Auto-dispatch the next bridge actor",
+        "description": "Compose a continuation prompt from the run task and recent transcript, then dispatch one turn to next_actor. This is one-step automation, not a daemon.",
+        "operationId": "autoStepAgentBridgeRun",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "description": "Bridge run identifier.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "prompt": {
+                    "type": "string"
+                  },
+                  "context_turns": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Auto-step dispatch result",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "required": [
+                    "auto_step"
+                  ],
+                  "properties": {
+                    "schema_version": {
+                      "type": "integer",
+                      "enum": [
+                        1
+                      ]
+                    },
+                    "event_id": {
+                      "type": "string"
+                    },
+                    "run_id": {
+                      "type": "string"
+                    },
+                    "ts": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "event_type": {
+                      "type": "string",
+                      "enum": [
+                        "run_started",
+                        "run_failed",
+                        "run_completed",
+                        "turn.started",
+                        "turn.result",
+                        "turn.completed",
+                        "turn.repair_requested",
+                        "footer_ok",
+                        "footer_malformed",
+                        "footer_missing"
+                      ]
+                    },
+                    "turn_index": {
+                      "type": "integer"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "harness": {
+                      "type": "string"
+                    },
+                    "session_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "parse_status": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "ok",
+                        "missing",
+                        "malformed",
+                        null
+                      ]
+                    },
+                    "payload": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "auto_step": {
+                      "type": "object",
+                      "required": [
+                        "role",
+                        "context_turns"
+                      ],
+                      "properties": {
+                        "role": {
+                          "type": "string"
+                        },
+                        "context_turns": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or malformed JSON",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalid_json": {
+                    "summary": "Invalid JSON body",
+                    "value": {
+                      "error": "Invalid JSON in request body",
+                      "code": "INVALID_JSON",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "missing_field": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "error": "Missing required field: task",
+                      "code": "MISSING_FIELD",
+                      "field": "task",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_value": {
+                    "summary": "Invalid field value",
+                    "value": {
+                      "error": "Invalid value for 'rounds': must be between 1 and 12",
+                      "code": "INVALID_VALUE",
+                      "field": "rounds",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication required or token invalid",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "missing_token": {
+                    "summary": "No authentication token",
+                    "value": {
+                      "error": "Authentication required",
+                      "code": "AUTH_REQUIRED",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_token": {
+                    "summary": "Invalid or expired token",
+                    "value": {
+                      "error": "Invalid or expired authentication token",
+                      "code": "INVALID_TOKEN",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Insufficient permissions for this operation",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "insufficient_permissions": {
+                    "summary": "Insufficient permissions",
+                    "value": {
+                      "error": "You do not have permission to access this resource",
+                      "code": "FORBIDDEN",
+                      "required_role": "admin",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "resource_owner": {
+                    "summary": "Not resource owner",
+                    "value": {
+                      "error": "You do not have permission to modify this debate",
+                      "code": "NOT_OWNER",
+                      "resource_type": "debate",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict - The request could not be completed",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/agent-bridge/runs/{run_id}/dispatch": {
+      "post": {
+        "tags": [
+          "Agent Bridge"
+        ],
+        "summary": "Dispatch one bridge turn",
+        "description": "Dispatch one prompt to a registered role in an active bridge run.",
+        "operationId": "dispatchAgentBridgeTurn",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "description": "Bridge run identifier.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "role",
+                  "prompt"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "role": {
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Agent bridge turn event",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "schema_version",
+                    "event_id",
+                    "run_id",
+                    "ts",
+                    "event_type",
+                    "turn_index",
+                    "role",
+                    "harness",
+                    "session_id",
+                    "parse_status",
+                    "payload"
+                  ],
+                  "properties": {
+                    "schema_version": {
+                      "type": "integer",
+                      "enum": [
+                        1
+                      ]
+                    },
+                    "event_id": {
+                      "type": "string"
+                    },
+                    "run_id": {
+                      "type": "string"
+                    },
+                    "ts": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "event_type": {
+                      "type": "string",
+                      "enum": [
+                        "run_started",
+                        "run_failed",
+                        "run_completed",
+                        "turn.started",
+                        "turn.result",
+                        "turn.completed",
+                        "turn.repair_requested",
+                        "footer_ok",
+                        "footer_malformed",
+                        "footer_missing"
+                      ]
+                    },
+                    "turn_index": {
+                      "type": "integer"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "harness": {
+                      "type": "string"
+                    },
+                    "session_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "parse_status": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "ok",
+                        "missing",
+                        "malformed",
+                        null
+                      ]
+                    },
+                    "payload": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or malformed JSON",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalid_json": {
+                    "summary": "Invalid JSON body",
+                    "value": {
+                      "error": "Invalid JSON in request body",
+                      "code": "INVALID_JSON",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "missing_field": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "error": "Missing required field: task",
+                      "code": "MISSING_FIELD",
+                      "field": "task",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_value": {
+                    "summary": "Invalid field value",
+                    "value": {
+                      "error": "Invalid value for 'rounds': must be between 1 and 12",
+                      "code": "INVALID_VALUE",
+                      "field": "rounds",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication required or token invalid",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "missing_token": {
+                    "summary": "No authentication token",
+                    "value": {
+                      "error": "Authentication required",
+                      "code": "AUTH_REQUIRED",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_token": {
+                    "summary": "Invalid or expired token",
+                    "value": {
+                      "error": "Invalid or expired authentication token",
+                      "code": "INVALID_TOKEN",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Insufficient permissions for this operation",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "insufficient_permissions": {
+                    "summary": "Insufficient permissions",
+                    "value": {
+                      "error": "You do not have permission to access this resource",
+                      "code": "FORBIDDEN",
+                      "required_role": "admin",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "resource_owner": {
+                    "summary": "Not resource owner",
+                    "value": {
+                      "error": "You do not have permission to modify this debate",
+                      "code": "NOT_OWNER",
+                      "resource_type": "debate",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict - The request could not be completed",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
                 }
               }
             }
@@ -117286,6 +118594,283 @@
           }
         },
         "x-aragora-stability": "stable"
+      }
+    },
+    "/api/v1/coordination/active-work": {
+      "get": {
+        "tags": [
+          "Coordination"
+        ],
+        "summary": "Get active agent work snapshot",
+        "operationId": "getCoordinationActiveWork",
+        "description": "Return a compact, agent-readable snapshot over existing fleet claims, developer leases, merge queue entries, worktree sessions, and active agent bridge runs.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "base",
+            "in": "query",
+            "required": false,
+            "description": "Base branch for worktree status.",
+            "schema": {
+              "type": "string",
+              "default": "main"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Active work snapshot",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "schema_version",
+                    "repo_root",
+                    "base_branch",
+                    "generated_at",
+                    "active_owners",
+                    "claimed_paths",
+                    "avoid_paths",
+                    "worktrees",
+                    "fleet_claims",
+                    "active_leases",
+                    "merge_queue",
+                    "bridge_runs",
+                    "counts",
+                    "source_errors"
+                  ],
+                  "properties": {
+                    "schema_version": {
+                      "type": "integer",
+                      "enum": [
+                        1
+                      ]
+                    },
+                    "repo_root": {
+                      "type": "string"
+                    },
+                    "base_branch": {
+                      "type": "string"
+                    },
+                    "generated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "active_owners": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "claimed_paths": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "avoid_paths": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "avoid_path_hints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "worktrees": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "fleet_claims": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "active_leases": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "merge_queue": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "bridge_runs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "counts": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "source_errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Authentication required or token invalid",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "missing_token": {
+                    "summary": "No authentication token",
+                    "value": {
+                      "error": "Authentication required",
+                      "code": "AUTH_REQUIRED",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_token": {
+                    "summary": "Invalid or expired token",
+                    "value": {
+                      "error": "Invalid or expired authentication token",
+                      "code": "INVALID_TOKEN",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Insufficient permissions for this operation",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "insufficient_permissions": {
+                    "summary": "Insufficient permissions",
+                    "value": {
+                      "error": "You do not have permission to access this resource",
+                      "code": "FORBIDDEN",
+                      "required_role": "admin",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "resource_owner": {
+                    "summary": "Not resource owner",
+                    "value": {
+                      "error": "You do not have permission to modify this debate",
+                      "code": "NOT_OWNER",
+                      "resource_type": "debate",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
       }
     },
     "/api/v1/coordination/approve/{request_id}": {

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -280,6 +280,8 @@ tags:
   description: Diagnostics operations
 - name: MCP
   description: MCP operations
+- name: Coordination
+  description: Coordination operations
 - name: Mentions
   description: Mentions operations
 - name: Feedback Hub
@@ -348,8 +350,6 @@ tags:
   description: Agent Bridge operations
 - name: Activity
   description: Activity operations
-- name: Coordination
-  description: Coordination operations
 - name: Debate Interventions
   description: Debate Interventions operations
 - name: Federation
@@ -40549,7 +40549,7 @@ paths:
       summary: List agent bridge runs
       description: List persisted agent bridge runs in newest-first order.
       operationId: listAgentBridgeRuns
-      security:
+      security: &id282
       - bearerAuth: []
       parameters:
       - name: limit
@@ -40615,36 +40615,36 @@ paths:
                       - last_event_id
                       properties:
                         schema_version: *id279
-                        run_id:
+                        run_id: &id283
                           type: string
-                        task:
+                        task: &id284
                           type: string
-                        status:
+                        status: &id285
                           type: string
-                        created_at:
-                          type: string
-                          format: date-time
-                        updated_at:
+                        created_at: &id286
                           type: string
                           format: date-time
-                        completed_at:
+                        updated_at: &id287
+                          type: string
+                          format: date-time
+                        completed_at: &id288
                           type:
                           - string
                           - 'null'
                           format: date-time
-                        last_turn_index:
+                        last_turn_index: &id289
                           type: integer
                         next_actor: &id280
                           type:
                           - string
                           - 'null'
-                        repair_budget_per_turn:
+                        repair_budget_per_turn: &id290
                           type: integer
-                        footer_mode:
+                        footer_mode: &id291
                           type: string
-                        worktree_cleanup_mode:
+                        worktree_cleanup_mode: &id292
                           type: string
-                        participants:
+                        participants: &id293
                           type: array
                           items:
                             type: object
@@ -40662,7 +40662,7 @@ paths:
                                 type: string
                         last_event_id: *id280
                   next_cursor: *id280
-        '400':
+        '400': &id294
           description: Bad request - Invalid input or malformed JSON
           headers: *id281
           content:
@@ -40690,7 +40690,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401':
+        '401': &id295
           description: Unauthorized - Authentication required or token invalid
           headers: *id281
           content:
@@ -40710,7 +40710,7 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403':
+        '403': &id296
           description: Forbidden - Insufficient permissions for this operation
           headers: *id281
           content:
@@ -40732,7 +40732,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500':
+        '500': &id297
           description: Internal server error - Unexpected error occurred
           headers: *id281
           content:
@@ -40747,6 +40747,165 @@ paths:
                     code: INTERNAL_ERROR
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+    post:
+      tags:
+      - Agent Bridge
+      summary: Start agent bridge run
+      description: Start a persisted bridge run without dispatching a turn. This operator-local write endpoint is separately
+        feature-gated because subsequent dispatch can spawn local model harness processes.
+      operationId: startAgentBridgeRun
+      security: *id282
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - task
+              - actors
+              additionalProperties: false
+              properties:
+                task:
+                  type: string
+                actors:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - role
+                    - harness
+                    additionalProperties: false
+                    properties:
+                      role:
+                        type: string
+                      harness:
+                        type: string
+                      model:
+                        type: string
+                      session_id:
+                        type: string
+                      worktree_path:
+                        type: string
+                      worktree_agent_slug:
+                        type: string
+                      branch:
+                        type: string
+                      harness_options:
+                        type: object
+                        additionalProperties: true
+                  minItems: 1
+                run_id:
+                  type: string
+                next_actor:
+                  type: string
+                worktree_path:
+                  type: string
+                worktree_agent_slug:
+                  type: string
+                repair_budget_per_turn:
+                  type: integer
+                  minimum: 0
+                  default: 1
+      responses:
+        '201':
+          description: Started agent bridge run
+          headers: *id281
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                - schema_version
+                - run_id
+                - task
+                - status
+                - created_at
+                - updated_at
+                - completed_at
+                - last_turn_index
+                - next_actor
+                - repair_budget_per_turn
+                - footer_mode
+                - worktree_cleanup_mode
+                - participants
+                - last_event_id
+                - roles
+                - worktree_path
+                - worktree_agent_slug
+                properties:
+                  schema_version: *id279
+                  run_id: *id283
+                  task: *id284
+                  status: *id285
+                  created_at: *id286
+                  updated_at: *id287
+                  completed_at: *id288
+                  last_turn_index: *id289
+                  next_actor: *id280
+                  repair_budget_per_turn: *id290
+                  footer_mode: *id291
+                  worktree_cleanup_mode: *id292
+                  participants: *id293
+                  last_event_id: *id280
+                  roles:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      additionalProperties: false
+                      required:
+                      - role
+                      - harness
+                      - model
+                      - session_id
+                      - worktree_agent_slug
+                      - worktree_path
+                      - branch
+                      - session_status
+                      - started_at
+                      - last_turn_index
+                      - last_completed_at
+                      properties:
+                        role:
+                          type: string
+                        harness:
+                          type: string
+                        model:
+                          type: string
+                        session_id: *id280
+                        worktree_agent_slug: *id280
+                        worktree_path: *id280
+                        branch: *id280
+                        session_status:
+                          type: string
+                          enum:
+                          - not_started
+                          - active
+                          - completed
+                          - failed
+                        started_at: *id288
+                        last_turn_index:
+                          type: integer
+                        last_completed_at: *id288
+                        harness_options:
+                          type: object
+                          additionalProperties: true
+                  worktree_path: *id280
+                  worktree_agent_slug: *id280
+        '400': *id294
+        '401': *id295
+        '403': *id296
+        '409':
+          description: Conflict - The request could not be completed
+          headers: *id281
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500': *id297
       x-aragora-stability: experimental
   /api/v1/agent-bridge/runs/{run_id}:
     get:
@@ -40768,16 +40927,16 @@ paths:
         '200':
           description: Agent bridge run detail
           headers:
-            X-Request-ID: &id284
+            X-Request-ID: &id300
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id285
+            X-Response-Time: &id301
               description: Server processing time in milliseconds
               schema:
                 type: integer
-            ETag: &id286
+            ETag: &id302
               description: Weak entity tag for polling and conditional requests.
               schema:
                 type: string
@@ -40821,14 +40980,14 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-                  completed_at: &id283
+                  completed_at: &id299
                     type:
                     - string
                     - 'null'
                     format: date-time
                   last_turn_index:
                     type: integer
-                  next_actor: &id282
+                  next_actor: &id298
                     type:
                     - string
                     - 'null'
@@ -40854,7 +41013,7 @@ paths:
                           type: string
                         model:
                           type: string
-                  last_event_id: *id282
+                  last_event_id: *id298
                   roles:
                     type: object
                     additionalProperties:
@@ -40879,10 +41038,10 @@ paths:
                           type: string
                         model:
                           type: string
-                        session_id: *id282
-                        worktree_agent_slug: *id282
-                        worktree_path: *id282
-                        branch: *id282
+                        session_id: *id298
+                        worktree_agent_slug: *id298
+                        worktree_path: *id298
+                        branch: *id298
                         session_status:
                           type: string
                           enum:
@@ -40890,26 +41049,26 @@ paths:
                           - active
                           - completed
                           - failed
-                        started_at: *id283
+                        started_at: *id299
                         last_turn_index:
                           type: integer
-                        last_completed_at: *id283
+                        last_completed_at: *id299
                         harness_options:
                           type: object
                           additionalProperties: true
-                  worktree_path: *id282
-                  worktree_agent_slug: *id282
+                  worktree_path: *id298
+                  worktree_agent_slug: *id298
         '304':
           description: Not modified
           headers:
-            X-Request-ID: *id284
-            X-Response-Time: *id285
-            ETag: *id286
+            X-Request-ID: *id300
+            X-Response-Time: *id301
+            ETag: *id302
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id287
-            X-Request-ID: *id284
-            X-Response-Time: *id285
+          headers: &id303
+            X-Request-ID: *id300
+            X-Response-Time: *id301
           content:
             application/json:
               schema:
@@ -40929,7 +41088,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id287
+          headers: *id303
           content:
             application/json:
               schema:
@@ -40951,7 +41110,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id287
+          headers: *id303
           content:
             application/json:
               schema:
@@ -40967,7 +41126,442 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id287
+          headers: *id303
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/agent-bridge/runs/{run_id}/auto-step:
+    post:
+      tags:
+      - Agent Bridge
+      summary: Auto-dispatch the next bridge actor
+      description: Compose a continuation prompt from the run task and recent transcript, then dispatch one turn to next_actor.
+        This is one-step automation, not a daemon.
+      operationId: autoStepAgentBridgeRun
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: run_id
+        in: path
+        required: true
+        description: Bridge run identifier.
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                prompt:
+                  type: string
+                context_turns:
+                  type: integer
+                  minimum: 1
+                  maximum: 20
+                  default: 5
+      responses:
+        '200':
+          description: Auto-step dispatch result
+          headers: &id304
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                required:
+                - auto_step
+                properties:
+                  schema_version:
+                    type: integer
+                    enum:
+                    - 1
+                  event_id:
+                    type: string
+                  run_id:
+                    type: string
+                  ts:
+                    type: string
+                    format: date-time
+                  event_type:
+                    type: string
+                    enum:
+                    - run_started
+                    - run_failed
+                    - run_completed
+                    - turn.started
+                    - turn.result
+                    - turn.completed
+                    - turn.repair_requested
+                    - footer_ok
+                    - footer_malformed
+                    - footer_missing
+                  turn_index:
+                    type: integer
+                  role:
+                    type: string
+                  harness:
+                    type: string
+                  session_id:
+                    type:
+                    - string
+                    - 'null'
+                  parse_status:
+                    type:
+                    - string
+                    - 'null'
+                    enum:
+                    - ok
+                    - missing
+                    - malformed
+                    - null
+                  payload:
+                    type: object
+                    additionalProperties: true
+                  auto_step:
+                    type: object
+                    required:
+                    - role
+                    - context_turns
+                    properties:
+                      role:
+                        type: string
+                      context_turns:
+                        type: integer
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id304
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id304
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id304
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id304
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '409':
+          description: Conflict - The request could not be completed
+          headers: *id304
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id304
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/agent-bridge/runs/{run_id}/dispatch:
+    post:
+      tags:
+      - Agent Bridge
+      summary: Dispatch one bridge turn
+      description: Dispatch one prompt to a registered role in an active bridge run.
+      operationId: dispatchAgentBridgeTurn
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: run_id
+        in: path
+        required: true
+        description: Bridge run identifier.
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - role
+              - prompt
+              additionalProperties: false
+              properties:
+                role:
+                  type: string
+                prompt:
+                  type: string
+      responses:
+        '200':
+          description: Agent bridge turn event
+          headers: &id305
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                - schema_version
+                - event_id
+                - run_id
+                - ts
+                - event_type
+                - turn_index
+                - role
+                - harness
+                - session_id
+                - parse_status
+                - payload
+                properties:
+                  schema_version:
+                    type: integer
+                    enum:
+                    - 1
+                  event_id:
+                    type: string
+                  run_id:
+                    type: string
+                  ts:
+                    type: string
+                    format: date-time
+                  event_type:
+                    type: string
+                    enum:
+                    - run_started
+                    - run_failed
+                    - run_completed
+                    - turn.started
+                    - turn.result
+                    - turn.completed
+                    - turn.repair_requested
+                    - footer_ok
+                    - footer_malformed
+                    - footer_missing
+                  turn_index:
+                    type: integer
+                  role:
+                    type: string
+                  harness:
+                    type: string
+                  session_id:
+                    type:
+                    - string
+                    - 'null'
+                  parse_status:
+                    type:
+                    - string
+                    - 'null'
+                    enum:
+                    - ok
+                    - missing
+                    - malformed
+                    - null
+                  payload:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id305
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id305
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id305
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id305
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '409':
+          description: Conflict - The request could not be completed
+          headers: *id305
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id305
           content:
             application/json:
               schema:
@@ -41016,16 +41610,16 @@ paths:
         '200':
           description: Paginated list of agent bridge events
           headers:
-            X-Request-ID: &id290
+            X-Request-ID: &id308
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id291
+            X-Response-Time: &id309
               description: Server processing time in milliseconds
               schema:
                 type: integer
-            ETag: &id292
+            ETag: &id310
               description: Weak entity tag for polling and conditional requests.
               schema:
                 type: string
@@ -41038,7 +41632,7 @@ paths:
                 - schema_version
                 - events
                 properties:
-                  schema_version: &id288
+                  schema_version: &id306
                     type: integer
                     enum:
                     - 1
@@ -41060,7 +41654,7 @@ paths:
                       - parse_status
                       - payload
                       properties:
-                        schema_version: *id288
+                        schema_version: *id306
                         event_id:
                           type: string
                         run_id:
@@ -41087,7 +41681,7 @@ paths:
                           type: string
                         harness:
                           type: string
-                        session_id: &id289
+                        session_id: &id307
                           type:
                           - string
                           - 'null'
@@ -41103,18 +41697,18 @@ paths:
                         payload:
                           type: object
                           additionalProperties: true
-                  next_cursor: *id289
+                  next_cursor: *id307
         '304':
           description: Not modified
           headers:
-            X-Request-ID: *id290
-            X-Response-Time: *id291
-            ETag: *id292
+            X-Request-ID: *id308
+            X-Response-Time: *id309
+            ETag: *id310
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id293
-            X-Request-ID: *id290
-            X-Response-Time: *id291
+          headers: &id311
+            X-Request-ID: *id308
+            X-Response-Time: *id309
           content:
             application/json:
               schema:
@@ -41142,7 +41736,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id293
+          headers: *id311
           content:
             application/json:
               schema:
@@ -41162,7 +41756,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id293
+          headers: *id311
           content:
             application/json:
               schema:
@@ -41184,7 +41778,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id293
+          headers: *id311
           content:
             application/json:
               schema:
@@ -41200,7 +41794,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id293
+          headers: *id311
           content:
             application/json:
               schema:
@@ -41233,7 +41827,7 @@ paths:
       responses:
         '200':
           description: Reconstructed agent bridge transcript
-          headers: &id295
+          headers: &id313
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -41277,7 +41871,7 @@ paths:
                         started_at:
                           type: string
                           format: date-time
-                        completed_at: &id294
+                        completed_at: &id312
                           type:
                           - string
                           - 'null'
@@ -41301,7 +41895,7 @@ paths:
                             properties:
                               summary:
                                 type: string
-                              next_actor: *id294
+                              next_actor: *id312
                               needs_human:
                                 type: boolean
                               done:
@@ -41319,7 +41913,7 @@ paths:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id295
+          headers: *id313
           content:
             application/json:
               schema:
@@ -41339,7 +41933,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id295
+          headers: *id313
           content:
             application/json:
               schema:
@@ -41361,7 +41955,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id295
+          headers: *id313
           content:
             application/json:
               schema:
@@ -41377,7 +41971,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id295
+          headers: *id313
           content:
             application/json:
               schema:
@@ -41949,7 +42543,7 @@ paths:
       responses:
         '200':
           description: Head-to-head comparison data
-          headers: &id296
+          headers: &id314
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -41974,7 +42568,7 @@ paths:
                     type: number
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id296
+          headers: *id314
           content:
             application/json:
               schema:
@@ -41990,7 +42584,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id296
+          headers: *id314
           content:
             application/json:
               schema:
@@ -42038,7 +42632,7 @@ paths:
       responses:
         '200':
           description: Opponent briefing data
-          headers: &id297
+          headers: &id315
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -42067,7 +42661,7 @@ paths:
                       type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id297
+          headers: *id315
           content:
             application/json:
               schema:
@@ -42083,7 +42677,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id297
+          headers: *id315
           content:
             application/json:
               schema:
@@ -42774,7 +43368,7 @@ paths:
       responses:
         '200':
           description: Persona data
-          headers: &id298
+          headers: &id316
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -42814,7 +43408,7 @@ paths:
       responses:
         '200':
           description: Success
-          headers: *id298
+          headers: *id316
           content:
             application/json:
               schema:
@@ -42846,7 +43440,7 @@ paths:
       responses:
         '200':
           description: Success
-          headers: *id298
+          headers: *id316
           content:
             application/json:
               schema:
@@ -42908,7 +43502,7 @@ paths:
       responses:
         '200':
           description: Agent profile
-          headers: &id299
+          headers: &id317
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -42924,7 +43518,7 @@ paths:
                 $ref: '#/components/schemas/Agent'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id299
+          headers: *id317
           content:
             application/json:
               schema:
@@ -42940,7 +43534,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id299
+          headers: *id317
           content:
             application/json:
               schema:
@@ -45002,12 +45596,12 @@ paths:
         '200':
           description: Spend budget status
           headers:
-            X-Request-ID: &id300
+            X-Request-ID: &id318
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id301
+            X-Response-Time: &id319
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -45079,9 +45673,9 @@ paths:
                     - 'null'
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id302
-            X-Request-ID: *id300
-            X-Response-Time: *id301
+          headers: &id320
+            X-Request-ID: *id318
+            X-Response-Time: *id319
           content:
             application/json:
               schema:
@@ -45098,7 +45692,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id302
+          headers: *id320
           content:
             application/json:
               schema:
@@ -45128,12 +45722,12 @@ paths:
         '200':
           description: Spend by agent
           headers:
-            X-Request-ID: &id303
+            X-Request-ID: &id321
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id304
+            X-Response-Time: &id322
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -45175,9 +45769,9 @@ paths:
                           description: Percentage of the workspace spend attributed to the agent
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id305
-            X-Request-ID: *id303
-            X-Response-Time: *id304
+          headers: &id323
+            X-Request-ID: *id321
+            X-Response-Time: *id322
           content:
             application/json:
               schema:
@@ -45194,7 +45788,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id305
+          headers: *id323
           content:
             application/json:
               schema:
@@ -45230,12 +45824,12 @@ paths:
         '200':
           description: Spend by decision
           headers:
-            X-Request-ID: &id306
+            X-Request-ID: &id324
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id307
+            X-Response-Time: &id325
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -45273,9 +45867,9 @@ paths:
                     type: integer
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id308
-            X-Request-ID: *id306
-            X-Response-Time: *id307
+          headers: &id326
+            X-Request-ID: *id324
+            X-Response-Time: *id325
           content:
             application/json:
               schema:
@@ -45292,7 +45886,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id308
+          headers: *id326
           content:
             application/json:
               schema:
@@ -45327,12 +45921,12 @@ paths:
         '200':
           description: Spend summary
           headers:
-            X-Request-ID: &id309
+            X-Request-ID: &id327
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id310
+            X-Response-Time: &id328
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -45383,9 +45977,9 @@ paths:
                     description: Average spend per recorded API call
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id311
-            X-Request-ID: *id309
-            X-Response-Time: *id310
+          headers: &id329
+            X-Request-ID: *id327
+            X-Response-Time: *id328
           content:
             application/json:
               schema:
@@ -45402,7 +45996,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id311
+          headers: *id329
           content:
             application/json:
               schema:
@@ -45446,12 +46040,12 @@ paths:
         '200':
           description: Spend trends
           headers:
-            X-Request-ID: &id312
+            X-Request-ID: &id330
               description: Unique request identifier for tracing and debugging
               schema:
                 type: string
                 format: uuid
-            X-Response-Time: &id313
+            X-Response-Time: &id331
               description: Server processing time in milliseconds
               schema:
                 type: integer
@@ -45490,9 +46084,9 @@ paths:
                     description: Budget-manager trend rows for the selected period
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: &id314
-            X-Request-ID: *id312
-            X-Response-Time: *id313
+          headers: &id332
+            X-Request-ID: *id330
+            X-Response-Time: *id331
           content:
             application/json:
               schema:
@@ -45509,7 +46103,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id314
+          headers: *id332
           content:
             application/json:
               schema:
@@ -46098,9 +46692,9 @@ paths:
                           format: date-time
                   count:
                     type: integer
-        '401': &id316
+        '401': &id334
           description: Unauthorized - Authentication required or token invalid
-          headers: &id315
+          headers: &id333
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46127,9 +46721,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id317
+        '404': &id335
           description: Not found - The requested resource does not exist
-          headers: *id315
+          headers: *id333
           content:
             application/json:
               schema:
@@ -46191,10 +46785,10 @@ paths:
                     format: date-time
                   message:
                     type: string
-        '401': *id316
+        '401': *id334
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id315
+          headers: *id333
           content:
             application/json:
               schema:
@@ -46214,7 +46808,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id317
+        '404': *id335
         '503':
           description: Service unavailable
       security:
@@ -46237,8 +46831,8 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id316
-        '404': *id317
+        '401': *id334
+        '404': *id335
         '503':
           description: Service unavailable
       security:
@@ -46585,7 +47179,7 @@ paths:
       responses:
         '200':
           description: Filtered audit entries
-          headers: &id318
+          headers: &id336
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46608,7 +47202,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id318
+          headers: *id336
           content:
             application/json:
               schema:
@@ -46628,7 +47222,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id318
+          headers: *id336
           content:
             application/json:
               schema:
@@ -47019,7 +47613,7 @@ paths:
       responses:
         '200':
           description: Compliance report
-          headers: &id319
+          headers: &id337
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47047,7 +47641,7 @@ paths:
                     format: date
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id319
+          headers: *id337
           content:
             application/json:
               schema:
@@ -47075,7 +47669,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id319
+          headers: *id337
           content:
             application/json:
               schema:
@@ -47095,7 +47689,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id319
+          headers: *id337
           content:
             application/json:
               schema:
@@ -47243,7 +47837,7 @@ paths:
       summary: List audit sessions
       operationId: listAuditSessions
       description: List audit sessions with optional filters.
-      security: &id321
+      security: &id339
       - {}
       parameters:
       - name: status
@@ -47261,7 +47855,7 @@ paths:
       responses:
         '200':
           description: Sessions
-          headers: &id320
+          headers: &id338
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47275,9 +47869,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '500': &id322
+        '500': &id340
           description: Internal server error - Unexpected error occurred
-          headers: *id320
+          headers: *id338
           content:
             application/json:
               schema:
@@ -47297,7 +47891,7 @@ paths:
       summary: Create audit session
       operationId: createAuditSessions
       description: Create a new audit session.
-      security: *id321
+      security: *id339
       requestBody:
         required: true
         content:
@@ -47321,14 +47915,14 @@ paths:
       responses:
         '200':
           description: Session created
-          headers: *id320
+          headers: *id338
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id320
+          headers: *id338
           content:
             application/json:
               schema:
@@ -47354,7 +47948,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': *id322
+        '500': *id340
       x-aragora-stability: stable
   /api/v1/audit/sessions/{session_id}:
     get:
@@ -47363,7 +47957,7 @@ paths:
       summary: Get audit session
       operationId: getAuditSession
       description: Get audit session details.
-      security: &id324
+      security: &id342
       - {}
       parameters:
       - name: session_id
@@ -47374,7 +47968,7 @@ paths:
       responses:
         '200':
           description: Session
-          headers: &id323
+          headers: &id341
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47388,9 +47982,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '404': &id325
+        '404': &id343
           description: Not found - The requested resource does not exist
-          headers: *id323
+          headers: *id341
           content:
             application/json:
               schema:
@@ -47404,9 +47998,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id326
+        '500': &id344
           description: Internal server error - Unexpected error occurred
-          headers: *id323
+          headers: *id341
           content:
             application/json:
               schema:
@@ -47426,7 +48020,7 @@ paths:
       summary: Delete audit session
       operationId: deleteAuditSession
       description: Delete an audit session.
-      security: *id324
+      security: *id342
       parameters:
       - name: session_id
         in: path
@@ -47436,13 +48030,13 @@ paths:
       responses:
         '200':
           description: Session deleted
-          headers: *id323
+          headers: *id341
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '404': *id325
-        '500': *id326
+        '404': *id343
+        '500': *id344
       x-aragora-stability: stable
   /api/v1/audit/sessions/{session_id}/cancel:
     post:
@@ -47462,7 +48056,7 @@ paths:
       responses:
         '200':
           description: Audit cancelled
-          headers: &id327
+          headers: &id345
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47478,7 +48072,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id327
+          headers: *id345
           content:
             application/json:
               schema:
@@ -47494,7 +48088,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id327
+          headers: *id345
           content:
             application/json:
               schema:
@@ -47526,7 +48120,7 @@ paths:
       responses:
         '200':
           description: Event stream
-          headers: &id328
+          headers: &id346
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47542,7 +48136,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id328
+          headers: *id346
           content:
             application/json:
               schema:
@@ -47558,7 +48152,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id328
+          headers: *id346
           content:
             application/json:
               schema:
@@ -47594,7 +48188,7 @@ paths:
       responses:
         '200':
           description: Findings
-          headers: &id329
+          headers: &id347
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47610,7 +48204,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id329
+          headers: *id347
           content:
             application/json:
               schema:
@@ -47626,7 +48220,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id329
+          headers: *id347
           content:
             application/json:
               schema:
@@ -47681,7 +48275,7 @@ paths:
       responses:
         '200':
           description: Intervention recorded
-          headers: &id330
+          headers: &id348
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47697,7 +48291,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id330
+          headers: *id348
           content:
             application/json:
               schema:
@@ -47725,7 +48319,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id330
+          headers: *id348
           content:
             application/json:
               schema:
@@ -47741,7 +48335,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id330
+          headers: *id348
           content:
             application/json:
               schema:
@@ -47773,7 +48367,7 @@ paths:
       responses:
         '200':
           description: Audit paused
-          headers: &id331
+          headers: &id349
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47789,7 +48383,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id331
+          headers: *id349
           content:
             application/json:
               schema:
@@ -47805,7 +48399,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id331
+          headers: *id349
           content:
             application/json:
               schema:
@@ -47841,7 +48435,7 @@ paths:
       responses:
         '200':
           description: Report
-          headers: &id332
+          headers: &id350
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47857,7 +48451,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id332
+          headers: *id350
           content:
             application/json:
               schema:
@@ -47873,7 +48467,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id332
+          headers: *id350
           content:
             application/json:
               schema:
@@ -47905,7 +48499,7 @@ paths:
       responses:
         '200':
           description: Audit resumed
-          headers: &id333
+          headers: &id351
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47921,7 +48515,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id333
+          headers: *id351
           content:
             application/json:
               schema:
@@ -47937,7 +48531,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id333
+          headers: *id351
           content:
             application/json:
               schema:
@@ -47969,7 +48563,7 @@ paths:
       responses:
         '200':
           description: Audit started
-          headers: &id334
+          headers: &id352
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47985,7 +48579,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id334
+          headers: *id352
           content:
             application/json:
               schema:
@@ -48001,7 +48595,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id334
+          headers: *id352
           content:
             application/json:
               schema:
@@ -48057,7 +48651,7 @@ paths:
       responses:
         '200':
           description: Verification result with integrity status
-          headers: &id335
+          headers: &id353
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48080,7 +48674,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id335
+          headers: *id353
           content:
             application/json:
               schema:
@@ -48100,7 +48694,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id335
+          headers: *id353
           content:
             application/json:
               schema:
@@ -48256,9 +48850,9 @@ paths:
                     format: date-time
                   message:
                     type: string
-        '401': &id337
+        '401': &id355
           description: Unauthorized - Authentication required or token invalid
-          headers: &id336
+          headers: &id354
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48287,7 +48881,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id336
+          headers: *id354
           content:
             application/json:
               schema:
@@ -48307,9 +48901,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id338
+        '404': &id356
           description: Not found - The requested resource does not exist
-          headers: *id336
+          headers: *id354
           content:
             application/json:
               schema:
@@ -48345,8 +48939,8 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id337
-        '404': *id338
+        '401': *id355
+        '404': *id356
         '503':
           description: Service unavailable
       security:
@@ -48395,9 +48989,9 @@ paths:
                           format: date-time
                   count:
                     type: integer
-        '401': &id340
+        '401': &id358
           description: Unauthorized - Authentication required or token invalid
-          headers: &id339
+          headers: &id357
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48424,9 +49018,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id341
+        '404': &id359
           description: Not found - The requested resource does not exist
-          headers: *id339
+          headers: *id357
           content:
             application/json:
               schema:
@@ -48488,10 +49082,10 @@ paths:
                     format: date-time
                   message:
                     type: string
-        '401': *id340
+        '401': *id358
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id339
+          headers: *id357
           content:
             application/json:
               schema:
@@ -48511,7 +49105,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id341
+        '404': *id359
         '503':
           description: Service unavailable
       security:
@@ -48534,8 +49128,8 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id340
-        '404': *id341
+        '401': *id358
+        '404': *id359
         '503':
           description: Service unavailable
       security:
@@ -48753,7 +49347,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id342
+          headers: &id360
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48790,7 +49384,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id342
+          headers: *id360
           content:
             application/json:
               schema:
@@ -48810,7 +49404,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id342
+          headers: *id360
           content:
             application/json:
               schema:
@@ -49166,7 +49760,7 @@ paths:
                 additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id343
+          headers: &id361
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49203,7 +49797,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id343
+          headers: *id361
           content:
             application/json:
               schema:
@@ -49223,7 +49817,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id343
+          headers: *id361
           content:
             application/json:
               schema:
@@ -49245,7 +49839,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id343
+          headers: *id361
           content:
             application/json:
               schema:
@@ -49261,14 +49855,14 @@ paths:
                     trace_id: req_abc123xyz
         '409':
           description: Conflict - The request could not be completed
-          headers: *id343
+          headers: *id361
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         '402':
           description: Payment required - Quota exceeded, upgrade required
-          headers: *id343
+          headers: *id361
           content:
             application/json:
               schema:
@@ -49286,7 +49880,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id343
+          headers: *id361
           content:
             application/json:
               schema:
@@ -49303,7 +49897,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id343
+          headers: *id361
           content:
             application/json:
               schema:
@@ -49630,7 +50224,7 @@ paths:
           description: Redirect to GitHub OAuth consent screen
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id344
+          headers: &id362
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49667,7 +50261,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id344
+          headers: *id362
           content:
             application/json:
               schema:
@@ -49684,7 +50278,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id344
+          headers: *id362
           content:
             application/json:
               schema:
@@ -49723,7 +50317,7 @@ paths:
           description: Redirect to success URL with auth token
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id345
+          headers: &id363
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49760,7 +50354,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id345
+          headers: *id363
           content:
             application/json:
               schema:
@@ -49794,7 +50388,7 @@ paths:
           description: Redirect to Google OAuth consent screen
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id346
+          headers: &id364
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49831,7 +50425,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id346
+          headers: *id364
           content:
             application/json:
               schema:
@@ -49848,7 +50442,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id346
+          headers: *id364
           content:
             application/json:
               schema:
@@ -49893,7 +50487,7 @@ paths:
           description: Redirect to success URL with auth token
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id347
+          headers: &id365
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49930,7 +50524,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id347
+          headers: *id365
           content:
             application/json:
               schema:
@@ -49975,7 +50569,7 @@ paths:
       responses:
         '200':
           description: Account linked successfully
-          headers: &id348
+          headers: &id366
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49996,7 +50590,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id348
+          headers: *id366
           content:
             application/json:
               schema:
@@ -50024,7 +50618,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id348
+          headers: *id366
           content:
             application/json:
               schema:
@@ -50174,7 +50768,7 @@ paths:
       responses:
         '200':
           description: Account unlinked successfully
-          headers: &id349
+          headers: &id367
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50195,7 +50789,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id349
+          headers: *id367
           content:
             application/json:
               schema:
@@ -50223,7 +50817,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id349
+          headers: *id367
           content:
             application/json:
               schema:
@@ -50243,7 +50837,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id349
+          headers: *id367
           content:
             application/json:
               schema:
@@ -50858,7 +51452,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id350
+          headers: &id368
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50895,7 +51489,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id350
+          headers: *id368
           content:
             application/json:
               schema:
@@ -52279,7 +52873,7 @@ paths:
       responses:
         '200':
           description: Interaction response
-          headers: &id351
+          headers: &id369
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52300,7 +52894,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id351
+          headers: *id369
           content:
             application/json:
               schema:
@@ -52329,7 +52923,7 @@ paths:
       responses:
         '200':
           description: Discord integration status
-          headers: &id352
+          headers: &id370
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52352,7 +52946,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id352
+          headers: *id370
           content:
             application/json:
               schema:
@@ -52401,7 +52995,7 @@ paths:
       responses:
         '200':
           description: Email integration status
-          headers: &id353
+          headers: &id371
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52424,7 +53018,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id353
+          headers: *id371
           content:
             application/json:
               schema:
@@ -52561,7 +53155,7 @@ paths:
       responses:
         '200':
           description: Google Chat integration status
-          headers: &id354
+          headers: &id372
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52582,7 +53176,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id354
+          headers: *id372
           content:
             application/json:
               schema:
@@ -52710,7 +53304,7 @@ paths:
       responses:
         '200':
           description: Command acknowledged
-          headers: &id355
+          headers: &id373
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52734,7 +53328,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id355
+          headers: *id373
           content:
             application/json:
               schema:
@@ -52805,7 +53399,7 @@ paths:
       responses:
         '200':
           description: Event processed
-          headers: &id356
+          headers: &id374
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52826,7 +53420,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id356
+          headers: *id374
           content:
             application/json:
               schema:
@@ -52881,7 +53475,7 @@ paths:
       responses:
         '200':
           description: Interaction handled
-          headers: &id357
+          headers: &id375
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52893,7 +53487,7 @@ paths:
                 type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id357
+          headers: *id375
           content:
             application/json:
               schema:
@@ -52933,7 +53527,7 @@ paths:
       responses:
         '200':
           description: Slack integration status
-          headers: &id358
+          headers: &id376
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -52959,7 +53553,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id358
+          headers: *id376
           content:
             application/json:
               schema:
@@ -53092,7 +53686,7 @@ paths:
       responses:
         '200':
           description: Telegram integration status
-          headers: &id359
+          headers: &id377
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53115,7 +53709,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id359
+          headers: *id377
           content:
             application/json:
               schema:
@@ -53219,7 +53813,7 @@ paths:
       responses:
         '200':
           description: Update processed
-          headers: &id360
+          headers: &id378
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53231,7 +53825,7 @@ paths:
                 type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id360
+          headers: *id378
           content:
             application/json:
               schema:
@@ -53278,7 +53872,7 @@ paths:
       responses:
         '200':
           description: WhatsApp integration status
-          headers: &id361
+          headers: &id379
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53301,7 +53895,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id361
+          headers: *id379
           content:
             application/json:
               schema:
@@ -53467,7 +54061,7 @@ paths:
       responses:
         '200':
           description: Zoom integration status
-          headers: &id362
+          headers: &id380
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53488,7 +54082,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id362
+          headers: *id380
           content:
             application/json:
               schema:
@@ -53628,37 +54222,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BudgetListResponse'
-        '400': &id363
+        '400': &id381
           description: Bad request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '401': &id364
+        '401': &id382
           description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '404': &id365
+        '404': &id383
           description: Not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '402': &id366
+        '402': &id384
           description: Quota exceeded
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '429': &id367
+        '429': &id385
           description: Rate limited
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': &id368
+        '500': &id386
           description: Server error
           content:
             application/json:
@@ -53692,12 +54286,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
-        '400': *id363
-        '401': *id364
-        '404': *id365
-        '402': *id366
-        '429': *id367
-        '500': *id368
+        '400': *id381
+        '401': *id382
+        '404': *id383
+        '402': *id384
+        '429': *id385
+        '500': *id386
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -53863,37 +54457,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
-        '400': &id369
+        '400': &id387
           description: Bad request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '401': &id370
+        '401': &id388
           description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '404': &id371
+        '404': &id389
           description: Not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '402': &id372
+        '402': &id390
           description: Quota exceeded
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '429': &id373
+        '429': &id391
           description: Rate limited
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': &id374
+        '500': &id392
           description: Server error
           content:
             application/json:
@@ -53928,12 +54522,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Budget'
-        '400': *id369
-        '401': *id370
-        '404': *id371
-        '402': *id372
-        '429': *id373
-        '500': *id374
+        '400': *id387
+        '401': *id388
+        '404': *id389
+        '402': *id390
+        '429': *id391
+        '500': *id392
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -53962,12 +54556,12 @@ paths:
                     type: boolean
                   budget_id:
                     type: string
-        '400': *id369
-        '401': *id370
-        '404': *id371
-        '402': *id372
-        '429': *id373
-        '500': *id374
+        '400': *id387
+        '401': *id388
+        '404': *id389
+        '402': *id390
+        '429': *id391
+        '500': *id392
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -54473,7 +55067,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id375
+          headers: &id393
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54510,7 +55104,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id375
+          headers: *id393
           content:
             application/json:
               schema:
@@ -54548,7 +55142,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id376
+          headers: &id394
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54585,7 +55179,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id376
+          headers: *id394
           content:
             application/json:
               schema:
@@ -54671,7 +55265,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id377
+          headers: &id395
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54708,7 +55302,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id377
+          headers: *id395
           content:
             application/json:
               schema:
@@ -54762,7 +55356,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id378
+          headers: &id396
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54799,7 +55393,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id378
+          headers: *id396
           content:
             application/json:
               schema:
@@ -54849,7 +55443,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id379
+          headers: &id397
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54886,7 +55480,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id379
+          headers: *id397
           content:
             application/json:
               schema:
@@ -55001,7 +55595,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id380
+          headers: &id398
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55038,7 +55632,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id380
+          headers: *id398
           content:
             application/json:
               schema:
@@ -55085,7 +55679,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id381
+          headers: &id399
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55122,7 +55716,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id381
+          headers: *id399
           content:
             application/json:
               schema:
@@ -55171,7 +55765,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id382
+          headers: &id400
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55208,7 +55802,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id382
+          headers: *id400
           content:
             application/json:
               schema:
@@ -55271,7 +55865,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id383
+          headers: &id401
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55308,7 +55902,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id383
+          headers: *id401
           content:
             application/json:
               schema:
@@ -55354,7 +55948,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id384
+          headers: &id402
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55391,7 +55985,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id384
+          headers: *id402
           content:
             application/json:
               schema:
@@ -55483,7 +56077,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id385
+          headers: &id403
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55520,7 +56114,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id385
+          headers: *id403
           content:
             application/json:
               schema:
@@ -55617,13 +56211,13 @@ paths:
       summary: Get pipeline
       operationId: getPipeline
       description: Get a pipeline result by ID.
-      security: &id386
+      security: &id404
       - {}
       parameters:
       - name: id
         in: path
         required: true
-        schema: &id387
+        schema: &id405
           type: string
         description: Pipeline ID
       responses:
@@ -55633,9 +56227,9 @@ paths:
             application/json:
               schema:
                 type: object
-        '404': &id388
+        '404': &id406
           description: Not found - The requested resource does not exist
-          headers: &id389
+          headers: &id407
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55665,12 +56259,12 @@ paths:
       summary: Save pipeline canvas state
       operationId: savePipeline
       description: Save the current canvas state for a pipeline.
-      security: *id386
+      security: *id404
       parameters:
       - name: id
         in: path
         required: true
-        schema: *id387
+        schema: *id405
         description: Pipeline ID
       requestBody:
         required: true
@@ -55685,10 +56279,10 @@ paths:
             application/json:
               schema:
                 type: object
-        '404': *id388
+        '404': *id406
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id389
+          headers: *id407
           content:
             application/json:
               schema:
@@ -55746,7 +56340,7 @@ paths:
                 type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: &id390
+          headers: &id408
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55771,7 +56365,7 @@ paths:
                     trace_id: req_abc123xyz
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id390
+          headers: *id408
           content:
             application/json:
               schema:
@@ -55887,7 +56481,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id391
+          headers: &id409
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55924,7 +56518,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id391
+          headers: *id409
           content:
             application/json:
               schema:
@@ -56501,7 +57095,7 @@ paths:
       responses:
         '200':
           description: Channel summary
-          headers: &id392
+          headers: &id410
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56517,7 +57111,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id392
+          headers: *id410
           content:
             application/json:
               schema:
@@ -56595,7 +57189,7 @@ paths:
       responses:
         '200':
           description: Injected context
-          headers: &id393
+          headers: &id411
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56611,7 +57205,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id393
+          headers: *id411
           content:
             application/json:
               schema:
@@ -56639,7 +57233,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id393
+          headers: *id411
           content:
             application/json:
               schema:
@@ -56690,7 +57284,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id394
+          headers: &id412
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56706,7 +57300,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id394
+          headers: *id412
           content:
             application/json:
               schema:
@@ -56734,7 +57328,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id394
+          headers: *id412
           content:
             application/json:
               schema:
@@ -56790,7 +57384,7 @@ paths:
       responses:
         '200':
           description: Knowledge stored
-          headers: &id395
+          headers: &id413
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56806,7 +57400,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id395
+          headers: *id413
           content:
             application/json:
               schema:
@@ -56834,7 +57428,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id395
+          headers: *id413
           content:
             application/json:
               schema:
@@ -57120,7 +57714,7 @@ paths:
       responses:
         '200':
           description: Classification result with level and confidence
-          headers: &id396
+          headers: &id414
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57143,7 +57737,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id396
+          headers: *id414
           content:
             application/json:
               schema:
@@ -57171,7 +57765,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id396
+          headers: *id414
           content:
             application/json:
               schema:
@@ -57213,7 +57807,7 @@ paths:
       responses:
         '200':
           description: Policy details for the sensitivity level
-          headers: &id397
+          headers: &id415
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57240,7 +57834,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id397
+          headers: *id415
           content:
             application/json:
               schema:
@@ -57268,7 +57862,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id397
+          headers: *id415
           content:
             application/json:
               schema:
@@ -57669,7 +58263,7 @@ paths:
       responses:
         '200':
           description: Dependency analysis
-          headers: &id398
+          headers: &id416
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57685,7 +58279,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseDependencyAnalysisResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id398
+          headers: *id416
           content:
             application/json:
               schema:
@@ -57713,7 +58307,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id398
+          headers: *id416
           content:
             application/json:
               schema:
@@ -57733,7 +58327,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id398
+          headers: *id416
           content:
             application/json:
               schema:
@@ -57755,7 +58349,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id398
+          headers: *id416
           content:
             application/json:
               schema:
@@ -57850,7 +58444,7 @@ paths:
       responses:
         '200':
           description: License check
-          headers: &id399
+          headers: &id417
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57866,7 +58460,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseLicenseCheckResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id399
+          headers: *id417
           content:
             application/json:
               schema:
@@ -57894,7 +58488,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id399
+          headers: *id417
           content:
             application/json:
               schema:
@@ -57914,7 +58508,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id399
+          headers: *id417
           content:
             application/json:
               schema:
@@ -57936,7 +58530,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id399
+          headers: *id417
           content:
             application/json:
               schema:
@@ -57962,7 +58556,7 @@ paths:
       responses:
         '200':
           description: Cache cleared
-          headers: &id400
+          headers: &id418
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57978,7 +58572,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id400
+          headers: *id418
           content:
             application/json:
               schema:
@@ -57998,7 +58592,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id400
+          headers: *id418
           content:
             application/json:
               schema:
@@ -58020,7 +58614,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id400
+          headers: *id418
           content:
             application/json:
               schema:
@@ -58264,7 +58858,7 @@ paths:
       responses:
         '200':
           description: Package vulnerabilities
-          headers: &id401
+          headers: &id419
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58280,7 +58874,7 @@ paths:
                 $ref: '#/components/schemas/CodebasePackageVulnerabilityResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id401
+          headers: *id419
           content:
             application/json:
               schema:
@@ -58300,7 +58894,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id401
+          headers: *id419
           content:
             application/json:
               schema:
@@ -58322,7 +58916,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id401
+          headers: *id419
           content:
             application/json:
               schema:
@@ -58379,7 +58973,7 @@ paths:
       responses:
         '200':
           description: Scan started
-          headers: &id402
+          headers: &id420
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58395,7 +58989,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id402
+          headers: *id420
           content:
             application/json:
               schema:
@@ -58423,7 +59017,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id402
+          headers: *id420
           content:
             application/json:
               schema:
@@ -58455,7 +59049,7 @@ paths:
       responses:
         '200':
           description: Scan result
-          headers: &id403
+          headers: &id421
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58471,7 +59065,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id403
+          headers: *id421
           content:
             application/json:
               schema:
@@ -58487,7 +59081,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id403
+          headers: *id421
           content:
             application/json:
               schema:
@@ -58513,7 +59107,7 @@ paths:
       responses:
         '200':
           description: Scan list
-          headers: &id404
+          headers: &id422
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58529,7 +59123,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id404
+          headers: *id422
           content:
             application/json:
               schema:
@@ -58582,7 +59176,7 @@ paths:
       responses:
         '200':
           description: SBOM generated
-          headers: &id405
+          headers: &id423
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58598,7 +59192,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSBOMResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id405
+          headers: *id423
           content:
             application/json:
               schema:
@@ -58626,7 +59220,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id405
+          headers: *id423
           content:
             application/json:
               schema:
@@ -58646,7 +59240,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id405
+          headers: *id423
           content:
             application/json:
               schema:
@@ -58668,7 +59262,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id405
+          headers: *id423
           content:
             application/json:
               schema:
@@ -58721,7 +59315,7 @@ paths:
       responses:
         '200':
           description: Vulnerability scan
-          headers: &id406
+          headers: &id424
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58737,7 +59331,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseDependencyScanResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id406
+          headers: *id424
           content:
             application/json:
               schema:
@@ -58765,7 +59359,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id406
+          headers: *id424
           content:
             application/json:
               schema:
@@ -58785,7 +59379,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id406
+          headers: *id424
           content:
             application/json:
               schema:
@@ -58807,7 +59401,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id406
+          headers: *id424
           content:
             application/json:
               schema:
@@ -58969,7 +59563,7 @@ paths:
       responses:
         '200':
           description: Analysis
-          headers: &id407
+          headers: &id425
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58985,7 +59579,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id407
+          headers: *id425
           content:
             application/json:
               schema:
@@ -59013,7 +59607,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id407
+          headers: *id425
           content:
             application/json:
               schema:
@@ -59073,7 +59667,7 @@ paths:
       responses:
         '200':
           description: Audit started
-          headers: &id408
+          headers: &id426
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59089,7 +59683,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id408
+          headers: *id426
           content:
             application/json:
               schema:
@@ -59117,7 +59711,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id408
+          headers: *id426
           content:
             application/json:
               schema:
@@ -59154,7 +59748,7 @@ paths:
       responses:
         '200':
           description: Audit status
-          headers: &id409
+          headers: &id427
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59170,7 +59764,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id409
+          headers: *id427
           content:
             application/json:
               schema:
@@ -59186,7 +59780,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id409
+          headers: *id427
           content:
             application/json:
               schema:
@@ -59218,7 +59812,7 @@ paths:
       responses:
         '200':
           description: Call graph
-          headers: &id410
+          headers: &id428
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59234,7 +59828,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id410
+          headers: *id428
           content:
             application/json:
               schema:
@@ -59266,7 +59860,7 @@ paths:
       responses:
         '200':
           description: Dead code
-          headers: &id411
+          headers: &id429
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59282,7 +59876,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id411
+          headers: *id429
           content:
             application/json:
               schema:
@@ -59324,7 +59918,7 @@ paths:
       responses:
         '200':
           description: Duplicates
-          headers: &id412
+          headers: &id430
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59340,7 +59934,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseDuplicateListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id412
+          headers: *id430
           content:
             application/json:
               schema:
@@ -59360,7 +59954,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id412
+          headers: *id430
           content:
             application/json:
               schema:
@@ -59382,7 +59976,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id412
+          headers: *id430
           content:
             application/json:
               schema:
@@ -59424,7 +60018,7 @@ paths:
       responses:
         '200':
           description: Hotspots
-          headers: &id413
+          headers: &id431
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59440,7 +60034,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseHotspotListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id413
+          headers: *id431
           content:
             application/json:
               schema:
@@ -59460,7 +60054,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id413
+          headers: *id431
           content:
             application/json:
               schema:
@@ -59482,7 +60076,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id413
+          headers: *id431
           content:
             application/json:
               schema:
@@ -59534,7 +60128,7 @@ paths:
       responses:
         '200':
           description: Impact
-          headers: &id414
+          headers: &id432
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59550,7 +60144,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id414
+          headers: *id432
           content:
             application/json:
               schema:
@@ -59578,7 +60172,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id414
+          headers: *id432
           content:
             application/json:
               schema:
@@ -59610,7 +60204,7 @@ paths:
       responses:
         '200':
           description: Metrics report
-          headers: &id415
+          headers: &id433
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59626,7 +60220,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsReportResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id415
+          headers: *id433
           content:
             application/json:
               schema:
@@ -59646,7 +60240,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id415
+          headers: *id433
           content:
             application/json:
               schema:
@@ -59668,7 +60262,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id415
+          headers: *id433
           content:
             application/json:
               schema:
@@ -59684,7 +60278,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id415
+          headers: *id433
           content:
             application/json:
               schema:
@@ -59741,7 +60335,7 @@ paths:
       responses:
         '200':
           description: Metrics analysis started
-          headers: &id416
+          headers: &id434
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59757,7 +60351,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsStartResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id416
+          headers: *id434
           content:
             application/json:
               schema:
@@ -59785,7 +60379,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id416
+          headers: *id434
           content:
             application/json:
               schema:
@@ -59805,7 +60399,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id416
+          headers: *id434
           content:
             application/json:
               schema:
@@ -59827,7 +60421,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id416
+          headers: *id434
           content:
             application/json:
               schema:
@@ -59864,7 +60458,7 @@ paths:
       responses:
         '200':
           description: File metrics
-          headers: &id417
+          headers: &id435
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59880,7 +60474,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseFileMetricsResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id417
+          headers: *id435
           content:
             application/json:
               schema:
@@ -59900,7 +60494,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id417
+          headers: *id435
           content:
             application/json:
               schema:
@@ -59922,7 +60516,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id417
+          headers: *id435
           content:
             application/json:
               schema:
@@ -59938,7 +60532,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id417
+          headers: *id435
           content:
             application/json:
               schema:
@@ -59980,7 +60574,7 @@ paths:
       responses:
         '200':
           description: Metrics history
-          headers: &id418
+          headers: &id436
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59996,7 +60590,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsHistoryResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id418
+          headers: *id436
           content:
             application/json:
               schema:
@@ -60016,7 +60610,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id418
+          headers: *id436
           content:
             application/json:
               schema:
@@ -60038,7 +60632,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id418
+          headers: *id436
           content:
             application/json:
               schema:
@@ -60075,7 +60669,7 @@ paths:
       responses:
         '200':
           description: Metrics report
-          headers: &id419
+          headers: &id437
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60091,7 +60685,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsReportResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id419
+          headers: *id437
           content:
             application/json:
               schema:
@@ -60111,7 +60705,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id419
+          headers: *id437
           content:
             application/json:
               schema:
@@ -60133,7 +60727,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id419
+          headers: *id437
           content:
             application/json:
               schema:
@@ -60149,7 +60743,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id419
+          headers: *id437
           content:
             application/json:
               schema:
@@ -60199,7 +60793,7 @@ paths:
       responses:
         '200':
           description: SAST findings
-          headers: &id420
+          headers: &id438
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60215,7 +60809,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id420
+          headers: *id438
           content:
             application/json:
               schema:
@@ -60235,7 +60829,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id420
+          headers: *id438
           content:
             application/json:
               schema:
@@ -60257,7 +60851,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id420
+          headers: *id438
           content:
             application/json:
               schema:
@@ -60289,7 +60883,7 @@ paths:
       responses:
         '200':
           description: OWASP summary
-          headers: &id421
+          headers: &id439
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60305,7 +60899,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id421
+          headers: *id439
           content:
             application/json:
               schema:
@@ -60325,7 +60919,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id421
+          headers: *id439
           content:
             application/json:
               schema:
@@ -60347,7 +60941,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id421
+          headers: *id439
           content:
             application/json:
               schema:
@@ -60396,7 +60990,7 @@ paths:
       responses:
         '200':
           description: Scan started
-          headers: &id422
+          headers: &id440
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60412,7 +61006,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanStartResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id422
+          headers: *id440
           content:
             application/json:
               schema:
@@ -60440,7 +61034,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id422
+          headers: *id440
           content:
             application/json:
               schema:
@@ -60460,7 +61054,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id422
+          headers: *id440
           content:
             application/json:
               schema:
@@ -60482,7 +61076,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id422
+          headers: *id440
           content:
             application/json:
               schema:
@@ -60514,7 +61108,7 @@ paths:
       responses:
         '200':
           description: Latest scan
-          headers: &id423
+          headers: &id441
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60530,7 +61124,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id423
+          headers: *id441
           content:
             application/json:
               schema:
@@ -60550,7 +61144,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id423
+          headers: *id441
           content:
             application/json:
               schema:
@@ -60572,7 +61166,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id423
+          headers: *id441
           content:
             application/json:
               schema:
@@ -60588,7 +61182,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id423
+          headers: *id441
           content:
             application/json:
               schema:
@@ -60637,7 +61231,7 @@ paths:
       responses:
         '200':
           description: SAST scan started
-          headers: &id424
+          headers: &id442
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60653,7 +61247,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id424
+          headers: *id442
           content:
             application/json:
               schema:
@@ -60681,7 +61275,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id424
+          headers: *id442
           content:
             application/json:
               schema:
@@ -60701,7 +61295,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id424
+          headers: *id442
           content:
             application/json:
               schema:
@@ -60723,7 +61317,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id424
+          headers: *id442
           content:
             application/json:
               schema:
@@ -60760,7 +61354,7 @@ paths:
       responses:
         '200':
           description: SAST scan status
-          headers: &id425
+          headers: &id443
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60776,7 +61370,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id425
+          headers: *id443
           content:
             application/json:
               schema:
@@ -60796,7 +61390,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id425
+          headers: *id443
           content:
             application/json:
               schema:
@@ -60818,7 +61412,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id425
+          headers: *id443
           content:
             application/json:
               schema:
@@ -60834,7 +61428,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id425
+          headers: *id443
           content:
             application/json:
               schema:
@@ -60872,7 +61466,7 @@ paths:
       responses:
         '200':
           description: Secrets scan started
-          headers: &id426
+          headers: &id444
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60888,7 +61482,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanStartResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id426
+          headers: *id444
           content:
             application/json:
               schema:
@@ -60916,7 +61510,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id426
+          headers: *id444
           content:
             application/json:
               schema:
@@ -60936,7 +61530,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id426
+          headers: *id444
           content:
             application/json:
               schema:
@@ -60958,7 +61552,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id426
+          headers: *id444
           content:
             application/json:
               schema:
@@ -60990,7 +61584,7 @@ paths:
       responses:
         '200':
           description: Secrets scan
-          headers: &id427
+          headers: &id445
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61006,7 +61600,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id427
+          headers: *id445
           content:
             application/json:
               schema:
@@ -61026,7 +61620,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id427
+          headers: *id445
           content:
             application/json:
               schema:
@@ -61048,7 +61642,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id427
+          headers: *id445
           content:
             application/json:
               schema:
@@ -61064,7 +61658,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id427
+          headers: *id445
           content:
             application/json:
               schema:
@@ -61101,7 +61695,7 @@ paths:
       responses:
         '200':
           description: Secrets scan
-          headers: &id428
+          headers: &id446
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61117,7 +61711,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id428
+          headers: *id446
           content:
             application/json:
               schema:
@@ -61137,7 +61731,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id428
+          headers: *id446
           content:
             application/json:
               schema:
@@ -61159,7 +61753,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id428
+          headers: *id446
           content:
             application/json:
               schema:
@@ -61175,7 +61769,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id428
+          headers: *id446
           content:
             application/json:
               schema:
@@ -61212,7 +61806,7 @@ paths:
       responses:
         '200':
           description: Scan result
-          headers: &id429
+          headers: &id447
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61228,7 +61822,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id429
+          headers: *id447
           content:
             application/json:
               schema:
@@ -61248,7 +61842,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id429
+          headers: *id447
           content:
             application/json:
               schema:
@@ -61270,7 +61864,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id429
+          headers: *id447
           content:
             application/json:
               schema:
@@ -61286,7 +61880,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id429
+          headers: *id447
           content:
             application/json:
               schema:
@@ -61332,7 +61926,7 @@ paths:
       responses:
         '200':
           description: Scan list
-          headers: &id430
+          headers: &id448
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61348,7 +61942,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id430
+          headers: *id448
           content:
             application/json:
               schema:
@@ -61368,7 +61962,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id430
+          headers: *id448
           content:
             application/json:
               schema:
@@ -61390,7 +61984,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id430
+          headers: *id448
           content:
             application/json:
               schema:
@@ -61422,7 +62016,7 @@ paths:
       responses:
         '200':
           description: Secrets scan list
-          headers: &id431
+          headers: &id449
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61438,7 +62032,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id431
+          headers: *id449
           content:
             application/json:
               schema:
@@ -61458,7 +62052,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id431
+          headers: *id449
           content:
             application/json:
               schema:
@@ -61480,7 +62074,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id431
+          headers: *id449
           content:
             application/json:
               schema:
@@ -61512,7 +62106,7 @@ paths:
       responses:
         '200':
           description: Secrets list
-          headers: &id432
+          headers: &id450
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61528,7 +62122,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id432
+          headers: *id450
           content:
             application/json:
               schema:
@@ -61548,7 +62142,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id432
+          headers: *id450
           content:
             application/json:
               schema:
@@ -61570,7 +62164,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id432
+          headers: *id450
           content:
             application/json:
               schema:
@@ -61602,7 +62196,7 @@ paths:
       responses:
         '200':
           description: Symbols
-          headers: &id433
+          headers: &id451
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61618,7 +62212,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id433
+          headers: *id451
           content:
             application/json:
               schema:
@@ -61670,7 +62264,7 @@ paths:
       responses:
         '200':
           description: Answer
-          headers: &id434
+          headers: &id452
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61686,7 +62280,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id434
+          headers: *id452
           content:
             application/json:
               schema:
@@ -61714,7 +62308,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id434
+          headers: *id452
           content:
             application/json:
               schema:
@@ -61768,7 +62362,7 @@ paths:
       responses:
         '200':
           description: Vulnerability list
-          headers: &id435
+          headers: &id453
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61784,7 +62378,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseVulnerabilityListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id435
+          headers: *id453
           content:
             application/json:
               schema:
@@ -61804,7 +62398,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id435
+          headers: *id453
           content:
             application/json:
               schema:
@@ -61826,7 +62420,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id435
+          headers: *id453
           content:
             application/json:
               schema:
@@ -62399,9 +62993,9 @@ paths:
                     - string
                     - 'null'
                     format: date-time
-        '401': &id437
+        '401': &id455
           description: Unauthorized - Authentication required or token invalid
-          headers: &id436
+          headers: &id454
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62428,9 +63022,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id438
+        '403': &id456
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id436
+          headers: *id454
           content:
             application/json:
               schema:
@@ -62450,9 +63044,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id439
+        '404': &id457
           description: Not found - The requested resource does not exist
-          headers: *id436
+          headers: *id454
           content:
             application/json:
               schema:
@@ -62466,9 +63060,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id440
+        '500': &id458
           description: Internal server error - Unexpected error occurred
-          headers: *id436
+          headers: *id454
           content:
             application/json:
               schema:
@@ -62543,7 +63137,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id436
+          headers: *id454
           content:
             application/json:
               schema:
@@ -62569,10 +63163,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id437
-        '403': *id438
-        '404': *id439
-        '500': *id440
+        '401': *id455
+        '403': *id456
+        '404': *id457
+        '500': *id458
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -62646,9 +63240,9 @@ paths:
                           format: date-time
                   total:
                     type: integer
-        '401': &id442
+        '401': &id460
           description: Unauthorized - Authentication required or token invalid
-          headers: &id441
+          headers: &id459
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62675,9 +63269,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id443
+        '500': &id461
           description: Internal server error - Unexpected error occurred
-          headers: *id441
+          headers: *id459
           content:
             application/json:
               schema:
@@ -62764,7 +63358,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id441
+          headers: *id459
           content:
             application/json:
               schema:
@@ -62790,10 +63384,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id442
+        '401': *id460
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id441
+          headers: *id459
           content:
             application/json:
               schema:
@@ -62813,7 +63407,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id443
+        '500': *id461
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -62850,7 +63444,7 @@ paths:
                         type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id444
+          headers: &id462
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62879,7 +63473,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id444
+          headers: *id462
           content:
             application/json:
               schema:
@@ -62941,9 +63535,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '401': &id446
+        '401': &id464
           description: Unauthorized - Authentication required or token invalid
-          headers: &id445
+          headers: &id463
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62970,9 +63564,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id447
+        '404': &id465
           description: Not found - The requested resource does not exist
-          headers: *id445
+          headers: *id463
           content:
             application/json:
               schema:
@@ -62986,9 +63580,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id448
+        '500': &id466
           description: Internal server error - Unexpected error occurred
-          headers: *id445
+          headers: *id463
           content:
             application/json:
               schema:
@@ -63029,9 +63623,9 @@ paths:
                     type: boolean
                   action_id:
                     type: string
-        '401': *id446
-        '404': *id447
-        '500': *id448
+        '401': *id464
+        '404': *id465
+        '500': *id466
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -63076,7 +63670,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id449
+          headers: &id467
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63113,7 +63707,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id449
+          headers: *id467
           content:
             application/json:
               schema:
@@ -63133,7 +63727,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id449
+          headers: *id467
           content:
             application/json:
               schema:
@@ -63155,7 +63749,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id449
+          headers: *id467
           content:
             application/json:
               schema:
@@ -63197,7 +63791,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id450
+          headers: &id468
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63226,7 +63820,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id450
+          headers: *id468
           content:
             application/json:
               schema:
@@ -63248,7 +63842,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id450
+          headers: *id468
           content:
             application/json:
               schema:
@@ -63264,7 +63858,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id450
+          headers: *id468
           content:
             application/json:
               schema:
@@ -63317,7 +63911,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id451
+          headers: &id469
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63346,7 +63940,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id451
+          headers: *id469
           content:
             application/json:
               schema:
@@ -63368,7 +63962,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id451
+          headers: *id469
           content:
             application/json:
               schema:
@@ -63384,7 +63978,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id451
+          headers: *id469
           content:
             application/json:
               schema:
@@ -63437,7 +64031,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id452
+          headers: &id470
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63466,7 +64060,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id452
+          headers: *id470
           content:
             application/json:
               schema:
@@ -63488,7 +64082,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id452
+          headers: *id470
           content:
             application/json:
               schema:
@@ -63504,7 +64098,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id452
+          headers: *id470
           content:
             application/json:
               schema:
@@ -63557,9 +64151,9 @@ paths:
                             type: string
                   total:
                     type: integer
-        '401': &id454
+        '401': &id472
           description: Unauthorized - Authentication required or token invalid
-          headers: &id453
+          headers: &id471
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63586,9 +64180,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id455
+        '500': &id473
           description: Internal server error - Unexpected error occurred
-          headers: *id453
+          headers: *id471
           content:
             application/json:
               schema:
@@ -63664,7 +64258,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id453
+          headers: *id471
           content:
             application/json:
               schema:
@@ -63690,10 +64284,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id454
+        '401': *id472
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id453
+          headers: *id471
           content:
             application/json:
               schema:
@@ -63713,7 +64307,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id455
+        '500': *id473
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -63764,9 +64358,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '401': &id457
+        '401': &id475
           description: Unauthorized - Authentication required or token invalid
-          headers: &id456
+          headers: &id474
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63793,9 +64387,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id458
+        '404': &id476
           description: Not found - The requested resource does not exist
-          headers: *id456
+          headers: *id474
           content:
             application/json:
               schema:
@@ -63809,9 +64403,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id459
+        '500': &id477
           description: Internal server error - Unexpected error occurred
-          headers: *id456
+          headers: *id474
           content:
             application/json:
               schema:
@@ -63889,7 +64483,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id456
+          headers: *id474
           content:
             application/json:
               schema:
@@ -63915,10 +64509,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id457
-        '403': &id460
+        '401': *id475
+        '403': &id478
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id456
+          headers: *id474
           content:
             application/json:
               schema:
@@ -63938,8 +64532,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id458
-        '500': *id459
+        '404': *id476
+        '500': *id477
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -63968,10 +64562,10 @@ paths:
                     type: boolean
                   policy_id:
                     type: string
-        '401': *id457
-        '403': *id460
-        '404': *id458
-        '500': *id459
+        '401': *id475
+        '403': *id478
+        '404': *id476
+        '500': *id477
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -64046,9 +64640,9 @@ paths:
                               type: integer
                   total:
                     type: integer
-        '401': &id462
+        '401': &id480
           description: Unauthorized - Authentication required or token invalid
-          headers: &id461
+          headers: &id479
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64075,9 +64669,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id463
+        '500': &id481
           description: Internal server error - Unexpected error occurred
-          headers: *id461
+          headers: *id479
           content:
             application/json:
               schema:
@@ -64141,7 +64735,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id461
+          headers: *id479
           content:
             application/json:
               schema:
@@ -64167,10 +64761,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id462
+        '401': *id480
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id461
+          headers: *id479
           content:
             application/json:
               schema:
@@ -64192,7 +64786,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id461
+          headers: *id479
           content:
             application/json:
               schema:
@@ -64207,7 +64801,7 @@ paths:
                     window: 1 minute
                     retry_after: 45
                     trace_id: req_abc123xyz
-        '500': *id463
+        '500': *id481
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -64281,9 +64875,9 @@ paths:
                             type: string
                           steps_taken:
                             type: integer
-        '401': &id465
+        '401': &id483
           description: Unauthorized - Authentication required or token invalid
-          headers: &id464
+          headers: &id482
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64310,9 +64904,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id466
+        '404': &id484
           description: Not found - The requested resource does not exist
-          headers: *id464
+          headers: *id482
           content:
             application/json:
               schema:
@@ -64326,9 +64920,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id467
+        '500': &id485
           description: Internal server error - Unexpected error occurred
-          headers: *id464
+          headers: *id482
           content:
             application/json:
               schema:
@@ -64372,7 +64966,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id464
+          headers: *id482
           content:
             application/json:
               schema:
@@ -64398,9 +64992,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id465
-        '404': *id466
-        '500': *id467
+        '401': *id483
+        '404': *id484
+        '500': *id485
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -64431,7 +65025,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id468
+          headers: &id486
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64468,7 +65062,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id468
+          headers: *id486
           content:
             application/json:
               schema:
@@ -64488,7 +65082,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id468
+          headers: *id486
           content:
             application/json:
               schema:
@@ -64510,7 +65104,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id468
+          headers: *id486
           content:
             application/json:
               schema:
@@ -64526,7 +65120,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id468
+          headers: *id486
           content:
             application/json:
               schema:
@@ -65334,12 +65928,12 @@ paths:
         schema:
           type: boolean
           default: true
-      security: &id470
+      security: &id488
       - bearerAuth: []
       responses:
         '200':
           description: Agent list
-          headers: &id469
+          headers: &id487
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65353,9 +65947,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ControlPlaneAgentList'
-        '401': &id471
+        '401': &id489
           description: Unauthorized - Authentication required or token invalid
-          headers: *id469
+          headers: *id487
           content:
             application/json:
               schema:
@@ -65373,9 +65967,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id472
+        '403': &id490
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id469
+          headers: *id487
           content:
             application/json:
               schema:
@@ -65395,9 +65989,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id473
+        '500': &id491
           description: Internal server error - Unexpected error occurred
-          headers: *id469
+          headers: *id487
           content:
             application/json:
               schema:
@@ -65417,7 +66011,7 @@ paths:
       summary: Register agent
       operationId: createControlPlaneAgents
       description: Register an agent with capabilities and model metadata.
-      security: *id470
+      security: *id488
       requestBody:
         required: true
         content:
@@ -65443,14 +66037,14 @@ paths:
       responses:
         '201':
           description: Agent registered
-          headers: *id469
+          headers: *id487
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ControlPlaneAgent'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id469
+          headers: *id487
           content:
             application/json:
               schema:
@@ -65476,9 +66070,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id471
-        '403': *id472
-        '500': *id473
+        '401': *id489
+        '403': *id490
+        '500': *id491
       x-aragora-stability: stable
   /api/v1/control-plane/agents/{agent_id}:
     get:
@@ -65487,7 +66081,7 @@ paths:
       summary: Get agent
       operationId: getControlPlaneAgent
       description: Get a specific agent by ID.
-      security: &id475
+      security: &id493
       - bearerAuth: []
       parameters:
       - name: agent_id
@@ -65498,7 +66092,7 @@ paths:
       responses:
         '200':
           description: Agent details
-          headers: &id474
+          headers: &id492
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65512,9 +66106,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ControlPlaneAgent'
-        '401': &id476
+        '401': &id494
           description: Unauthorized - Authentication required or token invalid
-          headers: *id474
+          headers: *id492
           content:
             application/json:
               schema:
@@ -65532,9 +66126,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id477
+        '403': &id495
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id474
+          headers: *id492
           content:
             application/json:
               schema:
@@ -65554,9 +66148,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id478
+        '404': &id496
           description: Not found - The requested resource does not exist
-          headers: *id474
+          headers: *id492
           content:
             application/json:
               schema:
@@ -65570,9 +66164,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id479
+        '500': &id497
           description: Internal server error - Unexpected error occurred
-          headers: *id474
+          headers: *id492
           content:
             application/json:
               schema:
@@ -65592,7 +66186,7 @@ paths:
       summary: Unregister agent
       operationId: deleteControlPlaneAgent
       description: Unregister an agent by ID.
-      security: *id475
+      security: *id493
       parameters:
       - name: agent_id
         in: path
@@ -65602,7 +66196,7 @@ paths:
       responses:
         '200':
           description: Agent unregistered
-          headers: *id474
+          headers: *id492
           content:
             application/json:
               schema:
@@ -65612,10 +66206,10 @@ paths:
                     type: string
                   unregistered:
                     type: boolean
-        '401': *id476
-        '403': *id477
-        '404': *id478
-        '500': *id479
+        '401': *id494
+        '403': *id495
+        '404': *id496
+        '500': *id497
       x-aragora-stability: stable
   /api/v1/control-plane/agents/{agent_id}/heartbeat:
     post:
@@ -65644,7 +66238,7 @@ paths:
       responses:
         '200':
           description: Heartbeat accepted
-          headers: &id480
+          headers: &id498
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65667,7 +66261,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id480
+          headers: *id498
           content:
             application/json:
               schema:
@@ -65687,7 +66281,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id480
+          headers: *id498
           content:
             application/json:
               schema:
@@ -65709,7 +66303,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id480
+          headers: *id498
           content:
             application/json:
               schema:
@@ -65725,7 +66319,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id480
+          headers: *id498
           content:
             application/json:
               schema:
@@ -65862,7 +66456,7 @@ paths:
       responses:
         '200':
           description: Decisionmaking completed
-          headers: &id481
+          headers: &id499
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65878,14 +66472,14 @@ paths:
                 $ref: '#/components/schemas/DeliberationSyncResponse'
         '202':
           description: Decisionmaking queued
-          headers: *id481
+          headers: *id499
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeliberationQueuedResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id481
+          headers: *id499
           content:
             application/json:
               schema:
@@ -65913,7 +66507,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id481
+          headers: *id499
           content:
             application/json:
               schema:
@@ -65933,7 +66527,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id481
+          headers: *id499
           content:
             application/json:
               schema:
@@ -65955,7 +66549,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id481
+          headers: *id499
           content:
             application/json:
               schema:
@@ -66015,7 +66609,7 @@ paths:
       responses:
         '200':
           description: Decisionmaking record
-          headers: &id482
+          headers: &id500
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66031,7 +66625,7 @@ paths:
                 $ref: '#/components/schemas/DeliberationRecord'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id482
+          headers: *id500
           content:
             application/json:
               schema:
@@ -66051,7 +66645,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id482
+          headers: *id500
           content:
             application/json:
               schema:
@@ -66073,7 +66667,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id482
+          headers: *id500
           content:
             application/json:
               schema:
@@ -66089,7 +66683,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id482
+          headers: *id500
           content:
             application/json:
               schema:
@@ -66121,7 +66715,7 @@ paths:
       responses:
         '200':
           description: Decisionmaking status
-          headers: &id483
+          headers: &id501
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66137,7 +66731,7 @@ paths:
                 $ref: '#/components/schemas/DeliberationStatus'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id483
+          headers: *id501
           content:
             application/json:
               schema:
@@ -66157,7 +66751,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id483
+          headers: *id501
           content:
             application/json:
               schema:
@@ -66179,7 +66773,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id483
+          headers: *id501
           content:
             application/json:
               schema:
@@ -66205,7 +66799,7 @@ paths:
       responses:
         '200':
           description: System health
-          headers: &id484
+          headers: &id502
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66221,7 +66815,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneHealth'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id484
+          headers: *id502
           content:
             application/json:
               schema:
@@ -66241,7 +66835,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id484
+          headers: *id502
           content:
             application/json:
               schema:
@@ -66263,7 +66857,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id484
+          headers: *id502
           content:
             application/json:
               schema:
@@ -66316,7 +66910,7 @@ paths:
       responses:
         '200':
           description: Agent health
-          headers: &id485
+          headers: &id503
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66344,7 +66938,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id485
+          headers: *id503
           content:
             application/json:
               schema:
@@ -66364,7 +66958,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id485
+          headers: *id503
           content:
             application/json:
               schema:
@@ -66386,7 +66980,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id485
+          headers: *id503
           content:
             application/json:
               schema:
@@ -66402,7 +66996,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id485
+          headers: *id503
           content:
             application/json:
               schema:
@@ -66428,7 +67022,7 @@ paths:
       responses:
         '200':
           description: Metrics snapshot
-          headers: &id486
+          headers: &id504
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66444,7 +67038,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneMetrics'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id486
+          headers: *id504
           content:
             application/json:
               schema:
@@ -66464,7 +67058,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id486
+          headers: *id504
           content:
             application/json:
               schema:
@@ -66486,7 +67080,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id486
+          headers: *id504
           content:
             application/json:
               schema:
@@ -66602,7 +67196,7 @@ paths:
       responses:
         '200':
           description: Queue snapshot
-          headers: &id487
+          headers: &id505
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66618,7 +67212,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneQueue'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id487
+          headers: *id505
           content:
             application/json:
               schema:
@@ -66638,7 +67232,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id487
+          headers: *id505
           content:
             application/json:
               schema:
@@ -66660,7 +67254,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id487
+          headers: *id505
           content:
             application/json:
               schema:
@@ -66728,7 +67322,7 @@ paths:
       responses:
         '200':
           description: Control plane stats
-          headers: &id488
+          headers: &id506
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66744,7 +67338,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneStats'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id488
+          headers: *id506
           content:
             application/json:
               schema:
@@ -66764,7 +67358,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id488
+          headers: *id506
           content:
             application/json:
               schema:
@@ -66786,7 +67380,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id488
+          headers: *id506
           content:
             application/json:
               schema:
@@ -66861,7 +67455,7 @@ paths:
       responses:
         '201':
           description: Task submitted
-          headers: &id489
+          headers: &id507
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66877,7 +67471,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneTaskCreated'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id489
+          headers: *id507
           content:
             application/json:
               schema:
@@ -66905,7 +67499,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id489
+          headers: *id507
           content:
             application/json:
               schema:
@@ -66925,7 +67519,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id489
+          headers: *id507
           content:
             application/json:
               schema:
@@ -66947,7 +67541,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id489
+          headers: *id507
           content:
             application/json:
               schema:
@@ -66991,7 +67585,7 @@ paths:
       responses:
         '200':
           description: Task claim result
-          headers: &id490
+          headers: &id508
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67007,7 +67601,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneTaskClaimResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id490
+          headers: *id508
           content:
             application/json:
               schema:
@@ -67027,7 +67621,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id490
+          headers: *id508
           content:
             application/json:
               schema:
@@ -67049,7 +67643,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id490
+          headers: *id508
           content:
             application/json:
               schema:
@@ -67081,7 +67675,7 @@ paths:
       responses:
         '200':
           description: Task details
-          headers: &id491
+          headers: &id509
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67097,7 +67691,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneTask'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id491
+          headers: *id509
           content:
             application/json:
               schema:
@@ -67117,7 +67711,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id491
+          headers: *id509
           content:
             application/json:
               schema:
@@ -67139,7 +67733,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id491
+          headers: *id509
           content:
             application/json:
               schema:
@@ -67155,7 +67749,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id491
+          headers: *id509
           content:
             application/json:
               schema:
@@ -67187,7 +67781,7 @@ paths:
       responses:
         '200':
           description: Task cancelled
-          headers: &id492
+          headers: &id510
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67211,7 +67805,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id492
+          headers: *id510
           content:
             application/json:
               schema:
@@ -67231,7 +67825,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id492
+          headers: *id510
           content:
             application/json:
               schema:
@@ -67253,7 +67847,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id492
+          headers: *id510
           content:
             application/json:
               schema:
@@ -67269,7 +67863,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id492
+          headers: *id510
           content:
             application/json:
               schema:
@@ -67314,7 +67908,7 @@ paths:
       responses:
         '200':
           description: Task completed
-          headers: &id493
+          headers: &id511
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67338,7 +67932,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id493
+          headers: *id511
           content:
             application/json:
               schema:
@@ -67358,7 +67952,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id493
+          headers: *id511
           content:
             application/json:
               schema:
@@ -67380,7 +67974,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id493
+          headers: *id511
           content:
             application/json:
               schema:
@@ -67396,7 +67990,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id493
+          headers: *id511
           content:
             application/json:
               schema:
@@ -67441,7 +68035,7 @@ paths:
       responses:
         '200':
           description: Task failed
-          headers: &id494
+          headers: &id512
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67465,7 +68059,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id494
+          headers: *id512
           content:
             application/json:
               schema:
@@ -67485,7 +68079,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id494
+          headers: *id512
           content:
             application/json:
               schema:
@@ -67507,7 +68101,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id494
+          headers: *id512
           content:
             application/json:
               schema:
@@ -67523,7 +68117,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id494
+          headers: *id512
           content:
             application/json:
               schema:
@@ -67537,6 +68131,169 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
+  /api/v1/coordination/active-work:
+    get:
+      tags:
+      - Coordination
+      summary: Get active agent work snapshot
+      operationId: getCoordinationActiveWork
+      description: Return a compact, agent-readable snapshot over existing fleet claims, developer leases, merge queue entries,
+        worktree sessions, and active agent bridge runs.
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: base
+        in: query
+        required: false
+        description: Base branch for worktree status.
+        schema:
+          type: string
+          default: main
+      responses:
+        '200':
+          description: Active work snapshot
+          headers: &id513
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - schema_version
+                - repo_root
+                - base_branch
+                - generated_at
+                - active_owners
+                - claimed_paths
+                - avoid_paths
+                - worktrees
+                - fleet_claims
+                - active_leases
+                - merge_queue
+                - bridge_runs
+                - counts
+                - source_errors
+                properties:
+                  schema_version:
+                    type: integer
+                    enum:
+                    - 1
+                  repo_root:
+                    type: string
+                  base_branch:
+                    type: string
+                  generated_at:
+                    type: string
+                    format: date-time
+                  active_owners:
+                    type: array
+                    items:
+                      type: object
+                  claimed_paths:
+                    type: array
+                    items:
+                      type: string
+                  avoid_paths:
+                    type: array
+                    items:
+                      type: string
+                  avoid_path_hints:
+                    type: array
+                    items:
+                      type: object
+                  worktrees:
+                    type: array
+                    items:
+                      type: object
+                  fleet_claims:
+                    type: array
+                    items:
+                      type: object
+                  active_leases:
+                    type: array
+                    items:
+                      type: object
+                  merge_queue:
+                    type: array
+                    items:
+                      type: object
+                  bridge_runs:
+                    type: array
+                    items:
+                      type: object
+                  counts:
+                    type: object
+                    additionalProperties: true
+                  source_errors:
+                    type: array
+                    items:
+                      type: object
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id513
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id513
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id513
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
   /api/v1/coordination/approve/{request_id}:
     post:
       summary: Approve coordination request
@@ -68277,7 +69034,7 @@ paths:
       responses:
         '200':
           description: Cost summary
-          headers: &id495
+          headers: &id514
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68293,7 +69050,7 @@ paths:
                 $ref: '#/components/schemas/CostSummaryResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id495
+          headers: *id514
           content:
             application/json:
               schema:
@@ -68313,7 +69070,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id495
+          headers: *id514
           content:
             application/json:
               schema:
@@ -68335,7 +69092,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id495
+          headers: *id514
           content:
             application/json:
               schema:
@@ -68386,7 +69143,7 @@ paths:
       responses:
         '200':
           description: Alerts
-          headers: &id496
+          headers: &id515
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68402,7 +69159,7 @@ paths:
                 $ref: '#/components/schemas/CostAlertsResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id496
+          headers: *id515
           content:
             application/json:
               schema:
@@ -68422,7 +69179,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id496
+          headers: *id515
           content:
             application/json:
               schema:
@@ -68444,7 +69201,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id496
+          headers: *id515
           content:
             application/json:
               schema:
@@ -68494,7 +69251,7 @@ paths:
       responses:
         '201':
           description: Alert created
-          headers: &id497
+          headers: &id516
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68510,7 +69267,7 @@ paths:
                 $ref: '#/components/schemas/CostAlertCreateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id497
+          headers: *id516
           content:
             application/json:
               schema:
@@ -68538,7 +69295,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id497
+          headers: *id516
           content:
             application/json:
               schema:
@@ -68558,7 +69315,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id497
+          headers: *id516
           content:
             application/json:
               schema:
@@ -68580,7 +69337,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id497
+          headers: *id516
           content:
             application/json:
               schema:
@@ -68612,7 +69369,7 @@ paths:
       responses:
         '200':
           description: Alert dismissed
-          headers: &id498
+          headers: &id517
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68628,7 +69385,7 @@ paths:
                 $ref: '#/components/schemas/CostDismissAlertResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id498
+          headers: *id517
           content:
             application/json:
               schema:
@@ -68648,7 +69405,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id498
+          headers: *id517
           content:
             application/json:
               schema:
@@ -68670,7 +69427,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id498
+          headers: *id517
           content:
             application/json:
               schema:
@@ -68686,7 +69443,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id498
+          headers: *id517
           content:
             application/json:
               schema:
@@ -68925,7 +69682,7 @@ paths:
       responses:
         '200':
           description: Cost breakdown
-          headers: &id499
+          headers: &id518
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68941,7 +69698,7 @@ paths:
                 $ref: '#/components/schemas/CostBreakdownResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id499
+          headers: *id518
           content:
             application/json:
               schema:
@@ -68961,7 +69718,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id499
+          headers: *id518
           content:
             application/json:
               schema:
@@ -68983,7 +69740,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id499
+          headers: *id518
           content:
             application/json:
               schema:
@@ -69015,7 +69772,7 @@ paths:
       responses:
         '200':
           description: Budget updated
-          headers: &id500
+          headers: &id519
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69031,7 +69788,7 @@ paths:
                 $ref: '#/components/schemas/CostBudgetResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id500
+          headers: *id519
           content:
             application/json:
               schema:
@@ -69059,7 +69816,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id500
+          headers: *id519
           content:
             application/json:
               schema:
@@ -69079,7 +69836,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id500
+          headers: *id519
           content:
             application/json:
               schema:
@@ -69101,7 +69858,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id500
+          headers: *id519
           content:
             application/json:
               schema:
@@ -69122,7 +69879,7 @@ paths:
       summary: List budgets
       operationId: listCostsBudgets
       description: List all budgets for the workspace.
-      security: &id502
+      security: &id521
       - {}
       parameters:
       - name: workspace_id
@@ -69137,7 +69894,7 @@ paths:
       responses:
         '200':
           description: Budgets list
-          headers: &id501
+          headers: &id520
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69151,9 +69908,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostBudgetsListResponse'
-        '401': &id503
+        '401': &id522
           description: Unauthorized - Authentication required or token invalid
-          headers: *id501
+          headers: *id520
           content:
             application/json:
               schema:
@@ -69171,9 +69928,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id504
+        '403': &id523
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id501
+          headers: *id520
           content:
             application/json:
               schema:
@@ -69193,9 +69950,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id505
+        '500': &id524
           description: Internal server error - Unexpected error occurred
-          headers: *id501
+          headers: *id520
           content:
             application/json:
               schema:
@@ -69215,7 +69972,7 @@ paths:
       summary: Create budget
       operationId: createCostsBudgets
       description: Create a new budget for the workspace.
-      security: *id502
+      security: *id521
       requestBody:
         required: true
         content:
@@ -69225,14 +69982,14 @@ paths:
       responses:
         '201':
           description: Budget created
-          headers: *id501
+          headers: *id520
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostBudgetResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id501
+          headers: *id520
           content:
             application/json:
               schema:
@@ -69258,9 +70015,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id503
-        '403': *id504
-        '500': *id505
+        '401': *id522
+        '403': *id523
+        '500': *id524
       x-aragora-stability: stable
   /api/v1/costs/constraints/check:
     post:
@@ -69289,7 +70046,7 @@ paths:
       responses:
         '200':
           description: Constraint check result
-          headers: &id506
+          headers: &id525
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69305,7 +70062,7 @@ paths:
                 $ref: '#/components/schemas/CostConstraintCheckResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id506
+          headers: *id525
           content:
             application/json:
               schema:
@@ -69333,7 +70090,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id506
+          headers: *id525
           content:
             application/json:
               schema:
@@ -69353,7 +70110,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id506
+          headers: *id525
           content:
             application/json:
               schema:
@@ -69375,7 +70132,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id506
+          headers: *id525
           content:
             application/json:
               schema:
@@ -69408,7 +70165,7 @@ paths:
       responses:
         '200':
           description: Debate session costs
-          headers: &id507
+          headers: &id526
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69451,7 +70208,7 @@ paths:
                         additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id507
+          headers: *id526
           content:
             application/json:
               schema:
@@ -69479,7 +70236,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id507
+          headers: *id526
           content:
             application/json:
               schema:
@@ -69499,7 +70256,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id507
+          headers: *id526
           content:
             application/json:
               schema:
@@ -69523,7 +70280,7 @@ paths:
           description: Cost tracker unavailable
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id507
+          headers: *id526
           content:
             application/json:
               schema:
@@ -69586,7 +70343,7 @@ paths:
       responses:
         '200':
           description: Debate cost line items
-          headers: &id508
+          headers: &id527
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69624,7 +70381,7 @@ paths:
                         type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id508
+          headers: *id527
           content:
             application/json:
               schema:
@@ -69652,7 +70409,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id508
+          headers: *id527
           content:
             application/json:
               schema:
@@ -69672,7 +70429,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id508
+          headers: *id527
           content:
             application/json:
               schema:
@@ -69696,7 +70453,7 @@ paths:
           description: Cost tracker unavailable
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id508
+          headers: *id527
           content:
             application/json:
               schema:
@@ -69729,7 +70486,7 @@ paths:
       responses:
         '200':
           description: Debate cost performance
-          headers: &id509
+          headers: &id528
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69777,7 +70534,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id509
+          headers: *id528
           content:
             application/json:
               schema:
@@ -69805,7 +70562,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id509
+          headers: *id528
           content:
             application/json:
               schema:
@@ -69825,7 +70582,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id509
+          headers: *id528
           content:
             application/json:
               schema:
@@ -69849,7 +70606,7 @@ paths:
           description: Cost tracker unavailable
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id509
+          headers: *id528
           content:
             application/json:
               schema:
@@ -69884,7 +70641,7 @@ paths:
       responses:
         '200':
           description: Efficiency metrics
-          headers: &id510
+          headers: &id529
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -69908,7 +70665,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id510
+          headers: *id529
           content:
             application/json:
               schema:
@@ -69928,7 +70685,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id510
+          headers: *id529
           content:
             application/json:
               schema:
@@ -69950,7 +70707,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id510
+          headers: *id529
           content:
             application/json:
               schema:
@@ -69993,7 +70750,7 @@ paths:
       responses:
         '200':
           description: Cost estimate
-          headers: &id511
+          headers: &id530
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70009,7 +70766,7 @@ paths:
                 $ref: '#/components/schemas/CostEstimateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id511
+          headers: *id530
           content:
             application/json:
               schema:
@@ -70037,7 +70794,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id511
+          headers: *id530
           content:
             application/json:
               schema:
@@ -70057,7 +70814,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id511
+          headers: *id530
           content:
             application/json:
               schema:
@@ -70079,7 +70836,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id511
+          headers: *id530
           content:
             application/json:
               schema:
@@ -70122,7 +70879,7 @@ paths:
       responses:
         '200':
           description: Export generated
-          headers: &id512
+          headers: &id531
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70145,7 +70902,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id512
+          headers: *id531
           content:
             application/json:
               schema:
@@ -70165,7 +70922,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id512
+          headers: *id531
           content:
             application/json:
               schema:
@@ -70187,7 +70944,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id512
+          headers: *id531
           content:
             application/json:
               schema:
@@ -70225,7 +70982,7 @@ paths:
       responses:
         '200':
           description: Forecast
-          headers: &id513
+          headers: &id532
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70250,7 +71007,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id513
+          headers: *id532
           content:
             application/json:
               schema:
@@ -70270,7 +71027,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id513
+          headers: *id532
           content:
             application/json:
               schema:
@@ -70292,7 +71049,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id513
+          headers: *id532
           content:
             application/json:
               schema:
@@ -70335,7 +71092,7 @@ paths:
       responses:
         '200':
           description: Detailed forecast
-          headers: &id514
+          headers: &id533
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70351,7 +71108,7 @@ paths:
                 $ref: '#/components/schemas/CostForecastDetailedResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id514
+          headers: *id533
           content:
             application/json:
               schema:
@@ -70371,7 +71128,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id514
+          headers: *id533
           content:
             application/json:
               schema:
@@ -70393,7 +71150,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id514
+          headers: *id533
           content:
             application/json:
               schema:
@@ -70457,7 +71214,7 @@ paths:
       responses:
         '200':
           description: Recommendations
-          headers: &id515
+          headers: &id534
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70480,7 +71237,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id515
+          headers: *id534
           content:
             application/json:
               schema:
@@ -70500,7 +71257,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id515
+          headers: *id534
           content:
             application/json:
               schema:
@@ -70522,7 +71279,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id515
+          headers: *id534
           content:
             application/json:
               schema:
@@ -70563,7 +71320,7 @@ paths:
       responses:
         '200':
           description: Detailed recommendations
-          headers: &id516
+          headers: &id535
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70579,7 +71336,7 @@ paths:
                 $ref: '#/components/schemas/CostRecommendationsDetailedResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id516
+          headers: *id535
           content:
             application/json:
               schema:
@@ -70599,7 +71356,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id516
+          headers: *id535
           content:
             application/json:
               schema:
@@ -70621,7 +71378,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id516
+          headers: *id535
           content:
             application/json:
               schema:
@@ -70732,7 +71489,7 @@ paths:
       responses:
         '200':
           description: Cost timeline
-          headers: &id517
+          headers: &id536
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70748,7 +71505,7 @@ paths:
                 $ref: '#/components/schemas/CostTimelineResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id517
+          headers: *id536
           content:
             application/json:
               schema:
@@ -70768,7 +71525,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id517
+          headers: *id536
           content:
             application/json:
               schema:
@@ -70790,7 +71547,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id517
+          headers: *id536
           content:
             application/json:
               schema:
@@ -70838,7 +71595,7 @@ paths:
       responses:
         '200':
           description: Usage data
-          headers: &id518
+          headers: &id537
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -70854,7 +71611,7 @@ paths:
                 $ref: '#/components/schemas/CostUsageResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id518
+          headers: *id537
           content:
             application/json:
               schema:
@@ -70874,7 +71631,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id518
+          headers: *id537
           content:
             application/json:
               schema:
@@ -70896,7 +71653,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id518
+          headers: *id537
           content:
             application/json:
               schema:
@@ -71542,7 +72299,7 @@ paths:
       responses:
         '200':
           description: Circuit breaker status with state and failure count
-          headers: &id519
+          headers: &id538
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71582,7 +72339,7 @@ paths:
       responses:
         '200':
           description: Circuit breaker reset confirmation
-          headers: *id519
+          headers: *id538
           content:
             application/json:
               schema:
@@ -71924,7 +72681,7 @@ paths:
       responses:
         '200':
           description: CVE details
-          headers: &id520
+          headers: &id539
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71940,7 +72697,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseCVEResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id520
+          headers: *id539
           content:
             application/json:
               schema:
@@ -71960,7 +72717,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id520
+          headers: *id539
           content:
             application/json:
               schema:
@@ -71982,7 +72739,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id520
+          headers: *id539
           content:
             application/json:
               schema:
@@ -71998,7 +72755,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id520
+          headers: *id539
           content:
             application/json:
               schema:
@@ -72045,7 +72802,7 @@ paths:
       responses:
         '200':
           description: Activity feed
-          headers: &id521
+          headers: &id540
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72080,7 +72837,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id521
+          headers: *id540
           content:
             application/json:
               schema:
@@ -72100,7 +72857,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id521
+          headers: *id540
           content:
             application/json:
               schema:
@@ -72181,7 +72938,7 @@ paths:
       responses:
         '200':
           description: Debate details
-          headers: &id522
+          headers: &id541
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72217,7 +72974,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id522
+          headers: *id541
           content:
             application/json:
               schema:
@@ -72237,7 +72994,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id522
+          headers: *id541
           content:
             application/json:
               schema:
@@ -72253,7 +73010,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id522
+          headers: *id541
           content:
             application/json:
               schema:
@@ -72405,7 +73162,7 @@ paths:
       responses:
         '200':
           description: Inbox summary
-          headers: &id523
+          headers: &id542
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72430,7 +73187,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id523
+          headers: *id542
           content:
             application/json:
               schema:
@@ -72450,7 +73207,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id523
+          headers: *id542
           content:
             application/json:
               schema:
@@ -72476,7 +73233,7 @@ paths:
       responses:
         '200':
           description: Labels list
-          headers: &id524
+          headers: &id543
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72506,7 +73263,7 @@ paths:
                           type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id524
+          headers: *id543
           content:
             application/json:
               schema:
@@ -72526,7 +73283,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id524
+          headers: *id543
           content:
             application/json:
               schema:
@@ -72552,7 +73309,7 @@ paths:
       responses:
         '200':
           description: Dashboard overview data
-          headers: &id525
+          headers: &id544
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72591,7 +73348,7 @@ paths:
                     - unhealthy
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id525
+          headers: *id544
           content:
             application/json:
               schema:
@@ -72611,7 +73368,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id525
+          headers: *id544
           content:
             application/json:
               schema:
@@ -72637,7 +73394,7 @@ paths:
       responses:
         '200':
           description: Pending actions
-          headers: &id526
+          headers: &id545
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72672,7 +73429,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id526
+          headers: *id545
           content:
             application/json:
               schema:
@@ -72692,7 +73449,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id526
+          headers: *id545
           content:
             application/json:
               schema:
@@ -72724,7 +73481,7 @@ paths:
       responses:
         '200':
           description: Action completed
-          headers: &id527
+          headers: &id546
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72748,7 +73505,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id527
+          headers: *id546
           content:
             application/json:
               schema:
@@ -72768,7 +73525,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id527
+          headers: *id546
           content:
             application/json:
               schema:
@@ -72784,7 +73541,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id527
+          headers: *id546
           content:
             application/json:
               schema:
@@ -72810,7 +73567,7 @@ paths:
       responses:
         '200':
           description: Quality metrics
-          headers: &id528
+          headers: &id547
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72835,7 +73592,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id528
+          headers: *id547
           content:
             application/json:
               schema:
@@ -72855,7 +73612,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id528
+          headers: *id547
           content:
             application/json:
               schema:
@@ -72881,7 +73638,7 @@ paths:
       responses:
         '200':
           description: Quick actions
-          headers: &id529
+          headers: &id548
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72911,7 +73668,7 @@ paths:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id529
+          headers: *id548
           content:
             application/json:
               schema:
@@ -72931,7 +73688,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id529
+          headers: *id548
           content:
             application/json:
               schema:
@@ -72963,7 +73720,7 @@ paths:
       responses:
         '200':
           description: Action executed
-          headers: &id530
+          headers: &id549
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72986,7 +73743,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id530
+          headers: *id549
           content:
             application/json:
               schema:
@@ -73006,7 +73763,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id530
+          headers: *id549
           content:
             application/json:
               schema:
@@ -73022,7 +73779,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id530
+          headers: *id549
           content:
             application/json:
               schema:
@@ -73054,7 +73811,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id531
+          headers: &id550
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73090,7 +73847,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id531
+          headers: *id550
           content:
             application/json:
               schema:
@@ -73110,7 +73867,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id531
+          headers: *id550
           content:
             application/json:
               schema:
@@ -73136,7 +73893,7 @@ paths:
       responses:
         '200':
           description: Stat cards
-          headers: &id532
+          headers: &id551
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73170,7 +73927,7 @@ paths:
                           - stable
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id532
+          headers: *id551
           content:
             application/json:
               schema:
@@ -73190,7 +73947,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id532
+          headers: *id551
           content:
             application/json:
               schema:
@@ -73216,7 +73973,7 @@ paths:
       responses:
         '200':
           description: Dashboard statistics
-          headers: &id533
+          headers: &id552
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73243,7 +74000,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id533
+          headers: *id552
           content:
             application/json:
               schema:
@@ -73263,7 +74020,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id533
+          headers: *id552
           content:
             application/json:
               schema:
@@ -73289,7 +74046,7 @@ paths:
       responses:
         '200':
           description: Team performance
-          headers: &id534
+          headers: &id553
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73319,7 +74076,7 @@ paths:
                           type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id534
+          headers: *id553
           content:
             application/json:
               schema:
@@ -73339,7 +74096,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id534
+          headers: *id553
           content:
             application/json:
               schema:
@@ -73371,7 +74128,7 @@ paths:
       responses:
         '200':
           description: Team performance detail
-          headers: &id535
+          headers: &id554
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73402,7 +74159,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id535
+          headers: *id554
           content:
             application/json:
               schema:
@@ -73422,7 +74179,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id535
+          headers: *id554
           content:
             application/json:
               schema:
@@ -73438,7 +74195,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id535
+          headers: *id554
           content:
             application/json:
               schema:
@@ -73464,7 +74221,7 @@ paths:
       responses:
         '200':
           description: Top senders
-          headers: &id536
+          headers: &id555
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73494,7 +74251,7 @@ paths:
                           type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id536
+          headers: *id555
           content:
             application/json:
               schema:
@@ -73514,7 +74271,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id536
+          headers: *id555
           content:
             application/json:
               schema:
@@ -73540,7 +74297,7 @@ paths:
       responses:
         '200':
           description: Urgent items
-          headers: &id537
+          headers: &id556
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73575,7 +74332,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id537
+          headers: *id556
           content:
             application/json:
               schema:
@@ -73595,7 +74352,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id537
+          headers: *id556
           content:
             application/json:
               schema:
@@ -73627,7 +74384,7 @@ paths:
       responses:
         '200':
           description: Item dismissed
-          headers: &id538
+          headers: &id557
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73648,7 +74405,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id538
+          headers: *id557
           content:
             application/json:
               schema:
@@ -73668,7 +74425,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id538
+          headers: *id557
           content:
             application/json:
               schema:
@@ -73684,7 +74441,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id538
+          headers: *id557
           content:
             application/json:
               schema:
@@ -73745,7 +74502,7 @@ paths:
       responses:
         '200':
           description: Debate created successfully
-          headers: &id539
+          headers: &id558
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73761,7 +74518,7 @@ paths:
                 $ref: '#/components/schemas/DebateCreateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id539
+          headers: *id558
           content:
             application/json:
               schema:
@@ -73789,7 +74546,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id539
+          headers: *id558
           content:
             application/json:
               schema:
@@ -73918,7 +74675,7 @@ paths:
       responses:
         '200':
           description: Meta-critique
-          headers: &id540
+          headers: &id559
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73957,7 +74714,7 @@ paths:
                       type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id540
+          headers: *id559
           content:
             application/json:
               schema:
@@ -74027,7 +74784,7 @@ paths:
       responses:
         '200':
           description: Paginated list of debates
-          headers: &id541
+          headers: &id560
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74049,9 +74806,9 @@ paths:
                   count:
                     type: integer
                     description: Total number of debates matching filters
-        '401': &id542
+        '401': &id561
           description: Unauthorized - Authentication required or token invalid
-          headers: *id541
+          headers: *id560
           content:
             application/json:
               schema:
@@ -74069,9 +74826,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '429': &id543
+        '429': &id562
           description: Too many requests - Rate limit exceeded
-          headers: *id541
+          headers: *id560
           content:
             application/json:
               schema:
@@ -74147,14 +74904,14 @@ paths:
       responses:
         '200':
           description: Debate created successfully
-          headers: *id541
+          headers: *id560
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DebateCreateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id541
+          headers: *id560
           content:
             application/json:
               schema:
@@ -74180,10 +74937,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id542
+        '401': *id561
         '402':
           description: Payment required - Quota exceeded, upgrade required
-          headers: *id541
+          headers: *id560
           content:
             application/json:
               schema:
@@ -74199,10 +74956,10 @@ paths:
                     resets_at: '2024-01-16T00:00:00Z'
                     upgrade_url: https://aragora.ai/pricing
                     trace_id: req_abc123xyz
-        '429': *id543
+        '429': *id562
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id541
+          headers: *id560
           content:
             application/json:
               schema:
@@ -74227,7 +74984,7 @@ paths:
       responses:
         '200':
           description: Active debates returned
-          headers: &id544
+          headers: &id563
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74274,7 +75031,7 @@ paths:
                 - debates
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id544
+          headers: *id563
           content:
             application/json:
               schema:
@@ -74530,7 +75287,7 @@ paths:
       responses:
         '200':
           description: Batch submitted
-          headers: &id545
+          headers: &id564
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74557,7 +75314,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id545
+          headers: *id564
           content:
             application/json:
               schema:
@@ -74600,7 +75357,7 @@ paths:
       responses:
         '200':
           description: Batch status
-          headers: &id546
+          headers: &id565
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74631,7 +75388,7 @@ paths:
                       type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id546
+          headers: *id565
           content:
             application/json:
               schema:
@@ -74851,7 +75608,7 @@ paths:
       responses:
         '200':
           description: Cost estimate
-          headers: &id547
+          headers: &id566
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74867,7 +75624,7 @@ paths:
                 $ref: '#/components/schemas/DebateCostEstimateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id547
+          headers: *id566
           content:
             application/json:
               schema:
@@ -75172,7 +75929,7 @@ paths:
       responses:
         '200':
           description: Debate graph
-          headers: &id548
+          headers: &id567
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75199,7 +75956,7 @@ paths:
                     type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id548
+          headers: *id567
           content:
             application/json:
               schema:
@@ -75298,7 +76055,7 @@ paths:
       responses:
         '200':
           description: Hybrid debates
-          headers: &id549
+          headers: &id568
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75341,9 +76098,9 @@ paths:
                 required:
                 - debates
                 - total
-        '401': &id550
+        '401': &id569
           description: Unauthorized - Authentication required or token invalid
-          headers: *id549
+          headers: *id568
           content:
             application/json:
               schema:
@@ -75361,9 +76118,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id551
+        '403': &id570
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id549
+          headers: *id568
           content:
             application/json:
               schema:
@@ -75383,9 +76140,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '429': &id552
+        '429': &id571
           description: Too many requests - Rate limit exceeded
-          headers: *id549
+          headers: *id568
           content:
             application/json:
               schema:
@@ -75400,9 +76157,9 @@ paths:
                     window: 1 minute
                     retry_after: 45
                     trace_id: req_abc123xyz
-        '500': &id553
+        '500': &id572
           description: Internal server error - Unexpected error occurred
-          headers: *id549
+          headers: *id568
           content:
             application/json:
               schema:
@@ -75465,7 +76222,7 @@ paths:
       responses:
         '201':
           description: Hybrid debate created
-          headers: *id549
+          headers: *id568
           content:
             application/json:
               schema:
@@ -75523,7 +76280,7 @@ paths:
                 additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id549
+          headers: *id568
           content:
             application/json:
               schema:
@@ -75549,10 +76306,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id550
-        '403': *id551
-        '429': *id552
-        '500': *id553
+        '401': *id569
+        '403': *id570
+        '429': *id571
+        '500': *id572
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -75574,7 +76331,7 @@ paths:
       responses:
         '200':
           description: Hybrid debate details
-          headers: &id554
+          headers: &id573
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75641,7 +76398,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id554
+          headers: *id573
           content:
             application/json:
               schema:
@@ -75661,7 +76418,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id554
+          headers: *id573
           content:
             application/json:
               schema:
@@ -75683,7 +76440,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id554
+          headers: *id573
           content:
             application/json:
               schema:
@@ -75699,7 +76456,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id554
+          headers: *id573
           content:
             application/json:
               schema:
@@ -75827,7 +76584,7 @@ paths:
       responses:
         '200':
           description: Matrix comparison
-          headers: &id555
+          headers: &id574
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75862,7 +76619,7 @@ paths:
                     - 'null'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id555
+          headers: *id574
           content:
             application/json:
               schema:
@@ -76081,7 +76838,7 @@ paths:
       responses:
         '200':
           description: Debate details
-          headers: &id556
+          headers: &id575
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76097,7 +76854,7 @@ paths:
                 $ref: '#/components/schemas/Debate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id556
+          headers: *id575
           content:
             application/json:
               schema:
@@ -76380,7 +77137,7 @@ paths:
       responses:
         '200':
           description: Counterfactuals
-          headers: &id557
+          headers: &id576
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76396,7 +77153,7 @@ paths:
                 $ref: '#/components/schemas/Counterfactuals'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id557
+          headers: *id576
           content:
             application/json:
               schema:
@@ -76434,7 +77191,7 @@ paths:
       responses:
         '200':
           description: Decision explanation
-          headers: &id558
+          headers: &id577
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76450,7 +77207,7 @@ paths:
                 $ref: '#/components/schemas/DecisionExplanation'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id558
+          headers: *id577
           content:
             application/json:
               schema:
@@ -76592,7 +77349,7 @@ paths:
       responses:
         '200':
           description: Argument injected
-          headers: &id559
+          headers: &id578
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76619,7 +77376,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id559
+          headers: *id578
           content:
             application/json:
               schema:
@@ -76647,7 +77404,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id559
+          headers: *id578
           content:
             application/json:
               schema:
@@ -76691,7 +77448,7 @@ paths:
       responses:
         '200':
           description: Intervention log
-          headers: &id560
+          headers: &id579
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76716,7 +77473,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id560
+          headers: *id579
           content:
             application/json:
               schema:
@@ -76754,7 +77511,7 @@ paths:
       responses:
         '200':
           description: Debate paused
-          headers: &id561
+          headers: &id580
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76780,7 +77537,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id561
+          headers: *id580
           content:
             application/json:
               schema:
@@ -76808,7 +77565,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id561
+          headers: *id580
           content:
             application/json:
               schema:
@@ -76846,7 +77603,7 @@ paths:
       responses:
         '200':
           description: Debate resumed
-          headers: &id562
+          headers: &id581
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76876,7 +77633,7 @@ paths:
                     - 'null'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id562
+          headers: *id581
           content:
             application/json:
               schema:
@@ -76904,7 +77661,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id562
+          headers: *id581
           content:
             application/json:
               schema:
@@ -76942,7 +77699,7 @@ paths:
       responses:
         '200':
           description: Intervention state
-          headers: &id563
+          headers: &id582
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76974,7 +77731,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id563
+          headers: *id582
           content:
             application/json:
               schema:
@@ -77018,7 +77775,7 @@ paths:
       responses:
         '200':
           description: Threshold updated
-          headers: &id564
+          headers: &id583
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77043,7 +77800,7 @@ paths:
                     type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id564
+          headers: *id583
           content:
             application/json:
               schema:
@@ -77071,7 +77828,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id564
+          headers: *id583
           content:
             application/json:
               schema:
@@ -77115,7 +77872,7 @@ paths:
       responses:
         '200':
           description: Weight updated
-          headers: &id565
+          headers: &id584
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77142,7 +77899,7 @@ paths:
                     type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id565
+          headers: *id584
           content:
             application/json:
               schema:
@@ -77170,7 +77927,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id565
+          headers: *id584
           content:
             application/json:
               schema:
@@ -77321,7 +78078,7 @@ paths:
       responses:
         '200':
           description: Summary
-          headers: &id566
+          headers: &id585
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77337,7 +78094,7 @@ paths:
                 $ref: '#/components/schemas/DebateSummary'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id566
+          headers: *id585
           content:
             application/json:
               schema:
@@ -77373,7 +78130,7 @@ paths:
       responses:
         '200':
           description: Vote pivots
-          headers: &id567
+          headers: &id586
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77389,7 +78146,7 @@ paths:
                 $ref: '#/components/schemas/VotePivots'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id567
+          headers: *id586
           content:
             application/json:
               schema:
@@ -77420,7 +78177,7 @@ paths:
       responses:
         '200':
           description: Delete result
-          headers: &id568
+          headers: &id587
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77437,9 +78194,9 @@ paths:
                 properties:
                   success:
                     type: boolean
-        '404': &id569
+        '404': &id588
           description: Not found - The requested resource does not exist
-          headers: *id568
+          headers: *id587
           content:
             application/json:
               schema:
@@ -77488,15 +78245,15 @@ paths:
       responses:
         '200':
           description: Debate details
-          headers: *id568
+          headers: *id587
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Debate'
-        '404': *id569
+        '404': *id588
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id568
+          headers: *id587
           content:
             application/json:
               schema:
@@ -77582,7 +78339,7 @@ paths:
       responses:
         '200':
           description: Archive result
-          headers: &id570
+          headers: &id589
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77601,7 +78358,7 @@ paths:
                     type: boolean
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id570
+          headers: *id589
           content:
             application/json:
               schema:
@@ -77717,7 +78474,7 @@ paths:
       responses:
         '200':
           description: Cancel result
-          headers: &id571
+          headers: &id590
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77738,7 +78495,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id571
+          headers: *id590
           content:
             application/json:
               schema:
@@ -77846,7 +78603,7 @@ paths:
       responses:
         '200':
           description: Clone result
-          headers: &id572
+          headers: &id591
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77865,7 +78622,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id572
+          headers: *id591
           content:
             application/json:
               schema:
@@ -77896,7 +78653,7 @@ paths:
       responses:
         '200':
           description: Consensus data
-          headers: &id573
+          headers: &id592
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77925,7 +78682,7 @@ paths:
                       type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id573
+          headers: *id592
           content:
             application/json:
               schema:
@@ -78091,7 +78848,7 @@ paths:
       responses:
         '200':
           description: Diagnostic report
-          headers: &id574
+          headers: &id593
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78207,7 +78964,7 @@ paths:
                   - Consider adding OPENROUTER_API_KEY as fallback for failed providers
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id574
+          headers: *id593
           content:
             application/json:
               schema:
@@ -78223,7 +78980,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id574
+          headers: *id593
           content:
             application/json:
               schema:
@@ -78304,7 +79061,7 @@ paths:
       responses:
         '200':
           description: Evidence chain
-          headers: &id575
+          headers: &id594
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78320,7 +79077,7 @@ paths:
                 $ref: '#/components/schemas/EvidenceChain'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id575
+          headers: *id594
           content:
             application/json:
               schema:
@@ -78351,7 +79108,7 @@ paths:
       responses:
         '200':
           description: Explainability data
-          headers: &id576
+          headers: &id595
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78378,7 +79135,7 @@ paths:
                     type: number
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id576
+          headers: *id595
           content:
             application/json:
               schema:
@@ -78409,7 +79166,7 @@ paths:
       responses:
         '200':
           description: Counterfactual scenarios
-          headers: &id577
+          headers: &id596
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78435,9 +79192,9 @@ paths:
                           type: string
                         probability:
                           type: number
-        '404': &id578
+        '404': &id597
           description: Not found - The requested resource does not exist
-          headers: *id577
+          headers: *id596
           content:
             application/json:
               schema:
@@ -78473,7 +79230,7 @@ paths:
       responses:
         '200':
           description: Counterfactual result
-          headers: *id577
+          headers: *id596
           content:
             application/json:
               schema:
@@ -78489,7 +79246,7 @@ paths:
                       type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id577
+          headers: *id596
           content:
             application/json:
               schema:
@@ -78515,7 +79272,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id578
+        '404': *id597
       x-aragora-stability: stable
   /api/v1/debates/{id}/explainability/factors:
     get:
@@ -78533,7 +79290,7 @@ paths:
       responses:
         '200':
           description: Factors
-          headers: &id579
+          headers: &id598
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78565,7 +79322,7 @@ paths:
                             type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id579
+          headers: *id598
           content:
             application/json:
               schema:
@@ -78596,7 +79353,7 @@ paths:
       responses:
         '200':
           description: Narrative
-          headers: &id580
+          headers: &id599
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78621,7 +79378,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id580
+          headers: *id599
           content:
             application/json:
               schema:
@@ -78652,7 +79409,7 @@ paths:
       responses:
         '200':
           description: Provenance
-          headers: &id581
+          headers: &id600
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78684,7 +79441,7 @@ paths:
                           type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id581
+          headers: *id600
           content:
             application/json:
               schema:
@@ -78773,7 +79530,7 @@ paths:
       responses:
         '200':
           description: Follow-up created
-          headers: &id582
+          headers: &id601
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78792,7 +79549,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id582
+          headers: *id601
           content:
             application/json:
               schema:
@@ -78835,7 +79592,7 @@ paths:
       responses:
         '201':
           description: Forked debate created
-          headers: &id583
+          headers: &id602
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78858,7 +79615,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id583
+          headers: *id602
           content:
             application/json:
               schema:
@@ -79031,7 +79788,7 @@ paths:
       responses:
         '200':
           description: Joined debate
-          headers: &id584
+          headers: &id603
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79056,7 +79813,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id584
+          headers: *id603
           content:
             application/json:
               schema:
@@ -79152,7 +79909,7 @@ paths:
       responses:
         '200':
           description: Message
-          headers: &id585
+          headers: &id604
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79168,7 +79925,7 @@ paths:
                 $ref: '#/components/schemas/Message'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id585
+          headers: *id604
           content:
             application/json:
               schema:
@@ -79196,7 +79953,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id585
+          headers: *id604
           content:
             application/json:
               schema:
@@ -79300,7 +80057,7 @@ paths:
       responses:
         '200':
           description: Pause result
-          headers: &id586
+          headers: &id605
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79321,7 +80078,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id586
+          headers: *id605
           content:
             application/json:
               schema:
@@ -79474,7 +80231,7 @@ paths:
       responses:
         '200':
           description: Resume result
-          headers: &id587
+          headers: &id606
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79495,7 +80252,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id587
+          headers: *id606
           content:
             application/json:
               schema:
@@ -79526,7 +80283,7 @@ paths:
       responses:
         '200':
           description: Rhetorical analysis
-          headers: &id588
+          headers: &id607
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79551,7 +80308,7 @@ paths:
                     type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id588
+          headers: *id607
           content:
             application/json:
               schema:
@@ -79582,7 +80339,7 @@ paths:
       responses:
         '200':
           description: Start result
-          headers: &id589
+          headers: &id608
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79603,7 +80360,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id589
+          headers: *id608
           content:
             application/json:
               schema:
@@ -79634,7 +80391,7 @@ paths:
       responses:
         '200':
           description: Stop result
-          headers: &id590
+          headers: &id609
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79655,7 +80412,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id590
+          headers: *id609
           content:
             application/json:
               schema:
@@ -79692,7 +80449,7 @@ paths:
       responses:
         '200':
           description: Suggestion recorded
-          headers: &id591
+          headers: &id610
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79715,7 +80472,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id591
+          headers: *id610
           content:
             application/json:
               schema:
@@ -79743,7 +80500,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id591
+          headers: *id610
           content:
             application/json:
               schema:
@@ -79796,7 +80553,7 @@ paths:
                 type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: &id592
+          headers: &id611
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79821,7 +80578,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id592
+          headers: *id611
           content:
             application/json:
               schema:
@@ -79851,7 +80608,7 @@ paths:
       responses:
         '200':
           description: Trickster status
-          headers: &id593
+          headers: &id612
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79882,7 +80639,7 @@ paths:
                     - 'null'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id593
+          headers: *id612
           content:
             application/json:
               schema:
@@ -79919,7 +80676,7 @@ paths:
       responses:
         '200':
           description: Debate updated
-          headers: &id594
+          headers: &id613
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79944,7 +80701,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id594
+          headers: *id613
           content:
             application/json:
               schema:
@@ -79972,7 +80729,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id594
+          headers: *id613
           content:
             application/json:
               schema:
@@ -80022,7 +80779,7 @@ paths:
       responses:
         '200':
           description: User input added
-          headers: &id595
+          headers: &id614
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80043,7 +80800,7 @@ paths:
                     type: boolean
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id595
+          headers: *id614
           content:
             application/json:
               schema:
@@ -80071,7 +80828,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id595
+          headers: *id614
           content:
             application/json:
               schema:
@@ -80102,7 +80859,7 @@ paths:
       responses:
         '200':
           description: Verification report
-          headers: &id596
+          headers: &id615
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80139,7 +80896,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id596
+          headers: *id615
           content:
             application/json:
               schema:
@@ -80182,7 +80939,7 @@ paths:
       responses:
         '200':
           description: Verification result
-          headers: &id597
+          headers: &id616
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80215,7 +80972,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id597
+          headers: *id616
           content:
             application/json:
               schema:
@@ -80243,7 +81000,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id597
+          headers: *id616
           content:
             application/json:
               schema:
@@ -80280,7 +81037,7 @@ paths:
       responses:
         '200':
           description: Vote recorded
-          headers: &id598
+          headers: &id617
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80305,7 +81062,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id598
+          headers: *id617
           content:
             application/json:
               schema:
@@ -80333,7 +81090,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id598
+          headers: *id617
           content:
             application/json:
               schema:
@@ -80829,7 +81586,7 @@ paths:
       summary: List decisions
       operationId: listDecisions
       description: List recent decision records (most recent first).
-      security: &id600
+      security: &id619
       - {}
       parameters:
       - name: limit
@@ -80841,7 +81598,7 @@ paths:
       responses:
         '200':
           description: Decision list
-          headers: &id599
+          headers: &id618
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80855,9 +81612,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DecisionList'
-        '500': &id601
+        '500': &id620
           description: Internal server error - Unexpected error occurred
-          headers: *id599
+          headers: *id618
           content:
             application/json:
               schema:
@@ -80877,7 +81634,7 @@ paths:
       summary: Create decision
       operationId: createDecisions
       description: Submit a decision request for debate, workflow, or gauntlet routing.
-      security: *id600
+      security: *id619
       requestBody:
         required: true
         content:
@@ -80887,14 +81644,14 @@ paths:
       responses:
         '200':
           description: Decision result
-          headers: *id599
+          headers: *id618
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DecisionResult'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id599
+          headers: *id618
           content:
             application/json:
               schema:
@@ -80920,7 +81677,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': *id601
+        '500': *id620
       x-aragora-stability: stable
   /api/v1/decisions/plans:
     post:
@@ -81073,7 +81830,7 @@ paths:
       responses:
         '200':
           description: Decision result
-          headers: &id602
+          headers: &id621
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81089,7 +81846,7 @@ paths:
                 $ref: '#/components/schemas/DecisionResult'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id602
+          headers: *id621
           content:
             application/json:
               schema:
@@ -81105,7 +81862,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id602
+          headers: *id621
           content:
             application/json:
               schema:
@@ -81137,7 +81894,7 @@ paths:
       responses:
         '200':
           description: Decision explanation
-          headers: &id603
+          headers: &id622
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81173,7 +81930,7 @@ paths:
                     description: Alternative outcomes under different conditions
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id603
+          headers: *id622
           content:
             application/json:
               schema:
@@ -81189,7 +81946,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id603
+          headers: *id622
           content:
             application/json:
               schema:
@@ -81221,7 +81978,7 @@ paths:
       responses:
         '200':
           description: Decision status
-          headers: &id604
+          headers: &id623
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81237,7 +81994,7 @@ paths:
                 $ref: '#/components/schemas/DecisionStatus'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id604
+          headers: *id623
           content:
             application/json:
               schema:
@@ -81502,7 +82259,7 @@ paths:
       responses:
         '200':
           description: Registered devices
-          headers: &id605
+          headers: &id624
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81537,7 +82294,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id605
+          headers: *id624
           content:
             application/json:
               schema:
@@ -81658,7 +82415,7 @@ paths:
       responses:
         '200':
           description: Shortcuts response
-          headers: &id606
+          headers: &id625
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81679,7 +82436,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id606
+          headers: *id625
           content:
             application/json:
               schema:
@@ -81845,7 +82602,7 @@ paths:
       responses:
         '201':
           description: Device registered
-          headers: &id607
+          headers: &id626
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81869,7 +82626,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id607
+          headers: *id626
           content:
             application/json:
               schema:
@@ -81926,7 +82683,7 @@ paths:
       responses:
         '200':
           description: Device details
-          headers: &id608
+          headers: &id627
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81955,9 +82712,9 @@ paths:
                     type: string
                   metadata:
                     type: object
-        '404': &id609
+        '404': &id628
           description: Not found - The requested resource does not exist
-          headers: *id608
+          headers: *id627
           content:
             application/json:
               schema:
@@ -82001,7 +82758,7 @@ paths:
       responses:
         '200':
           description: Device unregistered
-          headers: *id608
+          headers: *id627
           content:
             application/json:
               schema:
@@ -82009,7 +82766,7 @@ paths:
                 properties:
                   success:
                     type: boolean
-        '404': *id609
+        '404': *id628
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -84890,7 +85647,7 @@ paths:
       responses:
         '200':
           description: Decision explanation
-          headers: &id610
+          headers: &id629
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84906,7 +85663,7 @@ paths:
                 $ref: '#/components/schemas/DecisionExplanation'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id610
+          headers: *id629
           content:
             application/json:
               schema:
@@ -84922,7 +85679,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id610
+          headers: *id629
           content:
             application/json:
               schema:
@@ -84965,7 +85722,7 @@ paths:
       responses:
         '200':
           description: Batch created
-          headers: &id611
+          headers: &id630
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84981,7 +85738,7 @@ paths:
                 $ref: '#/components/schemas/ExplainabilityBatch'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id611
+          headers: *id630
           content:
             application/json:
               schema:
@@ -85024,7 +85781,7 @@ paths:
       responses:
         '200':
           description: Batch results
-          headers: &id612
+          headers: &id631
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85040,7 +85797,7 @@ paths:
                 $ref: '#/components/schemas/ExplainabilityBatchResults'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id612
+          headers: *id631
           content:
             application/json:
               schema:
@@ -85091,7 +85848,7 @@ paths:
       responses:
         '200':
           description: Batch status
-          headers: &id613
+          headers: &id632
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85107,7 +85864,7 @@ paths:
                 $ref: '#/components/schemas/ExplainabilityBatchStatus'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id613
+          headers: *id632
           content:
             application/json:
               schema:
@@ -85670,7 +86427,7 @@ paths:
       responses:
         '200':
           description: Feedback-hub routing history
-          headers: &id615
+          headers: &id634
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85694,24 +86451,24 @@ paths:
                       type: object
                       additionalProperties: true
                       properties:
-                        source: &id614
+                        source: &id633
                           type: string
                         targets_hit:
                           type: array
-                          items: *id614
+                          items: *id633
                         targets_failed:
                           type: array
-                          items: *id614
+                          items: *id633
                         errors:
                           type: array
-                          items: *id614
+                          items: *id633
                         routed_at:
                           type: number
                         success:
                           type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id615
+          headers: *id634
           content:
             application/json:
               schema:
@@ -85731,7 +86488,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id615
+          headers: *id634
           content:
             application/json:
               schema:
@@ -85753,7 +86510,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id615
+          headers: *id634
           content:
             application/json:
               schema:
@@ -85770,7 +86527,7 @@ paths:
                     trace_id: req_abc123xyz
         '503':
           description: Internal server error - Unexpected error occurred
-          headers: *id615
+          headers: *id634
           content:
             application/json:
               schema:
@@ -85797,7 +86554,7 @@ paths:
       responses:
         '200':
           description: Feedback-hub routing statistics
-          headers: &id618
+          headers: &id637
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85819,22 +86576,22 @@ paths:
                     type: object
                     additionalProperties: false
                     properties:
-                      total_routed: &id616
+                      total_routed: &id635
                         type: integer
-                      total_failures: *id616
-                      by_source: &id617
+                      total_failures: *id635
+                      by_source: &id636
                         type: object
                         additionalProperties:
                           type: integer
-                      by_target: *id617
-                      history_size: *id616
+                      by_target: *id636
+                      history_size: *id635
                       known_sources:
                         type: array
                         items:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id618
+          headers: *id637
           content:
             application/json:
               schema:
@@ -85854,7 +86611,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id618
+          headers: *id637
           content:
             application/json:
               schema:
@@ -85876,7 +86633,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id618
+          headers: *id637
           content:
             application/json:
               schema:
@@ -85893,7 +86650,7 @@ paths:
                     trace_id: req_abc123xyz
         '503':
           description: Internal server error - Unexpected error occurred
-          headers: *id618
+          headers: *id637
           content:
             application/json:
               schema:
@@ -86207,7 +86964,7 @@ paths:
                 properties:
                   channels:
                     type: array
-                    items: &id620
+                    items: &id639
                       type: object
                       properties:
                         name:
@@ -86221,9 +86978,9 @@ paths:
                           description: Channel availability status
                   total:
                     type: integer
-        '401': &id621
+        '401': &id640
           description: Unauthorized - Authentication required or token invalid
-          headers: &id619
+          headers: &id638
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -86250,9 +87007,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id622
+        '403': &id641
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id619
+          headers: *id638
           content:
             application/json:
               schema:
@@ -86272,9 +87029,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id623
+        '500': &id642
           description: Internal server error - Unexpected error occurred
-          headers: *id619
+          headers: *id638
           content:
             application/json:
               schema:
@@ -86320,12 +87077,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  channel: *id620
+                  channel: *id639
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id619
+          headers: *id638
           content:
             application/json:
               schema:
@@ -86351,9 +87108,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id621
-        '403': *id622
-        '500': *id623
+        '401': *id640
+        '403': *id641
+        '500': *id642
       x-aragora-stability: experimental
   /api/v1/gateway/config:
     post:
@@ -86511,9 +87268,9 @@ paths:
                           description: Arbitrary key-value metadata
                   total:
                     type: integer
-        '401': &id625
+        '401': &id644
           description: Unauthorized - Authentication required or token invalid
-          headers: &id624
+          headers: &id643
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -86540,9 +87297,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id626
+        '403': &id645
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id624
+          headers: *id643
           content:
             application/json:
               schema:
@@ -86562,9 +87319,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id627
+        '500': &id646
           description: Internal server error - Unexpected error occurred
-          headers: *id624
+          headers: *id643
           content:
             application/json:
               schema:
@@ -86631,7 +87388,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id624
+          headers: *id643
           content:
             application/json:
               schema:
@@ -86657,9 +87414,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id625
-        '403': *id626
-        '500': *id627
+        '401': *id644
+        '403': *id645
+        '500': *id646
       x-aragora-stability: stable
   /api/v1/gateway/devices/{device_id}:
     get:
@@ -86673,7 +87430,7 @@ paths:
         in: path
         required: true
         description: Unique device identifier
-        schema: &id629
+        schema: &id648
           type: string
       responses:
         '200':
@@ -86683,7 +87440,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  device: &id630
+                  device: &id649
                     type: object
                     properties:
                       device_id:
@@ -86724,9 +87481,9 @@ paths:
                       metadata:
                         type: object
                         description: Arbitrary key-value metadata
-        '401': &id631
+        '401': &id650
           description: Unauthorized - Authentication required or token invalid
-          headers: &id628
+          headers: &id647
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -86753,9 +87510,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id632
+        '403': &id651
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id628
+          headers: *id647
           content:
             application/json:
               schema:
@@ -86775,9 +87532,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id633
+        '404': &id652
           description: Not found - The requested resource does not exist
-          headers: *id628
+          headers: *id647
           content:
             application/json:
               schema:
@@ -86791,9 +87548,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id634
+        '500': &id653
           description: Internal server error - Unexpected error occurred
-          headers: *id628
+          headers: *id647
           content:
             application/json:
               schema:
@@ -86818,7 +87575,7 @@ paths:
         in: path
         required: true
         description: Unique device identifier
-        schema: *id629
+        schema: *id648
       requestBody:
         required: true
         content:
@@ -86853,12 +87610,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  device: *id630
+                  device: *id649
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id628
+          headers: *id647
           content:
             application/json:
               schema:
@@ -86884,10 +87641,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id631
-        '403': *id632
-        '404': *id633
-        '500': *id634
+        '401': *id650
+        '403': *id651
+        '404': *id652
+        '500': *id653
       x-aragora-stability: experimental
     delete:
       tags:
@@ -86900,7 +87657,7 @@ paths:
         in: path
         required: true
         description: Unique device identifier
-        schema: *id629
+        schema: *id648
       responses:
         '200':
           description: Device unregistered
@@ -86911,10 +87668,10 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id631
-        '403': *id632
-        '404': *id633
-        '500': *id634
+        '401': *id650
+        '403': *id651
+        '404': *id652
+        '500': *id653
       x-aragora-stability: stable
   /api/v1/gateway/health:
     get:
@@ -87015,9 +87772,9 @@ paths:
                           description: Message delivery status
                   total:
                     type: integer
-        '401': &id636
+        '401': &id655
           description: Unauthorized - Authentication required or token invalid
-          headers: &id635
+          headers: &id654
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87044,9 +87801,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id637
+        '403': &id656
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id635
+          headers: *id654
           content:
             application/json:
               schema:
@@ -87066,9 +87823,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id638
+        '500': &id657
           description: Internal server error - Unexpected error occurred
-          headers: *id635
+          headers: *id654
           content:
             application/json:
               schema:
@@ -87125,7 +87882,7 @@ paths:
                     description: Routing rule that matched
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id635
+          headers: *id654
           content:
             application/json:
               schema:
@@ -87151,9 +87908,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id636
-        '403': *id637
-        '500': *id638
+        '401': *id655
+        '403': *id656
+        '500': *id657
       x-aragora-stability: stable
   /api/v1/gateway/messages/route:
     delete:
@@ -87205,7 +87962,7 @@ paths:
         in: path
         required: true
         description: Unique message identifier
-        schema: &id640
+        schema: &id659
           type: string
       responses:
         '200':
@@ -87245,9 +88002,9 @@ paths:
                         - delivered
                         - failed
                         description: Message delivery status
-        '401': &id641
+        '401': &id660
           description: Unauthorized - Authentication required or token invalid
-          headers: &id639
+          headers: &id658
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87274,9 +88031,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id642
+        '403': &id661
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id639
+          headers: *id658
           content:
             application/json:
               schema:
@@ -87296,9 +88053,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id643
+        '404': &id662
           description: Not found - The requested resource does not exist
-          headers: *id639
+          headers: *id658
           content:
             application/json:
               schema:
@@ -87312,9 +88069,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id644
+        '500': &id663
           description: Internal server error - Unexpected error occurred
-          headers: *id639
+          headers: *id658
           content:
             application/json:
               schema:
@@ -87339,7 +88096,7 @@ paths:
         in: path
         required: true
         description: Unique message identifier
-        schema: *id640
+        schema: *id659
       responses:
         '200':
           description: Message deleted
@@ -87350,10 +88107,10 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id641
-        '403': *id642
-        '404': *id643
-        '500': *id644
+        '401': *id660
+        '403': *id661
+        '404': *id662
+        '500': *id663
       x-aragora-stability: experimental
   /api/v1/gateway/openclaw/actions:
     delete:
@@ -87600,7 +88357,7 @@ paths:
                 properties:
                   rules:
                     type: array
-                    items: &id646
+                    items: &id665
                       type: object
                       properties:
                         id:
@@ -87633,9 +88390,9 @@ paths:
                       routing_errors:
                         type: integer
                     description: Aggregate routing statistics
-        '401': &id647
+        '401': &id666
           description: Unauthorized - Authentication required or token invalid
-          headers: &id645
+          headers: &id664
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87662,9 +88419,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id648
+        '403': &id667
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id645
+          headers: *id664
           content:
             application/json:
               schema:
@@ -87684,9 +88441,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id649
+        '500': &id668
           description: Internal server error - Unexpected error occurred
-          headers: *id645
+          headers: *id664
           content:
             application/json:
               schema:
@@ -87742,12 +88499,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id646
+                  rule: *id665
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id645
+          headers: *id664
           content:
             application/json:
               schema:
@@ -87773,9 +88530,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id647
-        '403': *id648
-        '500': *id649
+        '401': *id666
+        '403': *id667
+        '500': *id668
       x-aragora-stability: stable
   /api/v1/gateway/routing/rules:
     delete:
@@ -87865,7 +88622,7 @@ paths:
         in: path
         required: true
         description: Unique routing rule identifier
-        schema: &id651
+        schema: &id670
           type: string
       responses:
         '200':
@@ -87875,7 +88632,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: &id652
+                  rule: &id671
                     type: object
                     properties:
                       id:
@@ -87896,9 +88653,9 @@ paths:
                       enabled:
                         type: boolean
                         description: Whether the rule is active
-        '401': &id653
+        '401': &id672
           description: Unauthorized - Authentication required or token invalid
-          headers: &id650
+          headers: &id669
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87925,9 +88682,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id654
+        '403': &id673
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id650
+          headers: *id669
           content:
             application/json:
               schema:
@@ -87947,9 +88704,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id655
+        '404': &id674
           description: Not found - The requested resource does not exist
-          headers: *id650
+          headers: *id669
           content:
             application/json:
               schema:
@@ -87963,9 +88720,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id656
+        '500': &id675
           description: Internal server error - Unexpected error occurred
-          headers: *id650
+          headers: *id669
           content:
             application/json:
               schema:
@@ -87990,7 +88747,7 @@ paths:
         in: path
         required: true
         description: Unique routing rule identifier
-        schema: *id651
+        schema: *id670
       requestBody:
         required: true
         content:
@@ -88021,12 +88778,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id652
+                  rule: *id671
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id650
+          headers: *id669
           content:
             application/json:
               schema:
@@ -88052,10 +88809,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id653
-        '403': *id654
-        '404': *id655
-        '500': *id656
+        '401': *id672
+        '403': *id673
+        '404': *id674
+        '500': *id675
       x-aragora-stability: experimental
     delete:
       tags:
@@ -88068,7 +88825,7 @@ paths:
         in: path
         required: true
         description: Unique routing rule identifier
-        schema: *id651
+        schema: *id670
       responses:
         '200':
           description: Routing rule deleted
@@ -88079,10 +88836,10 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id653
-        '403': *id654
-        '404': *id655
-        '500': *id656
+        '401': *id672
+        '403': *id673
+        '404': *id674
+        '500': *id675
       x-aragora-stability: experimental
   /api/v1/gauntlet:
     get:
@@ -88157,7 +88914,7 @@ paths:
       responses:
         '200':
           description: Risk heatmap details
-          headers: &id657
+          headers: &id676
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88173,7 +88930,7 @@ paths:
                 $ref: '#/components/schemas/RiskHeatmap'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id657
+          headers: *id676
           content:
             application/json:
               schema:
@@ -88384,7 +89141,7 @@ paths:
       responses:
         '200':
           description: Bundle of exported receipts
-          headers: &id658
+          headers: &id677
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88409,7 +89166,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id658
+          headers: *id677
           content:
             application/json:
               schema:
@@ -88452,7 +89209,7 @@ paths:
       responses:
         '200':
           description: Decision receipt details
-          headers: &id659
+          headers: &id678
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88468,7 +89225,7 @@ paths:
                 $ref: '#/components/schemas/DecisionReceipt'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id659
+          headers: *id678
           content:
             application/json:
               schema:
@@ -88706,7 +89463,7 @@ paths:
       responses:
         '200':
           description: Gauntlet run details
-          headers: &id660
+          headers: &id679
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88720,9 +89477,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GauntletRun'
-        '404': &id661
+        '404': &id680
           description: Not found - The requested resource does not exist
-          headers: *id660
+          headers: *id679
           content:
             application/json:
               schema:
@@ -88736,9 +89493,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id662
+        '500': &id681
           description: Internal server error - Unexpected error occurred
-          headers: *id660
+          headers: *id679
           content:
             application/json:
               schema:
@@ -88768,7 +89525,7 @@ paths:
       responses:
         '200':
           description: Gauntlet run deleted
-          headers: *id660
+          headers: *id679
           content:
             application/json:
               schema:
@@ -88778,8 +89535,8 @@ paths:
                     type: boolean
                   gauntlet_id:
                     type: string
-        '404': *id661
-        '500': *id662
+        '404': *id680
+        '500': *id681
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -88817,7 +89574,7 @@ paths:
       responses:
         '200':
           description: Gauntlet comparison results
-          headers: &id663
+          headers: &id682
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88833,7 +89590,7 @@ paths:
                 $ref: '#/components/schemas/GauntletComparison'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id663
+          headers: *id682
           content:
             application/json:
               schema:
@@ -88849,7 +89606,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id663
+          headers: *id682
           content:
             application/json:
               schema:
@@ -89083,7 +89840,7 @@ paths:
       responses:
         '200':
           description: Descendant genomes
-          headers: &id664
+          headers: &id683
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89115,7 +89872,7 @@ paths:
                             type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id664
+          headers: *id683
           content:
             application/json:
               schema:
@@ -89131,7 +89888,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id664
+          headers: *id683
           content:
             application/json:
               schema:
@@ -89257,7 +90014,7 @@ paths:
       responses:
         '200':
           description: Genome details
-          headers: &id665
+          headers: &id684
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89285,7 +90042,7 @@ paths:
                     format: date-time
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id665
+          headers: *id684
           content:
             application/json:
               schema:
@@ -89301,7 +90058,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id665
+          headers: *id684
           content:
             application/json:
               schema:
@@ -89533,7 +90290,7 @@ paths:
       responses:
         '200':
           description: Issues created
-          headers: &id666
+          headers: &id685
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89549,7 +90306,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id666
+          headers: *id685
           content:
             application/json:
               schema:
@@ -89577,7 +90334,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id666
+          headers: *id685
           content:
             application/json:
               schema:
@@ -89597,7 +90354,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id666
+          headers: *id685
           content:
             application/json:
               schema:
@@ -89648,7 +90405,7 @@ paths:
       responses:
         '200':
           description: Issues created
-          headers: &id667
+          headers: &id686
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89664,7 +90421,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id667
+          headers: *id686
           content:
             application/json:
               schema:
@@ -89692,7 +90449,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id667
+          headers: *id686
           content:
             application/json:
               schema:
@@ -89712,7 +90469,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id667
+          headers: *id686
           content:
             application/json:
               schema:
@@ -89762,7 +90519,7 @@ paths:
       responses:
         '200':
           description: PR created
-          headers: &id668
+          headers: &id687
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89778,7 +90535,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id668
+          headers: *id687
           content:
             application/json:
               schema:
@@ -89806,7 +90563,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id668
+          headers: *id687
           content:
             application/json:
               schema:
@@ -89826,7 +90583,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id668
+          headers: *id687
           content:
             application/json:
               schema:
@@ -89847,7 +90604,7 @@ paths:
       summary: Get sync status
       operationId: getGithubAuditSync
       description: Get status of a GitHub audit sync.
-      security: &id670
+      security: &id689
       - {}
       parameters:
       - name: session_id
@@ -89858,7 +90615,7 @@ paths:
       responses:
         '200':
           description: Sync status
-          headers: &id669
+          headers: &id688
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89872,9 +90629,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id671
+        '401': &id690
           description: Unauthorized - Authentication required or token invalid
-          headers: *id669
+          headers: *id688
           content:
             application/json:
               schema:
@@ -89892,9 +90649,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id672
+        '404': &id691
           description: Not found - The requested resource does not exist
-          headers: *id669
+          headers: *id688
           content:
             application/json:
               schema:
@@ -89908,9 +90665,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id673
+        '500': &id692
           description: Internal server error - Unexpected error occurred
-          headers: *id669
+          headers: *id688
           content:
             application/json:
               schema:
@@ -89930,7 +90687,7 @@ paths:
       summary: Sync findings
       operationId: createGithubAuditSync
       description: Sync an audit session to GitHub.
-      security: *id670
+      security: *id689
       parameters:
       - name: session_id
         in: path
@@ -89940,14 +90697,14 @@ paths:
       responses:
         '200':
           description: Sync started
-          headers: *id669
+          headers: *id688
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id671
-        '404': *id672
-        '500': *id673
+        '401': *id690
+        '404': *id691
+        '500': *id692
       x-aragora-stability: experimental
   /api/v1/github/pr/review:
     post:
@@ -89967,7 +90724,7 @@ paths:
       responses:
         '200':
           description: Review started
-          headers: &id674
+          headers: &id693
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -89983,7 +90740,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRReviewTriggerResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id674
+          headers: *id693
           content:
             application/json:
               schema:
@@ -90011,7 +90768,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id674
+          headers: *id693
           content:
             application/json:
               schema:
@@ -90031,7 +90788,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id674
+          headers: *id693
           content:
             application/json:
               schema:
@@ -90053,7 +90810,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id674
+          headers: *id693
           content:
             application/json:
               schema:
@@ -90085,7 +90842,7 @@ paths:
       responses:
         '200':
           description: Review status
-          headers: &id675
+          headers: &id694
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -90101,7 +90858,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRReviewStatusResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id675
+          headers: *id694
           content:
             application/json:
               schema:
@@ -90121,7 +90878,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id675
+          headers: *id694
           content:
             application/json:
               schema:
@@ -90143,7 +90900,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id675
+          headers: *id694
           content:
             application/json:
               schema:
@@ -90159,7 +90916,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id675
+          headers: *id694
           content:
             application/json:
               schema:
@@ -90196,7 +90953,7 @@ paths:
       responses:
         '200':
           description: PR details
-          headers: &id676
+          headers: &id695
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -90212,7 +90969,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRDetailsResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id676
+          headers: *id695
           content:
             application/json:
               schema:
@@ -90240,7 +90997,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id676
+          headers: *id695
           content:
             application/json:
               schema:
@@ -90260,7 +91017,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id676
+          headers: *id695
           content:
             application/json:
               schema:
@@ -90282,7 +91039,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id676
+          headers: *id695
           content:
             application/json:
               schema:
@@ -90298,7 +91055,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id676
+          headers: *id695
           content:
             application/json:
               schema:
@@ -90336,7 +91093,7 @@ paths:
       responses:
         '200':
           description: Review submitted
-          headers: &id677
+          headers: &id696
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -90352,7 +91109,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRSubmitReviewResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id677
+          headers: *id696
           content:
             application/json:
               schema:
@@ -90380,7 +91137,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id677
+          headers: *id696
           content:
             application/json:
               schema:
@@ -90400,7 +91157,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id677
+          headers: *id696
           content:
             application/json:
               schema:
@@ -90422,7 +91179,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id677
+          headers: *id696
           content:
             application/json:
               schema:
@@ -90459,7 +91216,7 @@ paths:
       responses:
         '200':
           description: Review list
-          headers: &id678
+          headers: &id697
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -90475,7 +91232,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRReviewListResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id678
+          headers: *id697
           content:
             application/json:
               schema:
@@ -90503,7 +91260,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id678
+          headers: *id697
           content:
             application/json:
               schema:
@@ -90523,7 +91280,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id678
+          headers: *id697
           content:
             application/json:
               schema:
@@ -90545,7 +91302,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id678
+          headers: *id697
           content:
             application/json:
               schema:
@@ -90713,7 +91470,7 @@ paths:
       summary: List drafts
       operationId: listGmailDrafts
       description: List Gmail drafts.
-      security: &id680
+      security: &id699
       - {}
       parameters:
       - name: user_id
@@ -90731,7 +91488,7 @@ paths:
       responses:
         '200':
           description: Drafts
-          headers: &id679
+          headers: &id698
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -90745,9 +91502,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id681
+        '401': &id700
           description: Unauthorized - Authentication required or token invalid
-          headers: *id679
+          headers: *id698
           content:
             application/json:
               schema:
@@ -90765,9 +91522,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id682
+        '500': &id701
           description: Internal server error - Unexpected error occurred
-          headers: *id679
+          headers: *id698
           content:
             application/json:
               schema:
@@ -90787,7 +91544,7 @@ paths:
       summary: Create draft
       operationId: createGmailDrafts
       description: Create a Gmail draft.
-      security: *id680
+      security: *id699
       requestBody:
         required: true
         content:
@@ -90829,14 +91586,14 @@ paths:
       responses:
         '200':
           description: Draft created
-          headers: *id679
+          headers: *id698
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id679
+          headers: *id698
           content:
             application/json:
               schema:
@@ -90862,8 +91619,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id681
-        '500': *id682
+        '401': *id700
+        '500': *id701
       x-aragora-stability: experimental
   /api/v1/gmail/drafts/{draft_id}:
     get:
@@ -90872,7 +91629,7 @@ paths:
       summary: Get draft
       operationId: getGmailDraft
       description: Get a Gmail draft by ID.
-      security: &id684
+      security: &id703
       - {}
       parameters:
       - name: draft_id
@@ -90887,7 +91644,7 @@ paths:
       responses:
         '200':
           description: Draft
-          headers: &id683
+          headers: &id702
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -90901,9 +91658,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id685
+        '401': &id704
           description: Unauthorized - Authentication required or token invalid
-          headers: *id683
+          headers: *id702
           content:
             application/json:
               schema:
@@ -90921,9 +91678,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id686
+        '404': &id705
           description: Not found - The requested resource does not exist
-          headers: *id683
+          headers: *id702
           content:
             application/json:
               schema:
@@ -90937,9 +91694,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id687
+        '500': &id706
           description: Internal server error - Unexpected error occurred
-          headers: *id683
+          headers: *id702
           content:
             application/json:
               schema:
@@ -90959,7 +91716,7 @@ paths:
       summary: Update draft
       operationId: updateGmailDraft
       description: Update a Gmail draft.
-      security: *id684
+      security: *id703
       parameters:
       - name: draft_id
         in: path
@@ -91003,14 +91760,14 @@ paths:
       responses:
         '200':
           description: Draft updated
-          headers: *id683
+          headers: *id702
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id683
+          headers: *id702
           content:
             application/json:
               schema:
@@ -91036,9 +91793,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id685
-        '404': *id686
-        '500': *id687
+        '401': *id704
+        '404': *id705
+        '500': *id706
       x-aragora-stability: experimental
     delete:
       tags:
@@ -91046,7 +91803,7 @@ paths:
       summary: Delete draft
       operationId: deleteGmailDraft
       description: Delete a Gmail draft.
-      security: *id684
+      security: *id703
       parameters:
       - name: draft_id
         in: path
@@ -91060,14 +91817,14 @@ paths:
       responses:
         '200':
           description: Draft deleted
-          headers: *id683
+          headers: *id702
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id685
-        '404': *id686
-        '500': *id687
+        '401': *id704
+        '404': *id705
+        '500': *id706
       x-aragora-stability: experimental
   /api/v1/gmail/drafts/{draft_id}/send:
     post:
@@ -91087,7 +91844,7 @@ paths:
       responses:
         '200':
           description: Draft sent
-          headers: &id688
+          headers: &id707
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91103,7 +91860,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id688
+          headers: *id707
           content:
             application/json:
               schema:
@@ -91123,7 +91880,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id688
+          headers: *id707
           content:
             application/json:
               schema:
@@ -91144,7 +91901,7 @@ paths:
       summary: List Gmail filters
       operationId: listGmailFilters
       description: List Gmail filters.
-      security: &id690
+      security: &id709
       - {}
       parameters:
       - name: user_id
@@ -91154,7 +91911,7 @@ paths:
       responses:
         '200':
           description: Filters
-          headers: &id689
+          headers: &id708
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91168,9 +91925,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id691
+        '401': &id710
           description: Unauthorized - Authentication required or token invalid
-          headers: *id689
+          headers: *id708
           content:
             application/json:
               schema:
@@ -91188,9 +91945,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id692
+        '500': &id711
           description: Internal server error - Unexpected error occurred
-          headers: *id689
+          headers: *id708
           content:
             application/json:
               schema:
@@ -91210,7 +91967,7 @@ paths:
       summary: Create Gmail filter
       operationId: createGmailFilters
       description: Create a Gmail filter.
-      security: *id690
+      security: *id709
       requestBody:
         required: true
         content:
@@ -91252,14 +92009,14 @@ paths:
       responses:
         '200':
           description: Filter created
-          headers: *id689
+          headers: *id708
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id689
+          headers: *id708
           content:
             application/json:
               schema:
@@ -91285,8 +92042,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id691
-        '500': *id692
+        '401': *id710
+        '500': *id711
       x-aragora-stability: experimental
   /api/v1/gmail/filters/{filter_id}:
     delete:
@@ -91310,7 +92067,7 @@ paths:
       responses:
         '200':
           description: Filter deleted
-          headers: &id693
+          headers: &id712
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91326,7 +92083,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id693
+          headers: *id712
           content:
             application/json:
               schema:
@@ -91346,7 +92103,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id693
+          headers: *id712
           content:
             application/json:
               schema:
@@ -91362,7 +92119,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id693
+          headers: *id712
           content:
             application/json:
               schema:
@@ -91425,7 +92182,7 @@ paths:
       summary: List Gmail labels
       operationId: listGmailLabels
       description: List Gmail labels for a connected account.
-      security: &id695
+      security: &id714
       - {}
       parameters:
       - name: user_id
@@ -91435,7 +92192,7 @@ paths:
       responses:
         '200':
           description: Labels
-          headers: &id694
+          headers: &id713
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91449,9 +92206,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id696
+        '401': &id715
           description: Unauthorized - Authentication required or token invalid
-          headers: *id694
+          headers: *id713
           content:
             application/json:
               schema:
@@ -91469,9 +92226,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id697
+        '500': &id716
           description: Internal server error - Unexpected error occurred
-          headers: *id694
+          headers: *id713
           content:
             application/json:
               schema:
@@ -91491,7 +92248,7 @@ paths:
       summary: Create Gmail label
       operationId: createGmailLabels
       description: Create a Gmail label.
-      security: *id695
+      security: *id714
       requestBody:
         required: true
         content:
@@ -91512,14 +92269,14 @@ paths:
       responses:
         '200':
           description: Label created
-          headers: *id694
+          headers: *id713
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id694
+          headers: *id713
           content:
             application/json:
               schema:
@@ -91545,8 +92302,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id696
-        '500': *id697
+        '401': *id715
+        '500': *id716
       x-aragora-stability: experimental
   /api/v1/gmail/labels/{label_id}:
     patch:
@@ -91555,7 +92312,7 @@ paths:
       summary: Update Gmail label
       operationId: patchGmailLabel
       description: Update a Gmail label.
-      security: &id699
+      security: &id718
       - {}
       parameters:
       - name: label_id
@@ -91581,7 +92338,7 @@ paths:
       responses:
         '200':
           description: Label updated
-          headers: &id698
+          headers: &id717
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91597,7 +92354,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id698
+          headers: *id717
           content:
             application/json:
               schema:
@@ -91623,9 +92380,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id700
+        '401': &id719
           description: Unauthorized - Authentication required or token invalid
-          headers: *id698
+          headers: *id717
           content:
             application/json:
               schema:
@@ -91643,9 +92400,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id701
+        '404': &id720
           description: Not found - The requested resource does not exist
-          headers: *id698
+          headers: *id717
           content:
             application/json:
               schema:
@@ -91659,9 +92416,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id702
+        '500': &id721
           description: Internal server error - Unexpected error occurred
-          headers: *id698
+          headers: *id717
           content:
             application/json:
               schema:
@@ -91681,7 +92438,7 @@ paths:
       summary: Delete Gmail label
       operationId: deleteGmailLabel
       description: Delete a Gmail label.
-      security: *id699
+      security: *id718
       parameters:
       - name: label_id
         in: path
@@ -91695,14 +92452,14 @@ paths:
       responses:
         '200':
           description: Label deleted
-          headers: *id698
+          headers: *id717
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id700
-        '404': *id701
-        '500': *id702
+        '401': *id719
+        '404': *id720
+        '500': *id721
       x-aragora-stability: experimental
   /api/v1/gmail/messages:
     post:
@@ -91743,7 +92500,7 @@ paths:
       responses:
         '200':
           description: Message archived
-          headers: &id703
+          headers: &id722
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91759,7 +92516,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id703
+          headers: *id722
           content:
             application/json:
               schema:
@@ -91779,7 +92536,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id703
+          headers: *id722
           content:
             application/json:
               schema:
@@ -91820,7 +92577,7 @@ paths:
       responses:
         '200':
           description: Attachment
-          headers: &id704
+          headers: &id723
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91836,7 +92593,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id704
+          headers: *id723
           content:
             application/json:
               schema:
@@ -91856,7 +92613,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id704
+          headers: *id723
           content:
             application/json:
               schema:
@@ -91872,7 +92629,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id704
+          headers: *id723
           content:
             application/json:
               schema:
@@ -91921,7 +92678,7 @@ paths:
       responses:
         '200':
           description: Labels updated
-          headers: &id705
+          headers: &id724
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -91937,7 +92694,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id705
+          headers: *id724
           content:
             application/json:
               schema:
@@ -91965,7 +92722,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id705
+          headers: *id724
           content:
             application/json:
               schema:
@@ -91985,7 +92742,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id705
+          headers: *id724
           content:
             application/json:
               schema:
@@ -92028,7 +92785,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id706
+          headers: &id725
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92044,7 +92801,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id706
+          headers: *id725
           content:
             application/json:
               schema:
@@ -92064,7 +92821,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id706
+          headers: *id725
           content:
             application/json:
               schema:
@@ -92107,7 +92864,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id707
+          headers: &id726
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92123,7 +92880,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id707
+          headers: *id726
           content:
             application/json:
               schema:
@@ -92143,7 +92900,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id707
+          headers: *id726
           content:
             application/json:
               schema:
@@ -92186,7 +92943,7 @@ paths:
       responses:
         '200':
           description: Message trashed
-          headers: &id708
+          headers: &id727
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92202,7 +92959,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id708
+          headers: *id727
           content:
             application/json:
               schema:
@@ -92222,7 +92979,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id708
+          headers: *id727
           content:
             application/json:
               schema:
@@ -92534,7 +93291,7 @@ paths:
       responses:
         '200':
           description: Threads
-          headers: &id709
+          headers: &id728
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92550,7 +93307,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id709
+          headers: *id728
           content:
             application/json:
               schema:
@@ -92570,7 +93327,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id709
+          headers: *id728
           content:
             application/json:
               schema:
@@ -92606,7 +93363,7 @@ paths:
       responses:
         '200':
           description: Thread
-          headers: &id710
+          headers: &id729
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92622,7 +93379,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id710
+          headers: *id729
           content:
             application/json:
               schema:
@@ -92642,7 +93399,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id710
+          headers: *id729
           content:
             application/json:
               schema:
@@ -92658,7 +93415,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id710
+          headers: *id729
           content:
             application/json:
               schema:
@@ -92690,7 +93447,7 @@ paths:
       responses:
         '200':
           description: Thread archived
-          headers: &id711
+          headers: &id730
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92706,7 +93463,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id711
+          headers: *id730
           content:
             application/json:
               schema:
@@ -92726,7 +93483,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id711
+          headers: *id730
           content:
             application/json:
               schema:
@@ -92778,7 +93535,7 @@ paths:
       responses:
         '200':
           description: Thread updated
-          headers: &id712
+          headers: &id731
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92794,7 +93551,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id712
+          headers: *id731
           content:
             application/json:
               schema:
@@ -92814,7 +93571,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id712
+          headers: *id731
           content:
             application/json:
               schema:
@@ -92859,7 +93616,7 @@ paths:
       responses:
         '200':
           description: Thread trashed
-          headers: &id713
+          headers: &id732
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -92875,7 +93632,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id713
+          headers: *id732
           content:
             application/json:
               schema:
@@ -92895,7 +93652,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id713
+          headers: *id732
           content:
             application/json:
               schema:
@@ -92987,7 +93744,7 @@ paths:
       responses:
         '200':
           description: Graph debate details
-          headers: &id714
+          headers: &id733
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -93016,7 +93773,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id714
+          headers: *id733
           content:
             application/json:
               schema:
@@ -94263,7 +95020,7 @@ paths:
       responses:
         '200':
           description: List of mentions
-          headers: &id715
+          headers: &id734
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94286,7 +95043,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id715
+          headers: *id734
           content:
             application/json:
               schema:
@@ -94306,7 +95063,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id715
+          headers: *id734
           content:
             application/json:
               schema:
@@ -94328,7 +95085,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id715
+          headers: *id734
           content:
             application/json:
               schema:
@@ -94569,7 +95326,7 @@ paths:
       summary: Create routing rule
       operationId: createInboxRoutingRules
       description: Create a routing rule for inbox automation.
-      security: &id717
+      security: &id736
       - {}
       requestBody:
         required: true
@@ -94580,7 +95337,7 @@ paths:
       responses:
         '200':
           description: Rule created
-          headers: &id716
+          headers: &id735
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94596,7 +95353,7 @@ paths:
                 $ref: '#/components/schemas/RoutingRuleResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id716
+          headers: *id735
           content:
             application/json:
               schema:
@@ -94622,9 +95379,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id718
+        '401': &id737
           description: Unauthorized - Authentication required or token invalid
-          headers: *id716
+          headers: *id735
           content:
             application/json:
               schema:
@@ -94642,9 +95399,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id719
+        '403': &id738
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id716
+          headers: *id735
           content:
             application/json:
               schema:
@@ -94664,9 +95421,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id720
+        '500': &id739
           description: Internal server error - Unexpected error occurred
-          headers: *id716
+          headers: *id735
           content:
             application/json:
               schema:
@@ -94686,7 +95443,7 @@ paths:
       summary: List routing rules
       operationId: listInboxRoutingRules
       description: List routing rules for a workspace.
-      security: *id717
+      security: *id736
       parameters:
       - name: workspace_id
         in: query
@@ -94707,14 +95464,14 @@ paths:
       responses:
         '200':
           description: Rule list
-          headers: *id716
+          headers: *id735
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RoutingRuleListResponse'
-        '401': *id718
-        '403': *id719
-        '500': *id720
+        '401': *id737
+        '403': *id738
+        '500': *id739
       x-aragora-stability: stable
   /api/v1/inbox/routing/rules/{id}:
     patch:
@@ -94723,7 +95480,7 @@ paths:
       summary: Update routing rule
       operationId: patchInboxRoutingRule
       description: Update an inbox routing rule.
-      security: &id722
+      security: &id741
       - {}
       parameters:
       - name: id
@@ -94740,7 +95497,7 @@ paths:
       responses:
         '200':
           description: Rule updated
-          headers: &id721
+          headers: &id740
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94756,7 +95513,7 @@ paths:
                 $ref: '#/components/schemas/RoutingRuleResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id721
+          headers: *id740
           content:
             application/json:
               schema:
@@ -94782,9 +95539,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id723
+        '401': &id742
           description: Unauthorized - Authentication required or token invalid
-          headers: *id721
+          headers: *id740
           content:
             application/json:
               schema:
@@ -94802,9 +95559,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id724
+        '403': &id743
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id721
+          headers: *id740
           content:
             application/json:
               schema:
@@ -94824,9 +95581,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id725
+        '404': &id744
           description: Not found - The requested resource does not exist
-          headers: *id721
+          headers: *id740
           content:
             application/json:
               schema:
@@ -94840,9 +95597,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id726
+        '500': &id745
           description: Internal server error - Unexpected error occurred
-          headers: *id721
+          headers: *id740
           content:
             application/json:
               schema:
@@ -94862,7 +95619,7 @@ paths:
       summary: Delete routing rule
       operationId: deleteInboxRoutingRule
       description: Delete an inbox routing rule.
-      security: *id722
+      security: *id741
       parameters:
       - name: id
         in: path
@@ -94872,15 +95629,15 @@ paths:
       responses:
         '200':
           description: Rule deleted
-          headers: *id721
+          headers: *id740
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RoutingRuleDeleteResponse'
-        '401': *id723
-        '403': *id724
-        '404': *id725
-        '500': *id726
+        '401': *id742
+        '403': *id743
+        '404': *id744
+        '500': *id745
       x-aragora-stability: experimental
   /api/v1/inbox/routing/rules/{id}/test:
     post:
@@ -94906,7 +95663,7 @@ paths:
       responses:
         '200':
           description: Rule test
-          headers: &id727
+          headers: &id746
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94922,7 +95679,7 @@ paths:
                 $ref: '#/components/schemas/RoutingRuleTestResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id727
+          headers: *id746
           content:
             application/json:
               schema:
@@ -94950,7 +95707,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id727
+          headers: *id746
           content:
             application/json:
               schema:
@@ -94970,7 +95727,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id727
+          headers: *id746
           content:
             application/json:
               schema:
@@ -94992,7 +95749,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id727
+          headers: *id746
           content:
             application/json:
               schema:
@@ -95008,7 +95765,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id727
+          headers: *id746
           content:
             application/json:
               schema:
@@ -95052,7 +95809,7 @@ paths:
       summary: Create shared inbox
       operationId: createInboxShared
       description: Create a shared inbox for collaborative triage.
-      security: &id729
+      security: &id748
       - {}
       requestBody:
         required: true
@@ -95063,7 +95820,7 @@ paths:
       responses:
         '200':
           description: Inbox created
-          headers: &id728
+          headers: &id747
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95079,7 +95836,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id728
+          headers: *id747
           content:
             application/json:
               schema:
@@ -95105,9 +95862,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id730
+        '401': &id749
           description: Unauthorized - Authentication required or token invalid
-          headers: *id728
+          headers: *id747
           content:
             application/json:
               schema:
@@ -95125,9 +95882,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id731
+        '403': &id750
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id728
+          headers: *id747
           content:
             application/json:
               schema:
@@ -95147,9 +95904,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id732
+        '500': &id751
           description: Internal server error - Unexpected error occurred
-          headers: *id728
+          headers: *id747
           content:
             application/json:
               schema:
@@ -95169,7 +95926,7 @@ paths:
       summary: List shared inboxes
       operationId: listInboxShared
       description: List shared inboxes for a workspace.
-      security: *id729
+      security: *id748
       parameters:
       - name: workspace_id
         in: query
@@ -95182,14 +95939,14 @@ paths:
       responses:
         '200':
           description: Inbox list
-          headers: *id728
+          headers: *id747
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SharedInboxListResponse'
-        '401': *id730
-        '403': *id731
-        '500': *id732
+        '401': *id749
+        '403': *id750
+        '500': *id751
       x-aragora-stability: stable
   /api/v1/inbox/shared/{id}:
     get:
@@ -95209,7 +95966,7 @@ paths:
       responses:
         '200':
           description: Inbox detail
-          headers: &id733
+          headers: &id752
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95225,7 +95982,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id733
+          headers: *id752
           content:
             application/json:
               schema:
@@ -95245,7 +96002,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id733
+          headers: *id752
           content:
             application/json:
               schema:
@@ -95267,7 +96024,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id733
+          headers: *id752
           content:
             application/json:
               schema:
@@ -95283,7 +96040,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id733
+          headers: *id752
           content:
             application/json:
               schema:
@@ -95335,7 +96092,7 @@ paths:
       responses:
         '200':
           description: Inbox messages
-          headers: &id734
+          headers: &id753
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95351,7 +96108,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxMessageListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id734
+          headers: *id753
           content:
             application/json:
               schema:
@@ -95371,7 +96128,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id734
+          headers: *id753
           content:
             application/json:
               schema:
@@ -95393,7 +96150,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id734
+          headers: *id753
           content:
             application/json:
               schema:
@@ -95409,7 +96166,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id734
+          headers: *id753
           content:
             application/json:
               schema:
@@ -95452,7 +96209,7 @@ paths:
       responses:
         '200':
           description: Message assigned
-          headers: &id735
+          headers: &id754
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95468,7 +96225,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxMessageResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id735
+          headers: *id754
           content:
             application/json:
               schema:
@@ -95496,7 +96253,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id735
+          headers: *id754
           content:
             application/json:
               schema:
@@ -95516,7 +96273,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id735
+          headers: *id754
           content:
             application/json:
               schema:
@@ -95538,7 +96295,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id735
+          headers: *id754
           content:
             application/json:
               schema:
@@ -95554,7 +96311,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id735
+          headers: *id754
           content:
             application/json:
               schema:
@@ -95597,7 +96354,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id736
+          headers: &id755
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95613,7 +96370,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxMessageResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id736
+          headers: *id755
           content:
             application/json:
               schema:
@@ -95641,7 +96398,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id736
+          headers: *id755
           content:
             application/json:
               schema:
@@ -95661,7 +96418,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id736
+          headers: *id755
           content:
             application/json:
               schema:
@@ -95683,7 +96440,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id736
+          headers: *id755
           content:
             application/json:
               schema:
@@ -95699,7 +96456,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id736
+          headers: *id755
           content:
             application/json:
               schema:
@@ -95742,7 +96499,7 @@ paths:
       responses:
         '200':
           description: Tag added
-          headers: &id737
+          headers: &id756
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95758,7 +96515,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxMessageResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id737
+          headers: *id756
           content:
             application/json:
               schema:
@@ -95786,7 +96543,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id737
+          headers: *id756
           content:
             application/json:
               schema:
@@ -95806,7 +96563,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id737
+          headers: *id756
           content:
             application/json:
               schema:
@@ -95828,7 +96585,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id737
+          headers: *id756
           content:
             application/json:
               schema:
@@ -95844,7 +96601,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id737
+          headers: *id756
           content:
             application/json:
               schema:
@@ -96034,7 +96791,7 @@ paths:
       summary: List inbox trust wedge receipts
       operationId: listInboxTrustWedgeReceipts
       description: List receipt-backed inbox review decisions staged by the trust wedge.
-      security: &id739
+      security: &id758
       - {}
       parameters:
       - name: state
@@ -96058,7 +96815,7 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt list
-          headers: &id738
+          headers: &id757
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96072,9 +96829,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InboxTrustWedgeReceiptListResponse'
-        '400': &id740
+        '400': &id759
           description: Bad request - Invalid input or malformed JSON
-          headers: *id738
+          headers: *id757
           content:
             application/json:
               schema:
@@ -96100,9 +96857,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id741
+        '401': &id760
           description: Unauthorized - Authentication required or token invalid
-          headers: *id738
+          headers: *id757
           content:
             application/json:
               schema:
@@ -96120,9 +96877,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id742
+        '403': &id761
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id738
+          headers: *id757
           content:
             application/json:
               schema:
@@ -96142,9 +96899,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id743
+        '500': &id762
           description: Internal server error - Unexpected error occurred
-          headers: *id738
+          headers: *id757
           content:
             application/json:
               schema:
@@ -96164,7 +96921,7 @@ paths:
       summary: Create inbox trust wedge receipt
       operationId: createInboxTrustWedgeReceipt
       description: Stage a receipt-gated inbox action for later review or execution.
-      security: *id739
+      security: *id758
       requestBody:
         required: true
         content:
@@ -96174,15 +96931,15 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt staged
-          headers: *id738
+          headers: *id757
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/InboxTrustWedgeActionResponse'
-        '400': *id740
-        '401': *id741
-        '403': *id742
-        '500': *id743
+        '400': *id759
+        '401': *id760
+        '403': *id761
+        '500': *id762
       x-aragora-stability: experimental
   /api/v1/inbox/wedge/receipts/{receipt_id}:
     get:
@@ -96202,7 +96959,7 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt
-          headers: &id744
+          headers: &id763
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96218,7 +96975,7 @@ paths:
                 $ref: '#/components/schemas/InboxTrustWedgeEnvelope'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id744
+          headers: *id763
           content:
             application/json:
               schema:
@@ -96238,7 +96995,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id744
+          headers: *id763
           content:
             application/json:
               schema:
@@ -96260,7 +97017,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id744
+          headers: *id763
           content:
             application/json:
               schema:
@@ -96276,7 +97033,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id744
+          headers: *id763
           content:
             application/json:
               schema:
@@ -96308,7 +97065,7 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt executed
-          headers: &id745
+          headers: &id764
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96324,7 +97081,7 @@ paths:
                 $ref: '#/components/schemas/InboxTrustWedgeActionResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id745
+          headers: *id764
           content:
             application/json:
               schema:
@@ -96352,7 +97109,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id745
+          headers: *id764
           content:
             application/json:
               schema:
@@ -96372,7 +97129,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id745
+          headers: *id764
           content:
             application/json:
               schema:
@@ -96394,7 +97151,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id745
+          headers: *id764
           content:
             application/json:
               schema:
@@ -96410,7 +97167,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id745
+          headers: *id764
           content:
             application/json:
               schema:
@@ -96448,7 +97205,7 @@ paths:
       responses:
         '200':
           description: Trust wedge receipt reviewed
-          headers: &id746
+          headers: &id765
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96464,7 +97221,7 @@ paths:
                 $ref: '#/components/schemas/InboxTrustWedgeActionResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id746
+          headers: *id765
           content:
             application/json:
               schema:
@@ -96492,7 +97249,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id746
+          headers: *id765
           content:
             application/json:
               schema:
@@ -96512,7 +97269,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id746
+          headers: *id765
           content:
             application/json:
               schema:
@@ -96534,7 +97291,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id746
+          headers: *id765
           content:
             application/json:
               schema:
@@ -96550,7 +97307,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id746
+          headers: *id765
           content:
             application/json:
               schema:
@@ -96970,9 +97727,9 @@ paths:
                     type: object
                   enabled:
                     type: boolean
-        '401': &id748
+        '401': &id767
           description: Unauthorized - Authentication required or token invalid
-          headers: &id747
+          headers: &id766
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96999,9 +97756,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id749
+        '404': &id768
           description: Not found - The requested resource does not exist
-          headers: *id747
+          headers: *id766
           content:
             application/json:
               schema:
@@ -97015,9 +97772,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id750
+        '500': &id769
           description: Internal server error - Unexpected error occurred
-          headers: *id747
+          headers: *id766
           content:
             application/json:
               schema:
@@ -97073,7 +97830,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id747
+          headers: *id766
           content:
             application/json:
               schema:
@@ -97099,9 +97856,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id748
-        '404': *id749
-        '500': *id750
+        '401': *id767
+        '404': *id768
+        '500': *id769
       x-aragora-stability: experimental
     delete:
       tags:
@@ -97130,9 +97887,9 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '401': *id748
-        '404': *id749
-        '500': *id750
+        '401': *id767
+        '404': *id768
+        '500': *id769
       x-aragora-stability: experimental
   /api/v1/integrations/discord/callback:
     get:
@@ -97160,7 +97917,7 @@ paths:
           description: Redirect to success page
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id751
+          headers: &id770
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97197,7 +97954,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id751
+          headers: *id770
           content:
             application/json:
               schema:
@@ -97224,7 +97981,7 @@ paths:
           description: Redirect to Discord OAuth
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id752
+          headers: &id771
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97261,7 +98018,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id752
+          headers: *id771
           content:
             application/json:
               schema:
@@ -97281,7 +98038,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id752
+          headers: *id771
           content:
             application/json:
               schema:
@@ -97767,7 +98524,7 @@ paths:
           description: Redirect to success page
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id753
+          headers: &id772
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97804,7 +98561,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id753
+          headers: *id772
           content:
             application/json:
               schema:
@@ -97881,7 +98638,7 @@ paths:
           description: Redirect to Slack OAuth
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id754
+          headers: &id773
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97918,7 +98675,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id754
+          headers: *id773
           content:
             application/json:
               schema:
@@ -97938,7 +98695,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id754
+          headers: *id773
           content:
             application/json:
               schema:
@@ -97998,7 +98755,7 @@ paths:
                     format: uri
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id755
+          headers: &id774
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98027,7 +98784,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id755
+          headers: *id774
           content:
             application/json:
               schema:
@@ -98084,7 +98841,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id756
+          headers: &id775
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98113,7 +98870,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id756
+          headers: *id775
           content:
             application/json:
               schema:
@@ -98157,7 +98914,7 @@ paths:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id757
+          headers: &id776
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98186,7 +98943,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id757
+          headers: *id776
           content:
             application/json:
               schema:
@@ -98252,7 +99009,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id758
+          headers: &id777
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98281,7 +99038,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id758
+          headers: *id777
           content:
             application/json:
               schema:
@@ -98321,7 +99078,7 @@ paths:
           description: Redirect to success page
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id759
+          headers: &id778
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98358,7 +99115,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id759
+          headers: *id778
           content:
             application/json:
               schema:
@@ -98507,7 +99264,7 @@ paths:
           description: Redirect to Microsoft OAuth
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id760
+          headers: &id779
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98544,7 +99301,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id760
+          headers: *id779
           content:
             application/json:
               schema:
@@ -98564,7 +99321,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id760
+          headers: *id779
           content:
             application/json:
               schema:
@@ -98779,7 +99536,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id761
+          headers: &id780
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98808,7 +99565,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id761
+          headers: *id780
           content:
             application/json:
               schema:
@@ -99268,9 +100025,9 @@ paths:
                   connected_at:
                     type: string
                     format: date-time
-        '401': &id763
+        '401': &id782
           description: Unauthorized - Authentication required or token invalid
-          headers: &id762
+          headers: &id781
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99299,7 +100056,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id762
+          headers: *id781
           content:
             application/json:
               schema:
@@ -99313,9 +100070,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id764
+        '500': &id783
           description: Internal server error - Unexpected error occurred
-          headers: *id762
+          headers: *id781
           content:
             application/json:
               schema:
@@ -99372,9 +100129,9 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '400': &id765
+        '400': &id784
           description: Bad request - Invalid input or malformed JSON
-          headers: *id762
+          headers: *id781
           content:
             application/json:
               schema:
@@ -99400,8 +100157,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id763
-        '500': *id764
+        '401': *id782
+        '500': *id783
       x-aragora-stability: stable
     patch:
       tags:
@@ -99443,9 +100200,9 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '400': *id765
-        '401': *id763
-        '500': *id764
+        '400': *id784
+        '401': *id782
+        '500': *id783
       x-aragora-stability: stable
     delete:
       tags:
@@ -99474,8 +100231,8 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '401': *id763
-        '500': *id764
+        '401': *id782
+        '500': *id783
       x-aragora-stability: stable
   /api/v1/integrations/{type}/test:
     post:
@@ -99509,7 +100266,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id766
+          headers: &id785
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99538,7 +100295,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id766
+          headers: *id785
           content:
             application/json:
               schema:
@@ -99904,7 +100661,7 @@ paths:
       responses:
         '200':
           description: List of checkpoints
-          headers: &id767
+          headers: &id786
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99918,9 +100675,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointList'
-        '401': &id768
+        '401': &id787
           description: Unauthorized - Authentication required or token invalid
-          headers: *id767
+          headers: *id786
           content:
             application/json:
               schema:
@@ -99972,14 +100729,14 @@ paths:
       responses:
         '201':
           description: Checkpoint created
-          headers: *id767
+          headers: *id786
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointMetadata'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id767
+          headers: *id786
           content:
             application/json:
               schema:
@@ -100005,7 +100762,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id768
+        '401': *id787
         '409':
           description: Checkpoint with this name already exists
           content:
@@ -100067,7 +100824,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id769
+          headers: &id788
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100104,7 +100861,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id769
+          headers: *id788
           content:
             application/json:
               schema:
@@ -100124,7 +100881,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id769
+          headers: *id788
           content:
             application/json:
               schema:
@@ -100157,7 +100914,7 @@ paths:
       responses:
         '200':
           description: Checkpoint metadata
-          headers: &id770
+          headers: &id789
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100171,9 +100928,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointMetadata'
-        '401': &id771
+        '401': &id790
           description: Unauthorized - Authentication required or token invalid
-          headers: *id770
+          headers: *id789
           content:
             application/json:
               schema:
@@ -100191,9 +100948,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id772
+        '404': &id791
           description: Not found - The requested resource does not exist
-          headers: *id770
+          headers: *id789
           content:
             application/json:
               schema:
@@ -100225,7 +100982,7 @@ paths:
       responses:
         '200':
           description: Checkpoint deleted
-          headers: *id770
+          headers: *id789
           content:
             application/json:
               schema:
@@ -100237,8 +100994,8 @@ paths:
                   name:
                     type: string
                     description: Name of deleted checkpoint
-        '401': *id771
-        '404': *id772
+        '401': *id790
+        '404': *id791
       x-aragora-stability: stable
   /api/v1/km/checkpoints/{checkpoint_name}/compare:
     get:
@@ -100279,7 +101036,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id773
+          headers: &id792
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100308,7 +101065,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id773
+          headers: *id792
           content:
             application/json:
               schema:
@@ -100348,7 +101105,7 @@ paths:
                 format: binary
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id774
+          headers: &id793
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100377,7 +101134,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id774
+          headers: *id793
           content:
             application/json:
               schema:
@@ -100428,7 +101185,7 @@ paths:
       responses:
         '200':
           description: Restore result
-          headers: &id775
+          headers: &id794
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100444,7 +101201,7 @@ paths:
                 $ref: '#/components/schemas/RestoreResult'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id775
+          headers: *id794
           content:
             application/json:
               schema:
@@ -100472,7 +101229,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id775
+          headers: *id794
           content:
             application/json:
               schema:
@@ -100492,7 +101249,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id775
+          headers: *id794
           content:
             application/json:
               schema:
@@ -100633,7 +101390,7 @@ paths:
       summary: List facts
       operationId: listKnowledgeFacts
       description: List knowledge facts with optional filtering.
-      security: &id777
+      security: &id796
       - bearerAuth: []
       parameters:
       - name: workspace_id
@@ -100669,7 +101426,7 @@ paths:
       responses:
         '200':
           description: Knowledge facts
-          headers: &id776
+          headers: &id795
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100683,9 +101440,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFactList'
-        '500': &id778
+        '500': &id797
           description: Internal server error - Unexpected error occurred
-          headers: *id776
+          headers: *id795
           content:
             application/json:
               schema:
@@ -100705,7 +101462,7 @@ paths:
       summary: Create fact
       operationId: createKnowledgeFact
       description: Create a new knowledge fact.
-      security: *id777
+      security: *id796
       requestBody:
         required: true
         content:
@@ -100738,14 +101495,14 @@ paths:
       responses:
         '201':
           description: Created fact
-          headers: *id776
+          headers: *id795
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id776
+          headers: *id795
           content:
             application/json:
               schema:
@@ -100771,7 +101528,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': *id778
+        '500': *id797
       x-aragora-stability: stable
   /api/v1/knowledge/facts/relations:
     post:
@@ -100822,7 +101579,7 @@ paths:
       responses:
         '200':
           description: Relation added
-          headers: &id779
+          headers: &id798
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100851,7 +101608,7 @@ paths:
                     description: Type of relation
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id779
+          headers: *id798
           content:
             application/json:
               schema:
@@ -100883,7 +101640,7 @@ paths:
 
         - Supersession history (if applicable)'
       operationId: getKnowledgeFact
-      security: &id781
+      security: &id800
       - bearerAuth: []
       parameters:
       - name: fact_id
@@ -100894,7 +101651,7 @@ paths:
       responses:
         '200':
           description: Knowledge fact
-          headers: &id780
+          headers: &id799
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100908,9 +101665,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
-        '404': &id782
+        '404': &id801
           description: Not found - The requested resource does not exist
-          headers: *id780
+          headers: *id799
           content:
             application/json:
               schema:
@@ -100924,9 +101681,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id783
+        '500': &id802
           description: Internal server error - Unexpected error occurred
-          headers: *id780
+          headers: *id799
           content:
             application/json:
               schema:
@@ -100960,7 +101717,7 @@ paths:
 
         **Note:** Updates create an audit trail. Consider superseding instead of updating for significant changes.'
       operationId: updateKnowledgeFact
-      security: *id781
+      security: *id800
       parameters:
       - name: fact_id
         in: path
@@ -100991,13 +101748,13 @@ paths:
       responses:
         '200':
           description: Updated fact
-          headers: *id780
+          headers: *id799
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
-        '404': *id782
-        '500': *id783
+        '404': *id801
+        '500': *id802
       x-aragora-stability: experimental
     delete:
       tags:
@@ -101017,7 +101774,7 @@ paths:
 
         **Note:** Deleted facts can be restored by admin if needed.'
       operationId: deleteKnowledgeFact
-      security: *id781
+      security: *id800
       parameters:
       - name: fact_id
         in: path
@@ -101027,7 +101784,7 @@ paths:
       responses:
         '200':
           description: Deleted fact
-          headers: *id780
+          headers: *id799
           content:
             application/json:
               schema:
@@ -101039,8 +101796,8 @@ paths:
                   fact_id:
                     type: string
                     description: ID of deleted fact
-        '404': *id782
-        '500': *id783
+        '404': *id801
+        '500': *id802
       x-aragora-stability: experimental
   /api/v1/knowledge/facts/{fact_id}/contradictions:
     get:
@@ -101078,7 +101835,7 @@ paths:
       responses:
         '200':
           description: Contradicting facts
-          headers: &id784
+          headers: &id803
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101094,7 +101851,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeFactList'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id784
+          headers: *id803
           content:
             application/json:
               schema:
@@ -101126,7 +101883,7 @@ paths:
 
         - derived_from: Source facts used to derive this one'
       operationId: listKnowledgeRelations
-      security: &id786
+      security: &id805
       - bearerAuth: []
       parameters:
       - name: fact_id
@@ -101137,7 +101894,7 @@ paths:
       responses:
         '200':
           description: Fact relations
-          headers: &id785
+          headers: &id804
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101151,9 +101908,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeQueryResponse'
-        '500': &id787
+        '500': &id806
           description: Internal server error - Unexpected error occurred
-          headers: *id785
+          headers: *id804
           content:
             application/json:
               schema:
@@ -101187,7 +101944,7 @@ paths:
 
         - evidence: Supporting evidence for the relation'
       operationId: addKnowledgeRelation
-      security: *id786
+      security: *id805
       parameters:
       - name: fact_id
         in: path
@@ -101224,7 +101981,7 @@ paths:
       responses:
         '200':
           description: Relation added
-          headers: *id785
+          headers: *id804
           content:
             application/json:
               schema:
@@ -101242,7 +101999,7 @@ paths:
                   relation_type:
                     type: string
                     description: Type of relation
-        '500': *id787
+        '500': *id806
       x-aragora-stability: experimental
   /api/v1/knowledge/facts/{fact_id}/verify:
     post:
@@ -101274,7 +102031,7 @@ paths:
       responses:
         '200':
           description: Fact verification started
-          headers: &id788
+          headers: &id807
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101303,7 +102060,7 @@ paths:
                     description: Verification status
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id788
+          headers: *id807
           content:
             application/json:
               schema:
@@ -101737,7 +102494,7 @@ paths:
       responses:
         '200':
           description: Culture patterns
-          headers: &id789
+          headers: &id808
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101753,7 +102510,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id789
+          headers: *id808
           content:
             application/json:
               schema:
@@ -101769,7 +102526,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id789
+          headers: *id808
           content:
             application/json:
               schema:
@@ -102413,7 +103170,7 @@ paths:
       responses:
         '200':
           description: Audit trail
-          headers: &id790
+          headers: &id809
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102429,7 +103186,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id790
+          headers: *id809
           content:
             application/json:
               schema:
@@ -102482,7 +103239,7 @@ paths:
       responses:
         '200':
           description: User audit
-          headers: &id791
+          headers: &id810
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102498,7 +103255,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id791
+          headers: *id810
           content:
             application/json:
               schema:
@@ -102514,7 +103271,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id791
+          headers: *id810
           content:
             application/json:
               schema:
@@ -102580,7 +103337,7 @@ paths:
       responses:
         '200':
           description: Permission check
-          headers: &id792
+          headers: &id811
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102596,7 +103353,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id792
+          headers: *id811
           content:
             application/json:
               schema:
@@ -102624,7 +103381,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id792
+          headers: *id811
           content:
             application/json:
               schema:
@@ -102656,7 +103413,7 @@ paths:
       responses:
         '200':
           description: Permissions
-          headers: &id793
+          headers: &id812
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102672,7 +103429,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id793
+          headers: *id812
           content:
             application/json:
               schema:
@@ -102688,7 +103445,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id793
+          headers: *id812
           content:
             application/json:
               schema:
@@ -102735,7 +103492,7 @@ paths:
       responses:
         '200':
           description: Role created
-          headers: &id794
+          headers: &id813
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102751,7 +103508,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id794
+          headers: *id813
           content:
             application/json:
               schema:
@@ -102779,7 +103536,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id794
+          headers: *id813
           content:
             application/json:
               schema:
@@ -102831,7 +103588,7 @@ paths:
       responses:
         '200':
           description: Role assigned
-          headers: &id795
+          headers: &id814
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102847,7 +103604,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id795
+          headers: *id814
           content:
             application/json:
               schema:
@@ -102875,7 +103632,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id795
+          headers: *id814
           content:
             application/json:
               schema:
@@ -102920,7 +103677,7 @@ paths:
       responses:
         '200':
           description: Role revoked
-          headers: &id796
+          headers: &id815
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102936,7 +103693,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id796
+          headers: *id815
           content:
             application/json:
               schema:
@@ -102964,7 +103721,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id796
+          headers: *id815
           content:
             application/json:
               schema:
@@ -102990,7 +103747,7 @@ paths:
       responses:
         '200':
           description: Stats
-          headers: &id797
+          headers: &id816
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103006,7 +103763,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id797
+          headers: *id816
           content:
             application/json:
               schema:
@@ -103451,7 +104208,7 @@ paths:
       responses:
         '200':
           description: Node revalidated
-          headers: &id798
+          headers: &id817
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103467,7 +104224,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id798
+          headers: *id817
           content:
             application/json:
               schema:
@@ -103495,7 +104252,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id798
+          headers: *id817
           content:
             application/json:
               schema:
@@ -103511,7 +104268,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id798
+          headers: *id817
           content:
             application/json:
               schema:
@@ -103669,7 +104426,7 @@ paths:
       responses:
         '200':
           description: Sync triggered
-          headers: &id799
+          headers: &id818
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103685,7 +104442,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id799
+          headers: *id818
           content:
             application/json:
               schema:
@@ -103713,7 +104470,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id799
+          headers: *id818
           content:
             application/json:
               schema:
@@ -103729,7 +104486,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id799
+          headers: *id818
           content:
             application/json:
               schema:
@@ -103770,7 +104527,7 @@ paths:
       responses:
         '200':
           description: Knowledge query response
-          headers: &id800
+          headers: &id819
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103786,7 +104543,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeQueryResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id800
+          headers: *id819
           content:
             application/json:
               schema:
@@ -103814,7 +104571,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id800
+          headers: *id819
           content:
             application/json:
               schema:
@@ -103896,7 +104653,7 @@ paths:
       responses:
         '200':
           description: Knowledge search response
-          headers: &id801
+          headers: &id820
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103912,7 +104669,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeSearchResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id801
+          headers: *id820
           content:
             application/json:
               schema:
@@ -103940,7 +104697,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id801
+          headers: *id820
           content:
             application/json:
               schema:
@@ -103971,7 +104728,7 @@ paths:
       responses:
         '200':
           description: Knowledge stats
-          headers: &id802
+          headers: &id821
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103987,7 +104744,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeStats'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id802
+          headers: *id821
           content:
             application/json:
               schema:
@@ -104862,7 +105619,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id803
+          headers: &id822
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -104911,7 +105668,7 @@ paths:
                         type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id803
+          headers: *id822
           content:
             application/json:
               schema:
@@ -104939,7 +105696,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id803
+          headers: *id822
           content:
             application/json:
               schema:
@@ -104954,7 +105711,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id803
+          headers: *id822
           content:
             application/json:
               schema:
@@ -104974,7 +105731,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id803
+          headers: *id822
           content:
             application/json:
               schema:
@@ -105051,7 +105808,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id804
+          headers: &id823
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -105100,7 +105857,7 @@ paths:
                         type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id804
+          headers: *id823
           content:
             application/json:
               schema:
@@ -105128,7 +105885,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id804
+          headers: *id823
           content:
             application/json:
               schema:
@@ -105143,7 +105900,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id804
+          headers: *id823
           content:
             application/json:
               schema:
@@ -105163,7 +105920,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id804
+          headers: *id823
           content:
             application/json:
               schema:
@@ -105205,7 +105962,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id805
+          headers: &id824
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -105232,7 +105989,7 @@ paths:
                           type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id805
+          headers: *id824
           content:
             application/json:
               schema:
@@ -105260,7 +106017,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id805
+          headers: *id824
           content:
             application/json:
               schema:
@@ -105275,7 +106032,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id805
+          headers: *id824
           content:
             application/json:
               schema:
@@ -105295,7 +106052,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id805
+          headers: *id824
           content:
             application/json:
               schema:
@@ -105328,7 +106085,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id806
+          headers: &id825
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -105369,7 +106126,7 @@ paths:
                               type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id806
+          headers: *id825
           content:
             application/json:
               schema:
@@ -105397,7 +106154,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id806
+          headers: *id825
           content:
             application/json:
               schema:
@@ -105412,7 +106169,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id806
+          headers: *id825
           content:
             application/json:
               schema:
@@ -105428,7 +106185,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id806
+          headers: *id825
           content:
             application/json:
               schema:
@@ -105448,7 +106205,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id806
+          headers: *id825
           content:
             application/json:
               schema:
@@ -105489,7 +106246,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id807
+          headers: &id826
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -105509,7 +106266,7 @@ paths:
                     additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id807
+          headers: *id826
           content:
             application/json:
               schema:
@@ -105537,7 +106294,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id807
+          headers: *id826
           content:
             application/json:
               schema:
@@ -105552,7 +106309,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id807
+          headers: *id826
           content:
             application/json:
               schema:
@@ -105568,7 +106325,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id807
+          headers: *id826
           content:
             application/json:
               schema:
@@ -105588,7 +106345,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id807
+          headers: *id826
           content:
             application/json:
               schema:
@@ -105629,7 +106386,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id808
+          headers: &id827
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -105649,7 +106406,7 @@ paths:
                     additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id808
+          headers: *id827
           content:
             application/json:
               schema:
@@ -105677,7 +106434,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id808
+          headers: *id827
           content:
             application/json:
               schema:
@@ -105692,7 +106449,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id808
+          headers: *id827
           content:
             application/json:
               schema:
@@ -105708,7 +106465,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id808
+          headers: *id827
           content:
             application/json:
               schema:
@@ -105728,7 +106485,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id808
+          headers: *id827
           content:
             application/json:
               schema:
@@ -105785,7 +106542,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id809
+          headers: &id828
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -105805,7 +106562,7 @@ paths:
                     additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id809
+          headers: *id828
           content:
             application/json:
               schema:
@@ -105833,7 +106590,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id809
+          headers: *id828
           content:
             application/json:
               schema:
@@ -105848,7 +106605,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id809
+          headers: *id828
           content:
             application/json:
               schema:
@@ -105864,7 +106621,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id809
+          headers: *id828
           content:
             application/json:
               schema:
@@ -105884,7 +106641,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id809
+          headers: *id828
           content:
             application/json:
               schema:
@@ -105983,7 +106740,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id810
+          headers: &id829
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106038,7 +106795,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id810
+          headers: *id829
           content:
             application/json:
               schema:
@@ -106066,7 +106823,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id810
+          headers: *id829
           content:
             application/json:
               schema:
@@ -106081,7 +106838,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id810
+          headers: *id829
           content:
             application/json:
               schema:
@@ -106101,7 +106858,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id810
+          headers: *id829
           content:
             application/json:
               schema:
@@ -106480,7 +107237,7 @@ paths:
       responses:
         '200':
           description: Matrix debate details
-          headers: &id811
+          headers: &id830
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106509,7 +107266,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id811
+          headers: *id830
           content:
             application/json:
               schema:
@@ -106542,7 +107299,7 @@ paths:
       responses:
         '200':
           description: MCP tool catalog
-          headers: &id812
+          headers: &id831
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106584,7 +107341,7 @@ paths:
                     type: integer
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id812
+          headers: *id831
           content:
             application/json:
               schema:
@@ -106617,7 +107374,7 @@ paths:
       responses:
         '200':
           description: MCP tool details
-          headers: &id813
+          headers: &id832
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106655,7 +107412,7 @@ paths:
                             default: {}
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id813
+          headers: *id832
           content:
             application/json:
               schema:
@@ -106671,7 +107428,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id813
+          headers: *id832
           content:
             application/json:
               schema:
@@ -110605,7 +111362,7 @@ paths:
       responses:
         '200':
           description: Crash telemetry page
-          headers: &id815
+          headers: &id834
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110626,13 +111383,13 @@ paths:
                     items:
                       type: object
                       additionalProperties: true
-                  total: &id814
+                  total: &id833
                     type: integer
-                  limit: *id814
-                  offset: *id814
+                  limit: *id833
+                  offset: *id833
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id815
+          headers: *id834
           content:
             application/json:
               schema:
@@ -110652,7 +111409,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id815
+          headers: *id834
           content:
             application/json:
               schema:
@@ -110672,9 +111429,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '429': &id817
+        '429': &id836
           description: Too many requests - Rate limit exceeded
-          headers: *id815
+          headers: *id834
           content:
             application/json:
               schema:
@@ -110713,35 +111470,35 @@ paths:
                     type: object
                     additionalProperties: true
                     properties:
-                      message: &id816
+                      message: &id835
                         type: string
-                      stack: *id816
-                      componentStack: *id816
-                      url: *id816
-                      timestamp: *id816
-                      userAgent: *id816
-                      sessionId: *id816
-                      componentName: *id816
-                      fingerprint: *id816
+                      stack: *id835
+                      componentStack: *id835
+                      url: *id835
+                      timestamp: *id835
+                      userAgent: *id835
+                      sessionId: *id835
+                      componentName: *id835
+                      fingerprint: *id835
                   maxItems: 50
               required:
               - reports
       responses:
         '202':
           description: Crash telemetry accepted
-          headers: *id815
+          headers: *id834
           content:
             application/json:
               schema:
                 type: object
                 additionalProperties: false
                 properties:
-                  accepted: *id814
-                  duplicates: *id814
-                  total_stored: *id814
+                  accepted: *id833
+                  duplicates: *id833
+                  total_stored: *id833
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id815
+          headers: *id834
           content:
             application/json:
               schema:
@@ -110767,7 +111524,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '429': *id817
+        '429': *id836
       security: []
       x-aragora-stability: stable
   /api/v1/observability/crashes/stats:
@@ -110780,7 +111537,7 @@ paths:
       responses:
         '200':
           description: Crash telemetry stats
-          headers: &id820
+          headers: &id839
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110796,23 +111553,23 @@ paths:
                 type: object
                 additionalProperties: false
                 properties:
-                  total_ingested: &id818
+                  total_ingested: &id837
                     type: integer
-                  total_stored: *id818
-                  total_duplicates: *id818
-                  total_rate_limited: *id818
-                  unique_fingerprints: *id818
-                  last_hour: *id818
-                  last_24h: *id818
-                  top_fingerprints: &id819
+                  total_stored: *id837
+                  total_duplicates: *id837
+                  total_rate_limited: *id837
+                  unique_fingerprints: *id837
+                  last_hour: *id837
+                  last_24h: *id837
+                  top_fingerprints: &id838
                     type: array
                     items:
                       type: object
                       additionalProperties: true
-                  top_components: *id819
+                  top_components: *id838
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id820
+          headers: *id839
           content:
             application/json:
               schema:
@@ -110832,7 +111589,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id820
+          headers: *id839
           content:
             application/json:
               schema:
@@ -110854,7 +111611,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id820
+          headers: *id839
           content:
             application/json:
               schema:
@@ -110884,7 +111641,7 @@ paths:
       responses:
         '200':
           description: Aggregated observability dashboard
-          headers: &id823
+          headers: &id842
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110900,23 +111657,23 @@ paths:
                 type: object
                 additionalProperties: true
                 properties:
-                  timestamp: &id822
+                  timestamp: &id841
                     type: number
-                  debate_metrics: &id821
+                  debate_metrics: &id840
                     type: object
                     additionalProperties: true
-                  agent_rankings: *id821
-                  circuit_breakers: *id821
-                  self_improve: *id821
+                  agent_rankings: *id840
+                  circuit_breakers: *id840
+                  self_improve: *id840
                   alerts:
                     type: array
-                    items: *id821
-                  system_health: *id821
-                  error_rates: *id821
-                  collection_time_ms: *id822
+                    items: *id840
+                  system_health: *id840
+                  error_rates: *id840
+                  collection_time_ms: *id841
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id823
+          headers: *id842
           content:
             application/json:
               schema:
@@ -110936,7 +111693,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id823
+          headers: *id842
           content:
             application/json:
               schema:
@@ -110958,7 +111715,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id823
+          headers: *id842
           content:
             application/json:
               schema:
@@ -110986,7 +111743,7 @@ paths:
       responses:
         '200':
           description: Aggregated observability metrics
-          headers: &id824
+          headers: &id843
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111003,7 +111760,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id824
+          headers: *id843
           content:
             application/json:
               schema:
@@ -111023,7 +111780,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id824
+          headers: *id843
           content:
             application/json:
               schema:
@@ -111045,7 +111802,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id824
+          headers: *id843
           content:
             application/json:
               schema:
@@ -111119,7 +111876,7 @@ paths:
                         format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id825
+          headers: &id844
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111148,7 +111905,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id825
+          headers: *id844
           content:
             application/json:
               schema:
@@ -111170,7 +111927,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id825
+          headers: *id844
           content:
             application/json:
               schema:
@@ -111269,7 +112026,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id826
+          headers: &id845
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111306,7 +112063,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id826
+          headers: *id845
           content:
             application/json:
               schema:
@@ -111326,7 +112083,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id826
+          headers: *id845
           content:
             application/json:
               schema:
@@ -111430,9 +112187,9 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/StarterTemplate'
-        '401': &id828
+        '401': &id847
           description: Unauthorized - Authentication required or token invalid
-          headers: &id827
+          headers: &id846
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111459,9 +112216,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id829
+        '500': &id848
           description: Internal server error - Unexpected error occurred
-          headers: *id827
+          headers: *id846
           content:
             application/json:
               schema:
@@ -111551,7 +112308,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id827
+          headers: *id846
           content:
             application/json:
               schema:
@@ -111577,8 +112334,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id828
-        '500': *id829
+        '401': *id847
+        '500': *id848
       x-aragora-stability: stable
   /api/v1/onboarding/flow/step:
     get:
@@ -111700,7 +112457,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id830
+          headers: &id849
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111737,7 +112494,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id830
+          headers: *id849
           content:
             application/json:
               schema:
@@ -111757,7 +112514,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id830
+          headers: *id849
           content:
             application/json:
               schema:
@@ -111846,7 +112603,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id831
+          headers: &id850
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111883,7 +112640,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id831
+          headers: *id850
           content:
             application/json:
               schema:
@@ -111903,7 +112660,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id831
+          headers: *id850
           content:
             application/json:
               schema:
@@ -111997,7 +112754,7 @@ paths:
                     - 'null'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id832
+          headers: &id851
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112026,7 +112783,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id832
+          headers: *id851
           content:
             application/json:
               schema:
@@ -112226,7 +112983,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id833
+          headers: &id852
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112263,7 +113020,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id833
+          headers: *id852
           content:
             application/json:
               schema:
@@ -112283,7 +113040,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id833
+          headers: *id852
           content:
             application/json:
               schema:
@@ -112305,7 +113062,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id833
+          headers: *id852
           content:
             application/json:
               schema:
@@ -112321,7 +113078,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id833
+          headers: *id852
           content:
             application/json:
               schema:
@@ -112413,7 +113170,7 @@ paths:
                         description: Action metadata
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id834
+          headers: &id853
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112442,7 +113199,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id834
+          headers: *id853
           content:
             application/json:
               schema:
@@ -112464,7 +113221,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id834
+          headers: *id853
           content:
             application/json:
               schema:
@@ -112480,7 +113237,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id834
+          headers: *id853
           content:
             application/json:
               schema:
@@ -112574,7 +113331,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id835
+          headers: &id854
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112611,7 +113368,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id835
+          headers: *id854
           content:
             application/json:
               schema:
@@ -112631,7 +113388,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id835
+          headers: *id854
           content:
             application/json:
               schema:
@@ -112653,7 +113410,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id835
+          headers: *id854
           content:
             application/json:
               schema:
@@ -112669,7 +113426,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id835
+          headers: *id854
           content:
             application/json:
               schema:
@@ -112762,7 +113519,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id836
+          headers: &id855
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112791,7 +113548,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id836
+          headers: *id855
           content:
             application/json:
               schema:
@@ -112813,7 +113570,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id836
+          headers: *id855
           content:
             application/json:
               schema:
@@ -112911,7 +113668,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id837
+          headers: &id856
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112948,7 +113705,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id837
+          headers: *id856
           content:
             application/json:
               schema:
@@ -112968,7 +113725,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id837
+          headers: *id856
           content:
             application/json:
               schema:
@@ -112990,7 +113747,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id837
+          headers: *id856
           content:
             application/json:
               schema:
@@ -113006,7 +113763,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id837
+          headers: *id856
           content:
             application/json:
               schema:
@@ -113106,7 +113863,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id838
+          headers: &id857
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113143,7 +113900,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id838
+          headers: *id857
           content:
             application/json:
               schema:
@@ -113163,7 +113920,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id838
+          headers: *id857
           content:
             application/json:
               schema:
@@ -113185,7 +113942,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id838
+          headers: *id857
           content:
             application/json:
               schema:
@@ -113201,7 +113958,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id838
+          headers: *id857
           content:
             application/json:
               schema:
@@ -113300,7 +114057,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id839
+          headers: &id858
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113329,7 +114086,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id839
+          headers: *id858
           content:
             application/json:
               schema:
@@ -113351,7 +114108,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id839
+          headers: *id858
           content:
             application/json:
               schema:
@@ -113378,7 +114135,7 @@ paths:
         description: Filter by credential type
         schema:
           type: string
-          enum: &id840
+          enum: &id859
           - api_key
           - oauth_token
           - password
@@ -113395,7 +114152,7 @@ paths:
                 properties:
                   credentials:
                     type: array
-                    items: &id842
+                    items: &id861
                       type: object
                       description: Credential metadata (never includes actual secret values)
                       properties:
@@ -113407,7 +114164,7 @@ paths:
                           description: Human-readable credential name
                         credential_type:
                           type: string
-                          enum: *id840
+                          enum: *id859
                           description: Type of credential
                         user_id:
                           type: string
@@ -113442,9 +114199,9 @@ paths:
                           description: Credential metadata
                   total:
                     type: integer
-        '401': &id843
+        '401': &id862
           description: Unauthorized - Authentication required or token invalid
-          headers: &id841
+          headers: &id860
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113471,9 +114228,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id844
+        '403': &id863
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id841
+          headers: *id860
           content:
             application/json:
               schema:
@@ -113493,9 +114250,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id845
+        '500': &id864
           description: Internal server error - Unexpected error occurred
-          headers: *id841
+          headers: *id860
           content:
             application/json:
               schema:
@@ -113531,7 +114288,7 @@ paths:
                   description: Human-readable credential name
                 credential_type:
                   type: string
-                  enum: *id840
+                  enum: *id859
                   description: Type of credential
                 value:
                   type: string
@@ -113551,12 +114308,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  credential: *id842
+                  credential: *id861
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id841
+          headers: *id860
           content:
             application/json:
               schema:
@@ -113582,9 +114339,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id843
-        '403': *id844
-        '500': *id845
+        '401': *id862
+        '403': *id863
+        '500': *id864
       x-aragora-stability: stable
   /api/v1/openclaw/credentials/{credential_id}:
     delete:
@@ -113612,7 +114369,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id846
+          headers: &id865
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113641,7 +114398,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id846
+          headers: *id865
           content:
             application/json:
               schema:
@@ -113663,7 +114420,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id846
+          headers: *id865
           content:
             application/json:
               schema:
@@ -113679,7 +114436,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id846
+          headers: *id865
           content:
             application/json:
               schema:
@@ -113782,7 +114539,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id847
+          headers: &id866
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113819,7 +114576,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id847
+          headers: *id866
           content:
             application/json:
               schema:
@@ -113839,7 +114596,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id847
+          headers: *id866
           content:
             application/json:
               schema:
@@ -113861,7 +114618,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id847
+          headers: *id866
           content:
             application/json:
               schema:
@@ -113877,7 +114634,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id847
+          headers: *id866
           content:
             application/json:
               schema:
@@ -113988,7 +114745,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id848
+          headers: &id867
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114017,7 +114774,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id848
+          headers: *id867
           content:
             application/json:
               schema:
@@ -114039,7 +114796,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id848
+          headers: *id867
           content:
             application/json:
               schema:
@@ -114076,7 +114833,7 @@ paths:
                 properties:
                   rules:
                     type: array
-                    items: &id850
+                    items: &id869
                       type: object
                       properties:
                         name:
@@ -114108,9 +114865,9 @@ paths:
                           description: Whether the rule is active
                   total:
                     type: integer
-        '401': &id851
+        '401': &id870
           description: Unauthorized - Authentication required or token invalid
-          headers: &id849
+          headers: &id868
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114137,9 +114894,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id852
+        '403': &id871
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id849
+          headers: *id868
           content:
             application/json:
               schema:
@@ -114159,9 +114916,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id853
+        '500': &id872
           description: Internal server error - Unexpected error occurred
-          headers: *id849
+          headers: *id868
           content:
             application/json:
               schema:
@@ -114228,12 +114985,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id850
+                  rule: *id869
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id849
+          headers: *id868
           content:
             application/json:
               schema:
@@ -114259,9 +115016,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id851
-        '403': *id852
-        '500': *id853
+        '401': *id870
+        '403': *id871
+        '500': *id872
       x-aragora-stability: stable
   /api/v1/openclaw/policy/rules/{rule_name}:
     delete:
@@ -114289,7 +115046,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id854
+          headers: &id873
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114318,7 +115075,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id854
+          headers: *id873
           content:
             application/json:
               schema:
@@ -114340,7 +115097,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id854
+          headers: *id873
           content:
             application/json:
               schema:
@@ -114356,7 +115113,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id854
+          headers: *id873
           content:
             application/json:
               schema:
@@ -114383,7 +115140,7 @@ paths:
         description: Filter by session status
         schema:
           type: string
-          enum: &id855
+          enum: &id874
           - active
           - idle
           - closing
@@ -114412,7 +115169,7 @@ paths:
                 properties:
                   sessions:
                     type: array
-                    items: &id857
+                    items: &id876
                       type:
                       - object
                       - 'null'
@@ -114436,7 +115193,7 @@ paths:
                           type:
                           - string
                           - 'null'
-                          enum: *id855
+                          enum: *id874
                           description: Current session status
                         created_at:
                           type:
@@ -114464,9 +115221,9 @@ paths:
                           description: Session metadata
                   total:
                     type: integer
-        '401': &id858
+        '401': &id877
           description: Unauthorized - Authentication required or token invalid
-          headers: &id856
+          headers: &id875
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114493,9 +115250,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id859
+        '403': &id878
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id856
+          headers: *id875
           content:
             application/json:
               schema:
@@ -114515,9 +115272,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id860
+        '500': &id879
           description: Internal server error - Unexpected error occurred
-          headers: *id856
+          headers: *id875
           content:
             application/json:
               schema:
@@ -114558,12 +115315,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: *id857
+                  session: *id876
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id856
+          headers: *id875
           content:
             application/json:
               schema:
@@ -114589,9 +115346,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id858
-        '403': *id859
-        '500': *id860
+        '401': *id877
+        '403': *id878
+        '500': *id879
       x-aragora-stability: stable
   /api/v1/openclaw/sessions/{session_id}:
     get:
@@ -114605,7 +115362,7 @@ paths:
         in: path
         required: true
         description: Unique session identifier
-        schema: &id862
+        schema: &id881
           type: string
       responses:
         '200':
@@ -114615,7 +115372,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: &id863
+                  session: &id882
                     type:
                     - object
                     - 'null'
@@ -114670,9 +115427,9 @@ paths:
                       metadata:
                         type: object
                         description: Session metadata
-        '401': &id864
+        '401': &id883
           description: Unauthorized - Authentication required or token invalid
-          headers: &id861
+          headers: &id880
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114699,9 +115456,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id865
+        '403': &id884
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id861
+          headers: *id880
           content:
             application/json:
               schema:
@@ -114721,9 +115478,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id866
+        '404': &id885
           description: Not found - The requested resource does not exist
-          headers: *id861
+          headers: *id880
           content:
             application/json:
               schema:
@@ -114737,9 +115494,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id867
+        '500': &id886
           description: Internal server error - Unexpected error occurred
-          headers: *id861
+          headers: *id880
           content:
             application/json:
               schema:
@@ -114764,7 +115521,7 @@ paths:
         in: path
         required: true
         description: Unique session identifier
-        schema: *id862
+        schema: *id881
       responses:
         '200':
           description: Session closed
@@ -114773,13 +115530,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: *id863
+                  session: *id882
                   message:
                     type: string
-        '401': *id864
-        '403': *id865
-        '404': *id866
-        '500': *id867
+        '401': *id883
+        '403': *id884
+        '404': *id885
+        '500': *id886
       x-aragora-stability: stable
   /api/v1/openclaw/sessions/{session_id}/end:
     post:
@@ -114862,7 +115619,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id868
+          headers: &id887
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114891,7 +115648,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id868
+          headers: *id887
           content:
             application/json:
               schema:
@@ -114913,7 +115670,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id868
+          headers: *id887
           content:
             application/json:
               schema:
@@ -114929,7 +115686,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id868
+          headers: *id887
           content:
             application/json:
               schema:
@@ -114979,7 +115736,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id869
+          headers: &id888
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115008,7 +115765,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id869
+          headers: *id888
           content:
             application/json:
               schema:
@@ -115030,7 +115787,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id869
+          headers: *id888
           content:
             application/json:
               schema:
@@ -115105,7 +115862,7 @@ paths:
       responses:
         '200':
           description: Deliberation status.
-          headers: &id870
+          headers: &id889
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115164,7 +115921,7 @@ paths:
                         type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id870
+          headers: *id889
           content:
             application/json:
               schema:
@@ -115184,7 +115941,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id870
+          headers: *id889
           content:
             application/json:
               schema:
@@ -115206,7 +115963,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id870
+          headers: *id889
           content:
             application/json:
               schema:
@@ -115222,7 +115979,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id870
+          headers: *id889
           content:
             application/json:
               schema:
@@ -115279,7 +116036,7 @@ paths:
       responses:
         '200':
           description: Orchestration template list.
-          headers: &id871
+          headers: &id890
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115325,7 +116082,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id871
+          headers: *id890
           content:
             application/json:
               schema:
@@ -115345,7 +116102,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id871
+          headers: *id890
           content:
             application/json:
               schema:
@@ -115367,7 +116124,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id871
+          headers: *id890
           content:
             application/json:
               schema:
@@ -115717,7 +116474,7 @@ paths:
       responses:
         '200':
           description: Conversation
-          headers: &id872
+          headers: &id891
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115733,7 +116490,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id872
+          headers: *id891
           content:
             application/json:
               schema:
@@ -115753,7 +116510,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id872
+          headers: *id891
           content:
             application/json:
               schema:
@@ -115769,7 +116526,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id872
+          headers: *id891
           content:
             application/json:
               schema:
@@ -115800,7 +116557,7 @@ paths:
       responses:
         '200':
           description: Folders
-          headers: &id873
+          headers: &id892
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115816,7 +116573,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id873
+          headers: *id892
           content:
             application/json:
               schema:
@@ -115836,7 +116593,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id873
+          headers: *id892
           content:
             application/json:
               schema:
@@ -115883,7 +116640,7 @@ paths:
       responses:
         '200':
           description: Messages
-          headers: &id874
+          headers: &id893
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115899,7 +116656,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id874
+          headers: *id893
           content:
             application/json:
               schema:
@@ -115919,7 +116676,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id874
+          headers: *id893
           content:
             application/json:
               schema:
@@ -116003,7 +116760,7 @@ paths:
       summary: Get message
       operationId: getOutlookMessage
       description: Fetch Outlook message details.
-      security: &id876
+      security: &id895
       - {}
       parameters:
       - name: message_id
@@ -116018,7 +116775,7 @@ paths:
       responses:
         '200':
           description: Message
-          headers: &id875
+          headers: &id894
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116032,9 +116789,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id877
+        '401': &id896
           description: Unauthorized - Authentication required or token invalid
-          headers: *id875
+          headers: *id894
           content:
             application/json:
               schema:
@@ -116052,9 +116809,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id878
+        '404': &id897
           description: Not found - The requested resource does not exist
-          headers: *id875
+          headers: *id894
           content:
             application/json:
               schema:
@@ -116068,9 +116825,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id879
+        '500': &id898
           description: Internal server error - Unexpected error occurred
-          headers: *id875
+          headers: *id894
           content:
             application/json:
               schema:
@@ -116090,7 +116847,7 @@ paths:
       summary: Delete message
       operationId: deleteOutlookMessage
       description: Delete an Outlook message.
-      security: *id876
+      security: *id895
       parameters:
       - name: message_id
         in: path
@@ -116100,14 +116857,14 @@ paths:
       responses:
         '200':
           description: Message deleted
-          headers: *id875
+          headers: *id894
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id877
-        '404': *id878
-        '500': *id879
+        '401': *id896
+        '404': *id897
+        '500': *id898
       x-aragora-stability: stable
   /api/v1/outlook/messages/{message_id}/move:
     post:
@@ -116142,7 +116899,7 @@ paths:
       responses:
         '200':
           description: Message moved
-          headers: &id880
+          headers: &id899
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116158,7 +116915,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id880
+          headers: *id899
           content:
             application/json:
               schema:
@@ -116178,7 +116935,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id880
+          headers: *id899
           content:
             application/json:
               schema:
@@ -116223,7 +116980,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id881
+          headers: &id900
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116239,7 +116996,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id881
+          headers: *id900
           content:
             application/json:
               schema:
@@ -116259,7 +117016,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id881
+          headers: *id900
           content:
             application/json:
               schema:
@@ -116301,7 +117058,7 @@ paths:
       responses:
         '200':
           description: OAuth complete
-          headers: &id882
+          headers: &id901
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116317,7 +117074,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id882
+          headers: *id901
           content:
             application/json:
               schema:
@@ -116345,7 +117102,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id882
+          headers: *id901
           content:
             application/json:
               schema:
@@ -116381,7 +117138,7 @@ paths:
       responses:
         '200':
           description: OAuth URL
-          headers: &id883
+          headers: &id902
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116397,7 +117154,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id883
+          headers: *id902
           content:
             application/json:
               schema:
@@ -116425,7 +117182,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id883
+          headers: *id902
           content:
             application/json:
               schema:
@@ -116473,7 +117230,7 @@ paths:
       responses:
         '200':
           description: Reply sent
-          headers: &id884
+          headers: &id903
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116489,7 +117246,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id884
+          headers: *id903
           content:
             application/json:
               schema:
@@ -116517,7 +117274,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id884
+          headers: *id903
           content:
             application/json:
               schema:
@@ -116537,7 +117294,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id884
+          headers: *id903
           content:
             application/json:
               schema:
@@ -116572,7 +117329,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id885
+          headers: &id904
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116588,7 +117345,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id885
+          headers: *id904
           content:
             application/json:
               schema:
@@ -116608,7 +117365,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id885
+          headers: *id904
           content:
             application/json:
               schema:
@@ -116672,7 +117429,7 @@ paths:
       responses:
         '200':
           description: Message sent
-          headers: &id886
+          headers: &id905
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116688,7 +117445,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id886
+          headers: *id905
           content:
             application/json:
               schema:
@@ -116716,7 +117473,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id886
+          headers: *id905
           content:
             application/json:
               schema:
@@ -116736,7 +117493,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id886
+          headers: *id905
           content:
             application/json:
               schema:
@@ -116767,7 +117524,7 @@ paths:
       responses:
         '200':
           description: Status
-          headers: &id887
+          headers: &id906
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116783,7 +117540,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id887
+          headers: *id906
           content:
             application/json:
               schema:
@@ -116803,7 +117560,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id887
+          headers: *id906
           content:
             application/json:
               schema:
@@ -117022,7 +117779,7 @@ paths:
       responses:
         '201':
           description: Workflow created from Hive Mind pattern
-          headers: &id888
+          headers: &id907
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117038,7 +117795,7 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id888
+          headers: *id907
           content:
             application/json:
               schema:
@@ -117115,7 +117872,7 @@ paths:
       responses:
         '201':
           description: Workflow created from MapReduce pattern
-          headers: &id889
+          headers: &id908
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117131,7 +117888,7 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id889
+          headers: *id908
           content:
             application/json:
               schema:
@@ -117202,7 +117959,7 @@ paths:
       responses:
         '201':
           description: Workflow created from Review Cycle pattern
-          headers: &id890
+          headers: &id909
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117218,7 +117975,7 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id890
+          headers: *id909
           content:
             application/json:
               schema:
@@ -117261,7 +118018,7 @@ paths:
       responses:
         '200':
           description: Pattern template details
-          headers: &id891
+          headers: &id910
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117277,7 +118034,7 @@ paths:
                 $ref: '#/components/schemas/PatternTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id891
+          headers: *id910
           content:
             application/json:
               schema:
@@ -118491,7 +119248,7 @@ paths:
       responses:
         '200':
           description: List of playbooks
-          headers: &id892
+          headers: &id911
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118665,7 +119422,7 @@ paths:
                   count: 1
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id892
+          headers: *id911
           content:
             application/json:
               schema:
@@ -118702,7 +119459,7 @@ paths:
       responses:
         '200':
           description: Playbook details
-          headers: &id893
+          headers: &id912
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118866,7 +119623,7 @@ paths:
                   metadata: {}
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id893
+          headers: *id912
           content:
             application/json:
               schema:
@@ -118946,7 +119703,7 @@ paths:
       responses:
         '202':
           description: Playbook run queued
-          headers: &id894
+          headers: &id913
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119047,7 +119804,7 @@ paths:
                     consensus_threshold: 0.75
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id894
+          headers: *id913
           content:
             application/json:
               schema:
@@ -119075,7 +119832,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id894
+          headers: *id913
           content:
             application/json:
               schema:
@@ -119091,7 +119848,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id894
+          headers: *id913
           content:
             application/json:
               schema:
@@ -119111,7 +119868,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id894
+          headers: *id913
           content:
             application/json:
               schema:
@@ -119164,13 +119921,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  type: &id896
+                  type: &id915
                     type: string
-                  option: &id895
+                  option: &id914
                     type: object
-                  preflight: *id895
-                  error: *id896
-                  code: *id896
+                  preflight: *id914
+                  error: *id915
+                  code: *id915
                   retry_after:
                     type: integer
       x-aragora-stability: stable
@@ -119334,7 +120091,7 @@ paths:
       responses:
         '200':
           description: Landing feedback summary
-          headers: &id897
+          headers: &id916
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119360,7 +120117,7 @@ paths:
       responses:
         '202':
           description: Feedback accepted
-          headers: *id897
+          headers: *id916
           content:
             application/json:
               schema:
@@ -119398,9 +120155,9 @@ paths:
                 properties:
                   ok:
                     type: boolean
-                  id: &id898
+                  id: &id917
                     type: string
-                  review_status: *id898
+                  review_status: *id917
                   reviewed_at:
                     type:
                     - string
@@ -119783,7 +120540,7 @@ paths:
       - name: name
         in: path
         required: true
-        schema: &id899
+        schema: &id918
           type: string
         description: Plugin name (lowercase alphanumeric with hyphens)
       requestBody:
@@ -119801,7 +120558,7 @@ paths:
       responses:
         '200':
           description: Installation result
-          headers: &id900
+          headers: &id919
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119833,12 +120590,12 @@ paths:
       - name: name
         in: path
         required: true
-        schema: *id899
+        schema: *id918
         description: Plugin name (lowercase alphanumeric with hyphens)
       responses:
         '200':
           description: Uninstallation result
-          headers: *id900
+          headers: *id919
           content:
             application/json:
               schema:
@@ -120112,7 +120869,7 @@ paths:
       summary: Get policy by ID
       operationId: getPolicy
       description: Retrieve a specific governance policy by its unique identifier.
-      security: &id902
+      security: &id921
       - bearerAuth: []
       parameters:
       - name: policy_id
@@ -120124,7 +120881,7 @@ paths:
       responses:
         '200':
           description: Policy details
-          headers: &id901
+          headers: &id920
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120138,9 +120895,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Policy'
-        '401': &id903
+        '401': &id922
           description: Unauthorized - Authentication required or token invalid
-          headers: *id901
+          headers: *id920
           content:
             application/json:
               schema:
@@ -120158,9 +120915,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id904
+        '403': &id923
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id901
+          headers: *id920
           content:
             application/json:
               schema:
@@ -120180,9 +120937,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id905
+        '404': &id924
           description: Not found - The requested resource does not exist
-          headers: *id901
+          headers: *id920
           content:
             application/json:
               schema:
@@ -120196,9 +120953,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id906
+        '500': &id925
           description: Internal server error - Unexpected error occurred
-          headers: *id901
+          headers: *id920
           content:
             application/json:
               schema:
@@ -120219,7 +120976,7 @@ paths:
       summary: Update policy
       operationId: updatePolicy
       description: Update an existing governance policy. Validates for conflicts with other active policies.
-      security: *id902
+      security: *id921
       parameters:
       - name: policy_id
         in: path
@@ -120254,14 +121011,14 @@ paths:
       responses:
         '200':
           description: Policy updated
-          headers: *id901
+          headers: *id920
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Policy'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id901
+          headers: *id920
           content:
             application/json:
               schema:
@@ -120287,16 +121044,16 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id903
-        '403': *id904
-        '404': *id905
+        '401': *id922
+        '403': *id923
+        '404': *id924
         '409':
           description: Policy conflict detected with existing policies
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id906
+        '500': *id925
       x-aragora-stability: experimental
     delete:
       tags:
@@ -120305,7 +121062,7 @@ paths:
       summary: Delete policy
       operationId: deletePolicy
       description: Delete a governance policy by ID. Active policies must be disabled before deletion.
-      security: *id902
+      security: *id921
       parameters:
       - name: policy_id
         in: path
@@ -120316,7 +121073,7 @@ paths:
       responses:
         '200':
           description: Policy deleted
-          headers: *id901
+          headers: *id920
           content:
             application/json:
               schema:
@@ -120326,16 +121083,16 @@ paths:
                     type: string
                   deleted:
                     type: boolean
-        '401': *id903
-        '403': *id904
-        '404': *id905
+        '401': *id922
+        '403': *id923
+        '404': *id924
         '409':
           description: Cannot delete an active policy - disable it first
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id906
+        '500': *id925
       x-aragora-stability: stable
   /api/v1/postman.json:
     get:
@@ -120386,7 +121143,7 @@ paths:
       responses:
         '200':
           description: Account deletion scheduled
-          headers: &id907
+          headers: &id926
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120413,7 +121170,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id907
+          headers: *id926
           content:
             application/json:
               schema:
@@ -120441,7 +121198,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id907
+          headers: *id926
           content:
             application/json:
               schema:
@@ -120461,7 +121218,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id907
+          headers: *id926
           content:
             application/json:
               schema:
@@ -120494,7 +121251,7 @@ paths:
       responses:
         '200':
           description: Privacy data inventory
-          headers: &id908
+          headers: &id927
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120532,7 +121289,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id908
+          headers: *id927
           content:
             application/json:
               schema:
@@ -120574,7 +121331,7 @@ paths:
       responses:
         '200':
           description: User data export
-          headers: &id909
+          headers: &id928
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120626,7 +121383,7 @@ paths:
                         type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id909
+          headers: *id928
           content:
             application/json:
               schema:
@@ -120657,7 +121414,7 @@ paths:
       responses:
         '200':
           description: Privacy preferences
-          headers: &id910
+          headers: &id929
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120669,10 +121426,10 @@ paths:
                 type: integer
           content:
             application/json:
-              schema: &id912
+              schema: &id931
                 type: object
                 properties:
-                  preferences: &id911
+                  preferences: &id930
                     type: object
                     properties:
                       do_not_sell:
@@ -120683,9 +121440,9 @@ paths:
                         type: boolean
                       third_party_sharing:
                         type: boolean
-        '401': &id913
+        '401': &id932
           description: Unauthorized - Authentication required or token invalid
-          headers: *id910
+          headers: *id929
           content:
             application/json:
               schema:
@@ -120716,17 +121473,17 @@ paths:
         required: true
         content:
           application/json:
-            schema: *id911
+            schema: *id930
       responses:
         '200':
           description: Privacy preferences updated
-          headers: *id910
+          headers: *id929
           content:
             application/json:
-              schema: *id912
+              schema: *id931
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id910
+          headers: *id929
           content:
             application/json:
               schema:
@@ -120752,7 +121509,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id913
+        '401': *id932
       x-aragora-stability: stable
   /api/v1/probes/capability:
     post:
@@ -120877,7 +121634,7 @@ paths:
       responses:
         '200':
           description: Prompt intent
-          headers: &id915
+          headers: &id934
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120892,7 +121649,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  intent: &id914
+                  intent: &id933
                     type: object
                     additionalProperties: true
                   timing:
@@ -120901,13 +121658,13 @@ paths:
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id914
+                      stage_durations_ms: *id933
                       operation_timings:
                         type: array
-                        items: *id914
+                        items: *id933
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id915
+          headers: *id934
           content:
             application/json:
               schema:
@@ -120962,7 +121719,7 @@ paths:
       responses:
         '200':
           description: Clarifying questions
-          headers: &id918
+          headers: &id937
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120977,9 +121734,9 @@ paths:
               schema:
                 type: object
                 properties:
-                  questions: &id917
+                  questions: &id936
                     type: array
-                    items: &id916
+                    items: &id935
                       type: object
                       additionalProperties: true
                   timing:
@@ -120988,11 +121745,11 @@ paths:
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id916
-                      operation_timings: *id917
+                      stage_durations_ms: *id935
+                      operation_timings: *id936
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id918
+          headers: *id937
           content:
             application/json:
               schema:
@@ -121046,7 +121803,7 @@ paths:
       responses:
         '200':
           description: Research report
-          headers: &id920
+          headers: &id939
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121061,7 +121818,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  research: &id919
+                  research: &id938
                     type: object
                     additionalProperties: true
                   timing:
@@ -121070,13 +121827,13 @@ paths:
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id919
+                      stage_durations_ms: *id938
                       operation_timings:
                         type: array
-                        items: *id919
+                        items: *id938
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id920
+          headers: *id939
           content:
             application/json:
               schema:
@@ -121125,13 +121882,13 @@ paths:
                   description: Natural-language operator prompt to transform into a structured specification.
                 context:
                   description: Optional contextual data to pass into the prompt-engine stage.
-                profile: &id921
+                profile: &id940
                   type: string
-                autonomy: *id921
-                skip_research: &id922
+                autonomy: *id940
+                skip_research: &id941
                   type: boolean
-                skip_interrogation: *id922
-                decision_plan: &id923
+                skip_interrogation: *id941
+                decision_plan: &id942
                   type: object
                   additionalProperties: true
               required:
@@ -121139,7 +121896,7 @@ paths:
       responses:
         '200':
           description: Prompt-engine pipeline result
-          headers: &id925
+          headers: &id944
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121155,35 +121912,35 @@ paths:
                 type: object
                 additionalProperties: true
                 properties:
-                  specification: *id923
-                  spec_bundle: *id923
-                  intent: *id923
-                  questions: &id924
+                  specification: *id942
+                  spec_bundle: *id942
+                  intent: *id942
+                  questions: &id943
                     type: array
-                    items: *id923
+                    items: *id942
                   research:
                     anyOf:
-                    - *id923
+                    - *id942
                     - type: 'null'
-                  auto_approved: *id922
+                  auto_approved: *id941
                   stages_completed:
                     type: array
-                    items: *id921
-                  validation: *id923
+                    items: *id940
+                  validation: *id942
                   timing:
                     type: object
                     additionalProperties: true
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id923
-                      operation_timings: *id924
-                  run: *id923
-                  decision_plan: *id923
-                  execution: *id923
+                      stage_durations_ms: *id942
+                      operation_timings: *id943
+                  run: *id942
+                  decision_plan: *id942
+                  execution: *id942
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id925
+          headers: *id944
           content:
             application/json:
               schema:
@@ -121211,13 +121968,13 @@ paths:
                     trace_id: req_abc123xyz
         '422':
           description: Specification is not execution-grade
-          headers: *id925
+          headers: *id944
           content:
             application/json:
-              schema: *id923
+              schema: *id942
         '503':
           description: Internal server error - Unexpected error occurred
-          headers: *id925
+          headers: *id944
           content:
             application/json:
               schema:
@@ -121243,17 +122000,17 @@ paths:
       parameters:
       - name: status
         in: query
-        schema: &id926
+        schema: &id945
           type: string
       - name: plan_id
         in: query
-        schema: *id926
+        schema: *id945
       - name: debate_id
         in: query
-        schema: *id926
+        schema: *id945
       - name: execution_id
         in: query
-        schema: *id926
+        schema: *id945
       - name: limit
         in: query
         schema:
@@ -121310,7 +122067,7 @@ paths:
       responses:
         '200':
           description: Prompt-engine run
-          headers: &id927
+          headers: &id946
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121330,7 +122087,7 @@ paths:
                     additionalProperties: true
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id927
+          headers: *id946
           content:
             application/json:
               schema:
@@ -121366,19 +122123,19 @@ paths:
                   type: object
                   description: PromptIntent payload returned by decompose or by the full pipeline.
                   additionalProperties: true
-                questions: &id929
+                questions: &id948
                   type: array
-                  items: &id928
+                  items: &id947
                     type: object
                     additionalProperties: true
-                research: *id928
+                research: *id947
                 context: {}
               required:
               - intent
       responses:
         '200':
           description: Prompt specification
-          headers: &id930
+          headers: &id949
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121393,19 +122150,19 @@ paths:
               schema:
                 type: object
                 properties:
-                  specification: *id928
-                  spec_bundle: *id928
+                  specification: *id947
+                  spec_bundle: *id947
                   timing:
                     type: object
                     additionalProperties: true
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id928
-                      operation_timings: *id929
+                      stage_durations_ms: *id947
+                      operation_timings: *id948
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id930
+          headers: *id949
           content:
             application/json:
               schema:
@@ -121449,7 +122206,7 @@ paths:
               type: object
               additionalProperties: true
               properties:
-                specification: &id931
+                specification: &id950
                   type: object
                   additionalProperties: true
               required:
@@ -121457,7 +122214,7 @@ paths:
       responses:
         '200':
           description: Validation result
-          headers: &id932
+          headers: &id951
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121472,21 +122229,21 @@ paths:
               schema:
                 type: object
                 properties:
-                  validation: *id931
-                  spec_bundle: *id931
+                  validation: *id950
+                  spec_bundle: *id950
                   timing:
                     type: object
                     additionalProperties: true
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id931
+                      stage_durations_ms: *id950
                       operation_timings:
                         type: array
-                        items: *id931
+                        items: *id950
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id932
+          headers: *id951
           content:
             application/json:
               schema:
@@ -121599,9 +122356,9 @@ paths:
                           - placeholder_backed
                           - details
                           properties:
-                            id: &id933
+                            id: &id952
                               type: string
-                            name: *id933
+                            name: *id952
                             readiness:
                               type: string
                               enum:
@@ -121610,12 +122367,12 @@ paths:
                               description: Readiness state for this exposed public surface.
                             paths:
                               type: array
-                              items: *id933
+                              items: *id952
                               description: Public paths that belong to this surface.
-                            message: *id933
-                            backend_conditional: &id934
+                            message: *id952
+                            backend_conditional: &id953
                               type: boolean
-                            placeholder_backed: *id934
+                            placeholder_backed: *id953
                             details:
                               type: object
                               additionalProperties: true
@@ -122333,7 +123090,7 @@ paths:
       responses:
         '200':
           description: List of jobs
-          headers: &id935
+          headers: &id954
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122370,9 +123127,9 @@ paths:
                           format: date-time
                   total:
                     type: integer
-        '401': &id936
+        '401': &id955
           description: Unauthorized - Authentication required or token invalid
-          headers: *id935
+          headers: *id954
           content:
             application/json:
               schema:
@@ -122435,7 +123192,7 @@ paths:
       responses:
         '201':
           description: Job created
-          headers: *id935
+          headers: *id954
           content:
             application/json:
               schema:
@@ -122447,7 +123204,7 @@ paths:
                     type: string
                   position:
                     type: integer
-        '401': *id936
+        '401': *id955
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -122467,7 +123224,7 @@ paths:
       responses:
         '200':
           description: Job details
-          headers: &id937
+          headers: &id956
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122499,9 +123256,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '404': &id938
+        '404': &id957
           description: Not found - The requested resource does not exist
-          headers: *id937
+          headers: *id956
           content:
             application/json:
               schema:
@@ -122533,7 +123290,7 @@ paths:
       responses:
         '200':
           description: Job cancelled
-          headers: *id937
+          headers: *id956
           content:
             application/json:
               schema:
@@ -122541,7 +123298,7 @@ paths:
                 properties:
                   cancelled:
                     type: boolean
-        '404': *id938
+        '404': *id957
         '409':
           description: Job cannot be cancelled (already running or completed)
           content:
@@ -122572,7 +123329,7 @@ paths:
       responses:
         '200':
           description: Job re-queued
-          headers: &id939
+          headers: &id958
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122593,7 +123350,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id939
+          headers: *id958
           content:
             application/json:
               schema:
@@ -122863,7 +123620,7 @@ paths:
       responses:
         '200':
           description: Ralph blocker breakdown
-          headers: &id940
+          headers: &id959
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122884,7 +123641,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id940
+          headers: *id959
           content:
             application/json:
               schema:
@@ -122904,7 +123661,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id940
+          headers: *id959
           content:
             application/json:
               schema:
@@ -122926,7 +123683,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id940
+          headers: *id959
           content:
             application/json:
               schema:
@@ -122954,7 +123711,7 @@ paths:
       responses:
         '200':
           description: Ralph campaigns
-          headers: &id941
+          headers: &id960
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122979,7 +123736,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id941
+          headers: *id960
           content:
             application/json:
               schema:
@@ -122999,7 +123756,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id941
+          headers: *id960
           content:
             application/json:
               schema:
@@ -123021,7 +123778,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id941
+          headers: *id960
           content:
             application/json:
               schema:
@@ -123049,7 +123806,7 @@ paths:
       responses:
         '200':
           description: Ralph campaign overview
-          headers: &id942
+          headers: &id961
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123070,7 +123827,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id942
+          headers: *id961
           content:
             application/json:
               schema:
@@ -123090,7 +123847,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id942
+          headers: *id961
           content:
             application/json:
               schema:
@@ -123112,7 +123869,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id942
+          headers: *id961
           content:
             application/json:
               schema:
@@ -123321,7 +124078,7 @@ paths:
       responses:
         '200':
           description: Readiness report
-          headers: &id943
+          headers: &id962
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123442,7 +124199,7 @@ paths:
                   timestamp: '2026-02-21T12:00:00Z'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id943
+          headers: *id962
           content:
             application/json:
               schema:
@@ -123519,7 +124276,7 @@ paths:
       responses:
         '200':
           description: Receipt delivery history
-          headers: &id944
+          headers: &id963
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123546,7 +124303,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id944
+          headers: *id963
           content:
             application/json:
               schema:
@@ -123566,7 +124323,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id944
+          headers: *id963
           content:
             application/json:
               schema:
@@ -123601,7 +124358,7 @@ paths:
       responses:
         '200':
           description: Recently anchored receipts
-          headers: &id945
+          headers: &id964
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123626,7 +124383,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id945
+          headers: *id964
           content:
             application/json:
               schema:
@@ -123646,7 +124403,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id945
+          headers: *id964
           content:
             application/json:
               schema:
@@ -123680,7 +124437,7 @@ paths:
       responses:
         '200':
           description: Receipt anchor verification status
-          headers: &id946
+          headers: &id965
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123705,7 +124462,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id946
+          headers: *id965
           content:
             application/json:
               schema:
@@ -123725,7 +124482,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id946
+          headers: *id965
           content:
             application/json:
               schema:
@@ -123741,7 +124498,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id946
+          headers: *id965
           content:
             application/json:
               schema:
@@ -123818,7 +124575,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id947
+          headers: &id966
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123855,7 +124612,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id947
+          headers: *id966
           content:
             application/json:
               schema:
@@ -123875,7 +124632,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id947
+          headers: *id966
           content:
             application/json:
               schema:
@@ -123891,7 +124648,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id947
+          headers: *id966
           content:
             application/json:
               schema:
@@ -123984,7 +124741,7 @@ paths:
       responses:
         '200':
           description: Bulk resolution results
-          headers: &id948
+          headers: &id967
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124000,7 +124757,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id948
+          headers: *id967
           content:
             application/json:
               schema:
@@ -124028,7 +124785,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id948
+          headers: *id967
           content:
             application/json:
               schema:
@@ -124098,7 +124855,7 @@ paths:
       responses:
         '200':
           description: Reconciliation job started
-          headers: &id949
+          headers: &id968
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124114,7 +124871,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id949
+          headers: *id968
           content:
             application/json:
               schema:
@@ -124142,7 +124899,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id949
+          headers: *id968
           content:
             application/json:
               schema:
@@ -124234,7 +124991,7 @@ paths:
       responses:
         '200':
           description: Approval confirmation
-          headers: &id950
+          headers: &id969
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124250,7 +125007,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id950
+          headers: *id969
           content:
             application/json:
               schema:
@@ -124266,7 +125023,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id950
+          headers: *id969
           content:
             application/json:
               schema:
@@ -124347,7 +125104,7 @@ paths:
       responses:
         '200':
           description: Resolution confirmation
-          headers: &id951
+          headers: &id970
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124363,7 +125120,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id951
+          headers: *id970
           content:
             application/json:
               schema:
@@ -124391,7 +125148,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id951
+          headers: *id970
           content:
             application/json:
               schema:
@@ -124407,7 +125164,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id951
+          headers: *id970
           content:
             application/json:
               schema:
@@ -125196,7 +125953,7 @@ paths:
       responses:
         '200':
           description: List of expiring items
-          headers: &id952
+          headers: &id971
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125219,7 +125976,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id952
+          headers: *id971
           content:
             application/json:
               schema:
@@ -125250,7 +126007,7 @@ paths:
       responses:
         '200':
           description: List of retention policies
-          headers: &id953
+          headers: &id972
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125264,9 +126021,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicyList'
-        '401': &id954
+        '401': &id973
           description: Unauthorized - Authentication required or token invalid
-          headers: *id953
+          headers: *id972
           content:
             application/json:
               schema:
@@ -125324,14 +126081,14 @@ paths:
       responses:
         '201':
           description: Policy created
-          headers: *id953
+          headers: *id972
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicy'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id953
+          headers: *id972
           content:
             application/json:
               schema:
@@ -125357,10 +126114,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id954
+        '401': *id973
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id953
+          headers: *id972
           content:
             application/json:
               schema:
@@ -125471,7 +126228,7 @@ paths:
       responses:
         '200':
           description: Execution result with affected items count
-          headers: &id955
+          headers: &id974
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125494,7 +126251,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id955
+          headers: *id974
           content:
             application/json:
               schema:
@@ -125514,7 +126271,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id955
+          headers: *id974
           content:
             application/json:
               schema:
@@ -125536,7 +126293,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id955
+          headers: *id974
           content:
             application/json:
               schema:
@@ -125605,7 +126362,7 @@ paths:
       responses:
         '200':
           description: Rolling-window triage metrics
-          headers: &id957
+          headers: &id976
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125627,7 +126384,7 @@ paths:
                     - 7d
                     - 30d
                     properties:
-                      7d: &id956
+                      7d: &id975
                         type: object
                         additionalProperties: false
                         required:
@@ -125724,7 +126481,7 @@ paths:
                               type: string
                             description: Explanations keyed by metric name for any null-valued metric above. Empty when no
                               metrics were suppressed.
-                      30d: *id956
+                      30d: *id975
                   drift:
                     type: object
                     additionalProperties:
@@ -125761,7 +126518,7 @@ paths:
           description: "Not Modified \u2014 ETag matched If-None-Match."
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id957
+          headers: *id976
           content:
             application/json:
               schema:
@@ -125781,7 +126538,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id957
+          headers: *id976
           content:
             application/json:
               schema:
@@ -125803,7 +126560,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id957
+          headers: *id976
           content:
             application/json:
               schema:
@@ -125820,7 +126577,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id957
+          headers: *id976
           content:
             application/json:
               schema:
@@ -125924,7 +126681,7 @@ paths:
       responses:
         '200':
           description: Review details
-          headers: &id958
+          headers: &id977
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125952,9 +126709,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '400': &id959
+        '400': &id978
           description: Bad request - Invalid input or malformed JSON
-          headers: *id958
+          headers: *id977
           content:
             application/json:
               schema:
@@ -125980,9 +126737,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id960
+        '404': &id979
           description: Not found - The requested resource does not exist
-          headers: *id958
+          headers: *id977
           content:
             application/json:
               schema:
@@ -125996,9 +126753,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id961
+        '500': &id980
           description: Internal server error - Unexpected error occurred
-          headers: *id958
+          headers: *id977
           content:
             application/json:
               schema:
@@ -126047,7 +126804,7 @@ paths:
       responses:
         '200':
           description: Review updated
-          headers: *id958
+          headers: *id977
           content:
             application/json:
               schema:
@@ -126057,9 +126814,9 @@ paths:
                     type: boolean
                   review_id:
                     type: string
-        '400': *id959
-        '404': *id960
-        '500': *id961
+        '400': *id978
+        '404': *id979
+        '500': *id980
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -126079,7 +126836,7 @@ paths:
       responses:
         '200':
           description: Review deleted
-          headers: *id958
+          headers: *id977
           content:
             application/json:
               schema:
@@ -126089,8 +126846,8 @@ paths:
                     type: boolean
                   deleted_id:
                     type: string
-        '404': *id960
-        '500': *id961
+        '404': *id979
+        '500': *id980
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -126845,7 +127602,7 @@ paths:
       responses:
         '200':
           description: Execution timeline
-          headers: &id962
+          headers: &id981
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -126866,7 +127623,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id962
+          headers: *id981
           content:
             application/json:
               schema:
@@ -126886,7 +127643,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id962
+          headers: *id981
           content:
             application/json:
               schema:
@@ -127024,7 +127781,7 @@ paths:
       responses:
         '201':
           description: Queued improvement goal
-          headers: &id963
+          headers: &id982
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127058,7 +127815,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id963
+          headers: *id982
           content:
             application/json:
               schema:
@@ -127086,7 +127843,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id963
+          headers: *id982
           content:
             application/json:
               schema:
@@ -127106,7 +127863,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id963
+          headers: *id982
           content:
             application/json:
               schema:
@@ -127156,7 +127913,7 @@ paths:
       responses:
         '200':
           description: Deleted queue item
-          headers: &id964
+          headers: &id983
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127190,7 +127947,7 @@ paths:
                         type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id964
+          headers: *id983
           content:
             application/json:
               schema:
@@ -127210,7 +127967,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id964
+          headers: *id983
           content:
             application/json:
               schema:
@@ -127232,7 +127989,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id964
+          headers: *id983
           content:
             application/json:
               schema:
@@ -127290,7 +128047,7 @@ paths:
       responses:
         '200':
           description: Updated queue item priority
-          headers: &id965
+          headers: &id984
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127324,7 +128081,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id965
+          headers: *id984
           content:
             application/json:
               schema:
@@ -127352,7 +128109,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id965
+          headers: *id984
           content:
             application/json:
               schema:
@@ -127372,7 +128129,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id965
+          headers: *id984
           content:
             application/json:
               schema:
@@ -127394,7 +128151,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id965
+          headers: *id984
           content:
             application/json:
               schema:
@@ -127431,7 +128188,7 @@ paths:
       responses:
         '200':
           description: Learning insights
-          headers: &id966
+          headers: &id985
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127452,7 +128209,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id966
+          headers: *id985
           content:
             application/json:
               schema:
@@ -127472,7 +128229,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id966
+          headers: *id985
           content:
             application/json:
               schema:
@@ -127506,7 +128263,7 @@ paths:
       responses:
         '200':
           description: Meta-planner goals
-          headers: &id967
+          headers: &id986
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127527,7 +128284,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id967
+          headers: *id986
           content:
             application/json:
               schema:
@@ -127547,7 +128304,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id967
+          headers: *id986
           content:
             application/json:
               schema:
@@ -127580,7 +128337,7 @@ paths:
       responses:
         '200':
           description: Metrics comparison
-          headers: &id968
+          headers: &id987
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127601,7 +128358,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id968
+          headers: *id987
           content:
             application/json:
               schema:
@@ -127621,7 +128378,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id968
+          headers: *id987
           content:
             application/json:
               schema:
@@ -127808,7 +128565,7 @@ paths:
       responses:
         '200':
           description: Cycle trends
-          headers: &id971
+          headers: &id990
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127828,16 +128585,16 @@ paths:
                     type: object
                     additionalProperties: true
                     properties:
-                      cycles: &id970
+                      cycles: &id989
                         type: array
-                        items: &id969
+                        items: &id988
                           type: object
                           additionalProperties: true
-                      summary: *id969
-                      run_costs: *id970
+                      summary: *id988
+                      run_costs: *id989
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id971
+          headers: *id990
           content:
             application/json:
               schema:
@@ -127857,7 +128614,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id971
+          headers: *id990
           content:
             application/json:
               schema:
@@ -129823,7 +130580,7 @@ paths:
       responses:
         '200':
           description: Spectate events emitted
-          headers: &id972
+          headers: &id991
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -129844,7 +130601,7 @@ paths:
                     type: string
         '503':
           description: Bridge unavailable
-          headers: *id972
+          headers: *id991
           content:
             application/json:
               schema:
@@ -129869,12 +130626,12 @@ paths:
       - name: debate_id
         in: query
         description: Limit results to one debate.
-        schema: &id973
+        schema: &id992
           type: string
       - name: pipeline_id
         in: query
         description: Limit results to one pipeline.
-        schema: *id973
+        schema: *id992
       responses:
         '200':
           description: Recent spectate events
@@ -129937,12 +130694,12 @@ paths:
       - name: debate_id
         in: query
         description: Limit results to one debate.
-        schema: &id974
+        schema: &id993
           type: string
       - name: pipeline_id
         in: query
         description: Limit results to one pipeline.
-        schema: *id974
+        schema: *id993
       - name: format
         in: query
         description: Use `sse` to request a finite SSE snapshot instead of JSON.
@@ -130557,13 +131314,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id975
+        schema: &id994
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id975
+        schema: *id994
       responses:
         '200':
           description: Ticket updated
@@ -130594,13 +131351,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id976
+        schema: &id995
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id976
+        schema: *id995
       responses:
         '200':
           description: Reply sent
@@ -130881,7 +131638,7 @@ paths:
       responses:
         '200':
           description: Active leases
-          headers: &id977
+          headers: &id996
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -130906,7 +131663,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id977
+          headers: *id996
           content:
             application/json:
               schema:
@@ -130926,7 +131683,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id977
+          headers: *id996
           content:
             application/json:
               schema:
@@ -131026,7 +131783,7 @@ paths:
       responses:
         '200':
           description: Completion receipt
-          headers: &id978
+          headers: &id997
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131047,7 +131804,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id978
+          headers: *id997
           content:
             application/json:
               schema:
@@ -131067,7 +131824,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id978
+          headers: *id997
           content:
             application/json:
               schema:
@@ -131089,7 +131846,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id978
+          headers: *id997
           content:
             application/json:
               schema:
@@ -131152,7 +131909,7 @@ paths:
       responses:
         '200':
           description: Updated lease
-          headers: &id979
+          headers: &id998
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131173,7 +131930,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id979
+          headers: *id998
           content:
             application/json:
               schema:
@@ -131193,7 +131950,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id979
+          headers: *id998
           content:
             application/json:
               schema:
@@ -131215,7 +131972,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id979
+          headers: *id998
           content:
             application/json:
               schema:
@@ -131249,7 +132006,7 @@ paths:
       responses:
         '200':
           description: Released lease
-          headers: &id980
+          headers: &id999
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131270,7 +132027,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id980
+          headers: *id999
           content:
             application/json:
               schema:
@@ -131290,7 +132047,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id980
+          headers: *id999
           content:
             application/json:
               schema:
@@ -131312,7 +132069,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id980
+          headers: *id999
           content:
             application/json:
               schema:
@@ -131358,7 +132115,7 @@ paths:
       responses:
         '200':
           description: Queue items
-          headers: &id981
+          headers: &id1000
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131383,7 +132140,7 @@ paths:
                 additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id981
+          headers: *id1000
           content:
             application/json:
               schema:
@@ -131411,7 +132168,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id981
+          headers: *id1000
           content:
             application/json:
               schema:
@@ -131431,7 +132188,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id981
+          headers: *id1000
           content:
             application/json:
               schema:
@@ -131464,7 +132221,7 @@ paths:
       responses:
         '200':
           description: Queue statistics
-          headers: &id982
+          headers: &id1001
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131485,7 +132242,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id982
+          headers: *id1001
           content:
             application/json:
               schema:
@@ -131505,7 +132262,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id982
+          headers: *id1001
           content:
             application/json:
               schema:
@@ -131554,7 +132311,7 @@ paths:
       responses:
         '200':
           description: Queue synchronization result
-          headers: &id983
+          headers: &id1002
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131575,7 +132332,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id983
+          headers: *id1002
           content:
             application/json:
               schema:
@@ -131595,7 +132352,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id983
+          headers: *id1002
           content:
             application/json:
               schema:
@@ -131617,7 +132374,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id983
+          headers: *id1002
           content:
             application/json:
               schema:
@@ -131650,7 +132407,7 @@ paths:
       responses:
         '200':
           description: Queue item
-          headers: &id984
+          headers: &id1003
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131671,7 +132428,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id984
+          headers: *id1003
           content:
             application/json:
               schema:
@@ -131691,7 +132448,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id984
+          headers: *id1003
           content:
             application/json:
               schema:
@@ -131713,7 +132470,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id984
+          headers: *id1003
           content:
             application/json:
               schema:
@@ -131787,7 +132544,7 @@ paths:
       responses:
         '201':
           description: Created lease
-          headers: &id985
+          headers: &id1004
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131808,7 +132565,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id985
+          headers: *id1004
           content:
             application/json:
               schema:
@@ -131828,7 +132585,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id985
+          headers: *id1004
           content:
             application/json:
               schema:
@@ -131850,7 +132607,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id985
+          headers: *id1004
           content:
             application/json:
               schema:
@@ -131897,7 +132654,7 @@ paths:
       responses:
         '200':
           description: Salvage candidates
-          headers: &id986
+          headers: &id1005
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131922,7 +132679,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id986
+          headers: *id1005
           content:
             application/json:
               schema:
@@ -131942,7 +132699,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id986
+          headers: *id1005
           content:
             application/json:
               schema:
@@ -132268,7 +133025,7 @@ paths:
       responses:
         '200':
           description: Template registry listing
-          headers: &id987
+          headers: &id1006
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132341,7 +133098,7 @@ paths:
                 - approved_by
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id987
+          headers: *id1006
           content:
             application/json:
               schema:
@@ -132418,7 +133175,7 @@ paths:
       responses:
         '200':
           description: Email scan
-          headers: &id988
+          headers: &id1007
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132434,7 +133191,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id988
+          headers: *id1007
           content:
             application/json:
               schema:
@@ -132462,7 +133219,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id988
+          headers: *id1007
           content:
             application/json:
               schema:
@@ -132482,7 +133239,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id988
+          headers: *id1007
           content:
             application/json:
               schema:
@@ -132514,7 +133271,7 @@ paths:
       responses:
         '200':
           description: Hash result
-          headers: &id989
+          headers: &id1008
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132530,7 +133287,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id989
+          headers: *id1008
           content:
             application/json:
               schema:
@@ -132550,7 +133307,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id989
+          headers: *id1008
           content:
             application/json:
               schema:
@@ -132597,7 +133354,7 @@ paths:
       responses:
         '200':
           description: Hash results
-          headers: &id990
+          headers: &id1009
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132613,7 +133370,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id990
+          headers: *id1009
           content:
             application/json:
               schema:
@@ -132641,7 +133398,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id990
+          headers: *id1009
           content:
             application/json:
               schema:
@@ -132661,7 +133418,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id990
+          headers: *id1009
           content:
             application/json:
               schema:
@@ -132693,7 +133450,7 @@ paths:
       responses:
         '200':
           description: IP result
-          headers: &id991
+          headers: &id1010
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132709,7 +133466,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id991
+          headers: *id1010
           content:
             application/json:
               schema:
@@ -132729,7 +133486,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id991
+          headers: *id1010
           content:
             application/json:
               schema:
@@ -132770,7 +133527,7 @@ paths:
       responses:
         '200':
           description: IP results
-          headers: &id992
+          headers: &id1011
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132786,7 +133543,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id992
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -132814,7 +133571,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id992
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -132834,7 +133591,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id992
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -132860,7 +133617,7 @@ paths:
       responses:
         '200':
           description: Status
-          headers: &id993
+          headers: &id1012
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132876,7 +133633,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id993
+          headers: *id1012
           content:
             application/json:
               schema:
@@ -132896,7 +133653,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id993
+          headers: *id1012
           content:
             application/json:
               schema:
@@ -132935,7 +133692,7 @@ paths:
       responses:
         '200':
           description: Threat result
-          headers: &id994
+          headers: &id1013
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132951,7 +133708,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id994
+          headers: *id1013
           content:
             application/json:
               schema:
@@ -132979,7 +133736,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id994
+          headers: *id1013
           content:
             application/json:
               schema:
@@ -132999,7 +133756,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id994
+          headers: *id1013
           content:
             application/json:
               schema:
@@ -133040,7 +133797,7 @@ paths:
       responses:
         '200':
           description: Threat results
-          headers: &id995
+          headers: &id1014
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133056,7 +133813,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id995
+          headers: *id1014
           content:
             application/json:
               schema:
@@ -133084,7 +133841,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id995
+          headers: *id1014
           content:
             application/json:
               schema:
@@ -133104,7 +133861,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id995
+          headers: *id1014
           content:
             application/json:
               schema:
@@ -133346,7 +134103,7 @@ paths:
       responses:
         '200':
           description: Tournament details
-          headers: &id996
+          headers: &id1015
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133376,9 +134133,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '404': &id997
+        '404': &id1016
           description: Not found - The requested resource does not exist
-          headers: *id996
+          headers: *id1015
           content:
             application/json:
               schema:
@@ -133392,9 +134149,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id998
+        '500': &id1017
           description: Internal server error - Unexpected error occurred
-          headers: *id996
+          headers: *id1015
           content:
             application/json:
               schema:
@@ -133424,7 +134181,7 @@ paths:
       responses:
         '200':
           description: Tournament deleted
-          headers: *id996
+          headers: *id1015
           content:
             application/json:
               schema:
@@ -133434,8 +134191,8 @@ paths:
                     type: boolean
                   deleted_id:
                     type: string
-        '404': *id997
-        '500': *id998
+        '404': *id1016
+        '500': *id1017
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -134339,7 +135096,7 @@ paths:
       responses:
         '200':
           description: List of linked providers
-          headers: &id999
+          headers: &id1018
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134366,7 +135123,7 @@ paths:
                           format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id999
+          headers: *id1018
           content:
             application/json:
               schema:
@@ -134983,9 +135740,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '404': &id1001
+        '404': &id1020
           description: Not found - The requested resource does not exist
-          headers: &id1000
+          headers: &id1019
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135046,7 +135803,7 @@ paths:
       responses:
         '200':
           description: Vertical configuration updated
-          headers: *id1000
+          headers: *id1019
           content:
             application/json:
               schema:
@@ -135058,7 +135815,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1000
+          headers: *id1019
           content:
             application/json:
               schema:
@@ -135084,7 +135841,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1001
+        '404': *id1020
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -135599,7 +136356,7 @@ paths:
                     format: date-time
         '404':
           description: Delivery not found
-          headers: &id1002
+          headers: &id1021
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135629,7 +136386,7 @@ paths:
           description: Delivery deleted
         '404':
           description: Delivery not found
-          headers: *id1002
+          headers: *id1021
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -136256,7 +137013,7 @@ paths:
       - name: id
         in: path
         required: true
-        schema: &id1003
+        schema: &id1022
           type: string
           format: uuid
         description: Webhook ID
@@ -136304,7 +137061,7 @@ paths:
                 - enabled
         '404':
           description: Webhook not found
-          headers: &id1004
+          headers: &id1023
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136327,7 +137084,7 @@ paths:
       - name: id
         in: path
         required: true
-        schema: *id1003
+        schema: *id1022
         description: Webhook ID
       requestBody:
         required: true
@@ -136391,7 +137148,7 @@ paths:
                 - enabled
         '404':
           description: Webhook not found
-          headers: *id1004
+          headers: *id1023
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -136405,14 +137162,14 @@ paths:
       - name: id
         in: path
         required: true
-        schema: *id1003
+        schema: *id1022
         description: Webhook ID
       responses:
         '204':
           description: Webhook deleted
         '404':
           description: Webhook not found
-          headers: *id1004
+          headers: *id1023
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -136484,7 +137241,7 @@ paths:
       responses:
         '200':
           description: List of pending approvals
-          headers: &id1005
+          headers: &id1024
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136507,7 +137264,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1005
+          headers: *id1024
           content:
             application/json:
               schema:
@@ -136560,7 +137317,7 @@ paths:
       responses:
         '200':
           description: Approval submitted
-          headers: &id1006
+          headers: &id1025
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136583,7 +137340,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1006
+          headers: *id1025
           content:
             application/json:
               schema:
@@ -136611,7 +137368,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1006
+          headers: *id1025
           content:
             application/json:
               schema:
@@ -136631,7 +137388,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1006
+          headers: *id1025
           content:
             application/json:
               schema:
@@ -136737,7 +137494,7 @@ paths:
       responses:
         '200':
           description: Execution details with step progress
-          headers: &id1007
+          headers: &id1026
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136764,9 +137521,9 @@ paths:
                     type: array
                     items:
                       type: object
-        '404': &id1008
+        '404': &id1027
           description: Not found - The requested resource does not exist
-          headers: *id1007
+          headers: *id1026
           content:
             application/json:
               schema:
@@ -136796,7 +137553,7 @@ paths:
       responses:
         '200':
           description: Execution cancelled
-          headers: *id1007
+          headers: *id1026
           content:
             application/json:
               schema:
@@ -136808,7 +137565,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1007
+          headers: *id1026
           content:
             application/json:
               schema:
@@ -136834,7 +137591,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1008
+        '404': *id1027
       x-aragora-stability: stable
   /api/v1/workflow-templates:
     get:
@@ -136883,7 +137640,7 @@ paths:
       responses:
         '200':
           description: Workflow template
-          headers: &id1009
+          headers: &id1028
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136899,7 +137656,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1009
+          headers: *id1028
           content:
             application/json:
               schema:
@@ -136983,7 +137740,7 @@ paths:
       responses:
         '200':
           description: Pattern template details
-          headers: &id1010
+          headers: &id1029
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137020,7 +137777,7 @@ paths:
                       type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1010
+          headers: *id1029
           content:
             application/json:
               schema:
@@ -137066,7 +137823,7 @@ paths:
       responses:
         '201':
           description: Workflow instantiated
-          headers: &id1011
+          headers: &id1030
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137087,7 +137844,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1011
+          headers: *id1030
           content:
             application/json:
               schema:
@@ -137115,7 +137872,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1011
+          headers: *id1030
           content:
             application/json:
               schema:
@@ -137131,7 +137888,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1011
+          headers: *id1030
           content:
             application/json:
               schema:
@@ -137218,7 +137975,7 @@ paths:
       responses:
         '201':
           description: Created template instance
-          headers: &id1012
+          headers: &id1031
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137234,7 +137991,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1012
+          headers: *id1031
           content:
             application/json:
               schema:
@@ -137262,7 +138019,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1012
+          headers: *id1031
           content:
             application/json:
               schema:
@@ -137358,7 +138115,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id1013
+          headers: &id1032
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137374,7 +138131,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1013
+          headers: *id1032
           content:
             application/json:
               schema:
@@ -137556,7 +138313,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1014
+          headers: &id1033
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137593,7 +138350,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1014
+          headers: *id1033
           content:
             application/json:
               schema:
@@ -137650,7 +138407,7 @@ paths:
       responses:
         '200':
           description: List of workflows with pagination
-          headers: &id1015
+          headers: &id1034
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137711,14 +138468,14 @@ paths:
       responses:
         '201':
           description: Workflow created
-          headers: *id1015
+          headers: *id1034
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1015
+          headers: *id1034
           content:
             application/json:
               schema:
@@ -137855,7 +138612,7 @@ paths:
       responses:
         '200':
           description: Workflow execution details
-          headers: &id1016
+          headers: &id1035
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137878,9 +138635,9 @@ paths:
                     type: string
                   result:
                     type: object
-        '404': &id1017
+        '404': &id1036
           description: Not found - The requested resource does not exist
-          headers: *id1016
+          headers: *id1035
           content:
             application/json:
               schema:
@@ -137913,7 +138670,7 @@ paths:
       responses:
         '200':
           description: Workflow execution deleted
-          headers: *id1016
+          headers: *id1035
           content:
             application/json:
               schema:
@@ -137925,7 +138682,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1016
+          headers: *id1035
           content:
             application/json:
               schema:
@@ -137951,7 +138708,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1017
+        '404': *id1036
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -138107,7 +138864,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id1018
+          headers: &id1037
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138121,9 +138878,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowTemplate'
-        '404': &id1019
+        '404': &id1038
           description: Not found - The requested resource does not exist
-          headers: *id1018
+          headers: *id1037
           content:
             application/json:
               schema:
@@ -138185,14 +138942,14 @@ paths:
       responses:
         '200':
           description: Workflow template updated
-          headers: *id1018
+          headers: *id1037
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowTemplate'
-        '400': &id1020
+        '400': &id1039
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1018
+          headers: *id1037
           content:
             application/json:
               schema:
@@ -138218,7 +138975,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1019
+        '404': *id1038
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -138238,7 +138995,7 @@ paths:
       responses:
         '200':
           description: Workflow template deleted
-          headers: *id1018
+          headers: *id1037
           content:
             application/json:
               schema:
@@ -138248,8 +139005,8 @@ paths:
                     type: boolean
                   template_id:
                     type: string
-        '400': *id1020
-        '404': *id1019
+        '400': *id1039
+        '404': *id1038
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -138318,7 +139075,7 @@ paths:
       responses:
         '200':
           description: Workflow definition
-          headers: &id1021
+          headers: &id1040
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138332,9 +139089,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-        '404': &id1022
+        '404': &id1041
           description: Not found - The requested resource does not exist
-          headers: *id1021
+          headers: *id1040
           content:
             application/json:
               schema:
@@ -138370,14 +139127,14 @@ paths:
       responses:
         '200':
           description: Workflow updated
-          headers: *id1021
+          headers: *id1040
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1021
+          headers: *id1040
           content:
             application/json:
               schema:
@@ -138403,7 +139160,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1022
+        '404': *id1041
       x-aragora-stability: stable
     delete:
       tags:
@@ -138420,7 +139177,7 @@ paths:
       responses:
         '200':
           description: Workflow deleted
-          headers: *id1021
+          headers: *id1040
           content:
             application/json:
               schema:
@@ -138430,7 +139187,7 @@ paths:
                     type: boolean
                   workflow_id:
                     type: string
-        '404': *id1022
+        '404': *id1041
       x-aragora-stability: stable
     patch:
       summary: Update a workflow
@@ -138489,7 +139246,7 @@ paths:
       responses:
         '200':
           description: Workflow execution result or execution ID
-          headers: &id1023
+          headers: &id1042
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138512,7 +139269,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1023
+          headers: *id1042
           content:
             application/json:
               schema:
@@ -138540,7 +139297,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1023
+          headers: *id1042
           content:
             application/json:
               schema:
@@ -138556,7 +139313,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1023
+          headers: *id1042
           content:
             application/json:
               schema:
@@ -138642,7 +139399,7 @@ paths:
       responses:
         '200':
           description: List of workflow versions
-          headers: &id1024
+          headers: &id1043
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138665,7 +139422,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1024
+          headers: *id1043
           content:
             application/json:
               schema:
@@ -138743,7 +139500,7 @@ paths:
       responses:
         '200':
           description: List of workspaces
-          headers: &id1025
+          headers: &id1044
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138757,9 +139514,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceList'
-        '401': &id1026
+        '401': &id1045
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1025
+          headers: *id1044
           content:
             application/json:
               schema:
@@ -138814,14 +139571,14 @@ paths:
       responses:
         '201':
           description: Workspace created
-          headers: *id1025
+          headers: *id1044
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1025
+          headers: *id1044
           content:
             application/json:
               schema:
@@ -138847,10 +139604,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1026
+        '401': *id1045
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1025
+          headers: *id1044
           content:
             application/json:
               schema:
@@ -138895,7 +139652,7 @@ paths:
       responses:
         '200':
           description: Available RBAC profiles with role details
-          headers: &id1027
+          headers: &id1046
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138923,7 +139680,7 @@ paths:
                             type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1027
+          headers: *id1046
           content:
             application/json:
               schema:
@@ -138960,7 +139717,7 @@ paths:
       responses:
         '200':
           description: Workspace details
-          headers: &id1028
+          headers: &id1047
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138974,9 +139731,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
-        '401': &id1029
+        '401': &id1048
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1028
+          headers: *id1047
           content:
             application/json:
               schema:
@@ -138994,9 +139751,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1030
+        '403': &id1049
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1028
+          headers: *id1047
           content:
             application/json:
               schema:
@@ -139016,9 +139773,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1031
+        '404': &id1050
           description: Not found - The requested resource does not exist
-          headers: *id1028
+          headers: *id1047
           content:
             application/json:
               schema:
@@ -139050,7 +139807,7 @@ paths:
       responses:
         '200':
           description: Workspace deleted
-          headers: *id1028
+          headers: *id1047
           content:
             application/json:
               schema:
@@ -139060,9 +139817,9 @@ paths:
                     type: boolean
                   workspace_id:
                     type: string
-        '401': *id1029
-        '403': *id1030
-        '404': *id1031
+        '401': *id1048
+        '403': *id1049
+        '404': *id1050
       x-aragora-stability: stable
   /api/v1/workspaces/{workspace_id}/activity:
     get:
@@ -139275,7 +140032,7 @@ paths:
       responses:
         '200':
           description: Member added
-          headers: &id1032
+          headers: &id1051
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139298,7 +140055,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1032
+          headers: *id1051
           content:
             application/json:
               schema:
@@ -139326,7 +140083,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1032
+          headers: *id1051
           content:
             application/json:
               schema:
@@ -139346,7 +140103,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1032
+          headers: *id1051
           content:
             application/json:
               schema:
@@ -139482,7 +140239,7 @@ paths:
       responses:
         '200':
           description: Role updated successfully
-          headers: &id1033
+          headers: &id1052
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139505,7 +140262,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1033
+          headers: *id1052
           content:
             application/json:
               schema:
@@ -139533,7 +140290,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1033
+          headers: *id1052
           content:
             application/json:
               schema:
@@ -139553,7 +140310,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1033
+          headers: *id1052
           content:
             application/json:
               schema:
@@ -139575,7 +140332,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1033
+          headers: *id1052
           content:
             application/json:
               schema:
@@ -139627,7 +140384,7 @@ paths:
       responses:
         '200':
           description: Workspace roles with assignment permissions
-          headers: &id1034
+          headers: &id1053
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139654,7 +140411,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1034
+          headers: *id1053
           content:
             application/json:
               schema:
@@ -139674,7 +140431,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1034
+          headers: *id1053
           content:
             application/json:
               schema:
@@ -139696,7 +140453,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1034
+          headers: *id1053
           content:
             application/json:
               schema:
@@ -139882,9 +140639,9 @@ paths:
                           type: integer
                   total:
                     type: integer
-        '401': &id1036
+        '401': &id1055
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1035
+          headers: &id1054
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139911,9 +140668,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1037
+        '403': &id1056
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1035
+          headers: *id1054
           content:
             application/json:
               schema:
@@ -139933,9 +140690,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id1038
+        '500': &id1057
           description: Internal server error - Unexpected error occurred
-          headers: *id1035
+          headers: *id1054
           content:
             application/json:
               schema:
@@ -140008,7 +140765,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1035
+          headers: *id1054
           content:
             application/json:
               schema:
@@ -140034,15 +140791,15 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1036
-        '403': *id1037
+        '401': *id1055
+        '403': *id1056
         '409':
           description: Another backup is already in progress
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id1038
+        '500': *id1057
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -140109,9 +140866,9 @@ paths:
                   expires_at:
                     type: string
                     format: date-time
-        '401': &id1040
+        '401': &id1059
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1039
+          headers: &id1058
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140138,9 +140895,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1041
+        '403': &id1060
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1039
+          headers: *id1058
           content:
             application/json:
               schema:
@@ -140160,9 +140917,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1042
+        '404': &id1061
           description: Not found - The requested resource does not exist
-          headers: *id1039
+          headers: *id1058
           content:
             application/json:
               schema:
@@ -140176,9 +140933,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1043
+        '500': &id1062
           description: Internal server error - Unexpected error occurred
-          headers: *id1039
+          headers: *id1058
           content:
             application/json:
               schema:
@@ -140220,16 +140977,16 @@ paths:
                     type: boolean
                   backup_id:
                     type: string
-        '401': *id1040
-        '403': *id1041
-        '404': *id1042
+        '401': *id1059
+        '403': *id1060
+        '404': *id1061
         '409':
           description: Cannot delete an in-progress backup
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id1043
+        '500': *id1062
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -140298,7 +141055,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1044
+          headers: &id1063
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140327,7 +141084,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1044
+          headers: *id1063
           content:
             application/json:
               schema:
@@ -140349,7 +141106,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1044
+          headers: *id1063
           content:
             application/json:
               schema:
@@ -140428,7 +141185,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1045
+          headers: &id1064
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140457,7 +141214,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1045
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -140479,7 +141236,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1045
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -140495,7 +141252,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1045
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -140580,7 +141337,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1046
+          headers: &id1065
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140609,7 +141366,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1046
+          headers: *id1065
           content:
             application/json:
               schema:
@@ -140631,7 +141388,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1046
+          headers: *id1065
           content:
             application/json:
               schema:
@@ -140724,9 +141481,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '401': &id1048
+        '401': &id1067
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1047
+          headers: &id1066
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140753,9 +141510,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1049
+        '403': &id1068
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1047
+          headers: *id1066
           content:
             application/json:
               schema:
@@ -140775,9 +141532,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1050
+        '404': &id1069
           description: Not found - The requested resource does not exist
-          headers: *id1047
+          headers: *id1066
           content:
             application/json:
               schema:
@@ -140791,9 +141548,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1051
+        '500': &id1070
           description: Internal server error - Unexpected error occurred
-          headers: *id1047
+          headers: *id1066
           content:
             application/json:
               schema:
@@ -140873,7 +141630,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1047
+          headers: *id1066
           content:
             application/json:
               schema:
@@ -140899,16 +141656,16 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1048
-        '403': *id1049
-        '404': *id1050
+        '401': *id1067
+        '403': *id1068
+        '404': *id1069
         '409':
           description: Another DR execution is already in progress
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id1051
+        '500': *id1070
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -140992,7 +141749,7 @@ paths:
                         type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1052
+          headers: &id1071
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141021,7 +141778,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1052
+          headers: *id1071
           content:
             application/json:
               schema:
@@ -141074,7 +141831,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1053
+          headers: &id1072
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141103,7 +141860,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1053
+          headers: *id1072
           content:
             application/json:
               schema:
@@ -141140,7 +141897,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1054
+          headers: &id1073
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141169,7 +141926,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1054
+          headers: *id1073
           content:
             application/json:
               schema:
@@ -141221,7 +141978,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1055
+          headers: &id1074
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141250,7 +142007,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1055
+          headers: *id1074
           content:
             application/json:
               schema:
@@ -141291,7 +142048,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1056
+          headers: &id1075
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141320,7 +142077,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1056
+          headers: *id1075
           content:
             application/json:
               schema:
@@ -141377,7 +142134,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1057
+          headers: &id1076
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141414,7 +142171,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1057
+          headers: *id1076
           content:
             application/json:
               schema:
@@ -141434,7 +142191,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1057
+          headers: *id1076
           content:
             application/json:
               schema:
@@ -141490,9 +142247,9 @@ paths:
                       type: object
                   health:
                     type: object
-        '400': &id1059
+        '400': &id1078
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1058
+          headers: &id1077
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141527,9 +142284,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id1060
+        '401': &id1079
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1058
+          headers: *id1077
           content:
             application/json:
               schema:
@@ -141547,9 +142304,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id1061
+        '404': &id1080
           description: Not found - The requested resource does not exist
-          headers: *id1058
+          headers: *id1077
           content:
             application/json:
               schema:
@@ -141563,9 +142320,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1062
+        '500': &id1081
           description: Internal server error - Unexpected error occurred
-          headers: *id1058
+          headers: *id1077
           content:
             application/json:
               schema:
@@ -141623,10 +142380,10 @@ paths:
                     type: string
                   workspace_id:
                     type: string
-        '400': *id1059
-        '401': *id1060
-        '404': *id1061
-        '500': *id1062
+        '400': *id1078
+        '401': *id1079
+        '404': *id1080
+        '500': *id1081
       x-aragora-stability: stable
   /api/v2/integrations/{type}/health:
     get:
@@ -141698,7 +142455,7 @@ paths:
                 - healthy
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1063
+          headers: &id1082
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141735,7 +142492,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1063
+          headers: *id1082
           content:
             application/json:
               schema:
@@ -141755,7 +142512,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1063
+          headers: *id1082
           content:
             application/json:
               schema:
@@ -141771,7 +142528,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1063
+          headers: *id1082
           content:
             application/json:
               schema:
@@ -141839,7 +142596,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1064
+          headers: &id1083
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141876,7 +142633,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1064
+          headers: *id1083
           content:
             application/json:
               schema:
@@ -141896,7 +142653,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1064
+          headers: *id1083
           content:
             application/json:
               schema:
@@ -141912,7 +142669,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1064
+          headers: *id1083
           content:
             application/json:
               schema:
@@ -142105,7 +142862,7 @@ paths:
       responses:
         '200':
           description: Marketplace categories.
-          headers: &id1065
+          headers: &id1084
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142126,7 +142883,7 @@ paths:
                       type: string
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1065
+          headers: *id1084
           content:
             application/json:
               schema:
@@ -142221,7 +142978,7 @@ paths:
       responses:
         '200':
           description: Marketplace templates.
-          headers: &id1066
+          headers: &id1085
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142246,9 +143003,9 @@ paths:
                     type: integer
                   offset:
                     type: integer
-        '400': &id1067
+        '400': &id1086
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1066
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -142274,9 +143031,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': &id1068
+        '500': &id1087
           description: Internal server error - Unexpected error occurred
-          headers: *id1066
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -142330,7 +143087,7 @@ paths:
       responses:
         '201':
           description: Template created.
-          headers: *id1066
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -142340,10 +143097,10 @@ paths:
                     type: string
                   success:
                     type: boolean
-        '400': *id1067
+        '400': *id1086
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1066
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -142363,7 +143120,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1066
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -142383,7 +143140,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id1068
+        '500': *id1087
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/import:
     post:
@@ -142426,7 +143183,7 @@ paths:
       responses:
         '201':
           description: Template imported.
-          headers: &id1069
+          headers: &id1088
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142447,7 +143204,7 @@ paths:
                     type: boolean
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1069
+          headers: *id1088
           content:
             application/json:
               schema:
@@ -142475,7 +143232,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1069
+          headers: *id1088
           content:
             application/json:
               schema:
@@ -142495,7 +143252,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1069
+          headers: *id1088
           content:
             application/json:
               schema:
@@ -142517,7 +143274,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1069
+          headers: *id1088
           content:
             application/json:
               schema:
@@ -142543,13 +143300,13 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: &id1071
+        schema: &id1090
           type: string
         description: Marketplace template ID.
       responses:
         '200':
           description: Template details.
-          headers: &id1070
+          headers: &id1089
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142584,9 +143341,9 @@ paths:
                     type: integer
                   average_rating:
                     type: number
-        '400': &id1072
+        '400': &id1091
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1070
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -142612,9 +143369,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id1073
+        '404': &id1092
           description: Not found - The requested resource does not exist
-          headers: *id1070
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -142628,9 +143385,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1074
+        '500': &id1093
           description: Internal server error - Unexpected error occurred
-          headers: *id1070
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -142656,12 +143413,12 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: *id1071
+        schema: *id1090
         description: Marketplace template ID.
       responses:
         '200':
           description: Template deleted.
-          headers: *id1070
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -142671,10 +143428,10 @@ paths:
                     type: boolean
                   deleted:
                     type: string
-        '400': *id1072
+        '400': *id1091
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1070
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -142694,7 +143451,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1070
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -142714,8 +143471,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id1073
-        '500': *id1074
+        '404': *id1092
+        '500': *id1093
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/{template_id}/export:
     get:
@@ -142741,7 +143498,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1075
+          headers: &id1094
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142778,7 +143535,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1075
+          headers: *id1094
           content:
             application/json:
               schema:
@@ -142794,7 +143551,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1075
+          headers: *id1094
           content:
             application/json:
               schema:
@@ -142820,13 +143577,13 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: &id1077
+        schema: &id1096
           type: string
         description: Marketplace template ID.
       responses:
         '200':
           description: Template ratings.
-          headers: &id1076
+          headers: &id1095
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142859,9 +143616,9 @@ paths:
                     type: number
                   count:
                     type: integer
-        '400': &id1078
+        '400': &id1097
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1076
+          headers: *id1095
           content:
             application/json:
               schema:
@@ -142887,9 +143644,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id1079
+        '404': &id1098
           description: Not found - The requested resource does not exist
-          headers: *id1076
+          headers: *id1095
           content:
             application/json:
               schema:
@@ -142903,9 +143660,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1080
+        '500': &id1099
           description: Internal server error - Unexpected error occurred
-          headers: *id1076
+          headers: *id1095
           content:
             application/json:
               schema:
@@ -142931,7 +143688,7 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: *id1077
+        schema: *id1096
         description: Marketplace template ID.
       requestBody:
         required: true
@@ -142952,7 +143709,7 @@ paths:
       responses:
         '200':
           description: Template rating saved.
-          headers: *id1076
+          headers: *id1095
           content:
             application/json:
               schema:
@@ -142962,10 +143719,10 @@ paths:
                     type: boolean
                   average_rating:
                     type: number
-        '400': *id1078
+        '400': *id1097
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1076
+          headers: *id1095
           content:
             application/json:
               schema:
@@ -142985,7 +143742,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1076
+          headers: *id1095
           content:
             application/json:
               schema:
@@ -143005,8 +143762,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id1079
-        '500': *id1080
+        '404': *id1098
+        '500': *id1099
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/{template_id}/star:
     post:
@@ -143027,7 +143784,7 @@ paths:
       responses:
         '200':
           description: Template starred.
-          headers: &id1081
+          headers: &id1100
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143048,7 +143805,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1081
+          headers: *id1100
           content:
             application/json:
               schema:
@@ -143076,7 +143833,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1081
+          headers: *id1100
           content:
             application/json:
               schema:
@@ -143096,7 +143853,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1081
+          headers: *id1100
           content:
             application/json:
               schema:
@@ -143118,7 +143875,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1081
+          headers: *id1100
           content:
             application/json:
               schema:
@@ -143134,7 +143891,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1081
+          headers: *id1100
           content:
             application/json:
               schema:
@@ -143302,7 +144059,7 @@ paths:
                       type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1082
+          headers: &id1101
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143339,7 +144096,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1082
+          headers: *id1101
           content:
             application/json:
               schema:
@@ -143359,7 +144116,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1082
+          headers: *id1101
           content:
             application/json:
               schema:
@@ -143381,7 +144138,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1082
+          headers: *id1101
           content:
             application/json:
               schema:
@@ -143539,7 +144296,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1083
+          headers: &id1102
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143576,7 +144333,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1083
+          headers: *id1102
           content:
             application/json:
               schema:
@@ -143596,7 +144353,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1083
+          headers: *id1102
           content:
             application/json:
               schema:
@@ -143618,7 +144375,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1083
+          headers: *id1102
           content:
             application/json:
               schema:
@@ -143651,7 +144408,7 @@ paths:
       responses:
         '200':
           description: Deliberation status.
-          headers: &id1084
+          headers: &id1103
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143710,7 +144467,7 @@ paths:
                         type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1084
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -143730,7 +144487,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1084
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -143752,7 +144509,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1084
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -143768,7 +144525,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1084
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -143825,7 +144582,7 @@ paths:
       responses:
         '200':
           description: Orchestration template list.
-          headers: &id1085
+          headers: &id1104
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143871,7 +144628,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1085
+          headers: *id1104
           content:
             application/json:
               schema:
@@ -143891,7 +144648,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1085
+          headers: *id1104
           content:
             application/json:
               schema:
@@ -143913,7 +144670,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1085
+          headers: *id1104
           content:
             application/json:
               schema:
@@ -143939,7 +144696,7 @@ paths:
       responses:
         '200':
           description: Receipt list
-          headers: &id1086
+          headers: &id1105
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143974,7 +144731,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1086
+          headers: *id1105
           content:
             application/json:
               schema:
@@ -143994,7 +144751,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1086
+          headers: *id1105
           content:
             application/json:
               schema:
@@ -144021,7 +144778,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id1087
+          headers: &id1106
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144046,7 +144803,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1087
+          headers: *id1106
           content:
             application/json:
               schema:
@@ -144066,7 +144823,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1087
+          headers: *id1106
           content:
             application/json:
               schema:
@@ -144105,7 +144862,7 @@ paths:
       responses:
         '200':
           description: Shared receipt payload
-          headers: &id1088
+          headers: &id1107
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144128,7 +144885,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1088
+          headers: *id1107
           content:
             application/json:
               schema:
@@ -144146,7 +144903,7 @@ paths:
           description: Share link expired or access limit reached
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1088
+          headers: *id1107
           content:
             application/json:
               schema:
@@ -144173,7 +144930,7 @@ paths:
       responses:
         '200':
           description: Receipt stats
-          headers: &id1089
+          headers: &id1108
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144203,7 +144960,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1089
+          headers: *id1108
           content:
             application/json:
               schema:
@@ -144223,7 +144980,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1089
+          headers: *id1108
           content:
             application/json:
               schema:
@@ -144255,7 +145012,7 @@ paths:
       responses:
         '200':
           description: Receipt details
-          headers: &id1090
+          headers: &id1109
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144285,7 +145042,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1090
+          headers: *id1109
           content:
             application/json:
               schema:
@@ -144305,7 +145062,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1090
+          headers: *id1109
           content:
             application/json:
               schema:
@@ -144321,7 +145078,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1090
+          headers: *id1109
           content:
             application/json:
               schema:
@@ -144354,7 +145111,7 @@ paths:
       responses:
         '200':
           description: Exported receipt
-          headers: &id1091
+          headers: &id1110
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144377,7 +145134,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1091
+          headers: *id1110
           content:
             application/json:
               schema:
@@ -144397,7 +145154,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1091
+          headers: *id1110
           content:
             application/json:
               schema:
@@ -144413,7 +145170,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1091
+          headers: *id1110
           content:
             application/json:
               schema:
@@ -144476,7 +145233,7 @@ paths:
                     description: Channel-specific formatted content
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1092
+          headers: &id1111
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144513,7 +145270,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1092
+          headers: *id1111
           content:
             application/json:
               schema:
@@ -144533,7 +145290,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1092
+          headers: *id1111
           content:
             application/json:
               schema:
@@ -144549,7 +145306,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1092
+          headers: *id1111
           content:
             application/json:
               schema:
@@ -144631,7 +145388,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1093
+          headers: &id1112
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144668,7 +145425,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1093
+          headers: *id1112
           content:
             application/json:
               schema:
@@ -144688,7 +145445,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1093
+          headers: *id1112
           content:
             application/json:
               schema:
@@ -144704,7 +145461,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1093
+          headers: *id1112
           content:
             application/json:
               schema:
@@ -144745,7 +145502,7 @@ paths:
       responses:
         '200':
           description: Receipt shared
-          headers: &id1094
+          headers: &id1113
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144777,7 +145534,7 @@ paths:
                     - type: 'null'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1094
+          headers: *id1113
           content:
             application/json:
               schema:
@@ -144797,7 +145554,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1094
+          headers: *id1113
           content:
             application/json:
               schema:
@@ -144819,7 +145576,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1094
+          headers: *id1113
           content:
             application/json:
               schema:
@@ -144835,7 +145592,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1094
+          headers: *id1113
           content:
             application/json:
               schema:
@@ -144857,7 +145614,7 @@ paths:
       summary: Verify receipt
       operationId: verifyReceiptById
       description: Verify receipt integrity.
-      security: &id1096
+      security: &id1115
       - bearerAuth: []
       parameters:
       - name: receipt_id
@@ -144868,7 +145625,7 @@ paths:
       responses:
         '200':
           description: Verification result
-          headers: &id1095
+          headers: &id1114
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -144892,9 +145649,9 @@ paths:
                   verified_at:
                     type: string
                     format: date-time
-        '401': &id1097
+        '401': &id1116
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1095
+          headers: *id1114
           content:
             application/json:
               schema:
@@ -144912,9 +145669,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id1098
+        '404': &id1117
           description: Not found - The requested resource does not exist
-          headers: *id1095
+          headers: *id1114
           content:
             application/json:
               schema:
@@ -144928,9 +145685,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1099
+        '500': &id1118
           description: Internal server error - Unexpected error occurred
-          headers: *id1095
+          headers: *id1114
           content:
             application/json:
               schema:
@@ -144951,7 +145708,7 @@ paths:
       summary: Verify receipt integrity
       operationId: verifyReceiptIntegrity
       description: Verify receipt integrity with payload.
-      security: *id1096
+      security: *id1115
       parameters:
       - name: receipt_id
         in: path
@@ -144961,7 +145718,7 @@ paths:
       responses:
         '200':
           description: Integrity verification result
-          headers: *id1095
+          headers: *id1114
           content:
             application/json:
               schema:
@@ -144973,9 +145730,9 @@ paths:
                     type: boolean
                   integrity_verified:
                     type: boolean
-        '401': *id1097
-        '404': *id1098
-        '500': *id1099
+        '401': *id1116
+        '404': *id1117
+        '500': *id1118
       x-aragora-stability: experimental
   /api/v2/receipts/{receipt_id}/verify-signature:
     post:
@@ -144996,7 +145753,7 @@ paths:
       responses:
         '200':
           description: Signature verification result
-          headers: &id1100
+          headers: &id1119
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -145021,7 +145778,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1100
+          headers: *id1119
           content:
             application/json:
               schema:
@@ -145041,7 +145798,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1100
+          headers: *id1119
           content:
             application/json:
               schema:
@@ -145057,7 +145814,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1100
+          headers: *id1119
           content:
             application/json:
               schema:
@@ -145658,9 +146415,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '404': &id1102
+        '404': &id1121
           description: Not found - The requested resource does not exist
-          headers: &id1101
+          headers: &id1120
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -145721,7 +146478,7 @@ paths:
       responses:
         '200':
           description: Vertical configuration updated
-          headers: *id1101
+          headers: *id1120
           content:
             application/json:
               schema:
@@ -145733,7 +146490,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1101
+          headers: *id1120
           content:
             application/json:
               schema:
@@ -145759,7 +146516,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1102
+        '404': *id1121
       security:
       - bearerAuth: []
       deprecated: true
@@ -145863,7 +146620,7 @@ paths:
       responses:
         '200':
           description: List of pending approvals
-          headers: &id1103
+          headers: &id1122
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -145886,7 +146643,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1103
+          headers: *id1122
           content:
             application/json:
               schema:
@@ -145939,7 +146696,7 @@ paths:
       responses:
         '200':
           description: Approval submitted
-          headers: &id1104
+          headers: &id1123
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -145962,7 +146719,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1104
+          headers: *id1123
           content:
             application/json:
               schema:
@@ -145990,7 +146747,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1104
+          headers: *id1123
           content:
             application/json:
               schema:
@@ -146010,7 +146767,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1104
+          headers: *id1123
           content:
             application/json:
               schema:
@@ -146088,7 +146845,7 @@ paths:
       responses:
         '200':
           description: Execution details with step progress
-          headers: &id1105
+          headers: &id1124
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -146115,9 +146872,9 @@ paths:
                     type: array
                     items:
                       type: object
-        '404': &id1106
+        '404': &id1125
           description: Not found - The requested resource does not exist
-          headers: *id1105
+          headers: *id1124
           content:
             application/json:
               schema:
@@ -146147,7 +146904,7 @@ paths:
       responses:
         '200':
           description: Execution cancelled
-          headers: *id1105
+          headers: *id1124
           content:
             application/json:
               schema:
@@ -146159,7 +146916,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1105
+          headers: *id1124
           content:
             application/json:
               schema:
@@ -146185,7 +146942,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1106
+        '404': *id1125
       deprecated: true
       x-aragora-stability: deprecated
   /api/workflow-templates:
@@ -146234,7 +146991,7 @@ paths:
       responses:
         '200':
           description: Workflow template
-          headers: &id1107
+          headers: &id1126
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -146250,7 +147007,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1107
+          headers: *id1126
           content:
             application/json:
               schema:
@@ -146369,7 +147126,7 @@ paths:
       responses:
         '201':
           description: Created template instance
-          headers: &id1108
+          headers: &id1127
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -146385,7 +147142,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1108
+          headers: *id1127
           content:
             application/json:
               schema:
@@ -146413,7 +147170,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1108
+          headers: *id1127
           content:
             application/json:
               schema:
@@ -146509,7 +147266,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id1109
+          headers: &id1128
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -146525,7 +147282,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1109
+          headers: *id1128
           content:
             application/json:
               schema:
@@ -146707,7 +147464,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1110
+          headers: &id1129
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -146744,7 +147501,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1110
+          headers: *id1129
           content:
             application/json:
               schema:
@@ -146801,7 +147558,7 @@ paths:
       responses:
         '200':
           description: List of workflows with pagination
-          headers: &id1111
+          headers: &id1130
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -146862,14 +147619,14 @@ paths:
       responses:
         '201':
           description: Workflow created
-          headers: *id1111
+          headers: *id1130
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1111
+          headers: *id1130
           content:
             application/json:
               schema:
@@ -146912,7 +147669,7 @@ paths:
       responses:
         '200':
           description: Workflow definition
-          headers: &id1112
+          headers: &id1131
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -146926,9 +147683,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-        '404': &id1113
+        '404': &id1132
           description: Not found - The requested resource does not exist
-          headers: *id1112
+          headers: *id1131
           content:
             application/json:
               schema:
@@ -146964,14 +147721,14 @@ paths:
       responses:
         '200':
           description: Workflow updated
-          headers: *id1112
+          headers: *id1131
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1112
+          headers: *id1131
           content:
             application/json:
               schema:
@@ -146997,7 +147754,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1113
+        '404': *id1132
       deprecated: true
       x-aragora-stability: deprecated
     delete:
@@ -147014,7 +147771,7 @@ paths:
       responses:
         '200':
           description: Workflow deleted
-          headers: *id1112
+          headers: *id1131
           content:
             application/json:
               schema:
@@ -147024,7 +147781,7 @@ paths:
                     type: boolean
                   workflow_id:
                     type: string
-        '404': *id1113
+        '404': *id1132
       deprecated: true
       x-aragora-stability: deprecated
   /api/workflows/{workflow_id}/execute:
@@ -147056,7 +147813,7 @@ paths:
       responses:
         '200':
           description: Workflow execution result or execution ID
-          headers: &id1114
+          headers: &id1133
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -147079,7 +147836,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1114
+          headers: *id1133
           content:
             application/json:
               schema:
@@ -147107,7 +147864,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1114
+          headers: *id1133
           content:
             application/json:
               schema:
@@ -147123,7 +147880,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1114
+          headers: *id1133
           content:
             application/json:
               schema:
@@ -147158,7 +147915,7 @@ paths:
       responses:
         '200':
           description: List of workflow versions
-          headers: &id1115
+          headers: &id1134
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -147181,7 +147938,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1115
+          headers: *id1134
           content:
             application/json:
               schema:
@@ -147220,7 +147977,7 @@ paths:
       responses:
         '200':
           description: List of workspaces
-          headers: &id1116
+          headers: &id1135
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -147234,9 +147991,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceList'
-        '401': &id1117
+        '401': &id1136
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1116
+          headers: *id1135
           content:
             application/json:
               schema:
@@ -147291,14 +148048,14 @@ paths:
       responses:
         '201':
           description: Workspace created
-          headers: *id1116
+          headers: *id1135
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1116
+          headers: *id1135
           content:
             application/json:
               schema:
@@ -147324,10 +148081,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1117
+        '401': *id1136
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1116
+          headers: *id1135
           content:
             application/json:
               schema:
@@ -147372,7 +148129,7 @@ paths:
       responses:
         '200':
           description: Available RBAC profiles with role details
-          headers: &id1118
+          headers: &id1137
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -147400,7 +148157,7 @@ paths:
                             type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1118
+          headers: *id1137
           content:
             application/json:
               schema:
@@ -147437,7 +148194,7 @@ paths:
       responses:
         '200':
           description: Workspace details
-          headers: &id1119
+          headers: &id1138
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -147451,9 +148208,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
-        '401': &id1120
+        '401': &id1139
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1119
+          headers: *id1138
           content:
             application/json:
               schema:
@@ -147471,9 +148228,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1121
+        '403': &id1140
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1119
+          headers: *id1138
           content:
             application/json:
               schema:
@@ -147493,9 +148250,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1122
+        '404': &id1141
           description: Not found - The requested resource does not exist
-          headers: *id1119
+          headers: *id1138
           content:
             application/json:
               schema:
@@ -147527,7 +148284,7 @@ paths:
       responses:
         '200':
           description: Workspace deleted
-          headers: *id1119
+          headers: *id1138
           content:
             application/json:
               schema:
@@ -147537,9 +148294,9 @@ paths:
                     type: boolean
                   workspace_id:
                     type: string
-        '401': *id1120
-        '403': *id1121
-        '404': *id1122
+        '401': *id1139
+        '403': *id1140
+        '404': *id1141
       deprecated: true
       x-aragora-stability: deprecated
   /api/workspaces/{workspace_id}/members:
@@ -147577,7 +148334,7 @@ paths:
       responses:
         '200':
           description: Member added
-          headers: &id1123
+          headers: &id1142
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -147600,7 +148357,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1123
+          headers: *id1142
           content:
             application/json:
               schema:
@@ -147628,7 +148385,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1123
+          headers: *id1142
           content:
             application/json:
               schema:
@@ -147648,7 +148405,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1123
+          headers: *id1142
           content:
             application/json:
               schema:
@@ -147733,7 +148490,7 @@ paths:
       responses:
         '200':
           description: Role updated successfully
-          headers: &id1124
+          headers: &id1143
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -147756,7 +148513,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1124
+          headers: *id1143
           content:
             application/json:
               schema:
@@ -147784,7 +148541,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1124
+          headers: *id1143
           content:
             application/json:
               schema:
@@ -147804,7 +148561,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1124
+          headers: *id1143
           content:
             application/json:
               schema:
@@ -147826,7 +148583,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1124
+          headers: *id1143
           content:
             application/json:
               schema:
@@ -147878,7 +148635,7 @@ paths:
       responses:
         '200':
           description: Workspace roles with assignment permissions
-          headers: &id1125
+          headers: &id1144
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -147905,7 +148662,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1125
+          headers: *id1144
           content:
             application/json:
               schema:
@@ -147925,7 +148682,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1125
+          headers: *id1144
           content:
             application/json:
               schema:
@@ -147947,7 +148704,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1125
+          headers: *id1144
           content:
             application/json:
               schema:
@@ -148504,9 +149261,9 @@ paths:
                         format: date-time
                       location:
                         type: string
-        '401': &id1127
+        '401': &id1146
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1126
+          headers: &id1145
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -148533,9 +149290,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1128
+        '403': &id1147
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1126
+          headers: *id1145
           content:
             application/json:
               schema:
@@ -148555,9 +149312,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1129
+        '404': &id1148
           description: Not found - The requested resource does not exist
-          headers: *id1126
+          headers: *id1145
           content:
             application/json:
               schema:
@@ -148628,9 +149385,9 @@ paths:
                     type: string
                   displayName:
                     type: string
-        '400': &id1130
+        '400': &id1149
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1126
+          headers: *id1145
           content:
             application/json:
               schema:
@@ -148656,9 +149413,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1127
-        '403': *id1128
-        '404': *id1129
+        '401': *id1146
+        '403': *id1147
+        '404': *id1148
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -148721,10 +149478,10 @@ paths:
                     type: string
                   displayName:
                     type: string
-        '400': *id1130
-        '401': *id1127
-        '403': *id1128
-        '404': *id1129
+        '400': *id1149
+        '401': *id1146
+        '403': *id1147
+        '404': *id1148
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -148744,9 +149501,9 @@ paths:
       responses:
         '204':
           description: Group deleted successfully
-        '401': *id1127
-        '403': *id1128
-        '404': *id1129
+        '401': *id1146
+        '403': *id1147
+        '404': *id1148
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -148899,9 +149656,9 @@ paths:
                         format: date-time
                       location:
                         type: string
-        '401': &id1132
+        '401': &id1151
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1131
+          headers: &id1150
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -148928,9 +149685,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1133
+        '403': &id1152
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1131
+          headers: *id1150
           content:
             application/json:
               schema:
@@ -148950,9 +149707,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1134
+        '404': &id1153
           description: Not found - The requested resource does not exist
-          headers: *id1131
+          headers: *id1150
           content:
             application/json:
               schema:
@@ -149037,9 +149794,9 @@ paths:
                     type: string
                   active:
                     type: boolean
-        '400': &id1135
+        '400': &id1154
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1131
+          headers: *id1150
           content:
             application/json:
               schema:
@@ -149065,9 +149822,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1132
-        '403': *id1133
-        '404': *id1134
+        '401': *id1151
+        '403': *id1152
+        '404': *id1153
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -149132,10 +149889,10 @@ paths:
                     type: string
                   active:
                     type: boolean
-        '400': *id1135
-        '401': *id1132
-        '403': *id1133
-        '404': *id1134
+        '400': *id1154
+        '401': *id1151
+        '403': *id1152
+        '404': *id1153
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -149155,9 +149912,9 @@ paths:
       responses:
         '204':
           description: User deleted successfully
-        '401': *id1132
-        '403': *id1133
-        '404': *id1134
+        '401': *id1151
+        '403': *id1152
+        '404': *id1153
       security:
       - bearerAuth: []
       x-aragora-stability: stable

--- a/sdk/python/aragora_sdk/namespaces/agent_bridge.py
+++ b/sdk/python/aragora_sdk/namespaces/agent_bridge.py
@@ -28,6 +28,58 @@ class AgentBridgeAPI:
             params["cursor"] = cursor
         return self._client.request("GET", "/api/v1/agent-bridge/runs", params=params)
 
+    def start_run(
+        self,
+        *,
+        task: str,
+        actors: list[dict[str, Any]],
+        run_id: str | None = None,
+        next_actor: str | None = None,
+        worktree_path: str | None = None,
+        worktree_agent_slug: str | None = None,
+        repair_budget_per_turn: int | None = None,
+    ) -> dict[str, Any]:
+        """Start an agent-bridge run without dispatching a turn."""
+        data: dict[str, Any] = {"task": task, "actors": actors}
+        if run_id is not None:
+            data["run_id"] = run_id
+        if next_actor is not None:
+            data["next_actor"] = next_actor
+        if worktree_path is not None:
+            data["worktree_path"] = worktree_path
+        if worktree_agent_slug is not None:
+            data["worktree_agent_slug"] = worktree_agent_slug
+        if repair_budget_per_turn is not None:
+            data["repair_budget_per_turn"] = repair_budget_per_turn
+        return self._client.request("POST", "/api/v1/agent-bridge/runs", json=data)
+
+    def dispatch_turn(self, run_id: str, *, role: str, prompt: str) -> dict[str, Any]:
+        """Dispatch one bridge turn to a run role."""
+        return self._client.request(
+            "POST",
+            f"/api/v1/agent-bridge/runs/{run_id}/dispatch",
+            json={"role": role, "prompt": prompt},
+        )
+
+    def auto_step(
+        self,
+        run_id: str,
+        *,
+        prompt: str | None = None,
+        context_turns: int | None = None,
+    ) -> dict[str, Any]:
+        """Dispatch one turn to the run's next_actor."""
+        data: dict[str, Any] = {}
+        if prompt is not None:
+            data["prompt"] = prompt
+        if context_turns is not None:
+            data["context_turns"] = context_turns
+        return self._client.request(
+            "POST",
+            f"/api/v1/agent-bridge/runs/{run_id}/auto-step",
+            json=data,
+        )
+
 
 class AsyncAgentBridgeAPI:
     """Asynchronous Agent Bridge API."""
@@ -48,3 +100,55 @@ class AsyncAgentBridgeAPI:
         if cursor is not None:
             params["cursor"] = cursor
         return await self._client.request("GET", "/api/v1/agent-bridge/runs", params=params)
+
+    async def start_run(
+        self,
+        *,
+        task: str,
+        actors: list[dict[str, Any]],
+        run_id: str | None = None,
+        next_actor: str | None = None,
+        worktree_path: str | None = None,
+        worktree_agent_slug: str | None = None,
+        repair_budget_per_turn: int | None = None,
+    ) -> dict[str, Any]:
+        """Start an agent-bridge run without dispatching a turn."""
+        data: dict[str, Any] = {"task": task, "actors": actors}
+        if run_id is not None:
+            data["run_id"] = run_id
+        if next_actor is not None:
+            data["next_actor"] = next_actor
+        if worktree_path is not None:
+            data["worktree_path"] = worktree_path
+        if worktree_agent_slug is not None:
+            data["worktree_agent_slug"] = worktree_agent_slug
+        if repair_budget_per_turn is not None:
+            data["repair_budget_per_turn"] = repair_budget_per_turn
+        return await self._client.request("POST", "/api/v1/agent-bridge/runs", json=data)
+
+    async def dispatch_turn(self, run_id: str, *, role: str, prompt: str) -> dict[str, Any]:
+        """Dispatch one bridge turn to a run role."""
+        return await self._client.request(
+            "POST",
+            f"/api/v1/agent-bridge/runs/{run_id}/dispatch",
+            json={"role": role, "prompt": prompt},
+        )
+
+    async def auto_step(
+        self,
+        run_id: str,
+        *,
+        prompt: str | None = None,
+        context_turns: int | None = None,
+    ) -> dict[str, Any]:
+        """Dispatch one turn to the run's next_actor."""
+        data: dict[str, Any] = {}
+        if prompt is not None:
+            data["prompt"] = prompt
+        if context_turns is not None:
+            data["context_turns"] = context_turns
+        return await self._client.request(
+            "POST",
+            f"/api/v1/agent-bridge/runs/{run_id}/auto-step",
+            json=data,
+        )

--- a/sdk/python/tests/test_agent_bridge.py
+++ b/sdk/python/tests/test_agent_bridge.py
@@ -26,6 +26,46 @@ def test_agent_bridge_list_runs_uses_cursor_contract() -> None:
         client.close()
 
 
+def test_agent_bridge_start_and_dispatch_routes() -> None:
+    with patch.object(AragoraClient, "request") as mock_request:
+        mock_request.return_value = {"schema_version": 1, "run_id": "bridge-1"}
+        client = AragoraClient(base_url="https://api.aragora.ai", api_key="test-key")
+        agent_bridge = AgentBridgeAPI(client)
+
+        agent_bridge.start_run(
+            task="Coordinate review",
+            actors=[{"role": "implementer", "harness": "codex"}],
+            run_id="bridge-1",
+            next_actor="implementer",
+            repair_budget_per_turn=2,
+        )
+        agent_bridge.dispatch_turn("bridge-1", role="implementer", prompt="Proceed")
+        agent_bridge.auto_step("bridge-1", context_turns=3)
+
+        assert mock_request.call_args_list[0].args == ("POST", "/api/v1/agent-bridge/runs")
+        assert mock_request.call_args_list[0].kwargs["json"] == {
+            "task": "Coordinate review",
+            "actors": [{"role": "implementer", "harness": "codex"}],
+            "run_id": "bridge-1",
+            "next_actor": "implementer",
+            "repair_budget_per_turn": 2,
+        }
+        assert mock_request.call_args_list[1].args == (
+            "POST",
+            "/api/v1/agent-bridge/runs/bridge-1/dispatch",
+        )
+        assert mock_request.call_args_list[1].kwargs["json"] == {
+            "role": "implementer",
+            "prompt": "Proceed",
+        }
+        assert mock_request.call_args_list[2].args == (
+            "POST",
+            "/api/v1/agent-bridge/runs/bridge-1/auto-step",
+        )
+        assert mock_request.call_args_list[2].kwargs["json"] == {"context_turns": 3}
+        client.close()
+
+
 @pytest.mark.asyncio
 async def test_async_agent_bridge_list_runs_uses_cursor_contract() -> None:
     with patch.object(AragoraAsyncClient, "request") as mock_request:
@@ -42,3 +82,38 @@ async def test_async_agent_bridge_list_runs_uses_cursor_contract() -> None:
                 "/api/v1/agent-bridge/runs",
                 params={"limit": 20, "cursor": "run:def"},
             )
+
+
+@pytest.mark.asyncio
+async def test_async_agent_bridge_start_and_dispatch_routes() -> None:
+    with patch.object(AragoraAsyncClient, "request") as mock_request:
+        mock_request.return_value = {"schema_version": 1, "run_id": "bridge-1"}
+        async with AragoraAsyncClient(
+            base_url="https://api.aragora.ai", api_key="test-key"
+        ) as client:
+            agent_bridge = AsyncAgentBridgeAPI(client)
+
+            await agent_bridge.start_run(
+                task="Coordinate review",
+                actors=[{"role": "implementer", "harness": "codex"}],
+            )
+            await agent_bridge.dispatch_turn("bridge-1", role="implementer", prompt="Proceed")
+            await agent_bridge.auto_step("bridge-1", prompt="Continue")
+
+            assert mock_request.call_args_list[0].args == (
+                "POST",
+                "/api/v1/agent-bridge/runs",
+            )
+            assert mock_request.call_args_list[0].kwargs["json"] == {
+                "task": "Coordinate review",
+                "actors": [{"role": "implementer", "harness": "codex"}],
+            }
+            assert mock_request.call_args_list[1].args == (
+                "POST",
+                "/api/v1/agent-bridge/runs/bridge-1/dispatch",
+            )
+            assert mock_request.call_args_list[2].args == (
+                "POST",
+                "/api/v1/agent-bridge/runs/bridge-1/auto-step",
+            )
+            assert mock_request.call_args_list[2].kwargs["json"] == {"prompt": "Continue"}

--- a/sdk/typescript/src/namespaces/__tests__/agent-bridge.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/agent-bridge.test.ts
@@ -29,4 +29,44 @@ describe('AgentBridgeAPI', () => {
       params: { limit: 10, cursor: 'run:first' },
     });
   });
+
+  it('maps startRun to the write-gated bridge route', async () => {
+    mockClient.request.mockResolvedValue({ schema_version: 1, run_id: 'bridge-1' });
+
+    await api.startRun({
+      task: 'Coordinate review',
+      actors: [{ role: 'implementer', harness: 'codex' }],
+      run_id: 'bridge-1',
+      next_actor: 'implementer',
+    });
+
+    expect(mockClient.request).toHaveBeenCalledWith('POST', '/api/v1/agent-bridge/runs', {
+      body: {
+        task: 'Coordinate review',
+        actors: [{ role: 'implementer', harness: 'codex' }],
+        run_id: 'bridge-1',
+        next_actor: 'implementer',
+      },
+    });
+  });
+
+  it('maps dispatchTurn and autoStep to run-scoped write routes', async () => {
+    mockClient.request.mockResolvedValue({ schema_version: 1, event_id: 'evt-1' });
+
+    await api.dispatchTurn('bridge-1', { role: 'reviewer', prompt: 'Review this' });
+    await api.autoStep('bridge-1', { context_turns: 3 });
+
+    expect(mockClient.request).toHaveBeenNthCalledWith(
+      1,
+      'POST',
+      '/api/v1/agent-bridge/runs/bridge-1/dispatch',
+      { body: { role: 'reviewer', prompt: 'Review this' } }
+    );
+    expect(mockClient.request).toHaveBeenNthCalledWith(
+      2,
+      'POST',
+      '/api/v1/agent-bridge/runs/bridge-1/auto-step',
+      { body: { context_turns: 3 } }
+    );
+  });
 });

--- a/sdk/typescript/src/namespaces/agent-bridge.ts
+++ b/sdk/typescript/src/namespaces/agent-bridge.ts
@@ -27,6 +27,17 @@ export interface AgentBridgeRun {
   last_event_id: string | null;
 }
 
+export interface AgentBridgeActor {
+  role: string;
+  harness: string;
+  model?: string;
+  session_id?: string;
+  worktree_path?: string;
+  worktree_agent_slug?: string;
+  branch?: string;
+  harness_options?: Record<string, unknown>;
+}
+
 export interface ListAgentBridgeRunsOptions {
   limit?: number;
   cursor?: string;
@@ -36,6 +47,35 @@ export interface AgentBridgeRunListResponse {
   schema_version: 1;
   runs: AgentBridgeRun[];
   next_cursor?: string | null;
+}
+
+export interface StartAgentBridgeRunOptions {
+  task: string;
+  actors: AgentBridgeActor[];
+  run_id?: string;
+  next_actor?: string;
+  worktree_path?: string;
+  worktree_agent_slug?: string;
+  repair_budget_per_turn?: number;
+}
+
+export interface AgentBridgeTurnRecord {
+  schema_version: 1;
+  event_id: string;
+  run_id: string;
+  ts: string;
+  event_type: string;
+  turn_index: number;
+  role: string;
+  harness: string;
+  session_id: string | null;
+  parse_status: string | null;
+  payload: Record<string, unknown>;
+}
+
+export interface AutoStepAgentBridgeRunOptions {
+  prompt?: string;
+  context_turns?: number;
 }
 
 export class AgentBridgeAPI {
@@ -52,6 +92,39 @@ export class AgentBridgeAPI {
     }
     return this.client.request<AgentBridgeRunListResponse>('GET', '/api/v1/agent-bridge/runs', {
       params,
+    });
+  }
+
+  /** Start an agent-bridge run without dispatching a turn. */
+  async startRun(options: StartAgentBridgeRunOptions): Promise<AgentBridgeRun & { roles: Record<string, unknown> }> {
+    return this.client.request<AgentBridgeRun & { roles: Record<string, unknown> }>(
+      'POST',
+      '/api/v1/agent-bridge/runs',
+      { body: options }
+    );
+  }
+
+  /** Dispatch one bridge turn to a run role. */
+  async dispatchTurn(
+    runId: string,
+    options: { role: string; prompt: string }
+  ): Promise<AgentBridgeTurnRecord> {
+    return this.client.request<AgentBridgeTurnRecord>(
+      'POST',
+      `/api/v1/agent-bridge/runs/${runId}/dispatch`,
+      { body: options }
+    );
+  }
+
+  /** Dispatch one turn to the run's next_actor. */
+  async autoStep(
+    runId: string,
+    options?: AutoStepAgentBridgeRunOptions
+  ): Promise<AgentBridgeTurnRecord & { auto_step: { role: string; context_turns: number } }> {
+    return this.client.request<
+      AgentBridgeTurnRecord & { auto_step: { role: string; context_turns: number } }
+    >('POST', `/api/v1/agent-bridge/runs/${runId}/auto-step`, {
+      body: options ?? {},
     });
   }
 }

--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -17378,7 +17378,11 @@ export interface paths {
          */
         get: operations["listAgentBridgeRuns"];
         put?: never;
-        post?: never;
+        /**
+         * Start agent bridge run
+         * @description Start a persisted bridge run without dispatching a turn. This operator-local write endpoint is separately feature-gated because subsequent dispatch can spawn local model harness processes.
+         */
+        post: operations["startAgentBridgeRun"];
         delete?: never;
         options?: never;
         head?: never;
@@ -17399,6 +17403,46 @@ export interface paths {
         get: operations["getAgentBridgeRun"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agent-bridge/runs/{run_id}/auto-step": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Auto-dispatch the next bridge actor
+         * @description Compose a continuation prompt from the run task and recent transcript, then dispatch one turn to next_actor. This is one-step automation, not a daemon.
+         */
+        post: operations["autoStepAgentBridgeRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agent-bridge/runs/{run_id}/dispatch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dispatch one bridge turn
+         * @description Dispatch one prompt to a registered role in an active bridge run.
+         */
+        post: operations["dispatchAgentBridgeTurn"];
         delete?: never;
         options?: never;
         head?: never;
@@ -28666,6 +28710,26 @@ export interface paths {
          * @description Mark a task as failed.
          */
         post: operations["createControlPlaneTasksFail"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/coordination/active-work": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get active agent work snapshot
+         * @description Return a compact, agent-readable snapshot over existing fleet claims, developer leases, merge queue entries, worktree sessions, and active agent bridge runs.
+         */
+        get: operations["getCoordinationActiveWork"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -98671,6 +98735,165 @@ export interface operations {
             };
         };
     };
+    startAgentBridgeRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    task: string;
+                    actors: {
+                        role: string;
+                        harness: string;
+                        model?: string;
+                        session_id?: string;
+                        worktree_path?: string;
+                        worktree_agent_slug?: string;
+                        branch?: string;
+                        harness_options?: {
+                            [key: string]: unknown;
+                        };
+                    }[];
+                    run_id?: string;
+                    next_actor?: string;
+                    worktree_path?: string;
+                    worktree_agent_slug?: string;
+                    /** @default 1 */
+                    repair_budget_per_turn?: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Started agent bridge run */
+            201: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {integer} */
+                        schema_version: 1;
+                        run_id: string;
+                        task: string;
+                        status: string;
+                        /** Format: date-time */
+                        created_at: string;
+                        /** Format: date-time */
+                        updated_at: string;
+                        /** Format: date-time */
+                        completed_at: string | null;
+                        last_turn_index: number;
+                        next_actor: string | null;
+                        repair_budget_per_turn: number;
+                        footer_mode: string;
+                        worktree_cleanup_mode: string;
+                        participants: {
+                            role: string;
+                            harness: string;
+                            model: string;
+                        }[];
+                        last_event_id: string | null;
+                        roles: {
+                            [key: string]: {
+                                role: string;
+                                harness: string;
+                                model: string;
+                                session_id: string | null;
+                                worktree_agent_slug: string | null;
+                                worktree_path: string | null;
+                                branch: string | null;
+                                /** @enum {string} */
+                                session_status: "not_started" | "active" | "completed" | "failed";
+                                /** Format: date-time */
+                                started_at: string | null;
+                                last_turn_index: number;
+                                /** Format: date-time */
+                                last_completed_at: string | null;
+                                harness_options?: {
+                                    [key: string]: unknown;
+                                };
+                            };
+                        };
+                        worktree_path: string | null;
+                        worktree_agent_slug: string | null;
+                    };
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - Authentication required or token invalid */
+            401: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden - Insufficient permissions for this operation */
+            403: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Conflict - The request could not be completed */
+            409: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     getAgentBridgeRun: {
         parameters: {
             query?: never;
@@ -98785,6 +99008,273 @@ export interface operations {
             };
             /** @description Not found - The requested resource does not exist */
             404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    autoStepAgentBridgeRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Bridge run identifier. */
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    prompt?: string;
+                    /** @default 5 */
+                    context_turns?: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Auto-step dispatch result */
+            200: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {integer} */
+                        schema_version?: 1;
+                        event_id?: string;
+                        run_id?: string;
+                        /** Format: date-time */
+                        ts?: string;
+                        /** @enum {string} */
+                        event_type?: "run_started" | "run_failed" | "run_completed" | "turn.started" | "turn.result" | "turn.completed" | "turn.repair_requested" | "footer_ok" | "footer_malformed" | "footer_missing";
+                        turn_index?: number;
+                        role?: string;
+                        harness?: string;
+                        session_id?: string | null;
+                        /** @enum {string|null} */
+                        parse_status?: "ok" | "missing" | "malformed" | null;
+                        payload?: {
+                            [key: string]: unknown;
+                        };
+                        auto_step: {
+                            role: string;
+                            context_turns: number;
+                        };
+                    } & {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - Authentication required or token invalid */
+            401: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden - Insufficient permissions for this operation */
+            403: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Conflict - The request could not be completed */
+            409: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    dispatchAgentBridgeTurn: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Bridge run identifier. */
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    role: string;
+                    prompt: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Agent bridge turn event */
+            200: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {integer} */
+                        schema_version: 1;
+                        event_id: string;
+                        run_id: string;
+                        /** Format: date-time */
+                        ts: string;
+                        /** @enum {string} */
+                        event_type: "run_started" | "run_failed" | "run_completed" | "turn.started" | "turn.result" | "turn.completed" | "turn.repair_requested" | "footer_ok" | "footer_malformed" | "footer_missing";
+                        turn_index: number;
+                        role: string;
+                        harness: string;
+                        session_id: string | null;
+                        /** @enum {string|null} */
+                        parse_status: "ok" | "missing" | "malformed" | null;
+                        payload: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - Authentication required or token invalid */
+            401: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden - Insufficient permissions for this operation */
+            403: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Conflict - The request could not be completed */
+            409: {
                 headers: {
                     /** @description Unique request identifier for tracing and debugging */
                     "X-Request-ID"?: string;
@@ -121441,6 +121931,92 @@ export interface operations {
             };
             /** @description Not found - The requested resource does not exist */
             404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getCoordinationActiveWork: {
+        parameters: {
+            query?: {
+                /** @description Base branch for worktree status. */
+                base?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Active work snapshot */
+            200: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {integer} */
+                        schema_version: 1;
+                        repo_root: string;
+                        base_branch: string;
+                        /** Format: date-time */
+                        generated_at: string;
+                        active_owners: Record<string, never>[];
+                        claimed_paths: string[];
+                        avoid_paths: string[];
+                        avoid_path_hints?: Record<string, never>[];
+                        worktrees: Record<string, never>[];
+                        fleet_claims: Record<string, never>[];
+                        active_leases: Record<string, never>[];
+                        merge_queue: Record<string, never>[];
+                        bridge_runs: Record<string, never>[];
+                        counts: {
+                            [key: string]: unknown;
+                        };
+                        source_errors: Record<string, never>[];
+                    };
+                };
+            };
+            /** @description Unauthorized - Authentication required or token invalid */
+            401: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden - Insufficient permissions for this operation */
+            403: {
                 headers: {
                     /** @description Unique request identifier for tracing and debugging */
                     "X-Request-ID"?: string;

--- a/tests/handlers/control_plane/test_coordination.py
+++ b/tests/handlers/control_plane/test_coordination.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,6 +23,8 @@ from aragora.coordination.cross_workspace import (
     SharingScope,
 )
 from aragora.server.handlers.control_plane import ControlPlaneHandler
+from aragora.swarm.agent_bridge.store import BridgeStore
+from aragora.swarm.agent_bridge.types import BridgeRun, Participant
 from aragora.worktree.integration_worker import FleetIntegrationOutcome
 
 
@@ -479,6 +482,88 @@ class TestFleetStatus:
         data = json.loads(result.body)
         assert data["coordination"]["counts"] == {}
         assert "database is locked" in data["coordination"]["error"]
+
+    @patch("aragora.server.handlers.control_plane.coordination.FleetCoordinationStore")
+    @patch("aragora.server.handlers.control_plane.coordination.build_fleet_rows")
+    @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
+    def test_active_work_compacts_fleet_leases_and_bridge_runs(
+        self,
+        mock_resolve,
+        mock_build,
+        mock_store_cls,
+        tmp_path: Path,
+        handler: ControlPlaneHandler,
+    ):
+        from aragora.nomic.dev_coordination import DevCoordinationStore
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        mock_resolve.return_value = repo
+        mock_build.return_value = [
+            {
+                "session_id": "session-a",
+                "agent": "codex",
+                "path": str(repo / ".worktrees" / "session-a"),
+                "branch": "codex/session-a",
+            }
+        ]
+        store = MagicMock()
+        store.list_claims.return_value = [
+            {"session_id": "session-a", "path": "aragora/server/handlers/agent_bridge.py"}
+        ]
+        store.list_merge_queue.return_value = [
+            {"session_id": "session-a", "branch": "codex/session-a", "receipt_id": "receipt-1"}
+        ]
+        mock_store_cls.return_value = store
+        DevCoordinationStore(repo_root=repo).claim_lease(
+            task_id="task-1",
+            title="Step C",
+            owner_agent="factory",
+            owner_session_id="factory-1",
+            branch="factory/step-c",
+            worktree_path=str(repo / ".worktrees" / "factory"),
+            claimed_paths=["aragora/review/invalidation.py"],
+            allowed_globs=["tests/review/**"],
+            metadata={"receipt_id": "receipt-2"},
+            allow_overlap=True,
+        )
+        bridge_store = BridgeStore(repo)
+        bridge_store.save_run(
+            BridgeRun(
+                run_id="bridge-active",
+                task="Cross-check a PR",
+                created_at="2026-04-25T15:00:00Z",
+                updated_at="2026-04-25T15:05:00Z",
+                status="running",
+                completed_at=None,
+                last_turn_index=1,
+                next_actor="reviewer",
+                repair_budget_per_turn=1,
+                footer_mode="prompt_injected",
+                worktree_cleanup_mode="operator_triggered",
+                participants=[Participant(role="reviewer", harness="claude", model="opus")],
+                worktree_path=str(repo),
+                worktree_agent_slug="codex",
+            )
+        )
+
+        result = handler._handle_active_work({})
+
+        assert result.status_code == 200
+        data = json.loads(result.body)
+        assert data["repo_root"] == str(repo)
+        assert data["claimed_paths"] == ["aragora/server/handlers/agent_bridge.py"]
+        assert data["avoid_paths"] == [
+            "aragora/review/invalidation.py",
+            "aragora/server/handlers/agent_bridge.py",
+            "tests/review/**",
+        ]
+        assert data["bridge_runs"][0]["run_id"] == "bridge-active"
+        owners = {owner["session_id"]: owner for owner in data["active_owners"]}
+        assert owners["session-a"]["claimed_paths"] == ["aragora/server/handlers/agent_bridge.py"]
+        assert owners["factory-1"]["receipt_ids"] == ["receipt-2"]
+        assert owners["bridge:bridge-active:reviewer"]["bridge_run_ids"] == ["bridge-active"]
 
     @patch("aragora.server.handlers.control_plane.coordination.build_fleet_rows")
     @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")

--- a/tests/handlers/test_agent_bridge_handler.py
+++ b/tests/handlers/test_agent_bridge_handler.py
@@ -24,10 +24,21 @@ def _parse_json_body(result: object) -> dict[str, object]:
     return json.loads(body) if body else {}
 
 
-def _mock_http_handler(*, headers: dict[str, str] | None = None) -> MagicMock:
+def _mock_http_handler(*, headers: dict[str, str] | None = None, command: str = "GET") -> MagicMock:
     mock = MagicMock()
     mock.headers = headers or {}
+    mock.command = command
     mock.client_address = ("127.0.0.1", 12345)
+    return mock
+
+
+def _mock_json_post(body: dict[str, object]) -> MagicMock:
+    raw = json.dumps(body).encode("utf-8")
+    mock = _mock_http_handler(
+        headers={"Content-Length": str(len(raw)), "Content-Type": "application/json"},
+        command="POST",
+    )
+    mock.rfile.read.return_value = raw
     return mock
 
 
@@ -640,6 +651,223 @@ def test_malformed_cursor_returns_400(
     assert result is not None
     assert result.status_code == 400
     assert _parse_json_body(result) == {"error": "Invalid bridge cursor"}
+
+
+def test_start_run_write_api_persists_role_keyed_sessions(bridge_repo: Path) -> None:
+    handler = AgentBridgeHandler(
+        ctx={"agent_bridge_repo_root": str(bridge_repo), "agent_bridge_write_enabled": True}
+    )
+
+    result = handler.handle(
+        "/api/v1/agent-bridge/runs",
+        {},
+        _mock_json_post(
+            {
+                "run_id": "bridge-http-start",
+                "task": "Coordinate a no-op smoke",
+                "next_actor": "implementer",
+                "worktree_path": str(bridge_repo),
+                "worktree_agent_slug": "codex-http",
+                "actors": [
+                    {
+                        "role": "implementer",
+                        "harness": "codex",
+                        "model": "gpt-5.5",
+                        "harness_options": {"reasoning_effort": "low"},
+                    },
+                    {"role": "reviewer", "harness": "claude", "model": "claude-opus-4-7"},
+                ],
+            }
+        ),
+    )
+
+    assert result is not None
+    assert result.status_code == 201
+    payload = _parse_json_body(result)
+    assert payload["run_id"] == "bridge-http-start"
+    assert payload["status"] == "running"
+    assert payload["next_actor"] == "implementer"
+    assert set(payload["roles"]) == {"implementer", "reviewer"}
+    assert payload["roles"]["implementer"]["harness_options"] == {"reasoning_effort": "low"}
+
+
+def test_start_run_rejects_write_gate_disabled(bridge_repo: Path) -> None:
+    handler = AgentBridgeHandler(ctx={"agent_bridge_repo_root": str(bridge_repo)})
+
+    result = handler.handle(
+        "/api/v1/agent-bridge/runs",
+        {},
+        _mock_json_post({"task": "blocked", "actors": [{"role": "a", "harness": "codex"}]}),
+    )
+
+    assert result is not None
+    assert result.status_code == 403
+    assert _parse_json_body(result) == {"error": "Agent bridge write API is disabled"}
+
+
+def test_dispatch_turn_write_api_uses_injected_broker(
+    bridge_repo: Path,
+    store: BridgeStore,
+) -> None:
+    run = _write_run(
+        store,
+        run_id="bridge-dispatch",
+        created_at="2026-04-21T20:00:00Z",
+        updated_at="2026-04-21T20:01:00Z",
+    )
+    fake_event = _turn_event(
+        run_id=run.run_id,
+        turn_index=1,
+        seq=2,
+        event_type="footer_ok",
+        role="reviewer",
+        ts="2026-04-21T20:02:00Z",
+        parse_status="ok",
+        payload={"footer": BridgeFooter("ok", None, False, True, [], []).to_dict()},
+    )
+    broker = MagicMock()
+    broker.dispatch_turn.return_value = fake_event
+    handler = AgentBridgeHandler(
+        ctx={
+            "agent_bridge_repo_root": str(bridge_repo),
+            "agent_bridge_write_enabled": True,
+            "agent_bridge_broker": broker,
+        }
+    )
+
+    result = handler.handle(
+        "/api/v1/agent-bridge/runs/bridge-dispatch/dispatch",
+        {},
+        _mock_json_post({"role": "reviewer", "prompt": "Review this"}),
+    )
+
+    assert result is not None
+    assert result.status_code == 200
+    broker.dispatch_turn.assert_called_once_with(
+        run_id="bridge-dispatch",
+        role="reviewer",
+        prompt="Review this",
+    )
+    payload = _parse_json_body(result)
+    assert payload["event_id"] == fake_event.event_id
+
+
+def test_dispatch_rejects_completed_run(
+    bridge_repo: Path,
+    store: BridgeStore,
+) -> None:
+    _write_run(
+        store,
+        run_id="bridge-completed",
+        created_at="2026-04-21T20:00:00Z",
+        updated_at="2026-04-21T20:01:00Z",
+        status="completed",
+        next_actor=None,
+    )
+    handler = AgentBridgeHandler(
+        ctx={"agent_bridge_repo_root": str(bridge_repo), "agent_bridge_write_enabled": True}
+    )
+
+    result = handler.handle(
+        "/api/v1/agent-bridge/runs/bridge-completed/dispatch",
+        {},
+        _mock_json_post({"role": "reviewer", "prompt": "Review this"}),
+    )
+
+    assert result is not None
+    assert result.status_code == 409
+
+
+def test_auto_step_dispatches_next_actor_with_composed_prompt(
+    bridge_repo: Path,
+    store: BridgeStore,
+) -> None:
+    run = _write_run(
+        store,
+        run_id="bridge-auto-step",
+        created_at="2026-04-21T20:00:00Z",
+        updated_at="2026-04-21T20:01:00Z",
+        next_actor="reviewer",
+    )
+    store.append_event(
+        run.run_id,
+        _turn_event(
+            run_id=run.run_id,
+            turn_index=1,
+            seq=0,
+            event_type="turn.result",
+            role="implementer",
+            ts="2026-04-21T20:01:00Z",
+            parse_status="ok",
+            payload={
+                "message_text": _footer_text(
+                    "Implemented a patch.",
+                    summary="patch ready",
+                    next_actor="reviewer",
+                )
+            },
+        ),
+    )
+    fake_event = _turn_event(
+        run_id=run.run_id,
+        turn_index=2,
+        seq=2,
+        event_type="footer_ok",
+        role="reviewer",
+        ts="2026-04-21T20:02:00Z",
+        parse_status="ok",
+        payload={"footer": BridgeFooter("reviewed", None, False, True, [], []).to_dict()},
+    )
+    broker = MagicMock()
+    broker.dispatch_turn.return_value = fake_event
+    handler = AgentBridgeHandler(
+        ctx={
+            "agent_bridge_repo_root": str(bridge_repo),
+            "agent_bridge_write_enabled": True,
+            "agent_bridge_broker": broker,
+        }
+    )
+
+    result = handler.handle(
+        "/api/v1/agent-bridge/runs/bridge-auto-step/auto-step",
+        {},
+        _mock_json_post({"context_turns": 1}),
+    )
+
+    assert result is not None
+    assert result.status_code == 200
+    kwargs = broker.dispatch_turn.call_args.kwargs
+    assert kwargs["run_id"] == "bridge-auto-step"
+    assert kwargs["role"] == "reviewer"
+    assert "Implemented a patch." in kwargs["prompt"]
+    payload = _parse_json_body(result)
+    assert payload["auto_step"] == {"role": "reviewer", "context_turns": 1}
+
+
+@pytest.mark.no_auto_auth
+def test_rbac_write_requires_agent_bridge_write_permission(
+    bridge_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aragora.server.auth import auth_config
+
+    monkeypatch.setattr(auth_config, "enabled", True)
+    handler = AgentBridgeHandler(
+        ctx={"agent_bridge_repo_root": str(bridge_repo), "agent_bridge_write_enabled": True}
+    )
+    http = _mock_json_post({"task": "blocked", "actors": [{"role": "a", "harness": "codex"}]})
+    http._auth_context = AuthorizationContext(
+        user_id="viewer-1",
+        user_email="viewer@example.com",
+        org_id="org-1",
+        roles={"developer"},
+        permissions={"agent_bridge:read"},
+    )
+
+    result = handler.handle("/api/v1/agent-bridge/runs", {}, http)
+
+    assert result is not None
+    assert result.status_code == 403
 
 
 @pytest.mark.no_auto_auth

--- a/tests/handlers/test_agent_bridge_handler.py
+++ b/tests/handlers/test_agent_bridge_handler.py
@@ -687,8 +687,12 @@ def test_start_run_write_api_persists_role_keyed_sessions(bridge_repo: Path) -> 
     assert payload["run_id"] == "bridge-http-start"
     assert payload["status"] == "running"
     assert payload["next_actor"] == "implementer"
-    assert set(payload["roles"]) == {"implementer", "reviewer"}
-    assert payload["roles"]["implementer"]["harness_options"] == {"reasoning_effort": "low"}
+    roles = payload["roles"]
+    assert isinstance(roles, dict)
+    assert set(roles) == {"implementer", "reviewer"}
+    implementer_role = roles["implementer"]
+    assert isinstance(implementer_role, dict)
+    assert implementer_role["harness_options"] == {"reasoning_effort": "low"}
 
 
 def test_start_run_rejects_write_gate_disabled(bridge_repo: Path) -> None:
@@ -842,6 +846,39 @@ def test_auto_step_dispatches_next_actor_with_composed_prompt(
     assert "Implemented a patch." in kwargs["prompt"]
     payload = _parse_json_body(result)
     assert payload["auto_step"] == {"role": "reviewer", "context_turns": 1}
+
+
+def test_auto_step_rejects_awaiting_human_run(
+    bridge_repo: Path,
+    store: BridgeStore,
+) -> None:
+    _write_run(
+        store,
+        run_id="bridge-needs-human",
+        created_at="2026-04-21T20:00:00Z",
+        updated_at="2026-04-21T20:01:00Z",
+        status="awaiting_human",
+        next_actor="reviewer",
+    )
+    broker = MagicMock()
+    handler = AgentBridgeHandler(
+        ctx={
+            "agent_bridge_repo_root": str(bridge_repo),
+            "agent_bridge_write_enabled": True,
+            "agent_bridge_broker": broker,
+        }
+    )
+
+    result = handler.handle(
+        "/api/v1/agent-bridge/runs/bridge-needs-human/auto-step",
+        {},
+        _mock_json_post({"context_turns": 1}),
+    )
+
+    assert result is not None
+    assert result.status_code == 409
+    assert _parse_json_body(result)["error"] == "Bridge run is awaiting human input"
+    broker.dispatch_turn.assert_not_called()
 
 
 @pytest.mark.no_auto_auth


### PR DESCRIPTION
## Summary

Adds the operator-local Agent Bridge ops plane requested in the orchestration refinement plan:

- Adds `ARAGORA_FEATURE_AGENT_BRIDGE_WRITE` and `PERM_AGENT_BRIDGE_WRITE` so read-only bridge visibility does not silently enable process-spawning writes.
- Adds write-gated bridge endpoints:
  - `POST /api/v1/agent-bridge/runs`
  - `POST /api/v1/agent-bridge/runs/{run_id}/dispatch`
  - `POST /api/v1/agent-bridge/runs/{run_id}/auto-step`
- Adds `GET /api/v1/coordination/active-work`, a compact agent-readable snapshot over fleet claims, dev leases, merge queue entries, worktrees, and active bridge runs.
- Extends OpenAPI plus Python and TypeScript SDK namespaces.
- Upgrades the existing `/autonomous/bridge` UI from read-only copy to operator-actionable controls guarded by the server-side write gate.

## Why this matters

This preserves the key generalized capability: state-preserving harness interoperability. Claude Code, Codex, Droid, etc. keep their own native sessions and context, while Aragora supplies a durable broker, footer contract, active-work snapshot, and operator-gated handoff API. That is materially different from frameworks that absorb agents into one runtime object model.

## Validation

- `python3 scripts/agent_bridge_live_smoke.py --repo /private/tmp/aragora-agent-ops-plane --artifact-dir /private/tmp/aragora-agent-bridge-live-smoke` passed before implementation.
- `python3 -m pytest tests/handlers/test_agent_bridge_handler.py tests/handlers/control_plane/test_coordination.py sdk/python/tests/test_agent_bridge.py -q` passed: 71 tests.
- `python3 -m ruff check` on touched Python files passed.
- `python3 -m mypy aragora/server/handlers/agent_bridge.py sdk/python/aragora_sdk/namespaces/agent_bridge.py` passed.
- `npm test -- --run src/namespaces/__tests__/agent-bridge.test.ts` in `sdk/typescript` passed.
- `npm run typecheck` in `sdk/typescript` passed.
- `npx tsc --noEmit --pretty false` in `aragora/live` passed.
- Targeted ESLint for touched bridge UI files passed.
- OpenAPI generation includes the new agent-bridge write endpoints and `/api/v1/coordination/active-work`.

## Notes

`aragora/server/handlers/control_plane/coordination.py` still has existing standalone mypy union-attr errors unrelated to this PR; the focused runtime tests cover the new active-work path.