### PR TITLE
fix(boss-loop): bound terminal json summaries

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -2327,7 +2327,9 @@ def cmd_swarm(args: argparse.Namespace) -> None:
 
         loop_result = asyncio.run(loop.run(on_status=_on_status))
         if as_json:
-            print(json.dumps(loop_result.to_dict(), indent=2))
+            to_bounded_dict = getattr(loop_result, "to_bounded_dict", None)
+            payload = to_bounded_dict() if callable(to_bounded_dict) else loop_result.to_dict()
+            print(json.dumps(payload, indent=2))
         else:
             print(f"\nBoss loop finished: {loop_result.stop_reason}")
             print(

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -194,6 +194,141 @@ class BossIterationStatus:
         return result
 
 
+_BOSS_LOOP_JSON_OUTPUT_BYTES = 64 * 1024
+_BOSS_LOOP_RECEIPT_TEXT_BYTES = 2 * 1024
+_BOSS_LOOP_RESULT_TEXT_BYTES = 2 * 1024
+_BOSS_LOOP_RESULT_MAX_LIST_ITEMS = 16
+_BOSS_LOOP_RESULT_MAX_DICT_ITEMS = 32
+
+
+def _truncate_middle_text(value: Any, *, max_bytes: int) -> str:
+    text = str(value)
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= max_bytes:
+        return text
+    marker = f"\n...[truncated {len(encoded) - max_bytes} bytes]...\n"
+    marker_bytes = marker.encode("utf-8")
+    if len(marker_bytes) >= max_bytes:
+        return encoded[:max_bytes].decode("utf-8", errors="ignore")
+    budget = max_bytes - len(marker_bytes)
+    head_bytes = max(0, budget // 2)
+    tail_bytes = max(0, budget - head_bytes)
+    head = encoded[:head_bytes].decode("utf-8", errors="ignore")
+    tail = encoded[-tail_bytes:].decode("utf-8", errors="ignore") if tail_bytes else ""
+    return f"{head}{marker}{tail}"
+
+
+def _bounded_text_list(
+    values: Any,
+    *,
+    max_items: int = _BOSS_LOOP_RESULT_MAX_LIST_ITEMS,
+    max_bytes: int = _BOSS_LOOP_RESULT_TEXT_BYTES,
+) -> list[str]:
+    if not isinstance(values, list):
+        values = [values] if values else []
+    bounded = [
+        _truncate_middle_text(item, max_bytes=max_bytes)
+        for item in values[:max_items]
+        if str(item).strip()
+    ]
+    if len(values) > max_items:
+        bounded.append(f"...[truncated {len(values) - max_items} additional item(s)]...")
+    return bounded
+
+
+def _bounded_json_value(
+    value: Any,
+    *,
+    max_depth: int = 4,
+    max_items: int = _BOSS_LOOP_RESULT_MAX_DICT_ITEMS,
+    max_string_bytes: int = _BOSS_LOOP_RESULT_TEXT_BYTES,
+) -> Any:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _truncate_middle_text(value, max_bytes=max_string_bytes)
+    if max_depth <= 0:
+        return _truncate_middle_text(repr(value), max_bytes=max_string_bytes)
+    if isinstance(value, dict):
+        bounded: dict[str, Any] = {}
+        items = list(value.items())
+        for key, item in items[:max_items]:
+            bounded[str(key)] = _bounded_json_value(
+                item,
+                max_depth=max_depth - 1,
+                max_items=max_items,
+                max_string_bytes=max_string_bytes,
+            )
+        if len(items) > max_items:
+            bounded["_truncated_keys"] = len(items) - max_items
+        return bounded
+    if isinstance(value, (list, tuple, set)):
+        items = list(value)
+        bounded_list = [
+            _bounded_json_value(
+                item,
+                max_depth=max_depth - 1,
+                max_items=max_items,
+                max_string_bytes=max_string_bytes,
+            )
+            for item in items[:max_items]
+        ]
+        if len(items) > max_items:
+            bounded_list.append({"_truncated_items": len(items) - max_items})
+        return bounded_list
+    return _truncate_middle_text(value, max_bytes=max_string_bytes)
+
+
+def _bounded_issue_payload(
+    issue: dict[str, Any] | None, *, include_body: bool = True
+) -> dict[str, Any] | None:
+    if not isinstance(issue, dict):
+        return None
+    bounded: dict[str, Any] = {}
+    for key in (
+        "number",
+        "title",
+        "labels",
+        "url",
+        "state",
+        "created_at",
+        "lane_id",
+        "lane_hints",
+    ):
+        if key in issue:
+            bounded[key] = _bounded_json_value(issue[key], max_depth=2, max_string_bytes=512)
+    if include_body and "body" in issue:
+        bounded["body"] = _truncate_middle_text(issue["body"], max_bytes=1024)
+    return bounded
+
+
+def _minimal_status_payload(status: dict[str, Any]) -> dict[str, Any]:
+    selected_issue = status.get("selected_issue")
+    return {
+        "iteration": status.get("iteration"),
+        "run_id": status.get("run_id"),
+        "timestamp": status.get("timestamp"),
+        "selected_issue": _bounded_issue_payload(selected_issue, include_body=False),
+        "worker_status": status.get("worker_status"),
+        "stop_reason": status.get("stop_reason"),
+        "needs_human_reasons": _bounded_text_list(
+            status.get("needs_human_reasons", []),
+            max_items=4,
+            max_bytes=512,
+        ),
+        "next_actions": _bounded_text_list(
+            status.get("next_actions", []),
+            max_items=4,
+            max_bytes=512,
+        ),
+        "elapsed_seconds": status.get("elapsed_seconds"),
+        "error": _truncate_middle_text(status.get("error", "") or "", max_bytes=512) or None,
+        "worker_outcome": status.get("worker_outcome"),
+        "configured_max_parallel_dispatches": status.get("configured_max_parallel_dispatches"),
+        "effective_parallel_dispatches": status.get("effective_parallel_dispatches"),
+    }
+
+
 @dataclass
 class BossLoopResult:
     """Final result of a Boss loop run."""
@@ -229,6 +364,157 @@ class BossLoopResult:
             "configured_max_parallel_dispatches": self.configured_max_parallel_dispatches,
             "effective_parallel_dispatches_observed": self.effective_parallel_dispatches_observed,
         }
+
+    def to_bounded_dict(self, *, max_bytes: int = _BOSS_LOOP_JSON_OUTPUT_BYTES) -> dict[str, Any]:
+        """Return an operator-facing result summary safe for terminal JSON output.
+
+        The raw result can contain full issue bodies and worker-sourced
+        needs-human text. Real post-worker failures have put multi-MB payloads
+        here, making the final ``json.dumps`` path look hung. Keep ``to_dict``
+        unchanged for in-process callers, but make CLI/receipt output bounded.
+        """
+
+        def _bounded_status(status: Any) -> dict[str, Any]:
+            raw = dict(status) if isinstance(status, dict) else {}
+            return {
+                "iteration": raw.get("iteration"),
+                "run_id": raw.get("run_id"),
+                "timestamp": raw.get("timestamp"),
+                "runner_freshness": _bounded_json_value(
+                    raw.get("runner_freshness", {}),
+                    max_depth=3,
+                    max_items=16,
+                    max_string_bytes=512,
+                ),
+                "selected_issue": _bounded_issue_payload(raw.get("selected_issue")),
+                "worker_status": raw.get("worker_status"),
+                "stop_reason": raw.get("stop_reason"),
+                "needs_human_reasons": _bounded_text_list(
+                    raw.get("needs_human_reasons", []),
+                    max_items=8,
+                    max_bytes=_BOSS_LOOP_RESULT_TEXT_BYTES,
+                ),
+                "next_actions": _bounded_text_list(
+                    raw.get("next_actions", []),
+                    max_items=8,
+                    max_bytes=_BOSS_LOOP_RESULT_TEXT_BYTES,
+                ),
+                "elapsed_seconds": raw.get("elapsed_seconds"),
+                "error": (_truncate_middle_text(raw.get("error", "") or "", max_bytes=512) or None),
+                "worker_outcome": raw.get("worker_outcome"),
+                "configured_max_parallel_dispatches": raw.get("configured_max_parallel_dispatches"),
+                "effective_parallel_dispatches": raw.get("effective_parallel_dispatches"),
+            }
+
+        statuses = list(self.iteration_statuses)
+        payload: dict[str, Any] = {
+            "mode": "boss-loop",
+            "run_id": self.run_id,
+            "iterations_completed": self.iterations_completed,
+            "total_elapsed_seconds": self.total_elapsed_seconds,
+            "stop_reason": self.stop_reason,
+            "issues_attempted": [
+                item
+                for item in (_bounded_issue_payload(issue) for issue in self.issues_attempted[:16])
+                if item is not None
+            ],
+            "issues_completed": [
+                item
+                for item in (_bounded_issue_payload(issue) for issue in self.issues_completed[:16])
+                if item is not None
+            ],
+            "issues_failed": [
+                item
+                for item in (_bounded_issue_payload(issue) for issue in self.issues_failed[:16])
+                if item is not None
+            ],
+            "iteration_statuses": [_bounded_status(status) for status in statuses[-16:]],
+            "needs_human_reasons": _bounded_text_list(self.needs_human_reasons),
+            "next_actions": _bounded_text_list(self.next_actions),
+            "sanitation_summary": _bounded_text_list(self.sanitation_summary, max_items=16),
+            "configured_max_parallel_dispatches": self.configured_max_parallel_dispatches,
+            "effective_parallel_dispatches_observed": self.effective_parallel_dispatches_observed,
+            "_bounded": True,
+            "_truncation": {
+                "issues_attempted_omitted": max(0, len(self.issues_attempted) - 16),
+                "issues_completed_omitted": max(0, len(self.issues_completed) - 16),
+                "issues_failed_omitted": max(0, len(self.issues_failed) - 16),
+                "iteration_statuses_omitted": max(0, len(statuses) - 16),
+            },
+        }
+
+        def _serialised_size(candidate: dict[str, Any]) -> int:
+            return len(json.dumps(candidate, default=str).encode("utf-8"))
+
+        serialised_size = _serialised_size(payload)
+        if serialised_size > max_bytes:
+            payload["iteration_statuses"] = [
+                _minimal_status_payload(dict(status) if isinstance(status, dict) else {})
+                for status in statuses[-8:]
+            ]
+            for key in ("issues_attempted", "issues_completed", "issues_failed"):
+                bounded_issues = []
+                for issue in getattr(self, key)[:8]:
+                    bounded_issue = _bounded_issue_payload(issue, include_body=False)
+                    if bounded_issue is not None:
+                        bounded_issues.append(bounded_issue)
+                payload[key] = bounded_issues
+            payload["needs_human_reasons"] = _bounded_text_list(
+                self.needs_human_reasons,
+                max_items=8,
+                max_bytes=512,
+            )
+            payload["next_actions"] = _bounded_text_list(
+                self.next_actions,
+                max_items=8,
+                max_bytes=512,
+            )
+            payload["sanitation_summary"] = _bounded_text_list(
+                self.sanitation_summary,
+                max_items=8,
+                max_bytes=512,
+            )
+            payload["_truncated"] = True
+            serialised_size = _serialised_size(payload)
+
+        if serialised_size > max_bytes:
+            payload = {
+                "mode": "boss-loop",
+                "run_id": self.run_id,
+                "iterations_completed": self.iterations_completed,
+                "total_elapsed_seconds": self.total_elapsed_seconds,
+                "stop_reason": self.stop_reason,
+                "issues_attempted": len(self.issues_attempted),
+                "issues_completed": len(self.issues_completed),
+                "issues_failed": len(self.issues_failed),
+                "needs_human_reasons": _bounded_text_list(
+                    self.needs_human_reasons,
+                    max_items=4,
+                    max_bytes=512,
+                ),
+                "next_actions": _bounded_text_list(
+                    self.next_actions,
+                    max_items=4,
+                    max_bytes=512,
+                ),
+                "configured_max_parallel_dispatches": self.configured_max_parallel_dispatches,
+                "effective_parallel_dispatches_observed": (
+                    self.effective_parallel_dispatches_observed
+                ),
+                "_bounded": True,
+                "_truncated": True,
+                "_overflow": True,
+            }
+            serialised_size = _serialised_size(payload)
+
+        payload["_truncated"] = bool(
+            payload.get("_truncated")
+            or payload.get("_overflow")
+            or any(value for value in payload.get("_truncation", {}).values())
+            or "[truncated" in json.dumps(payload, default=str)
+        )
+        payload["_serialised_bytes"] = _serialised_size(payload)
+        return payload
 
 
 @dataclass(slots=True)
@@ -1255,9 +1541,21 @@ class BossLoop:
                     "effective_parallel_dispatches_observed": (
                         result.effective_parallel_dispatches_observed
                     ),
-                    "needs_human_reasons": list(result.needs_human_reasons),
-                    "next_actions": list(result.next_actions),
-                    "sanitation_summary": list(result.sanitation_summary),
+                    "needs_human_reasons": _bounded_text_list(
+                        result.needs_human_reasons,
+                        max_items=16,
+                        max_bytes=_BOSS_LOOP_RECEIPT_TEXT_BYTES,
+                    ),
+                    "next_actions": _bounded_text_list(
+                        result.next_actions,
+                        max_items=16,
+                        max_bytes=_BOSS_LOOP_RECEIPT_TEXT_BYTES,
+                    ),
+                    "sanitation_summary": _bounded_text_list(
+                        result.sanitation_summary,
+                        max_items=16,
+                        max_bytes=_BOSS_LOOP_RECEIPT_TEXT_BYTES,
+                    ),
                 },
                 verdict=verdict,
                 confidence=(completed / attempted) if attempted else 0.0,

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -565,6 +565,45 @@ class TestSwarmParser:
         assert config.auto_continue_on_needs_human is True
         assert '"mode": "boss-loop"' in capsys.readouterr().out
 
+    def test_cmd_swarm_boss_loop_json_uses_bounded_result(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="boss-loop",
+            autonomy="guided",
+            json=True,
+            boss_repo="synaptent/aragora",
+            boss_issue_list="101",
+            boss_issue_number=None,
+            worker_model="claude",
+            review_model="codex",
+            labels=["boss-ready"],
+            boss_label_filter=None,
+            allow_missing_validation_contract=False,
+            ping_pong=False,
+            no_dispatch=False,
+            claude_runner_profiles=None,
+            max_consecutive_failures=3,
+        )
+
+        class _FakeBossLoopResult:
+            def to_dict(self):
+                raise AssertionError("raw boss-loop result should not be used for --json")
+
+            def to_bounded_dict(self):
+                return {
+                    "mode": "boss-loop",
+                    "run_id": "boss-run-bounded",
+                    "_bounded": True,
+                }
+
+        fake_loop = SimpleNamespace(run=AsyncMock(return_value=_FakeBossLoopResult()))
+
+        with patch("aragora.swarm.boss_loop.BossLoop", return_value=fake_loop):
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"run_id": "boss-run-bounded"' in out
+        assert '"_bounded": true' in out
+
     def test_cmd_swarm_preflight_routes_to_module_without_contract(self, capsys):
         args = _swarm_args(
             swarm_action_or_goal="preflight",

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -2837,6 +2837,58 @@ class TestStatusPayloadShape:
         assert parsed["configured_max_parallel_dispatches"] == 1
         assert parsed["effective_parallel_dispatches_observed"] is None
 
+    def test_loop_result_bounded_dict_caps_unbounded_operator_payload(self):
+        huge_reason = (
+            "contract_preflight: Drifted fields: ['permissions']\n"
+            + ("x" * (4 * 1024 * 1024))
+            + "\nTAIL_SENTINEL"
+        )
+        huge_body = "Acceptance criteria\n" + ("body context\n" * 200_000)
+        result = BossLoopResult(
+            run_id="boss-test-bounded",
+            iterations_completed=1,
+            total_elapsed_seconds=10.0,
+            stop_reason="needs_human",
+            issues_attempted=[{"number": 6187, "title": "Freshness fix", "body": huge_body}],
+            issues_completed=[],
+            issues_failed=[{"number": 6187, "title": "Freshness fix", "body": huge_body}],
+            iteration_statuses=[
+                {
+                    "iteration": 1,
+                    "run_id": "boss-test-bounded",
+                    "runner_freshness": {
+                        "fresh": True,
+                        "details": {"raw_probe": "runner" * 500_000},
+                    },
+                    "selected_issue": {
+                        "number": 6187,
+                        "title": "Freshness fix",
+                        "body": huge_body,
+                    },
+                    "worker_status": "needs_human",
+                    "stop_reason": "needs_human",
+                    "needs_human_reasons": [huge_reason],
+                    "next_actions": [huge_reason],
+                    "elapsed_seconds": 313.0,
+                }
+            ],
+            needs_human_reasons=[huge_reason],
+            next_actions=[huge_reason],
+        )
+
+        started_at = time.perf_counter()
+        payload = result.to_bounded_dict(max_bytes=32 * 1024)
+        elapsed = time.perf_counter() - started_at
+        serialized = json.dumps(payload, sort_keys=True).encode("utf-8")
+
+        assert elapsed < 2.0
+        assert len(serialized) < 34 * 1024
+        assert payload["_bounded"] is True
+        assert payload["_truncated"] is True
+        assert "contract_preflight" in payload["needs_human_reasons"][0]
+        assert "TAIL_SENTINEL" in payload["needs_human_reasons"][0]
+        assert len(payload["iteration_statuses"][0]["selected_issue"].get("body", "")) < 2048
+
     def test_freshness_result_serializable(self):
         result = _fresh_result(fresh=True)
         payload = result.to_dict()

--- a/tests/swarm/test_boss_loop_receipts.py
+++ b/tests/swarm/test_boss_loop_receipts.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from aragora.receipts.lane import LaneCompletionReceipt, validate_receipt
-from aragora.swarm.boss_loop import BossLoop, BossLoopConfig, BossStopReason, RunnerFreshnessResult
+from aragora.swarm.boss_loop import (
+    BossLoop,
+    BossLoopConfig,
+    BossLoopResult,
+    BossStopReason,
+    RunnerFreshnessResult,
+)
 
 UTC = timezone.utc
 
@@ -44,6 +51,35 @@ class TestBossLoopOperationalReceipts:
         assert kwargs["action"] == "run_completed"
         assert kwargs["inputs"]["run_id"] == result.run_id
         assert kwargs["outputs"]["stop_reason"] == BossStopReason.NO_SUITABLE_ISSUE.value
+
+    def test_terminal_receipt_bounds_operator_text(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(max_iterations=1, iteration_interval_seconds=0.0))
+        huge_reason = (
+            "contract_preflight: Drifted fields: ['permissions']\n"
+            + ("x" * (2 * 1024 * 1024))
+            + "\nTAIL_SENTINEL"
+        )
+        result = BossLoopResult(
+            run_id=loop.run_id,
+            iterations_completed=1,
+            total_elapsed_seconds=5.0,
+            stop_reason=BossStopReason.NEEDS_HUMAN.value,
+            issues_attempted=[{"number": 6187}],
+            issues_completed=[],
+            issues_failed=[{"number": 6187}],
+            iteration_statuses=[],
+            needs_human_reasons=[huge_reason],
+            next_actions=[huge_reason],
+        )
+
+        with patch("aragora.receipts.provenance.emit_operational_receipt") as emit_receipt:
+            loop._emit_terminal_receipt(result)
+
+        outputs = emit_receipt.call_args.kwargs["outputs"]
+        encoded = json.dumps(outputs, sort_keys=True).encode("utf-8")
+        assert len(encoded) < 8 * 1024
+        assert "contract_preflight" in outputs["needs_human_reasons"][0]
+        assert "TAIL_SENTINEL" in outputs["needs_human_reasons"][0]
 
     def test_receipt_failures_do_not_block_run_completion(self) -> None:
         feed = MagicMock()


### PR DESCRIPTION
## Summary
- add a bounded `BossLoopResult.to_bounded_dict()` projection for operator-facing JSON output
- route `swarm boss-loop --json` through the bounded projection instead of raw `to_dict()`
- truncate terminal receipt needs-human/next-action text before receipt signing/persistence

## Why
A constrained #6187 validation after #6774 proved the permissions drift was fixed, then exposed a separate high-CPU spin in the final boss-loop JSON/result emission path. The process stayed in Python `_json` encode/scan with a zero-byte `--json` output file. This caps that final result surface while preserving the raw in-memory `to_dict()` result for internal callers.

## Validation
- `python3 -m pytest tests/swarm/test_boss_loop.py::TestStatusPayloadShape::test_loop_result_bounded_dict_caps_unbounded_operator_payload tests/swarm/test_boss_loop_receipts.py::TestBossLoopOperationalReceipts::test_terminal_receipt_bounds_operator_text tests/cli/test_swarm_command.py::TestSwarmParser::test_cmd_swarm_boss_loop_json_uses_bounded_result -q --tb=short --timeout=60`
- `python3 -m pytest tests/swarm/test_boss_loop.py::TestStatusPayloadShape tests/swarm/test_boss_loop_receipts.py tests/cli/test_swarm_command.py -q --tb=short --timeout=120`
- `python3 -m ruff check aragora/swarm/boss_loop.py aragora/cli/commands/swarm.py tests/swarm/test_boss_loop.py tests/swarm/test_boss_loop_receipts.py tests/cli/test_swarm_command.py`
- `python3 -m ruff format --check aragora/swarm/boss_loop.py aragora/cli/commands/swarm.py tests/swarm/test_boss_loop.py tests/swarm/test_boss_loop_receipts.py tests/cli/test_swarm_command.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`