### PR TITLE
fix(swarm): align preflight permission contracts

### DIFF
--- a/aragora/swarm/dispatch_contract_gate.py
+++ b/aragora/swarm/dispatch_contract_gate.py
@@ -12,11 +12,11 @@ from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.env_utils import git_safe_env
 from aragora.swarm.preflight import (
     PreflightReceipt,
+    _preflight_launch_config,
     run_contract_preflight_receipt,
 )
 from aragora.swarm.terminal_truth import TerminalClass, classify_preflight_failure
 from aragora.swarm.worker_contract import WorkerContract, build_worker_contract
-from aragora.swarm.worker_process import LaunchConfig
 from aragora.swarm.worker_launcher import build_worker_runtime_env
 
 
@@ -407,18 +407,19 @@ def dispatch_contract_gate(
         ),
         admin_approved=True,
     )
-    launch_config = LaunchConfig(
-        base_branch=loop.config.target_branch,
-        execution_mode=loop.config.execution_mode,
+    # The expected contract is for the scratch preflight worker, not the final
+    # boss-loop worker.  Build it with the same preflight-owned LaunchConfig
+    # that ``preflight._run_worker`` will use, otherwise loop-level permission
+    # flags (for example allow_codex_full_auto=False) can drift from the
+    # launcher-rebuilt contract and block every real dispatch.
+    launch_config = _preflight_launch_config(
+        agent=target_agent,
+        contract=None,
         claude_profile=(
             str((selected_runner or {}).get("profile", "")).strip() or None
             if target_agent == "claude"
             else None
         ),
-        allow_claude_dangerously_skip_permissions=(
-            loop.config.allow_claude_dangerously_skip_permissions
-        ),
-        allow_codex_full_auto=loop.config.allow_codex_full_auto,
     )
     contract_valid = True
     preview_contract: WorkerContract | None = None

--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -1457,6 +1457,7 @@ def _preflight_launch_config(
     *,
     agent: str,
     contract: WorkerContract | None,
+    claude_profile: str | None = None,
 ) -> LaunchConfig:
     """Build the preflight-owned ``LaunchConfig``.
 
@@ -1472,10 +1473,15 @@ def _preflight_launch_config(
       launcher env did not.
 
     See ``docs/plans/2026-04-17-worker-drift-diagnosis.md``.
+    ``claude_profile`` lets preview call-sites model the same preflight-owned
+    launch config before a preview contract exists.  It uses the same
+    ``"default"`` sentinel handling as the contract-derived path.
     """
     launcher_profile: str | None = None
-    if contract is not None and str(agent or "").strip().lower() == "claude":
-        raw_profile = str(contract.profile or "").strip()
+    if str(agent or "").strip().lower() == "claude":
+        raw_profile = str(claude_profile or "").strip()
+        if not raw_profile and contract is not None:
+            raw_profile = str(contract.profile or "").strip()
         if raw_profile and raw_profile.lower() != "default":
             launcher_profile = raw_profile
     return LaunchConfig(

--- a/tests/swarm/test_dispatch_contract_gate.py
+++ b/tests/swarm/test_dispatch_contract_gate.py
@@ -342,6 +342,63 @@ class TestDispatchContractGate:
         assert result is None
         mock_runtime_env.assert_called_once()
 
+    def test_preview_contract_uses_preflight_permissions_not_loop_permissions(
+        self, tmp_path
+    ) -> None:
+        """The previewed contract models the scratch preflight worker.
+
+        The final boss-loop worker may run with ``allow_codex_full_auto=False``,
+        but the scratch preflight worker owns a disposable worktree and runs with
+        its preflight LaunchConfig.  Previewing the loop-level worker permission
+        caused the real 2026-04-28 drift:
+        expected ``{"allow_full_auto": false}``, actual ``{"allow_full_auto": true}``.
+        """
+        loop = _make_loop(allow_codex_full_auto=False)
+        issue = _make_issue(111)
+        spec = MagicMock()
+        spec.work_orders = None
+        spec.file_scope_hints = ["aragora/swarm/preflight.py"]
+        spec.mission_context_policies = {}
+        captured_configs = []
+
+        def fake_build_worker_contract(**kwargs):
+            captured_configs.append(kwargs["config"])
+            return _make_valid_contract_mock()
+
+        with (
+            patch(
+                "aragora.swarm.dispatch_contract_gate.build_worker_contract",
+                side_effect=fake_build_worker_contract,
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate._persist_preview_contract",
+                return_value=tmp_path / "contract.json",
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate.run_contract_preflight_receipt",
+                return_value=_make_passing_receipt(),
+            ),
+            patch(
+                "aragora.swarm.dispatch_contract_gate.CredentialEnvelope.from_environment"
+            ) as mock_env,
+        ):
+            mock_env.return_value.missing_slices.return_value = []
+            mock_env.return_value.preflight_cache_payload.return_value = {}
+
+            result = dispatch_contract_gate(
+                loop,
+                issue,
+                spec,
+                selected_runner={"runner_type": "codex"},
+                requested_target_agent="codex",
+                worker_env=None,
+                claimed_runner_id=None,
+            )
+
+        assert result is None
+        assert captured_configs
+        assert captured_configs[0].allow_codex_full_auto is True
+
     def test_preview_contract_fallback_preserves_spec_mission_lineage(self, tmp_path) -> None:
         """Specs without explicit work_orders must still carry mission lineage into the preview contract."""
         loop = _make_loop()

--- a/tests/swarm/test_worker_contract_drift_alignment.py
+++ b/tests/swarm/test_worker_contract_drift_alignment.py
@@ -21,6 +21,8 @@ Pre-v1.2 these tests fail on two independent axes:
    carries ``metadata.admin_approved=True``). Preview also sets
    ``ARAGORA_CLAUDE_PROFILE`` but the preflight launcher does not (no
    profile plumbing).
+3. ``permissions`` drift: preview copied the boss-loop worker permissions
+   while the preflight launcher uses a preflight-owned scratch-worker config.
 
 Diagnosis: see ``docs/plans/2026-04-17-worker-drift-diagnosis.md``.
 """
@@ -31,12 +33,10 @@ from pathlib import Path
 
 import pytest
 
-from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.swarm import dispatch_contract_gate as gate_mod
 from aragora.swarm import preflight as preflight_mod
 from aragora.swarm.worker_contract import WorkerContract, build_worker_contract
 from aragora.swarm.worker_launcher import build_worker_runtime_env
-from aragora.swarm.worker_process import LaunchConfig
 
 
 # --- Helpers mirroring the production paths ---------------------------------
@@ -66,12 +66,10 @@ def _build_preview_contract_via_production_helpers(
         claude_profile=selected_profile if target_agent == "claude" else None,
         admin_approved=True,
     )
-    launch_config = LaunchConfig(
-        base_branch="main",
-        execution_mode=ExecutionMode.AUTONOMOUS,
+    launch_config = preflight_mod._preflight_launch_config(
+        agent=target_agent,
+        contract=None,
         claude_profile=selected_profile if target_agent == "claude" else None,
-        allow_claude_dangerously_skip_permissions=True,
-        allow_codex_full_auto=True,
     )
     preview_work_order = {
         "file_scope": ["scripts/reconcile_b0_pr_truth.py"],
@@ -107,27 +105,14 @@ def _build_preflight_launcher_contract_via_production_helpers(
     """
     work_order = preflight_mod._work_order(target_agent, contract=expected_contract)
 
-    # Mirror preflight._run_worker's LaunchConfig construction, including
-    # the v1.2 fix that threads the expected contract's profile into
-    # ``claude_profile``.  This test will read the production helper
-    # directly once the fix lands; for now we mirror inline so the test
-    # fails deterministically on pre-v1.2 main and passes post-fix.
-    launcher_profile: str | None = None
-    if target_agent == "claude":
-        raw_profile = str(expected_contract.profile or "").strip()
-        if raw_profile and raw_profile.lower() != "default":
-            launcher_profile = raw_profile
-    preflight_config = LaunchConfig(
-        allow_claude_dangerously_skip_permissions=True,
-        allow_codex_full_auto=True,
-        use_managed_session_script=False,
-        require_explicit_approval=False,
-        claude_profile=launcher_profile,
+    preflight_config = preflight_mod._preflight_launch_config(
+        agent=target_agent,
+        contract=expected_contract,
     )
     launcher_env = build_worker_runtime_env(
         agent=target_agent,
         worker_env_overrides={},
-        claude_profile=launcher_profile,
+        claude_profile=preflight_config.claude_profile,
         admin_approved=True,
     )
     return build_worker_contract(
@@ -304,6 +289,42 @@ def test_preflight_run_worker_ignores_profile_for_non_claude_agents() -> None:
         contract=expected,
     )
     assert cfg.claude_profile is None
+
+
+def test_preflight_launch_config_preview_permissions_match_actual_launcher() -> None:
+    """Preview contracts must use the same scratch-worker permissions as the
+    actual preflight launcher, independent of boss-loop worker flags.
+
+    This locks the 2026-04-28 regression where boss-loop validation reported
+    ``Drifted fields: ['permissions']`` because the preview expected
+    ``allow_full_auto=False`` while the preflight launcher rebuilt
+    ``allow_full_auto=True``.
+    """
+    preview_cfg = preflight_mod._preflight_launch_config(
+        agent="codex",
+        contract=None,
+    )
+    expected = WorkerContract(
+        runner_type="codex-cli",
+        agent="codex",
+        model="default",
+        profile="default",
+        permissions={"allow_full_auto": True},
+        execution_mode="autonomous",
+        git_auth_mode="https",
+        gh_api_auth_mode="none",
+        budget={"max_wall_time_seconds": 2400.0, "no_progress_timeout_seconds": 3600.0},
+        env_checksum="abc",
+        mission_context_policy={"role": "worker", "required_sources": []},
+    )
+    actual_cfg = preflight_mod._preflight_launch_config(
+        agent="codex",
+        contract=expected,
+    )
+
+    assert preview_cfg.allow_codex_full_auto is True
+    assert actual_cfg.allow_codex_full_auto is True
+    assert preview_cfg.allow_codex_full_auto == actual_cfg.allow_codex_full_auto
 
 
 # --- Production dispatch-gate call must pass admin_approved=True ------------


### PR DESCRIPTION
## Summary
- make dispatch-contract preview build the same preflight-owned LaunchConfig that the scratch preflight worker uses
- preserve Claude profile/default handling while avoiding loop-level permission drift for Codex workers
- add regressions for the 2026-04-28 permissions drift: expected allow_full_auto=false vs actual allow_full_auto=true

## Validation
- python3 -m pytest tests/swarm/test_worker_contract.py tests/swarm/test_worker_contract_drift_alignment.py tests/swarm/test_dispatch_contract_gate.py tests/swarm/test_preflight.py -q --tb=short --timeout=120
- python3 -m ruff check aragora/swarm/dispatch_contract_gate.py aragora/swarm/preflight.py tests/swarm/test_worker_contract_drift_alignment.py tests/swarm/test_dispatch_contract_gate.py
- python3 -m ruff format --check aragora/swarm/dispatch_contract_gate.py aragora/swarm/preflight.py tests/swarm/test_worker_contract_drift_alignment.py tests/swarm/test_dispatch_contract_gate.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD