### PR TITLE
docs(status): 2026-04-28 boss-loop verify-restock report

### DIFF
--- a/docs/status/2026-04-28-boss-loop-verify-restock.md
+++ b/docs/status/2026-04-28-boss-loop-verify-restock.md
@@ -1,0 +1,180 @@
+# Boss Loop One-Shot Verify-Then-Restock — 2026-04-28
+
+One-shot pass over the boss loop: verify health, inspect terminal-class signal,
+sanity-check the swarm test suite, and decide whether to restock the queue.
+
+- Triggered by: human one-shot run (no automation handoff)
+- Repo state: HEAD pinned at `516d0cc0 fix(boss-loop): honor acceptance gate failures (#6778)` (matches `origin/main`)
+- Environment: shared session container, fresh deps installed for this run
+  (pydantic, pydantic-settings, cryptography, defusedxml, aiohttp, numpy,
+  idna, pytest, pytest-asyncio). No `.aragora/overnight/` runtime state present.
+
+## Phase 1 — Verify
+
+### 1a. `python scripts/verify_system_health.py`
+
+```
+Running system diagnostics...
+{
+  "agent_health": {
+    "null_bytes_found": false,
+    "timeout_handling_present": true,
+    "cli_integration_present": true
+  },
+  "loop_id_routing": {
+    "loop_id_binding_present": true,
+    "validation_present": true
+  },
+  "auth_readiness": {
+    "module_exists": false,
+    "check_auth_implemented": false,
+    "websocket_support": false
+  }
+}
+
+Prioritized fixes:
+- LOW: Add auth module - security scaffolding
+```
+
+Result: PASS for agent health and loop-id routing. The auth-readiness section
+flags the same pre-existing LOW-priority gap (auth scaffolding missing) as the
+2026-04-25 run — not a stop-the-world issue.
+
+### 1b. `python scripts/analyze_boss_metrics.py --metrics-file benchmarks/fixtures/swarm/sample_boss_metrics.jsonl`
+
+The live metrics path (`.aragora/overnight/boss_metrics.jsonl`) is absent in
+this environment — no overnight loop has run here. The analyzer was exercised
+against the bundled fixture only, to confirm the tool still loads and renders:
+
+```
+records: 3
+prompt_chars avg: 1166.7
+enriched_context_chars avg: 583.3
+deliverable rate: 33%
+terminal-truth no-rescue rate: 33%
+terminal-truth meets 30d target: False
+terminal-truth actionable failures: 1
+publish actions: opened_pr: 1
+families: blocked: 1, rescue: 1, success: 1
+classes: blocked_not_dispatch_bounded: 1, deliverable_branch_pushed: 1, rescue_worker_crash: 1
+```
+
+Status: tool loads and renders correctly end-to-end. **No live boss-metrics
+dataset is available to evaluate against the 30%-blocked / 60%-no-rescue
+thresholds in this environment.** Fixture numbers are not representative.
+
+Note: `analyze_boss_metrics.py` requires `PYTHONPATH` to be set to the repo
+root when invoked from the scripts directory; running bare (`python
+scripts/analyze_boss_metrics.py`) emits `ModuleNotFoundError: No module named
+'aragora'`. This is pre-existing (not a regression).
+
+### 1c. Last ~50 cycles of `boss_metrics.jsonl`
+
+Cannot be inspected — `.aragora/overnight/boss_metrics.jsonl` is absent in
+this environment. Recommend re-running this verify pass from the host that owns
+the live overnight loop, or pointing `--metrics-file` at a synced snapshot.
+
+### 1d. Boss loop import + swarm test suite
+
+**Import:** `python -c "from aragora.swarm.boss_loop import BossLoop"`
+
+First attempt raised a `pyo3_runtime.PanicException` (cffi/Rust ABI conflict
+between the Debian system `cryptography` 41.0.7 and the pip-installed wheel).
+Resolved by running `pip install cryptography --force-reinstall`, after which
+the system package's C extension was superseded by the wheel. Re-run succeeded:
+
+```
+SECURITY: python3-saml unavailable - SAML signature validation disabled
+(ModuleNotFoundError: No module named 'onelogin'). Install python3-saml to
+enable secure SAML authentication.
+IMPORT_OK
+```
+
+The SAML warning is pre-existing (python3-saml is an optional dep). Import
+status: **PASS**.
+
+**pytest:** `python -m pytest tests/swarm/ -q -x --ignore=tests/swarm/perf`
+(`tests/swarm/perf` does not exist in this checkout, so `--ignore` is a no-op.)
+
+- **1 failed, 330 passed, 1 skipped in 369.40s (0:06:09)**
+- Failing test:
+  `tests/swarm/test_boss_loop.py::TestBossLoop::test_needs_human_truthy_junk_deliverable_does_not_auto_continue`
+
+Failure summary:
+
+```
+assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+AssertionError: assert 'consecutive_failures' == 'no_suitable_issue'
+
+tests/swarm/test_boss_loop.py:1907: AssertionError
+
+WARNING  aragora.swarm.boss_worker_lifecycle:boss_worker_lifecycle.py:438
+  boss_loop_skip issue=#1 (needs_human, no deliverable, auto-continue on)
+WARNING  aragora.swarm.boss_worker_lifecycle:boss_worker_lifecycle.py:395
+  boss_loop_stop issue=#1 (needs_human, no typed deliverable, consecutive
+  failure threshold reached)
+```
+
+The test configures `auto_continue_on_needs_human=True` and a dispatch that
+returns `{"status": "needs_human", "deliverable": "branch-ready"}` — a truthy
+but untyped ("junk") deliverable. The expected behaviour is `NO_SUITABLE_ISSUE`
+(the loop should skip and exhaust the feed). The actual behaviour is
+`consecutive_failures`: the lifecycle layer counts the needs_human+junk-deliverable
+skip as a consecutive failure and stops on the threshold before exhausting the
+feed. This is a **new regression** introduced by `#6778` (`fix(boss-loop):
+honor acceptance gate failures`) — the 2026-04-25 run passed a different test
+(`test_specific_issue_number_scope_conflict_reports_overlap_reason`); today's
+failing test is distinct. The #6778 fix tightened consecutive-failure accounting
+and inadvertently made untyped-deliverable auto-continue paths count as failures
+rather than clean skips.
+
+## Phase 2 — Restock decision
+
+`aragora/swarm/queue_autofill.py` is now passive types only — `maybe_autofill_queue`
+was removed. Without GitHub auth in this environment, the live `boss-ready`
+issue count cannot be queried directly. Per operator discipline, `scripts/generate_boss_issues.py`
+was **not** invoked.
+
+**Action: SKIP restock.** The 2026-04-25 run observed a queue depth of 16 (well
+above the 5-issue threshold), and no commit since then touches the restock
+logic or closes a mass of boss-ready issues. Queue saturation is presumed
+unchanged. Running the generator would only deepen an already-saturated queue
+and increase pressure on duplicate-detection filters.
+
+## Recommended follow-up issues (NOT filed by this run)
+
+1. **`boss-loop: junk-deliverable auto-continue skip counted as consecutive failure`** —
+   `tests/swarm/test_boss_loop.py::TestBossLoop::test_needs_human_truthy_junk_deliverable_does_not_auto_continue`
+   fails because a needs_human result with an untyped deliverable (`"branch-ready"`)
+   under `auto_continue_on_needs_human=True` hits the consecutive_failures threshold
+   instead of resolving to `NO_SUITABLE_ISSUE`. Root cause: `#6778` tightened
+   consecutive-failure accounting; the skip path in
+   `aragora/swarm/boss_worker_lifecycle.py:438` logs the skip but the counter
+   is still incremented at line ~395 before the feed is exhausted. Fix: a skip
+   caused by an untyped deliverable under auto-continue should not increment the
+   consecutive-failure counter. Suggested labels: `boss-ready`, `priority:high`,
+   regression.
+
+2. **`analyze_boss_metrics.py: requires PYTHONPATH; no graceful auto-detect`** —
+   Running `python scripts/analyze_boss_metrics.py` without setting `PYTHONPATH`
+   fails with `ModuleNotFoundError`. A shebang or `sys.path` fixup at the script
+   top would make it runnable from any CWD. Pre-existing; low priority.
+
+3. **`cryptography wheel vs Debian system package ABI conflict`** —
+   The pyo3 panic on import affects any fresh container where the Debian
+   `cryptography` 41.0.7 package is installed alongside a pip wheel. Pinning
+   the pip install or adding a `--break-system-packages` note to the setup docs
+   would prevent this from tripping up future CI runs. Low priority.
+
+4. **`auth scaffolding gap flagged by verify_system_health`** — pre-existing
+   LOW priority; carried forward for visibility, not introduced by this run.
+
+## Outcome
+
+- Verify: **FAIL** — one new regression-class test failure introduced by `#6778`
+  (`test_needs_human_truthy_junk_deliverable_does_not_auto_continue`);
+  all other 330 tests pass. Cannot evaluate live terminal-class distribution
+  from this host.
+- Restock: **SKIPPED** — no GitHub auth available; queue presumed saturated at
+  ≥16 issues from prior run; `generate_boss_issues.py` was not invoked.
+- No issues or PRs opened by this run.


### PR DESCRIPTION
## Summary

- Adds `docs/status/2026-04-28-boss-loop-verify-restock.md` — one-shot verify-then-restock pass against HEAD `516d0cc0`.
- Mirrors the structure of the 2026-04-25 reference report.

## Key findings

- `verify_system_health`: PASS (same pre-existing LOW auth-scaffolding gap).
- `analyze_boss_metrics` fixture run: tool works; live metrics absent in this environment.
- `BossLoop` import: PASS (required cffi/pyo3 workaround for Debian vs pip cryptography conflict).
- `pytest tests/swarm/`: **330 passed, 1 failed, 1 skipped** in 369s.
  - **New regression from #6778** — `test_needs_human_truthy_junk_deliverable_does_not_auto_continue` fails: junk-deliverable auto-continue skip increments the consecutive-failure counter, causing `consecutive_failures` stop instead of `NO_SUITABLE_ISSUE`.
- Restock: SKIPPED — no GitHub auth in session; queue presumed saturated (≥16 from prior run).

## Test plan

- [ ] Confirm report renders correctly in docs browser.
- [ ] Verify the regression described in finding #1 is tracked as a follow-up issue.

https://claude.ai/code/session_01DVirG5x4a4xjeMTfMuKzyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVirG5x4a4xjeMTfMuKzyX)_