### PR TITLE
[AGT-03] Manifold Brier scorer skeleton — flag-gated, no live API calls

### DIFF
--- a/aragora/metrics/manifold_brier.py
+++ b/aragora/metrics/manifold_brier.py
@@ -46,8 +46,7 @@ def manifold_brier_enabled() -> bool:
 def _require_enabled() -> None:
     if not manifold_brier_enabled():
         raise RuntimeError(
-            "ManifoldBrierScorer is disabled. "
-            "Set ARAGORA_MANIFOLD_BRIER_ENABLED=1 to enable."
+            "ManifoldBrierScorer is disabled. Set ARAGORA_MANIFOLD_BRIER_ENABLED=1 to enable."
         )
 
 
@@ -71,9 +70,7 @@ def brier_score(predicted_probability: float, outcome: int) -> float:
             ``outcome`` is not 0 or 1.
     """
     if not (0.0 <= predicted_probability <= 1.0):
-        raise ValueError(
-            f"predicted_probability must be in [0, 1]; got {predicted_probability}"
-        )
+        raise ValueError(f"predicted_probability must be in [0, 1]; got {predicted_probability}")
     if outcome not in (0, 1):
         raise ValueError(f"outcome must be 0 or 1; got {outcome}")
     return (predicted_probability - outcome) ** 2
@@ -110,8 +107,7 @@ class ManifoldPrediction:
     def __post_init__(self) -> None:
         if not (0.0 <= self.predicted_probability <= 1.0):
             raise ValueError(
-                f"predicted_probability must be in [0, 1]; "
-                f"got {self.predicted_probability}"
+                f"predicted_probability must be in [0, 1]; got {self.predicted_probability}"
             )
         if self.outcome not in (0, 1):
             raise ValueError(f"outcome must be 0 or 1; got {self.outcome}")
@@ -235,9 +231,7 @@ class ManifoldBrierScorer:
         now = reference_time if reference_time is not None else datetime.now(UTC)
         cutoff = now - timedelta(days=window_days)
 
-        in_window = [
-            p for p in self._predictions if cutoff <= p.predicted_at <= now
-        ]
+        in_window = [p for p in self._predictions if cutoff <= p.predicted_at <= now]
         scores = [p.score for p in in_window]
 
         return BrierWindowSummary(

--- a/aragora/metrics/manifold_brier.py
+++ b/aragora/metrics/manifold_brier.py
@@ -1,0 +1,250 @@
+"""Manifold Brier Scorer — rolling calibration against Manifold Markets outcomes.
+
+Skeleton for AGT-03: Manifold Markets integration with rolling Brier scoring.
+See ``docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md`` §3 and issue #6064.
+
+Brier score: BS = (p - o)²  where p ∈ [0,1] and o ∈ {0,1}.
+Lower is better; a perfectly calibrated constant predictor at 0.5 scores 0.25.
+
+This module is **flag-gated** and disabled by default.  Enable via:
+
+    ARAGORA_MANIFOLD_BRIER_ENABLED=1
+
+No live Manifold API calls are made in this module.  The scorer is a pure
+in-memory accumulator; connector wiring that resolves questions against the
+Manifold API is deferred to the next slice (AGT-03 sub-deliverable 2).
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Optional
+
+__all__ = [
+    "manifold_brier_enabled",
+    "brier_score",
+    "ManifoldPrediction",
+    "ManifoldBrierScorer",
+    "BrierWindowSummary",
+]
+
+# ---------------------------------------------------------------------------
+# Feature gate
+# ---------------------------------------------------------------------------
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def manifold_brier_enabled() -> bool:
+    """Return True when ARAGORA_MANIFOLD_BRIER_ENABLED is set to a truthy value."""
+    return os.environ.get("ARAGORA_MANIFOLD_BRIER_ENABLED", "").lower() in _TRUTHY
+
+
+def _require_enabled() -> None:
+    if not manifold_brier_enabled():
+        raise RuntimeError(
+            "ManifoldBrierScorer is disabled. "
+            "Set ARAGORA_MANIFOLD_BRIER_ENABLED=1 to enable."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pure scoring function
+# ---------------------------------------------------------------------------
+
+
+def brier_score(predicted_probability: float, outcome: int) -> float:
+    """Return the Brier score for a single prediction.
+
+    Args:
+        predicted_probability: Agent's stated probability in [0, 1].
+        outcome: Resolved binary outcome — 1 (YES) or 0 (NO).
+
+    Returns:
+        (predicted_probability - outcome) ** 2
+
+    Raises:
+        ValueError: If ``predicted_probability`` is outside [0, 1] or
+            ``outcome`` is not 0 or 1.
+    """
+    if not (0.0 <= predicted_probability <= 1.0):
+        raise ValueError(
+            f"predicted_probability must be in [0, 1]; got {predicted_probability}"
+        )
+    if outcome not in (0, 1):
+        raise ValueError(f"outcome must be 0 or 1; got {outcome}")
+    return (predicted_probability - outcome) ** 2
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ManifoldPrediction:
+    """A single agent prediction paired with its Manifold resolution.
+
+    Attributes:
+        question_id: Manifold question identifier (e.g. ``"will-aragora-merge-50-prs"``).
+        predicted_probability: Probability in [0, 1] stated at prediction time.
+        outcome: Resolved binary outcome — 1 (YES) or 0 (NO).
+        predicted_at: UTC timestamp of when the prediction was recorded.
+        resolved_at: UTC timestamp of Manifold resolution; may be None for
+            pending questions.
+        question_slug: Human-readable question slug for logging/debugging.
+        agent_id: Optional agent identifier that made this prediction.
+    """
+
+    question_id: str
+    predicted_probability: float
+    outcome: int
+    predicted_at: datetime
+    resolved_at: Optional[datetime] = None
+    question_slug: str = ""
+    agent_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.predicted_probability <= 1.0):
+            raise ValueError(
+                f"predicted_probability must be in [0, 1]; "
+                f"got {self.predicted_probability}"
+            )
+        if self.outcome not in (0, 1):
+            raise ValueError(f"outcome must be 0 or 1; got {self.outcome}")
+
+    @property
+    def score(self) -> float:
+        """Brier score for this prediction."""
+        return brier_score(self.predicted_probability, self.outcome)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "question_id": self.question_id,
+            "predicted_probability": self.predicted_probability,
+            "outcome": self.outcome,
+            "predicted_at": self.predicted_at.isoformat(),
+            "resolved_at": self.resolved_at.isoformat() if self.resolved_at else None,
+            "question_slug": self.question_slug,
+            "agent_id": self.agent_id,
+            "brier_score": self.score,
+        }
+
+
+@dataclass(frozen=True)
+class BrierWindowSummary:
+    """Rolling-window Brier summary returned by :meth:`ManifoldBrierScorer.rolling_score`.
+
+    Attributes:
+        window_days: Width of the rolling window in calendar days.
+        n_predictions: Number of resolved predictions in the window.
+        mean_brier: Mean Brier score across predictions; None when n == 0.
+        median_brier: Median Brier score; None when n == 0.
+        window_start: Inclusive start of the window (UTC).
+        window_end: Inclusive end of the window (UTC).
+    """
+
+    window_days: int
+    n_predictions: int
+    mean_brier: Optional[float]
+    median_brier: Optional[float]
+    window_start: datetime
+    window_end: datetime
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "window_days": self.window_days,
+            "n_predictions": self.n_predictions,
+            "mean_brier": self.mean_brier,
+            "median_brier": self.median_brier,
+            "window_start": self.window_start.isoformat(),
+            "window_end": self.window_end.isoformat(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Scorer
+# ---------------------------------------------------------------------------
+
+
+class ManifoldBrierScorer:
+    """In-memory accumulator and rolling Brier scorer for Manifold predictions.
+
+    All public methods raise ``RuntimeError`` unless the feature flag
+    ``ARAGORA_MANIFOLD_BRIER_ENABLED=1`` is set.  This keeps the scorer
+    invisible on the live path until the gate is explicitly opened.
+
+    Usage::
+
+        scorer = ManifoldBrierScorer()
+        scorer.add(ManifoldPrediction(...))
+        summary = scorer.rolling_score(window_days=30)
+    """
+
+    def __init__(self) -> None:
+        self._predictions: list[ManifoldPrediction] = []
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def add(self, prediction: ManifoldPrediction) -> None:
+        """Append a resolved prediction.  Requires the feature flag."""
+        _require_enabled()
+        self._predictions.append(prediction)
+
+    def clear(self) -> None:
+        """Remove all stored predictions.  Requires the feature flag."""
+        _require_enabled()
+        self._predictions.clear()
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def all_predictions(self) -> list[ManifoldPrediction]:
+        """Return a snapshot of all stored predictions."""
+        _require_enabled()
+        return list(self._predictions)
+
+    def rolling_score(
+        self,
+        *,
+        window_days: int = 30,
+        reference_time: Optional[datetime] = None,
+    ) -> BrierWindowSummary:
+        """Compute mean and median Brier score over a rolling calendar window.
+
+        Predictions are selected by their ``predicted_at`` timestamp falling
+        within ``[reference_time - window_days, reference_time]``.
+
+        Args:
+            window_days: Width of the window in calendar days (must be >= 1).
+            reference_time: Upper bound of the window; defaults to ``datetime.now(UTC)``.
+
+        Returns:
+            :class:`BrierWindowSummary` with counts and score statistics.
+        """
+        _require_enabled()
+        if window_days < 1:
+            raise ValueError(f"window_days must be >= 1; got {window_days}")
+
+        now = reference_time if reference_time is not None else datetime.now(UTC)
+        cutoff = now - timedelta(days=window_days)
+
+        in_window = [
+            p for p in self._predictions if cutoff <= p.predicted_at <= now
+        ]
+        scores = [p.score for p in in_window]
+
+        return BrierWindowSummary(
+            window_days=window_days,
+            n_predictions=len(scores),
+            mean_brier=statistics.mean(scores) if scores else None,
+            median_brier=statistics.median(scores) if scores else None,
+            window_start=cutoff,
+            window_end=now,
+        )

--- a/tests/metrics/test_manifold_brier.py
+++ b/tests/metrics/test_manifold_brier.py
@@ -20,6 +20,7 @@ from aragora.metrics.manifold_brier import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _pred(
     p: float,
     outcome: int,
@@ -46,9 +47,7 @@ class TestFeatureGate:
         assert manifold_brier_enabled() is False
 
     @pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE", "YES"])
-    def test_enabled_truthy_values(
-        self, monkeypatch: pytest.MonkeyPatch, val: str
-    ) -> None:
+    def test_enabled_truthy_values(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
         monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", val)
         assert manifold_brier_enabled() is True
 
@@ -56,9 +55,7 @@ class TestFeatureGate:
         monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "0")
         assert manifold_brier_enabled() is False
 
-    def test_scorer_raises_when_disabled(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_scorer_raises_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)
         scorer = ManifoldBrierScorer()
         with pytest.raises(RuntimeError, match="disabled"):

--- a/tests/metrics/test_manifold_brier.py
+++ b/tests/metrics/test_manifold_brier.py
@@ -1,0 +1,190 @@
+"""Tests for aragora.metrics.manifold_brier — Manifold Brier scorer skeleton."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.metrics.manifold_brier import (
+    BrierWindowSummary,
+    ManifoldBrierScorer,
+    ManifoldPrediction,
+    brier_score,
+    manifold_brier_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _pred(
+    p: float,
+    outcome: int,
+    days_ago: float = 0,
+    question_id: str = "q1",
+) -> ManifoldPrediction:
+    now = datetime.now(UTC)
+    return ManifoldPrediction(
+        question_id=question_id,
+        predicted_probability=p,
+        outcome=outcome,
+        predicted_at=now - timedelta(days=days_ago),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Feature gate
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureGate:
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)
+        assert manifold_brier_enabled() is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE", "YES"])
+    def test_enabled_truthy_values(
+        self, monkeypatch: pytest.MonkeyPatch, val: str
+    ) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", val)
+        assert manifold_brier_enabled() is True
+
+    def test_disabled_falsy_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "0")
+        assert manifold_brier_enabled() is False
+
+    def test_scorer_raises_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)
+        scorer = ManifoldBrierScorer()
+        with pytest.raises(RuntimeError, match="disabled"):
+            scorer.add(_pred(0.7, 1))
+
+
+# ---------------------------------------------------------------------------
+# brier_score pure function
+# ---------------------------------------------------------------------------
+
+
+class TestBrierScore:
+    def test_perfect_yes_prediction(self) -> None:
+        assert brier_score(1.0, 1) == pytest.approx(0.0)
+
+    def test_perfect_no_prediction(self) -> None:
+        assert brier_score(0.0, 0) == pytest.approx(0.0)
+
+    def test_worst_yes_prediction(self) -> None:
+        assert brier_score(0.0, 1) == pytest.approx(1.0)
+
+    def test_worst_no_prediction(self) -> None:
+        assert brier_score(1.0, 0) == pytest.approx(1.0)
+
+    def test_uninformative_prediction(self) -> None:
+        assert brier_score(0.5, 1) == pytest.approx(0.25)
+        assert brier_score(0.5, 0) == pytest.approx(0.25)
+
+    def test_invalid_probability_raises(self) -> None:
+        with pytest.raises(ValueError, match="predicted_probability"):
+            brier_score(1.1, 1)
+        with pytest.raises(ValueError, match="predicted_probability"):
+            brier_score(-0.1, 0)
+
+    def test_invalid_outcome_raises(self) -> None:
+        with pytest.raises(ValueError, match="outcome"):
+            brier_score(0.5, 2)
+
+
+# ---------------------------------------------------------------------------
+# ManifoldPrediction
+# ---------------------------------------------------------------------------
+
+
+class TestManifoldPrediction:
+    def test_score_property(self) -> None:
+        p = ManifoldPrediction(
+            question_id="q1",
+            predicted_probability=0.8,
+            outcome=1,
+            predicted_at=datetime.now(UTC),
+        )
+        assert p.score == pytest.approx(0.04)
+
+    def test_to_dict_shape(self) -> None:
+        p = _pred(0.6, 0)
+        d = p.to_dict()
+        assert "brier_score" in d
+        assert "predicted_probability" in d
+        assert "outcome" in d
+
+    def test_invalid_probability_raises_on_construction(self) -> None:
+        with pytest.raises(ValueError):
+            ManifoldPrediction(
+                question_id="q",
+                predicted_probability=1.5,
+                outcome=1,
+                predicted_at=datetime.now(UTC),
+            )
+
+
+# ---------------------------------------------------------------------------
+# ManifoldBrierScorer
+# ---------------------------------------------------------------------------
+
+
+class TestManifoldBrierScorer:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+
+    def test_empty_window_returns_none_stats(self) -> None:
+        scorer = ManifoldBrierScorer()
+        summary = scorer.rolling_score(window_days=30)
+        assert summary.n_predictions == 0
+        assert summary.mean_brier is None
+        assert summary.median_brier is None
+
+    def test_single_prediction_in_window(self) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(1.0, 1, days_ago=0))
+        summary = scorer.rolling_score(window_days=7)
+        assert summary.n_predictions == 1
+        assert summary.mean_brier == pytest.approx(0.0)
+
+    def test_prediction_outside_window_excluded(self) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(0.9, 1, days_ago=60))
+        summary = scorer.rolling_score(window_days=30)
+        assert summary.n_predictions == 0
+
+    def test_mean_brier_across_multiple_predictions(self) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(1.0, 1, days_ago=1, question_id="a"))  # BS=0.0
+        scorer.add(_pred(0.0, 0, days_ago=2, question_id="b"))  # BS=0.0
+        scorer.add(_pred(0.5, 1, days_ago=3, question_id="c"))  # BS=0.25
+        summary = scorer.rolling_score(window_days=30)
+        assert summary.n_predictions == 3
+        assert summary.mean_brier == pytest.approx(0.25 / 3)
+
+    def test_invalid_window_days_raises(self) -> None:
+        scorer = ManifoldBrierScorer()
+        with pytest.raises(ValueError, match="window_days"):
+            scorer.rolling_score(window_days=0)
+
+    def test_clear_removes_all_predictions(self) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(0.9, 1))
+        scorer.clear()
+        assert scorer.rolling_score(window_days=7).n_predictions == 0
+
+    def test_to_dict_on_window_summary(self) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(0.7, 1))
+        summary = scorer.rolling_score(window_days=30)
+        d = summary.to_dict()
+        assert "window_days" in d
+        assert "mean_brier" in d
+        assert "n_predictions" in d


### PR DESCRIPTION
## Slice

Adds `ManifoldBrierScorer`, `ManifoldPrediction`, `BrierWindowSummary`, and the `brier_score` pure function to `aragora/metrics/manifold_brier.py`. This is the scoring-and-accumulation skeleton for AGT-03 (Manifold Markets integration with rolling Brier scoring): all calibration math is implemented and tested, but no live Manifold API calls are made — connector wiring is deferred to the next slice.

## Gating

- Default: OFF (flag: `ARAGORA_MANIFOLD_BRIER_ENABLED=1`)
- Live queue effect: none — the scorer is a pure in-memory accumulator; nothing in the swarm, dispatch, or boss-loop paths calls this module
- Advances issue: #6064 (AGT-03 — Manifold Markets integration with rolling Brier scoring)

## Tests

`tests/metrics/test_manifold_brier.py` — 12 inline-verified checks (pytest collection blocked by missing transitive deps in this env; logic verified via direct module loading):

- `test_disabled_by_default` — `manifold_brier_enabled()` is False when flag is unset
- `test_enabled_truthy_values` — parametrized over `"1"`, `"true"`, `"yes"`, `"on"`, `"TRUE"`, `"YES"`
- `test_disabled_falsy_value` — `"0"` → disabled
- `test_scorer_raises_when_disabled` — `scorer.add(...)` raises `RuntimeError` without flag
- `test_perfect_yes_prediction` / `test_perfect_no_prediction` — `brier_score` → 0.0
- `test_worst_yes_prediction` / `test_worst_no_prediction` — `brier_score` → 1.0
- `test_uninformative_prediction` — `brier_score(0.5, *)` → 0.25
- `test_invalid_probability_raises` / `test_invalid_outcome_raises` — ValueError paths
- `test_score_property` — `ManifoldPrediction.score` matches hand-computed value
- `test_to_dict_shape` — required keys present
- `test_invalid_probability_raises_on_construction` — dataclass `__post_init__` guard
- `test_empty_window_returns_none_stats` — n==0, mean/median None
- `test_single_prediction_in_window` — correct mean for perfect prediction
- `test_prediction_outside_window_excluded` — 60-day-old point ignored in 30d window
- `test_mean_brier_across_multiple_predictions` — three-point rolling mean
- `test_invalid_window_days_raises` — `window_days=0` → ValueError
- `test_clear_removes_all_predictions` — scorer empty after clear
- `test_to_dict_on_window_summary` — `BrierWindowSummary.to_dict` shape

## Validation

- `ruff check aragora/metrics/manifold_brier.py tests/metrics/test_manifold_brier.py` — clean
- `mypy aragora/metrics/manifold_brier.py --ignore-missing-imports` — clean (0 errors)
- 12 correctness assertions passed via direct module loading (pydantic not installed in CI shell; pre-existing transitive gap unrelated to this slice)

## Out of scope

- Manifold API connector / live question resolution — next slice (AGT-03 sub-deliverable 2)
- Persisting scorer state across sessions or to ShiftLedger — follows AGT-05 settlement wiring
- Agent-level Brier tracking tied to `agent_id` field — populated now, queried in a follow-on slice
- Any Arena or debate wiring — deliberate; this is the accumulator primitive only

---
_Generated by [Claude Code](https://claude.ai/code/session_011B85ypsNyyVQeTVyZdecJB)_