### PR TITLE
fix(boss-loop): honor acceptance gate failures

### DIFF
--- a/aragora/swarm/boss_worker_lifecycle.py
+++ b/aragora/swarm/boss_worker_lifecycle.py
@@ -155,10 +155,15 @@ def finalize_worker_result(
         )
 
     if worker_result.get("status") == "needs_human":
-        _terminal_outcome, normalized_deliverable_type = qualify_worker_result_terminal_state(
+        terminal_outcome, normalized_deliverable_type = qualify_worker_result_terminal_state(
             worker_result
         )
         has_deliverable = bool(normalized_deliverable_type)
+        worker_outcome_text = str(worker_result.get("outcome", "")).strip().lower()
+        has_rejected_deliverable = has_deliverable and worker_outcome_text in {
+            "acceptance_gate_failed",
+            "merge_gate_failed",
+        }
         sanitizer_outcome = str(worker_result.get("sanitizer_outcome", "")).strip().lower()
         raw_deliverable = worker_result.get("deliverable")
         has_untyped_deliverable = isinstance(raw_deliverable, dict) and bool(raw_deliverable)
@@ -173,6 +178,39 @@ def finalize_worker_result(
                 loop.config.max_retries_per_issue + 1,
             )
             loop._pending_handoff_prompts.pop(issue_number, None)
+        if has_rejected_deliverable:
+            loop._failed_issues.append(issue_dict)
+            loop._log_value_outcome(issue_dict, "needs_human", elapsed_seconds)
+            reasons = [
+                str(reason).strip()
+                for reason in worker_result.get("reasons", [])
+                if str(reason).strip()
+            ] or [
+                f"Worker returned a {normalized_deliverable_type} deliverable, "
+                f"but terminal outcome is {terminal_outcome}."
+            ]
+            loop._append_iteration_metrics(
+                iteration=iteration,
+                issue_number=issue_number,
+                worker_result=worker_result,
+                elapsed_seconds=elapsed_seconds,
+            )
+            return BossIterationStatus(
+                iteration=iteration,
+                run_id=loop.run_id,
+                timestamp=timestamp,
+                runner_freshness=runner_freshness,
+                selected_issue=issue_dict,
+                worker_status="needs_human",
+                stop_reason=BossStopReason.NEEDS_HUMAN.value,
+                needs_human_reasons=reasons,
+                next_actions=[
+                    "Review the rejected deliverable before counting this issue complete."
+                ],
+                elapsed_seconds=elapsed_seconds,
+                worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
+            )
+
         if has_deliverable:
             loop._completed_issues.append(issue_dict)
             loop._consecutive_failures = 0

--- a/aragora/swarm/terminal_truth.py
+++ b/aragora/swarm/terminal_truth.py
@@ -272,6 +272,7 @@ _WORKER_OUTCOME_TO_TERMINAL: dict[str, str] = {
     "timeout_with_salvage": "deliverable_created",  # salvaged commits are real deliverables
     "scope_violation": "blocked",
     "merge_gate_failed": "needs_human",
+    "acceptance_gate_failed": "needs_human",
 }
 
 _SUCCESS_OUTCOMES: frozenset[str] = frozenset({"deliverable_created", "pr_adopted"})

--- a/tests/swarm/test_boss_worker_lifecycle.py
+++ b/tests/swarm/test_boss_worker_lifecycle.py
@@ -384,6 +384,26 @@ class TestFinalizeWorkerResultNeedsHumanWithDeliverable:
 
         assert loop._consecutive_failures == 0
 
+    def test_acceptance_gate_failed_deliverable_is_not_completed(self):
+        loop = _make_loop()
+        issue = _make_issue(number=6187)
+        result = _call_finalize(
+            loop,
+            {
+                "status": "needs_human",
+                "outcome": "acceptance_gate_failed",
+                "deliverable": {"type": "branch", "branch": "codex/swarm-example"},
+                "reasons": ["acceptance gate failed"],
+            },
+            issue=issue,
+        )
+
+        assert result.worker_status == "needs_human"
+        assert result.stop_reason == BossStopReason.NEEDS_HUMAN.value
+        assert result.worker_outcome == "acceptance_gate_failed"
+        assert loop._completed_issues == []
+        assert any(item["number"] == 6187 for item in loop._failed_issues)
+
 
 # ---------------------------------------------------------------------------
 # finalize_worker_result — needs_human with sanitizer drop/quarantine


### PR DESCRIPTION
## Summary
- map `acceptance_gate_failed` to `needs_human` terminal truth
- stop counting rejected typed deliverables as completed boss-loop issues
- add a regression for the exact `needs_human` + branch deliverable + `acceptance_gate_failed` case surfaced by #6187 validation

## Why
After #6777, the constrained #6187 dispatch completed without JSON spin, but returned a branch deliverable with `worker_outcome=acceptance_gate_failed`. Boss-loop still counted the issue as completed because any typed deliverable from a `needs_human` worker was treated as success. That corrupts throughput/rescue metrics and can incorrectly drain the queue.

## Validation
- `python3 -m pytest tests/swarm/test_boss_worker_lifecycle.py::TestFinalizeWorkerResultNeedsHumanWithDeliverable::test_acceptance_gate_failed_deliverable_is_not_completed tests/swarm/test_boss_worker_lifecycle.py::TestFinalizeWorkerResultNeedsHumanWithDeliverable -q --tb=short --timeout=60`
- `python3 -m pytest tests/swarm/test_boss_worker_lifecycle.py::TestFinalizeWorkerResultNeedsHumanWithDeliverable -q --tb=short --timeout=60`
- `python3 -m pytest tests/swarm/test_terminal_truth_benchmark.py tests/swarm/test_worker_outcome_classification.py -q --tb=short --timeout=120`
- `python3 -m ruff check aragora/swarm/boss_worker_lifecycle.py aragora/swarm/terminal_truth.py tests/swarm/test_boss_worker_lifecycle.py`
- `python3 -m ruff format --check aragora/swarm/boss_worker_lifecycle.py aragora/swarm/terminal_truth.py tests/swarm/test_boss_worker_lifecycle.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Note: `tests/swarm/test_boss_loop_autonomy.py::test_full_auto_continues_when_needs_human_has_deliverable` returned `idle` before dispatch in this live worktree, so it was not used as proof for this patch.