### PR TITLE
fix(boss-loop): honor open PRs before retry exhaustion

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1238,14 +1238,18 @@ class BossLoop:
                 issue_number,
                 repo_slug=self._repo_slug_for_issue(issue),
             )
+        open_boss_prs: list[dict[str, Any]] | None = None
         for num, count in self._issue_attempt_counts.items():
             if count >= self.config.max_retries_per_issue:
                 try:
                     issue_number = int(num)
                 except (TypeError, ValueError):
                     continue
-                if self._has_open_pr_for_issue(issue_number):
-                    continue
+                if self.config.repo:
+                    if open_boss_prs is None:
+                        open_boss_prs = self._list_open_boss_harvest_prs()
+                    if self._has_open_pr_for_issue(issue_number, open_boss_prs):
+                        continue
                 already_maxed.add(issue_number)
                 if count == self.config.max_retries_per_issue and self.config.repo:
                     self._auto_decompose_stuck_issue(issue_number, issues)
@@ -3175,7 +3179,23 @@ class BossLoop:
             )
         return open_boss_prs
 
-    def _has_open_pr_for_issue(self, issue_number: int) -> str | None:
+    @staticmethod
+    def _open_boss_pr_url_for_issue(
+        open_prs: list[dict[str, Any]],
+        issue_number: int,
+    ) -> str | None:
+        suffix = f"issue-{issue_number}"
+        for pr in open_prs:
+            head_ref = str(pr.get("headRefName", ""))
+            if head_ref.endswith(suffix) or f"issue-{issue_number}-" in head_ref:
+                return str(pr.get("url") or "")
+        return None
+
+    def _has_open_pr_for_issue(
+        self,
+        issue_number: int,
+        open_prs: list[dict[str, Any]] | None = None,
+    ) -> str | None:
         """Check if there is already an open boss-loop PR for the given issue.
 
         Returns the PR URL if found, otherwise ``None``.  Uses the cached
@@ -3183,13 +3203,9 @@ class BossLoop:
         naming convention ``aragora/boss-harvest/issue-{N}`` encodes the issue
         number so a substring match is sufficient.
         """
-        open_prs = self._list_open_boss_harvest_prs()
-        suffix = f"issue-{issue_number}"
-        for pr in open_prs:
-            head_ref = str(pr.get("headRefName", ""))
-            if head_ref.endswith(suffix) or f"issue-{issue_number}-" in head_ref:
-                return str(pr.get("url") or "")
-        return None
+        if open_prs is None:
+            open_prs = self._list_open_boss_harvest_prs()
+        return self._open_boss_pr_url_for_issue(open_prs, issue_number)
 
     def _git_repo_cmd(
         self,

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1244,6 +1244,8 @@ class BossLoop:
                     issue_number = int(num)
                 except (TypeError, ValueError):
                     continue
+                if self._has_open_pr_for_issue(issue_number):
+                    continue
                 already_maxed.add(issue_number)
                 if count == self.config.max_retries_per_issue and self.config.repo:
                     self._auto_decompose_stuck_issue(issue_number, issues)

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -7343,6 +7343,47 @@ class TestPublishedPrTerminal:
             f"next_actions should mention existing PR, got {actions}"
         )
 
+    def test_already_maxed_issue_numbers_lists_open_prs_once(self):
+        """Retry exhaustion checks open PR state once per scan, not once per issue."""
+        loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
+        loop._issue_attempt_counts = {
+            42: loop.config.max_retries_per_issue,
+            43: loop.config.max_retries_per_issue,
+            44: loop.config.max_retries_per_issue,
+        }
+
+        open_prs = [
+            {
+                "number": 200,
+                "headRefName": "aragora/boss-harvest/issue-42-boss-aaa",
+                "url": "https://github.com/synaptent/aragora/pull/200",
+            },
+            {
+                "number": 201,
+                "headRefName": "aragora/boss-harvest/issue-43-boss-bbb",
+                "url": "https://github.com/synaptent/aragora/pull/201",
+            },
+        ]
+
+        with (
+            patch.object(loop, "_hydrate_issue_attempt_count", return_value=0),
+            patch.object(
+                loop, "_list_open_boss_harvest_prs", return_value=open_prs
+            ) as mock_list_open_prs,
+            patch.object(loop, "_auto_decompose_stuck_issue") as mock_decompose,
+        ):
+            result = loop._already_maxed_issue_numbers(
+                [
+                    _make_issue(42, "Existing PR one"),
+                    _make_issue(43, "Existing PR two"),
+                    _make_issue(44, "No PR"),
+                ]
+            )
+
+        assert result == {44}
+        mock_list_open_prs.assert_called_once()
+        mock_decompose.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Decomposition guardrails (Task 1 + Task 4)

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -7305,6 +7305,7 @@ class TestPublishedPrTerminal:
             freshness_checker=lambda **kw: _fresh_result(fresh=True),
         )
         loop._dispatch_issue = _dispatch
+        loop._issue_attempt_counts[42] = loop.config.max_retries_per_issue
 
         # Simulate that an open PR already exists for issue #42
         existing_pr_url = "https://github.com/synaptent/aragora/pull/200"


### PR DESCRIPTION
## Summary
- lets an existing boss-harvest PR take precedence over retry exhaustion in boss-loop issue selection
- adds regression coverage for maxed retry state plus an existing open PR

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/swarm/test_boss_loop.py::TestPublishedPrTerminal::test_existing_open_pr_skips_dispatch -q -p no:rerunfailures -p no:cacheprovider
- ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- ruff format --check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Main repro: the same focused test fails on origin/main because issue #42 is not added to issues_completed when persisted retry state is already maxed.