### PR TITLE
fix(benchmarks): preserve corpus freshness linkage

### DIFF
--- a/docs/benchmarks/benchmark_corpus_freshness.json
+++ b/docs/benchmarks/benchmark_corpus_freshness.json
@@ -2,12 +2,18 @@
   "schema_version": 1,
   "entries": [
     {
-      "issue": 5839,
-      "track": "TW-02",
-      "corpus": "tw-01-bounded-execution-v1",
-      "revision": "rev-1",
-      "status": "restock_pending",
-      "action": "Retire or replace stale closed issues before the next recurring benchmark truth publication."
+      "corpus_id": "tw-01-bounded-execution-v1",
+      "revision": 4,
+      "stale_issue_numbers": [
+        5844,
+        5903,
+        5887
+      ],
+      "target_kind": "issue",
+      "target": "#5839",
+      "title": "[TW-02] Restock stale issues in tw-01-bounded-execution-v1 rev-1",
+      "url": "https://github.com/synaptent/aragora/issues/5839",
+      "notes": "Follow-up retained for the recurring TW-02 status surface after rev-4 retired the stale rev-3 corpus members."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- re-salvage the benchmark corpus freshness linkage repair onto current main
- keep the diff scoped to docs/benchmarks/benchmark_corpus_freshness.json
- avoid publishing stale branch codex/swarm-eeef7ef7-micro-3-salvage, which had diverged into a 69-file diff

## Validation
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 -m json.tool docs/benchmarks/benchmark_corpus_freshness.json

Refs #6729