### PR TITLE
[AGT-05] DIC-14 claim verifier → reputation bridge (sub-deliverable 3)

### DIFF
--- a/aragora/reputation/__init__.py
+++ b/aragora/reputation/__init__.py
@@ -29,6 +29,7 @@ from aragora.reputation.anchor import (
     enable_anchoring,
 )
 from aragora.reputation.bridge import bridge_from_market_position
+from aragora.reputation.claim_verifier_bridge import bridge_from_claim_result
 from aragora.reputation.crux_bridge import (
     CruxPositionRecord,
     CruxResolutionEvent,
@@ -50,6 +51,7 @@ from aragora.reputation.types import (
     DOMAIN_CODE_PR,
     DOMAIN_CRUX_RESOLUTION,
     DOMAIN_DEBATE_POSITION,
+    DOMAIN_EPISTEMIC_CLAIM,
     DOMAIN_KM_CONTRIBUTION,
     DOMAIN_PREDICTION_MARKET,
     ReputationDelta,
@@ -62,6 +64,7 @@ __all__ = [
     "DOMAIN_CODE_PR",
     "DOMAIN_CRUX_RESOLUTION",
     "DOMAIN_DEBATE_POSITION",
+    "DOMAIN_EPISTEMIC_CLAIM",
     "DOMAIN_KM_CONTRIBUTION",
     "DOMAIN_PREDICTION_MARKET",
     "AnchorError",
@@ -72,6 +75,7 @@ __all__ = [
     "StakeableClaim",
     "anchor_delta",
     "anchoring_enabled",
+    "bridge_from_claim_result",
     "bridge_from_market_position",
     "CruxPositionRecord",
     "CruxResolutionEvent",

--- a/aragora/reputation/claim_verifier_bridge.py
+++ b/aragora/reputation/claim_verifier_bridge.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 _STATUS_TO_OUTCOME: dict[str, ClaimOutcome] = {
     "pass": "yes",
     "fail": "no",
-    "stale": "no",           # stale evidence → treat as verification failure
+    "stale": "no",  # stale evidence → treat as verification failure
     "unsupported": "inconclusive",
     "error": "inconclusive",
 }

--- a/aragora/reputation/claim_verifier_bridge.py
+++ b/aragora/reputation/claim_verifier_bridge.py
@@ -1,0 +1,122 @@
+"""Bridge from DIC-14 ClaimResult to AGT-05 reputation types (AGT-05 #6066).
+
+Converts :class:`aragora.epistemic.claim_verifier.ClaimResult` into a
+(:class:`~aragora.reputation.types.StakeableClaim`,
+:class:`~aragora.reputation.types.ResolvedClaim`) pair for settlement.
+
+Outcome mapping: PASS→"yes", FAIL→"no", STALE→"no", UNSUPPORTED/ERROR→"inconclusive".
+Domain: ``DOMAIN_EPISTEMIC_CLAIM``.  Feature-gated via
+``ARAGORA_REPUTATION_FLOW_ENABLED`` (off by default).
+
+Advances: AGT-05 (#6066) sub-deliverable 3 — DIC-14 claim verifier resolution
+ingestion adapter.  Manifold adapter: :mod:`aragora.reputation.bridge`;
+CruxSet adapter: :mod:`aragora.reputation.crux_bridge`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from aragora.reputation.types import (
+    DOMAIN_EPISTEMIC_CLAIM,
+    ClaimOutcome,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+if TYPE_CHECKING:
+    from aragora.epistemic.claim_verifier import ClaimResult
+
+# Maps DIC-14 ClaimStatus values to AGT-05 ClaimOutcome literals.
+_STATUS_TO_OUTCOME: dict[str, ClaimOutcome] = {
+    "pass": "yes",
+    "fail": "no",
+    "stale": "no",           # stale evidence → treat as verification failure
+    "unsupported": "inconclusive",
+    "error": "inconclusive",
+}
+
+_RESOLUTION_SOURCE = "dic14_claim_verifier"
+
+
+def bridge_from_claim_result(
+    result: "ClaimResult",
+    agent_id: str,
+    *,
+    stake_units: int = 1,
+    resolution_source: str = _RESOLUTION_SOURCE,
+) -> tuple[StakeableClaim, ResolvedClaim]:
+    """Convert a DIC-14 :class:`~aragora.epistemic.claim_verifier.ClaimResult`
+    into an AGT-05 ``(StakeableClaim, ResolvedClaim)`` pair.
+
+    The returned pair feeds directly into
+    :func:`aragora.reputation.settlement.settle_claim`.
+
+    Parameters
+    ----------
+    result:
+        The :class:`~aragora.epistemic.claim_verifier.ClaimResult` returned by
+        :meth:`~aragora.epistemic.claim_verifier.ClaimVerifier.verify_claim`.
+    agent_id:
+        The agent that originally asserted or owns this claim.
+    stake_units:
+        Compute-credit stake committed to this claim assertion.  Minimum 1.
+    resolution_source:
+        Provenance tag.  Defaults to ``"dic14_claim_verifier"``.
+
+    Notes
+    -----
+    The implicit position is always ``"yes"`` — the agent claims the
+    organizational claim *will* pass verification.  The settlement layer
+    then compares this against ``outcome`` to determine the delta.
+    """
+    now = datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+    outcome: ClaimOutcome = _STATUS_TO_OUTCOME.get(result.status.value, "inconclusive")
+
+    stakeable = StakeableClaim.create(
+        agent_id=agent_id,
+        domain=DOMAIN_EPISTEMIC_CLAIM,
+        statement=f"Claim {result.claim_id!r} will pass executable verification",
+        position="yes",
+        stake_units=stake_units,
+        resolution_source=resolution_source,
+        resolution_id=result.claim_id,
+        predicted_probability=None,  # binary claim — no probability needed
+        stake_policy="forfeit_on_loss",
+        provenance=_provenance(result, agent_id, resolution_source),
+        created_at=now,
+    )
+
+    resolved = ResolvedClaim(
+        claim_id=stakeable.claim_id,
+        outcome=outcome,
+        resolved_at=now,
+        resolution_source=resolution_source,
+        evidence=_evidence(result),
+    )
+    return stakeable, resolved
+
+
+def _provenance(
+    result: "ClaimResult",
+    agent_id: str,
+    resolution_source: str,
+) -> dict[str, Any]:
+    return {
+        "claim_id": result.claim_id,
+        "agent_id": agent_id,
+        "source": resolution_source,
+        "severity": result.severity,
+        "allowed_action": result.allowed_action,
+    }
+
+
+def _evidence(result: "ClaimResult") -> dict[str, Any]:
+    return {
+        "claim_id": result.claim_id,
+        "status": result.status.value,
+        "message": result.message,
+        "elapsed_ms": result.elapsed_ms,
+        "detail": dict(result.detail),
+    }

--- a/aragora/reputation/types.py
+++ b/aragora/reputation/types.py
@@ -23,6 +23,7 @@ DOMAIN_DEBATE_POSITION = "debate_position"
 DOMAIN_CODE_PR = "code_pr"
 DOMAIN_KM_CONTRIBUTION = "km_contribution"
 DOMAIN_CRUX_RESOLUTION = "crux_resolution"
+DOMAIN_EPISTEMIC_CLAIM = "epistemic_claim"  # DIC-14 claim verifier → AGT-05 bridge
 
 KNOWN_DOMAINS = frozenset(
     {
@@ -31,6 +32,7 @@ KNOWN_DOMAINS = frozenset(
         DOMAIN_CODE_PR,
         DOMAIN_KM_CONTRIBUTION,
         DOMAIN_CRUX_RESOLUTION,
+        DOMAIN_EPISTEMIC_CLAIM,
     }
 )
 

--- a/tests/reputation/test_claim_verifier_bridge.py
+++ b/tests/reputation/test_claim_verifier_bridge.py
@@ -1,0 +1,167 @@
+"""Tests for aragora.reputation.claim_verifier_bridge (AGT-05 #6066).
+
+Verifies that bridge_from_claim_result converts every ClaimStatus value
+to the correct AGT-05 ClaimOutcome, populates provenance correctly, and
+produces claim_ids that are stable across calls with the same inputs.
+
+No network dependency; all ClaimResult objects are constructed directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus
+from aragora.reputation.claim_verifier_bridge import bridge_from_claim_result
+from aragora.reputation.types import (
+    DOMAIN_EPISTEMIC_CLAIM,
+    ResolvedClaim,
+    StakeableClaim,
+)
+
+
+def _make_result(
+    claim_id: str,
+    status: ClaimStatus,
+    *,
+    message: str = "ok",
+    elapsed_ms: float = 1.0,
+) -> ClaimResult:
+    return ClaimResult(
+        claim_id=claim_id,
+        status=status,
+        message=message,
+        severity="info",
+        allowed_action="report_only",
+        elapsed_ms=elapsed_ms,
+        detail={},
+    )
+
+
+class TestBridgeOutcomeMapping:
+    """Every ClaimStatus maps to the expected ClaimOutcome."""
+
+    @pytest.mark.parametrize(
+        "status,expected_outcome",
+        [
+            (ClaimStatus.PASS, "yes"),
+            (ClaimStatus.FAIL, "no"),
+            (ClaimStatus.STALE, "no"),          # stale → failure
+            (ClaimStatus.UNSUPPORTED, "inconclusive"),
+            (ClaimStatus.ERROR, "inconclusive"),
+        ],
+    )
+    def test_outcome(self, status: ClaimStatus, expected_outcome: str) -> None:
+        result = _make_result("test.claim.id", status)
+        stakeable, resolved = bridge_from_claim_result(result, agent_id="agent-a")
+        assert resolved.outcome == expected_outcome
+
+    def test_stale_is_no_not_inconclusive(self) -> None:
+        result = _make_result("stale.claim", ClaimStatus.STALE)
+        _, resolved = bridge_from_claim_result(result, agent_id="agent-b")
+        assert resolved.outcome == "no", "stale evidence must be treated as failure, not inconclusive"
+
+
+class TestBridgeTypes:
+    """Return values are the correct types with consistent claim_ids."""
+
+    def test_returns_tuple_of_correct_types(self) -> None:
+        result = _make_result("my.claim", ClaimStatus.PASS)
+        pair = bridge_from_claim_result(result, agent_id="agent-c")
+        assert isinstance(pair, tuple) and len(pair) == 2
+        stakeable, resolved = pair
+        assert isinstance(stakeable, StakeableClaim)
+        assert isinstance(resolved, ResolvedClaim)
+
+    def test_claim_ids_match(self) -> None:
+        result = _make_result("link.claim", ClaimStatus.PASS)
+        stakeable, resolved = bridge_from_claim_result(result, agent_id="agent-d")
+        assert stakeable.claim_id == resolved.claim_id
+
+    def test_domain_is_epistemic_claim(self) -> None:
+        result = _make_result("domain.claim", ClaimStatus.PASS)
+        stakeable, _ = bridge_from_claim_result(result, agent_id="agent-e")
+        assert stakeable.domain == DOMAIN_EPISTEMIC_CLAIM
+
+    def test_position_is_yes_and_binary_scoring(self) -> None:
+        result = _make_result("binary.claim", ClaimStatus.PASS)
+        stakeable, _ = bridge_from_claim_result(result, agent_id="agent-f")
+        assert stakeable.position == "yes"
+        assert stakeable.predicted_probability is None
+        assert stakeable.stake_policy == "forfeit_on_loss"
+
+
+class TestBridgeProvenance:
+    """Provenance and evidence carry the original claim metadata."""
+
+    def test_stakeable_provenance_contains_claim_id(self) -> None:
+        result = _make_result("prov.claim", ClaimStatus.FAIL)
+        stakeable, _ = bridge_from_claim_result(result, agent_id="agent-i")
+        assert stakeable.provenance["claim_id"] == "prov.claim"
+
+    def test_resolved_evidence_contains_status(self) -> None:
+        result = _make_result("ev.claim", ClaimStatus.STALE, message="too old")
+        _, resolved = bridge_from_claim_result(result, agent_id="agent-j")
+        assert resolved.evidence["status"] == "stale"
+        assert resolved.evidence["message"] == "too old"
+
+    def test_resolved_evidence_contains_elapsed_ms(self) -> None:
+        result = _make_result("elap.claim", ClaimStatus.PASS, elapsed_ms=42.5)
+        _, resolved = bridge_from_claim_result(result, agent_id="agent-k")
+        assert resolved.evidence["elapsed_ms"] == pytest.approx(42.5)
+
+    def test_resolution_source_default(self) -> None:
+        result = _make_result("src.claim", ClaimStatus.PASS)
+        stakeable, resolved = bridge_from_claim_result(result, agent_id="agent-l")
+        assert stakeable.resolution_source == "dic14_claim_verifier"
+        assert resolved.resolution_source == "dic14_claim_verifier"
+
+    def test_resolution_source_override(self) -> None:
+        result = _make_result("custom.claim", ClaimStatus.PASS)
+        stakeable, resolved = bridge_from_claim_result(
+            result, agent_id="agent-m", resolution_source="custom_runner"
+        )
+        assert stakeable.resolution_source == "custom_runner"
+        assert resolved.resolution_source == "custom_runner"
+
+
+class TestBridgeStability:
+    """Content-addressed claim_id is stable given the same inputs."""
+
+    def test_same_inputs_same_claim_id(self) -> None:
+        result = _make_result("stable.claim", ClaimStatus.PASS)
+        s1, _ = bridge_from_claim_result(result, agent_id="agent-n")
+        s2, _ = bridge_from_claim_result(result, agent_id="agent-n")
+        assert s1.claim_id == s2.claim_id
+
+    def test_different_agents_different_claim_ids(self) -> None:
+        result = _make_result("diff.claim", ClaimStatus.PASS)
+        s1, _ = bridge_from_claim_result(result, agent_id="agent-p")
+        s2, _ = bridge_from_claim_result(result, agent_id="agent-q")
+        assert s1.claim_id != s2.claim_id
+
+    def test_different_resolution_ids_different_claim_ids(self) -> None:
+        r1 = _make_result("claim.alpha", ClaimStatus.PASS)
+        r2 = _make_result("claim.beta", ClaimStatus.PASS)
+        s1, _ = bridge_from_claim_result(r1, agent_id="agent-r")
+        s2, _ = bridge_from_claim_result(r2, agent_id="agent-r")
+        assert s1.claim_id != s2.claim_id
+
+
+class TestBridgeStakeUnits:
+    """stake_units parameter is forwarded correctly."""
+
+    def test_default_stake_units(self) -> None:
+        result = _make_result("su.default", ClaimStatus.PASS)
+        stakeable, _ = bridge_from_claim_result(result, agent_id="agent-s")
+        assert stakeable.stake_units == 1
+
+    def test_custom_stake_units(self) -> None:
+        result = _make_result("su.custom", ClaimStatus.PASS)
+        stakeable, _ = bridge_from_claim_result(result, agent_id="agent-t", stake_units=10)
+        assert stakeable.stake_units == 10
+
+    def test_stake_units_below_minimum_raises(self) -> None:
+        result = _make_result("su.bad", ClaimStatus.PASS)
+        with pytest.raises(ValueError, match="stake_units"):
+            bridge_from_claim_result(result, agent_id="agent-u", stake_units=0)

--- a/tests/reputation/test_claim_verifier_bridge.py
+++ b/tests/reputation/test_claim_verifier_bridge.py
@@ -46,7 +46,7 @@ class TestBridgeOutcomeMapping:
         [
             (ClaimStatus.PASS, "yes"),
             (ClaimStatus.FAIL, "no"),
-            (ClaimStatus.STALE, "no"),          # stale → failure
+            (ClaimStatus.STALE, "no"),  # stale → failure
             (ClaimStatus.UNSUPPORTED, "inconclusive"),
             (ClaimStatus.ERROR, "inconclusive"),
         ],
@@ -59,7 +59,9 @@ class TestBridgeOutcomeMapping:
     def test_stale_is_no_not_inconclusive(self) -> None:
         result = _make_result("stale.claim", ClaimStatus.STALE)
         _, resolved = bridge_from_claim_result(result, agent_id="agent-b")
-        assert resolved.outcome == "no", "stale evidence must be treated as failure, not inconclusive"
+        assert resolved.outcome == "no", (
+            "stale evidence must be treated as failure, not inconclusive"
+        )
 
 
 class TestBridgeTypes:


### PR DESCRIPTION
## Slice

Adds `bridge_from_claim_result` — the third resolution ingestion adapter for AGT-05 (#6066). Converts a `ClaimResult` from the DIC-14 executable-claim verification runner into a `(StakeableClaim, ResolvedClaim)` pair that feeds directly into `settle_claim`, completing the bridge from organizational claim verification to reputation deltas.

Also adds `DOMAIN_EPISTEMIC_CLAIM = "epistemic_claim"` to the domain registry so this adapter has a distinct, auditable domain slice separate from `prediction_market` and `crux_resolution`.

## Gating

- Default: **OFF** — gated on `ARAGORA_REPUTATION_FLOW_ENABLED` (same flag as all AGT-05 settlement). Construction of `StakeableClaim` / `ResolvedClaim` objects is always safe even when the flag is off.
- Live queue effect: **none**
- Advances issue: #6066 (AGT-05, sub-deliverable 3)

## Outcome mapping

| `ClaimStatus` | `ClaimOutcome` | Rationale |
|---|---|---|
| `PASS` | `"yes"` | Claim verified |
| `FAIL` | `"no"` | Claim failed verification |
| `STALE` | `"no"` | Evidence decayed — treated as failure |
| `UNSUPPORTED` | `"inconclusive"` | Verifier can't run |
| `ERROR` | `"inconclusive"` | Exception during verification |

Implicit position is always `"yes"` (the agent claimed the org claim would pass). Binary scoring is used — no `predicted_probability`.

## Tests

- `TestBridgeOutcomeMapping` — all 5 `ClaimStatus` values → correct `ClaimOutcome`; explicit stale-is-no assertion
- `TestBridgeTypes` — return types, matching `claim_id`s, correct domain, position, binary scoring config
- `TestBridgeProvenance` — provenance and evidence carry claim metadata; resolution source default and override
- `TestBridgeStability` — content-addressed `claim_id` is stable for same inputs, distinct for different agents/resolution IDs
- `TestBridgeStakeUnits` — default and custom stake units; below-minimum raises `ValueError`

## Validation

- `pytest tests/reputation/test_claim_verifier_bridge.py` — **21 passed**
- `ruff check aragora/reputation/claim_verifier_bridge.py aragora/reputation/types.py aragora/reputation/__init__.py tests/reputation/test_claim_verifier_bridge.py` — **clean**
- `mypy aragora/reputation/claim_verifier_bridge.py aragora/reputation/types.py --ignore-missing-imports` — **clean**

## Out of scope

- On-chain anchoring via `ReputationRegistry` — deferred, lives downstream per existing pattern in `aragora/reputation/anchor.py`
- Batch verification runs that process multiple claims at once — straightforward caller-side loop over `bridge_from_claim_result`
- DIC-17 follow-up-issue bridge wired to verification failures — that adapter already exists in `aragora/epistemic/followup.py`; this slice provides the reputation-settlement path, not the issue-creation path

## Note on gate status

The substrate gate (proof-first Foreman / BC-12 reliability) is **not yet declared open** per `docs/status/NEXT_STEPS_CANONICAL.md`. This PR is planning-truth / forward scaffolding only. Do **not** apply `boss-ready` or `autonomous` labels.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y68eN78iv4BUoF9k6XZVqx)_