### PR TITLE
[H1-06] Add public dogfood cadence tracker

### DIFF
--- a/docs/status/PUBLIC_DOGFOOD_CADENCE.md
+++ b/docs/status/PUBLIC_DOGFOOD_CADENCE.md
@@ -1,0 +1,69 @@
+# Public Dogfood Cadence
+
+Last updated: 2026-04-27T04:15Z
+
+This is the H1-06 execution surface for issue #6232. It prepares the founder
+to run 12 real aragora.ai debates over 30 days and publish one concrete
+write-up. No debates are recorded here until they actually happen.
+
+## 30-Day Target
+
+| Target | Required proof |
+| --- | --- |
+| 12 debates | Shareable aragora.ai debate links or private receipt IDs |
+| 3 debates per week | At least one strategy, one technical, and one product or hiring debate per week |
+| 1 blog post | Public URL plus short distribution note |
+| 3 reader feedback notes | Names may be private; capture feedback text or summary |
+
+## Debate Prompt Queue
+
+| Slot | Question class | Candidate prompt | Public-safe angle |
+| --- | --- | --- | --- |
+| 1 | Strategy | Should Aragora optimize the next 30 days for canonical-green soak proof or design-partner outreach? | Shows agents surfacing tradeoffs between proof and growth. |
+| 2 | Technical | What is the safest sequence for recovering from the Mac Studio runner disk incident without invalidating proof-first evidence? | Turns an operational incident into a decision-quality example. |
+| 3 | Product | Which H1 proof surface should be most visible to a first design partner: benchmark scorecard, PR velocity, or run ledger? | Demonstrates prioritization under scarce founder time. |
+| 4 | Strategy | What is the narrowest credible wedge from Tool to Teammate that preserves the maximalist roadmap? | Connects public thesis to measured scope control. |
+| 5 | Technical | Should CS-01a and CS-01b inherit parent roadmap codes through issue bodies or should the parser accept subcodes directly? | Concrete example of low-blast-radius engineering judgment. |
+| 6 | Hiring | What qualities would make a first design-partner operator successful with Aragora in the next 30 days? | Converts product needs into an operator profile. |
+| 7 | Product | What should the first public "chicken nuggets" story be: runner recovery, proof-first queue discipline, or heterogeneous agent disagreement? | Picks the blog narrative from real evidence. |
+| 8 | Strategy | Which delayed H2/H3 ideas are most dangerous if started before H1 proof lands? | Shows disciplined maximalism without scope denial. |
+| 9 | Technical | How should autonomous PR throughput be capped when CI is degraded but local validation is green? | Makes bounded autonomy legible to engineering buyers. |
+| 10 | Product | What would convince a regulated buyer that Aragora is marketable now without overstating enforcement guarantees? | Bridges EU AI Act packaging to actual proof. |
+| 11 | Strategy | How should Aragora balance Dependabot/security maintenance against proof-first reliability work? | Demonstrates portfolio triage, not just coding. |
+| 12 | Technical | What should the acceptance criteria be for the next canonical-green 12h window? | Produces a public checklist for the next proof run. |
+
+## Blog Post Outline
+
+Working title: "The Chicken Nuggets Test for Agentic Work"
+
+1. Concrete setup: ask multiple agents a real founder question with enough context to disagree.
+2. The surprising disagreement: one agent optimizes for speed, another for proof, another for buyer trust.
+3. The synthesis: the useful answer is not the average answer; it is a bounded decision with explicit non-goals.
+4. The receipt: link to a public-safe debate, the accepted decision, and the follow-up artifact or PR.
+5. The claim boundary: Aragora is not claiming broad autonomy yet; it is proving reliable bounded execution first.
+
+## Debate Receipt Checklist
+
+Before counting a debate toward H1-06:
+
+- The question was real, not a demo-only prompt.
+- The debate produced a decision, not just brainstormed options.
+- The winning decision names at least one rejected alternative.
+- A receipt exists: public URL, private receipt ID, or repo artifact.
+- Sensitive data was removed before public sharing.
+- The result maps to one of: strategy, technical, product, hiring.
+- The follow-up action is either completed, queued, or explicitly rejected.
+
+## Tracking Table
+
+| Date | Question class | Prompt slot | Debate link or receipt | Public-safe? | Follow-up artifact | Reader feedback |
+| --- | --- | --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+## Distribution Checklist
+
+- Publish one debate or excerpt on aragora.ai.
+- Share the blog post on LinkedIn and X with the public debate link.
+- Ask three readers for one sentence of feedback.
+- Capture feedback here without overstating endorsement.
+- If a reader asks for a demo or design-partner call, link it back to H2-01.


### PR DESCRIPTION
## Summary

Adds a founder-ready H1-06 public dogfood cadence surface with 12 candidate real debate prompts, a blog-post outline, a debate receipt checklist, and a tracking table. This prepares the cadence without claiming any debates have already run.

## Scope

Parent epic: #6226
Related issue: #6232

## Verification

- `python3 scripts/reconcile_status_docs.py --strict` -> PASS
- `python3 scripts/check_docs_consistency.py` -> PASS
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

## Non-goals

- Does not claim any public debates have already happened.
- Does not publish a blog post or external social post.
- Does not merge, relabel, restart, or clean runner/worktree state.
- Does not touch held PRs #6650, #6655, #6658, #6659, or #6707.

## Notes

Mac Studio runner health was verified before opening this PR via Self-Hosted Fleet Probe run 24975379404.