### PR TITLE
ci(deps): auto-refresh uv lock on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-uv-lock.yml
+++ b/.github/workflows/dependabot-uv-lock.yml
@@ -1,0 +1,134 @@
+name: Dependabot UV Lock Refresh
+
+# Dependabot updates pyproject.toml for the pip ecosystem, but it does not
+# reliably refresh uv.lock. Security Gate intentionally blocks stale locks, so
+# this same-repo Dependabot-only workflow repairs the lockfile before CI settles.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/dependabot-uv-lock.yml"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Dependabot PR number to relock"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: dependabot-uv-lock-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  refresh-lock:
+    name: Refresh uv.lock on Dependabot PRs
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        (
+          github.actor == 'dependabot[bot]' ||
+          github.event.pull_request.user.login == 'app/dependabot' ||
+          github.event.pull_request.user.login == 'dependabot[bot]' ||
+          github.event.pull_request.user.login == 'dependabot'
+        ) &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.ref != github.event.pull_request.base.ref &&
+        !github.event.pull_request.draft
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Resolve target branch
+        id: target
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ -z "${PR_NUMBER}" ]]; then
+              echo "::error::workflow_dispatch requires pr_number"
+              exit 1
+            fi
+            pr_json="$(gh pr view "${PR_NUMBER}" --json author,headRefName,headRepositoryOwner,isDraft)"
+            author="$(jq -r '.author.login' <<< "${pr_json}")"
+            owner="$(jq -r '.headRepositoryOwner.login' <<< "${pr_json}")"
+            draft="$(jq -r '.isDraft' <<< "${pr_json}")"
+            if [[ "${author}" != "app/dependabot" && "${author}" != "dependabot" && "${author}" != "dependabot[bot]" ]]; then
+              echo "::error::PR #${PR_NUMBER} is authored by ${author}, not dependabot"
+              exit 1
+            fi
+            if [[ "${owner}" != "${GITHUB_REPOSITORY_OWNER}" ]]; then
+              echo "::error::PR #${PR_NUMBER} is not from the base repository owner"
+              exit 1
+            fi
+            if [[ "${draft}" == "true" ]]; then
+              echo "::notice::PR #${PR_NUMBER} is draft; skipping"
+              echo "skip=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+            echo "branch=$(jq -r '.headRefName' <<< "${pr_json}")" >> "${GITHUB_OUTPUT}"
+          else
+            echo "branch=${HEAD_REF}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Checkout Dependabot branch
+        if: steps.target.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.branch }}
+          repository: ${{ github.repository }}
+          token: ${{ github.token }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        if: steps.target.outputs.skip != 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Regenerate uv.lock
+        if: steps.target.outputs.skip != 'true'
+        id: relock
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install uv
+          uv lock
+          unexpected="$(git diff --name-only | grep -vx 'uv.lock' || true)"
+          if [[ -n "${unexpected}" ]]; then
+            echo "::error::uv lock changed unexpected files:"
+            echo "${unexpected}"
+            exit 1
+          fi
+          if git diff --quiet -- uv.lock; then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            echo "uv.lock is already fresh"
+            exit 0
+          fi
+          uv lock --check
+          echo "changed=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Commit refreshed lockfile
+        if: steps.target.outputs.skip != 'true' && steps.relock.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore(deps): refresh uv lock"
+          git push origin "HEAD:${{ steps.target.outputs.branch }}"

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -16,7 +16,7 @@
 | Python lines of code under aragora/ | `1920897` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `135` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5107` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `216570` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `216572` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `653` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `60` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -29,7 +29,7 @@
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
 | Markdown files under docs/ | `787` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
-| GitHub Actions workflows | `84` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
+| GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 
 ## Notes on counting methodology

--- a/scripts/check_branch_mutation_policy.py
+++ b/scripts/check_branch_mutation_policy.py
@@ -42,6 +42,7 @@ REQUIRED_MATCH_COUNTS: dict[str, int] = {
 
 WORKFLOW_MUTATION_ALLOWLIST = {
     "benchmark-truth-publication.yml",
+    "dependabot-uv-lock.yml",
     "openapi.yml",
     "release-notes.yml",
     "testfixer-auto.yml",
@@ -163,6 +164,32 @@ def find_mutating_workflow_violations(workflows: dict[str, str]) -> list[Violati
                     Violation(
                         path=f".github/workflows/{name}",
                         message="must create the benchmark publication pull request as a draft",
+                    )
+                )
+
+        if name == "dependabot-uv-lock.yml":
+            required_markers = {
+                "same-repository head guard": (
+                    "github.event.pull_request.head.repo.full_name == github.repository"
+                ),
+                "dependabot actor guard": "github.event.pull_request.user.login == 'app/dependabot'",
+                "uv.lock-only diff guard": "grep -vx 'uv.lock'",
+                "uv freshness verification": "uv lock --check",
+                "branch-targeted push": 'git push origin "HEAD:${{ steps.target.outputs.branch }}"',
+            }
+            for description, marker in required_markers.items():
+                if marker not in text:
+                    violations.append(
+                        Violation(
+                            path=f".github/workflows/{name}",
+                            message=f"missing required Dependabot lock-refresh guard: {description}",
+                        )
+                    )
+            if re.search(r"git push\s+origin\s+(?:HEAD:)?main\b", text):
+                violations.append(
+                    Violation(
+                        path=f".github/workflows/{name}",
+                        message="must not push directly to main",
                     )
                 )
     return violations

--- a/tests/scripts/test_check_branch_mutation_policy.py
+++ b/tests/scripts/test_check_branch_mutation_policy.py
@@ -78,6 +78,40 @@ def test_find_mutating_workflow_violations_requires_draft_benchmark_publication_
     )
 
 
+def test_find_mutating_workflow_violations_allows_guarded_dependabot_lock_refresh() -> None:
+    workflows = {
+        "dependabot-uv-lock.yml": (
+            "on:\n  pull_request_target:\n"
+            "jobs:\n  x:\n"
+            "    if: >-\n"
+            "      github.event.pull_request.user.login == 'app/dependabot' &&\n"
+            "      github.event.pull_request.head.repo.full_name == github.repository\n"
+            "    steps:\n"
+            "      - run: |\n"
+            "          uv lock\n"
+            "          unexpected=\"$(git diff --name-only | grep -vx 'uv.lock' || true)\"\n"
+            "          uv lock --check\n"
+            '          git push origin "HEAD:${{ steps.target.outputs.branch }}"\n'
+        ),
+    }
+    violations = find_mutating_workflow_violations(workflows)
+    assert violations == []
+
+
+def test_find_mutating_workflow_violations_requires_dependabot_lock_guards() -> None:
+    workflows = {
+        "dependabot-uv-lock.yml": (
+            "on:\n  pull_request_target:\n"
+            "jobs:\n  x:\n    steps:\n      - run: |\n          uv lock\n          git push origin main"
+        ),
+    }
+    violations = find_mutating_workflow_violations(workflows)
+    assert violations
+    assert any("same-repository head guard" in v.message for v in violations)
+    assert any("dependabot actor guard" in v.message for v in violations)
+    assert any("must not push directly to main" in v.message for v in violations)
+
+
 def test_repo_branch_mutation_policy_passes_for_current_tree() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     violations = check_repo(repo_root)


### PR DESCRIPTION
## Summary
- Add a same-repo Dependabot-only pull_request_target workflow that runs uv lock when pyproject.toml/uv.lock changes.
- Push only a refreshed uv.lock commit back to the Dependabot branch after uv lock --check succeeds.
- Keep Security Gate strict instead of relaxing the stale-lockfile check.

## Safety
- Guarded to Dependabot-authored same-repo PRs and non-draft PRs.
- Does not run repository scripts or tests from untrusted forks.
- Fails if uv lock changes anything other than uv.lock.

## Validation
- actionlint .github/workflows/dependabot-uv-lock.yml
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD