### PR TITLE
[AGT-03] Calibration curve reporting for ManifoldBrierScorer

### DIFF
--- a/aragora/metrics/manifold_brier.py
+++ b/aragora/metrics/manifold_brier.py
@@ -21,6 +21,7 @@ import os
 import statistics
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal, ROUND_FLOOR
 from typing import Any, Optional
 
 __all__ = [
@@ -313,10 +314,12 @@ class ManifoldBrierScorer:
         sum_predicted: list[float] = [0.0] * n_bins
 
         for pred in self._predictions:
-            # Multiply instead of divide to avoid e.g. 0.3/0.1 == 2.999...
-            # Add a sub-ULP epsilon (1e-9) to snap values that are floating-
-            # point representations of exact boundaries into the correct bin.
-            idx = min(int(pred.predicted_probability * n_bins + 1e-9), n_bins - 1)
+            # Interpret the shortest decimal rendering of the probability so
+            # operator-entered boundaries like 0.3 are binned as exact decimals
+            # without widening the high-exclusive side of each bracket.
+            decimal_probability = Decimal(str(pred.predicted_probability))
+            idx = int((decimal_probability * n_bins).to_integral_value(rounding=ROUND_FLOOR))
+            idx = min(idx, n_bins - 1)
             counts_total[idx] += 1
             sum_predicted[idx] += pred.predicted_probability
             if pred.outcome == 1:

--- a/aragora/metrics/manifold_brier.py
+++ b/aragora/metrics/manifold_brier.py
@@ -313,8 +313,10 @@ class ManifoldBrierScorer:
         sum_predicted: list[float] = [0.0] * n_bins
 
         for pred in self._predictions:
-            # Map probability to bin index; clamp p==1.0 into last bin.
-            idx = min(int(pred.predicted_probability / step), n_bins - 1)
+            # Multiply instead of divide to avoid e.g. 0.3/0.1 == 2.999...
+            # Add a sub-ULP epsilon (1e-9) to snap values that are floating-
+            # point representations of exact boundaries into the correct bin.
+            idx = min(int(pred.predicted_probability * n_bins + 1e-9), n_bins - 1)
             counts_total[idx] += 1
             sum_predicted[idx] += pred.predicted_probability
             if pred.outcome == 1:

--- a/aragora/metrics/manifold_brier.py
+++ b/aragora/metrics/manifold_brier.py
@@ -29,6 +29,7 @@ __all__ = [
     "ManifoldPrediction",
     "ManifoldBrierScorer",
     "BrierWindowSummary",
+    "CalibrationBin",
 ]
 
 # ---------------------------------------------------------------------------
@@ -161,6 +162,41 @@ class BrierWindowSummary:
         }
 
 
+@dataclass(frozen=True)
+class CalibrationBin:
+    """One probability bracket in a calibration curve.
+
+    A calibration curve divides ``[0, 1]`` into equal-width bins and, for
+    each bin, reports how often predictions in that bracket resolved YES.
+    A well-calibrated agent has ``fraction_yes ≈ mean_predicted`` in every
+    bin.
+
+    Attributes:
+        low: Inclusive lower bound of the bracket.
+        high: Exclusive upper bound (last bin is [low, 1.0] inclusive).
+        count: Number of resolved predictions in this bracket.
+        fraction_yes: Empirical frequency of ``outcome == 1``; None when
+            ``count == 0``.
+        mean_predicted: Mean ``predicted_probability`` in this bracket; None
+            when ``count == 0``.
+    """
+
+    low: float
+    high: float
+    count: int
+    fraction_yes: Optional[float]
+    mean_predicted: Optional[float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "low": self.low,
+            "high": self.high,
+            "count": self.count,
+            "fraction_yes": self.fraction_yes,
+            "mean_predicted": self.mean_predicted,
+        }
+
+
 # ---------------------------------------------------------------------------
 # Scorer
 # ---------------------------------------------------------------------------
@@ -242,3 +278,58 @@ class ManifoldBrierScorer:
             window_start=cutoff,
             window_end=now,
         )
+
+    def calibration_curve(self, *, n_bins: int = 10) -> list[CalibrationBin]:
+        """Compute a reliability diagram calibration curve over all stored predictions.
+
+        Divides ``[0, 1]`` into ``n_bins`` equal-width brackets and, for each
+        bracket, reports the empirical YES frequency and the mean predicted
+        probability.  A well-calibrated agent has ``fraction_yes ≈
+        mean_predicted`` in every non-empty bin.
+
+        Predictions with ``predicted_probability == 1.0`` fall into the last
+        bin (``[1 - step, 1.0]`` inclusive upper bound).
+
+        Args:
+            n_bins: Number of equal-width bins (must be between 2 and 100).
+
+        Returns:
+            A list of :class:`CalibrationBin` of length ``n_bins``, ordered
+            from low to high probability.  Empty bins have ``count == 0`` and
+            ``fraction_yes == mean_predicted == None``.
+
+        Raises:
+            RuntimeError: If the feature flag is not enabled.
+            ValueError: If ``n_bins`` is outside ``[2, 100]``.
+        """
+        _require_enabled()
+        if not (2 <= n_bins <= 100):
+            raise ValueError(f"n_bins must be in [2, 100]; got {n_bins}")
+
+        step = 1.0 / n_bins
+        # Each bin: counts_yes, counts_total, sum_predicted
+        counts_yes: list[int] = [0] * n_bins
+        counts_total: list[int] = [0] * n_bins
+        sum_predicted: list[float] = [0.0] * n_bins
+
+        for pred in self._predictions:
+            # Map probability to bin index; clamp p==1.0 into last bin.
+            idx = min(int(pred.predicted_probability / step), n_bins - 1)
+            counts_total[idx] += 1
+            sum_predicted[idx] += pred.predicted_probability
+            if pred.outcome == 1:
+                counts_yes[idx] += 1
+
+        bins: list[CalibrationBin] = []
+        for i in range(n_bins):
+            n = counts_total[i]
+            bins.append(
+                CalibrationBin(
+                    low=round(i * step, 10),
+                    high=round((i + 1) * step, 10),
+                    count=n,
+                    fraction_yes=(counts_yes[i] / n) if n > 0 else None,
+                    mean_predicted=(sum_predicted[i] / n) if n > 0 else None,
+                )
+            )
+        return bins

--- a/tests/metrics/test_manifold_brier.py
+++ b/tests/metrics/test_manifold_brier.py
@@ -309,3 +309,29 @@ class TestCalibrationCurve:
         curve = scorer.calibration_curve(n_bins=20)
         assert len(curve) == 20
         assert sum(b.count for b in curve) == 1
+
+    @pytest.mark.parametrize(
+        "prob,expected_bin",
+        [
+            # Exact decimal boundaries that are slightly below their target
+            # value in IEEE 754, triggering int(p / step) = n-1 instead of n.
+            (0.3, 3),   # 0.3/0.1 == 2.9999... → must land in bin 3 [0.3, 0.4)
+            (0.6, 6),   # 0.6/0.1 == 5.9999... → must land in bin 6 [0.6, 0.7)
+            (0.7, 7),   # 0.7/0.1 == 6.9999... → must land in bin 7 [0.7, 0.8)
+            # p=1.0 must clamp to the last bin, not overflow.
+            (1.0, 9),
+            # Values strictly inside a bin are unaffected.
+            (0.05, 0),
+            (0.35, 3),
+            (0.95, 9),
+        ],
+    )
+    def test_exact_boundary_bin_placement(self, prob: float, expected_bin: int) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(prob, 1, question_id=f"q_{prob}"))
+        curve = scorer.calibration_curve(n_bins=10)
+        assert curve[expected_bin].count == 1, (
+            f"p={prob} landed in bin {next(i for i, b in enumerate(curve) if b.count)}, "
+            f"expected bin {expected_bin}"
+        )
+        assert sum(b.count for b in curve) == 1

--- a/tests/metrics/test_manifold_brier.py
+++ b/tests/metrics/test_manifold_brier.py
@@ -315,9 +315,9 @@ class TestCalibrationCurve:
         [
             # Exact decimal boundaries that are slightly below their target
             # value in IEEE 754, triggering int(p / step) = n-1 instead of n.
-            (0.3, 3),   # 0.3/0.1 == 2.9999... → must land in bin 3 [0.3, 0.4)
-            (0.6, 6),   # 0.6/0.1 == 5.9999... → must land in bin 6 [0.6, 0.7)
-            (0.7, 7),   # 0.7/0.1 == 6.9999... → must land in bin 7 [0.7, 0.8)
+            (0.3, 3),  # 0.3/0.1 == 2.9999... → must land in bin 3 [0.3, 0.4)
+            (0.6, 6),  # 0.6/0.1 == 5.9999... → must land in bin 6 [0.6, 0.7)
+            (0.7, 7),  # 0.7/0.1 == 6.9999... → must land in bin 7 [0.7, 0.8)
             # p=1.0 must clamp to the last bin, not overflow.
             (1.0, 9),
             # Values strictly inside a bin are unaffected.

--- a/tests/metrics/test_manifold_brier.py
+++ b/tests/metrics/test_manifold_brier.py
@@ -9,6 +9,7 @@ import pytest
 
 from aragora.metrics.manifold_brier import (
     BrierWindowSummary,
+    CalibrationBin,
     ManifoldBrierScorer,
     ManifoldPrediction,
     brier_score,
@@ -185,3 +186,126 @@ class TestManifoldBrierScorer:
         assert "window_days" in d
         assert "mean_brier" in d
         assert "n_predictions" in d
+
+
+# ---------------------------------------------------------------------------
+# CalibrationBin
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationBin:
+    def test_to_dict_shape(self) -> None:
+        b = CalibrationBin(low=0.1, high=0.2, count=3, fraction_yes=0.67, mean_predicted=0.15)
+        d = b.to_dict()
+        assert d == {
+            "low": 0.1,
+            "high": 0.2,
+            "count": 3,
+            "fraction_yes": 0.67,
+            "mean_predicted": 0.15,
+        }
+
+    def test_empty_bin_nones(self) -> None:
+        b = CalibrationBin(low=0.0, high=0.1, count=0, fraction_yes=None, mean_predicted=None)
+        assert b.fraction_yes is None
+        assert b.mean_predicted is None
+
+
+# ---------------------------------------------------------------------------
+# ManifoldBrierScorer.calibration_curve
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationCurve:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+
+    def test_returns_n_bins_entries(self) -> None:
+        scorer = ManifoldBrierScorer()
+        curve = scorer.calibration_curve(n_bins=10)
+        assert len(curve) == 10
+
+    def test_empty_scorer_all_empty_bins(self) -> None:
+        scorer = ManifoldBrierScorer()
+        curve = scorer.calibration_curve(n_bins=5)
+        assert all(b.count == 0 for b in curve)
+        assert all(b.fraction_yes is None for b in curve)
+        assert all(b.mean_predicted is None for b in curve)
+
+    def test_bin_boundaries_are_contiguous(self) -> None:
+        scorer = ManifoldBrierScorer()
+        curve = scorer.calibration_curve(n_bins=4)
+        for i in range(len(curve) - 1):
+            assert curve[i].high == pytest.approx(curve[i + 1].low)
+
+    def test_first_bin_low_is_zero(self) -> None:
+        scorer = ManifoldBrierScorer()
+        curve = scorer.calibration_curve(n_bins=10)
+        assert curve[0].low == pytest.approx(0.0)
+
+    def test_last_bin_high_is_one(self) -> None:
+        scorer = ManifoldBrierScorer()
+        curve = scorer.calibration_curve(n_bins=10)
+        assert curve[-1].high == pytest.approx(1.0)
+
+    def test_probability_one_falls_in_last_bin(self) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(1.0, 1))
+        curve = scorer.calibration_curve(n_bins=10)
+        # p=1.0 must land in the last bin, not overflow
+        assert curve[-1].count == 1
+        total = sum(b.count for b in curve)
+        assert total == 1
+
+    def test_fraction_yes_perfect_calibration(self) -> None:
+        # All predictions at ~0.75 → last bin before 0.8 should have fraction_yes=1.0
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(0.75, 1, question_id="a"))
+        scorer.add(_pred(0.75, 1, question_id="b"))
+        curve = scorer.calibration_curve(n_bins=10)
+        # p=0.75 → bin index 7 ([0.7, 0.8))
+        bin_7 = curve[7]
+        assert bin_7.count == 2
+        assert bin_7.fraction_yes == pytest.approx(1.0)
+        assert bin_7.mean_predicted == pytest.approx(0.75)
+
+    def test_fraction_yes_mixed_outcomes(self) -> None:
+        scorer = ManifoldBrierScorer()
+        # Put 2 YES and 2 NO in the 0.2–0.3 bracket (p=0.25)
+        for _ in range(2):
+            scorer.add(_pred(0.25, 1, question_id=f"yes_{_}"))
+        for _ in range(2):
+            scorer.add(_pred(0.25, 0, question_id=f"no_{_}"))
+        curve = scorer.calibration_curve(n_bins=10)
+        # p=0.25 → bin index 2 ([0.2, 0.3))
+        bin_2 = curve[2]
+        assert bin_2.count == 4
+        assert bin_2.fraction_yes == pytest.approx(0.5)
+
+    def test_total_count_equals_num_predictions(self) -> None:
+        scorer = ManifoldBrierScorer()
+        for i in range(6):
+            scorer.add(_pred(i / 10, 0, question_id=f"q{i}"))
+        curve = scorer.calibration_curve(n_bins=10)
+        assert sum(b.count for b in curve) == 6
+
+    def test_invalid_n_bins_raises(self) -> None:
+        scorer = ManifoldBrierScorer()
+        with pytest.raises(ValueError, match="n_bins"):
+            scorer.calibration_curve(n_bins=1)
+        with pytest.raises(ValueError, match="n_bins"):
+            scorer.calibration_curve(n_bins=101)
+
+    def test_disabled_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)
+        scorer = ManifoldBrierScorer()
+        with pytest.raises(RuntimeError, match="disabled"):
+            scorer.calibration_curve()
+
+    def test_custom_n_bins(self) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(0.5, 1))
+        curve = scorer.calibration_curve(n_bins=20)
+        assert len(curve) == 20
+        assert sum(b.count for b in curve) == 1

--- a/tests/metrics/test_manifold_brier.py
+++ b/tests/metrics/test_manifold_brier.py
@@ -335,3 +335,39 @@ class TestCalibrationCurve:
             f"expected bin {expected_bin}"
         )
         assert sum(b.count for b in curve) == 1
+
+    @pytest.mark.parametrize(
+        "prob,expected_bin",
+        [(i / 10, min(i, 9)) for i in range(11)],
+    )
+    def test_all_decimal_boundaries_are_low_inclusive(self, prob: float, expected_bin: int) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(prob, 1, question_id=f"boundary_{prob}"))
+        curve = scorer.calibration_curve(n_bins=10)
+
+        assert curve[expected_bin].count == 1, (
+            f"p={prob} landed in bin {next(i for i, b in enumerate(curve) if b.count)}, "
+            f"expected bin {expected_bin}"
+        )
+        assert sum(b.count for b in curve) == 1
+
+    @pytest.mark.parametrize(
+        "prob,expected_bin",
+        [
+            (0.2999999999, 2),
+            (0.5999999999, 5),
+            (0.6999999999, 6),
+        ],
+    )
+    def test_values_below_boundary_remain_high_exclusive(
+        self, prob: float, expected_bin: int
+    ) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(_pred(prob, 1, question_id=f"below_boundary_{prob}"))
+        curve = scorer.calibration_curve(n_bins=10)
+
+        assert curve[expected_bin].count == 1, (
+            f"p={prob} landed in bin {next(i for i, b in enumerate(curve) if b.count)}, "
+            f"expected bin {expected_bin}"
+        )
+        assert sum(b.count for b in curve) == 1


### PR DESCRIPTION
## Slice

Adds `CalibrationBin` dataclass and `calibration_curve()` method to
`ManifoldBrierScorer` in `aragora/metrics/manifold_brier.py`. This is
AGT-03 sub-deliverable #4 (calibration curve reporting per agent): bin
resolved predictions by probability bracket and report the empirical YES
frequency so operators can visually inspect how well each agent's stated
probabilities match realized outcomes.

## Gating

- Default: OFF (flag: `ARAGORA_MANIFOLD_BRIER_ENABLED` — same gate as the
  existing scorer; no new env var introduced)
- Live queue effect: none
- Advances issue: #6064 (AGT-03 Manifold Markets integration with rolling
  Brier scoring)

## Tests

- `TestCalibrationBin.test_to_dict_shape` — verifies CalibrationBin
  serialization shape
- `TestCalibrationBin.test_empty_bin_nones` — empty bins carry None stats
- `TestCalibrationCurve.test_returns_n_bins_entries` — curve length equals
  n_bins
- `TestCalibrationCurve.test_empty_scorer_all_empty_bins` — no predictions
  → all bins empty
- `TestCalibrationCurve.test_bin_boundaries_are_contiguous` — adjacent
  bin edges are equal (no gaps or overlaps)
- `TestCalibrationCurve.test_first_bin_low_is_zero` / `test_last_bin_high_is_one`
  — covers full [0, 1] range
- `TestCalibrationCurve.test_probability_one_falls_in_last_bin` — p=1.0
  clamps to last bin, not out-of-bounds
- `TestCalibrationCurve.test_fraction_yes_perfect_calibration` — all-YES
  predictions at p=0.75 land in correct bin with fraction_yes=1.0
- `TestCalibrationCurve.test_fraction_yes_mixed_outcomes` — 2 YES + 2 NO
  at p=0.25 → fraction_yes=0.5
- `TestCalibrationCurve.test_total_count_equals_num_predictions` — sum of
  bin counts equals total stored predictions
- `TestCalibrationCurve.test_invalid_n_bins_raises` — n_bins=1 and n_bins=101
  raise ValueError
- `TestCalibrationCurve.test_disabled_raises` — feature flag off → RuntimeError
- `TestCalibrationCurve.test_custom_n_bins` — n_bins=20 works correctly

## Validation

- `python3` (isolated module test) — 15 assertions passed
- `ruff check aragora/metrics/manifold_brier.py tests/metrics/test_manifold_brier.py` — clean
- `mypy aragora/metrics/manifold_brier.py --ignore-missing-imports` — clean

## Out of scope

- Wiring the calibration curve output into the AGT-05 reputation flow or
  operator-truth dashboards — that is a follow-on slice after AGT-05
  settlement is production-green.
- Per-agent filtering (the scorer is already per-agent at the instance level;
  agent-keyed aggregation across instances is an AGT-05 / AGT-06 concern).
- Metaculus and synthetic-GitHub calibration curves — same pattern, trivially
  addable after AGT-05 lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_011Xo1Xwmz2KnhcYZXRmCcMz)_