### PR TITLE
fix(debate): preserve rounds_completed across partial-round failures (B2/B4)

### DIFF
--- a/aragora/debate/debate_state.py
+++ b/aragora/debate/debate_state.py
@@ -421,7 +421,15 @@ class DebateContext:
 
         if self.result:
             self.result.duration_seconds = time.time() - self.start_time
-            rounds_used = self.current_round or self.result.rounds_used
+            # Resolve rounds_used by precedence:
+            #   1. self.current_round (only set explicitly by graph-style flows)
+            #   2. self.result.rounds_used (set by debate_rounds._execute_round
+            #      after each round's revision phase completes)
+            #   3. self.partial_rounds (set at the *start* of each round, so a
+            #      round that fails after partial work still contributes; this
+            #      ensures a debate that crashed in critique/revision/novelty
+            #      does not silently report rounds_used == rounds_completed == 0)
+            rounds_used = self.current_round or self.result.rounds_used or self.partial_rounds
             self.result.rounds_used = rounds_used
             self.result.rounds_completed = rounds_used
             if self.winner_agent:

--- a/aragora/debate/phases/convergence_tracker.py
+++ b/aragora/debate/phases/convergence_tracker.py
@@ -273,8 +273,38 @@ class DebateConvergenceTracker:
         if not current_proposals:
             return
 
-        # Compute novelty against prior proposals
-        novelty_result = self.novelty_tracker.compute_novelty(current_proposals, round_num)
+        # Compute novelty against prior proposals.
+        #
+        # ``compute_novelty`` typically delegates to an embedding service
+        # (Gemini/Claude/etc). If that service is unavailable (expired key,
+        # rate limit, transient network error) we must NOT abort the entire
+        # debate-rounds phase: novelty tracking is observational only and
+        # the round loop has its own convergence checks. Surface the failure
+        # in logs and metadata, then return early so the round can proceed.
+        try:
+            novelty_result = self.novelty_tracker.compute_novelty(current_proposals, round_num)
+        except Exception as exc:  # noqa: BLE001 - external embedding boundary
+            logger.warning(
+                "novelty_tracker_failed round=%s error=%s: skipping novelty tracking for this round",
+                round_num,
+                exc,
+            )
+            try:
+                if hasattr(ctx, "result") and ctx.result is not None:
+                    metadata = getattr(ctx.result, "metadata", None)
+                    if isinstance(metadata, dict):
+                        failures = metadata.setdefault("novelty_tracker_failures", [])
+                        if isinstance(failures, list):
+                            failures.append(
+                                {
+                                    "round": round_num,
+                                    "error_class": type(exc).__name__,
+                                    "error_message": str(exc)[:200],
+                                }
+                            )
+            except (AttributeError, TypeError):
+                pass
+            return
 
         # Update context with novelty scores
         for agent, novelty in novelty_result.per_agent_novelty.items():

--- a/aragora/debate/phases/debate_rounds.py
+++ b/aragora/debate/phases/debate_rounds.py
@@ -1727,7 +1727,7 @@ class DebateRoundsPhase:
         event_type: str,
         ctx: DebateContext,
         round_num: int,
-        data: dict = None,
+        data: dict | None = None,
     ) -> None:
         """Fire propulsion event to push work to the next stage."""
         await fire_propulsion_event(
@@ -1736,5 +1736,5 @@ class DebateRoundsPhase:
             round_num,
             self._propulsion_engine,
             self._enable_propulsion,
-            data,
+            data or {},
         )

--- a/aragora/debate/phases/debate_rounds.py
+++ b/aragora/debate/phases/debate_rounds.py
@@ -533,6 +533,15 @@ class DebateRoundsPhase:
         """
         result = ctx.result
 
+        # Record partial-round progress at round start so that DebateState
+        # finalization, timeout recovery, and post-failure inspection all see
+        # the rounds we *attempted* even if this round raises before its
+        # success path sets ``result.rounds_used`` at the end. Without this,
+        # a failure inside critique/revision/novelty leaves
+        # ``rounds_used == rounds_completed == 0`` even though one or more
+        # rounds were partially executed (dogfood-discovered 2026-04-28).
+        ctx.partial_rounds = round_num
+
         # Track round start time for slow debate detection
         _round_start_time = time.time()
 

--- a/tests/debate/phases/test_convergence_tracker.py
+++ b/tests/debate/phases/test_convergence_tracker.py
@@ -802,6 +802,53 @@ class TestTrackNovelty:
 
         trickster.create_novelty_challenge.assert_called_once()
 
+    def test_track_novelty_swallows_compute_failure(self):
+        """compute_novelty raising should NOT abort the debate-rounds phase.
+
+        Regression test (B4 from 2026-04-28 evolution-round dogfood):
+        when ``self.novelty_tracker.compute_novelty`` raises (e.g. expired
+        Gemini embedding key), ``track_novelty`` must catch and log the
+        failure rather than re-raising, otherwise the entire debate-rounds
+        phase fails and ``rounds_used`` / ``rounds_completed`` stay at 0
+        even though one or more rounds may have made meaningful progress.
+        """
+        novelty_tracker = MagicMock()
+        novelty_tracker.compute_novelty.side_effect = RuntimeError(
+            "External service 'Gemini Embedding' failed: API key expired"
+        )
+
+        tracker = DebateConvergenceTracker(novelty_tracker=novelty_tracker)
+        ctx = MockDebateContext()
+        ctx.proposals = {"agent1": "p1", "agent2": "p2"}
+
+        # Must not raise.
+        tracker.track_novelty(ctx, round_num=1)
+
+        # No novelty data was recorded on context.
+        assert ctx.avg_novelty == 0.0
+        # add_to_history must not be called when compute failed.
+        novelty_tracker.add_to_history.assert_not_called()
+
+    def test_track_novelty_records_failure_in_metadata(self):
+        """A swallowed compute failure surfaces in result.metadata for audit."""
+        novelty_tracker = MagicMock()
+        novelty_tracker.compute_novelty.side_effect = ValueError("rate-limited")
+
+        tracker = DebateConvergenceTracker(novelty_tracker=novelty_tracker)
+        ctx = MockDebateContext()
+        ctx.proposals = {"a": "x"}
+
+        # MockResult has no metadata field, so attach one.
+        ctx.result.metadata = {}
+
+        tracker.track_novelty(ctx, round_num=3)
+
+        failures = ctx.result.metadata.get("novelty_tracker_failures")
+        assert isinstance(failures, list) and len(failures) == 1
+        assert failures[0]["round"] == 3
+        assert failures[0]["error_class"] == "ValueError"
+        assert "rate-limited" in failures[0]["error_message"]
+
 
 # =============================================================================
 # check_rlm_ready_quorum Method Tests

--- a/tests/debate/test_debate_state.py
+++ b/tests/debate/test_debate_state.py
@@ -289,6 +289,65 @@ class TestFinalizeResult:
         assert ctx.result.rounds_used == 4
         assert ctx.result.rounds_completed == 4
 
+    def test_finalize_falls_back_to_partial_rounds(self):
+        """When current_round and result.rounds_used are both 0 but
+        partial_rounds is set, finalize_result must use partial_rounds.
+
+        Regression test (B4 from 2026-04-28 evolution-round dogfood):
+        when a debate-rounds phase fails partway through (e.g. expired
+        Gemini embedding key during novelty tracking), the round loop
+        never reaches the line that sets ``result.rounds_used = round_num``.
+        Without consulting ``ctx.partial_rounds``, the finalized result
+        reports ``rounds_used == rounds_completed == 0`` even though the
+        phase made meaningful progress on round 1.
+        """
+        ctx = DebateContext()
+        ctx.start_time = 0
+        ctx.current_round = 0
+        ctx.partial_rounds = 1
+        ctx.result = MagicMock()
+        ctx.result.rounds_used = 0
+        ctx.result.status = ""
+        ctx.result.consensus_reached = False
+        ctx.agents = []
+
+        ctx.finalize_result()
+        assert ctx.result.rounds_used == 1
+        assert ctx.result.rounds_completed == 1
+
+    def test_finalize_prefers_explicit_rounds_over_partial(self):
+        """When result.rounds_used is set explicitly (success path), use
+        that and ignore partial_rounds (which may lag by one)."""
+        ctx = DebateContext()
+        ctx.start_time = 0
+        ctx.current_round = 0
+        ctx.partial_rounds = 2  # round 2 started but didn't complete
+        ctx.result = MagicMock()
+        ctx.result.rounds_used = 1  # round 1 completed
+        ctx.result.status = ""
+        ctx.result.consensus_reached = False
+        ctx.agents = []
+
+        ctx.finalize_result()
+        assert ctx.result.rounds_used == 1
+        assert ctx.result.rounds_completed == 1
+
+    def test_finalize_zero_rounds_when_no_progress(self):
+        """When nothing has happened, rounds stays 0 (existing behavior)."""
+        ctx = DebateContext()
+        ctx.start_time = 0
+        ctx.current_round = 0
+        ctx.partial_rounds = 0
+        ctx.result = MagicMock()
+        ctx.result.rounds_used = 0
+        ctx.result.status = ""
+        ctx.result.consensus_reached = False
+        ctx.agents = []
+
+        ctx.finalize_result()
+        assert ctx.result.rounds_used == 0
+        assert ctx.result.rounds_completed == 0
+
     def test_finalize_sets_winner(self):
         ctx = DebateContext()
         ctx.start_time = 0


### PR DESCRIPTION
## Summary

Dogfood-discovered (2026-04-28 evolution-round) bug: a debate that crashed in critique/revision/novelty tracking would report \`rounds_used == rounds_completed == 0\` in the finalized result and receipts, even though one or more rounds had produced meaningful work (synthesis, winner, critiques).

The trigger in our case was an expired Gemini embedding API key surfacing as a \`RuntimeError\` from \`compute_novelty()\`, which propagated up through \`track_novelty()\` and aborted the entire debate-rounds phase.

## Root cause

Three layers all assumed the success path:

1. \`convergence_tracker.track_novelty\` did not wrap \`compute_novelty()\` in try/except. An embedding-service failure (Gemini key expired, rate-limited, transient network) would re-raise into the round loop and abort the phase.
2. \`debate_rounds._execute_round\` only set \`result.rounds_used = round_num\` *after* the round's revision phase fully completed. A failure earlier in the round left no record of attempted progress.
3. \`DebateState.finalize_result\` resolved \`rounds_used\` from \`current_round or result.rounds_used\`. Both are 0 when a round fails partway, so the finalized receipt under-reported.

## Minimal repro (pre-fix)

Mock \`novelty_tracker.compute_novelty\` to raise \`RuntimeError(\"embedding service down\")\` on round 1. The Arena produces a synthesis and winner from the proposal phase, but \`result.rounds_used\` and \`result.rounds_completed\` are both 0.

## Fix

Three coordinated changes:

1. **\`aragora/debate/phases/convergence_tracker.py\`** — wrap \`compute_novelty()\` in try/except. On failure, log a warning, append a structured entry to \`result.metadata['novelty_tracker_failures']\` (round, error_class, error_message), and return early. Novelty tracking is observational; an external embedding outage must not abort the debate-rounds phase.

2. **\`aragora/debate/phases/debate_rounds.py\`** — set \`ctx.partial_rounds = round_num\` at the START of each round so a round that fails after partial work still contributes to round counting.

3. **\`aragora/debate/debate_state.py\`** — \`finalize_result\` resolves \`rounds_used\` by precedence: \`self.current_round\` (graph-style flows) → \`self.result.rounds_used\` (success path) → \`self.partial_rounds\` (partial-round fallback).

## Tests

5 new regression tests, all green:

- \`tests/debate/phases/test_convergence_tracker.py\` (2 new)
  - \`test_track_novelty_swallows_compute_failure\` — \`compute_novelty\` raising must not propagate; novelty data must not be recorded; \`add_to_history\` must not be called.
  - \`test_track_novelty_records_failure_in_metadata\` — failure surfaces in \`result.metadata['novelty_tracker_failures']\` for audit.

- \`tests/debate/test_debate_state.py\` (3 new)
  - \`test_finalize_falls_back_to_partial_rounds\` — when \`current_round=0\` and \`result.rounds_used=0\` but \`partial_rounds=1\`, finalize uses 1.
  - \`test_finalize_prefers_explicit_rounds_over_partial\` — \`result.rounds_used=1\` (success path) wins over \`partial_rounds=2\`.
  - \`test_finalize_zero_rounds_when_no_progress\` — preserves the existing 0 behavior when nothing happened.

\`\`\`
89 passed in 6.21s
\`\`\`

## Impact

- Receipts now accurately report attempted rounds even on partial-round failures.
- An expired embedding key no longer cascades into a full debate abort; novelty tracking degrades gracefully and the round loop continues.
- No behavior change on the success path (\`current_round\` and \`result.rounds_used\` both take precedence).

## Notes

- mypy errors visible on \`debate_rounds.py\` (lines 1153, 1170, 1222, 1246, 1484, 1506, 1730) are pre-existing on \`origin/main\`; my single-line addition at line 543 is well below them.
- ruff check + ruff format both clean on all 5 changed files.
- preflight (\`scripts/automation_pr_preflight.sh\`) ok.

## Provenance

Phase B of approved Refined Round 2026-04-29 Full Scope (Phases A-G). Sibling: PR #6805 (Phase A: B1 grok default model + B3 gauntlet imports + plan docs).

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>