### PR TITLE
test(swarm): isolate keepalive empty-queue tests

### DIFF
--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1538,7 +1538,7 @@ class TestRunnerFreshness:
 
 class TestBossLoop:
     def test_no_fresh_runner_stops_immediately(self):
-        config = _boss_config()
+        config = _boss_config(auto_refill_threshold=0)
         feed = MagicMock(spec=GitHubIssueFeed)
         feed.fetch.return_value = [_make_issue(1, "Runner blocked issue")]
         loop = BossLoop(
@@ -1587,7 +1587,7 @@ class TestBossLoop:
         feed = MagicMock(spec=GitHubIssueFeed)
         feed.fetch.return_value = []
 
-        config = _boss_config()
+        config = _boss_config(auto_refill_threshold=0)
         loop = BossLoop(
             config=config,
             issue_feed=feed,
@@ -1606,7 +1606,11 @@ class TestBossLoop:
         feed = MagicMock(spec=GitHubIssueFeed)
         feed.fetch.return_value = []
 
-        config = _boss_config(no_suitable_issue_keepalive=True, max_iterations=4)
+        config = _boss_config(
+            no_suitable_issue_keepalive=True,
+            max_iterations=4,
+            auto_refill_threshold=0,
+        )
         loop = BossLoop(
             config=config,
             issue_feed=feed,
@@ -1628,7 +1632,11 @@ class TestBossLoop:
         feed = MagicMock(spec=GitHubIssueFeed)
         feed.fetch.return_value = []
 
-        config = _boss_config(no_suitable_issue_keepalive=False, max_iterations=4)
+        config = _boss_config(
+            no_suitable_issue_keepalive=False,
+            max_iterations=4,
+            auto_refill_threshold=0,
+        )
         loop = BossLoop(
             config=config,
             issue_feed=feed,
@@ -1645,7 +1653,11 @@ class TestBossLoop:
         feed = MagicMock(spec=GitHubIssueFeed)
         feed.fetch.return_value = []
 
-        config = _boss_config(no_suitable_issue_keepalive=True, max_iterations=4)
+        config = _boss_config(
+            no_suitable_issue_keepalive=True,
+            max_iterations=4,
+            auto_refill_threshold=0,
+        )
         loop = BossLoop(
             config=config,
             issue_feed=feed,


### PR DESCRIPTION
## Summary

Fixes the A2 keepalive test isolation gap by disabling strategic auto-refill scanner work in empty-queue boss-loop tests. This keeps the tests focused on stop-reason and keepalive behavior instead of invoking the repo-wide strategic scanner on each empty iteration.

## Verification

- `python3 -m pytest tests/swarm/test_boss_loop.py -k "no_suitable_issue or keepalive" --timeout=30 --tb=short` -> 6 passed
- `python3 -m pytest tests/scripts/test_run_proof_first_shift.py -q` -> 54 passed
- `python3 -m ruff check tests/swarm/test_boss_loop.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

## Non-goals

- Does not change production boss-loop keepalive behavior.
- Does not restart proof-first shift or mutate queue labels.
- Does not touch held PRs #6650, #6655, #6658, #6659, or #6707.

## Runner note

Mac Studio runner health was verified before opening this PR via Self-Hosted Fleet Probe run 24975379404.