### PR TITLE
ci(security): fix TruffleHog docker tag (drop v prefix on version input)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -737,7 +737,12 @@ jobs:
       - name: Run TruffleHog
         uses: trufflesecurity/trufflehog@v3.95.2
         with:
-          version: v3.95.2
+          # GHCR publishes the trufflehog image without the leading "v"
+          # (ghcr.io/trufflesecurity/trufflehog:3.95.2 exists; :v3.95.2 does not),
+          # so the action's docker pull fails with "manifest unknown" when we
+          # pass version: v3.95.2. Action ref `@v3.95.2` is correct (release tag);
+          # only the docker tag drops the v.
+          version: 3.95.2
           extra_args: --only-verified
 
   helm-lint:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -425,5 +425,10 @@ jobs:
       - name: Run TruffleHog
         uses: trufflesecurity/trufflehog@v3.95.2
         with:
-          version: v3.95.2
+          # GHCR publishes the trufflehog image without the leading "v"
+          # (ghcr.io/trufflesecurity/trufflehog:3.95.2 exists; :v3.95.2 does not),
+          # so the action's docker pull fails with "manifest unknown" when we
+          # pass version: v3.95.2. Action ref `@v3.95.2` is correct (release tag);
+          # only the docker tag drops the v.
+          version: 3.95.2
           extra_args: --only-verified


### PR DESCRIPTION
## Problem

Lint + Secret Scanning workflows have been failing on every commit to main since 2026-04-21:

\`\`\`
Unable to find image 'ghcr.io/trufflesecurity/trufflehog:v3.95.2' locally
docker: Error response from daemon: manifest unknown
Process completed with exit code 125.
\`\`\`

Confirmed failing on at least:
- d5f0c6f7 (#6616 threshold recalibration) at 04:12 UTC
- 958abeb3 at 04:13 UTC
- 7bafc35d at 04:18 UTC

## Cause

The TruffleHog GitHub Action's composite step does \`docker run ... ghcr.io/trufflesecurity/trufflehog:\${VERSION}\`. GHCR publishes the trufflehog image **without** the leading \`v\` (\`3.95.2\` exists; \`v3.95.2\` does not). Passing \`version: v3.95.2\` produces a docker pull against a non-existent tag.

The action ref \`@v3.95.2\` IS correct — that's the GitHub release tag which uses the v prefix. Only the docker tag (the \`version:\` input) needs the v dropped.

## Verified before commit

\`\`\`
$ docker manifest inspect ghcr.io/trufflesecurity/trufflehog:3.95.2
{ ... valid manifest ... }

$ docker manifest inspect ghcr.io/trufflesecurity/trufflehog:v3.95.2
manifest unknown
\`\`\`

## Changes

Two files, identical change:
- \`.github/workflows/lint.yml\` — \`version: v3.95.2\` → \`version: 3.95.2\`
- \`.github/workflows/security.yml\` — same

Comment added to each citing the GHCR/release-tag mismatch so future maintainers don't re-add the v prefix.

## Risk

CI-config only. No production code touched. Expected effect: Secret Scanning workflow stops returning manifest-unknown failures.

## Validation

- YAML parses cleanly on both files
- \`grep -n 'version: v3.95.2' .github/workflows/{lint,security}.yml\` → only matches in comment text (explanation), no live config

🤖 Generated with [Claude Code](https://claude.com/claude-code)