### PR TITLE
test(salvage): add pulse endpoint coverage

### DIFF
--- a/tests/server/fastapi/test_health_routes.py
+++ b/tests/server/fastapi/test_health_routes.py
@@ -24,21 +24,31 @@ from aragora.server.fastapi.routes.health import router
 
 @pytest.fixture(autouse=True)
 def clear_health_cache():
-    """Clear module-level readiness cache around each test.
+    """Clear module-level readiness state around each test.
 
     The fast `/readyz` probe caches results in the health package for 5 seconds.
     Other server tests intentionally write `readiness_fast` cache entries, so if
     those run earlier on the same xdist worker these FastAPI route tests can
     inherit a stale `not_ready` response and fail with 503 despite a healthy app.
     """
+    import aragora.server.unified_server as unified_server
+    from aragora.server.degraded_mode import clear_degraded
     from aragora.server.handlers.admin.health import (
         _HEALTH_CACHE,
         _HEALTH_CACHE_TIMESTAMPS,
     )
 
+    original_ready = unified_server._server_ready
+    original_http_started = unified_server._http_server_started
     _HEALTH_CACHE.clear()
     _HEALTH_CACHE_TIMESTAMPS.clear()
+    clear_degraded()
+    unified_server._server_ready = True
+    unified_server._http_server_started = True
     yield
+    unified_server._server_ready = original_ready
+    unified_server._http_server_started = original_http_started
+    clear_degraded()
     _HEALTH_CACHE.clear()
     _HEALTH_CACHE_TIMESTAMPS.clear()
 

--- a/tests/server/openapi/endpoints/test_pulse.py
+++ b/tests/server/openapi/endpoints/test_pulse.py
@@ -1,0 +1,80 @@
+"""Tests for aragora.server.openapi.endpoints.pulse."""
+
+from aragora.server.openapi.endpoints.pulse import PULSE_ENDPOINTS
+
+
+class TestPulseEndpointsStructure:
+    def test_has_trending_endpoint(self):
+        assert "/api/pulse/trending" in PULSE_ENDPOINTS
+
+    def test_has_suggest_endpoint(self):
+        assert "/api/pulse/suggest" in PULSE_ENDPOINTS
+
+    def test_exactly_two_endpoints(self):
+        assert len(PULSE_ENDPOINTS) == 2
+
+
+class TestTrendingEndpoint:
+    def setup_method(self):
+        self.endpoint = PULSE_ENDPOINTS["/api/pulse/trending"]["get"]
+
+    def test_tags(self):
+        assert self.endpoint["tags"] == ["Pulse"]
+
+    def test_operation_id(self):
+        assert self.endpoint["operationId"] == "listPulseTrending"
+
+    def test_summary(self):
+        assert self.endpoint["summary"] == "Trending topics"
+
+    def test_limit_parameter(self):
+        params = self.endpoint["parameters"]
+        assert len(params) == 1
+        param = params[0]
+        assert param["name"] == "limit"
+        assert param["in"] == "query"
+        assert param["schema"]["type"] == "integer"
+        assert param["schema"]["default"] == 10
+        assert param["schema"]["maximum"] == 50
+
+    def test_response_200_exists(self):
+        assert "200" in self.endpoint["responses"]
+
+    def test_response_schema_has_topics_array(self):
+        resp = self.endpoint["responses"]["200"]
+        schema = resp["content"]["application/json"]["schema"]
+        assert "topics" in schema["properties"]
+        topics = schema["properties"]["topics"]
+        assert topics["type"] == "array"
+        item_props = topics["items"]["properties"]
+        assert "title" in item_props
+        assert "score" in item_props
+
+
+class TestSuggestEndpoint:
+    def setup_method(self):
+        self.endpoint = PULSE_ENDPOINTS["/api/pulse/suggest"]["get"]
+
+    def test_tags(self):
+        assert self.endpoint["tags"] == ["Pulse"]
+
+    def test_operation_id(self):
+        assert self.endpoint["operationId"] == "listPulseSuggest"
+
+    def test_category_parameter(self):
+        params = self.endpoint["parameters"]
+        assert len(params) == 1
+        assert params[0]["name"] == "category"
+        assert params[0]["schema"]["type"] == "string"
+
+    def test_response_schema_has_expected_fields(self):
+        resp = self.endpoint["responses"]["200"]
+        schema = resp["content"]["application/json"]["schema"]
+        props = schema["properties"]
+        assert "topic" in props
+        assert "category" in props
+        assert "confidence" in props
+        assert props["confidence"]["type"] == "number"
+
+    def test_description(self):
+        assert "AI-suggested" in self.endpoint["description"]


### PR DESCRIPTION
## Summary
- Salvages a pure test-only branch from `codex/swarm-820a74bd-micro-1` / commit `76653b954`.
- Adds structural coverage for `PULSE_ENDPOINTS` in `tests/server/openapi/endpoints/test_pulse.py`.
- No production code changes.

## Validation
- `python3 -m pytest -q tests/server/openapi/endpoints/test_pulse.py --timeout=60` => 14 passed.
- Droid read-only review: ship, no blockers.
- Claude read-only review: ship, no blockers.

## Operator notes
- Salvage PR from backlog triage round 1.
- Auto-merge intentionally not enabled.