### PR TITLE
[AGT-05] ReputationDeltaReversed schema + reverse_delta() on ReputationStore

### DIFF
--- a/aragora/reputation/__init__.py
+++ b/aragora/reputation/__init__.py
@@ -44,6 +44,7 @@ from aragora.reputation.types import (
     DOMAIN_KM_CONTRIBUTION,
     DOMAIN_PREDICTION_MARKET,
     ReputationDelta,
+    ReputationDeltaReversed,
     ResolvedClaim,
     StakeableClaim,
 )
@@ -57,6 +58,7 @@ __all__ = [
     "AnchorError",
     "AnchorReceipt",
     "ReputationDelta",
+    "ReputationDeltaReversed",
     "ResolvedClaim",
     "StakeableClaim",
     "anchor_delta",

--- a/aragora/reputation/store.py
+++ b/aragora/reputation/store.py
@@ -28,6 +28,7 @@ Out of scope for this PR:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
@@ -38,7 +39,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from aragora.reputation.types import ReputationDelta
+from aragora.reputation.types import ReputationDelta, ReputationDeltaReversed
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +108,8 @@ class ReputationStore:
 
     def __init__(self, path: Path | None = None) -> None:
         self._deltas: dict[str, list[ReputationDelta]] = defaultdict(list)
+        self._delta_by_id: dict[str, ReputationDelta] = {}
+        self._reversals: dict[str, ReputationDeltaReversed] = {}
         self._path = path
         if path is not None:
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -127,6 +130,7 @@ class ReputationStore:
         if self._path is not None:
             self._append_to_file(delta)
         self._deltas[delta.agent_id].append(delta)
+        self._delta_by_id[delta.delta_id] = delta
 
     def _append_to_file(self, delta: ReputationDelta) -> None:
         try:
@@ -149,12 +153,13 @@ class ReputationStore:
         The score is unbounded; callers normalise it for dispatch-eligibility.
         """
         deltas = self._deltas.get(agent_id, [])
-        if not deltas:
+        live = [d for d in deltas if d.delta_id not in self._reversals]
+        if not live:
             return 0.0
         if not apply_decay:
-            return sum(d.delta for d in deltas)
+            return sum(d.delta for d in live)
         now = datetime.now(tz=UTC)
-        return sum(d.delta * _decay_weight(d, now) for d in deltas)
+        return sum(d.delta * _decay_weight(d, now) for d in live)
 
     def agent_ids(self) -> list[str]:
         """Return sorted list of agent IDs that have at least one delta."""
@@ -179,6 +184,51 @@ class ReputationStore:
         """Return per-agent score summaries, sorted descending by score."""
         scores = [self.agent_score(aid, apply_decay=apply_decay) for aid in self._deltas]
         return sorted(scores, key=lambda s: s.running_score, reverse=True)
+
+    # ------------------------------------------------------------------
+    # Reversal (AGT-05 sub-deliverable #7)
+    # ------------------------------------------------------------------
+
+    def reverse_delta(
+        self,
+        delta_id: str,
+        *,
+        reason: dict[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> ReputationDeltaReversed:
+        """Roll back a :class:`ReputationDelta` by its *delta_id*.
+
+        The original delta is excluded from all future :meth:`get_score`
+        calls.  Returns a :class:`ReputationDeltaReversed` event.
+
+        Raises :class:`KeyError` if *delta_id* is unknown.
+        Raises :class:`ValueError` if *delta_id* has already been reversed.
+        """
+        original = self._delta_by_id.get(delta_id)
+        if original is None:
+            raise KeyError(f"delta_id {delta_id!r} not found in store")
+        if delta_id in self._reversals:
+            raise ValueError(f"delta_id {delta_id!r} has already been reversed")
+        timestamp = (now or datetime.now(tz=UTC)).isoformat().replace("+00:00", "Z")
+        reversal_material = json.dumps(
+            {"original_delta_id": delta_id, "reversed_at": timestamp}, sort_keys=True
+        )
+        reversal_id = "rev_" + hashlib.sha256(reversal_material.encode()).hexdigest()[:16]
+        reversal = ReputationDeltaReversed(
+            reversal_id=reversal_id,
+            original_delta_id=delta_id,
+            agent_id=original.agent_id,
+            domain=original.domain,
+            counter_delta=-original.delta,
+            reversed_at=timestamp,
+            reason=dict(reason or {}),
+        )
+        self._reversals[delta_id] = reversal
+        return reversal
+
+    def reversals_for(self, agent_id: str) -> list[ReputationDeltaReversed]:
+        """Return all reversal events for *agent_id*, in insertion order."""
+        return [r for r in self._reversals.values() if r.agent_id == agent_id]
 
     def __len__(self) -> int:
         """Return the total number of recorded deltas across all agents."""
@@ -207,6 +257,7 @@ class ReputationStore:
                     payload = json.loads(raw)
                     delta = ReputationDelta.from_json(payload)
                     store._deltas[delta.agent_id].append(delta)
+                    store._delta_by_id[delta.delta_id] = delta
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "ReputationStore: skipping invalid line %d in %s: %s",
@@ -219,6 +270,7 @@ class ReputationStore:
 
 __all__ = [
     "AgentScore",
+    "ReputationDeltaReversed",
     "ReputationStore",
     "ReputationStoreError",
     "enable_store",

--- a/aragora/reputation/store.py
+++ b/aragora/reputation/store.py
@@ -214,13 +214,14 @@ class ReputationStore:
         calls.  Returns a :class:`ReputationDeltaReversed` event.
 
         Raises :class:`KeyError` if *delta_id* is unknown.
-        Raises :class:`ValueError` if *delta_id* has already been reversed.
+        Repeated calls for an already-reversed delta are idempotent and
+        return the existing reversal event without writing a duplicate.
         """
         original = self._delta_by_id.get(delta_id)
         if original is None:
             raise KeyError(f"delta_id {delta_id!r} not found in store")
         if delta_id in self._reversals:
-            raise ValueError(f"delta_id {delta_id!r} has already been reversed")
+            return self._reversals[delta_id]
         timestamp = (now or datetime.now(tz=UTC)).isoformat().replace("+00:00", "Z")
         reversal_material = json.dumps(
             {"original_delta_id": delta_id, "reversed_at": timestamp}, sort_keys=True

--- a/aragora/reputation/store.py
+++ b/aragora/reputation/store.py
@@ -107,6 +107,12 @@ class ReputationStore:
     """
 
     def __init__(self, path: Path | None = None) -> None:
+        """Create an empty store.
+
+        *path* is the persistence target for new deltas and reversals.
+        It does **not** load existing records — call
+        :meth:`load_from_file` to reconstruct state from a prior run.
+        """
         self._deltas: dict[str, list[ReputationDelta]] = defaultdict(list)
         self._delta_by_id: dict[str, ReputationDelta] = {}
         self._reversals: dict[str, ReputationDeltaReversed] = {}

--- a/aragora/reputation/store.py
+++ b/aragora/reputation/store.py
@@ -111,6 +111,9 @@ class ReputationStore:
         self._delta_by_id: dict[str, ReputationDelta] = {}
         self._reversals: dict[str, ReputationDeltaReversed] = {}
         self._path = path
+        self._reversal_path: Path | None = (
+            path.parent / (path.stem + ".reversals.jsonl") if path is not None else None
+        )
         if path is not None:
             path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -139,6 +142,15 @@ class ReputationStore:
         except OSError as exc:
             raise ReputationStoreError(
                 f"could not persist reputation delta to {self._path}: {exc}"
+            ) from exc
+
+    def _append_reversal_to_file(self, reversal: ReputationDeltaReversed) -> None:
+        try:
+            with self._reversal_path.open("a", encoding="utf-8") as fh:  # type: ignore[union-attr]
+                fh.write(json.dumps(reversal.to_json(), sort_keys=True) + "\n")
+        except OSError as exc:
+            raise ReputationStoreError(
+                f"could not persist reversal to {self._reversal_path}: {exc}"
             ) from exc
 
     # ------------------------------------------------------------------
@@ -223,6 +235,8 @@ class ReputationStore:
             reversed_at=timestamp,
             reason=dict(reason or {}),
         )
+        if self._reversal_path is not None:
+            self._append_reversal_to_file(reversal)
         self._reversals[delta_id] = reversal
         return reversal
 
@@ -265,6 +279,25 @@ class ReputationStore:
                         path,
                         exc,
                     )
+        # Reload reversals from the companion file so reversed deltas stay
+        # excluded from get_score() after a process restart.
+        reversal_path = store._reversal_path
+        if reversal_path is not None and reversal_path.exists():
+            with reversal_path.open(encoding="utf-8") as fh:
+                for lineno, raw in enumerate(fh, 1):
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        reversal = ReputationDeltaReversed.from_json(json.loads(raw))
+                        store._reversals[reversal.original_delta_id] = reversal
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "ReputationStore: skipping invalid reversal line %d in %s: %s",
+                            lineno,
+                            reversal_path,
+                            exc,
+                        )
         return store
 
 

--- a/aragora/reputation/types.py
+++ b/aragora/reputation/types.py
@@ -271,6 +271,51 @@ class ReputationDelta:
         )
 
 
+@dataclass(frozen=True)
+class ReputationDeltaReversed:
+    """Event recording the roll-back of a :class:`ReputationDelta`.
+
+    Emitted when a resolution is re-opened or a dispute window fires.
+    ``counter_delta`` is ``-original.delta``; applying it to the running
+    score restores the pre-settlement state.  The original delta is
+    excluded from future :meth:`~aragora.reputation.store.ReputationStore.get_score`
+    calls once this reversal is recorded.
+
+    Sub-deliverable #7 of AGT-05 (issue #6066).
+    """
+
+    reversal_id: str
+    original_delta_id: str
+    agent_id: str
+    domain: str
+    counter_delta: float
+    reversed_at: str
+    reason: dict[str, Any]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "reversal_id": self.reversal_id,
+            "original_delta_id": self.original_delta_id,
+            "agent_id": self.agent_id,
+            "domain": self.domain,
+            "counter_delta": round(self.counter_delta, 6),
+            "reversed_at": self.reversed_at,
+            "reason": dict(self.reason),
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "ReputationDeltaReversed":
+        return cls(
+            reversal_id=str(data["reversal_id"]),
+            original_delta_id=str(data["original_delta_id"]),
+            agent_id=str(data["agent_id"]),
+            domain=str(data["domain"]),
+            counter_delta=float(data["counter_delta"]),
+            reversed_at=str(data["reversed_at"]),
+            reason=dict(data.get("reason") or {}),
+        )
+
+
 __all__ = [
     "DOMAIN_CODE_PR",
     "DOMAIN_CRUX_RESOLUTION",
@@ -280,6 +325,7 @@ __all__ = [
     "KNOWN_DOMAINS",
     "ClaimOutcome",
     "ReputationDelta",
+    "ReputationDeltaReversed",
     "ResolvedClaim",
     "ScoringRule",
     "StakePolicy",

--- a/tests/reputation/test_store.py
+++ b/tests/reputation/test_store.py
@@ -438,3 +438,20 @@ class TestDeltaReversal:
         store.record_delta(d)
         store.reverse_delta(d.delta_id)
         assert len(store) == 1
+
+    def test_reversal_survives_reload(self, tmp_path: Path) -> None:
+        """Reversed delta must stay excluded after load_from_file (durability)."""
+        ledger = tmp_path / "rep.jsonl"
+        store = ReputationStore(path=ledger)
+        d = _delta(delta=75.0)
+        store.record_delta(d)
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(75.0)
+
+        store.reverse_delta(d.delta_id, reason={"cause": "resolution_reopened"})
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(0.0)
+
+        # Reload from disk — the reversal file must be present and loaded
+        reloaded = ReputationStore.load_from_file(ledger)
+        assert reloaded.get_score("alice", apply_decay=False) == pytest.approx(0.0)
+        assert len(reloaded.reversals_for("alice")) == 1
+        assert reloaded.reversals_for("alice")[0].original_delta_id == d.delta_id

--- a/tests/reputation/test_store.py
+++ b/tests/reputation/test_store.py
@@ -351,13 +351,17 @@ class TestDeltaReversal:
         with pytest.raises(KeyError, match="not found"):
             store.reverse_delta("does_not_exist")
 
-    def test_reverse_already_reversed_raises_value_error(self) -> None:
+    def test_reverse_already_reversed_is_idempotent(self) -> None:
         store = ReputationStore()
         d = _delta(delta=10.0)
         store.record_delta(d)
-        store.reverse_delta(d.delta_id)
-        with pytest.raises(ValueError, match="already been reversed"):
-            store.reverse_delta(d.delta_id)
+        first = store.reverse_delta(d.delta_id, reason={"cause": "first"})
+
+        second = store.reverse_delta(d.delta_id, reason={"cause": "second"})
+
+        assert second == first
+        assert len(store.reversals_for("alice")) == 1
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(0.0)
 
     def test_reverse_returns_correct_reversal_event(self) -> None:
         store = ReputationStore()
@@ -455,3 +459,39 @@ class TestDeltaReversal:
         assert reloaded.get_score("alice", apply_decay=False) == pytest.approx(0.0)
         assert len(reloaded.reversals_for("alice")) == 1
         assert reloaded.reversals_for("alice")[0].original_delta_id == d.delta_id
+
+    def test_reversal_after_reload_survives_second_reload(self, tmp_path: Path) -> None:
+        """Persist reverse_delta() called after reconstructing from an existing ledger."""
+        ledger = tmp_path / "rep.jsonl"
+        store = ReputationStore(path=ledger)
+        d = _delta(delta=75.0)
+        store.record_delta(d)
+
+        reloaded = ReputationStore.load_from_file(ledger)
+        assert reloaded.get_score("alice", apply_decay=False) == pytest.approx(75.0)
+
+        reloaded.reverse_delta(d.delta_id, reason={"cause": "resolution_reopened"})
+
+        reloaded_again = ReputationStore.load_from_file(ledger)
+        assert reloaded_again.get_score("alice", apply_decay=False) == pytest.approx(0.0)
+        assert len(reloaded_again.reversals_for("alice")) == 1
+        assert reloaded_again.reversals_for("alice")[0].original_delta_id == d.delta_id
+
+    def test_persisted_reversal_is_idempotent_after_reload(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "rep.jsonl"
+        store = ReputationStore(path=ledger)
+        d = _delta(delta=25.0)
+        store.record_delta(d)
+        first = store.reverse_delta(d.delta_id, reason={"cause": "first"})
+
+        reloaded = ReputationStore.load_from_file(ledger)
+        second = reloaded.reverse_delta(d.delta_id, reason={"cause": "second"})
+
+        assert second == first
+        assert reloaded.get_score("alice", apply_decay=False) == pytest.approx(0.0)
+        reversal_lines = [
+            line
+            for line in (tmp_path / "rep.reversals.jsonl").read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(reversal_lines) == 1

--- a/tests/reputation/test_store.py
+++ b/tests/reputation/test_store.py
@@ -22,6 +22,7 @@ from aragora.reputation.types import (
     DOMAIN_DEBATE_POSITION,
     DOMAIN_PREDICTION_MARKET,
     ReputationDelta,
+    ReputationDeltaReversed,
     ResolvedClaim,
     StakeableClaim,
 )
@@ -327,3 +328,113 @@ class TestPersistence:
                 store.record_delta(_delta(delta=10.0))
         assert len(store) == 0
         assert store.get_score("alice", apply_decay=False) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# AGT-05 sub-deliverable #7: ReputationDeltaReversed + reverse_delta()
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaReversal:
+    def test_reverse_removes_delta_from_score(self) -> None:
+        store = ReputationStore()
+        d = _delta(delta=50.0)
+        store.record_delta(d)
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(50.0)
+
+        store.reverse_delta(d.delta_id)
+
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(0.0)
+
+    def test_reverse_unknown_delta_id_raises_key_error(self) -> None:
+        store = ReputationStore()
+        with pytest.raises(KeyError, match="not found"):
+            store.reverse_delta("does_not_exist")
+
+    def test_reverse_already_reversed_raises_value_error(self) -> None:
+        store = ReputationStore()
+        d = _delta(delta=10.0)
+        store.record_delta(d)
+        store.reverse_delta(d.delta_id)
+        with pytest.raises(ValueError, match="already been reversed"):
+            store.reverse_delta(d.delta_id)
+
+    def test_reverse_returns_correct_reversal_event(self) -> None:
+        store = ReputationStore()
+        d = _delta(delta=30.0)
+        store.record_delta(d)
+
+        reversal = store.reverse_delta(d.delta_id, reason={"cause": "reopened_resolution"})
+
+        assert isinstance(reversal, ReputationDeltaReversed)
+        assert reversal.original_delta_id == d.delta_id
+        assert reversal.agent_id == d.agent_id
+        assert reversal.domain == d.domain
+        assert reversal.counter_delta == pytest.approx(-30.0)
+        assert reversal.reason == {"cause": "reopened_resolution"}
+        assert reversal.reversal_id.startswith("rev_")
+
+    def test_reverse_partial_cancels_only_that_delta(self) -> None:
+        store = ReputationStore()
+        d1 = _delta(delta=40.0, agent_id="alice", resolution_id="r1")
+        d2 = _delta(delta=20.0, agent_id="alice", resolution_id="r2")
+        store.record_delta(d1)
+        store.record_delta(d2)
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(60.0)
+
+        store.reverse_delta(d1.delta_id)
+
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(20.0)
+
+    def test_reverse_does_not_affect_other_agents(self) -> None:
+        store = ReputationStore()
+        da = _delta(delta=50.0, agent_id="alice", resolution_id="r1")
+        db = _delta(delta=70.0, agent_id="bob", resolution_id="r2")
+        store.record_delta(da)
+        store.record_delta(db)
+
+        store.reverse_delta(da.delta_id)
+
+        assert store.get_score("alice", apply_decay=False) == pytest.approx(0.0)
+        assert store.get_score("bob", apply_decay=False) == pytest.approx(70.0)
+
+    def test_reversals_for_returns_all_reversals_for_agent(self) -> None:
+        store = ReputationStore()
+        d1 = _delta(delta=10.0, agent_id="alice", resolution_id="r1")
+        d2 = _delta(delta=20.0, agent_id="alice", resolution_id="r2")
+        d3 = _delta(delta=30.0, agent_id="bob", resolution_id="r3")
+        store.record_delta(d1)
+        store.record_delta(d2)
+        store.record_delta(d3)
+
+        store.reverse_delta(d1.delta_id)
+        store.reverse_delta(d3.delta_id)
+
+        alice_reversals = store.reversals_for("alice")
+        assert len(alice_reversals) == 1
+        assert alice_reversals[0].original_delta_id == d1.delta_id
+
+        bob_reversals = store.reversals_for("bob")
+        assert len(bob_reversals) == 1
+        assert bob_reversals[0].original_delta_id == d3.delta_id
+
+    def test_reversal_to_json_round_trip(self) -> None:
+        store = ReputationStore()
+        d = _delta(delta=-15.0)
+        store.record_delta(d)
+        reversal = store.reverse_delta(d.delta_id, reason={"source": "dispute"})
+
+        payload = reversal.to_json()
+        rebuilt = ReputationDeltaReversed.from_json(payload)
+
+        assert rebuilt.reversal_id == reversal.reversal_id
+        assert rebuilt.original_delta_id == reversal.original_delta_id
+        assert rebuilt.counter_delta == pytest.approx(reversal.counter_delta)
+        assert rebuilt.reason == {"source": "dispute"}
+
+    def test_len_unchanged_after_reversal(self) -> None:
+        store = ReputationStore()
+        d = _delta(delta=10.0)
+        store.record_delta(d)
+        store.reverse_delta(d.delta_id)
+        assert len(store) == 1


### PR DESCRIPTION
## Slice

Adds `ReputationDeltaReversed` dataclass (to `aragora/reputation/types.py`) and `reverse_delta()` / `reversals_for()` methods (to `ReputationStore` in `aragora/reputation/store.py`), implementing AGT-05 sub-deliverable #7: the reversal/re-opening path that rolls back a `ReputationDelta` when a resolved claim is re-opened or a dispute window fires.

The original delta is excluded from all future `get_score()` calls once reversed; `counter_delta` records `-original.delta` for audit.

## Gating

- Default: OFF (flag: `ARAGORA_REPUTATION_FLOW_ENABLED` — same gate as the existing `ReputationStore`; no new env var introduced)
- Live queue effect: none
- Advances issue: #6066 (AGT-05 Skin-in-the-game reputation flow)

## Tests

- `test_reverse_removes_delta_from_score` — reversed delta no longer contributes to running score
- `test_reverse_unknown_delta_id_raises_key_error` — KeyError on unknown ID
- `test_reverse_already_reversed_raises_value_error` — ValueError on double reversal
- `test_reverse_returns_correct_reversal_event` — `ReputationDeltaReversed` fields correct (agent_id, domain, counter_delta = -original.delta, reversal_id prefix)
- `test_reverse_partial_cancels_only_that_delta` — reversing one of two deltas leaves the other intact
- `test_reverse_does_not_affect_other_agents` — reversal is isolated to the owning agent
- `test_reversals_for_returns_all_reversals_for_agent` — per-agent reversal query returns correct subset
- `test_reversal_to_json_round_trip` — `to_json()` / `from_json()` round-trip preserves all fields
- `test_len_unchanged_after_reversal` — `__len__` counts total recorded deltas (not live count)

## Validation

- `pytest tests/reputation/` `--noconftest` — 101 passed (92 pre-existing + 9 new)
- `ruff check aragora/reputation/types.py aragora/reputation/store.py aragora/reputation/__init__.py tests/reputation/test_store.py` — clean
- `mypy aragora/reputation/types.py aragora/reputation/store.py aragora/reputation/__init__.py --ignore-missing-imports` — clean

## Out of scope

- Persistence of reversals to disk (follow-on slice: write reversals to a parallel `.reversals.jsonl` alongside the main delta JSONL; load on `load_from_file`).
- On-chain anchoring of reversal events via `aragora/blockchain/contracts/reputation.py` — lives in AGT-05 anchor sub-deliverable.
- Dispatch-eligibility wiring that acts on reversal events — lives in the team-selector integration follow-on (`enable_agt05_reputation_selection` flag on `TeamSelectorConfig`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoFL9AT3HUuP8VSVsghuHP)_