### PR TITLE
fix(swarm): degrade status when coordination db is unreadable

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -24,6 +24,7 @@ import logging
 import os
 from pathlib import Path
 import shlex
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -3209,12 +3210,28 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         from aragora.swarm.session_coordinator import read_directives as coord_read
 
         repo_root = resolve_repo_root(Path.cwd())
-        supervisor = SwarmSupervisor(repo_root=repo_root)
-        payload = supervisor.status_summary(
-            run_id=run_id,
-            limit=int(getattr(args, "status_limit", 20)),
-            refresh_scaling=refresh_scaling,
-        )
+        try:
+            supervisor = SwarmSupervisor(repo_root=repo_root)
+            payload = supervisor.status_summary(
+                run_id=run_id,
+                limit=int(getattr(args, "status_limit", 20)),
+                refresh_scaling=refresh_scaling,
+            )
+        except (sqlite3.Error, OSError, RuntimeError) as exc:
+            payload = {
+                "runs": [],
+                "counts": {
+                    "runs": 0,
+                    "queued_work_orders": 0,
+                    "leased_work_orders": 0,
+                    "completed_work_orders": 0,
+                },
+                "coordination": {
+                    "available": False,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            }
         base_branch = str(getattr(args, "target_branch", "main") or "main")
         worktrees = build_fleet_rows(
             repo_root,

--- a/aragora/nomic/dev_coordination/core.py
+++ b/aragora/nomic/dev_coordination/core.py
@@ -187,9 +187,13 @@ class DevCoordinationStore:
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.db_path, timeout=_SQLITE_BUSY_TIMEOUT_MS / 1000.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
+        except Exception:
+            conn.close()
+            raise
         return conn
 
     def _ensure_schema(self) -> None:

--- a/tests/cli/test_swarm_status_command.py
+++ b/tests/cli/test_swarm_status_command.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import sqlite3
 from unittest.mock import patch
 
 from aragora.cli.commands.swarm import cmd_swarm
@@ -265,6 +266,49 @@ def test_cmd_swarm_status_json_includes_operator_status(tmp_path: Path, capsys) 
     payload = json.loads(capsys.readouterr().out)
     assert payload["operator_status"]["summary"]["queue_depth"] == 5
     assert payload["operator_status"]["summary"]["unique_issues_attempted"] == 1
+
+
+def test_cmd_swarm_status_json_degrades_when_coordination_store_unreadable(
+    tmp_path: Path, capsys
+) -> None:
+    with (
+        patch("aragora.worktree.fleet.resolve_repo_root", return_value=tmp_path),
+        patch("aragora.worktree.fleet.build_fleet_rows", return_value=[]),
+        patch("aragora.worktree.fleet.FleetCoordinationStore") as store_cls,
+        patch(
+            "aragora.swarm.reporter.build_integrator_view",
+            return_value={"summary": {}, "next_actions": []},
+        ),
+        patch(
+            "aragora.swarm.session_coordinator.read_directives",
+            return_value={
+                "summary": {
+                    "directive_count": 0,
+                    "session_count": 0,
+                    "claim_count": 0,
+                    "finding_count": 0,
+                },
+                "directives": [],
+                "claims": [],
+                "findings": [],
+            },
+        ),
+        patch(
+            "aragora.swarm.SwarmSupervisor",
+            side_effect=sqlite3.OperationalError("unable to open database file"),
+        ),
+        patch("aragora.cli.commands.swarm_status._boss_ready_queue_depth", return_value=0),
+    ):
+        store_cls.return_value.list_claims.return_value = []
+        store_cls.return_value.list_merge_queue.return_value = []
+
+        cmd_swarm(_swarm_status_args(json=True, boss_repo="synaptent/aragora"))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["runs"] == 0
+    assert payload["coordination"]["available"] is False
+    assert payload["coordination"]["error_type"] == "OperationalError"
+    assert payload["operator_status"]["summary"]["queue_depth"] == 0
 
 
 def test_cmd_swarm_status_text_includes_operator_metrics(tmp_path: Path, capsys) -> None:

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -73,6 +74,30 @@ def test_connect_sets_busy_timeout(store: DevCoordinationStore) -> None:
     finally:
         conn.close()
     assert timeout_ms == 60_000
+
+
+def test_connect_closes_connection_when_pragma_setup_fails(repo: Path) -> None:
+    class FailingConnection:
+        row_factory: object = None
+        closed = False
+
+        def execute(self, _sql: str) -> None:
+            raise sqlite3.OperationalError("unable to open database file")
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = FailingConnection()
+    store = object.__new__(DevCoordinationStore)
+    store.db_path = repo / ".git" / "aragora-agent-state" / "dev_coordination.db"
+
+    with (
+        patch("aragora.nomic.dev_coordination.core.sqlite3.connect", return_value=conn),
+        pytest.raises(sqlite3.OperationalError, match="unable to open database file"),
+    ):
+        store._connect()
+
+    assert conn.closed is True
 
 
 def test_dev_coordination_store_allows_shared_db_env_override(


### PR DESCRIPTION
## Summary
- make `swarm status --json` return a truthful degraded coordination payload when the coordination DB cannot be opened
- keep fleet/integrator/operator status surfaces available in that degraded mode
- close SQLite connections if PRAGMA setup fails to avoid ResourceWarning noise

## Validation
- `python3 -m pytest tests/cli/test_swarm_status_command.py tests/nomic/test_dev_coordination.py::test_connect_closes_connection_when_pragma_setup_fails -q`
- `python3 -m ruff check aragora/cli/commands/swarm.py aragora/nomic/dev_coordination/core.py tests/cli/test_swarm_status_command.py tests/nomic/test_dev_coordination.py`
- `python3 -m ruff format aragora/cli/commands/swarm.py aragora/nomic/dev_coordination/core.py tests/cli/test_swarm_status_command.py tests/nomic/test_dev_coordination.py --check`
- real proof: `python3 -m aragora.cli.main swarm status --json > /tmp/aragora-status-proof.json 2> /tmp/aragora-status-proof.err` exits 0 with empty stderr and `coordination.available=false`