### PR TITLE
feat(km): add KMMetricsHealthBridge (additive, no caller migration)

### DIFF
--- a/aragora/knowledge/mound/metrics_health_bridge.py
+++ b/aragora/knowledge/mound/metrics_health_bridge.py
@@ -1,0 +1,216 @@
+"""
+KMMetricsHealthBridge — wires ConnectionHealthMonitor into KMMetrics.
+
+The async paths of ``ConnectionHealthMonitor`` (now well-tested via
+PR #6784) produce ``HealthStatus`` snapshots: ``healthy``,
+``consecutive_failures``, ``latency_ms``. ``KMMetrics`` separately
+exposes ``get_health()``, but it has no awareness of underlying
+connection health. This bridge module periodically polls the monitor
+and feeds each snapshot into ``KMMetrics.record(...)`` as an
+operation sample so that connection latency and connection failures
+appear inside the existing health report alongside query / store /
+cache metrics.
+
+This is the first deliverable proposed by P4 in
+``docs/plans/2026-04-28-p4-first-deliverable-km-observability.md``.
+
+Design constraints
+------------------
+
+- **Additive only**: this module does not modify ``KMMetrics`` or
+  ``ConnectionHealthMonitor``. It depends on the public surface of
+  both and on no private attribute.
+- **Cancel-safe**: the bridge owns one ``asyncio.Task``. ``stop()``
+  cancels it and awaits cancellation, never raising.
+- **Bounded**: each tick performs at most one ``check_health()`` call
+  and one ``record()`` call. Exceptions are logged and absorbed —
+  bridge failures must not break the underlying monitor or metrics.
+- **No I/O outside what the monitor and metrics already do**: this
+  module never touches the file system, network, gh, or git.
+- **Operation type reuse**: connection health samples are recorded as
+  ``OperationType.QUERY`` (a real DB round-trip) so that latency rolls
+  into the existing query-latency thresholds without needing a new
+  enum value or a metrics schema migration. This is documented and
+  tested.
+
+Public surface
+--------------
+
+- :class:`KMMetricsHealthBridge`
+- :func:`build_bridge`
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from aragora.knowledge.mound.metrics import KMMetrics, OperationType
+from aragora.knowledge.mound.resilience.health import (
+    ConnectionHealthMonitor,
+    HealthStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "KMMetricsHealthBridge",
+    "HealthSnapshotSink",
+    "build_bridge",
+]
+
+
+class HealthSnapshotSink(Protocol):
+    """Minimal interface a sink must implement.
+
+    Used to keep ``KMMetricsHealthBridge`` testable without coupling
+    to the full ``KMMetrics`` API surface. ``KMMetrics`` itself
+    satisfies this protocol via its ``record`` method.
+    """
+
+    def record(
+        self,
+        operation: OperationType,
+        latency_ms: float,
+        success: bool = True,
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+@dataclass(frozen=True)
+class _BridgeConfig:
+    interval_s: float
+    operation_type: OperationType
+
+
+class KMMetricsHealthBridge:
+    """Periodically poll a ConnectionHealthMonitor and record each
+    HealthStatus snapshot into a KMMetrics-shaped sink.
+
+    Lifecycle mirrors ``ConnectionHealthMonitor``:
+
+    >>> bridge = KMMetricsHealthBridge(monitor, sink)
+    >>> await bridge.start()
+    ... # ... bridge polls in the background ...
+    >>> await bridge.stop()
+
+    A single bridge instance owns at most one task. Calling
+    ``start()`` while already running is a no-op.
+    """
+
+    def __init__(
+        self,
+        monitor: ConnectionHealthMonitor,
+        sink: HealthSnapshotSink,
+        *,
+        interval_s: float = 10.0,
+        operation_type: OperationType = OperationType.QUERY,
+    ) -> None:
+        if interval_s <= 0:
+            raise ValueError(f"interval_s must be positive, got {interval_s!r}")
+        self._monitor = monitor
+        self._sink = sink
+        self._config = _BridgeConfig(interval_s=interval_s, operation_type=operation_type)
+        self._task: asyncio.Task[None] | None = None
+        self._stopped = asyncio.Event()
+        self._tick_count = 0
+
+    @property
+    def tick_count(self) -> int:
+        """Number of completed poll cycles. Exposed for testing."""
+        return self._tick_count
+
+    @property
+    def is_running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    async def start(self) -> None:
+        """Start the background polling task. Idempotent."""
+        if self.is_running:
+            return
+        self._stopped.clear()
+        self._task = asyncio.create_task(self._poll_loop())
+        logger.info(
+            "KMMetricsHealthBridge started (interval=%.2fs, op=%s)",
+            self._config.interval_s,
+            self._config.operation_type.value,
+        )
+
+    async def stop(self) -> None:
+        """Stop the background polling task. Idempotent and cancel-safe."""
+        if self._task is None:
+            return
+        self._stopped.set()
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._task = None
+            logger.info("KMMetricsHealthBridge stopped")
+
+    async def tick_once(self) -> HealthStatus:
+        """Perform a single poll cycle without scheduling.
+
+        Useful in tests and in deterministic call sites that want to
+        force a sample on demand. Returns the ``HealthStatus`` that
+        was recorded.
+        """
+        status = await self._monitor.check_health()
+        self._record_snapshot(status)
+        self._tick_count += 1
+        return status
+
+    def _record_snapshot(self, status: HealthStatus) -> None:
+        """Translate a HealthStatus into a metrics sample."""
+        try:
+            self._sink.record(
+                operation=self._config.operation_type,
+                latency_ms=status.latency_ms or 0.0,
+                success=status.healthy,
+                error=status.last_error,
+                metadata={
+                    "source": "connection_health_monitor",
+                    "consecutive_failures": status.consecutive_failures,
+                    "last_check": status.last_check.isoformat(),
+                },
+            )
+        except (RuntimeError, ValueError, TypeError, AttributeError) as exc:
+            logger.warning("KMMetricsHealthBridge: sink.record raised: %s", exc)
+
+    async def _poll_loop(self) -> None:
+        """Background poll loop. Cancelled via ``stop()``."""
+        while not self._stopped.is_set():
+            try:
+                await asyncio.sleep(self._config.interval_s)
+                if self._stopped.is_set():
+                    break
+                status = await self._monitor.check_health()
+                self._record_snapshot(status)
+                self._tick_count += 1
+            except asyncio.CancelledError:
+                break
+            except (ConnectionError, TimeoutError, OSError) as exc:
+                logger.debug("Bridge poll error (expected): %s", exc)
+            except (RuntimeError, ValueError, TypeError, AttributeError) as exc:
+                logger.warning("Bridge poll error (unexpected): %s", exc)
+
+
+def build_bridge(
+    monitor: ConnectionHealthMonitor,
+    metrics: KMMetrics,
+    *,
+    interval_s: float = 10.0,
+) -> KMMetricsHealthBridge:
+    """Convenience factory for the common case where the sink is a
+    full :class:`KMMetrics` instance.
+
+    Returns an unstarted bridge; the caller is responsible for
+    invoking ``await bridge.start()`` and ``await bridge.stop()``.
+    """
+    return KMMetricsHealthBridge(monitor=monitor, sink=metrics, interval_s=interval_s)

--- a/tests/knowledge/mound/test_metrics_health_bridge.py
+++ b/tests/knowledge/mound/test_metrics_health_bridge.py
@@ -1,0 +1,299 @@
+"""Tests for ``aragora.knowledge.mound.metrics_health_bridge``.
+
+The bridge wires ``ConnectionHealthMonitor`` snapshots into the
+``KMMetrics.record(...)`` surface. These tests exercise the
+public lifecycle (``start``/``stop``/``tick_once``) and the
+translation from ``HealthStatus`` to operation samples without
+touching any database, network, or file system.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aragora.knowledge.mound.metrics import KMMetrics, OperationType
+from aragora.knowledge.mound.metrics_health_bridge import (
+    KMMetricsHealthBridge,
+    build_bridge,
+)
+from aragora.knowledge.mound.resilience.health import (
+    ConnectionHealthMonitor,
+    HealthStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSink:
+    """Minimal sink capturing every ``record(...)`` call."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def record(
+        self,
+        operation: OperationType,
+        latency_ms: float,
+        success: bool = True,
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self.calls.append(
+            {
+                "operation": operation,
+                "latency_ms": latency_ms,
+                "success": success,
+                "error": error,
+                "metadata": metadata,
+            }
+        )
+
+
+def _make_status(
+    *,
+    healthy: bool = True,
+    latency_ms: float | None = 12.5,
+    consecutive_failures: int = 0,
+    last_error: str | None = None,
+) -> HealthStatus:
+    return HealthStatus(
+        healthy=healthy,
+        last_check=datetime.now(UTC),
+        latency_ms=latency_ms,
+        consecutive_failures=consecutive_failures,
+        last_error=last_error,
+    )
+
+
+def _make_monitor_with_status(status: HealthStatus) -> ConnectionHealthMonitor:
+    """Build a ConnectionHealthMonitor whose ``check_health`` returns
+    ``status`` without actually touching the pool.
+    """
+    monitor = ConnectionHealthMonitor.__new__(ConnectionHealthMonitor)
+    monitor._pool = None  # noqa: SLF001
+    monitor._failure_threshold = 5  # noqa: SLF001
+    monitor._recovery_timeout = 30.0  # noqa: SLF001
+    monitor._health_check_interval = 10.0  # noqa: SLF001
+    monitor._status = status  # noqa: SLF001
+    monitor._check_task = None  # noqa: SLF001
+    monitor.check_health = AsyncMock(return_value=status)  # type: ignore[method-assign]
+    return monitor
+
+
+# ---------------------------------------------------------------------------
+# Construction & validation
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_rejects_non_positive_interval(self) -> None:
+        monitor = _make_monitor_with_status(_make_status())
+        sink = _RecordingSink()
+        with pytest.raises(ValueError, match="interval_s"):
+            KMMetricsHealthBridge(monitor, sink, interval_s=0)
+        with pytest.raises(ValueError, match="interval_s"):
+            KMMetricsHealthBridge(monitor, sink, interval_s=-1.0)
+
+    def test_initial_state(self) -> None:
+        monitor = _make_monitor_with_status(_make_status())
+        sink = _RecordingSink()
+        bridge = KMMetricsHealthBridge(monitor, sink, interval_s=1.0)
+        assert bridge.is_running is False
+        assert bridge.tick_count == 0
+
+
+# ---------------------------------------------------------------------------
+# tick_once: the deterministic surface
+# ---------------------------------------------------------------------------
+
+
+class TestTickOnce:
+    @pytest.mark.asyncio
+    async def test_records_healthy_snapshot(self) -> None:
+        status = _make_status(healthy=True, latency_ms=42.0)
+        monitor = _make_monitor_with_status(status)
+        sink = _RecordingSink()
+        bridge = KMMetricsHealthBridge(monitor, sink, interval_s=1.0)
+
+        result = await bridge.tick_once()
+
+        assert result is status
+        assert bridge.tick_count == 1
+        assert len(sink.calls) == 1
+        call = sink.calls[0]
+        assert call["operation"] == OperationType.QUERY
+        assert call["latency_ms"] == 42.0
+        assert call["success"] is True
+        assert call["error"] is None
+        assert call["metadata"]["source"] == "connection_health_monitor"
+        assert call["metadata"]["consecutive_failures"] == 0
+
+    @pytest.mark.asyncio
+    async def test_records_unhealthy_snapshot(self) -> None:
+        status = _make_status(
+            healthy=False,
+            latency_ms=None,
+            consecutive_failures=7,
+            last_error="ConnectionRefusedError",
+        )
+        monitor = _make_monitor_with_status(status)
+        sink = _RecordingSink()
+        bridge = KMMetricsHealthBridge(monitor, sink, interval_s=1.0)
+
+        await bridge.tick_once()
+
+        call = sink.calls[0]
+        assert call["success"] is False
+        assert call["latency_ms"] == 0.0  # None coerced to 0.0
+        assert call["error"] == "ConnectionRefusedError"
+        assert call["metadata"]["consecutive_failures"] == 7
+
+    @pytest.mark.asyncio
+    async def test_custom_operation_type(self) -> None:
+        status = _make_status()
+        monitor = _make_monitor_with_status(status)
+        sink = _RecordingSink()
+        bridge = KMMetricsHealthBridge(
+            monitor, sink, interval_s=1.0, operation_type=OperationType.SYNC
+        )
+
+        await bridge.tick_once()
+
+        assert sink.calls[0]["operation"] == OperationType.SYNC
+
+    @pytest.mark.asyncio
+    async def test_sink_failure_does_not_propagate(self) -> None:
+        class _BrokenSink:
+            def record(
+                self,
+                operation: OperationType,
+                latency_ms: float,
+                success: bool = True,
+                error: str | None = None,
+                metadata: dict[str, Any] | None = None,
+            ) -> None:
+                raise RuntimeError("sink boom")
+
+        status = _make_status()
+        monitor = _make_monitor_with_status(status)
+        bridge = KMMetricsHealthBridge(monitor, _BrokenSink(), interval_s=1.0)
+
+        # Must not raise — bridge swallows sink failures.
+        result = await bridge.tick_once()
+        assert result is status
+        assert bridge.tick_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: start / stop
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_then_stop_is_clean(self) -> None:
+        monitor = _make_monitor_with_status(_make_status())
+        sink = _RecordingSink()
+        bridge = KMMetricsHealthBridge(monitor, sink, interval_s=10.0)
+
+        await bridge.start()
+        assert bridge.is_running is True
+        await bridge.stop()
+        assert bridge.is_running is False
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self) -> None:
+        monitor = _make_monitor_with_status(_make_status())
+        bridge = KMMetricsHealthBridge(monitor, _RecordingSink(), interval_s=10.0)
+        await bridge.start()
+        first_task = bridge._task  # noqa: SLF001
+        await bridge.start()  # second call should be no-op
+        assert bridge._task is first_task  # noqa: SLF001
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_without_start_is_clean(self) -> None:
+        monitor = _make_monitor_with_status(_make_status())
+        bridge = KMMetricsHealthBridge(monitor, _RecordingSink(), interval_s=10.0)
+        # Must not raise.
+        await bridge.stop()
+        assert bridge.is_running is False
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self) -> None:
+        monitor = _make_monitor_with_status(_make_status())
+        bridge = KMMetricsHealthBridge(monitor, _RecordingSink(), interval_s=10.0)
+        await bridge.start()
+        await bridge.stop()
+        # Second stop must not raise.
+        await bridge.stop()
+        assert bridge.is_running is False
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_records_at_least_once(self) -> None:
+        monitor = _make_monitor_with_status(_make_status(latency_ms=3.0))
+        sink = _RecordingSink()
+        bridge = KMMetricsHealthBridge(monitor, sink, interval_s=0.01)
+
+        await bridge.start()
+        # Give the loop two intervals to complete.
+        await asyncio.sleep(0.05)
+        await bridge.stop()
+
+        assert bridge.tick_count >= 1
+        assert len(sink.calls) >= 1
+        assert all(call["operation"] == OperationType.QUERY for call in sink.calls)
+
+
+# ---------------------------------------------------------------------------
+# Integration with real KMMetrics
+# ---------------------------------------------------------------------------
+
+
+class TestKMMetricsIntegration:
+    @pytest.mark.asyncio
+    async def test_build_bridge_returns_unstarted_bridge(self) -> None:
+        monitor = _make_monitor_with_status(_make_status())
+        metrics = KMMetrics()
+        bridge = build_bridge(monitor, metrics, interval_s=5.0)
+        assert isinstance(bridge, KMMetricsHealthBridge)
+        assert bridge.is_running is False
+
+    @pytest.mark.asyncio
+    async def test_kmmetrics_records_bridge_sample(self) -> None:
+        status = _make_status(healthy=True, latency_ms=8.5)
+        monitor = _make_monitor_with_status(status)
+        metrics = KMMetrics()
+        bridge = build_bridge(monitor, metrics, interval_s=10.0)
+
+        await bridge.tick_once()
+
+        # KMMetrics get_stats() returns a dict keyed by op-value when no op
+        # is specified, only including operations with count > 0.
+        stats = metrics.get_stats()
+        assert "query" in stats
+        assert stats["query"]["count"] >= 1
+        assert stats["query"]["success_count"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_bridge_sample_marks_query_error(self) -> None:
+        status = _make_status(
+            healthy=False, latency_ms=None, last_error="OSError", consecutive_failures=3
+        )
+        monitor = _make_monitor_with_status(status)
+        metrics = KMMetrics()
+        bridge = build_bridge(monitor, metrics, interval_s=10.0)
+
+        await bridge.tick_once()
+
+        stats = metrics.get_stats()
+        assert "query" in stats
+        assert stats["query"]["error_count"] >= 1


### PR DESCRIPTION
## What

Pure additive module `aragora/knowledge/mound/metrics_health_bridge.py` (~210 LOC) plus a single test fixture (~280 LOC, 14 tests). First deliverable for the **P4 dark-week** corrective per `docs/plans/2026-04-28-p4-first-deliverable-km-observability.md` (drafted overnight on the docs branch).

## Why

The async paths of `ConnectionHealthMonitor` (now well-tested via PR #6784, also overnight) produce `HealthStatus` snapshots — `healthy`, `consecutive_failures`, `latency_ms`, `last_error` — but those snapshots have **no path into the existing KMMetrics observability surface**. `KMMetrics.get_health()` reports on query / store / cache thresholds without awareness of underlying connection health.

This PR closes that gap with a thin bridge that periodically polls the monitor and records each snapshot into `KMMetrics.record(...)` as a `OperationType.QUERY` sample (a real DB round-trip is itself a query). Connection latency and connection failures now roll into the existing query-latency thresholds without any metrics-schema migration or new enum value.

## Public surface

```python
from aragora.knowledge.mound.metrics_health_bridge import (
    KMMetricsHealthBridge,
    HealthSnapshotSink,
    build_bridge,
)

bridge = build_bridge(monitor, metrics, interval_s=10.0)
await bridge.start()
# ...
await bridge.stop()
```

A single bridge owns at most one `asyncio.Task`. `start()` is idempotent. `stop()` is idempotent and cancel-safe. `tick_once()` exposes a deterministic single-poll surface for tests and on-demand sampling.

## Constraints honored

- **Additive only**: no edits to `KMMetrics` or `ConnectionHealthMonitor`.
- **Cancel-safe lifecycle**: `start` / `stop` are idempotent; `stop` always awaits `CancelledError`.
- **Bounded per tick**: one `check_health` call, one `record` call.
- **No new I/O surfaces**: nothing the monitor and metrics don't already do.
- **No callers wired in this PR**: bridge is library-only; the operator decides where to wire it (likely the postgres-store factory, but that's a follow-up PR).
- **Sink failures absorbed**: a broken sink does not break the bridge.

## Validation

- 14/14 tests pass locally
- `ruff` + `ruff format --check` clean
- `mypy --strict` clean
- `scripts/automation_pr_preflight.sh origin/main HEAD` ok
- Adjacent test_metrics.py + test_metrics_health_bridge.py: 39/39 pass

## Operator review

**No rush. Operator review required. Auto-merge intentionally OFF.**

This pairs with PR #6784 (async-path coverage for the underlying monitor). Together they make P4 a measurable pillar again: observability is exercised by tests, and a deliverable bridge is available for wiring when an operator chooses.

If accepted, a follow-up PR would wire the bridge into the postgres-store factory or a comparable owner. If rejected, no harm — the module is unused.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>