### PR TITLE
fix(automation): tolerate list evidence in outbox reconcile

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -83,6 +83,16 @@ def _terminal_receipt_keys(receipt_dir: Path) -> set[str]:
     return keys
 
 
+def _branch_from_payload(payload: dict[str, Any]) -> str:
+    """Extract a branch from outbox payloads with historical shape drift."""
+    local_evidence = payload.get("local_evidence")
+    if isinstance(local_evidence, dict):
+        branch = str(local_evidence.get("branch") or "").strip()
+        if branch:
+            return branch
+    return str(payload.get("branch") or "").strip()
+
+
 def _write_synthetic_receipt(
     *,
     receipt_dir: Path,
@@ -192,8 +202,7 @@ def main(argv: list[str] | None = None) -> int:
             continue
         payload["__source_file"] = str(path)
         idem = str(payload.get("idempotency_key") or "").strip()
-        branch = payload.get("local_evidence", {}).get("branch") or payload.get("branch") or ""
-        branch = str(branch).strip()
+        branch = _branch_from_payload(payload)
 
         if not idem or not branch:
             counts["skipped_unparseable"] += 1

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -46,3 +46,23 @@ def test_dry_run_can_write_report_when_requested(
     assert len(reports) == 1
     payload = json.loads(reports[0].read_text(encoding="utf-8"))
     assert payload["applied"] is False
+
+
+def test_branch_from_payload_tolerates_list_local_evidence() -> None:
+    payload = {
+        "branch": "codex/openrouter-kimi-fallback-haiku",
+        "local_evidence": [
+            "older handoffs sometimes stored local evidence as bullet text",
+        ],
+    }
+
+    assert mod._branch_from_payload(payload) == "codex/openrouter-kimi-fallback-haiku"
+
+
+def test_branch_from_payload_prefers_structured_local_evidence() -> None:
+    payload = {
+        "branch": "codex/stale-top-level",
+        "local_evidence": {"branch": "codex/structured"},
+    }
+
+    assert mod._branch_from_payload(payload) == "codex/structured"


### PR DESCRIPTION
## Summary
- make automation outbox reconciliation tolerate historical handoffs where local_evidence is a list instead of a dict
- add regression coverage for list-shaped evidence and structured-evidence precedence
- unblock stale outbox cleanup passes that were crashing before they could archive satisfied handoffs

## Validation
- python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py
- python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py
- python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Non-sandbox cleanup performed
- archived 76 satisfied automation outbox handoffs after the fix allowed reconciliation to run
- refreshed automation GitHub status cache
- closed stale handoff issues #6748, #6749, #6752, and #6753 with evidence