### PR TITLE
fix(automation): dedupe handoffs by open PR branch

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -146,6 +146,7 @@ class Handoff:
     expires_at: str | None
     idempotency_key: str | None = None
     source_kind: str = "memory"
+    branch: str | None = None
 
 
 @dataclass(frozen=True)
@@ -732,6 +733,7 @@ def load_outbox_handoffs(
             expires_at=expires_at,
             idempotency_key=idempotency_key,
             source_kind="outbox",
+            branch=_outbox_evidence_value(payload, "branch") or None,
         )
         identity = (
             ("branch", branch_fingerprint)
@@ -889,7 +891,42 @@ def _pr_by_number(repo_root: Path, repo: str, number: int) -> dict[str, Any] | N
     return payload if isinstance(payload, dict) else None
 
 
+def _open_pr_by_branch(repo_root: Path, repo: str, branch: str | None) -> dict[str, Any] | None:
+    if not branch:
+        return None
+    proc = _run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--head",
+            branch,
+            "--json",
+            "number,title,url,state,headRefName",
+            "--limit",
+            "1",
+        ],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            proc.stderr.strip() or proc.stdout.strip() or "failed to list PRs by branch"
+        )
+    payload = json.loads(proc.stdout or "[]")
+    if not isinstance(payload, list) or not payload:
+        return None
+    first = payload[0]
+    return first if isinstance(first, dict) else None
+
+
 def _target_open_pr(repo_root: Path, repo: str, handoff: Handoff) -> dict[str, Any] | None:
+    branch_pr = _open_pr_by_branch(repo_root, repo, handoff.branch)
+    if branch_pr:
+        return branch_pr
     for number in _referenced_pr_numbers(handoff):
         pr = _pr_by_number(repo_root, repo, number)
         if isinstance(pr, dict) and str(pr.get("state") or "").upper() == "OPEN":

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -874,6 +874,67 @@ def test_decide_handoffs_routes_explicit_pr_followup_before_issue_cap(
     ]
 
 
+def test_decide_handoffs_routes_branch_handoff_to_open_pr_before_issue_cap(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / "outbox.json"),
+        task_title="Open PR for branch publisher receipt-dir CLI compatibility",
+        priority="HIGH",
+        body="body",
+        labels={},
+        expires_at=None,
+        source_kind="outbox",
+        branch="codex/branch-publisher-receipt-dir-compat",
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, json.dumps([{"number": 1}]), "")
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "pr", "list"] and "--head" in args:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 6741,
+                            "title": "fix(automation): accept branch publisher receipt dir flag",
+                            "url": "https://github.com/synaptent/aragora/pull/6741",
+                            "state": "OPEN",
+                            "headRefName": "codex/branch-publisher-receipt-dir-compat",
+                        }
+                    ]
+                ),
+                "",
+            )
+        if args[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=1,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="target_open_pr",
+            existing_pr_url="https://github.com/synaptent/aragora/pull/6741",
+        )
+    ]
+
+
 def test_decide_handoffs_respects_open_issue_cap(monkeypatch: Any, tmp_path: Path) -> None:
     handoff = Handoff(
         source_file=str(tmp_path / "memory.md"),


### PR DESCRIPTION
## Summary
- preserve outbox branch names on structured handoffs
- check for an open PR with the same head branch before creating a boss-ready issue
- add regression coverage for branch-head dedupe ahead of the issue cap

## Validation
- python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py
- python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- git diff --check origin/main...HEAD
- python3 scripts/publish_automation_handoffs.py --json --limit 20 --max-open-issues 100 --outbox-dir .aragora/automation-outbox --receipt-dir .aragora/automation-receipts verified #6742 is now target_open_pr rather than eligible issue creation