### PR TITLE
[AGT-05] Wire enable_agt05_reputation_selection into TeamSelectionConfig

### DIFF
--- a/aragora/debate/team_selector.py
+++ b/aragora/debate/team_selector.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from aragora.memory.continuum.core import ContinuumMemory
     from aragora.memory.store import CritiqueStore
     from aragora.ranking.pattern_matcher import TaskPatternMatcher
+    from aragora.reputation.selection_bridge import ReputationBridgeConfig
+    from aragora.reputation.store import ReputationStore
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +170,12 @@ class TeamSelectionConfig:
     # Blockchain staking reputation scoring (stake health, slash frequency)
     enable_staking_reputation: bool = False
     staking_reputation_weight: float = 0.15
+    # AGT-05 skin-in-the-game reputation dispatch eligibility (default off)
+    # When True and a ReputationStore is passed to TeamSelector, the bridge
+    # replaces the default calibration scorer so reputation deltas from
+    # resolved predictions and crux outcomes influence agent selection.
+    enable_agt05_reputation_selection: bool = False
+    reputation_bridge_config: ReputationBridgeConfig | None = None
 
 
 class TeamSelector:
@@ -207,6 +215,7 @@ class TeamSelector:
         control_plane_registry: Any | None = None,
         marketplace_registry: Any | None = None,
         staking_registry: Any | None = None,
+        reputation_store: ReputationStore | None = None,
     ):
         self.elo_system = elo_system
         # Auto-detect default CalibrationTracker if none provided.
@@ -261,6 +270,16 @@ class TeamSelector:
         self.marketplace_registry = marketplace_registry
         # Blockchain staking registry for reputation scoring
         self.staking_registry = staking_registry
+        # AGT-05: override calibration_tracker with reputation bridge when enabled.
+        # Placed after self.config is set so the flag is resolved correctly.
+        if self.config.enable_agt05_reputation_selection and reputation_store is not None:
+            from aragora.reputation.selection_bridge import ReputationCalibrationBridge
+
+            self.calibration_tracker = ReputationCalibrationBridge(
+                store=reputation_store,
+                config=self.config.reputation_bridge_config,
+            )
+            logger.debug("AGT-05 reputation bridge installed as calibration scorer")
         self.pulse_manager: Any = None  # Set externally or via Arena
         self.specialist_registry: Any = None  # Set externally or via Arena
         self._culture_recommendations_cache: dict[str, list[str]] = {}

--- a/tests/debate/test_agt05_team_selector_integration.py
+++ b/tests/debate/test_agt05_team_selector_integration.py
@@ -1,0 +1,146 @@
+"""AGT-05 TeamSelector ← ReputationCalibrationBridge integration tests.
+
+Verifies that ``enable_agt05_reputation_selection`` in ``TeamSelectionConfig``
+wires the AGT-05 reputation bridge as the calibration scorer when a
+``ReputationStore`` is supplied to ``TeamSelector.__init__``.
+
+Gating: ``ARAGORA_REPUTATION_FLOW_ENABLED`` (default off).
+Advances issue: #6066 (AGT-05 Skin-in-the-game reputation flow).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.debate.team_selector import TeamSelectionConfig, TeamSelector
+from aragora.reputation.selection_bridge import ReputationBridgeConfig, ReputationCalibrationBridge
+from aragora.reputation.store import ReputationStore
+from aragora.reputation.types import DOMAIN_PREDICTION_MARKET, ReputationDelta
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_delta(agent_id: str, delta: float = 10.0, idx: int = 0) -> ReputationDelta:
+    return ReputationDelta(
+        delta_id=f"delta_{agent_id}_{idx}",
+        agent_id=agent_id,
+        domain=DOMAIN_PREDICTION_MARKET,
+        claim_id=f"clm_{agent_id}_{idx}",
+        resolution_id=f"res_{agent_id}_{idx}",
+        delta=delta,
+        scoring_rule="binary",
+        applied_at="2026-04-28T00:00:00Z",
+        decay_half_life_days=None,
+        reason={"test": True},
+    )
+
+
+def _store_with_deltas(agent_id: str, count: int = 5, delta: float = 10.0) -> ReputationStore:
+    store = ReputationStore()
+    for i in range(count):
+        store.record_delta(_make_delta(agent_id, delta=delta, idx=i))
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Wiring tests (env flag not required — only constructor / config behaviour)
+# ---------------------------------------------------------------------------
+
+
+class TestTeamSelectorAgt05Wiring:
+    def test_default_flag_is_false(self):
+        assert TeamSelectionConfig().enable_agt05_reputation_selection is False
+
+    def test_default_bridge_config_is_none(self):
+        assert TeamSelectionConfig().reputation_bridge_config is None
+
+    def test_flag_off_bridge_not_installed(self):
+        store = ReputationStore()
+        cfg = TeamSelectionConfig(enable_agt05_reputation_selection=False)
+        selector = TeamSelector(config=cfg, reputation_store=store)
+        assert not isinstance(selector.calibration_tracker, ReputationCalibrationBridge)
+
+    def test_flag_on_no_store_no_bridge(self):
+        cfg = TeamSelectionConfig(enable_agt05_reputation_selection=True)
+        selector = TeamSelector(config=cfg, reputation_store=None)
+        assert not isinstance(selector.calibration_tracker, ReputationCalibrationBridge)
+
+    def test_flag_on_with_store_installs_bridge(self):
+        cfg = TeamSelectionConfig(enable_agt05_reputation_selection=True)
+        selector = TeamSelector(config=cfg, reputation_store=ReputationStore())
+        assert isinstance(selector.calibration_tracker, ReputationCalibrationBridge)
+
+    def test_explicit_tracker_superseded_by_bridge_when_flag_on(self):
+        """Bridge replaces an explicitly supplied calibration_tracker."""
+
+        class _Dummy:
+            def get_brier_score(self, agent_name: str, domain: str | None = None) -> float:
+                return 0.99
+
+            def get_brier_scores_batch(
+                self, agent_names: list[str], domain: str | None = None
+            ) -> dict[str, float]:
+                return dict.fromkeys(agent_names, 0.99)
+
+        cfg = TeamSelectionConfig(enable_agt05_reputation_selection=True)
+        selector = TeamSelector(
+            config=cfg,
+            reputation_store=ReputationStore(),
+            calibration_tracker=_Dummy(),  # type: ignore[arg-type]
+        )
+        assert isinstance(selector.calibration_tracker, ReputationCalibrationBridge)
+
+    def test_custom_bridge_config_forwarded_to_bridge(self):
+        bridge_cfg = ReputationBridgeConfig(min_samples=3, score_scale=50.0)
+        cfg = TeamSelectionConfig(
+            enable_agt05_reputation_selection=True,
+            reputation_bridge_config=bridge_cfg,
+        )
+        selector = TeamSelector(config=cfg, reputation_store=ReputationStore())
+        bridge = selector.calibration_tracker
+        assert isinstance(bridge, ReputationCalibrationBridge)
+        assert bridge._cfg.min_samples == 3
+        assert bridge._cfg.score_scale == pytest.approx(50.0)
+
+
+# ---------------------------------------------------------------------------
+# Scoring behaviour tests (require ARAGORA_REPUTATION_FLOW_ENABLED)
+# ---------------------------------------------------------------------------
+
+
+class TestTeamSelectorAgt05Scoring:
+    def test_neutral_when_env_flag_unset(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+        cfg = TeamSelectionConfig(enable_agt05_reputation_selection=True)
+        selector = TeamSelector(config=cfg, reputation_store=_store_with_deltas("agent-x"))
+        score = selector.calibration_tracker.get_brier_score("agent-x")  # type: ignore[union-attr]
+        assert score == pytest.approx(0.5)
+
+    def test_non_neutral_with_positive_score_and_env_flag(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+        bridge_cfg = ReputationBridgeConfig(min_samples=1, score_scale=10.0)
+        cfg = TeamSelectionConfig(
+            enable_agt05_reputation_selection=True,
+            reputation_bridge_config=bridge_cfg,
+        )
+        store = _store_with_deltas("agent-y", count=5, delta=10.0)
+        selector = TeamSelector(config=cfg, reputation_store=store)
+        score = selector.calibration_tracker.get_brier_score("agent-y")  # type: ignore[union-attr]
+        assert score < 0.5, f"expected lower-than-neutral Brier for positive rep; got {score}"
+
+    def test_batch_consistent_with_single(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+        bridge_cfg = ReputationBridgeConfig(min_samples=3, score_scale=50.0)
+        cfg = TeamSelectionConfig(
+            enable_agt05_reputation_selection=True,
+            reputation_bridge_config=bridge_cfg,
+        )
+        store = _store_with_deltas("agent-z", count=3, delta=5.0)
+        selector = TeamSelector(config=cfg, reputation_store=store)
+        bridge = selector.calibration_tracker
+        single = bridge.get_brier_score("agent-z")  # type: ignore[union-attr]
+        batch = bridge.get_brier_scores_batch(["agent-z"])  # type: ignore[union-attr]
+        assert single == pytest.approx(batch["agent-z"])


### PR DESCRIPTION
## Slice

Adds `enable_agt05_reputation_selection: bool = False` and `reputation_bridge_config: ReputationBridgeConfig | None = None` to `TeamSelectionConfig`, plus a `reputation_store: ReputationStore | None = None` parameter to `TeamSelector.__init__`. When the flag is `True` and a store is supplied, the already-shipped `ReputationCalibrationBridge` is installed as the `calibration_tracker`, routing skin-in-the-game reputation deltas into agent selection scores. This closes the explicit "follow-on slice" gap noted in `aragora/reputation/selection_bridge.py`.

## Gating

- Default: OFF (flag: `enable_agt05_reputation_selection = False` on `TeamSelectionConfig`; also guarded by `ARAGORA_REPUTATION_FLOW_ENABLED` env var inside the bridge)
- Live queue effect: none
- Advances issue: #6066 (AGT-05 Skin-in-the-game reputation flow)

## Tests

- `TestTeamSelectorAgt05Wiring.test_default_flag_is_false` — `enable_agt05_reputation_selection` defaults to `False`
- `TestTeamSelectorAgt05Wiring.test_default_bridge_config_is_none` — `reputation_bridge_config` defaults to `None`
- `TestTeamSelectorAgt05Wiring.test_flag_off_bridge_not_installed` — flag=False, store provided → bridge NOT installed
- `TestTeamSelectorAgt05Wiring.test_flag_on_no_store_no_bridge` — flag=True, store=None → bridge NOT installed (partial state)
- `TestTeamSelectorAgt05Wiring.test_flag_on_with_store_installs_bridge` — flag=True, store provided → bridge IS installed as `calibration_tracker`
- `TestTeamSelectorAgt05Wiring.test_explicit_tracker_superseded_by_bridge_when_flag_on` — bridge replaces an explicitly supplied `calibration_tracker` when flag+store are set
- `TestTeamSelectorAgt05Wiring.test_custom_bridge_config_forwarded_to_bridge` — `reputation_bridge_config` is forwarded to the bridge constructor
- `TestTeamSelectorAgt05Scoring.test_neutral_when_env_flag_unset` — bridge installed but `ARAGORA_REPUTATION_FLOW_ENABLED` unset → neutral 0.5
- `TestTeamSelectorAgt05Scoring.test_non_neutral_with_positive_score_and_env_flag` — env flag set + positive deltas → sub-0.5 pseudo-Brier
- `TestTeamSelectorAgt05Scoring.test_batch_consistent_with_single` — `get_brier_scores_batch` agrees with `get_brier_score`

## Validation

- Inline 9-assertion driver (importlib isolated, avoids full dep chain): **9/9 passed**
- `ruff check aragora/debate/team_selector.py tests/debate/test_agt05_team_selector_integration.py` — clean
- `mypy aragora/debate/team_selector.py --ignore-missing-imports` — clean

## Out of scope

- On-chain anchoring of reputation writes (`aragora/reputation/anchor.py`) — deferred to AGT-05 anchor sub-deliverable.
- Persistence and JSONL load/save for the store — already shipped in `aragora/reputation/store.py`.
- Hard suspension of agents (only soft downweighting via Brier mapping) — explicit policy gate per the AGT-05 spec.
- Metaculus and synthetic-GitHub resolution bridges — covered by `aragora/reputation/bridge.py` and `aragora/reputation/crux_bridge.py`; no wiring changes needed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7caFSrUyXQ4fNykRaPadD)_