### PR TITLE
fix(preflight): inherit allow_full_auto from expected contract

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -1460,27 +1460,64 @@ def _preflight_launch_config(
 ) -> LaunchConfig:
     """Build the preflight-owned ``LaunchConfig``.
 
-    Threads ``expected_contract.profile`` (when non-default, for claude
-    workers) into ``LaunchConfig.claude_profile`` so that the launcher's
-    rebuilt worker-contract matches the preview-persisted contract.
+    Threads ``expected_contract`` fields (profile, permissions) into the
+    launcher's ``LaunchConfig`` so that the launcher's rebuilt worker
+    contract matches the preview-persisted contract exactly. Without this
+    threading, ``_enforce_expected_contract()`` rejects the preflight
+    worker on field drift.
 
-    Pre-v1.2 this inheritance was missing, which caused two drift sources
-    that together tripped ``_enforce_expected_contract()``:
+    Drift sources we explicitly compensate for:
 
-    * ``profile`` field: preview "max-07" vs launcher "default"
-    * ``env_checksum`` field: preview env has ``ARAGORA_CLAUDE_PROFILE``,
+    * ``profile`` (claude only): preview "max-07" vs launcher "default".
+      Pre-v1.2 inheritance was missing.
+    * ``env_checksum``: preview env has ``ARAGORA_CLAUDE_PROFILE``,
       launcher env did not.
+    * ``permissions.allow_full_auto`` (codex) and
+      ``permissions.allow_dangerous_permissions`` (claude): preview built
+      via ``loop.config.allow_codex_full_auto`` /
+      ``loop.config.allow_claude_dangerously_skip_permissions``, which can
+      be ``False``; the launcher historically hardcoded both to ``True``.
+      With ``loop.config.allow_codex_full_auto=False`` (the safer default),
+      preview produces ``permissions={"allow_full_auto": false}`` while
+      the launcher produced ``{"allow_full_auto": true}`` → drift on
+      ``permissions``, blocking dispatch with
+      ``contract_preflight: drifted fields ['permissions']``.
+
+    The launcher's contract is rebuilt by ``WorkerLauncher`` via
+    ``build_worker_contract(config=...)``. The fix is to read the
+    permission booleans off the expected contract and feed them into the
+    ``LaunchConfig``, so both sides derive from the same source of truth.
+    Falls back to ``True`` (the historical default) only when the expected
+    contract did not specify a permission, preserving existing behaviour
+    for callers that pass ``contract=None``.
 
     See ``docs/plans/2026-04-17-worker-drift-diagnosis.md``.
     """
     launcher_profile: str | None = None
-    if contract is not None and str(agent or "").strip().lower() == "claude":
+    normalized_agent = str(agent or "").strip().lower()
+    if contract is not None and normalized_agent == "claude":
         raw_profile = str(contract.profile or "").strip()
         if raw_profile and raw_profile.lower() != "default":
             launcher_profile = raw_profile
+
+    # Mirror permission booleans from the expected contract so the launcher's
+    # rebuilt contract permissions match the preview's exactly. Without this,
+    # _enforce_expected_contract trips on permissions drift whenever
+    # loop.config disabled either flag.
+    contract_permissions: dict[str, Any] = {}
+    if contract is not None and isinstance(contract.permissions, dict):
+        contract_permissions = contract.permissions
+
+    # Default True preserves legacy behaviour for callers that pass
+    # contract=None or omit the relevant permission key. When the expected
+    # contract was built from loop.config with the field set to False, that
+    # value flows through here unchanged.
+    allow_dangerous = bool(contract_permissions.get("allow_dangerous_permissions", True))
+    allow_full_auto = bool(contract_permissions.get("allow_full_auto", True))
+
     return LaunchConfig(
-        allow_claude_dangerously_skip_permissions=True,
-        allow_codex_full_auto=True,
+        allow_claude_dangerously_skip_permissions=allow_dangerous,
+        allow_codex_full_auto=allow_full_auto,
         # Preflight already provisions and owns the disposable worktree.
         # Wrapping the worker in codex_session.sh tries to create another
         # managed worktree on top of it and fails before any commit happens.

--- a/tests/swarm/test_worker_contract_drift_alignment.py
+++ b/tests/swarm/test_worker_contract_drift_alignment.py
@@ -306,6 +306,140 @@ def test_preflight_run_worker_ignores_profile_for_non_claude_agents() -> None:
     assert cfg.claude_profile is None
 
 
+def test_preflight_run_worker_inherits_codex_allow_full_auto_false() -> None:
+    """Regression: when the expected contract has
+    ``permissions={"allow_full_auto": false}`` (because
+    ``loop.config.allow_codex_full_auto`` was False), the preflight
+    launcher must build its ``LaunchConfig`` with
+    ``allow_codex_full_auto=False`` so the rebuilt worker contract's
+    permissions match the preview-persisted contract's permissions
+    exactly. Pre-fix this was hardcoded to True, producing
+    ``contract_preflight: drifted fields ['permissions']`` and blocking
+    every dispatch on a config with full-auto disabled.
+
+    Evidence: ``.aragora/overnight/contract_drift_diagnostics.jsonl``
+    entries 2026-04-28T02:23:21Z and 02:24:48Z show
+    ``expected={"allow_full_auto": false}`` vs
+    ``actual={"allow_full_auto": true}`` for the codex agent.
+    """
+    expected = WorkerContract(
+        runner_type="codex-cli",
+        agent="codex",
+        model="default",
+        profile="default",
+        permissions={"allow_full_auto": False},
+        execution_mode="autonomous",
+        git_auth_mode="https",
+        gh_api_auth_mode="none",
+        budget={"max_wall_time_seconds": 2400.0, "no_progress_timeout_seconds": 3600.0},
+        env_checksum="abc",
+        mission_context_policy={"role": "worker", "required_sources": []},
+    )
+    cfg = preflight_mod._preflight_launch_config(
+        agent="codex",
+        contract=expected,
+    )
+    assert cfg.allow_codex_full_auto is False, (
+        "preflight launcher must mirror expected contract's "
+        "allow_full_auto=False, not hardcode True"
+    )
+
+    # Round-trip: rebuild the worker contract from the launcher's config and
+    # confirm permissions match what the preview produced. This is the exact
+    # comparison _enforce_expected_contract performs.
+    from aragora.swarm.worker_contract import build_worker_contract
+
+    rebuilt = build_worker_contract(
+        agent="codex",
+        config=cfg,
+        worktree_path="/tmp",
+        env={},
+    )
+    assert rebuilt.permissions == {"allow_full_auto": False}
+
+
+def test_preflight_run_worker_inherits_codex_allow_full_auto_true() -> None:
+    """Symmetric: when the expected contract permits full-auto, the
+    launcher must also permit it. Pinning the historical default
+    behaviour for the True case so this stays a real bidirectional
+    contract.
+    """
+    expected = WorkerContract(
+        runner_type="codex-cli",
+        agent="codex",
+        model="default",
+        profile="default",
+        permissions={"allow_full_auto": True},
+        execution_mode="autonomous",
+        git_auth_mode="https",
+        gh_api_auth_mode="none",
+        budget={"max_wall_time_seconds": 2400.0, "no_progress_timeout_seconds": 3600.0},
+        env_checksum="abc",
+        mission_context_policy={"role": "worker", "required_sources": []},
+    )
+    cfg = preflight_mod._preflight_launch_config(
+        agent="codex",
+        contract=expected,
+    )
+    assert cfg.allow_codex_full_auto is True
+
+
+def test_preflight_run_worker_inherits_claude_dangerous_permissions_false() -> None:
+    """Regression: same drift symmetry for claude's
+    ``allow_dangerous_permissions``. When loop.config disables it the
+    preview produces ``permissions={"allow_dangerous_permissions": false}``;
+    the launcher must mirror that so the rebuilt contract matches.
+    """
+    expected = WorkerContract(
+        runner_type="claude-cli",
+        agent="claude",
+        model="default",
+        profile="default",
+        permissions={"allow_dangerous_permissions": False},
+        execution_mode="autonomous",
+        git_auth_mode="https",
+        gh_api_auth_mode="none",
+        budget={"max_wall_time_seconds": 2400.0, "no_progress_timeout_seconds": 3600.0},
+        env_checksum="abc",
+        mission_context_policy={"role": "worker", "required_sources": []},
+    )
+    cfg = preflight_mod._preflight_launch_config(
+        agent="claude",
+        contract=expected,
+    )
+    assert cfg.allow_claude_dangerously_skip_permissions is False
+
+
+def test_preflight_run_worker_falls_back_to_true_when_contract_omits_permission() -> None:
+    """When the expected contract is None (legacy callers) or its
+    ``permissions`` dict omits the relevant key, the launcher must fall
+    back to the historical default of True so behaviour is preserved
+    for callers that haven't updated to thread the contract through.
+    """
+    cfg_none = preflight_mod._preflight_launch_config(agent="codex", contract=None)
+    assert cfg_none.allow_codex_full_auto is True
+    assert cfg_none.allow_claude_dangerously_skip_permissions is True
+
+    expected_no_permissions = WorkerContract(
+        runner_type="codex-cli",
+        agent="codex",
+        model="default",
+        profile="default",
+        permissions={},  # empty
+        execution_mode="autonomous",
+        git_auth_mode="https",
+        gh_api_auth_mode="none",
+        budget={"max_wall_time_seconds": 2400.0, "no_progress_timeout_seconds": 3600.0},
+        env_checksum="abc",
+        mission_context_policy={"role": "worker", "required_sources": []},
+    )
+    cfg_empty = preflight_mod._preflight_launch_config(
+        agent="codex",
+        contract=expected_no_permissions,
+    )
+    assert cfg_empty.allow_codex_full_auto is True
+
+
 # --- Production dispatch-gate call must pass admin_approved=True ------------
 
 


### PR DESCRIPTION
## Summary

Fixes the next blocker surfaced by #6773's validation: codex-target dispatch was rejected at preflight with \`contract_preflight: drifted fields ['permissions']\` whenever \`loop.config.allow_codex_full_auto=False\`.

## Drift evidence

\`.aragora/overnight/contract_drift_diagnostics.jsonl\`:

\`\`\`json
{"recorded_at": "2026-04-28T02:23:21Z", "agent": "codex",
 "drifted_fields": ["permissions"],
 "diff": {"permissions": {"expected": {"allow_full_auto": false},
                          "actual":   {"allow_full_auto": true}}}}
\`\`\`

## Cause

Two sides of the WorkerContract pipeline used different sources of truth for the same field:

| Side | Source | Result when `loop.config.allow_codex_full_auto=False` |
|---|---|---|
| Preview (`dispatch_contract_gate.py:421`) | `loop.config.allow_codex_full_auto` | `permissions={"allow_full_auto": false}` |
| Preflight launcher (`preflight.py:1483`) | **hardcoded `True`** | `permissions={"allow_full_auto": true}` |

`_enforce_expected_contract()` correctly flagged the asymmetry as drift and blocked dispatch.

## Fix

Read both `allow_full_auto` and `allow_dangerous_permissions` off the expected contract's `permissions` dict in `_preflight_launch_config`, and feed them into the launcher's `LaunchConfig`. Falls back to `True` (the historical default) when:
- no contract is provided (`contract=None`), or
- the contract's `permissions` dict omits the key

This preserves behaviour for legacy callers.

Now both sides derive from a single source of truth: \`loop.config\` flows into the persisted expected contract, which the preflight already receives, which the launcher then rebuilds the contract from.

## Tests

4 new in `tests/swarm/test_worker_contract_drift_alignment.py`:
- **`test_preflight_run_worker_inherits_codex_allow_full_auto_false`** — the regression. Asserts \`permissions={"allow_full_auto": false}\` on the expected contract produces \`allow_codex_full_auto=False\` on the LaunchConfig, AND verifies the rebuilt contract's permissions match exactly via round-trip through \`build_worker_contract()\` (the same comparison \`_enforce_expected_contract()\` performs).
- `test_preflight_run_worker_inherits_codex_allow_full_auto_true` — symmetric pinning of the True case.
- `test_preflight_run_worker_inherits_claude_dangerous_permissions_false` — same drift symmetry for claude's `allow_dangerous_permissions`.
- `test_preflight_run_worker_falls_back_to_true_when_contract_omits_permission` — legacy-caller compatibility.

All 8 pre-existing drift-alignment tests pass unmodified.

## Validation

- `pytest tests/swarm/test_worker_contract_drift_alignment.py`: **12 passed**
- `pytest tests/swarm/test_preflight.py + test_worker_contract.py + test_dispatch_contract_gate.py + test_worker_contract_drift_alignment.py`: **126 passed**
- `ruff check` + `ruff format`: clean
- `mypy aragora/swarm/preflight.py`: clean
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: ok

## Diff

\`\`\`
aragora/swarm/preflight.py                         |  57 +++-
tests/swarm/test_worker_contract_drift_alignment.py | 134 +++++++++++++++
2 files changed, 181 insertions(+), 10 deletions(-)
\`\`\`

Scope strictly within `dispatch_contract_gate`/`preflight`/tests as codex specified.

## Next step (per codex's directive)

After this merges: re-run exactly one constrained #6187 validation. If the spin doesn't recur and preflight clears, surface the next blocker (or merged-PR result). Do NOT unpause writers or start canonical-green.

Refs: codex post-#6773 directive 2026-04-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)