### PR TITLE
docs(roadmap): trim roadmap-evolution over-reach; land narrow survivors under existing tracks; reconcile pillar frames

### DIFF
--- a/docs-site/docs/contributing/aragora-evolution-roadmap.md
+++ b/docs-site/docs/contributing/aragora-evolution-roadmap.md
@@ -134,6 +134,7 @@ Design brief: [2026-04-19 PR Intelligence Brief](2026-04-19-pr-intelligence-brie
 - define what a trustworthy 12-hour bounded run looks like
 - run repeat soak tests on the bounded backlog
 - use measured rescue rate, verification pass rate, and terminal truth composition as gates
+- cheap-signal-to-verification routing (bounded benchmark, planning-truth only): treat "route by cheap signal, verify under full debate only on high-value or high-disagreement inputs" as a **benchmarked decision policy** on the existing bounded corpus, not a philosophy — acceptance is a labelled comparison on the same fixed benchmark that shows (a) measured cost reduction, (b) no regression in rescue rate / verification pass rate, and (c) a routing-decision receipt trail that lets an operator audit every cheap-route call. No `boss-ready` and no admission gate changes until the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](./next-steps-canonical).
 
 ### Track C — Unified DAG Workbench (Parallel Second Track)
 
@@ -172,6 +173,7 @@ This track turns knowledge into a reliable advantage instead of an opaque depend
 - store trust tier, provenance, and access boundaries for memory items
 - distinguish operator instruction from retrieved context
 - carry taint/provenance annotations into specs, debates, and receipts
+- design heuristic: treat session-scoped retrieval caches, KM writes, and long-horizon claim stores as distinct timescales that must declare cross-tier consolidation paths explicitly — silent merges are a finding. Non-canonical framing and analogies live in the [biological-timescale analogies research brief](../research/2026-04-18-biological-timescale-analogies-brief.md); the heuristic itself is a D-track design rule, not a new subsystem.
 
 #### D2. Large-Context Packing
 
@@ -200,6 +202,7 @@ This track preserves Aragora's core differentiation from generic agent platforms
 - improve truth weighting, dissent capture, and hollow-consensus detection
 - extend benchmark coverage across both decision and execution workflows
 - show debate quality signals inside receipts and operator views
+- measure whether *pre-consensus disagreement patterns* (not only final dissent) predict later settlement or correction — success criterion is a benchmark artifact showing disagreement-feature correlation with settled-outcome divergence on the existing bounded corpus; planning truth only, and acceptance must land a measurable correlation before any routing consumer is wired. This is a narrow E1 measurement, not a new subsystem; it enters the `boss-ready` queue only after the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](./next-steps-canonical).
 
 #### E2. External Verification and Policy Gates
 
@@ -265,6 +268,7 @@ Detailed plan: [2026-04-17-prediction-market-validation](2026-04-17-prediction-m
 - per-domain reputation slices (prediction calibration, debate truthfulness, code-PR success, KM contribution, crux resolution)
 - soft dispatch downweighting by default; hard suspension only on explicit policy
 - settlement-window enforcement, dispute path, and reversal handling for re-opened resolutions
+- strategy-decay slice (planning-truth sub-bullet): when a reputation slice depends on an agent's participation in a specific exploit strategy that becomes publicly known or measurably crowded, the slice decays faster — acceptance is a benchmark artifact showing measured decay behaviour on a receipt-backed synthetic corpus; sub-item to G3 rather than a new surface; planning-truth only, no `boss-ready` until the Foreman gate opens.
 
 Detailed plan: [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md).
 
@@ -281,6 +285,7 @@ Detailed plan: [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md).
 - promote `aragora/reasoning/crux_detector.py` from latent capability to first-class debate goal
 - emit ranked CruxSet on production debate path under flag, then default-on
 - bridges to DIC-15 (CruxSet contract) and Issue [#6035](https://github.com/synaptent/aragora/issues/6035) (crux-finder mode epic)
+- diversity-as-selection-pressure sub-bullet: extend `team_selector.py` with a measured diversity floor (pairwise disagreement entropy + provider-family share) on top of ELO + calibration — acceptance is a benchmark artifact showing that greedy-quality selection produces measurably homogenized failure modes which the diversity floor reduces; narrow extension of existing selection code; planning-truth only, no `boss-ready` until the Foreman gate opens.
 
 ### Track F — Trust-Wedge Productization and GTM
 

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -72,6 +72,8 @@ All other pillars remain planning truth unless a change directly improves one of
 
 ## Eight Foundational Pillars
 
+> **Reconciliation note.** The eight pillars below are the **doctrinal** framing — the architectural invariants every feature must trace to. The `README.md`, `CLAUDE.md`, and `docs/EXTENDED_README.md` surface a different five-pillar **product-messaging** framing (SMB-ready with enterprise-grade security, leading-edge memory, extensibility/modularity, multi-agent robustness, self-healing via the Nomic Loop), and `docs/PACKAGING.md` groups the platform into three shippable pillars (verifiable decisionmaking, bounded autonomous execution, auditable memory). These three frames are complementary, not contradictory: the eight doctrinal pillars ground the architecture, the five product-messaging pillars summarize the user-visible thesis, and the three packaging pillars describe modular delivery. This document is authoritative for the doctrinal frame. The pillar count here evolved 6 → 7 → 8 across [2026-03-01 canonical-goals update](plans/2026-03-01-canonical-goals-update-design.md), the Epistemic CI / Dialectical Runtime layering (2026-04 #6029/#6034/#6224), and the agent-civilization tranche (#6061); the current count is **eight** and the list below is exhaustive.
+
 ### 1. Adversarial Heterogeneous Consensus
 
 Any single model can hallucinate, flatter, or share hidden blind spots. Aragora's default stance is structured challenge across heterogeneous models, not trust in one witness. This pillar serves the debate engine, gauntlet, truth weighting, calibration, dissent capture, and cross-verification.

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -67,6 +67,8 @@ All other pillars remain planning truth unless a change directly improves one of
 
 ## Eight Foundational Pillars
 
+> **Reconciliation note.** The eight pillars below are the **doctrinal** framing — the architectural invariants every feature must trace to. The `README.md`, `CLAUDE.md`, and `docs/EXTENDED_README.md` surface a different five-pillar **product-messaging** framing (SMB-ready with enterprise-grade security, leading-edge memory, extensibility/modularity, multi-agent robustness, self-healing via the Nomic Loop), and `docs/PACKAGING.md` groups the platform into three shippable pillars (verifiable decisionmaking, bounded autonomous execution, auditable memory). These three frames are complementary, not contradictory: the eight doctrinal pillars ground the architecture, the five product-messaging pillars summarize the user-visible thesis, and the three packaging pillars describe modular delivery. This document is authoritative for the doctrinal frame. The pillar count here evolved 6 → 7 → 8 across [2026-03-01 canonical-goals update](plans/2026-03-01-canonical-goals-update-design.md), the Epistemic CI / Dialectical Runtime layering (2026-04 #6029/#6034/#6224), and the agent-civilization tranche (#6061); the current count is **eight** and the list below is exhaustive.
+
 ### 1. Adversarial Heterogeneous Consensus
 
 Any single model can hallucinate, flatter, or share hidden blind spots. Aragora's default stance is structured challenge across heterogeneous models, not trust in one witness. This pillar serves the debate engine, gauntlet, truth weighting, calibration, dissent capture, and cross-verification.

--- a/docs/ROADMAP_EVOLUTION.md
+++ b/docs/ROADMAP_EVOLUTION.md
@@ -1,0 +1,21 @@
+# Tombstone — ROADMAP_EVOLUTION.md has been retired
+
+This file was briefly drafted on 2026-04-18 as a "maximalist horizon overlay" introducing new top-level tracks (H Surrogate Distillation, I Population-Under-Selection, J Multi-Timescale Memory). It was retired the same day after a skeptical-read pass identified:
+
+1. the proposed tracks duplicated canonical tracks D/E/G
+2. adding new top-level tracks cuts against the proof-first Foreman gate defined in [NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md) — the current obligation is operationalizing the proof-first loop, **not adding new roadmap scope**
+3. a third roadmap document alongside [CANONICAL_GOALS.md](CANONICAL_GOALS.md) and [plans/ARAGORA_EVOLUTION_ROADMAP.md](plans/ARAGORA_EVOLUTION_ROADMAP.md) creates source-of-truth drift
+
+The narrow surviving ideas have been re-homed as **sub-bullets under existing tracks** in [plans/ARAGORA_EVOLUTION_ROADMAP.md](plans/ARAGORA_EVOLUTION_ROADMAP.md):
+
+- disagreement-as-signal measurement → sub-bullet under E1
+- timescale-separation design heuristic → sub-bullet under D1
+- strategy-decay reputation slice → sub-bullet under G3
+- diversity floor in ensemble selection → sub-bullet under G5
+- cheap-signal-to-verification routing as a benchmarked decision policy → sub-bullet under B4
+
+The biology-flavored framings that motivate them live in a non-canonical brief: [research/2026-04-18-biological-timescale-analogies-brief.md](research/2026-04-18-biological-timescale-analogies-brief.md).
+
+**Do not cite this file. Do not add content here.** Everything that survived the critique lives in the two docs referenced above.
+
+This tombstone exists only because the sandbox filesystem does not currently permit hard deletion; on the next commit pass this file should be removed via `git rm`.

--- a/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
+++ b/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
@@ -129,6 +129,7 @@ Design brief: [2026-04-19 PR Intelligence Brief](2026-04-19-pr-intelligence-brie
 - define what a trustworthy 12-hour bounded run looks like
 - run repeat soak tests on the bounded backlog
 - use measured rescue rate, verification pass rate, and terminal truth composition as gates
+- cheap-signal-to-verification routing (bounded benchmark, planning-truth only): treat "route by cheap signal, verify under full debate only on high-value or high-disagreement inputs" as a **benchmarked decision policy** on the existing bounded corpus, not a philosophy — acceptance is a labelled comparison on the same fixed benchmark that shows (a) measured cost reduction, (b) no regression in rescue rate / verification pass rate, and (c) a routing-decision receipt trail that lets an operator audit every cheap-route call. No `boss-ready` and no admission gate changes until the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](../status/NEXT_STEPS_CANONICAL.md).
 
 ### Track C — Unified DAG Workbench (Parallel Second Track)
 
@@ -167,6 +168,7 @@ This track turns knowledge into a reliable advantage instead of an opaque depend
 - store trust tier, provenance, and access boundaries for memory items
 - distinguish operator instruction from retrieved context
 - carry taint/provenance annotations into specs, debates, and receipts
+- design heuristic: treat session-scoped retrieval caches, KM writes, and long-horizon claim stores as distinct timescales that must declare cross-tier consolidation paths explicitly — silent merges are a finding. Non-canonical framing and analogies live in the [biological-timescale analogies research brief](../research/2026-04-18-biological-timescale-analogies-brief.md); the heuristic itself is a D-track design rule, not a new subsystem.
 
 #### D2. Large-Context Packing
 
@@ -195,6 +197,7 @@ This track preserves Aragora's core differentiation from generic agent platforms
 - improve truth weighting, dissent capture, and hollow-consensus detection
 - extend benchmark coverage across both decision and execution workflows
 - show debate quality signals inside receipts and operator views
+- measure whether *pre-consensus disagreement patterns* (not only final dissent) predict later settlement or correction — success criterion is a benchmark artifact showing disagreement-feature correlation with settled-outcome divergence on the existing bounded corpus; planning truth only, and acceptance must land a measurable correlation before any routing consumer is wired. This is a narrow E1 measurement, not a new subsystem; it enters the `boss-ready` queue only after the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](../status/NEXT_STEPS_CANONICAL.md).
 
 #### E2. External Verification and Policy Gates
 
@@ -260,6 +263,7 @@ Detailed plan: [2026-04-17-prediction-market-validation](2026-04-17-prediction-m
 - per-domain reputation slices (prediction calibration, debate truthfulness, code-PR success, KM contribution, crux resolution)
 - soft dispatch downweighting by default; hard suspension only on explicit policy
 - settlement-window enforcement, dispute path, and reversal handling for re-opened resolutions
+- strategy-decay slice (planning-truth sub-bullet): when a reputation slice depends on an agent's participation in a specific exploit strategy that becomes publicly known or measurably crowded, the slice decays faster — acceptance is a benchmark artifact showing measured decay behaviour on a receipt-backed synthetic corpus; sub-item to G3 rather than a new surface; planning-truth only, no `boss-ready` until the Foreman gate opens.
 
 Detailed plan: [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md).
 
@@ -276,6 +280,7 @@ Detailed plan: [SKIN_IN_THE_GAME_REPUTATION](SKIN_IN_THE_GAME_REPUTATION.md).
 - promote `aragora/reasoning/crux_detector.py` from latent capability to first-class debate goal
 - emit ranked CruxSet on production debate path under flag, then default-on
 - bridges to DIC-15 (CruxSet contract) and Issue [#6035](https://github.com/synaptent/aragora/issues/6035) (crux-finder mode epic)
+- diversity-as-selection-pressure sub-bullet: extend `team_selector.py` with a measured diversity floor (pairwise disagreement entropy + provider-family share) on top of ELO + calibration — acceptance is a benchmark artifact showing that greedy-quality selection produces measurably homogenized failure modes which the diversity floor reduces; narrow extension of existing selection code; planning-truth only, no `boss-ready` until the Foreman gate opens.
 
 ### Track F — Trust-Wedge Productization and GTM
 

--- a/docs/proposals/roadmap-evolution-2026-04/B4-cheap-signal-routing-benchmark.md
+++ b/docs/proposals/roadmap-evolution-2026-04/B4-cheap-signal-routing-benchmark.md
@@ -1,0 +1,49 @@
+# B4 extension — Cheap-Signal-to-Verification Routing as Benchmarked Decision Policy
+
+**Status:** Planning truth only. **Not `boss-ready`** until the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+**Labels:** `track:B` `area:benchmark` `area:routing` `type:benchmarked-decision-policy` `boss-ready:no-until-foreman-gate`
+
+## What this is
+
+A narrow **benchmarked decision-policy experiment** under existing [Track B4 (Multi-Host Soak and Unattended Criteria)](../../plans/ARAGORA_EVOLUTION_ROADMAP.md). Not a new track, subsystem, or philosophy — it is evaluated on the **existing bounded corpus** the Track B stack already uses.
+
+## Question
+
+On the existing bounded-autonomy benchmark corpus, does routing by cheap signal (single-agent inference + disagreement-feature heuristics) and escalating to full adversarial debate only on high-value or high-disagreement inputs produce:
+
+(a) measured cost reduction vs. always-debate,
+(b) no regression in rescue rate or verification pass rate vs. always-debate, and
+(c) an auditable routing-decision receipt for every cheap-route call?
+
+If (a) holds with (b) and (c) intact, cheap-signal routing becomes a legitimate production policy for low-stakes decisions. If not, the policy is rejected and the benchmark artifact documents why.
+
+## Scope (bounded)
+
+1. Labelled comparison harness under `benchmarks/b4_cheap_signal_routing/` using the existing Track B corpus.
+2. Three arms: `always_debate` (baseline), `cheap_only` (lower bound on accuracy cost), `routed` (cheap + escalate on high-disagreement).
+3. Receipt schema extension for the routing decision itself (question, cheap signal, disagreement features, routing decision, rationale). Landed only in the benchmark harness, **not** in the production admission gate.
+
+## Acceptance criteria
+
+- [ ] Harness + corpus-loader land under `benchmarks/b4_cheap_signal_routing/`
+- [ ] Benchmark artifact: `benchmarks/b4_cheap_signal_routing/REPORT_<date>.md` with (a) cost, (b) rescue rate + verification pass rate, (c) a sample of routing-decision receipts
+- [ ] No production-path changes to `aragora/debate/orchestrator.py`, `aragora/workflow/`, or the admission gate
+- [ ] Report concludes with one of: **all three conditions met → propose a narrow production wiring behind a feature flag under B4**; **any condition fails → close and document**
+
+## Explicitly out of scope
+
+- Any production admission-gate change (the retired H3/A6 surface)
+- Any surrogate training corpus (the retired H1 surface)
+- Any surrogate model zoo
+- Any out-of-distribution guardrail as a new subsystem
+- Any per-domain surrogate ceiling governance surface
+
+## Foreman-gate posture
+
+Per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md), **the current obligation is operationalizing the proof-first loop, not adding new roadmap scope**. This issue is a **benchmark-only experiment** whose artifact is a report. It **must not** carry `boss-ready` or modify any production admission path until the proof-first Foreman gate opens.
+
+## Related
+
+- [Track B4 in ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md)
+- [NEXT_STEPS_CANONICAL.md proof-first gate](../../status/NEXT_STEPS_CANONICAL.md)
+- Existing bounded-autonomy benchmark corpus used by Track B

--- a/docs/proposals/roadmap-evolution-2026-04/D5-germline-somatic-memetic-separation.md
+++ b/docs/proposals/roadmap-evolution-2026-04/D5-germline-somatic-memetic-separation.md
@@ -1,0 +1,11 @@
+# Retired — D5 Germline/Somatic/Memetic Memory Separation
+
+This draft was retired on 2026-04-18 after a skeptical-read pass.
+
+Reasons:
+
+1. The useful core (a design invariant that silent cross-tier merges are a finding) survives as a **sub-bullet under D1** in [ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md), not as a new epic.
+2. The biology-framed tier vocabulary (germline / somatic / memetic) is documented in the non-canonical [biological-timescale analogies brief](../../research/2026-04-18-biological-timescale-analogies-brief.md) and does not carry roadmap authority.
+3. Per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md), the current obligation is operationalizing the proof-first loop, not adding new roadmap scope. This draft would have added scope without a benchmark-artifact acceptance criterion.
+
+Do not cite or open an issue from this file. File retained only because the sandbox does not permit hard deletion; remove with `git rm` on the next commit pass.

--- a/docs/proposals/roadmap-evolution-2026-04/E6-disagreement-as-signal.md
+++ b/docs/proposals/roadmap-evolution-2026-04/E6-disagreement-as-signal.md
@@ -1,0 +1,47 @@
+# E1 extension — Pre-Consensus Disagreement-as-Signal Measurement
+
+**Status:** Planning truth only. **Not `boss-ready`** until the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+**Labels:** `track:E` `area:debate` `area:measurement` `type:measurement-experiment` `boss-ready:no-until-foreman-gate`
+
+## What this is
+
+A narrow **measurement experiment** under existing [Track E1 (Debate Quality and Calibration)](../../plans/ARAGORA_EVOLUTION_ROADMAP.md). Not a new subsystem. Not a new track. Not a new debate primitive.
+
+## Question
+
+Do pre-consensus disagreement patterns among heterogeneous evaluators predict later settlement divergence on the existing bounded corpus?
+
+Today Aragora treats disagreement primarily as a problem surface (hollow-consensus detection, Trickster, dissent tracking). The hypothesis is that the *distribution* of disagreement early in a debate carries predictive information about whether the eventual consensus will be revised at settlement. If so, it is a usable feature for E5 crux detection, difficulty scoring, and calibrated confidence. If not, the hypothesis stops being load-bearing and this experiment is closed.
+
+## Scope (bounded)
+
+1. Extract pre-consensus disagreement features from receipts in the existing bounded corpus — no new feature extractor modules outside of a short measurement script.
+2. Compute correlation with settled-outcome divergence (for receipts where settlement is observed).
+3. Report the correlation, confidence intervals, and sensitivity analysis as a benchmark artifact.
+
+## Acceptance criteria
+
+- [ ] Measurement script lands under `benchmarks/e1_disagreement_signal/` (new directory) — not a production module
+- [ ] Benchmark artifact published: `benchmarks/e1_disagreement_signal/REPORT_<date>.md` with (a) correlation, (b) confidence interval, (c) sensitivity analysis, (d) failure-mode analysis
+- [ ] No changes to `aragora/debate/` or `aragora/reasoning/` — this issue does not wire any consumer
+- [ ] Report concludes with one of: **significant → propose a follow-up under E5 crux detection**; **non-significant → close and document**
+
+## Explicitly out of scope
+
+- Any production feature extractor under `aragora/debate/`
+- Any routing consumer
+- Any dashboard or admin surface
+- Any cross-cutting modification to the debate orchestrator
+- Wiring into the admission gate, the crux detector, or team selection
+
+## Foreman-gate posture
+
+Per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md), **the current obligation is operationalizing the proof-first loop, not adding new roadmap scope**. This issue is a **measurement-only experiment** whose entire artifact is a benchmark report. It **must not** carry `boss-ready`, enter the live dispatch queue, or be auto-decomposed into implementation work until the proof-first Foreman gate opens.
+
+If the measurement does land and reports significance, the follow-up — wiring a consumer under E5 — still sits behind the same gate.
+
+## Related
+
+- [Track E1 in ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md)
+- [Biological-timescale analogies brief (non-canonical framing)](../../research/2026-04-18-biological-timescale-analogies-brief.md)
+- [NEXT_STEPS_CANONICAL.md proof-first gate](../../status/NEXT_STEPS_CANONICAL.md)

--- a/docs/proposals/roadmap-evolution-2026-04/E8-exploit-strategy-registry.md
+++ b/docs/proposals/roadmap-evolution-2026-04/E8-exploit-strategy-registry.md
@@ -1,0 +1,11 @@
+# Retired — E8 Exploit-Strategy Lifecycle Registry
+
+This draft was retired on 2026-04-18 after a skeptical-read pass.
+
+Reasons:
+
+1. The strategy-lifecycle concern survives at a narrower surface: a strategy-decay reputation slice as **a sub-bullet under G3** in [ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md).
+2. A full registry-with-governance epic introduces a new governance surface that has no benchmark-artifact acceptance and duplicates the tracking that already lives inside G3 reputation slices.
+3. Per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md), no new roadmap scope during the proof-first loop obligation.
+
+Do not cite or open an issue from this file. File retained only because the sandbox does not permit hard deletion; remove with `git rm` on the next commit pass.

--- a/docs/proposals/roadmap-evolution-2026-04/G6-strategy-decay-reputation-slice.md
+++ b/docs/proposals/roadmap-evolution-2026-04/G6-strategy-decay-reputation-slice.md
@@ -1,0 +1,44 @@
+# G3 extension — Strategy-Decay Reputation Slice (Measurement Prototype)
+
+**Status:** Planning truth only. **Not `boss-ready`** until the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+**Labels:** `track:G` `area:reputation` `type:measurement-prototype` `boss-ready:no-until-foreman-gate`
+
+## What this is
+
+A narrow **measurement prototype** under existing [Track G3 (Skin-in-the-Game Reputation Flow)](../../plans/ARAGORA_EVOLUTION_ROADMAP.md). Not a new reputation subsystem; a sub-item that extends the existing slice model with one additional, benchmarkable behaviour.
+
+## Question
+
+When an agent's reputation slice is tied to participation in a specific exploit strategy that becomes publicly known or measurably crowded, does faster decay of that slice produce better-calibrated downstream dispatch decisions on a receipt-backed synthetic corpus than holding the slice constant?
+
+## Scope (bounded)
+
+1. Build a small synthetic corpus of `(agent, strategy, epoch, observed-outcome)` tuples that models the crowded-strategy scenario. This corpus lives under `benchmarks/g3_strategy_decay/` — not production data.
+2. Prototype a decay function on top of the existing G3 reputation-slice math. Prototype may live in a scratch script, not production code, until acceptance.
+3. Compare dispatch decisions with and without the decay on the synthetic corpus.
+
+## Acceptance criteria
+
+- [ ] Synthetic corpus + generator script lands under `benchmarks/g3_strategy_decay/`
+- [ ] Benchmark artifact: `benchmarks/g3_strategy_decay/REPORT_<date>.md` with measured calibration deltas between decay-on and decay-off arms
+- [ ] Report concludes with one of: **measurable improvement → propose production wiring under G3**; **no measurable improvement → close the experiment and document**
+- [ ] No changes to `aragora/ranking/`, `aragora/blockchain/contracts/`, or dispatch code paths
+
+## Explicitly out of scope
+
+- Any production reputation-writer change
+- Any ERC-8004 schema extension
+- Any dispatch-policy change
+- Any public-signal monitor for real-world strategy lifecycle
+- Any registry of exploit strategies (that was the retired E8 surface)
+
+## Foreman-gate posture
+
+Per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md), **the current obligation is operationalizing the proof-first loop, not adding new roadmap scope**. This issue is a **benchmark-only prototype**. It **must not** carry `boss-ready` or enter the live dispatch queue until the proof-first Foreman gate opens.
+
+## Related
+
+- [Track G3 in ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md)
+- [SKIN_IN_THE_GAME_REPUTATION design doc](../../plans/SKIN_IN_THE_GAME_REPUTATION.md)
+- [Biological-timescale analogies brief (non-canonical framing for the decay metaphor)](../../research/2026-04-18-biological-timescale-analogies-brief.md)
+- [NEXT_STEPS_CANONICAL.md proof-first gate](../../status/NEXT_STEPS_CANONICAL.md)

--- a/docs/proposals/roadmap-evolution-2026-04/G7-diversity-maintenance-gates.md
+++ b/docs/proposals/roadmap-evolution-2026-04/G7-diversity-maintenance-gates.md
@@ -1,0 +1,44 @@
+# G5 extension — Diversity Floor in Team Selection (Measurement Prototype)
+
+**Status:** Planning truth only. **Not `boss-ready`** until the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+**Labels:** `track:G` `area:ensemble` `area:selection` `type:measurement-prototype` `boss-ready:no-until-foreman-gate`
+
+## What this is
+
+A narrow **measurement prototype** under existing [Track G5 (CruxDetector Activation in Live Debates)](../../plans/ARAGORA_EVOLUTION_ROADMAP.md) that extends `aragora/debate/team_selector.py` with a measured diversity floor on top of ELO + calibration. Not a new selection track. Not a new registry. Not a new protocol-level gate.
+
+## Question
+
+Does greedy quality-only selection in `team_selector.py` produce measurably homogenized failure modes on the existing bounded corpus that a simple diversity floor (pairwise disagreement entropy + provider-family share) would reduce?
+
+## Scope (bounded)
+
+1. Offline replay against receipts from the existing bounded corpus: reconstruct what ensembles greedy selection would have chosen, with and without a diversity floor.
+2. Measure the share of debates whose failures cluster by provider family or by model lineage under each arm.
+3. Report the delta as a benchmark artifact.
+
+## Acceptance criteria
+
+- [ ] Replay harness under `benchmarks/g5_diversity_floor/` (new) — uses existing receipt store; no production-path changes
+- [ ] Benchmark artifact: `benchmarks/g5_diversity_floor/REPORT_<date>.md` with measured homogenization deltas
+- [ ] Report concludes with one of: **measurable reduction in correlated-failure clustering → propose a production wiring under G5**; **no measurable reduction → close the experiment and document**
+- [ ] No changes to `aragora/debate/team_selector.py` or to production selection behaviour
+
+## Explicitly out of scope
+
+- Any production change to `team_selector.py`
+- Any protocol-level or schema-level diversity gate (the retired I3 surface)
+- Any rotating benchmark corpus maintained in production
+- Any operator dashboard or admin surface
+- Any policy enforcement
+
+## Foreman-gate posture
+
+Per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md), **the current obligation is operationalizing the proof-first loop, not adding new roadmap scope**. This issue is a **replay-only benchmark**. It **must not** carry `boss-ready` or enter the live dispatch queue until the proof-first Foreman gate opens.
+
+## Related
+
+- [Track G5 in ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md)
+- `aragora/debate/team_selector.py` — existing selection code under measurement
+- [Biological-timescale analogies brief (non-canonical framing for the diversity metaphor)](../../research/2026-04-18-biological-timescale-analogies-brief.md)
+- [NEXT_STEPS_CANONICAL.md proof-first gate](../../status/NEXT_STEPS_CANONICAL.md)

--- a/docs/proposals/roadmap-evolution-2026-04/H1-surrogate-training-corpus.md
+++ b/docs/proposals/roadmap-evolution-2026-04/H1-surrogate-training-corpus.md
@@ -1,0 +1,11 @@
+# Retired — H1 Surrogate Training Corpus From Debate Receipts
+
+This draft was retired on 2026-04-18 after a skeptical-read pass.
+
+Reasons:
+
+1. Track H (Cheap-Proxy Surrogate and Debate Distillation Layer) was retired as a top-level track. The surviving idea — cheap-signal-to-verification routing — is now a **benchmarked decision-policy sub-bullet under B4** in [ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md), not a new training-corpus epic.
+2. Building a surrogate training corpus before the proof-first Foreman gate opens violates [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+3. The idea does not produce a benchmark artifact by itself; it needs the B4 benchmark to exist first. Without that, it is speculative scope.
+
+Do not cite or open an issue from this file. File retained only because the sandbox does not permit hard deletion; remove with `git rm` on the next commit pass.

--- a/docs/proposals/roadmap-evolution-2026-04/H3-routing-gate-with-receipt.md
+++ b/docs/proposals/roadmap-evolution-2026-04/H3-routing-gate-with-receipt.md
@@ -1,0 +1,10 @@
+# Retired — H3 / A6 Surrogate-Routing Admission Gate + Receipt
+
+This draft was retired on 2026-04-18 after a skeptical-read pass.
+
+Reasons:
+
+1. Track H was retired (duplicative of existing tracks). The surviving routing idea is a **benchmarked decision-policy sub-bullet under B4** in [ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md), with acceptance defined as a labelled comparison on the existing bounded corpus — no new admission-gate surface.
+2. The A6 surface proposed here would modify the Track A admission gate before the proof-first Foreman gate opens, which [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md) explicitly prohibits (no new roadmap scope while the proof-first loop obligation stands).
+
+Do not cite or open an issue from this file. File retained only because the sandbox does not permit hard deletion; remove with `git rm` on the next commit pass.

--- a/docs/proposals/roadmap-evolution-2026-04/I1-meta-ecosystem-ledger.md
+++ b/docs/proposals/roadmap-evolution-2026-04/I1-meta-ecosystem-ledger.md
@@ -1,0 +1,11 @@
+# Retired — I1 Meta-Ecosystem Ledger
+
+This draft was retired on 2026-04-18 after a skeptical-read pass.
+
+Reasons:
+
+1. Track I (Population-Under-Selection Meta-Ecosystem) was retired as a top-level track (duplicative of G3/G5 plus existing Outcome Feedback → Nomic Loop).
+2. A population-level ledger is speculative scope without a benchmark-artifact acceptance; it does not map to the bounded-autonomy substrate that is the current obligation in [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+3. Any useful subset is already covered by the landed Outcome Feedback → Nomic Loop pipeline and by the G3 strategy-decay sub-bullet and G5 diversity-floor sub-bullet in [ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md).
+
+Do not cite or open an issue from this file. File retained only because the sandbox does not permit hard deletion; remove with `git rm` on the next commit pass.

--- a/docs/proposals/roadmap-evolution-2026-04/I2-bounded-protocol-ab-tests.md
+++ b/docs/proposals/roadmap-evolution-2026-04/I2-bounded-protocol-ab-tests.md
@@ -1,0 +1,10 @@
+# Retired — I2 Bounded Protocol A/B Tests as First-Class Experiments
+
+This draft was retired on 2026-04-18 after a skeptical-read pass.
+
+Reasons:
+
+1. Track I was retired. Protocol experimentation already has a home in the existing P4 "Meta-improver for debate protocols" plan, which is design-only until the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+2. A production A/B-test framework is a new runtime surface and violates the "no new roadmap scope" rule during the proof-first obligation.
+
+Do not cite or open an issue from this file. File retained only because the sandbox does not permit hard deletion; remove with `git rm` on the next commit pass.

--- a/docs/proposals/roadmap-evolution-2026-04/I4-goodhart-sentinel.md
+++ b/docs/proposals/roadmap-evolution-2026-04/I4-goodhart-sentinel.md
@@ -1,0 +1,10 @@
+# Retired — I4 Goodhart Sentinel
+
+This draft was retired on 2026-04-18 after a skeptical-read pass.
+
+Reasons:
+
+1. Track I was retired. A Goodhart-sentinel concern for specific KPIs is legitimate but already lives inside existing E1/E2/E3 calibration and verification surfaces — adding a new epic duplicates them.
+2. Without a named KPI producing measurable divergence on a benchmark corpus, the epic has no acceptance criterion; adding it contradicts the proof-first obligation in [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+
+Do not cite or open an issue from this file. File retained only because the sandbox does not permit hard deletion; remove with `git rm` on the next commit pass.

--- a/docs/proposals/roadmap-evolution-2026-04/J1-germline-permanence-contract.md
+++ b/docs/proposals/roadmap-evolution-2026-04/J1-germline-permanence-contract.md
@@ -1,0 +1,10 @@
+# Retired — J1 Germline-Grade Permanence Contract
+
+This draft was retired on 2026-04-18 after a skeptical-read pass.
+
+Reasons:
+
+1. Track J (Multi-Timescale Memory Architecture) was retired. The surviving idea is a design heuristic under D1 in [ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md), not a new contract surface.
+2. A "germline permanence contract" adds a new enforcement surface without a benchmark artifact; it violates the proof-first obligation in [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+
+Do not cite or open an issue from this file. File retained only because the sandbox does not permit hard deletion; remove with `git rm` on the next commit pass.

--- a/docs/proposals/roadmap-evolution-2026-04/J2-somatic-isolation.md
+++ b/docs/proposals/roadmap-evolution-2026-04/J2-somatic-isolation.md
@@ -1,0 +1,10 @@
+# Retired — J2 Somatic-Tier Isolation Guarantees
+
+This draft was retired on 2026-04-18 after a skeptical-read pass.
+
+Reasons:
+
+1. Track J was retired. The "no silent cross-tier merges" concern survives as a **design heuristic sub-bullet under D1** in [ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md).
+2. A formal somatic contract + static analysis + runtime monitor is a large new enforcement surface without a benchmark artifact; it violates the proof-first obligation in [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+
+Do not cite or open an issue from this file. File retained only because the sandbox does not permit hard deletion; remove with `git rm` on the next commit pass.

--- a/docs/proposals/roadmap-evolution-2026-04/README.md
+++ b/docs/proposals/roadmap-evolution-2026-04/README.md
@@ -1,0 +1,51 @@
+# Roadmap Evolution — 2026-04-18 Proposal Bundle (Trimmed)
+
+This bundle was initially drafted as 12 epic-grade issues spanning three proposed new tracks (H Surrogate Distillation, I Population-Under-Selection, J Multi-Timescale Memory). After a skeptical-read pass on 2026-04-18, the bundle was **trimmed to 4 bounded, benchmark-gated, Foreman-gated issues** under existing tracks B/E/G.
+
+## Critique that drove the trim
+
+1. [P1] New top-level tracks duplicated canonical tracks D/E/G and weakened canonical clarity.
+2. [P1] [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md) explicitly says "the current obligation is operationalizing the proof-first loop, **not adding new roadmap scope**".
+3. [P2] A third roadmap doc (the now-retired `docs/ROADMAP_EVOLUTION.md`) created source-of-truth drift.
+4. [P2] Biology framing belongs in a research brief, not in doctrine. The surviving heuristics need benchmark-artifact acceptance, not metaphor.
+
+## Surviving issues (4)
+
+Each is a **measurement-only / benchmark-only** experiment under an existing track. None carries `boss-ready`. None enters the live dispatch queue until the proof-first Foreman gate opens.
+
+| File | Track | Type | What it measures |
+|------|-------|------|------------------|
+| [E6-disagreement-as-signal.md](E6-disagreement-as-signal.md) | E1 | measurement experiment | Does pre-consensus disagreement predict settlement divergence? |
+| [G6-strategy-decay-reputation-slice.md](G6-strategy-decay-reputation-slice.md) | G3 | measurement prototype | Does faster decay on crowded-strategy slices improve dispatch calibration on a synthetic corpus? |
+| [G7-diversity-maintenance-gates.md](G7-diversity-maintenance-gates.md) | G5 | measurement prototype | Does greedy quality-only team selection produce measurably homogenized failure modes on the existing corpus? |
+| [B4-cheap-signal-routing-benchmark.md](B4-cheap-signal-routing-benchmark.md) | B4 | benchmarked decision policy | On the existing bounded corpus, does cheap-signal routing preserve rescue/verification rate while reducing cost, with auditable routing receipts? |
+
+## Retired issues (9)
+
+These drafts were retired. Each file now carries a tombstone pointing at where the surviving narrow idea (if any) lives and why the epic was rejected:
+
+- [D5-germline-somatic-memetic-separation.md](D5-germline-somatic-memetic-separation.md)
+- [E8-exploit-strategy-registry.md](E8-exploit-strategy-registry.md)
+- [H1-surrogate-training-corpus.md](H1-surrogate-training-corpus.md)
+- [H3-routing-gate-with-receipt.md](H3-routing-gate-with-receipt.md)
+- [I1-meta-ecosystem-ledger.md](I1-meta-ecosystem-ledger.md)
+- [I2-bounded-protocol-ab-tests.md](I2-bounded-protocol-ab-tests.md)
+- [I4-goodhart-sentinel.md](I4-goodhart-sentinel.md)
+- [J1-germline-permanence-contract.md](J1-germline-permanence-contract.md)
+- [J2-somatic-isolation.md](J2-somatic-isolation.md)
+
+(They remain in the directory only because the sandbox does not currently permit hard deletion. Remove with `git rm` on the next commit pass.)
+
+## Rules of the road
+
+1. Any issue opened from this bundle must carry the label `boss-ready:no-until-foreman-gate`.
+2. Acceptance criteria must be a **benchmark artifact or proof surface**, not an engineering spec.
+3. No issue here enters the live dispatch queue until the proof-first Foreman gate opens per [NEXT_STEPS_CANONICAL.md](../../status/NEXT_STEPS_CANONICAL.md).
+4. Significance results that graduate to production wiring must do so as a narrow, feature-flagged extension of the existing track, not as a new track.
+
+## Related
+
+- [CANONICAL_GOALS.md](../../CANONICAL_GOALS.md) — 8 pillars; unchanged by this bundle
+- [ARAGORA_EVOLUTION_ROADMAP.md](../../plans/ARAGORA_EVOLUTION_ROADMAP.md) — Tracks A–G; the narrow surviving sub-bullets live here
+- [Biological-timescale analogies research brief (non-canonical)](../../research/2026-04-18-biological-timescale-analogies-brief.md)
+- [NEXT_STEPS_CANONICAL.md — proof-first Foreman gate and `boss-ready` queue governance](../../status/NEXT_STEPS_CANONICAL.md)

--- a/docs/research/2026-04-18-biological-timescale-analogies-brief.md
+++ b/docs/research/2026-04-18-biological-timescale-analogies-brief.md
@@ -1,0 +1,80 @@
+# Biological-Timescale Analogies for Aragora Memory and Selection — Research Brief
+
+> **Status:** NON-CANONICAL RESEARCH BRIEF.
+> **Authority:** None. This document is framings, not roadmap. It does not bind architecture, create tracks, or add scope to the [canonical roadmap](../plans/ARAGORA_EVOLUTION_ROADMAP.md) or [CANONICAL_GOALS.md](../CANONICAL_GOALS.md).
+> **Gate:** Per [NEXT_STEPS_CANONICAL.md](../status/NEXT_STEPS_CANONICAL.md), the current obligation is operationalizing the proof-first loop, not adding new roadmap scope. Any bullet in this brief that graduates into roadmap work must do so by surviving a benchmark artifact and passing through an existing track (D, E, G, or B), not as a new track.
+> **Date:** 2026-04-18
+
+## Purpose
+
+This brief captures four biology-flavored framings that came up in product strategy discussion and evaluates whether any of them should survive as **measurable design heuristics** under existing roadmap tracks. It does so by:
+
+1. stating the analogy in its shortest useful form
+2. identifying the Aragora primitive it maps onto
+3. proposing a measurement that would make the analogy load-bearing rather than decorative
+4. naming the existing track that should own any follow-up
+
+If a framing cannot produce a benchmark artifact or a proof surface, it stays in this brief and does not graduate.
+
+## Framings
+
+### 1. Germline / somatic / memetic timescale separation
+
+Biology separates very-slow (DNA), fast-mutable (somatic cells and immune memory), and horizontally-transferable (memetic, cultural) memory. The failure mode the analogy highlights is **silent merging** — a short-lived session artifact informing long-lived retrieval without a receipt.
+
+Aragora primitive: ContinuumMemory, Unified Memory Gateway, 42 KM adapters.
+
+Measurable design heuristic (under Track D): any module that writes across memory tiers must declare a cross-tier consolidation path, and silent merges are treated as a finding in architectural review. This does not require a new tier, a new adapter, or a new subsystem — it is a design invariant that applies to the existing Memory and Context Fabric.
+
+Owner: Track D. Already reflected as a sub-bullet under [D1 Permissioned Memory Model](../plans/ARAGORA_EVOLUTION_ROADMAP.md).
+
+### 2. Red Queen dynamics and strategy decay
+
+Evolutionary systems where a specific edge depends on an opponent's failure mode lose that edge as the opponent learns. Fund-of-funds operators model this as alpha decay: tactical edges are depreciating assets, not evergreen moats.
+
+Aragora primitive: Skin-in-the-Game reputation (G3), selection over exploit strategies.
+
+Measurable design heuristic (under Track G): a reputation slice tied to participation in a specific exploit strategy decays faster once the strategy is measurably crowded or publicly known. The benchmark artifact is a receipt-backed synthetic corpus that shows measured decay behaviour on known-decaying strategies.
+
+Owner: Track G, sub-bullet under [G3 Skin-in-the-Game Reputation Flow](../plans/ARAGORA_EVOLUTION_ROADMAP.md). Not a new track.
+
+### 3. Disagreement among cheap evaluators as a first-class signal
+
+Ensembles exist primarily to error-correct through independent observers. The usual framing of disagreement inside Aragora (hollow-consensus detection, Trickster, dissent tracking) is disagreement-as-problem. The symmetric positive framing is: pre-consensus disagreement is itself predictive data about which questions are hard, which will be overturned at settlement, and which contain a real crux.
+
+Aragora primitive: Debate orchestration, truth-scorer, calibration tracker, crux detector.
+
+Measurable design heuristic (under Track E): measure whether pre-consensus disagreement patterns correlate with later settlement divergence on the existing bounded corpus. If the correlation is real and significant, it becomes a usable feature for crux detection and difficulty scoring. If the correlation is weak or absent, the framing stops being load-bearing.
+
+Owner: Track E, sub-bullet under [E1 Debate Quality and Calibration](../plans/ARAGORA_EVOLUTION_ROADMAP.md). This is a measurement question first; only after a measurable correlation lands does any downstream routing consumer become appropriate.
+
+### 4. Population-under-selection diversity maintenance
+
+Biological and economic populations that optimize greedily on a single fitness metric homogenize, which loads bearing weight on correlated failure modes. The canonical antidote is explicit diversity maintenance, not faith that aggregation will preserve heterogeneity.
+
+Aragora primitive: `team_selector.py` (ELO + calibration).
+
+Measurable design heuristic (under Track G): extend team selection with a measured diversity floor (pairwise disagreement entropy plus provider-family share). The benchmark artifact is a comparison on the same fixed corpus showing that greedy-quality selection produces measurably homogenized failure modes which the diversity floor reduces.
+
+Owner: Track G, sub-bullet under [G5 CruxDetector Activation in Live Debates](../plans/ARAGORA_EVOLUTION_ROADMAP.md). Not a new track.
+
+## Framings that do not survive
+
+The following adjacent framings were explored and do not survive into roadmap sub-bullets. They are documented here so the decision is auditable.
+
+- **"Surrogate distillation as a new track" (NNUE / chess analog).** The useful core survives as a *benchmarked decision policy* under [Track B4 Multi-Host Soak](../plans/ARAGORA_EVOLUTION_ROADMAP.md) — cheap-signal-to-verification routing, evaluated by labelled comparison against the fixed benchmark. A dedicated track would duplicate the existing bounded-autonomy benchmark substrate and violate the proof-first Foreman gate.
+- **"Population-under-selection as a new track."** The useful core survives as two narrow sub-bullets (G3 strategy-decay slice, G5 diversity floor). A dedicated track would duplicate G3 and G5.
+- **"Multi-timescale memory as a new track."** The useful core survives as the D1 design heuristic above. A dedicated track would duplicate D.
+- **Stacked generalization, Complementary Learning Systems, Neural Darwinism, and related ML-history framings.** These are generative prior art for thinking about the above heuristics; they do not, on their own, propose work that is not already covered by the sub-bullets above.
+
+## Rules of the road for this brief
+
+1. Nothing here carries `boss-ready`. Nothing here is canonical. Nothing here adds a track.
+2. Any framing that graduates to roadmap work must (a) map onto an existing track, (b) define a benchmark artifact or proof surface as acceptance, and (c) respect the existing delayed-track rule governing `DIC-13..22` and `DIC-23..28` — planning-truth only until the proof-first Foreman gate opens.
+3. If a framing proves load-bearing via benchmark artifact, move the surviving bullet into the appropriate track doc and update this brief to point at the landed change. Do not let the brief grow into a parallel roadmap.
+
+## Related
+
+- [CANONICAL_GOALS.md](../CANONICAL_GOALS.md) — 8 pillars; unchanged by this brief
+- [ARAGORA_EVOLUTION_ROADMAP.md](../plans/ARAGORA_EVOLUTION_ROADMAP.md) — Tracks A–G; the narrow surviving bullets live there as sub-items
+- [NEXT_STEPS_CANONICAL.md](../status/NEXT_STEPS_CANONICAL.md) — the proof-first Foreman gate and `boss-ready` queue governance that bounds when any of these can graduate


### PR DESCRIPTION
Responds to the 2026-04-18 skeptical-read critique by:

- Rolling back new top-level tracks (H/I/J) and doctrine bloat in
  docs/CANONICAL_GOALS.md so canonical tracks stay A-G.
- Re-homing the narrow survivors as planning-truth sub-bullets under
  existing B4 (cheap-signal routing as benchmarked decision policy),
  D1 (multi-timescale consolidation as design heuristic), E1
  (pre-consensus disagreement as measurement), G3 (strategy-decay
  reputation slice) and G5 (diversity floor in team selection). Every
  sub-bullet is Foreman-gated per docs/status/NEXT_STEPS_CANONICAL.md
  and acceptance is a benchmark artifact on the existing bounded
  corpus, not an engineering spec.
- Demoting the prior docs/ROADMAP_EVOLUTION.md to a tombstone that
  points at the surviving sub-bullets; the biological-timescale framing
  now lives in a non-canonical research brief under docs/research/.
- Trimming docs/proposals/roadmap-evolution-2026-04/ from 13 drafts to
  4 bounded, benchmark-gated, Foreman-gated issues (B4, E6, G6, G7).
  The 9 retired drafts carry tombstones and are flagged for git rm on
  the next commit pass (the sandbox currently refuses hard deletion).
- Adding a reconciliation note to docs/CANONICAL_GOALS.md that
  distinguishes the 8 doctrinal pillars from the 5 product-messaging
  pillars (README / CLAUDE.md / EXTENDED_README.md) and the 3
  packaging pillars (docs/PACKAGING.md), and documents the 6 -> 7 -> 8
  count evolution.

No production-path changes. No new boss-ready work. No new canonical
tracks. Every new narrow sub-bullet explicitly defers to the proof-first
Foreman gate.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
