### PR TITLE
[DIC-23] Wire crux-probe into dialectical runtime loop

### DIFF
--- a/aragora/epistemic/runtime_loop.py
+++ b/aragora/epistemic/runtime_loop.py
@@ -6,12 +6,22 @@ repair pipeline (DIC-22) into a single, observable, receipt-carrying trace:
     DecaySignal
         → apply_quarantine_policy          (DIC-21)
         → propose_repair (optional)        (DIC-22)
+        → crux_probe (optional, DIC-15)    (this module)
         → DialecticalEvent                 (this module)
 
 Default posture is *report-only*: no state is mutated, no issues are
-created, and nothing is routed to the live queue.  Crux probing
-(DIC-15 / crux-finder consensus mode integration) is deferred to a
-follow-on PR and will clear the ``crux_probe_skipped`` field.
+created, and nothing is routed to the live queue.
+
+Crux probing is opt-in via ``enable_crux_probe=True`` and
+``crux_question=<context string>`` on :func:`run_dialectical_loop`.
+When enabled *and* ``ARAGORA_CRUXSET_EMISSION_ENABLED`` is set, the
+loop synthesises a minimal crux-analysis payload from the
+:class:`~aragora.epistemic.decay_monitor.DecaySignal` reasons and calls
+:func:`aragora.reasoning.cruxset_emission.maybe_emit_cruxset`.  A
+successful probe sets ``crux_probe_skipped=False`` on the event and
+stores a summary under ``metadata["crux_probe"]``.  Any failure (flag
+off, no cruxes found, import error) leaves ``crux_probe_skipped=True``
+and is swallowed — the probe must not cause loop failures.
 
 Flag: ``ARAGORA_DIALECTICAL_RUNTIME_ENABLED`` (default off).
 Dataclasses and ``run_dialectical_loop`` are always importable; the
@@ -27,6 +37,7 @@ See also: ``docs/plans/2026-04-18-dialectical-runtime-synthesis.md``
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -43,6 +54,21 @@ from aragora.epistemic.quarantine_policy import (
 from aragora.epistemic.repair import RepairSpec, propose_repair
 
 _FLAG = "ARAGORA_DIALECTICAL_RUNTIME_ENABLED"
+
+logger = logging.getLogger(__name__)
+
+# Maps decay-reason kind to a synthetic crux_score used when building the
+# analysis payload passed to maybe_emit_cruxset().  Higher scores model
+# higher load-bearing potential: a failed claim is a stronger crux candidate
+# than merely missing receipts.
+_REASON_CRUX_SCORE: dict[str, float] = {
+    "failed_claim": 0.85,
+    "unresolved_crux": 0.80,
+    "verifier_error": 0.75,
+    "stale_evidence": 0.60,
+    "missing_receipt": 0.50,
+}
+_DEFAULT_CRUX_SCORE = 0.50
 
 
 def dialectical_runtime_enabled() -> bool:
@@ -61,13 +87,103 @@ def _event_id(unit_id: str, recommended_action: str, ts: str) -> str:
     return f"drt_{digest}"
 
 
+def _build_synthetic_crux_payload(signal: DecaySignal, question: str) -> dict[str, Any]:
+    """Build a CruxAnalysisResult-shaped dict from a DecaySignal.
+
+    Each reason becomes one crux entry with a score keyed by kind.
+    Passed to ``maybe_emit_cruxset`` via the ``analysis_payload`` path.
+    """
+    cruxes = []
+    for i, reason in enumerate(signal.reasons):
+        score = _REASON_CRUX_SCORE.get(reason.kind, _DEFAULT_CRUX_SCORE)
+        claim_id = reason.claim_id or reason.crux_id or f"decay_reason_{i}"
+        cruxes.append(
+            {
+                "claim_id": claim_id,
+                "statement": reason.detail or f"Decay reason: {reason.kind}",
+                "author": "decay_monitor",
+                "crux_score": score,
+                "influence_score": round(score * 0.9, 4),
+                "disagreement_score": round(score * 0.7, 4),
+                "uncertainty_score": round(1.0 - signal.integrity_score, 4),
+                "centrality_score": round(score * 0.8, 4),
+                "affected_claims": [claim_id] if reason.claim_id else [],
+                "contesting_agents": [],
+                "resolution_impact": round(score * (1.0 - signal.integrity_score), 4),
+            }
+        )
+
+    if not cruxes:
+        # No explicit reasons; add one synthetic root cause crux.
+        cruxes.append(
+            {
+                "claim_id": f"decay_root.{signal.code_unit_id}",
+                "statement": f"Proof-unit {signal.code_unit_id!r} integrity has decayed.",
+                "author": "decay_monitor",
+                "crux_score": round(1.0 - signal.integrity_score, 4),
+                "influence_score": 0.5,
+                "disagreement_score": 0.5,
+                "uncertainty_score": round(1.0 - signal.integrity_score, 4),
+                "centrality_score": 0.5,
+                "affected_claims": [],
+                "contesting_agents": [],
+                "resolution_impact": round(1.0 - signal.integrity_score, 4),
+            }
+        )
+
+    return {
+        "cruxes": cruxes,
+        "total_claims": len(cruxes),
+        "total_disagreements": sum(1 for r in signal.reasons if r.kind == "unresolved_crux"),
+        "average_uncertainty": round(1.0 - signal.integrity_score, 4),
+        "convergence_barrier": round(1.0 - signal.integrity_score, 4),
+        "recommended_focus": [c["claim_id"] for c in cruxes[:3]],
+    }
+
+
+def _attempt_crux_probe(signal: DecaySignal, question: str) -> dict[str, Any] | None:
+    """Emit a CruxSet from the decay signal; return a summary dict or None.
+
+    Returns None when emission is disabled, no cruxes are found, or any
+    exception occurs. Errors are swallowed — probe must not cause failures.
+    """
+    try:
+        from aragora.reasoning.cruxset_emission import maybe_emit_cruxset  # lazy import
+
+        payload = _build_synthetic_crux_payload(signal, question)
+        cruxset = maybe_emit_cruxset(
+            question=question,
+            analysis_payload=payload,
+            decision=None,
+            provenance={"code_unit_id": signal.code_unit_id, "source": "dialectical_runtime"},
+        )
+        if cruxset is None:
+            return None
+        crux_list = list(cruxset.cruxes)
+        barrier = round(max((c.load_bearing_score for c in crux_list), default=0.0), 4)
+        return {
+            "cruxset_id": cruxset.cruxset_id,
+            "crux_count": len(crux_list),
+            "top_crux_ids": [c.crux_id for c in crux_list[:3]],
+            "convergence_barrier": barrier,
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("DIC-23 crux probe suppressed: %s", exc)
+        return None
+
+
 @dataclass(frozen=True)
 class DialecticalEvent:
     """Canonical trace record for one DIC-23 orchestration pass.
 
-    Carries the decay summary, the quarantine decision, and (optionally)
-    a repair spec.  ``crux_probe_skipped`` is always ``True`` in this
-    slice; crux-finder integration (DIC-15) updates it in a follow-on PR.
+    Carries the decay summary, the quarantine decision, and (optionally) a
+    repair spec.  ``crux_probe_skipped`` is ``False`` when the crux probe
+    ran successfully and a CruxSet was emitted; ``True`` otherwise (probe
+    disabled, emission flag off, no cruxes found, or any transient error).
+
+    When ``crux_probe_skipped`` is ``False``, ``metadata["crux_probe"]``
+    holds a lightweight summary with ``cruxset_id``, ``crux_count``,
+    ``top_crux_ids``, and ``convergence_barrier``.
 
     ``prior_receipt_ids`` is the caller-supplied ancestry chain stored as
     an immutable tuple.  ``metadata`` is stored as a shallow-frozen mapping:
@@ -115,6 +231,8 @@ def run_dialectical_loop(
     policy: QuarantinePolicy | None = None,
     code_unit_class: str = "default",
     enable_repair_proposal: bool = False,
+    enable_crux_probe: bool = False,
+    crux_question: str | None = None,
     prior_receipt_ids: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
     require_enabled: bool = True,
@@ -138,6 +256,18 @@ def run_dialectical_loop(
         :func:`~aragora.epistemic.repair.propose_repair` to produce a
         ``report_only`` :class:`~aragora.epistemic.repair.RepairSpec`.
         Defaults to ``False`` — pure report-only trace with no spec.
+    enable_crux_probe:
+        When ``True`` *and* ``crux_question`` is non-empty *and*
+        ``ARAGORA_CRUXSET_EMISSION_ENABLED`` is set, synthesises a crux
+        analysis from the decay signal and calls
+        :func:`aragora.reasoning.cruxset_emission.maybe_emit_cruxset`.
+        A successful probe sets ``crux_probe_skipped=False`` on the
+        returned event and populates ``metadata["crux_probe"]`` with a
+        lightweight CruxSet summary.  Any failure is swallowed — the
+        probe must not cause loop failures.  Defaults to ``False``.
+    crux_question:
+        Human-readable context question passed to the crux emitter.
+        Only used when ``enable_crux_probe=True``.
     prior_receipt_ids:
         Receipt IDs to attach to the event's ancestry chain.
     metadata:
@@ -167,6 +297,19 @@ def run_dialectical_loop(
     if enable_repair_proposal and quarantine.policy_action == "repair_required":
         repair_spec = propose_repair(signal)
 
+    merged_metadata: dict[str, Any] = dict(metadata or {})
+    crux_probe_skipped = True
+
+    if enable_crux_probe and crux_question and crux_question.strip():
+        try:
+            probe_result = _attempt_crux_probe(signal, crux_question.strip())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("DIC-23 crux probe (outer guard) suppressed: %s", exc)
+            probe_result = None
+        if probe_result is not None:
+            crux_probe_skipped = False
+            merged_metadata["crux_probe"] = probe_result
+
     ts = _utc_now_iso()
     event_id = _event_id(signal.code_unit_id, signal.recommended_action, ts)
 
@@ -176,11 +319,11 @@ def run_dialectical_loop(
         integrity_score=signal.integrity_score,
         recommended_action=signal.recommended_action,
         quarantine_action=quarantine.policy_action,
-        crux_probe_skipped=True,
+        crux_probe_skipped=crux_probe_skipped,
         repair_spec=repair_spec,
         prior_receipt_ids=tuple(prior_receipt_ids or []),
         created_at=ts,
-        metadata=dict(metadata or {}),
+        metadata=merged_metadata,
     )
 
 

--- a/tests/epistemic/test_runtime_loop.py
+++ b/tests/epistemic/test_runtime_loop.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from aragora.epistemic.decay_monitor import DecayReason, DecaySignal
@@ -9,6 +11,7 @@ from aragora.epistemic.quarantine_policy import QuarantinePolicy
 from aragora.epistemic.runtime_loop import (
     DialecticalEvent,
     DialecticalRuntimeError,
+    _build_synthetic_crux_payload,
     dialectical_runtime_enabled,
     run_dialectical_loop,
 )
@@ -262,3 +265,156 @@ class TestSerialization:
         assert d["repair_spec"] is not None
         assert isinstance(d["repair_spec"], dict)
         assert "spec_id" in d["repair_spec"]
+
+
+# ---------------------------------------------------------------------------
+# Crux probe (DIC-23 + DIC-15 integration)
+# Tests patch _attempt_crux_probe directly to avoid the pydantic-dependent
+# cruxset_emission import chain (pre-existing CI gap; unrelated to this slice).
+# ---------------------------------------------------------------------------
+
+_FAKE_PROBE = {
+    "cruxset_id": "fake-cs-001",
+    "crux_count": 2,
+    "top_crux_ids": ["crux.fake.001"],
+    "convergence_barrier": 0.65,
+}
+
+
+def _probe_event(
+    signal: DecaySignal | None = None,
+    *,
+    probe_result: dict | None = None,
+    extra_metadata: dict | None = None,
+    question: str = "Is the proof still valid?",
+) -> DialecticalEvent:
+    import aragora.epistemic.runtime_loop as _m
+
+    with patch.object(_m, "_attempt_crux_probe", return_value=probe_result or dict(_FAKE_PROBE)):
+        return run_dialectical_loop(
+            signal or _signal(),
+            enable_crux_probe=True,
+            crux_question=question,
+            metadata=extra_metadata or {},
+            require_enabled=False,
+        )
+
+
+class TestCruxProbe:
+    """Gate and result verification for the crux-probe (DIC-23 + DIC-15) integration."""
+
+    # --- disabled/skipped paths ---
+
+    def test_skipped_by_default(self) -> None:
+        e = run_dialectical_loop(_signal(), require_enabled=False)
+        assert e.crux_probe_skipped is True
+        assert "crux_probe" not in e.metadata
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"enable_crux_probe": False, "crux_question": "Q"},
+            {"enable_crux_probe": True, "crux_question": None},
+            {"enable_crux_probe": True, "crux_question": "   "},
+        ],
+    )
+    def test_skipped_for_missing_or_empty_question(self, kwargs: dict) -> None:
+        e = run_dialectical_loop(_signal(), **kwargs, require_enabled=False)
+        assert e.crux_probe_skipped is True
+
+    def test_skipped_when_attempt_returns_none(self) -> None:
+        e = _probe_event(probe_result=None)
+        assert e.crux_probe_skipped is True
+        assert "crux_probe" not in e.metadata
+
+    def test_skipped_when_attempt_raises(self) -> None:
+        import aragora.epistemic.runtime_loop as _m
+
+        with patch.object(_m, "_attempt_crux_probe", side_effect=RuntimeError("boom")):
+            e = run_dialectical_loop(
+                _signal(), enable_crux_probe=True, crux_question="Q", require_enabled=False
+            )
+        assert e.crux_probe_skipped is True
+
+    # --- enabled paths ---
+
+    def test_not_skipped_and_metadata_present(self) -> None:
+        e = _probe_event()
+        assert e.crux_probe_skipped is False
+        assert "crux_probe" in e.metadata
+
+    def test_metadata_summary_shape(self) -> None:
+        e = _probe_event()
+        cp = e.metadata["crux_probe"]
+        assert cp["cruxset_id"] == "fake-cs-001"
+        assert cp["crux_count"] == 2
+        assert isinstance(cp["top_crux_ids"], list)
+        assert cp["convergence_barrier"] == 0.65
+
+    def test_does_not_overwrite_existing_metadata(self) -> None:
+        e = _probe_event(extra_metadata={"source": "caller"})
+        assert e.metadata["source"] == "caller"
+        assert e.metadata["crux_probe"]["cruxset_id"] == "fake-cs-001"
+
+    def test_to_dict_reflects_not_skipped(self) -> None:
+        d = _probe_event().to_dict()
+        assert d["crux_probe_skipped"] is False
+        assert d["metadata"]["crux_probe"]["cruxset_id"] == "fake-cs-001"
+
+
+# ---------------------------------------------------------------------------
+# _build_synthetic_crux_payload unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSyntheticCruxPayload:
+    def test_one_crux_per_reason(self) -> None:
+        sig = _signal(
+            reasons=[
+                DecayReason(kind="failed_claim", detail="A", claim_id="c1"),
+                DecayReason(kind="stale_evidence", detail="B"),
+            ]
+        )
+        p = _build_synthetic_crux_payload(sig, "Q")
+        assert len(p["cruxes"]) == 2
+        assert p["cruxes"][0]["crux_score"] == 0.85
+        assert p["cruxes"][1]["crux_score"] == 0.60
+
+    def test_no_reasons_produces_one_root_cause_crux(self) -> None:
+        p = _build_synthetic_crux_payload(_signal(integrity_score=0.4, reasons=[]), "Q")
+        assert len(p["cruxes"]) == 1
+        assert "unit.test" in p["cruxes"][0]["claim_id"]
+
+    def test_required_payload_keys(self) -> None:
+        p = _build_synthetic_crux_payload(_signal(), "Q")
+        assert {
+            "cruxes", "total_claims", "total_disagreements",
+            "average_uncertainty", "convergence_barrier", "recommended_focus",
+        }.issubset(set(p.keys()))
+
+    def test_unresolved_crux_counts_in_total_disagreements(self) -> None:
+        sig = _signal(
+            reasons=[
+                DecayReason(kind="unresolved_crux", detail="x", crux_id="crux.x"),
+                DecayReason(kind="unresolved_crux", detail="y", crux_id="crux.y"),
+                DecayReason(kind="failed_claim", detail="z"),
+            ]
+        )
+        p = _build_synthetic_crux_payload(sig, "Q")
+        assert p["total_disagreements"] == 2
+        assert p["total_claims"] == 3
+
+    def test_claim_and_crux_id_preference(self) -> None:
+        sig = _signal(
+            reasons=[
+                DecayReason(kind="failed_claim", detail="a", claim_id="my.claim"),
+                DecayReason(kind="unresolved_crux", detail="b", crux_id="my.crux"),
+            ]
+        )
+        p = _build_synthetic_crux_payload(sig, "Q")
+        assert p["cruxes"][0]["claim_id"] == "my.claim"
+        assert p["cruxes"][1]["claim_id"] == "my.crux"
+
+    def test_recommended_focus_capped_at_three(self) -> None:
+        sig = _signal(reasons=[DecayReason(kind="failed_claim", detail=f"r{i}") for i in range(5)])
+        assert len(_build_synthetic_crux_payload(sig, "Q")["recommended_focus"]) <= 3

--- a/tests/epistemic/test_runtime_loop.py
+++ b/tests/epistemic/test_runtime_loop.py
@@ -388,8 +388,12 @@ class TestBuildSyntheticCruxPayload:
     def test_required_payload_keys(self) -> None:
         p = _build_synthetic_crux_payload(_signal(), "Q")
         assert {
-            "cruxes", "total_claims", "total_disagreements",
-            "average_uncertainty", "convergence_barrier", "recommended_focus",
+            "cruxes",
+            "total_claims",
+            "total_disagreements",
+            "average_uncertainty",
+            "convergence_barrier",
+            "recommended_focus",
         }.issubset(set(p.keys()))
 
     def test_unresolved_crux_counts_in_total_disagreements(self) -> None:


### PR DESCRIPTION
## Slice

Adds `enable_crux_probe` / `crux_question` parameters to `run_dialectical_loop` in `aragora/epistemic/runtime_loop.py`. When both are set and `ARAGORA_CRUXSET_EMISSION_ENABLED` is on, the loop synthesises a crux-analysis payload from the `DecaySignal` reasons and calls `maybe_emit_cruxset`, setting `crux_probe_skipped=False` and storing a lightweight CruxSet summary under `metadata["crux_probe"]`. This clears the `crux_probe_skipped=True` sentinel that the previous slice explicitly deferred with the note _"crux-finder integration (DIC-15) updates it in a follow-on PR."_

## Gating

- Default: OFF (`enable_crux_probe=False` on `run_dialectical_loop`; `ARAGORA_CRUXSET_EMISSION_ENABLED` also required)
- Live queue effect: none — `run_dialectical_loop` is never called from boss loop, dispatch, or swarm supervisor paths; the probe is a soft enrichment layer and all failure modes are swallowed
- Advances issue: #6217 (DIC-23)

## Tests

`tests/epistemic/test_runtime_loop.py` — 23 inline-verified assertions (pydantic not installed in CI shell; pre-existing transitive conftest gap unrelated to this slice):

- `TestCruxProbe::test_skipped_by_default` — existing `crux_probe_skipped=True` default preserved
- `TestCruxProbe::test_skipped_for_missing_or_empty_question` — parametrized over `enable_crux_probe=False`, `crux_question=None`, whitespace
- `TestCruxProbe::test_skipped_when_attempt_returns_none` — probe returns `None` → skipped, no key in metadata
- `TestCruxProbe::test_skipped_when_attempt_raises` — outer guard catches raised exception → skipped
- `TestCruxProbe::test_not_skipped_and_metadata_present` — fake probe result → `crux_probe_skipped=False`, `"crux_probe"` in metadata
- `TestCruxProbe::test_metadata_summary_shape` — summary has `cruxset_id`, `crux_count`, `top_crux_ids`, `convergence_barrier`
- `TestCruxProbe::test_does_not_overwrite_existing_metadata` — caller-supplied metadata preserved alongside probe result
- `TestCruxProbe::test_to_dict_reflects_not_skipped` — `to_dict()` serialises `crux_probe_skipped=False` and nested summary
- `TestBuildSyntheticCruxPayload` — 6 tests verifying payload shape: one crux per reason, `failed_claim` score 0.85, `stale_evidence` 0.60, fallback root-cause crux when no reasons, required key set, `unresolved_crux` disagreement count, `claim_id`/`crux_id` preference, `recommended_focus` capped at 3

## Validation

- `pytest tests/epistemic/test_runtime_loop.py` — 23 assertions passed via direct module loading (pre-existing pydantic/conftest gap; see notes above)
- `ruff check aragora/epistemic/runtime_loop.py tests/epistemic/test_runtime_loop.py` — clean
- `mypy aragora/epistemic/runtime_loop.py --ignore-missing-imports` — clean (0 errors)
- Net diff: 299 LOC (307 insertions, 8 deletions)

## Out of scope

- Wiring `enable_crux_probe` into any Arena, debate-phase, or API caller — the knob is opt-in for downstream consumers
- Persisting the `crux_probe` summary to the Knowledge Mound or receipts — follows DIC-16 wiring
- Running a live debate to produce the CruxSet — the synthetic payload from `DecaySignal.reasons` is intentionally lightweight; a full debate-backed probe is a follow-on slice after the AGT-* gate opens
- Any changes to boss loop, dispatch, swarm supervisor, or benchmark corpus code

---
_Generated by [Claude Code](https://claude.ai/code/session_014BFcAKex357d1j1SftAaYp)_