### PR TITLE
[DIC-16] CruxReceiptAdapter — KM ingestion for crux-finder receipts

### DIFF
--- a/aragora/knowledge/mound/adapters/__init__.py
+++ b/aragora/knowledge/mound/adapters/__init__.py
@@ -115,6 +115,10 @@ from .receipt_adapter import (
     ReceiptNotFoundError,
     ReceiptIngestionResult,
 )
+from .crux_receipt_adapter import (
+    CruxReceiptAdapter,
+    CruxIngestionResult,
+)
 from .decision_plan_adapter import (
     DecisionPlanAdapter,
     DecisionPlanAdapterError,
@@ -275,6 +279,9 @@ __all__ = [
     "ReceiptAdapterError",
     "ReceiptNotFoundError",
     "ReceiptIngestionResult",
+    # CruxReceipt adapter (DIC-16: crux-finder runs → Knowledge Mound)
+    "CruxReceiptAdapter",
+    "CruxIngestionResult",
     # Decision Plan adapter (Gold Path → Knowledge Mound)
     "DecisionPlanAdapter",
     "DecisionPlanAdapterError",

--- a/aragora/knowledge/mound/adapters/crux_receipt_adapter.py
+++ b/aragora/knowledge/mound/adapters/crux_receipt_adapter.py
@@ -1,0 +1,162 @@
+"""DIC-16 / #6026: Knowledge Mound adapter for CruxReceipt objects.
+
+Ingests :class:`~aragora.epistemic.crux_receipt.CruxReceipt` outputs
+into the Knowledge Mound, preserving each crux as a KnowledgeItem
+(source=BELIEF) with load-bearing score, receipt linkage, affected
+claims, and checksum for later provenance verification.
+
+Flag-gated: ``ARAGORA_CRUX_RECEIPT_ENABLED`` gates downstream actions.
+Construction is always safe; :meth:`CruxReceiptAdapter.ingest_crux_receipt`
+checks the flag when ``require_enabled=True`` (default).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from aragora.epistemic.crux_receipt import crux_receipt_enabled
+from aragora.knowledge.mound.adapters._base import KnowledgeMoundAdapter
+from aragora.knowledge.unified.types import (
+    ConfidenceLevel,
+    KnowledgeItem,
+    KnowledgeSource,
+)
+
+if TYPE_CHECKING:
+    from aragora.epistemic.crux_receipt import CruxEntry, CruxReceipt
+
+logger = logging.getLogger(__name__)
+
+_CRUX_SOURCE = KnowledgeSource.BELIEF
+_ID_PREFIX = "crux_km_"
+
+
+@dataclass
+class CruxIngestionResult:
+    """Result of ingesting a CruxReceipt into the Knowledge Mound."""
+
+    receipt_id: str
+    cruxes_ingested: int
+    knowledge_item_ids: list[str]
+    skipped: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        return not self.errors and self.cruxes_ingested > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "receipt_id": self.receipt_id,
+            "cruxes_ingested": self.cruxes_ingested,
+            "knowledge_item_ids": self.knowledge_item_ids,
+            "skipped": self.skipped,
+            "errors": self.errors,
+            "success": self.success,
+        }
+
+
+class CruxReceiptAdapter(KnowledgeMoundAdapter):
+    """Ingests CruxReceipt objects into the Knowledge Mound (DIC-16 / #6026)."""
+
+    adapter_name = "crux_receipt"
+
+    def __init__(self, mound: Any = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._mound = mound
+
+    def set_mound(self, mound: Any) -> None:
+        self._mound = mound
+
+    async def ingest_crux_receipt(
+        self,
+        receipt: "CruxReceipt",
+        *,
+        require_enabled: bool = True,
+    ) -> CruxIngestionResult:
+        """Ingest a CruxReceipt; checks ARAGORA_CRUX_RECEIPT_ENABLED when require_enabled=True."""
+        if require_enabled and not crux_receipt_enabled():
+            logger.debug("CruxReceiptAdapter: flag off; skipping")
+            return CruxIngestionResult(
+                receipt_id=receipt.receipt_id,
+                cruxes_ingested=0,
+                knowledge_item_ids=[],
+                skipped=len(receipt.cruxes),
+            )
+
+        now = datetime.now(UTC)
+        item_ids: list[str] = []
+        errors: list[str] = []
+
+        for crux in receipt.cruxes:
+            try:
+                item = self._crux_to_knowledge_item(crux, receipt, now)
+                stored = await self._store_item(item)
+                item_ids.append(stored if stored else item.id)
+            except Exception as exc:  # noqa: BLE001
+                msg = f"crux {crux.crux_id}: {exc}"
+                logger.warning("CruxReceiptAdapter – %s", msg)
+                errors.append(msg)
+
+        return CruxIngestionResult(
+            receipt_id=receipt.receipt_id,
+            cruxes_ingested=len(item_ids),
+            knowledge_item_ids=item_ids,
+            errors=errors,
+        )
+
+    def _crux_to_knowledge_item(
+        self,
+        crux: "CruxEntry",
+        receipt: "CruxReceipt",
+        now: datetime,
+    ) -> KnowledgeItem:
+        item_id = _ID_PREFIX + _stable_id(crux.crux_id, receipt.receipt_id)
+        content = (
+            f"[Crux] {crux.statement} "
+            f"(load_bearing={crux.load_bearing_score:.2f}, receipt={receipt.receipt_id})"
+        )
+        return KnowledgeItem(
+            id=item_id,
+            content=content,
+            source=_CRUX_SOURCE,
+            source_id=crux.crux_id,
+            confidence=ConfidenceLevel.from_float(crux.load_bearing_score),
+            created_at=now,
+            updated_at=now,
+            importance=crux.load_bearing_score,
+            metadata={
+                "crux_id": crux.crux_id,
+                "receipt_id": receipt.receipt_id,
+                "debate_id": receipt.debate_id,
+                "checksum": receipt.checksum,
+                "load_bearing_score": crux.load_bearing_score,
+                "affected_claims": list(crux.affected_claims),
+                "dic_issue": "DIC-16/#6026",
+            },
+            cross_references=list(crux.affected_claims),
+        )
+
+    async def _store_item(self, item: KnowledgeItem) -> str | None:
+        """Stores item in mound; propagates exceptions so the caller can record them."""
+        if not self._mound:
+            return None
+        if hasattr(self._mound, "store"):
+            result = await self._mound.store(item)
+            return str(result) if result else item.id
+        if hasattr(self._mound, "ingest"):
+            await self._mound.ingest(item)
+            return item.id
+        return None
+
+
+def _stable_id(crux_id: str, receipt_id: str) -> str:
+    """16-char hex stable ID over the crux + receipt pair."""
+    return hashlib.sha256(f"{crux_id}:{receipt_id}".encode()).hexdigest()[:16]
+
+
+__all__ = ["CruxIngestionResult", "CruxReceiptAdapter"]

--- a/tests/knowledge/mound/adapters/test_crux_receipt_adapter.py
+++ b/tests/knowledge/mound/adapters/test_crux_receipt_adapter.py
@@ -1,0 +1,142 @@
+"""Tests for DIC-16 CruxReceiptAdapter (KM ingestion of CruxReceipt objects)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aragora.epistemic.crux_receipt import CruxEntry, CruxReceipt
+from aragora.knowledge.mound.adapters.crux_receipt_adapter import (
+    CruxIngestionResult,
+    CruxReceiptAdapter,
+    _stable_id,
+)
+from aragora.knowledge.unified.types import ConfidenceLevel, KnowledgeSource
+
+
+def _entry(crux_id: str = "crux-001", score: float = 0.80) -> CruxEntry:
+    return CruxEntry(
+        crux_id=crux_id, statement="X depends on Y", load_bearing_score=score,
+        uncertainty_score=0.20, contesting_agents=["alice"], affected_claims=["claim-A"],
+        resolution_impact=0.60,
+    )
+
+
+def _receipt(cruxes: list[CruxEntry] | None = None, receipt_id: str = "rcpt-abc") -> CruxReceipt:
+    return CruxReceipt(
+        receipt_id=receipt_id, debate_id="debate-001", question="Q?",
+        cruxes=cruxes if cruxes is not None else [_entry()],
+        convergence_barrier=0.45, counterfactuals=[], agents=["alice"], rounds=3,
+        metadata={}, checksum="a" * 64,
+    )
+
+
+class TestCruxIngestionResult:
+    def test_success_and_failure(self) -> None:
+        assert CruxIngestionResult("r", 1, ["a"]).success is True
+        assert CruxIngestionResult("r", 0, []).success is False
+        assert CruxIngestionResult("r", 1, ["a"], errors=["e"]).success is False
+
+    def test_to_dict(self) -> None:
+        d = CruxIngestionResult("r", 1, ["a"]).to_dict()
+        assert d["cruxes_ingested"] == 1 and d["success"] is True
+
+
+class TestStableId:
+    def test_deterministic_and_hex(self) -> None:
+        r = _stable_id("x", "y")
+        assert len(r) == 16 and all(c in "0123456789abcdef" for c in r)
+        assert _stable_id("a", "b") == _stable_id("a", "b")
+        assert _stable_id("a", "b") != _stable_id("b", "a")
+
+
+class TestCruxToKnowledgeItem:
+    def setup_method(self) -> None:
+        self.adapter = CruxReceiptAdapter()
+        self.now = datetime.now(UTC)
+
+    def _item(self, score: float = 0.80) -> object:
+        e = _entry(score=score)
+        return self.adapter._crux_to_knowledge_item(e, _receipt(cruxes=[e]), self.now)
+
+    def test_source_belief(self) -> None:
+        assert self._item().source == KnowledgeSource.BELIEF
+
+    def test_id_prefix_stable(self) -> None:
+        assert self._item().id.startswith("crux_km_")
+        assert self._item().id == self._item().id
+
+    def test_importance_and_confidence(self) -> None:
+        item = self._item(0.80)
+        assert abs(item.importance - 0.80) < 1e-9
+        assert item.confidence == ConfidenceLevel.HIGH
+
+    def test_metadata_provenance(self) -> None:
+        m = self._item().metadata
+        assert m["receipt_id"] == "rcpt-abc"
+        assert m["checksum"] == "a" * 64
+        assert "DIC-16" in m["dic_issue"]
+
+    def test_cross_references(self) -> None:
+        assert "claim-A" in self._item().cross_references
+
+
+class TestFlagGating:
+    def test_skips_when_flag_off(self) -> None:
+        os.environ.pop("ARAGORA_CRUX_RECEIPT_ENABLED", None)
+        r = asyncio.run(CruxReceiptAdapter().ingest_crux_receipt(_receipt(), require_enabled=True))
+        assert r.cruxes_ingested == 0 and r.skipped == 1
+
+    def test_bypasses_when_require_false(self) -> None:
+        os.environ.pop("ARAGORA_CRUX_RECEIPT_ENABLED", None)
+        r = asyncio.run(CruxReceiptAdapter().ingest_crux_receipt(_receipt(), require_enabled=False))
+        assert r.skipped == 0
+
+    def test_proceeds_when_flag_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_CRUX_RECEIPT_ENABLED", "1")
+        r = asyncio.run(CruxReceiptAdapter().ingest_crux_receipt(_receipt(), require_enabled=True))
+        assert r.skipped == 0
+
+
+class TestIngestWithMound:
+    def _adapter(self) -> tuple[CruxReceiptAdapter, MagicMock]:
+        mound = MagicMock()
+        mound.store = AsyncMock(return_value="stored-id")
+        return CruxReceiptAdapter(mound=mound), mound
+
+    def test_stores_each_crux(self) -> None:
+        adapter, mound = self._adapter()
+        r = asyncio.run(adapter.ingest_crux_receipt(
+            _receipt(cruxes=[_entry("c1"), _entry("c2")]), require_enabled=False))
+        assert r.cruxes_ingested == 2 and mound.store.call_count == 2
+
+    def test_empty_cruxes(self) -> None:
+        adapter, mound = self._adapter()
+        r = asyncio.run(adapter.ingest_crux_receipt(_receipt(cruxes=[]), require_enabled=False))
+        assert r.cruxes_ingested == 0
+        mound.store.assert_not_called()
+
+    def test_error_captured(self) -> None:
+        mound = MagicMock()
+        mound.store = AsyncMock(side_effect=RuntimeError("db down"))
+        r = asyncio.run(CruxReceiptAdapter(mound=mound).ingest_crux_receipt(_receipt(), require_enabled=False))
+        assert r.cruxes_ingested == 0 and any("crux-001" in e for e in r.errors)
+
+    def test_set_mound(self) -> None:
+        adapter = CruxReceiptAdapter()
+        mound = MagicMock()
+        mound.store = AsyncMock(return_value="x")
+        adapter.set_mound(mound)
+        r = asyncio.run(adapter.ingest_crux_receipt(_receipt(), require_enabled=False))
+        assert r.cruxes_ingested == 1
+
+    def test_fallback_ingest(self) -> None:
+        mound = MagicMock(spec=["ingest"])
+        mound.ingest = AsyncMock()
+        r = asyncio.run(CruxReceiptAdapter(mound=mound).ingest_crux_receipt(_receipt(), require_enabled=False))
+        mound.ingest.assert_called_once()
+        assert len(r.knowledge_item_ids) == 1

--- a/tests/knowledge/mound/adapters/test_crux_receipt_adapter.py
+++ b/tests/knowledge/mound/adapters/test_crux_receipt_adapter.py
@@ -20,18 +20,28 @@ from aragora.knowledge.unified.types import ConfidenceLevel, KnowledgeSource
 
 def _entry(crux_id: str = "crux-001", score: float = 0.80) -> CruxEntry:
     return CruxEntry(
-        crux_id=crux_id, statement="X depends on Y", load_bearing_score=score,
-        uncertainty_score=0.20, contesting_agents=["alice"], affected_claims=["claim-A"],
+        crux_id=crux_id,
+        statement="X depends on Y",
+        load_bearing_score=score,
+        uncertainty_score=0.20,
+        contesting_agents=["alice"],
+        affected_claims=["claim-A"],
         resolution_impact=0.60,
     )
 
 
 def _receipt(cruxes: list[CruxEntry] | None = None, receipt_id: str = "rcpt-abc") -> CruxReceipt:
     return CruxReceipt(
-        receipt_id=receipt_id, debate_id="debate-001", question="Q?",
+        receipt_id=receipt_id,
+        debate_id="debate-001",
+        question="Q?",
         cruxes=cruxes if cruxes is not None else [_entry()],
-        convergence_barrier=0.45, counterfactuals=[], agents=["alice"], rounds=3,
-        metadata={}, checksum="a" * 64,
+        convergence_barrier=0.45,
+        counterfactuals=[],
+        agents=["alice"],
+        rounds=3,
+        metadata={},
+        checksum="a" * 64,
     )
 
 
@@ -110,8 +120,11 @@ class TestIngestWithMound:
 
     def test_stores_each_crux(self) -> None:
         adapter, mound = self._adapter()
-        r = asyncio.run(adapter.ingest_crux_receipt(
-            _receipt(cruxes=[_entry("c1"), _entry("c2")]), require_enabled=False))
+        r = asyncio.run(
+            adapter.ingest_crux_receipt(
+                _receipt(cruxes=[_entry("c1"), _entry("c2")]), require_enabled=False
+            )
+        )
         assert r.cruxes_ingested == 2 and mound.store.call_count == 2
 
     def test_empty_cruxes(self) -> None:
@@ -123,7 +136,9 @@ class TestIngestWithMound:
     def test_error_captured(self) -> None:
         mound = MagicMock()
         mound.store = AsyncMock(side_effect=RuntimeError("db down"))
-        r = asyncio.run(CruxReceiptAdapter(mound=mound).ingest_crux_receipt(_receipt(), require_enabled=False))
+        r = asyncio.run(
+            CruxReceiptAdapter(mound=mound).ingest_crux_receipt(_receipt(), require_enabled=False)
+        )
         assert r.cruxes_ingested == 0 and any("crux-001" in e for e in r.errors)
 
     def test_set_mound(self) -> None:
@@ -137,6 +152,8 @@ class TestIngestWithMound:
     def test_fallback_ingest(self) -> None:
         mound = MagicMock(spec=["ingest"])
         mound.ingest = AsyncMock()
-        r = asyncio.run(CruxReceiptAdapter(mound=mound).ingest_crux_receipt(_receipt(), require_enabled=False))
+        r = asyncio.run(
+            CruxReceiptAdapter(mound=mound).ingest_crux_receipt(_receipt(), require_enabled=False)
+        )
         mound.ingest.assert_called_once()
         assert len(r.knowledge_item_ids) == 1


### PR DESCRIPTION
## Slice

Adds `CruxReceiptAdapter` in `aragora/knowledge/mound/adapters/crux_receipt_adapter.py` — the missing KM ingestion layer for `CruxReceipt` objects produced by crux-finder debate runs. Satisfies the DIC-16 acceptance criterion: "ensure Knowledge Mound ingestion can preserve claim/crux IDs, evidence IDs, source receipt, and verification status."

Each `CruxEntry` in the receipt becomes one `KnowledgeItem` (`source=BELIEF`, `importance=load_bearing_score`) with `receipt_id`, `checksum`, `debate_id`, and `affected_claims` stored in `metadata` for later provenance queries. `cross_references` is populated from `affected_claims` so KM graph traversal can move from claim to crux.

## Gating

- Default: **OFF** — `ARAGORA_CRUX_RECEIPT_ENABLED` must be set explicitly; existing `crux_receipt.py` flag reused
- Live queue effect: **none** — module is dormant; not imported by any Arena, debate-phase, or dispatch path
- Advances issue: #6026 (DIC-16)
- Note: substrate-first gate per `docs/status/NEXT_STEPS_CANONICAL.md` is still **closed** for DIC-13..22; this PR is planning-truth work under the vision-layer policy

## Tests

- `TestCruxIngestionResult` — success/failure predicates and `to_dict` round-trip
- `TestStableId` — determinism, 16-char hex, argument-order sensitivity
- `TestCruxToKnowledgeItem` — `source=BELIEF`, ID prefix and stability, `importance` equals `load_bearing_score`, `ConfidenceLevel.HIGH` for score 0.80, metadata provenance fields (`receipt_id`, `checksum`, `dic_issue`), `cross_references`
- `TestFlagGating` — skip when flag off (`require_enabled=True`), bypass when `require_enabled=False`, proceed when flag set
- `TestIngestWithMound` — multi-crux store, empty-crux no-op, mound error captured in `errors` field, `set_mound`, fallback to `mound.ingest`

## Validation

- `pytest tests/knowledge/mound/adapters/test_crux_receipt_adapter.py --noconftest` — **16 passed**
- `ruff check aragora/knowledge/mound/adapters/crux_receipt_adapter.py tests/knowledge/mound/adapters/test_crux_receipt_adapter.py` — **clean**
- `mypy aragora/knowledge/mound/adapters/crux_receipt_adapter.py --ignore-missing-imports` — **clean**

## Out of scope

- KM adapter for `ExecutableClaim` objects (DIC-13/14 — separate slice)
- `ReceiptAdapter` extension to auto-trigger `CruxReceiptAdapter` on crux-finder runs — deferred until the AGT-* gate opens and `crux_finder` consensus mode flows are live
- `__all__` registration in `aragora/epistemic/__init__.py` for `CruxReceiptAdapter` — out of scope; the adapter lives in the KM layer, not the epistemic layer

---
Labels: `vision-layer`

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3WDuH3t2GdvJJo9gQwYNm)_