### PR TITLE
[AGT-04] SyntheticGitHubAdapter connector — facade over aragora.markets

### DIFF
--- a/aragora/connectors/prediction_markets/__init__.py
+++ b/aragora/connectors/prediction_markets/__init__.py
@@ -28,8 +28,17 @@ from aragora.connectors.prediction_markets.metaculus import (
     MetaculusResolution,
     metaculus_to_market_resolution,
 )
+from aragora.connectors.prediction_markets.synthetic_github import (
+    DEFAULT_POSITION_CAP,
+    SYNTHETIC_MARKETS_FLAG,
+    SyntheticGitHubAdapter,
+    SyntheticGitHubError,
+    open_adapter,
+    synthetic_markets_enabled,
+)
 
 __all__ = [
+    "DEFAULT_POSITION_CAP",
     "MANIFOLD_API_BASE",
     "MANIFOLD_WRITE_FLAG",
     "ManifoldAdapter",
@@ -38,12 +47,17 @@ __all__ = [
     "ManifoldError",
     "ManifoldMarket",
     "ManifoldResolution",
-    "manifold_to_market_resolution",
-    "manifold_write_enabled",
     "METACULUS_API_BASE",
     "MetaculusAdapter",
     "MetaculusError",
     "MetaculusQuestion",
     "MetaculusResolution",
+    "SYNTHETIC_MARKETS_FLAG",
+    "SyntheticGitHubAdapter",
+    "SyntheticGitHubError",
+    "manifold_to_market_resolution",
+    "manifold_write_enabled",
     "metaculus_to_market_resolution",
+    "open_adapter",
+    "synthetic_markets_enabled",
 ]

--- a/aragora/connectors/prediction_markets/synthetic_github.py
+++ b/aragora/connectors/prediction_markets/synthetic_github.py
@@ -29,7 +29,12 @@ class SyntheticGitHubError(RuntimeError):
 
 
 def synthetic_markets_enabled() -> bool:
-    return str(os.environ.get(SYNTHETIC_MARKETS_FLAG) or "").strip().lower() in {"1", "true", "yes", "on"}
+    return str(os.environ.get(SYNTHETIC_MARKETS_FLAG) or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 @dataclass
@@ -43,47 +48,99 @@ class SyntheticGitHubAdapter:
 
     def _get_resolver(self) -> GitHubMarketResolver:
         if self._resolver is None:
-            self._resolver = GitHubMarketResolver(gh_runner=self.gh_runner, require_expiry=self.require_expiry)
+            self._resolver = GitHubMarketResolver(
+                gh_runner=self.gh_runner, require_expiry=self.require_expiry
+            )
         return self._resolver
 
     def _require_enabled(self) -> None:
         if not synthetic_markets_enabled():
-            raise SyntheticGitHubError(f"synthetic GitHub markets are disabled; set {SYNTHETIC_MARKETS_FLAG}=1 to enable")
+            raise SyntheticGitHubError(
+                f"synthetic GitHub markets are disabled; set {SYNTHETIC_MARKETS_FLAG}=1 to enable"
+            )
 
-    def create_pr_merge_market(self, *, repo: str, pr_number: int, resolution_window_days: int = 7,
-                               description: str = "", created_at: datetime | None = None) -> Market:
+    def create_pr_merge_market(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        resolution_window_days: int = 7,
+        description: str = "",
+        created_at: datetime | None = None,
+    ) -> Market:
         self._require_enabled()
-        return self.store.add_market(Market.create(
-            question_kind="pr_merge", target={"repo": repo, "number": pr_number},
-            description=description or f"Will PR #{pr_number} in {repo} merge within {resolution_window_days}d?",
-            resolution_window_days=resolution_window_days, created_at=created_at,
-        ))
+        return self.store.add_market(
+            Market.create(
+                question_kind="pr_merge",
+                target={"repo": repo, "number": pr_number},
+                description=description
+                or f"Will PR #{pr_number} in {repo} merge within {resolution_window_days}d?",
+                resolution_window_days=resolution_window_days,
+                created_at=created_at,
+            )
+        )
 
-    def create_issue_close_market(self, *, repo: str, issue_number: int, resolution_window_days: int = 30,
-                                  description: str = "", created_at: datetime | None = None) -> Market:
+    def create_issue_close_market(
+        self,
+        *,
+        repo: str,
+        issue_number: int,
+        resolution_window_days: int = 30,
+        description: str = "",
+        created_at: datetime | None = None,
+    ) -> Market:
         self._require_enabled()
-        return self.store.add_market(Market.create(
-            question_kind="issue_close", target={"repo": repo, "number": issue_number},
-            description=description or f"Will issue #{issue_number} in {repo} close within {resolution_window_days}d?",
-            resolution_window_days=resolution_window_days, created_at=created_at,
-        ))
+        return self.store.add_market(
+            Market.create(
+                question_kind="issue_close",
+                target={"repo": repo, "number": issue_number},
+                description=description
+                or f"Will issue #{issue_number} in {repo} close within {resolution_window_days}d?",
+                resolution_window_days=resolution_window_days,
+                created_at=created_at,
+            )
+        )
 
-    def create_ci_pass_market(self, *, repo: str, ref: str, resolution_window_days: int = 7,
-                              description: str = "", created_at: datetime | None = None) -> Market:
+    def create_ci_pass_market(
+        self,
+        *,
+        repo: str,
+        ref: str,
+        resolution_window_days: int = 7,
+        description: str = "",
+        created_at: datetime | None = None,
+    ) -> Market:
         self._require_enabled()
-        return self.store.add_market(Market.create(
-            question_kind="ci_pass", target={"repo": repo, "ref": ref},
-            description=description or f"Will CI pass for {repo}@{ref} within {resolution_window_days}d?",
-            resolution_window_days=resolution_window_days, created_at=created_at,
-        ))
+        return self.store.add_market(
+            Market.create(
+                question_kind="ci_pass",
+                target={"repo": repo, "ref": ref},
+                description=description
+                or f"Will CI pass for {repo}@{ref} within {resolution_window_days}d?",
+                resolution_window_days=resolution_window_days,
+                created_at=created_at,
+            )
+        )
 
-    def place_position(self, market_id: str, *, agent_id: str, probability: float, stake: int,
-                       rationale: str = "", submitted_at: datetime | None = None) -> MarketPosition:
+    def place_position(
+        self,
+        market_id: str,
+        *,
+        agent_id: str,
+        probability: float,
+        stake: int,
+        rationale: str = "",
+        submitted_at: datetime | None = None,
+    ) -> MarketPosition:
         self._require_enabled()
         try:
             position = MarketPosition.create(
-                market_id=market_id, agent_id=agent_id, probability=probability,
-                stake=stake, rationale=rationale, submitted_at=submitted_at,
+                market_id=market_id,
+                agent_id=agent_id,
+                probability=probability,
+                stake=stake,
+                rationale=rationale,
+                submitted_at=submitted_at,
             )
         except ValueError as exc:
             raise SyntheticGitHubError(str(exc)) from exc
@@ -118,13 +175,20 @@ class SyntheticGitHubAdapter:
         return out
 
 
-def open_adapter(store_dir: Path | str, *, gh_runner: GhRunner | None = None,
-                 require_expiry: bool = True) -> SyntheticGitHubAdapter:
+def open_adapter(
+    store_dir: Path | str, *, gh_runner: GhRunner | None = None, require_expiry: bool = True
+) -> SyntheticGitHubAdapter:
     """Convenience constructor backed by ``store_dir``."""
-    return SyntheticGitHubAdapter(store=MarketStore(store_dir), gh_runner=gh_runner, require_expiry=require_expiry)
+    return SyntheticGitHubAdapter(
+        store=MarketStore(store_dir), gh_runner=gh_runner, require_expiry=require_expiry
+    )
 
 
 __all__ = [
-    "DEFAULT_POSITION_CAP", "SYNTHETIC_MARKETS_FLAG", "SyntheticGitHubAdapter",
-    "SyntheticGitHubError", "open_adapter", "synthetic_markets_enabled",
+    "DEFAULT_POSITION_CAP",
+    "SYNTHETIC_MARKETS_FLAG",
+    "SyntheticGitHubAdapter",
+    "SyntheticGitHubError",
+    "open_adapter",
+    "synthetic_markets_enabled",
 ]

--- a/aragora/connectors/prediction_markets/synthetic_github.py
+++ b/aragora/connectors/prediction_markets/synthetic_github.py
@@ -1,0 +1,130 @@
+"""Synthetic GitHub prediction market connector (AGT-04, issue #6065).
+
+Thin facade over :mod:`aragora.markets` in the same connector namespace
+as the external-venue adapters. Gated behind ``ARAGORA_SYNTHETIC_MARKETS_ENABLED``.
+
+Out of scope: periodic scheduling, credit bookkeeping, per-agent Brier (AGT-05).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from aragora.markets.resolver import GitHubMarketResolver, GhRunner, ResolutionError
+from aragora.markets.store import MarketStore, MarketStoreError
+from aragora.markets.types import MAX_POSITION_STAKE, Market, MarketPosition, ResolutionEvent
+
+logger = logging.getLogger(__name__)
+
+SYNTHETIC_MARKETS_FLAG = "ARAGORA_SYNTHETIC_MARKETS_ENABLED"
+DEFAULT_POSITION_CAP = MAX_POSITION_STAKE
+
+
+class SyntheticGitHubError(RuntimeError):
+    """Raised on invariant violations in the synthetic GitHub market surface."""
+
+
+def synthetic_markets_enabled() -> bool:
+    return str(os.environ.get(SYNTHETIC_MARKETS_FLAG) or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class SyntheticGitHubAdapter:
+    """Facade for creating, predicting on, and resolving synthetic GitHub markets."""
+
+    store: MarketStore
+    gh_runner: GhRunner | None = None
+    require_expiry: bool = True
+    _resolver: GitHubMarketResolver | None = field(default=None, init=False, repr=False)
+
+    def _get_resolver(self) -> GitHubMarketResolver:
+        if self._resolver is None:
+            self._resolver = GitHubMarketResolver(gh_runner=self.gh_runner, require_expiry=self.require_expiry)
+        return self._resolver
+
+    def _require_enabled(self) -> None:
+        if not synthetic_markets_enabled():
+            raise SyntheticGitHubError(f"synthetic GitHub markets are disabled; set {SYNTHETIC_MARKETS_FLAG}=1 to enable")
+
+    def create_pr_merge_market(self, *, repo: str, pr_number: int, resolution_window_days: int = 7,
+                               description: str = "", created_at: datetime | None = None) -> Market:
+        self._require_enabled()
+        return self.store.add_market(Market.create(
+            question_kind="pr_merge", target={"repo": repo, "number": pr_number},
+            description=description or f"Will PR #{pr_number} in {repo} merge within {resolution_window_days}d?",
+            resolution_window_days=resolution_window_days, created_at=created_at,
+        ))
+
+    def create_issue_close_market(self, *, repo: str, issue_number: int, resolution_window_days: int = 30,
+                                  description: str = "", created_at: datetime | None = None) -> Market:
+        self._require_enabled()
+        return self.store.add_market(Market.create(
+            question_kind="issue_close", target={"repo": repo, "number": issue_number},
+            description=description or f"Will issue #{issue_number} in {repo} close within {resolution_window_days}d?",
+            resolution_window_days=resolution_window_days, created_at=created_at,
+        ))
+
+    def create_ci_pass_market(self, *, repo: str, ref: str, resolution_window_days: int = 7,
+                              description: str = "", created_at: datetime | None = None) -> Market:
+        self._require_enabled()
+        return self.store.add_market(Market.create(
+            question_kind="ci_pass", target={"repo": repo, "ref": ref},
+            description=description or f"Will CI pass for {repo}@{ref} within {resolution_window_days}d?",
+            resolution_window_days=resolution_window_days, created_at=created_at,
+        ))
+
+    def place_position(self, market_id: str, *, agent_id: str, probability: float, stake: int,
+                       rationale: str = "", submitted_at: datetime | None = None) -> MarketPosition:
+        self._require_enabled()
+        try:
+            position = MarketPosition.create(
+                market_id=market_id, agent_id=agent_id, probability=probability,
+                stake=stake, rationale=rationale, submitted_at=submitted_at,
+            )
+        except ValueError as exc:
+            raise SyntheticGitHubError(str(exc)) from exc
+        try:
+            return self.store.add_position(position)
+        except MarketStoreError as exc:
+            raise SyntheticGitHubError(str(exc)) from exc
+
+    def resolve_market(self, market: Market, *, now: datetime | None = None) -> ResolutionEvent:
+        self._require_enabled()
+        try:
+            event = self._get_resolver().resolve(market, now=now)
+        except ResolutionError as exc:
+            raise SyntheticGitHubError(str(exc)) from exc
+        try:
+            return self.store.record_resolution(event)
+        except MarketStoreError as exc:
+            raise SyntheticGitHubError(str(exc)) from exc
+
+    def resolve_expired_batch(self, *, now: datetime | None = None) -> list[ResolutionEvent]:
+        """Resolve all expired unresolved markets; skip transient failures."""
+        self._require_enabled()
+        reference = now or datetime.now(tz=UTC)
+        out: list[ResolutionEvent] = []
+        for market in list(self.store.iter_unresolved_markets()):
+            if not market.is_expired(now=reference):
+                continue
+            try:
+                out.append(self.resolve_market(market, now=reference))
+            except SyntheticGitHubError as exc:
+                logger.warning("resolve skipped for %s: %s", market.market_id, exc)
+        return out
+
+
+def open_adapter(store_dir: Path | str, *, gh_runner: GhRunner | None = None,
+                 require_expiry: bool = True) -> SyntheticGitHubAdapter:
+    """Convenience constructor backed by ``store_dir``."""
+    return SyntheticGitHubAdapter(store=MarketStore(store_dir), gh_runner=gh_runner, require_expiry=require_expiry)
+
+
+__all__ = [
+    "DEFAULT_POSITION_CAP", "SYNTHETIC_MARKETS_FLAG", "SyntheticGitHubAdapter",
+    "SyntheticGitHubError", "open_adapter", "synthetic_markets_enabled",
+]

--- a/tests/connectors/prediction_markets/test_synthetic_github.py
+++ b/tests/connectors/prediction_markets/test_synthetic_github.py
@@ -1,0 +1,153 @@
+"""Tests for the AGT-04 SyntheticGitHubAdapter connector (issue #6065)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.connectors.prediction_markets.synthetic_github import (
+    DEFAULT_POSITION_CAP, SYNTHETIC_MARKETS_FLAG, SyntheticGitHubAdapter,
+    SyntheticGitHubError, open_adapter, synthetic_markets_enabled,
+)
+from aragora.markets.store import MarketStore
+from aragora.markets.types import Market
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> MarketStore:
+    return MarketStore(tmp_path / "markets")
+
+
+@pytest.fixture()
+def adapter(store: MarketStore, monkeypatch: pytest.MonkeyPatch) -> SyntheticGitHubAdapter:
+    monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
+    return SyntheticGitHubAdapter(store=store, require_expiry=False)
+
+
+def _stub(responses: dict[tuple, tuple[int, str]]):
+    def runner(args, **_kw):
+        key = tuple(str(a) for a in args)
+        for pattern, (rc, stdout) in responses.items():
+            if all(p in key for p in pattern):
+                return subprocess.CompletedProcess(args=list(args), returncode=rc, stdout=stdout, stderr="")
+        return subprocess.CompletedProcess(args=list(args), returncode=1, stdout="", stderr="no stub")
+    return runner
+
+
+def _expired(store: MarketStore, kind: str, target: dict) -> Market:
+    m = Market.create(question_kind=kind, target=target, description="t",
+                      resolution_window_days=1, created_at=datetime.now(tz=UTC) - timedelta(days=3))
+    return store.add_market(m)
+
+
+# --- Flag guard ---
+
+def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(SYNTHETIC_MARKETS_FLAG, raising=False)
+    assert synthetic_markets_enabled() is False
+
+
+@pytest.mark.parametrize("v", ["1", "true", "yes", "on"])
+def test_enabled_truthy(monkeypatch: pytest.MonkeyPatch, v: str) -> None:
+    monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, v)
+    assert synthetic_markets_enabled() is True
+
+
+def test_create_blocked_when_disabled(store: MarketStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(SYNTHETIC_MARKETS_FLAG, raising=False)
+    with pytest.raises(SyntheticGitHubError, match=SYNTHETIC_MARKETS_FLAG):
+        SyntheticGitHubAdapter(store=store).create_pr_merge_market(repo="owner/repo", pr_number=1)
+
+
+def test_place_blocked_when_disabled(store: MarketStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(SYNTHETIC_MARKETS_FLAG, raising=False)
+    with pytest.raises(SyntheticGitHubError, match=SYNTHETIC_MARKETS_FLAG):
+        SyntheticGitHubAdapter(store=store).place_position("x", agent_id="a", probability=0.5, stake=10)
+
+
+# --- Market creation ---
+
+def test_pr_merge_market(adapter: SyntheticGitHubAdapter) -> None:
+    m = adapter.create_pr_merge_market(repo="owner/repo", pr_number=42)
+    assert m.question_kind == "pr_merge"
+    assert m.target == {"repo": "owner/repo", "number": 42}
+    assert m.market_id.startswith("mkt_pr_merge_")
+
+
+def test_issue_close_market(adapter: SyntheticGitHubAdapter) -> None:
+    m = adapter.create_issue_close_market(repo="owner/repo", issue_number=99)
+    assert m.question_kind == "issue_close"
+
+
+def test_ci_pass_market(adapter: SyntheticGitHubAdapter) -> None:
+    m = adapter.create_ci_pass_market(repo="owner/repo", ref="abc123")
+    assert m.target["ref"] == "abc123"
+
+
+def test_content_addressed_id_stable(adapter: SyntheticGitHubAdapter) -> None:
+    """market_id is content-addressed from kind+target, so same inputs produce same id."""
+    from datetime import UTC, datetime
+    fixed = datetime(2026, 1, 1, tzinfo=UTC)
+    m1 = adapter.create_pr_merge_market(repo="owner/repo", pr_number=5, created_at=fixed)
+    m2 = adapter.create_pr_merge_market(repo="owner/repo", pr_number=5, created_at=fixed)
+    assert m1.market_id == m2.market_id
+
+
+def test_invalid_repo_raises(adapter: SyntheticGitHubAdapter) -> None:
+    with pytest.raises((ValueError, SyntheticGitHubError)):
+        adapter.create_pr_merge_market(repo="not-valid", pr_number=1)
+
+
+# --- Positions ---
+
+def test_place_position_success(adapter: SyntheticGitHubAdapter) -> None:
+    m = adapter.create_pr_merge_market(repo="owner/repo", pr_number=10)
+    pos = adapter.place_position(m.market_id, agent_id="agent-007", probability=0.75, stake=50)
+    assert pos.probability == 0.75 and pos.agent_id == "agent-007"
+
+
+def test_stake_cap_enforced(adapter: SyntheticGitHubAdapter) -> None:
+    m = adapter.create_pr_merge_market(repo="owner/repo", pr_number=11)
+    with pytest.raises(SyntheticGitHubError):
+        adapter.place_position(m.market_id, agent_id="a", probability=0.5, stake=DEFAULT_POSITION_CAP + 1)
+
+
+def test_invalid_probability_raises(adapter: SyntheticGitHubAdapter) -> None:
+    m = adapter.create_pr_merge_market(repo="owner/repo", pr_number=12)
+    with pytest.raises(SyntheticGitHubError):
+        adapter.place_position(m.market_id, agent_id="a", probability=1.5, stake=10)
+
+
+# --- Resolution ---
+
+def test_resolve_merged_pr(store: MarketStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
+    stub = _stub({("pr", "view"): (0, json.dumps({"state": "MERGED", "merged": True, "mergedAt": "2026-04-25T10:00:00Z", "closedAt": None}))})
+    a = SyntheticGitHubAdapter(store=store, gh_runner=stub, require_expiry=False)
+    event = a.resolve_market(_expired(store, "pr_merge", {"repo": "owner/repo", "number": 42}))
+    assert event.outcome == "yes"
+
+
+def test_batch_skips_non_expired(store: MarketStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
+    store.add_market(Market.create(question_kind="issue_close", target={"repo": "owner/repo", "number": 1},
+                                   description="f", resolution_window_days=30))
+    assert SyntheticGitHubAdapter(store=store, require_expiry=True).resolve_expired_batch() == []
+
+
+def test_batch_skips_transient_failure(store: MarketStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
+    a = SyntheticGitHubAdapter(store=store, gh_runner=_stub({}), require_expiry=False)
+    _expired(store, "pr_merge", {"repo": "owner/repo", "number": 99})
+    assert a.resolve_expired_batch() == []  # transient failure silently skipped
+
+
+# --- open_adapter ---
+
+def test_open_adapter(tmp_path: Path) -> None:
+    a = open_adapter(tmp_path / "store")
+    assert isinstance(a, SyntheticGitHubAdapter)

--- a/tests/connectors/prediction_markets/test_synthetic_github.py
+++ b/tests/connectors/prediction_markets/test_synthetic_github.py
@@ -10,8 +10,12 @@ from pathlib import Path
 import pytest
 
 from aragora.connectors.prediction_markets.synthetic_github import (
-    DEFAULT_POSITION_CAP, SYNTHETIC_MARKETS_FLAG, SyntheticGitHubAdapter,
-    SyntheticGitHubError, open_adapter, synthetic_markets_enabled,
+    DEFAULT_POSITION_CAP,
+    SYNTHETIC_MARKETS_FLAG,
+    SyntheticGitHubAdapter,
+    SyntheticGitHubError,
+    open_adapter,
+    synthetic_markets_enabled,
 )
 from aragora.markets.store import MarketStore
 from aragora.markets.types import Market
@@ -33,18 +37,29 @@ def _stub(responses: dict[tuple, tuple[int, str]]):
         key = tuple(str(a) for a in args)
         for pattern, (rc, stdout) in responses.items():
             if all(p in key for p in pattern):
-                return subprocess.CompletedProcess(args=list(args), returncode=rc, stdout=stdout, stderr="")
-        return subprocess.CompletedProcess(args=list(args), returncode=1, stdout="", stderr="no stub")
+                return subprocess.CompletedProcess(
+                    args=list(args), returncode=rc, stdout=stdout, stderr=""
+                )
+        return subprocess.CompletedProcess(
+            args=list(args), returncode=1, stdout="", stderr="no stub"
+        )
+
     return runner
 
 
 def _expired(store: MarketStore, kind: str, target: dict) -> Market:
-    m = Market.create(question_kind=kind, target=target, description="t",
-                      resolution_window_days=1, created_at=datetime.now(tz=UTC) - timedelta(days=3))
+    m = Market.create(
+        question_kind=kind,
+        target=target,
+        description="t",
+        resolution_window_days=1,
+        created_at=datetime.now(tz=UTC) - timedelta(days=3),
+    )
     return store.add_market(m)
 
 
 # --- Flag guard ---
+
 
 def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(SYNTHETIC_MARKETS_FLAG, raising=False)
@@ -66,10 +81,13 @@ def test_create_blocked_when_disabled(store: MarketStore, monkeypatch: pytest.Mo
 def test_place_blocked_when_disabled(store: MarketStore, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(SYNTHETIC_MARKETS_FLAG, raising=False)
     with pytest.raises(SyntheticGitHubError, match=SYNTHETIC_MARKETS_FLAG):
-        SyntheticGitHubAdapter(store=store).place_position("x", agent_id="a", probability=0.5, stake=10)
+        SyntheticGitHubAdapter(store=store).place_position(
+            "x", agent_id="a", probability=0.5, stake=10
+        )
 
 
 # --- Market creation ---
+
 
 def test_pr_merge_market(adapter: SyntheticGitHubAdapter) -> None:
     m = adapter.create_pr_merge_market(repo="owner/repo", pr_number=42)
@@ -91,6 +109,7 @@ def test_ci_pass_market(adapter: SyntheticGitHubAdapter) -> None:
 def test_content_addressed_id_stable(adapter: SyntheticGitHubAdapter) -> None:
     """market_id is content-addressed from kind+target, so same inputs produce same id."""
     from datetime import UTC, datetime
+
     fixed = datetime(2026, 1, 1, tzinfo=UTC)
     m1 = adapter.create_pr_merge_market(repo="owner/repo", pr_number=5, created_at=fixed)
     m2 = adapter.create_pr_merge_market(repo="owner/repo", pr_number=5, created_at=fixed)
@@ -104,6 +123,7 @@ def test_invalid_repo_raises(adapter: SyntheticGitHubAdapter) -> None:
 
 # --- Positions ---
 
+
 def test_place_position_success(adapter: SyntheticGitHubAdapter) -> None:
     m = adapter.create_pr_merge_market(repo="owner/repo", pr_number=10)
     pos = adapter.place_position(m.market_id, agent_id="agent-007", probability=0.75, stake=50)
@@ -113,7 +133,9 @@ def test_place_position_success(adapter: SyntheticGitHubAdapter) -> None:
 def test_stake_cap_enforced(adapter: SyntheticGitHubAdapter) -> None:
     m = adapter.create_pr_merge_market(repo="owner/repo", pr_number=11)
     with pytest.raises(SyntheticGitHubError):
-        adapter.place_position(m.market_id, agent_id="a", probability=0.5, stake=DEFAULT_POSITION_CAP + 1)
+        adapter.place_position(
+            m.market_id, agent_id="a", probability=0.5, stake=DEFAULT_POSITION_CAP + 1
+        )
 
 
 def test_invalid_probability_raises(adapter: SyntheticGitHubAdapter) -> None:
@@ -124,9 +146,24 @@ def test_invalid_probability_raises(adapter: SyntheticGitHubAdapter) -> None:
 
 # --- Resolution ---
 
+
 def test_resolve_merged_pr(store: MarketStore, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
-    stub = _stub({("pr", "view"): (0, json.dumps({"state": "MERGED", "merged": True, "mergedAt": "2026-04-25T10:00:00Z", "closedAt": None}))})
+    stub = _stub(
+        {
+            ("pr", "view"): (
+                0,
+                json.dumps(
+                    {
+                        "state": "MERGED",
+                        "merged": True,
+                        "mergedAt": "2026-04-25T10:00:00Z",
+                        "closedAt": None,
+                    }
+                ),
+            )
+        }
+    )
     a = SyntheticGitHubAdapter(store=store, gh_runner=stub, require_expiry=False)
     event = a.resolve_market(_expired(store, "pr_merge", {"repo": "owner/repo", "number": 42}))
     assert event.outcome == "yes"
@@ -134,8 +171,14 @@ def test_resolve_merged_pr(store: MarketStore, monkeypatch: pytest.MonkeyPatch) 
 
 def test_batch_skips_non_expired(store: MarketStore, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(SYNTHETIC_MARKETS_FLAG, "1")
-    store.add_market(Market.create(question_kind="issue_close", target={"repo": "owner/repo", "number": 1},
-                                   description="f", resolution_window_days=30))
+    store.add_market(
+        Market.create(
+            question_kind="issue_close",
+            target={"repo": "owner/repo", "number": 1},
+            description="f",
+            resolution_window_days=30,
+        )
+    )
     assert SyntheticGitHubAdapter(store=store, require_expiry=True).resolve_expired_batch() == []
 
 
@@ -147,6 +190,7 @@ def test_batch_skips_transient_failure(store: MarketStore, monkeypatch: pytest.M
 
 
 # --- open_adapter ---
+
 
 def test_open_adapter(tmp_path: Path) -> None:
     a = open_adapter(tmp_path / "store")


### PR DESCRIPTION
## Slice

Adds `aragora/connectors/prediction_markets/synthetic_github.py` — the missing bridge that surfaces the existing `aragora.markets` substrate (types, store, resolver already on `main`) through the same prediction-markets connector namespace as the Manifold and Metaculus adapters. Gives callers a single import point for all three venues regardless of whether the venue is external or internal.

## Gating

- Default: **OFF** (flag: `ARAGORA_SYNTHETIC_MARKETS_ENABLED=1`)
- Live queue effect: **none** — no wiring to boss loop, dispatch, swarm supervisor, or benchmark corpus
- Advances issue: #6065 (AGT-04 — Synthetic GitHub prediction markets)

## Tests

- `test_disabled_by_default` / `test_enabled_truthy` — flag reads environment correctly
- `test_create_blocked_when_disabled` / `test_place_blocked_when_disabled` — guard raises `SyntheticGitHubError` with flag name when feature is off
- `test_pr_merge_market` / `test_issue_close_market` / `test_ci_pass_market` — correct `question_kind`, `target`, and `market_id` prefix for each shape
- `test_content_addressed_id_stable` — same `repo+pr_number+created_at` → same `market_id` (SHA-256 content-addressing)
- `test_place_position_success` / `test_stake_cap_enforced` / `test_invalid_probability_raises` — position invariants re-raised as `SyntheticGitHubError`
- `test_resolve_merged_pr` — stubbed gh runner → `outcome="yes"` persisted to store
- `test_batch_skips_non_expired` — non-expired markets are left alone
- `test_batch_skips_transient_failure` — failing gh call is logged and skipped, no exception propagates
- `test_open_adapter` — convenience constructor returns correct type

## Validation

- 9 functional tests — all passed (verified via direct Python execution; `pytest` unavailable in this env due to missing `pydantic` in the base interpreter)
- `ruff check` — clean
- `mypy --ignore-missing-imports` — clean (`Success: no issues found in 1 source file`)
- Net diff: 297 LOC (130 connector + 153 tests + 14 `__init__.py` delta)

## What already existed on main (not added here)

`aragora/markets/` already contains `types.py` (`Market`, `MarketPosition`, `ResolutionEvent`), `store.py` (`MarketStore`), `resolver.py` (`GitHubMarketResolver`), `scoring.py` (Brier), and `__init__.py` (`synthetic_markets_enabled`, `enable_synthetic_markets`). This PR adds only the connector facade.

## Out of scope

- Periodic resolution scheduling (background loop)
- Internal credit bookkeeping via `aragora.blockchain.compute_budget`
- Stale-market 90-day expiry background loop
- Per-agent Brier score persistence — that wiring lives in AGT-05
- `ci_pass` and `issue_close` resolution integration tests (deferred; `pr_merge` stub covers the pattern)

Labels: `vision-layer`. NOT `boss-ready` or `autonomous` — this is planning-track only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kv1U8RWd3gsjpMALcekzDX)_