### PR TITLE
fix(swarm): align proof-first boss fallback labels

### DIFF
--- a/scripts/run_proof_first_shift.py
+++ b/scripts/run_proof_first_shift.py
@@ -41,7 +41,9 @@ DEFAULT_LAUNCHD_START_TIMEOUT_SECONDS = 45.0
 DEFAULT_BOSS_TARGET_BRANCH = "main"
 DEFAULT_BOSS_WORKER_MODEL = "codex"
 DEFAULT_BOSS_REVIEW_MODEL = "codex"
-DEFAULT_BOSS_LABELS = ("autonomous", "boss-ready")
+# The proof-first queue reconciler keeps canonical work under boss-ready. Requiring
+# an extra "autonomous" label here silently makes the direct fallback see no work.
+DEFAULT_BOSS_LABELS = ("boss-ready",)
 DEFAULT_BOSS_MAX_TICKS = "200"
 DEFAULT_BOSS_INTERVAL_SECONDS = "90"
 DEFAULT_BOSS_MAX_CONSECUTIVE_FAILURES = "12"
@@ -761,6 +763,7 @@ def build_direct_boss_loop_command(*, repo: str) -> list[str]:
         "aragora.cli.main",
         "swarm",
         "boss-loop",
+        "--no-suitable-issue-keepalive",
         "--boss-repo",
         _env_or_default("BOSS_REPO", repo),
         "--target-branch",

--- a/tests/scripts/test_run_proof_first_shift.py
+++ b/tests/scripts/test_run_proof_first_shift.py
@@ -684,7 +684,15 @@ def test_build_direct_boss_loop_command_uses_env_configuration() -> None:
     ):
         command = mod.build_direct_boss_loop_command(repo="ignored/repo")
 
-    assert command[:6] == [command[0], "-u", "-m", "aragora.cli.main", "swarm", "boss-loop"]
+    assert command[:7] == [
+        command[0],
+        "-u",
+        "-m",
+        "aragora.cli.main",
+        "swarm",
+        "boss-loop",
+        "--no-suitable-issue-keepalive",
+    ]
     assert (
         "--boss-repo" in command
         and command[command.index("--boss-repo") + 1] == "synaptent/aragora"
@@ -699,6 +707,15 @@ def test_build_direct_boss_loop_command_uses_env_configuration() -> None:
     assert command[command.index("--autonomy") + 1] == "guided"
     assert command[command.index("--max-hours") + 1] == "6"
     assert command[command.index("--boss-max-parallel-dispatches") + 1] == "2"
+
+
+def test_build_direct_boss_loop_command_defaults_to_canonical_boss_ready_label() -> None:
+    with patch.dict("os.environ", {"BOSS_LABELS": ""}, clear=False):
+        command = mod.build_direct_boss_loop_command(repo="synaptent/aragora")
+
+    labels = [command[index + 1] for index, token in enumerate(command) if token == "--label"]
+    assert labels == ["boss-ready"]
+    assert "--no-suitable-issue-keepalive" in command
 
 
 def test_launchd_start_timeout_uses_default_for_non_throttled_state() -> None:


### PR DESCRIPTION
## Summary
- default proof-first direct boss-loop fallback to the canonical boss-ready label only
- add the boss-loop no-suitable-issue keepalive flag so direct fallback does not short-exit on a transient empty feed
- cover the command shape and default label behavior in focused tests

## Validation
- pytest tests/scripts/test_run_proof_first_shift.py -q
- ruff check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py
- ruff format --check scripts/run_proof_first_shift.py tests/scripts/test_run_proof_first_shift.py
- git diff --check
