### PR TITLE
feat(boss-loop): add --no-suitable-issue-keepalive opt-in flag

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -2281,6 +2281,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 getattr(args, "boss_auto_update_interval", 10) or 10
             ),
             use_llm_pre_dispatch_gate=bool(getattr(args, "boss_llm_pre_dispatch_gate", False)),
+            no_suitable_issue_keepalive=bool(getattr(args, "no_suitable_issue_keepalive", False)),
         )
         exec_argv = ["-m", "aragora.cli.main", *sys.argv[1:]]
         loop = BossLoop(config=boss_loop_config, exec_argv=exec_argv)

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2897,6 +2897,18 @@ def _add_swarm_parser(subparsers) -> None:
         ),
     )
     swarm_parser.add_argument(
+        "--no-suitable-issue-keepalive",
+        action="store_true",
+        dest="no_suitable_issue_keepalive",
+        help=(
+            "Opt in to long-running boss-loop: when no eligible issues are found, "
+            "log and sleep for --interval-seconds before retrying instead of exiting. "
+            "Use this to keep the boss-loop process alive for the full --max-hours window "
+            "(e.g. when launchd ThrottleInterval gaps would otherwise interfere). "
+            "Default off, preserving short-lived clean-exit lifecycle."
+        ),
+    )
+    swarm_parser.add_argument(
         "--source-file",
         help="Campaign planner or initiative rationale input markdown/text file",
     )

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -339,6 +339,14 @@ class BossLoopConfig:
     auto_refill_threshold: int = 5
     auto_refill_max: int = 10
 
+    # Long-running boss-loop keepalive: when true, NO_SUITABLE_ISSUE no
+    # longer terminates the run. The loop logs the empty queue and sleeps
+    # for iteration_interval_seconds before retrying, until max_iterations
+    # or another terminal stop reason fires. Off by default so the
+    # short-lived launchd lifecycle (clean exit + ThrottleInterval respawn)
+    # remains the default behavior.
+    no_suitable_issue_keepalive: bool = False
+
 
 # ---------------------------------------------------------------------------
 # Boss Loop
@@ -3778,8 +3786,20 @@ class BossLoop:
                 None,
             )
             if terminal_status is not None:
-                self._stop_reason = terminal_status.stop_reason
-                break
+                if (
+                    self.config.no_suitable_issue_keepalive
+                    and terminal_status.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+                ):
+                    logger.info(
+                        "no_suitable_issue at iteration %d/%d; keepalive enabled, "
+                        "sleeping %.0fs before retry",
+                        iteration,
+                        self.config.max_iterations,
+                        self.config.iteration_interval_seconds,
+                    )
+                else:
+                    self._stop_reason = terminal_status.stop_reason
+                    break
 
             # Periodic status logging
             if iteration % self.config.status_report_interval == 0:

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1601,6 +1601,83 @@ class TestBossLoop:
         assert len(result.issues_attempted) == 0
         assert "No suitable open issue" in result.needs_human_reasons[0]
 
+    def test_no_suitable_issue_keepalive_continues_until_max_iterations(self):
+        """With keepalive on, empty queues should not terminate the run."""
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = []
+
+        config = _boss_config(no_suitable_issue_keepalive=True, max_iterations=4)
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        result = asyncio.run(loop.run())
+
+        # Loop should drain to max_iterations rather than exit on first empty queue.
+        assert result.stop_reason == BossStopReason.MAX_ITERATIONS.value
+        assert result.iterations_completed == 4
+        # Every iteration's per-iteration stop_reason was still recorded so
+        # observers can see the queue was empty each tick.
+        per_iteration_reasons = [status.get("stop_reason") for status in result.iteration_statuses]
+        assert per_iteration_reasons == [BossStopReason.NO_SUITABLE_ISSUE.value] * 4
+
+    def test_no_suitable_issue_keepalive_off_terminates_on_first_empty_queue(self):
+        """Default behavior (keepalive off) must continue to short-exit cleanly."""
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = []
+
+        config = _boss_config(no_suitable_issue_keepalive=False, max_iterations=4)
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+        assert result.iterations_completed == 1
+
+    def test_no_suitable_issue_keepalive_does_not_swallow_other_terminal_reasons(self):
+        """Other terminal stop reasons must still terminate even with keepalive on."""
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = []
+
+        config = _boss_config(no_suitable_issue_keepalive=True, max_iterations=4)
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            # Force NO_FRESH_RUNNER on every iteration; keepalive must not catch it.
+            freshness_checker=lambda **kw: _fresh_result(
+                fresh=False, blocked_reason="runner_not_fresh"
+            ),
+        )
+
+        result = asyncio.run(loop.run())
+
+        # Empty queue is hit first, so NO_SUITABLE_ISSUE wins (and keepalive
+        # does swallow it). But once we feed an issue, freshness blocks it,
+        # which is a different terminal reason and must NOT be swallowed.
+        # Re-run with one available issue:
+        feed.fetch.return_value = [_make_issue(909, "Meta benchmark issue")]
+        loop2 = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(
+                fresh=False, blocked_reason="runner_not_fresh"
+            ),
+        )
+        result2 = asyncio.run(loop2.run())
+        assert result2.stop_reason == BossStopReason.NO_FRESH_RUNNER.value
+        assert result2.iterations_completed == 1
+
+        # First run with no issues: keepalive should let it ride out to
+        # max_iterations even though _every_ iteration emitted NO_SUITABLE_ISSUE.
+        assert result.stop_reason == BossStopReason.MAX_ITERATIONS.value
+        assert result.iterations_completed == 4
+
     def test_specific_issue_number_selects_target_issue(self):
         feed = MagicMock(spec=GitHubIssueFeed)
         feed.fetch.return_value = [


### PR DESCRIPTION
## Summary

Companion to #6668 (the proof-first shift launchd-throttle health fix). Adds an opt-in flag that lets long-running supervisors keep the boss-loop process alive across empty-queue gaps instead of exiting cleanly.

## Why both fixes?

- **#6668 (A3)** keeps the *current* short-lived launchd lifecycle and teaches the proof-first shift not to mistake the throttle window for a service failure.
- **This PR (A2)** adds an *alternative* lifecycle for long-running supervisors that prefer to spawn boss-loop directly with \`--max-hours\` and want a single in-process loop instead of relying on launchd respawn.

Both ship default-off so neither changes behavior unless explicitly enabled.

## Behavior

\`\`\`
aragora swarm boss-loop --no-suitable-issue-keepalive ...
\`\`\`

When set, per-iteration \`NO_SUITABLE_ISSUE\` stop reasons no longer terminate the run. The loop logs the empty queue and proceeds to the inter-iteration sleep, retrying on the next tick until \`max_iterations\` or another terminal stop reason fires (\`NO_FRESH_RUNNER\`, \`CONSECUTIVE_FAILURES\`, \`MAX_ITERATIONS\`, \`AUTO_UPDATE\`, \`NEEDS_HUMAN\`, etc).

Default off. With the default, every existing call site sees identical behavior.

## Implementation

- New \`BossLoopConfig.no_suitable_issue_keepalive: bool = False\` field
- \`run()\` loop: when terminal_status.stop_reason is \`NO_SUITABLE_ISSUE\` AND keepalive is set, log and continue; otherwise existing terminate-on-terminal-status path
- \`--no-suitable-issue-keepalive\` CLI flag wired through \`aragora swarm boss-loop\`

## Test plan

- [x] \`test_no_suitable_issue_keepalive_continues_until_max_iterations\` — empty queue + keepalive on runs to MAX_ITERATIONS, every iteration's per-iteration stop_reason still recorded
- [x] \`test_no_suitable_issue_keepalive_off_terminates_on_first_empty_queue\` — default behavior preserved
- [x] \`test_no_suitable_issue_keepalive_does_not_swallow_other_terminal_reasons\` — NO_FRESH_RUNNER still terminates with keepalive on
- [x] All 6 \`no_suitable_issue\` tests pass (3 pre-existing + 3 new) — verified \`pytest -k no_suitable_issue\` clean
- [x] \`ruff check\` + \`ruff format\` + \`mypy\` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)