### PR TITLE
fix(proof-first-shift): bump launchctl timeout + surface throttle verdict

### DIFF
--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -604,7 +604,7 @@ def inspect_launchd_service(label: str) -> LaunchdServiceStatus:
             ["launchctl", "print", f"gui/{uid}/{label}"],
             text=True,
             capture_output=True,
-            timeout=5,
+            timeout=15,
             check=False,
         )
     except OSError as exc:
@@ -1123,6 +1123,13 @@ def run_shift_cycle(
     merge_running = process_running(DEFAULT_MERGE_PROCESS_PATTERN)
 
     actions: list[str] = []
+    # Surface the throttle-helper's verdict in the cycle_tick payload so that
+    # transient launchd states (e.g. brief launchctl-print stalls right after
+    # a kickstart) can be diagnosed without re-running the shift. The marker
+    # is purely diagnostic: it does not influence restart logic.
+    if not boss_process_running and boss_throttle_reason:
+        verdict = "throttle_healthy" if boss_throttle_healthy else "throttle_unhealthy"
+        actions.append(f"boss_{verdict}: {boss_throttle_reason}")
     service_failures: list[str] = []
     runtime_failures: list[str] = []
     repeated_failure_classes: list[str] = []

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -22,7 +22,7 @@ def _run_shift_cycle(
     restart_service_side_effect: list[tuple[bool, str]] | None = None,
     trigger_benchmark_side_effect: Exception | None = None,
     ledger: ShiftLedger | None = None,
-    launchd_throttle_healthy: tuple[bool, str] = (False, "test default: throttle health off"),
+    launchd_throttle_healthy: tuple[bool, str] = (False, ""),
 ) -> dict[str, object]:
     boss_restart_patch = (
         patch(
@@ -864,6 +864,40 @@ def test_run_shift_cycle_does_not_burn_restart_budget_when_throttle_healthy() ->
     assert all("BossRestartFailed" not in str(f) for f in report.get("service_failures", []))
 
 
+def test_run_shift_cycle_records_throttle_healthy_diagnostic_in_actions() -> None:
+    """When the boss process isn't running and the throttle helper is healthy,
+    the cycle's actions list must surface the helper verdict so operators can
+    see WHY the cycle treated the boss as healthy without a live process."""
+    state = mod.ProofFirstRuntimeState(boss_restart_count=0)
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[False, True],
+        prs=[],
+        launchd_throttle_healthy=(True, "launchd throttle-healthy: log age=42s"),
+    )
+    assert any(
+        action.startswith("boss_throttle_healthy:") and "log age=42s" in action
+        for action in report["actions"]
+    ), f"expected throttle_healthy diagnostic in actions, got {report['actions']!r}"
+
+
+def test_run_shift_cycle_records_throttle_unhealthy_diagnostic_in_actions() -> None:
+    """When the throttle helper returns False, the cycle's actions list must
+    surface the helper's reason so a transient launchd failure mode (e.g.
+    launchctl-print stall after kickstart) is visible without rerunning."""
+    state = mod.ProofFirstRuntimeState(boss_restart_count=0)
+    report = _run_shift_cycle(
+        state,
+        process_running_side_effect=[False, True],
+        prs=[],
+        launchd_throttle_healthy=(False, "launchctl print timed out for boss-loop"),
+    )
+    assert any(
+        action.startswith("boss_throttle_unhealthy:") and "launchctl print timed out" in action
+        for action in report["actions"]
+    ), f"expected throttle_unhealthy diagnostic in actions, got {report['actions']!r}"
+
+
 def test_run_shift_cycle_exhausts_restart_budget_within_shift_window() -> None:
     state = mod.ProofFirstRuntimeState(boss_restart_count=1, merge_restart_count=1)
 
@@ -1068,7 +1102,7 @@ def test_run_shift_cycle_records_direct_bootstrap_when_launchd_service_is_missin
         patch("scripts.run_proof_first_shift.process_running", side_effect=[False, True]),
         patch(
             "scripts.run_proof_first_shift.is_launchd_throttle_healthy",
-            return_value=(False, "test default: throttle health off"),
+            return_value=(False, ""),
         ),
         patch("scripts.run_proof_first_shift.restart_service_via_launchd", return_value=(True, "")),
         patch("scripts.run_proof_first_shift.run_merge_arbiter_apply", return_value={"merged": []}),


### PR DESCRIPTION
## Summary

Follow-up to #6668. After A3 landed, a fresh proof-first shift still tripped \`RepeatedBossRestartFailure\` on cycle 2 (\`boss_running=false\` in the cycle_tick payload) — even though calling \`is_launchd_throttle_healthy\` directly **right after** the failure returned \`True\`.

**Root suspect:** \`launchctl print\` briefly stalled at the cycle-2 sample window (right after the cycle-1 kickstart). The previous 5s timeout was too aggressive; \`inspect_launchd_service\` returned \`state=\"\"\` on stall, and the helper fail-closed.

**The cycle_tick payload had no record of WHY the helper returned False**, making the failure mode undebuggable without rerunning the shift.

## Two surgical fixes

1. **Bump \`launchctl print\` timeout 5s → 15s.** Enough to ride out transient stalls without masking real outages.

2. **Surface the throttle-helper verdict in cycle_tick actions** as a diagnostic marker:
   \`\`\`
   \"boss_throttle_healthy: launchd throttle-healthy: log age=42s\"
   \"boss_throttle_unhealthy: launchctl print timed out for ...\"
   \`\`\`
   Operators can now read the cycle_tick payload after a failure and see exactly why the helper failed.

Behavior change is purely additive (diagnostic strings in actions); restart logic is unchanged.

## Test plan

- [x] 2 new cases for the diagnostic marker (healthy + unhealthy paths)
- [x] Existing 4 tests updated (empty default reason so they don't accidentally pick up the new diagnostic)
- [x] All 54 tests pass: \`pytest tests/scripts/test_run_proof_first_shift.py\` → 54 passed in 40.06s
- [x] \`ruff check\` + \`ruff format\` + \`mypy\` clean

## Follow-up

After merge: restart proof-first shift, watch the cycle_tick \`actions\` field for the throttle verdict marker. If it still trips RepeatedBossRestartFailure, the marker will surface exactly what went wrong, enabling a precise fix rather than another guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)