### PR TITLE
fix(swarm): preserve inherited roadmap codes on decomposed issues

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -37,7 +37,7 @@ from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRe
 from aragora.swarm.dispatch_contract_gate import dispatch_contract_gate  # noqa: F401
 from aragora.swarm.env_utils import git_safe_env
 from aragora.swarm.proof_first_queue import filter_noncanonical_boss_ready_issues
-from aragora.swarm.roadmap_priority import load_roadmap_priority_policy
+from aragora.swarm.roadmap_priority import extract_roadmap_codes, load_roadmap_priority_policy
 from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer  # noqa: F401
 from aragora.swarm.mission import GateType, GateVerdict
 from aragora.swarm.session_state import (
@@ -1796,6 +1796,16 @@ class BossLoop:
             body=issue.body or "",
             url=issue.url,
         )
+        inherited_roadmap_codes = self._inherited_roadmap_codes_for_decomposition(
+            issue=issue,
+            issues=issues,
+            lineage_root=lineage_root,
+        )
+        inherited_roadmap_line = (
+            f"- Inherited roadmap codes: {', '.join(inherited_roadmap_codes)}\n"
+            if inherited_roadmap_codes
+            else ""
+        )
 
         # Try LLM-based decomposition
         sub_issues_created = 0
@@ -1892,7 +1902,9 @@ class BossLoop:
                         f"## Decomposition Lineage\n"
                         f"- Root issue: #{lineage_root}\n"
                         f"- Parent issue: #{issue.number}\n"
-                        f"- Depth: {child_depth}\n\n"
+                        f"- Depth: {child_depth}\n"
+                        f"{inherited_roadmap_line}"
+                        "\n"
                         f"## Task\n{sub_desc}\n\n"
                         f"## Files\n{scope_lines}\n\n"
                         f"## Acceptance\n"
@@ -2021,6 +2033,23 @@ class BossLoop:
         if root_issue is not None and int(root_issue.number) != int(issue.number):
             texts.extend([root_issue.title, root_issue.body or ""])
         return policy.priority_for_text(*texts)
+
+    def _inherited_roadmap_codes_for_decomposition(
+        self,
+        *,
+        issue: GitHubIssue,
+        issues: list[GitHubIssue],
+        lineage_root: int,
+    ) -> tuple[str, ...]:
+        root_issue = next((item for item in issues if item.number == lineage_root), None)
+        if root_issue is None and lineage_root != int(issue.number):
+            root_issue = self._fetch_issue_by_number(lineage_root)
+
+        texts = [issue.title, issue.body or ""]
+        if root_issue is not None and int(root_issue.number) != int(issue.number):
+            texts.extend([root_issue.title, root_issue.body or ""])
+
+        return extract_roadmap_codes("\n".join(texts))
 
     @staticmethod
     def _decomposition_scope_entries(

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -5109,6 +5109,12 @@ def test_boss_loop_batch_auto_decomposes_maxed_retry_issue() -> None:
 
 
 def test_auto_decompose_carries_lineage_and_removes_ready_label() -> None:
+    root_issue = _make_issue(
+        4409,
+        "[CS-01..03] Reconcile proof-first status docs",
+        body="Keep roadmap docs narrower than measured proof.",
+        labels=[],
+    )
     issue = _make_issue(
         4412,
         "[from #4409] Add evidence metrics",
@@ -5145,13 +5151,14 @@ def test_auto_decompose_carries_lineage_and_removes_ready_label() -> None:
         patch("subprocess.run", side_effect=_run),
         patch("aragora.nomic.task_decomposer.TaskDecomposer", return_value=decomposer),
     ):
-        loop._auto_decompose_stuck_issue(4412, [issue])
+        loop._auto_decompose_stuck_issue(4412, [root_issue, issue])
 
     assert len(created) == 1
     create_body = created[0][created[0].index("--body") + 1]
     assert "Root issue: #4409" in create_body
     assert "Parent issue: #4412" in create_body
     assert "Depth: 2" in create_body
+    assert "Inherited roadmap codes: CS-01, CS-02, CS-03" in create_body
     assert edited
     assert "--add-label" in edited[-1]
     assert "boss-stuck" in edited[-1]

--- a/tests/swarm/test_proof_first_queue_classification.py
+++ b/tests/swarm/test_proof_first_queue_classification.py
@@ -43,6 +43,18 @@ def test_classifies_roadmap_do_now_lane(
     assert decision.blocked_codes == ()
 
 
+def test_subdecomposed_issue_uses_inherited_parent_roadmap_code() -> None:
+    decision = classify_proof_first_queue_issue(
+        "[CS-01b] Reconcile docs status surface",
+        "## Decomposition Lineage\n- Inherited roadmap codes: CS-01\n",
+        roadmap_policy=_ROADMAP_POLICY,
+    )
+
+    assert decision.allowed is True
+    assert decision.lane == "roadmap_do_now"
+    assert decision.roadmap_codes == ("CS-01",)
+
+
 @pytest.mark.parametrize(
     ("title", "body", "expected_blocked"),
     [


### PR DESCRIPTION
## Summary

Adds inherited roadmap codes to auto-decomposed child issue bodies so sub-codes like CS-01b can pass the existing proof-first roadmap fast path without loosening the roadmap-code regex. This implements the lower-blast-radius follow-up from the soak notes.

## Verification

- `python3 -m pytest tests/swarm/test_proof_first_queue_classification.py tests/swarm/test_boss_loop.py::test_auto_decompose_carries_lineage_and_removes_ready_label -q` -> 14 passed
- `python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py tests/swarm/test_proof_first_queue_classification.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

## Non-goals

- Does not change roadmap-code extraction regex semantics.
- Does not relabel or restock existing issues.
- Does not restart proof-first shift or touch held PRs #6650, #6655, #6658, #6659, or #6707.

## Runner note

Mac Studio runner health was verified before opening this PR via Self-Hosted Fleet Probe run 24975379404.