### PR TITLE
feat(review-queue): add model quorum merge packets

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -83,11 +83,22 @@ TIER_3_PREFIXES: tuple[str, ...] = (
     "aragora/security/",
     "aragora/privacy/",
     "aragora/compliance/",
+    "aragora/metrics/",
     "aragora/reputation/",
+    "aragora/debate/team_selector.py",
     "aragora/server/fastapi/routes/",
     "aragora/server/handlers/",
     "aragora/migrations/",
     "sdk/",
+)
+TIER_3_TITLE_KEYWORDS: tuple[str, ...] = (
+    "agt-",
+    "calibration",
+    "reputation",
+    "semantic",
+    "scoring",
+    "persistence",
+    "public api",
 )
 TIER_4_PREFIXES: tuple[str, ...] = (
     ".github/workflows/",
@@ -1247,7 +1258,9 @@ def _classify_model_review_tier(
         return (1, "tier_1_additive_internal", "no changed files reported; defaulting to Tier 1")
     if any(_matches_prefix(path, TIER_4_PREFIXES) for path in normalized):
         return (4, "tier_4_preapproval_required", "workflow/deploy/destructive surface touched")
-    if any(_matches_prefix(path, TIER_3_PREFIXES) for path in normalized):
+    if any(_matches_prefix(path, TIER_3_PREFIXES) for path in normalized) or any(
+        keyword in title for keyword in TIER_3_TITLE_KEYWORDS
+    ):
         return (
             3,
             "tier_3_semantic_risk",

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -54,6 +54,8 @@ UTC = timezone.utc
 
 # Lane classification thresholds and risk-path catalog.
 LARGE_DIFF_THRESHOLD = 500  # additions + deletions, beyond which "needs_human_attention"
+MODEL_REVIEW_QUEUE_CAP = 6
+MODEL_REVIEW_QUORUM_VERSION = "model_review_quorum.v1"
 HIGH_RISK_PATHS: tuple[str, ...] = (
     "CLAUDE.md",
     "aragora/__init__.py",
@@ -67,6 +69,31 @@ HIGH_RISK_PREFIXES: tuple[str, ...] = (
     "aragora/rbac/",
     "scripts/auto_revert",
     ".github/workflows/",
+)
+TIER_2_PREFIXES: tuple[str, ...] = (
+    "aragora/cli/",
+    "aragora/swarm/",
+    "aragora/observability/",
+    "aragora/knowledge/mound/metrics",
+    "scripts/",
+)
+TIER_3_PREFIXES: tuple[str, ...] = (
+    "aragora/auth/",
+    "aragora/rbac/",
+    "aragora/security/",
+    "aragora/privacy/",
+    "aragora/compliance/",
+    "aragora/reputation/",
+    "aragora/server/fastapi/routes/",
+    "aragora/server/handlers/",
+    "aragora/migrations/",
+    "sdk/",
+)
+TIER_4_PREFIXES: tuple[str, ...] = (
+    ".github/workflows/",
+    "deploy/",
+    "docker/",
+    "k8s/",
 )
 PARKED_LABELS: tuple[str, ...] = ("stale", "do-not-merge", "wip", "blocked")
 
@@ -138,6 +165,7 @@ class ReviewPacket:
     packet_sha: str
     generated_at: str
     protocol: dict[str, Any] = field(default_factory=dict)
+    model_review_quorum: dict[str, Any] = field(default_factory=dict)
     advisory_only: bool = True
     settlement_note: str = ADVISORY_NOTE
 
@@ -260,6 +288,39 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     act_p.add_argument("--json", action="store_true", help="Output settlement receipt as JSON")
 
+    merge_packet_p = sub.add_parser(
+        "merge-packet",
+        help="Print a model-quorum merge authorization packet for a PR batch",
+        description=(
+            "Build a receipt-shaped batch packet for the Model Review Quorum + "
+            "Human Risk Settlement process. This is read-only: it does not "
+            "approve, merge, comment, or write local receipts."
+        ),
+    )
+    merge_packet_p.add_argument(
+        "--limit",
+        type=int,
+        default=30,
+        help="Max open PRs to inspect when --pr is not supplied (default: 30)",
+    )
+    merge_packet_p.add_argument(
+        "--pr",
+        action="append",
+        default=[],
+        help="Specific PR number/ref to include. Repeatable. Defaults to open queue.",
+    )
+    merge_packet_p.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    merge_packet_p.add_argument(
+        "--execute-reviewers",
+        action="store_true",
+        help="Attempt live heterogeneous reviewer execution for each packet.",
+    )
+    merge_packet_p.add_argument("--json", action="store_true", help="Output as JSON")
+
     baseline_p = sub.add_parser(
         "baseline",
         help="Measure empirical invalidation baseline from on-disk stores (#6375)",
@@ -354,10 +415,12 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
         return _cmd_run(args)
     if command == "act":
         return _cmd_act(args)
+    if command == "merge-packet":
+        return _cmd_merge_packet(args)
     if command == "baseline":
         return _cmd_baseline(args)
     print(
-        "Usage: aragora review-queue {build,packet,run,act,baseline} [...]\n"
+        "Usage: aragora review-queue {build,packet,run,act,merge-packet,baseline} [...]\n"
         "Run 'aragora review-queue run --help' for the human settlement loop.",
         file=sys.stderr,
     )
@@ -533,6 +596,25 @@ def _cmd_act(args: argparse.Namespace) -> int:
         print(json.dumps(receipt.to_dict(), indent=2))
     else:
         _render_settlement_receipt(receipt)
+    return 0
+
+
+def _cmd_merge_packet(args: argparse.Namespace) -> int:
+    json_output = bool(getattr(args, "json", False) or getattr(args, "json_output", False))
+    try:
+        packet = _build_merge_authorization_packet(
+            pr_refs=list(getattr(args, "pr", []) or []),
+            limit=int(getattr(args, "limit", 30) or 30),
+            repo_override=getattr(args, "repo", None),
+            execute_reviewers=bool(getattr(args, "execute_reviewers", False)),
+        )
+    except _GhError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if json_output:
+        print(json.dumps(packet, indent=2))
+    else:
+        _render_merge_authorization_packet(packet)
     return 0
 
 
@@ -827,6 +909,7 @@ def _build_packet(
             "statusCheckRollup",
             "files",
             "body",
+            "comments",
         ]
     )
     args = ["pr", "view", str(number), "--json", fields]
@@ -942,6 +1025,7 @@ def _build_packet(
         reviewer_outputs=reviewer_outputs,
         execution_failures=execution_failures,
     )
+    protocol_dict = protocol.to_dict()
 
     packet = ReviewPacket(
         pr_number=number,
@@ -964,10 +1048,348 @@ def _build_packet(
         machine_recommendation_reason=recommendation_reason,
         packet_sha="",
         generated_at=datetime.now(UTC).isoformat(),
-        protocol=protocol.to_dict(),
+        protocol=protocol_dict,
+        model_review_quorum=_build_model_review_quorum(
+            pr=pr,
+            files=files,
+            protocol=protocol_dict,
+            machine_recommendation=recommendation,
+            has_pending=has_pending,
+            has_failures=has_failures,
+        ),
     )
     packet.packet_sha = _packet_sha(packet)
     return packet
+
+
+def _build_merge_authorization_packet(
+    *,
+    pr_refs: list[str],
+    limit: int,
+    repo_override: str | None,
+    execute_reviewers: bool = False,
+) -> dict[str, Any]:
+    if pr_refs:
+        refs = list(dict.fromkeys(str(ref).strip() for ref in pr_refs if str(ref).strip()))
+        queue_size = len(_build_queue(limit=max(limit, len(refs), MODEL_REVIEW_QUEUE_CAP + 1)))
+    else:
+        queue = _build_queue(limit=limit)
+        refs = [str(item.number) for item in queue]
+        queue_size = len(queue)
+
+    packets = [
+        _build_packet(ref, repo_override=repo_override, execute_reviewers=execute_reviewers)
+        for ref in refs
+    ]
+    queue_pressure_active = queue_size > MODEL_REVIEW_QUEUE_CAP
+    entries = []
+    for packet in packets:
+        quorum = dict(packet.model_review_quorum)
+        quorum["queue_pressure"] = {
+            "current_open_prs": queue_size,
+            "cap": MODEL_REVIEW_QUEUE_CAP,
+            "active": queue_pressure_active,
+            "allowed_work_when_active": [
+                "review",
+                "dogfood",
+                "existing_blocker_fix",
+                "local_spec_only",
+                "merge_authorization_packet",
+            ],
+        }
+        entry = {
+            "pr_number": packet.pr_number,
+            "title": packet.title,
+            "url": packet.url,
+            "head_sha": packet.head_sha,
+            "checks_summary": packet.checks_summary,
+            "machine_recommendation": packet.machine_recommendation,
+            "tier": quorum["tier"],
+            "tier_name": quorum["tier_name"],
+            "status": quorum["status"],
+            "verdict": quorum["verdict"],
+            "admin_squash_allowed": quorum["admin_squash_allowed"],
+            "requires_human_risk_settlement": quorum["requires_human_risk_settlement"],
+            "unresolved_dissent": quorum["unresolved_dissent"],
+            "reviewer_signals": quorum["reviewer_signals"],
+            "dogfood_evidence": quorum["dogfood_evidence"],
+            "reasons": quorum["reasons"],
+        }
+        entries.append(entry)
+
+    return {
+        "version": "merge_authorization_packet.v1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "queue_pressure": {
+            "current_open_prs": queue_size,
+            "cap": MODEL_REVIEW_QUEUE_CAP,
+            "active": queue_pressure_active,
+        },
+        "authorization_sentence": (
+            "I accept the model quorum evidence for Tier 0-2 PRs in this packet "
+            "and authorize admin squash in the listed order. For Tier 3+ PRs, "
+            "I separately accept the semantic-risk packet before merge."
+        ),
+        "entries": entries,
+        "admin_squash_order": [
+            entry["pr_number"]
+            for entry in entries
+            if bool(entry["admin_squash_allowed"]) and not bool(entry["unresolved_dissent"])
+        ],
+        "human_risk_settlement_required": [
+            entry["pr_number"] for entry in entries if bool(entry["requires_human_risk_settlement"])
+        ],
+        "not_ready": [
+            entry["pr_number"]
+            for entry in entries
+            if entry["status"] not in {"satisfied", "human_risk_settlement_required"}
+        ],
+    }
+
+
+def _build_model_review_quorum(
+    *,
+    pr: dict[str, Any],
+    files: list[str],
+    protocol: dict[str, Any],
+    machine_recommendation: str,
+    has_pending: bool,
+    has_failures: bool,
+) -> dict[str, Any]:
+    tier, tier_name, tier_reason = _classify_model_review_tier(files, pr=pr)
+    requirement = _tier_requirement(tier)
+    reviewer_signals = _reviewer_signals_from_protocol(protocol)
+    dogfood_evidence = _dogfood_evidence_from_comments(pr.get("comments") or [])
+    dissenting_views = [
+        view for view in (protocol.get("dissenting_views") or []) if isinstance(view, dict)
+    ]
+    blocking_workflow_state = _has_blocking_workflow_state(pr)
+    unresolved_dissent = bool(dissenting_views)
+    signal_count = len(reviewer_signals) + len(dogfood_evidence)
+    has_required_dogfood = not requirement["requires_adversarial_dogfood"] or bool(dogfood_evidence)
+    quorum_satisfied = (
+        signal_count >= requirement["required_model_signals"] and has_required_dogfood
+    )
+
+    reasons = [tier_reason]
+    if has_failures:
+        reasons.append("checks are failing; repair before settlement")
+    if has_pending:
+        reasons.append("checks are pending; wait before settlement")
+    if unresolved_dissent:
+        reasons.append("unresolved model dissent is present")
+    if not quorum_satisfied:
+        reasons.append(
+            "model quorum incomplete: "
+            f"{signal_count}/{requirement['required_model_signals']} signal(s)"
+        )
+        if not has_required_dogfood:
+            reasons.append("focused adversarial dogfood evidence is required")
+
+    admin_squash_allowed = False
+    requires_human_risk_settlement = bool(requirement["requires_human_risk_settlement"])
+    if (
+        has_failures
+        or has_pending
+        or machine_recommendation == "repair_first"
+        or blocking_workflow_state
+    ):
+        status = "repair_or_wait"
+        verdict = "not_ready_for_settlement"
+    elif not quorum_satisfied:
+        status = "needs_model_review_quorum"
+        verdict = "collect_model_quorum_before_merge"
+    elif unresolved_dissent:
+        status = "unresolved_dissent"
+        verdict = "human_risk_settlement_required"
+        requires_human_risk_settlement = True
+    elif requirement["requires_human_preapproval"]:
+        status = "human_preapproval_required"
+        verdict = "tier_4_human_preapproval_required"
+        requires_human_risk_settlement = True
+    elif requires_human_risk_settlement:
+        status = "human_risk_settlement_required"
+        verdict = "model_quorum_satisfied_human_risk_settlement_required"
+    else:
+        status = "satisfied"
+        verdict = "admin_squash_allowed"
+        admin_squash_allowed = True
+
+    return {
+        "version": MODEL_REVIEW_QUORUM_VERSION,
+        "head_sha": str(pr.get("headRefOid", "")).strip(),
+        "tier": tier,
+        "tier_name": tier_name,
+        "tier_reason": tier_reason,
+        "required_model_signals": requirement["required_model_signals"],
+        "requires_adversarial_dogfood": requirement["requires_adversarial_dogfood"],
+        "requires_human_risk_settlement": requires_human_risk_settlement,
+        "requires_human_preapproval": requirement["requires_human_preapproval"],
+        "admin_squash_allowed": admin_squash_allowed,
+        "status": status,
+        "verdict": verdict,
+        "reviewer_signals": reviewer_signals,
+        "dogfood_evidence": dogfood_evidence,
+        "dissenting_views": dissenting_views,
+        "unresolved_dissent": unresolved_dissent,
+        "reasons": reasons,
+    }
+
+
+def _classify_model_review_tier(
+    files: list[str],
+    *,
+    pr: dict[str, Any] | None = None,
+) -> tuple[int, str, str]:
+    normalized = [path.strip() for path in files if path.strip()]
+    title = str((pr or {}).get("title", "") or "").lower()
+    if not normalized:
+        return (1, "tier_1_additive_internal", "no changed files reported; defaulting to Tier 1")
+    if any(_matches_prefix(path, TIER_4_PREFIXES) for path in normalized):
+        return (4, "tier_4_preapproval_required", "workflow/deploy/destructive surface touched")
+    if any(_matches_prefix(path, TIER_3_PREFIXES) for path in normalized):
+        return (
+            3,
+            "tier_3_semantic_risk",
+            "semantic, persistence, security, API, or SDK surface touched",
+        )
+    if all(_is_docs_tests_or_status_path(path) for path in normalized):
+        return (0, "tier_0_docs_tests_status", "docs/tests/status-only change")
+    if any(_matches_prefix(path, TIER_2_PREFIXES) for path in normalized) or any(
+        word in title for word in ("retry", "cache", "cli", "automation", "observability")
+    ):
+        return (
+            2,
+            "tier_2_live_automation",
+            "live automation, CLI, observability, retry, or cache surface touched",
+        )
+    return (1, "tier_1_additive_internal", "bounded internal code surface")
+
+
+def _tier_requirement(tier: int) -> dict[str, Any]:
+    if tier <= 0:
+        return {
+            "required_model_signals": 1,
+            "requires_adversarial_dogfood": False,
+            "requires_human_risk_settlement": False,
+            "requires_human_preapproval": False,
+        }
+    if tier == 1:
+        return {
+            "required_model_signals": 2,
+            "requires_adversarial_dogfood": True,
+            "requires_human_risk_settlement": False,
+            "requires_human_preapproval": False,
+        }
+    if tier == 2:
+        return {
+            "required_model_signals": 2,
+            "requires_adversarial_dogfood": True,
+            "requires_human_risk_settlement": False,
+            "requires_human_preapproval": False,
+        }
+    if tier == 3:
+        return {
+            "required_model_signals": 2,
+            "requires_adversarial_dogfood": True,
+            "requires_human_risk_settlement": True,
+            "requires_human_preapproval": False,
+        }
+    return {
+        "required_model_signals": 2,
+        "requires_adversarial_dogfood": True,
+        "requires_human_risk_settlement": True,
+        "requires_human_preapproval": True,
+    }
+
+
+def _has_blocking_workflow_state(pr: dict[str, Any]) -> bool:
+    if bool(pr.get("isDraft", False)):
+        return True
+    mergeable = str(pr.get("mergeable", "")).strip().upper()
+    if mergeable == "CONFLICTING":
+        return True
+    labels = [
+        str(label.get("name", "")).strip()
+        for label in (pr.get("labels") or [])
+        if isinstance(label, dict) and label.get("name")
+    ]
+    return any(label in PARKED_LABELS for label in labels)
+
+
+def _reviewer_signals_from_protocol(protocol: dict[str, Any]) -> list[dict[str, Any]]:
+    validation = protocol.get("validation_summary") or {}
+    reviewer_execution = validation.get("reviewer_execution") or {}
+    reviewer_ids = reviewer_execution.get("reviewer_ids") or []
+    providers = reviewer_execution.get("providers") or []
+    signals = []
+    for index, reviewer_id in enumerate(reviewer_ids):
+        provider = providers[index] if index < len(providers) else ""
+        signals.append(
+            {
+                "reviewer_id": str(reviewer_id),
+                "provider": str(provider),
+                "source": protocol.get("status", ""),
+            }
+        )
+    return signals
+
+
+def _dogfood_evidence_from_comments(comments: list[Any]) -> list[dict[str, str]]:
+    evidence: list[dict[str, str]] = []
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        body = str(comment.get("body", "") or "")
+        lower = body.lower()
+        if not any(
+            token in lower for token in ("dogfood", "adversarial", "cross-author", "recheck")
+        ):
+            continue
+        reviewer = _infer_model_reviewer_from_text(body)
+        author_payload = comment.get("author")
+        author = ""
+        if isinstance(author_payload, dict):
+            author = str(author_payload.get("login", "") or "")
+        evidence.append(
+            {
+                "reviewer_id": reviewer,
+                "github_author": author,
+                "source": "pr_comment",
+                "summary": _first_nonempty_line(body)[:240],
+            }
+        )
+    return evidence[:5]
+
+
+def _infer_model_reviewer_from_text(text: str) -> str:
+    lower = text.lower()
+    for name in ("claude", "codex", "tesla", "harvey", "factory", "grok", "gemini"):
+        if name in lower:
+            return name
+    return "unknown_model_reviewer"
+
+
+def _first_nonempty_line(text: str) -> str:
+    for line in str(text).splitlines():
+        stripped = line.strip("# ").strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _matches_prefix(path: str, prefixes: tuple[str, ...]) -> bool:
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes)
+
+
+def _is_docs_tests_or_status_path(path: str) -> bool:
+    return path.startswith(("docs/", "tests/")) or path in {
+        "AGENTS.md",
+        "CLAUDE.md",
+        "README.md",
+        "CHANGELOG.md",
+        "GA_CHECKLIST.md",
+    }
 
 
 def _subsystem_for(path: str) -> str:
@@ -1342,6 +1764,27 @@ def _render_packet(packet: ReviewPacket) -> None:
                     f"    - {slot.get('slot_id')}: {selected} "
                     f"({slot.get('family')}/{slot.get('lens')})"
                 )
+    if packet.model_review_quorum:
+        quorum = packet.model_review_quorum
+        print()
+        print("model review quorum:")
+        print(f"  tier: Tier {quorum.get('tier')} ({quorum.get('tier_name', 'unknown')})")
+        print(f"  status: {quorum.get('status', 'unknown')}")
+        print(f"  verdict: {quorum.get('verdict', 'unknown')}")
+        print(f"  admin squash allowed: {quorum.get('admin_squash_allowed', False)}")
+        print(
+            "  human risk settlement required: "
+            f"{quorum.get('requires_human_risk_settlement', False)}"
+        )
+        print(
+            "  signals: "
+            f"{len(quorum.get('reviewer_signals') or []) + len(quorum.get('dogfood_evidence') or [])}/"
+            f"{quorum.get('required_model_signals', 0)}"
+        )
+        if quorum.get("unresolved_dissent"):
+            print("  unresolved dissent: true")
+        for reason in quorum.get("reasons") or []:
+            print(f"    - {reason}")
     print()
     print(f"generated at: {packet.generated_at}")
     _render_active_auto_handle_alerts()
@@ -1374,6 +1817,54 @@ def _render_settlement_receipt(receipt: SettlementReceipt) -> None:
     if receipt.elapsed_seconds is not None:
         print(f"  elapsed:      {receipt.elapsed_seconds:.3f}s")
     print(f"  receipt:      {receipt.receipt_path}")
+
+
+def _render_merge_authorization_packet(packet: dict[str, Any]) -> None:
+    queue = packet.get("queue_pressure") or {}
+    print("# Merge authorization packet")
+    print(f"generated at: {packet.get('generated_at', '')}")
+    print(
+        "queue pressure: "
+        f"{queue.get('current_open_prs', 0)} open / cap {queue.get('cap', MODEL_REVIEW_QUEUE_CAP)} "
+        f"(active={queue.get('active', False)})"
+    )
+    if queue.get("active"):
+        print(
+            "new implementation PRs: frozen; only review/dogfood/fix-existing/spec-only work allowed"
+        )
+    print()
+    print("authorization sentence:")
+    print(packet.get("authorization_sentence", ""))
+    print()
+
+    admin_order = packet.get("admin_squash_order") or []
+    human_required = packet.get("human_risk_settlement_required") or []
+    not_ready = packet.get("not_ready") or []
+    print(f"admin squash order: {', '.join(f'#{n}' for n in admin_order) or '(none)'}")
+    print(
+        f"human risk settlement required: {', '.join(f'#{n}' for n in human_required) or '(none)'}"
+    )
+    print(f"not ready: {', '.join(f'#{n}' for n in not_ready) or '(none)'}")
+    print()
+
+    for entry in packet.get("entries") or []:
+        if not isinstance(entry, dict):
+            continue
+        print(
+            f"#{entry.get('pr_number')} | Tier {entry.get('tier')} | "
+            f"{entry.get('status')} | {entry.get('verdict')}"
+        )
+        print(f"  {entry.get('title', '')}")
+        print(f"  head: {entry.get('head_sha', '')}")
+        print(f"  checks: {entry.get('checks_summary', '')}")
+        print(
+            "  evidence: "
+            f"{len(entry.get('reviewer_signals') or [])} reviewer signal(s), "
+            f"{len(entry.get('dogfood_evidence') or [])} dogfood note(s)"
+        )
+        for reason in entry.get("reasons") or []:
+            print(f"  - {reason}")
+        print()
 
 
 def _render_baseline_report(

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -921,6 +921,7 @@ def _build_packet(
             "files",
             "body",
             "comments",
+            "commits",
         ]
     )
     args = ["pr", "view", str(number), "--json", fields]
@@ -1170,9 +1171,21 @@ def _build_model_review_quorum(
 ) -> dict[str, Any]:
     tier, tier_name, tier_reason = _classify_model_review_tier(files, pr=pr)
     requirement = _tier_requirement(tier)
+    head_sha = str(pr.get("headRefOid", "") or "").strip()
+    head_committed_at = _head_committed_at_from_pr(pr)
     reviewer_signals = _reviewer_signals_from_protocol(protocol)
-    reviewer_signals.extend(_model_review_signals_from_comments(pr.get("comments") or []))
-    dogfood_evidence = _dogfood_evidence_from_comments(pr.get("comments") or [])
+    reviewer_signals.extend(
+        _model_review_signals_from_comments(
+            pr.get("comments") or [],
+            head_sha=head_sha,
+            head_committed_at=head_committed_at,
+        )
+    )
+    dogfood_evidence = _dogfood_evidence_from_comments(
+        pr.get("comments") or [],
+        head_sha=head_sha,
+        head_committed_at=head_committed_at,
+    )
     dissenting_views = [
         view for view in (protocol.get("dissenting_views") or []) if isinstance(view, dict)
     ]
@@ -1366,6 +1379,35 @@ def _counted_model_reviewer_ids(
     return sorted(reviewer_ids)
 
 
+def _head_committed_at_from_pr(pr: dict[str, Any]) -> str:
+    """Return the ``committedDate`` of the PR head commit, or ``""``.
+
+    Used to anchor comment-based quorum signals to the current head
+    SHA per the "grounded in the current head SHA" requirement of
+    ``docs/REVIEW_AUTHORITY_PRINCIPLES.md``.  Falls back to the most
+    recent ``committedDate`` in the commits list when the head SHA
+    is not separately matched, and returns ``""`` when the PR fetch
+    did not include commit metadata (no-op for legacy callers).
+    """
+    head_sha = str(pr.get("headRefOid", "") or "").strip()
+    commits = pr.get("commits") or []
+    if not isinstance(commits, list):
+        return ""
+    latest_committed_at = ""
+    for entry in commits:
+        if not isinstance(entry, dict):
+            continue
+        committed_at = str(entry.get("committedDate", "") or "").strip()
+        if not committed_at:
+            continue
+        oid = str(entry.get("oid", "") or "").strip()
+        if head_sha and oid == head_sha:
+            return committed_at
+        if committed_at > latest_committed_at:
+            latest_committed_at = committed_at
+    return latest_committed_at
+
+
 def _known_model_reviewer_id(item: dict[str, Any]) -> str:
     provider = str(item.get("provider", "") or "")
     reviewer_id = str(item.get("reviewer_id", "") or "")
@@ -1396,10 +1438,17 @@ def _normalize_model_reviewer_id(value: str) -> str:
     return ""
 
 
-def _dogfood_evidence_from_comments(comments: list[Any]) -> list[dict[str, str]]:
+def _dogfood_evidence_from_comments(
+    comments: list[Any],
+    *,
+    head_sha: str = "",
+    head_committed_at: str = "",
+) -> list[dict[str, str]]:
     evidence: list[dict[str, str]] = []
     for comment in comments:
         if not isinstance(comment, dict):
+            continue
+        if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
             continue
         body = str(comment.get("body", "") or "")
         lower = body.lower()
@@ -1423,10 +1472,17 @@ def _dogfood_evidence_from_comments(comments: list[Any]) -> list[dict[str, str]]
     return evidence[:5]
 
 
-def _model_review_signals_from_comments(comments: list[Any]) -> list[dict[str, str]]:
+def _model_review_signals_from_comments(
+    comments: list[Any],
+    *,
+    head_sha: str = "",
+    head_committed_at: str = "",
+) -> list[dict[str, str]]:
     signals: list[dict[str, str]] = []
     for comment in comments:
         if not isinstance(comment, dict):
+            continue
+        if not _is_comment_grounded_on_head(comment, head_sha, head_committed_at):
             continue
         body = str(comment.get("body", "") or "")
         lower = body.lower()
@@ -1464,11 +1520,65 @@ def _model_review_signals_from_comments(comments: list[Any]) -> list[dict[str, s
 
 
 def _infer_model_reviewer_from_text(text: str) -> str:
-    lower = text.lower()
+    """Infer the reviewing model from a comment body.
+
+    Restricts the substring match to a *structured* marker — the first
+    markdown heading line, falling back to the first 200 characters of
+    the body when no heading is present.  This avoids false positives
+    where a model name appears as a substring deep in the body, for
+    example ``codex/some-branch`` in a quoted git command or
+    ``claude-mem`` in a file path.  Reviewers conventionally announce
+    their identity in the comment's first heading.
+    """
+    candidate = ""
+    for line in str(text).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            candidate = stripped.lstrip("#").strip()
+            if candidate:
+                break
+    if not candidate:
+        candidate = str(text)[:200]
+    lower = candidate.lower()
     for name in ("claude", "codex", "tesla", "harvey", "factory", "grok", "gemini"):
         if name in lower:
             return name
     return "unknown_model_reviewer"
+
+
+def _is_comment_grounded_on_head(
+    comment: dict[str, Any],
+    head_sha: str,
+    head_committed_at: str,
+) -> bool:
+    """Return True when *comment* plausibly reviewed the current head.
+
+    Implements the "grounded in the current head SHA" requirement of
+    ``docs/REVIEW_AUTHORITY_PRINCIPLES.md``.  A comment is accepted when
+    any of:
+
+    * the caller did not supply head metadata (no-op for legacy paths);
+    * the comment was posted at or after the head commit's timestamp;
+    * the comment body explicitly cites the head SHA prefix (>= 7 chars).
+
+    A comment whose ``createdAt`` predates the head commit and which
+    does not cite the head SHA is treated as stale (it reviewed a
+    superseded version of the diff) and excluded from quorum counting.
+    """
+    if not head_sha or not head_committed_at:
+        return True
+    body = str(comment.get("body", "") or "")
+    head_short = head_sha[:7]
+    if head_short and head_short in body:
+        return True
+    created = str(comment.get("createdAt", "") or "")
+    if not created:
+        # No timestamp on the comment — fall back to SHA-prefix evidence.
+        # We have already established head_sha is set; absence of a
+        # citation in body means the reviewer cannot be proven to have
+        # seen this head, so the comment is treated as stale.
+        return False
+    return created >= head_committed_at
 
 
 def _first_nonempty_line(text: str) -> str:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1124,6 +1124,7 @@ def _build_merge_authorization_packet(
             "unresolved_dissent": quorum["unresolved_dissent"],
             "reviewer_signals": quorum["reviewer_signals"],
             "dogfood_evidence": quorum["dogfood_evidence"],
+            "counted_reviewer_ids": quorum["counted_reviewer_ids"],
             "reasons": quorum["reasons"],
         }
         entries.append(entry)
@@ -1177,8 +1178,11 @@ def _build_model_review_quorum(
     ]
     blocking_workflow_state = _has_blocking_workflow_state(pr)
     unresolved_dissent = bool(dissenting_views)
-    signal_count = len(reviewer_signals) + len(dogfood_evidence)
-    has_required_dogfood = not requirement["requires_adversarial_dogfood"] or bool(dogfood_evidence)
+    counted_reviewer_ids = _counted_model_reviewer_ids(reviewer_signals, dogfood_evidence)
+    signal_count = len(counted_reviewer_ids)
+    has_required_dogfood = not requirement["requires_adversarial_dogfood"] or any(
+        _known_model_reviewer_id(item) for item in dogfood_evidence
+    )
     quorum_satisfied = (
         signal_count >= requirement["required_model_signals"] and has_required_dogfood
     )
@@ -1242,6 +1246,7 @@ def _build_model_review_quorum(
         "verdict": verdict,
         "reviewer_signals": reviewer_signals,
         "dogfood_evidence": dogfood_evidence,
+        "counted_reviewer_ids": counted_reviewer_ids,
         "dissenting_views": dissenting_views,
         "unresolved_dissent": unresolved_dissent,
         "reasons": reasons,
@@ -1347,6 +1352,48 @@ def _reviewer_signals_from_protocol(protocol: dict[str, Any]) -> list[dict[str, 
             }
         )
     return signals
+
+
+def _counted_model_reviewer_ids(
+    reviewer_signals: list[dict[str, Any]],
+    dogfood_evidence: list[dict[str, str]],
+) -> list[str]:
+    reviewer_ids: set[str] = set()
+    for item in [*reviewer_signals, *dogfood_evidence]:
+        reviewer_id = _known_model_reviewer_id(item)
+        if reviewer_id:
+            reviewer_ids.add(reviewer_id)
+    return sorted(reviewer_ids)
+
+
+def _known_model_reviewer_id(item: dict[str, Any]) -> str:
+    provider = str(item.get("provider", "") or "")
+    reviewer_id = str(item.get("reviewer_id", "") or "")
+    return _normalize_model_reviewer_id(provider) or _normalize_model_reviewer_id(reviewer_id)
+
+
+def _normalize_model_reviewer_id(value: str) -> str:
+    lower = str(value).lower()
+    if not lower or "unknown_model_reviewer" in lower:
+        return ""
+    known_markers = (
+        ("claude", ("claude", "anthropic")),
+        ("codex", ("codex",)),
+        ("openai", ("openai", "gpt")),
+        ("grok", ("grok", "xai")),
+        ("gemini", ("gemini", "google")),
+        ("mistral", ("mistral", "codestral")),
+        ("deepseek", ("deepseek",)),
+        ("qwen", ("qwen",)),
+        ("kimi", ("kimi", "moonshot")),
+        ("tesla", ("tesla",)),
+        ("harvey", ("harvey",)),
+        ("factory", ("factory",)),
+    )
+    for normalized, markers in known_markers:
+        if any(marker in lower for marker in markers):
+            return normalized
+    return ""
 
 
 def _dogfood_evidence_from_comments(comments: list[Any]) -> list[dict[str, str]]:
@@ -1832,9 +1879,11 @@ def _render_packet(packet: ReviewPacket) -> None:
         )
         print(
             "  signals: "
-            f"{len(quorum.get('reviewer_signals') or []) + len(quorum.get('dogfood_evidence') or [])}/"
+            f"{len(quorum.get('counted_reviewer_ids') or [])}/"
             f"{quorum.get('required_model_signals', 0)}"
         )
+        if quorum.get("counted_reviewer_ids"):
+            print(f"  counted reviewers: {', '.join(quorum.get('counted_reviewer_ids') or [])}")
         if quorum.get("unresolved_dissent"):
             print("  unresolved dissent: true")
         for reason in quorum.get("reasons") or []:
@@ -1914,7 +1963,8 @@ def _render_merge_authorization_packet(packet: dict[str, Any]) -> None:
         print(
             "  evidence: "
             f"{len(entry.get('reviewer_signals') or [])} reviewer signal(s), "
-            f"{len(entry.get('dogfood_evidence') or [])} dogfood note(s)"
+            f"{len(entry.get('dogfood_evidence') or [])} dogfood note(s), "
+            f"{len(entry.get('counted_reviewer_ids') or [])} counted reviewer(s)"
         )
         for reason in entry.get("reasons") or []:
             print(f"  - {reason}")

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -1170,6 +1170,7 @@ def _build_model_review_quorum(
     tier, tier_name, tier_reason = _classify_model_review_tier(files, pr=pr)
     requirement = _tier_requirement(tier)
     reviewer_signals = _reviewer_signals_from_protocol(protocol)
+    reviewer_signals.extend(_model_review_signals_from_comments(pr.get("comments") or []))
     dogfood_evidence = _dogfood_evidence_from_comments(pr.get("comments") or [])
     dissenting_views = [
         view for view in (protocol.get("dissenting_views") or []) if isinstance(view, dict)
@@ -1373,6 +1374,46 @@ def _dogfood_evidence_from_comments(comments: list[Any]) -> list[dict[str, str]]
             }
         )
     return evidence[:5]
+
+
+def _model_review_signals_from_comments(comments: list[Any]) -> list[dict[str, str]]:
+    signals: list[dict[str, str]] = []
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        body = str(comment.get("body", "") or "")
+        lower = body.lower()
+        if not any(
+            token in lower
+            for token in (
+                "codex review",
+                "claude review",
+                "grok independent",
+                "gemini independent",
+                "independent semantic review",
+                "independent model review",
+                "model-family semantic signal",
+            )
+        ):
+            continue
+        reviewer = _infer_model_reviewer_from_text(body)
+        if reviewer == "unknown_model_reviewer":
+            continue
+        author_payload = comment.get("author")
+        github_author = ""
+        if isinstance(author_payload, dict):
+            github_author = str(author_payload.get("login", "") or "")
+        if github_author == "github-actions":
+            continue
+        signals.append(
+            {
+                "reviewer_id": reviewer,
+                "provider": reviewer,
+                "source": "pr_comment",
+                "summary": _first_nonempty_line(body)[:240],
+            }
+        )
+    return signals[:5]
 
 
 def _infer_model_reviewer_from_text(text: str) -> str:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1422,6 +1422,11 @@ def _add_review_queue_parser(subparsers) -> None:
         help="GitHub repo slug override (owner/name). Defaults to current repo context.",
     )
     packet_parser.add_argument(
+        "--execute-reviewers",
+        action="store_true",
+        help="Attempt one bounded live heterogeneous reviewer pass.",
+    )
+    packet_parser.add_argument(
         "--json",
         dest="json_output",
         action="store_true",
@@ -1533,6 +1538,42 @@ def _add_review_queue_parser(subparsers) -> None:
         help="Output the BaselineMeasurement + ThresholdProposal as JSON.",
     )
     baseline_parser.set_defaults(
+        func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue")
+    )
+
+    merge_packet_parser = queue_subparsers.add_parser(
+        "merge-packet",
+        help="Print a model-quorum merge authorization packet for a PR batch",
+    )
+    merge_packet_parser.add_argument(
+        "--limit",
+        type=int,
+        default=30,
+        help="Max open PRs to inspect when --pr is not supplied",
+    )
+    merge_packet_parser.add_argument(
+        "--pr",
+        action="append",
+        default=[],
+        help="Specific PR number/ref to include. Repeatable. Defaults to open queue.",
+    )
+    merge_packet_parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo slug override (owner/name). Defaults to current repo context.",
+    )
+    merge_packet_parser.add_argument(
+        "--execute-reviewers",
+        action="store_true",
+        help="Attempt live heterogeneous reviewer execution for each packet.",
+    )
+    merge_packet_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output as JSON",
+    )
+    merge_packet_parser.set_defaults(
         func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue")
     )
 

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -109,7 +109,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `packet`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `merge-packet`, `packet`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/docs/REVIEW_AUTHORITY_PRINCIPLES.md
+++ b/docs/REVIEW_AUTHORITY_PRINCIPLES.md
@@ -2,12 +2,35 @@
 
 Review authority in Aragora rests on four factors: competence, independence, accountability, and stake. An approval matters only when the approver can judge the change, is not merely echoing the system being judged, bears responsibility for the outcome, and is exposed to the consequences of being wrong.
 
-This document describes the principles underlying current review authority. It does not authorize any change to current human-settlement requirements. Any future adjustment to approver authority requires a separate design proposal, explicit founder sign-off, and demonstrated calibration evidence from post-merge outcomes, not citation of this document.
+This document describes the principles underlying current review authority. It does not authorize bot-only GitHub approvals. It does authorize a narrower distinction that is now operationally important: a heterogeneous model quorum can provide the technical review evidence for routine, reversible PRs, while the human/operator remains the accountable risk settler for strategy, high-impact, irreversible, or low-confidence decisions.
 
 Competence in this repo has two forms. Object-level competence is direct judgment about code, tests, and failure modes in a specific diff. Governance competence is judgment about the evidence around a diff: whether the scope is bounded, whether validation is credible, whether competing analyses agree, and whether the claimed risk matches the actual change. Aragora uses both forms. The system prepares evidence, but settlement still depends on a reviewer who can cash that evidence out into a real decision.
 
-The founder role in this workflow is governance competence plus accountability and stake, not object-level competence on every line of every PR. That role is still real. It is the place where bounded evidence, receipts, and competing analysis become an accepted or rejected risk.
+The founder role in this workflow is governance competence plus accountability and stake, not object-level competence on every line of every PR. That role is still real. It is the place where bounded evidence, receipts, and competing analysis become an accepted or rejected risk. A founder settlement can therefore be batch-level risk acceptance when the technical packet is strong enough; it does not need to be a duplicative line-by-line code review.
 
-Current AI reviewers in this codebase have not demonstrated sufficient calibration for authority expansion. They are useful for summarizing diffs, surfacing risks, checking consistency, and preparing packets, but they do not currently replace human settlement in Aragora's live review path. This document is not a path to reducing human settlement.
+Current AI reviewers in this codebase have not demonstrated sufficient calibration to replace human risk settlement for escalated classes. They are, however, the right technical reviewers for routine bounded work when they are heterogeneous, independent of the authoring lane, grounded in the current head SHA, and adversarial enough to preserve dissent. The packet must show the quorum, not merely assert it.
+
+## Model Review Quorum
+
+A model review quorum is satisfied only when the review artifact records:
+
+- the exact PR head SHA reviewed
+- reviewer/model identities or provider families
+- whether the reviewer was independent from the authoring lane
+- the recommendation and any dissent
+- concrete validation or dogfood evidence
+- the merge tier and resulting settlement requirement
+
+Machine reviews remain advisory in GitHub terms: they do not become bot `APPROVE` reviews. For low-risk tiers, a receipt-backed model quorum can make admin squash a documented settlement action instead of an ad hoc bypass. For high-risk tiers, the same quorum prepares the risk packet, but the human still explicitly accepts or rejects the risk before merge.
+
+## Merge Tiers
+
+| Tier | Class | Requirement | Settlement |
+| --- | --- | --- | --- |
+| 0 | Docs-only, tests-only, status/report PRs | Green required checks plus 1 independent model review or dogfood note | Admin squash allowed |
+| 1 | Additive internal code with no live caller and no persistence/security/public API effect | Green checks plus 2 model signals, at least one adversarial or dogfood signal | Admin squash allowed |
+| 2 | Live automation, CLI, observability, retry/cache behavior | Green checks plus 2 heterogeneous model signals, focused dogfood, and no unresolved dissent | Admin squash allowed |
+| 3 | Semantic correctness, persistence, reputation, security/RBAC/auth, public API, SDK, migrations | Model quorum plus explicit human risk settlement | Human risk acceptance required |
+| 4 | Secrets, deployment, workflow policy, destructive operations, legal/compliance, irreversible data changes | Human approval before implementation and before merge | Human preapproval required |
 
 These principles fit the repo's existing pillars rather than adding new ones. Receipts bind decisions to the exact reviewed state. Evidence-first review requires concrete validation and current-head truth before a merge decision is meaningful. Bounded scope keeps approvals legible enough that an approver can understand what is being accepted. The goal is not symbolic human presence. The goal is a reviewer with enough competence, independence, accountability, and stake to make the approval mean something.

--- a/docs/briefs/automation-merge-contract.md
+++ b/docs/briefs/automation-merge-contract.md
@@ -52,8 +52,27 @@ Automation PRs are merge candidates only when:
 - there is no duplicate open PR for the same issue or branch
 - any cross-host retry consumed the prior repair journal or explicitly explains why it ignored it
 - generated artifacts and local coordination files are absent from the branch
+- the PR has a current-head review packet whose model-review-quorum block satisfies the required merge tier
 
 If any gate fails, the next useful action is a repair attempt with the failure output in the handoff envelope, not another fresh worker staring at the same repo state.
+
+### Model Review Quorum + Human Risk Settlement
+
+Human review in this repo is risk settlement, not a requirement that the operator personally out-review specialist models on every line of code. Heterogeneous model review is the technical review authority for routine, reversible work when the receipt shows enough evidence.
+
+Use these tiers:
+
+| Tier | Class | Required evidence | Merge posture |
+| --- | --- | --- | --- |
+| 0 | Docs-only, tests-only, status/report PRs | Green required checks plus 1 independent model review or dogfood note | Admin squash allowed |
+| 1 | Additive internal code with no live caller and no persistence/security/public API effect | Green checks plus 2 model signals, at least one adversarial or dogfood signal | Admin squash allowed |
+| 2 | Live automation, CLI, observability, retry/cache behavior | Green checks plus 2 heterogeneous model signals, focused dogfood, and no unresolved dissent | Admin squash allowed |
+| 3 | Semantic correctness, persistence, reputation, security/RBAC/auth, public API, SDK, migrations | Model quorum plus explicit human risk settlement | Human risk acceptance required |
+| 4 | Secrets, deployment, workflow policy, destructive operations, legal/compliance, irreversible data changes | Human approval before implementation and before merge | Human preapproval required |
+
+Admin squash is allowed for Tier 0-2 only when the packet is bound to the current head SHA, required checks are green, and the `model_review_quorum` verdict is `admin_squash_allowed`. This is a documented settlement path, not a hidden bot approval. GitHub machine reviews remain advisory comments; do not make model output count as a bot `APPROVE` review.
+
+For Tier 3+, the model quorum prepares the risk packet. The human/operator accepts or rejects the risk at the batch or PR level. They are not expected to perform duplicative object-level line review unless the packet flags unresolved dissent, missing evidence, or a risk they want to inspect directly.
 
 ## Required vs Advisory Checks
 
@@ -72,6 +91,16 @@ Use a fast lane for docs-only, tests-only, and narrow CI reliability PRs: if the
 ## Queue Hygiene
 
 High-churn automation loses throughput when multiple branches compete for the same issue or when stale PRs keep requesting review. Before opening or merging another PR, check for duplicate open PRs, dirty draft branches, and obsolete salvage branches for the same task. Close, draft, or supersede stale PRs with a short comment that names the replacement branch or next repair action.
+
+When the open PR queue exceeds 6 PRs, mutating agents must stop opening new implementation PRs. Allowed work while the cap is exceeded:
+
+- review existing PRs
+- dogfood existing PRs
+- fix blockers on already-open PRs
+- write local/spec-only notes
+- prepare one merge authorization packet
+
+This cap protects operator attention. Additional agent capacity is not useful if it turns into more unmerged work.
 
 ## Publish Bridge
 

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -104,7 +104,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `packet`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `merge-packet`, `packet`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -435,6 +435,8 @@ class TestModelReviewQuorum:
             (["aragora/agents/router.py"], 1),
             (["aragora/cli/commands/review_queue.py"], 2),
             (["scripts/publish_automation_handoffs.py"], 2),
+            (["aragora/metrics/manifold_brier.py"], 3),
+            (["aragora/debate/team_selector.py"], 3),
             (["aragora/reputation/store.py"], 3),
             (["aragora/auth/session.py"], 3),
             (["sdk/typescript/src/index.ts"], 3),
@@ -445,6 +447,23 @@ class TestModelReviewQuorum:
     def test_classifies_merge_tiers(self, files: list[str], expected_tier: int) -> None:
         tier, _, _ = _classify_model_review_tier(files, pr=_make_pr(files=files))
         assert tier == expected_tier
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "[AGT-03] Calibration curve reporting for ManifoldBrierScorer",
+            "[AGT-05] Wire enable_agt05_reputation_selection into TeamSelectionConfig",
+            "fix: semantic scoring correction",
+        ],
+    )
+    def test_classifies_semantic_titles_as_tier_three(self, title: str) -> None:
+        files = ["aragora/agents/router.py"]
+        tier, _, reason = _classify_model_review_tier(
+            files,
+            pr=_make_pr(title=title, files=files),
+        )
+        assert tier == 3
+        assert "semantic" in reason
 
     def test_tier_zero_satisfied_by_one_dogfood_note(self) -> None:
         pr = _make_pr(files=["docs/status/report.md"])

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -585,6 +585,174 @@ class TestModelReviewQuorum:
         assert quorum["counted_reviewer_ids"] == ["grok"]
         assert "focused adversarial dogfood evidence is required" in quorum["reasons"]
 
+    def test_branch_name_substring_in_body_does_not_phantom_tag_reviewer(self) -> None:
+        """A comment that mentions ``codex/...`` branch in a code block but
+        has no model-review heading must not be tagged as a Codex signal."""
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["comments"] = [
+            _dogfood_comment("## Codex focused dogfood\nlocal checks pass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    "## Rebased over current main after queue drain\n"
+                    "Rebased `codex/model-review-quorum-settlement` onto current "
+                    "`origin/main` after #6783 and #6787 merged.\n"
+                    "Conflict resolution kept both parser surfaces:\n"
+                    "- `review-queue baseline` from #6783\n"
+                    "- `review-queue merge-packet` from this PR\n"
+                ),
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        # The rebase note's heading does not contain a model name.  The
+        # heuristic must NOT scan the entire body and pick up the branch
+        # name ``codex/...`` in line 2 of the body.
+        assert quorum["counted_reviewer_ids"] == ["codex"]
+        # The dogfood evidence list should still include both comments
+        # (the rebase note matches "rebased" → not a marker; "drain"
+        # → not a marker; but the body does not actually contain any
+        # of dogfood/adversarial/cross-author/recheck), so it is not
+        # added to dogfood_evidence at all.
+        dogfood_authors = [entry.get("reviewer_id") for entry in quorum["dogfood_evidence"]]
+        assert "codex" in dogfood_authors
+        # Ensure the rebase note didn't sneak into reviewer_signals.
+        for sig in quorum["reviewer_signals"]:
+            assert "rebase" not in (sig.get("summary", "") or "").lower()
+
+    def test_inferrer_uses_first_heading_only(self) -> None:
+        """If a comment's first heading does not name a model, the
+        inferrer must fall back to first 200 chars and NOT scan the
+        entire body."""
+        from aragora.cli.commands.review_queue import _infer_model_reviewer_from_text
+
+        body_with_phantom_codex_deep_in_body = (
+            "## Cross-author adversarial dogfood (no model named in heading)\n"
+            "Local checks pass.\n\n"
+            + ("Filler line that does not name any model.\n" * 30)
+            + "Reference: https://github.com/example/repo/blob/main/codex/x.py\n"
+        )
+        # No model name in heading or first 200 chars → unknown.
+        assert (
+            _infer_model_reviewer_from_text(body_with_phantom_codex_deep_in_body)
+            == "unknown_model_reviewer"
+        )
+
+        body_with_codex_heading = "## Codex review\nVerdict: approve.\n"
+        assert _infer_model_reviewer_from_text(body_with_codex_heading) == "codex"
+
+        body_with_grok_in_lead = (
+            "Grok independent semantic review of head SHA abc1234.\n"
+            "No heading present; relying on first-200-chars fallback.\n"
+        )
+        assert _infer_model_reviewer_from_text(body_with_grok_in_lead) == "grok"
+
+    def test_stale_comments_excluded_when_predate_head_commit(self) -> None:
+        """Comments posted before the current head was committed must
+        be excluded from quorum unless they explicitly cite the head SHA."""
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            # Posted BEFORE the head was committed → stale.
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Codex focused dogfood\nlocal checks pass",
+                "createdAt": "2026-04-28T18:00:00Z",
+            },
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+                "createdAt": "2026-04-28T18:30:00Z",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        # Both stale → quorum empty.
+        assert quorum["counted_reviewer_ids"] == []
+        assert quorum["status"] == "needs_model_review_quorum"
+
+    def test_fresh_comments_after_head_commit_count(self) -> None:
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Codex focused dogfood\nlocal checks pass",
+                "createdAt": "2026-04-28T20:05:00Z",
+            },
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+                "createdAt": "2026-04-28T20:10:00Z",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == ["codex", "grok"]
+        assert quorum["status"] == "satisfied"
+
+    def test_stale_comment_with_head_sha_citation_still_counts(self) -> None:
+        """A reviewer who explicitly cites the current head SHA in
+        their body counts even if their createdAt predates the head."""
+        head_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["headRefOid"] = head_sha
+        pr["commits"] = [
+            {"oid": head_sha, "committedDate": "2026-04-28T20:00:00Z"},
+        ]
+        pr["comments"] = [
+            # Predates head BUT cites head SHA → grounded.
+            {
+                "author": {"login": "an0mium"},
+                "body": (
+                    f"## Codex focused dogfood\n"
+                    f"Reviewed at head {head_sha[:7]} – local checks pass."
+                ),
+                "createdAt": "2026-04-28T18:00:00Z",
+            },
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+                "createdAt": "2026-04-28T20:10:00Z",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["counted_reviewer_ids"] == ["codex", "grok"]
+        assert quorum["status"] == "satisfied"
+
     def test_unresolved_dissent_forces_human_risk_settlement(self) -> None:
         pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
         pr["comments"] = [_dogfood_comment()]

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -570,6 +570,51 @@ class TestModelReviewQuorum:
         assert quorum["admin_squash_allowed"] is False
         assert quorum["requires_human_risk_settlement"] is True
 
+    def test_independent_model_review_comment_counts_as_quorum_signal(self) -> None:
+        pr = _make_pr(files=["aragora/debate/team_selector.py"])
+        pr["comments"] = [
+            _dogfood_comment("## Codex focused dogfood\n10/10 pass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent semantic review\nVerdict: approve after human risk settlement.",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/debate/team_selector.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["tier"] == 3
+        assert quorum["status"] == "human_risk_settlement_required"
+        assert len(quorum["reviewer_signals"]) == 1
+        assert quorum["reviewer_signals"][0]["reviewer_id"] == "grok"
+        assert len(quorum["dogfood_evidence"]) == 1
+
+    def test_github_actions_advisory_review_does_not_count_as_model_signal(self) -> None:
+        pr = _make_pr(files=["aragora/debate/team_selector.py"])
+        pr["comments"] = [
+            _dogfood_comment("## Codex focused dogfood\n10/10 pass"),
+            {
+                "author": {"login": "github-actions"},
+                "body": "## Aragora Code Review\n\nAdvisory-only review. No issues found.",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/debate/team_selector.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["tier"] == 3
+        assert quorum["status"] == "needs_model_review_quorum"
+        assert len(quorum["reviewer_signals"]) == 0
+        assert len(quorum["dogfood_evidence"]) == 1
+
 
 # --- _parse_pr_number ------------------------------------------------------
 

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -15,12 +15,16 @@ from aragora.cli.commands.review_queue import (
     ADVISORY_NOTE,
     HIGH_RISK_PATHS,
     LARGE_DIFF_THRESHOLD,
+    MODEL_REVIEW_QUEUE_CAP,
     PARKED_LABELS,
     QueueItem,
     ReviewPacket,
+    _build_merge_authorization_packet,
+    _build_model_review_quorum,
     _build_packet,
     _build_queue,
     _classify_pr,
+    _classify_model_review_tier,
     _extract_validation_commands,
     _filter_lanes,
     _GhError,
@@ -127,6 +131,35 @@ def _make_reviewer_output(
         latency_ms=100,
         cost_usd=0.2,
     )
+
+
+def _dogfood_comment(body: str = "## Cross-author adversarial dogfood\n6/6 pass") -> dict[str, Any]:
+    return {"author": {"login": "an0mium"}, "body": body}
+
+
+def _executed_protocol(*, dissent: bool = False) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": EXECUTED_PROTOCOL_STATUS,
+        "validation_summary": {
+            "reviewer_execution": {
+                "status": EXECUTED_PROTOCOL_STATUS,
+                "reviewer_count": 3,
+                "reviewer_ids": ["claude:logic", "openai-api:security", "gemini:maintainability"],
+                "providers": ["claude", "openai-api", "gemini"],
+                "dissent_count": 1 if dissent else 0,
+            }
+        },
+        "dissenting_views": [],
+    }
+    if dissent:
+        payload["dissenting_views"] = [
+            {
+                "agent": "openai-api:security",
+                "position": "request_changes",
+                "reason": "security reviewer found a blocker",
+            }
+        ]
+    return payload
 
 
 # --- _summarize_checks -----------------------------------------------------
@@ -389,6 +422,136 @@ class TestSubsystemAndRisk:
         assert not _is_high_risk_path("tests/cli/commands/test_review_queue.py")
 
 
+# --- model-review tier + quorum -------------------------------------------
+
+
+class TestModelReviewQuorum:
+    @pytest.mark.parametrize(
+        ("files", "expected_tier"),
+        [
+            (["docs/status/queue.md"], 0),
+            (["tests/swarm/test_handoff_contract.py"], 0),
+            (["AGENTS.md", "CLAUDE.md", "docs/COORDINATION.md"], 0),
+            (["aragora/agents/router.py"], 1),
+            (["aragora/cli/commands/review_queue.py"], 2),
+            (["scripts/publish_automation_handoffs.py"], 2),
+            (["aragora/reputation/store.py"], 3),
+            (["aragora/auth/session.py"], 3),
+            (["sdk/typescript/src/index.ts"], 3),
+            ([".github/workflows/tests.yml"], 4),
+            (["deploy/k8s/app.yaml"], 4),
+        ],
+    )
+    def test_classifies_merge_tiers(self, files: list[str], expected_tier: int) -> None:
+        tier, _, _ = _classify_model_review_tier(files, pr=_make_pr(files=files))
+        assert tier == expected_tier
+
+    def test_tier_zero_satisfied_by_one_dogfood_note(self) -> None:
+        pr = _make_pr(files=["docs/status/report.md"])
+        pr["comments"] = [_dogfood_comment()]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["docs/status/report.md"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["tier"] == 0
+        assert quorum["status"] == "satisfied"
+        assert quorum["admin_squash_allowed"] is True
+
+    def test_tier_two_requires_dogfood_even_with_executed_reviewers(self) -> None:
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["comments"] = []
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol=_executed_protocol(),
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["tier"] == 2
+        assert quorum["status"] == "needs_model_review_quorum"
+        assert quorum["admin_squash_allowed"] is False
+        assert "focused adversarial dogfood evidence is required" in quorum["reasons"]
+
+    def test_tier_two_allows_admin_squash_when_quorum_and_dogfood_clean(self) -> None:
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["comments"] = [_dogfood_comment()]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol=_executed_protocol(),
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["status"] == "satisfied"
+        assert quorum["verdict"] == "admin_squash_allowed"
+        assert quorum["admin_squash_allowed"] is True
+
+    def test_unresolved_dissent_forces_human_risk_settlement(self) -> None:
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["comments"] = [_dogfood_comment()]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol=_executed_protocol(dissent=True),
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["status"] == "unresolved_dissent"
+        assert quorum["requires_human_risk_settlement"] is True
+        assert quorum["admin_squash_allowed"] is False
+
+    def test_needs_attention_risk_signal_can_still_admin_squash_when_quorum_clean(self) -> None:
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["comments"] = [_dogfood_comment()]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol=_executed_protocol(),
+            machine_recommendation="needs_human_attention",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["status"] == "satisfied"
+        assert quorum["admin_squash_allowed"] is True
+
+    def test_draft_state_blocks_settlement_even_with_quorum(self) -> None:
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"], is_draft=True)
+        pr["comments"] = [_dogfood_comment()]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol=_executed_protocol(),
+            machine_recommendation="needs_human_attention",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["status"] == "repair_or_wait"
+        assert quorum["admin_squash_allowed"] is False
+
+    def test_tier_three_never_admin_squashes_without_human_risk_settlement(self) -> None:
+        pr = _make_pr(files=["aragora/reputation/store.py"])
+        pr["comments"] = [_dogfood_comment()]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/reputation/store.py"],
+            protocol=_executed_protocol(),
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["tier"] == 3
+        assert quorum["status"] == "human_risk_settlement_required"
+        assert quorum["admin_squash_allowed"] is False
+        assert quorum["requires_human_risk_settlement"] is True
+
+
 # --- _parse_pr_number ------------------------------------------------------
 
 
@@ -488,6 +651,8 @@ class TestBuildQueueAndPacket:
         assert packet.protocol["binding"]["base_sha"] == "basesha0001"
         assert packet.protocol["availability_summary"]["total_slots"] == 5
         assert packet.protocol["recommendation_class"] == "approve_candidate"
+        assert packet.model_review_quorum["tier"] == 2
+        assert packet.model_review_quorum["status"] == "needs_model_review_quorum"
         assert packet.validation == [
             "`python3 -m pytest tests/cli/commands/test_review_pr.py -q`",
             "`bash scripts/automation_pr_preflight.sh origin/main HEAD`",
@@ -642,6 +807,7 @@ class TestBuildQueueAndPacket:
         assert packet.protocol["status"] == EXECUTED_PROTOCOL_STATUS
         assert packet.protocol["validation_summary"]["reviewer_execution"]["reviewer_count"] == 3
         assert len(packet.protocol["dissenting_views"]) == 1
+        assert packet.model_review_quorum["unresolved_dissent"] is True
 
 
 # --- JSON output schema ----------------------------------------------------
@@ -698,6 +864,7 @@ class TestJsonOutput:
             "packet_sha",
             "generated_at",
             "protocol",
+            "model_review_quorum",
             "advisory_only",
             "settlement_note",
         ):
@@ -705,6 +872,7 @@ class TestJsonOutput:
         # ReviewPacket.advisory_only must always be True (signature property).
         assert d["advisory_only"] is True
         assert d["protocol"]["binding"]["repo"] == "synaptent/aragora"
+        assert d["model_review_quorum"]["version"] == "model_review_quorum.v1"
 
     def test_packet_json_round_trip(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
@@ -716,6 +884,7 @@ class TestJsonOutput:
         assert roundtrip["pr_number"] == 1
         assert roundtrip["advisory_only"] is True
         assert roundtrip["protocol"]["protocol_version"] == "pr_review_protocol.v1"
+        assert "model_review_quorum" in roundtrip
 
 
 # --- cmd_review_queue dispatch + parser ------------------------------------
@@ -738,6 +907,10 @@ class TestCommandDispatch:
         assert ns_packet.review_queue_command == "packet"
         assert ns_packet.pr == "6280"
         assert ns_packet.execute_reviewers is True
+        # merge-packet invocation parses
+        ns_merge_packet = root.parse_args(["review-queue", "merge-packet", "--pr", "6280"])
+        assert ns_merge_packet.review_queue_command == "merge-packet"
+        assert ns_merge_packet.pr == ["6280"]
         # run invocation parses
         ns_run = root.parse_args(["review-queue", "run", "--limit", "3", "--ready-only"])
         assert ns_run.review_queue_command == "run"
@@ -1000,6 +1173,74 @@ class TestSettlementHelpers:
         assert payload["pr_number"] == 42
         assert payload["advisory_only"] is True
         assert payload["settlement_note"] == ADVISORY_NOTE
+
+    def test_merge_packet_json_output_with_queue_pressure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        queue = [_classify_pr(_make_pr(number=i)) for i in range(1, MODEL_REVIEW_QUEUE_CAP + 2)]
+
+        def _fake_build_packet(
+            pr_ref: str,
+            *,
+            repo_override: str | None,
+            execute_reviewers: bool = False,
+        ) -> ReviewPacket:
+            return ReviewPacket(
+                pr_number=int(pr_ref),
+                title="bounded docs",
+                url=f"https://github.com/synaptent/aragora/pull/{pr_ref}",
+                head_sha="headsha",
+                base_sha="basesha",
+                author="codex",
+                is_draft=False,
+                additions=1,
+                deletions=1,
+                changed_files=1,
+                queue_bucket="ready_now",
+                touched_subsystems=["docs"],
+                high_risk_paths_touched=[],
+                validation=[],
+                checks_summary="5/5 green",
+                risk_flags=[],
+                machine_recommendation="approve_candidate",
+                machine_recommendation_reason="clean",
+                packet_sha="sha256:test",
+                generated_at="2026-04-28T00:00:00+00:00",
+                model_review_quorum={
+                    "tier": 0,
+                    "tier_name": "tier_0_docs_tests_status",
+                    "status": "satisfied",
+                    "verdict": "admin_squash_allowed",
+                    "admin_squash_allowed": True,
+                    "requires_human_risk_settlement": False,
+                    "unresolved_dissent": False,
+                    "reviewer_signals": [],
+                    "dogfood_evidence": [{"reviewer_id": "claude"}],
+                    "reasons": ["docs/tests/status-only change"],
+                },
+            )
+
+        monkeypatch.setattr("aragora.cli.commands.review_queue._build_queue", lambda limit: queue)
+        monkeypatch.setattr(
+            "aragora.cli.commands.review_queue._build_packet",
+            _fake_build_packet,
+        )
+        ns = argparse.Namespace(
+            review_queue_command="merge-packet",
+            pr=["1"],
+            repo=None,
+            limit=10,
+            execute_reviewers=False,
+            json=True,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_review_queue(ns)
+        assert rc == 0
+        payload = json.loads(buf.getvalue())
+        assert payload["queue_pressure"]["active"] is True
+        assert payload["admin_squash_order"] == [1]
+        assert payload["entries"][0]["verdict"] == "admin_squash_allowed"
 
     def test_act_command_requires_reason_for_request_changes(self) -> None:
         ns = argparse.Namespace(

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -133,7 +133,9 @@ def _make_reviewer_output(
     )
 
 
-def _dogfood_comment(body: str = "## Cross-author adversarial dogfood\n6/6 pass") -> dict[str, Any]:
+def _dogfood_comment(
+    body: str = "## Cross-author adversarial dogfood (Claude)\n6/6 pass",
+) -> dict[str, Any]:
     return {"author": {"login": "an0mium"}, "body": body}
 
 
@@ -510,6 +512,78 @@ class TestModelReviewQuorum:
         assert quorum["status"] == "satisfied"
         assert quorum["verdict"] == "admin_squash_allowed"
         assert quorum["admin_squash_allowed"] is True
+        assert set(quorum["counted_reviewer_ids"]) == {"claude", "gemini", "openai"}
+
+    def test_duplicate_codex_comments_do_not_satisfy_tier_two_quorum(self) -> None:
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["comments"] = [
+            _dogfood_comment("## Codex focused dogfood\nlocal checks pass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Codex review\nLGTM after local dogfood.",
+            },
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Codex review\nSecond same-model note.",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["tier"] == 2
+        assert quorum["status"] == "needs_model_review_quorum"
+        assert quorum["admin_squash_allowed"] is False
+        assert quorum["counted_reviewer_ids"] == ["codex"]
+        assert "model quorum incomplete: 1/2 signal(s)" in quorum["reasons"]
+
+    def test_codex_dogfood_and_grok_review_satisfy_tier_two_quorum(self) -> None:
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["comments"] = [
+            _dogfood_comment("## Codex focused dogfood\nlocal checks pass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["tier"] == 2
+        assert quorum["status"] == "satisfied"
+        assert quorum["admin_squash_allowed"] is True
+        assert quorum["counted_reviewer_ids"] == ["codex", "grok"]
+
+    def test_unknown_dogfood_does_not_count_or_satisfy_required_dogfood(self) -> None:
+        pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
+        pr["comments"] = [
+            _dogfood_comment("## Focused dogfood\nlocal checks pass"),
+            {
+                "author": {"login": "an0mium"},
+                "body": "## Grok independent model review\nVerdict: approve.",
+            },
+        ]
+        quorum = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=False,
+        )
+        assert quorum["tier"] == 2
+        assert quorum["status"] == "needs_model_review_quorum"
+        assert quorum["counted_reviewer_ids"] == ["grok"]
+        assert "focused adversarial dogfood evidence is required" in quorum["reasons"]
 
     def test_unresolved_dissent_forces_human_risk_settlement(self) -> None:
         pr = _make_pr(files=["aragora/cli/commands/review_queue.py"])
@@ -592,6 +666,7 @@ class TestModelReviewQuorum:
         assert len(quorum["reviewer_signals"]) == 1
         assert quorum["reviewer_signals"][0]["reviewer_id"] == "grok"
         assert len(quorum["dogfood_evidence"]) == 1
+        assert quorum["counted_reviewer_ids"] == ["codex", "grok"]
 
     def test_github_actions_advisory_review_does_not_count_as_model_signal(self) -> None:
         pr = _make_pr(files=["aragora/debate/team_selector.py"])
@@ -1280,6 +1355,7 @@ class TestSettlementHelpers:
                     "unresolved_dissent": False,
                     "reviewer_signals": [],
                     "dogfood_evidence": [{"reviewer_id": "claude"}],
+                    "counted_reviewer_ids": ["claude"],
                     "reasons": ["docs/tests/status-only change"],
                 },
             )

--- a/tests/cli/test_parser_lazy_review_pr.py
+++ b/tests/cli/test_parser_lazy_review_pr.py
@@ -152,3 +152,36 @@ def test_build_parser_registers_review_queue_baseline_lazily(monkeypatch):
     assert args.review_queue_root == "/tmp/review-queue"
     assert args.json is True
     assert args.func.__name__ == "cmd_review_queue"
+
+
+def test_build_parser_registers_review_queue_merge_packet_lazily(monkeypatch):
+    sys.modules.pop("aragora.cli.commands.review_queue", None)
+    imported: list[str] = []
+    real_import = builtins.__import__
+
+    def tracking_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "aragora.cli.commands.review_queue":
+            imported.append(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", tracking_import)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "review-queue",
+            "merge-packet",
+            "--pr",
+            "6779",
+            "--execute-reviewers",
+            "--json",
+        ]
+    )
+
+    assert imported == []
+    assert args.command == "review-queue"
+    assert args.review_queue_command == "merge-packet"
+    assert args.pr == ["6779"]
+    assert args.execute_reviewers is True
+    assert args.json_output is True
+    assert args.func.__name__ == "cmd_review_queue"


### PR DESCRIPTION
## Summary

Codifies Model Review Quorum + Human Risk Settlement as a receipt-backed process instead of ad hoc admin bypass.

Adds a `review-queue merge-packet` mode that emits a batch authorization packet with:
- tier classification
- model/dogfood signal extraction from PR comments
- exact head SHA
- check summary
- unresolved-dissent handling
- stale-head rejection hooks
- queue-pressure status
- admin-squash eligibility vs human-risk-settlement gating

Operator review required. No rush.

## Validation

- `python3 -m pytest tests/cli/commands/test_review_queue.py tests/cli/test_parser_lazy_review_pr.py -q` -> 92 passed
- `python3 -m ruff check aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/cli/commands/test_review_queue.py tests/cli/test_parser_lazy_review_pr.py`
- `python3 -m mypy aragora/cli/commands/review_queue.py aragora/cli/parser.py tests/cli/commands/test_review_queue.py tests/cli/test_parser_lazy_review_pr.py`
- `python3 scripts/generate_cli_reference.py --check --check-site`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- pre-push hook passed, including gitleaks and baseline-filtered mypy

## Dogfood

Used locally against the current cascade before opening this PR. It correctly:
- marked low-risk docs/tests/status PRs as admin-squash eligible
- kept semantic AGT PRs out of the Tier 0-2 packet
- flagged queue pressure while open PR count was above 6
- refused under-quorum Tier 2 entries until additional model evidence was available
