### PR TITLE
fix(queue): batch dev coordination work queue sync

### DIFF
--- a/aragora/nomic/dev_coordination/core.py
+++ b/aragora/nomic/dev_coordination/core.py
@@ -1600,7 +1600,12 @@ class DevCoordinationStore:
             if existing and existing.status in (WorkStatus.CLAIMED, WorkStatus.IN_PROGRESS):
                 counts["skipped_active"] += 1
                 continue
-            await work_queue.upsert(item, allow_reopen=True, preserve_claimed=True)
+            await work_queue.upsert(
+                item,
+                allow_reopen=True,
+                preserve_claimed=True,
+                persist=False,
+            )
             if existing is None:
                 counts["created"] += 1
             elif existing.status in (WorkStatus.COMPLETED, WorkStatus.FAILED):
@@ -1622,6 +1627,7 @@ class DevCoordinationStore:
                 completed = await work_queue.complete(
                     item_id,
                     result={"source": "dev_coordination", "reason": "task_no_longer_open"},
+                    persist=False,
                 )
                 if completed is not None:
                     counts["completed"] += 1
@@ -1658,7 +1664,12 @@ class DevCoordinationStore:
                 counts["skipped_active"] += 1
                 continue
 
-            await work_queue.upsert(item, allow_reopen=True, preserve_claimed=True)
+            await work_queue.upsert(
+                item,
+                allow_reopen=True,
+                preserve_claimed=True,
+                persist=False,
+            )
             if existing is None:
                 counts["created"] += 1
             elif existing.status in (WorkStatus.COMPLETED, WorkStatus.FAILED):
@@ -1680,6 +1691,7 @@ class DevCoordinationStore:
                 completed = await work_queue.complete(
                     item_id,
                     result={"source": "dev_coordination", "reason": "no_longer_pending"},
+                    persist=False,
                 )
                 if completed is not None:
                     counts["completed"] += 1

--- a/aragora/nomic/global_work_queue.py
+++ b/aragora/nomic/global_work_queue.py
@@ -443,6 +443,7 @@ class GlobalWorkQueue:
         priority: int | None = None,
         allow_reopen: bool = False,
         preserve_claimed: bool = True,
+        persist: bool = True,
     ) -> WorkItem:
         """Create or refresh a work item without stomping active claims."""
         async with self._lock:
@@ -478,7 +479,8 @@ class GlobalWorkQueue:
 
             self._items[work.id] = work
             self._add_to_heap(work)
-            await self._save_queue()
+            if persist:
+                await self._save_queue()
 
             logger.debug("Upserted work %s with priority %s", work.id, work.computed_priority)
             return work
@@ -564,6 +566,8 @@ class GlobalWorkQueue:
         self,
         work_id: str,
         result: Any | None = None,
+        *,
+        persist: bool = True,
     ) -> WorkItem | None:
         """
         Mark work as completed.
@@ -589,7 +593,8 @@ class GlobalWorkQueue:
 
             # Check for unblocked work
             await self._check_unblocked()
-            await self._save_queue()
+            if persist:
+                await self._save_queue()
 
             logger.info("Completed work %s", work_id)
             return work

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -7245,7 +7245,7 @@ def test_scan_salvage_sources_finds_worktree_and_stash(
 
 @pytest.mark.asyncio
 async def test_sync_pending_work_queue_projects_items(
-    repo: Path, store: DevCoordinationStore
+    repo: Path, store: DevCoordinationStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     lease = store.claim_lease(
         task_id="clb-sync",
@@ -7273,10 +7273,20 @@ async def test_sync_pending_work_queue_projects_items(
         likely_value=0.75,
     )
     queue = GlobalWorkQueue(storage_dir=repo / ".work_queue")
+    save_calls = 0
+    original_save_queue = queue._save_queue
+
+    async def counted_save_queue() -> None:
+        nonlocal save_calls
+        save_calls += 1
+        await original_save_queue()
+
+    monkeypatch.setattr(queue, "_save_queue", counted_save_queue)
 
     counts = await store.sync_pending_work_queue(queue)
 
     assert counts["created"] == 2
+    assert save_calls == 1
     items = await queue.list_items(limit=10)
     item_ids = {item.id for item in items}
     assert f"salvage:{salvage.candidate_id}" in item_ids


### PR DESCRIPTION
## Summary
- add deferred persistence to `GlobalWorkQueue.upsert()` and `complete()`
- batch dev-coordination queue projections so sync writes once via the existing final `reprioritize()` save
- add a regression asserting pending-work projection persists the queue once, not once per item

## Why
The constrained #6187 validation after #6776 no longer hit permissions drift, but the parent process went high-CPU in Python `_json` while writing `.work_queue/queue.tmp`. The live file descriptor and sample pointed at `GlobalWorkQueue._save_queue()` rewriting the full queue during `sync_pending_work_queue()` item-by-item projection. This removes that write amplification while preserving normal immediate persistence by default.

## Validation
- `python3 -m pytest tests/nomic/test_dev_coordination.py::test_sync_pending_work_queue_projects_items -q --tb=short --timeout=60`
- `python3 -m pytest tests/nomic/test_dev_coordination.py::test_sync_pending_work_queue_projects_items tests/nomic/test_dev_coordination.py::test_sync_developer_task_queue_projects_open_tasks tests/nomic/test_dev_coordination.py::test_sync_pending_work_queue_completes_resolved_items tests/nomic/test_dev_coordination.py::test_sync_pending_work_queue_reopens_terminal_items -q --tb=short --timeout=120`
- `python3 -m pytest tests/nomic/test_global_work_queue.py::TestEdgeCases::test_complete_already_completed tests/nomic/test_global_work_queue.py::TestEdgeCases::test_fail_already_failed tests/nomic/test_global_work_queue.py::TestEdgeCases::test_save_creates_storage_dir_when_missing -q --tb=short --timeout=120`
- `python3 -m ruff check aragora/nomic/global_work_queue.py aragora/nomic/dev_coordination/core.py tests/nomic/test_dev_coordination.py`
- `python3 -m ruff format --check aragora/nomic/global_work_queue.py aragora/nomic/dev_coordination/core.py tests/nomic/test_dev_coordination.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`