### PR TITLE
fix(cli): expose review-queue baseline in top-level parser

### DIFF
--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1478,6 +1478,64 @@ def _add_review_queue_parser(subparsers) -> None:
     )
     act_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
 
+    baseline_parser = queue_subparsers.add_parser(
+        "baseline",
+        help="Measure empirical invalidation baseline from on-disk stores (#6375)",
+        description=(
+            "Read the auto-handle calibration store and settlement receipts, "
+            "compute the empirical invalidation baseline, and propose an "
+            "auto-handle invalidation threshold. This command is read-only."
+        ),
+    )
+    baseline_parser.add_argument(
+        "--window-days",
+        type=int,
+        default=30,
+        help="Measurement-window width in days (default: 30).",
+    )
+    baseline_parser.add_argument(
+        "--min-samples",
+        type=int,
+        default=50,
+        help="Minimum human-settled sample size before using the measured baseline.",
+    )
+    baseline_parser.add_argument(
+        "--safety-margin",
+        type=float,
+        default=0.5,
+        help="Multiplier applied to the baseline when deriving the threshold.",
+    )
+    baseline_parser.add_argument(
+        "--minimum-meaningful-rate",
+        type=float,
+        default=0.01,
+        help="Floor below which threshold drift is indistinguishable from sample noise.",
+    )
+    baseline_parser.add_argument(
+        "--placeholder-value",
+        type=float,
+        default=0.05,
+        help="Threshold to use below the sample-size floor (default: 0.05).",
+    )
+    baseline_parser.add_argument(
+        "--calibration-db",
+        default=None,
+        help="Override the auto-handle calibration store path.",
+    )
+    baseline_parser.add_argument(
+        "--review-queue-root",
+        default=None,
+        help="Override the review-queue root used for settlement receipts.",
+    )
+    baseline_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the BaselineMeasurement + ThresholdProposal as JSON.",
+    )
+    baseline_parser.set_defaults(
+        func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue")
+    )
+
 
 def _add_codebase_audit_parser(subparsers) -> None:
     """Add the staged repository codebase audit parser."""

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference
@@ -109,7 +109,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `build`, `packet`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `packet`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -104,7 +104,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `build`, `packet`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `packet`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/tests/cli/test_parser_lazy_review_pr.py
+++ b/tests/cli/test_parser_lazy_review_pr.py
@@ -103,3 +103,52 @@ def test_build_parser_keeps_review_queue_runtime_lazy(monkeypatch):
     assert args.reason == "needs a test"
     assert args.json_output is True
     assert args.func.__name__ == "cmd_review_queue"
+
+
+def test_build_parser_registers_review_queue_baseline_lazily(monkeypatch):
+    sys.modules.pop("aragora.cli.commands.review_queue", None)
+    imported: list[str] = []
+    real_import = builtins.__import__
+
+    def tracking_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "aragora.cli.commands.review_queue":
+            imported.append(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", tracking_import)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "review-queue",
+            "baseline",
+            "--window-days",
+            "14",
+            "--min-samples",
+            "75",
+            "--safety-margin",
+            "0.4",
+            "--minimum-meaningful-rate",
+            "0.02",
+            "--placeholder-value",
+            "0.06",
+            "--calibration-db",
+            "/tmp/calibration.sqlite3",
+            "--review-queue-root",
+            "/tmp/review-queue",
+            "--json",
+        ]
+    )
+
+    assert imported == []
+    assert args.command == "review-queue"
+    assert args.review_queue_command == "baseline"
+    assert args.window_days == 14
+    assert args.min_samples == 75
+    assert args.safety_margin == 0.4
+    assert args.minimum_meaningful_rate == 0.02
+    assert args.placeholder_value == 0.06
+    assert args.calibration_db == "/tmp/calibration.sqlite3"
+    assert args.review_queue_root == "/tmp/review-queue"
+    assert args.json is True
+    assert args.func.__name__ == "cmd_review_queue"


### PR DESCRIPTION
## Summary

- expose the already-landed `review-queue baseline` subcommand through the top-level lazy CLI parser
- add a parser-level regression test proving the command stays lazy and parses all baseline options

## Context

#6608 Step C landed the handler/tests for `aragora review-queue baseline`, but the top-level `aragora.cli.parser` still only registered `build`, `packet`, `run`, and `act`. That meant the operator-facing command was available through the command module parser but not through the actual global CLI entrypoint.

## Validation

- `python3 -m pytest tests/cli/test_parser_lazy_review_pr.py tests/cli/commands/test_review_queue_baseline.py -q --timeout=60` — 25 passed
- `python3 -m ruff check aragora/cli/parser.py tests/cli/test_parser_lazy_review_pr.py`
- `PYTHONPATH=. python3 -m aragora.cli.main review-queue baseline --help`
- `git diff --check`
- push preflight hooks passed, including baseline-filtered mypy and gitleaks

Co-authored-by: codex[bot] <codex[bot]@users.noreply.github.com>
