### PR TITLE
fix(channels): replace broad exception handler with specific types in registry.py

### DIFF
--- a/aragora/channels/registry.py
+++ b/aragora/channels/registry.py
@@ -238,5 +238,5 @@ def _register_builtin_docks(registry: DockRegistry) -> None:
             registry.register(dock_class)
         except ImportError:
             logger.debug("%s dock not available (missing dependencies)", label)
-        except Exception:
-            logger.warning("Failed to register %s dock", label, exc_info=True)
+        except (AttributeError, TypeError, RuntimeError) as exc:
+            logger.warning("Failed to register %s dock: %s", label, exc)


### PR DESCRIPTION
Replace bare `except Exception` with `except (AttributeError, TypeError,
RuntimeError)` in _register_builtin_docks to catch only the realistic
failure modes: missing class attribute, invalid dock class type, or
runtime initialization errors.

Closes #4978

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
