### PR TITLE
feat(cli): aragora calibration {report,leaderboard} (AGT-03.3)

### DIFF
--- a/aragora/cli/commands/agt_calibration.py
+++ b/aragora/cli/commands/agt_calibration.py
@@ -1,0 +1,259 @@
+"""CLI commands: ``aragora calibration report`` and ``aragora calibration leaderboard``.
+
+AGT-03.3 calibration consumer surface.
+
+Reads the synthetic-market store (positions + resolutions) and produces
+per-agent rolling-window Brier scores using
+``aragora.markets.scoring.aggregate_brier``. This is the first operator
+surface that closes the AGT-03.3 loop: agents predict via market
+positions, markets resolve, and we report which agents are well- or
+poorly-calibrated.
+
+Read-only. Recording predictions and resolutions stays with the swarm
+runtime; this command only consumes already-recorded events.
+
+The report verb prints (or emits as JSON) the Brier breakdown for one
+or all agents over a rolling window. The leaderboard verb sorts agents
+by (decayed) Brier ascending — lower is better — with a minimum-sample
+floor so single-position agents do not dominate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from aragora.markets.scoring import BrierBreakdown, aggregate_brier
+from aragora.markets.store import MarketStore
+
+
+def _filter_positions_within_window(positions, resolutions, *, now: datetime, window_days: float):
+    """Return positions whose market resolution is within the rolling window.
+
+    Unresolved positions are kept (aggregate_brier will skip them); any
+    position whose resolution is older than ``window_days`` is dropped
+    so the rolling-window semantic is honored even when the underlying
+    store has a long history.
+    """
+    cutoff = now - timedelta(days=window_days)
+    out = []
+    for pos in positions:
+        resolution = resolutions.get(pos.market_id)
+        if resolution is None:
+            out.append(pos)
+            continue
+        try:
+            resolved_at = datetime.fromisoformat(
+                resolution.resolved_at.replace("Z", "+00:00")
+            ).astimezone(UTC)
+        except (ValueError, AttributeError):
+            out.append(pos)
+            continue
+        if resolved_at >= cutoff:
+            out.append(pos)
+    return out
+
+
+def _breakdown_to_dict(breakdown: BrierBreakdown) -> dict:
+    """Serialize a BrierBreakdown to a JSON-safe dict.
+
+    None values are preserved (rather than coerced to 0) so callers can
+    distinguish ``no scored positions`` from ``perfect-zero Brier``.
+    """
+    return {
+        "agent_id": breakdown.agent_id,
+        "scored_positions": breakdown.scored_positions,
+        "inconclusive_positions": breakdown.inconclusive_positions,
+        "mean_brier": breakdown.mean_brier,
+        "stake_weighted_brier": breakdown.stake_weighted_brier,
+        "decayed_brier": breakdown.decayed_brier,
+        "total_stake": breakdown.total_stake,
+    }
+
+
+def _format_brier(value: float | None) -> str:
+    """Format a Brier score for human-readable output."""
+    return f"{value:.4f}" if value is not None else "n/a"
+
+
+def cmd_calibration_report(args: argparse.Namespace) -> int:
+    """Print a per-agent Brier breakdown over a rolling window.
+
+    When ``--agent`` is omitted, prints a breakdown for every agent
+    that has at least one position in the window.
+    """
+    base_dir = Path(getattr(args, "store_dir", ".aragora_markets")).expanduser()
+    store = MarketStore(base_dir)
+
+    window_days = float(getattr(args, "window_days", 90.0))
+    half_life_days = getattr(args, "half_life_days", 30.0)
+    if half_life_days is not None:
+        half_life_days = float(half_life_days)
+
+    now = datetime.now(tz=UTC)
+    resolutions = store.resolutions_by_market()
+    all_positions = store.list_positions()
+    windowed = _filter_positions_within_window(
+        all_positions, resolutions, now=now, window_days=window_days
+    )
+
+    agent_filter = getattr(args, "agent", None)
+    if agent_filter:
+        agent_ids = [agent_filter]
+    else:
+        agent_ids = sorted({pos.agent_id for pos in windowed})
+
+    breakdowns: list[BrierBreakdown] = [
+        aggregate_brier(
+            agent_id=aid,
+            positions=windowed,
+            resolutions=resolutions,
+            now=now,
+            half_life_days=half_life_days,
+        )
+        for aid in agent_ids
+    ]
+
+    if getattr(args, "json", False):
+        out = {
+            "store_dir": str(base_dir),
+            "window_days": window_days,
+            "half_life_days": half_life_days,
+            "now": now.isoformat(),
+            "agents": [_breakdown_to_dict(b) for b in breakdowns],
+        }
+        print(json.dumps(out, sort_keys=True, indent=2))
+        return 0
+
+    if not breakdowns:
+        print(f"No positions found in {base_dir} within the last {window_days:.0f} days.")
+        return 0
+
+    print(
+        f"Calibration report (window={window_days:.0f}d, "
+        f"half_life={half_life_days}d, store={base_dir}):"
+    )
+    print(
+        f"  {'agent':<24s} {'scored':>7s} {'incon':>6s} "
+        f"{'mean':>9s} {'stake_wt':>10s} {'decayed':>9s} {'stake':>8s}"
+    )
+    for breakdown in breakdowns:
+        print(
+            f"  {breakdown.agent_id:<24s} {breakdown.scored_positions:>7d} "
+            f"{breakdown.inconclusive_positions:>6d} "
+            f"{_format_brier(breakdown.mean_brier):>9s} "
+            f"{_format_brier(breakdown.stake_weighted_brier):>10s} "
+            f"{_format_brier(breakdown.decayed_brier):>9s} "
+            f"{breakdown.total_stake:>8d}"
+        )
+    return 0
+
+
+def cmd_calibration_leaderboard(args: argparse.Namespace) -> int:
+    """Print agents sorted by Brier ascending (lower = better calibrated).
+
+    Honors a minimum scored-position floor so that agents with only a
+    handful of positions cannot dominate the leaderboard. The default
+    floor (5) matches the AGT-03 plan's "weekly rolling 90d Brier" cadence
+    of meaningful sample sizes.
+    """
+    base_dir = Path(getattr(args, "store_dir", ".aragora_markets")).expanduser()
+    store = MarketStore(base_dir)
+
+    window_days = float(getattr(args, "window_days", 90.0))
+    half_life_days = getattr(args, "half_life_days", 30.0)
+    if half_life_days is not None:
+        half_life_days = float(half_life_days)
+    min_scored = int(getattr(args, "min_scored", 5))
+    sort_by = getattr(args, "sort_by", "decayed") or "decayed"
+
+    if sort_by not in ("decayed", "mean", "stake_weighted"):
+        print(
+            f"Invalid --sort-by={sort_by!r}; expected one of decayed, mean, stake_weighted",
+        )
+        return 2
+
+    now = datetime.now(tz=UTC)
+    resolutions = store.resolutions_by_market()
+    all_positions = store.list_positions()
+    windowed = _filter_positions_within_window(
+        all_positions, resolutions, now=now, window_days=window_days
+    )
+
+    agent_ids = sorted({pos.agent_id for pos in windowed})
+    breakdowns: list[BrierBreakdown] = [
+        aggregate_brier(
+            agent_id=aid,
+            positions=windowed,
+            resolutions=resolutions,
+            now=now,
+            half_life_days=half_life_days,
+        )
+        for aid in agent_ids
+    ]
+
+    eligible = [b for b in breakdowns if b.scored_positions >= min_scored]
+    excluded = [b for b in breakdowns if b.scored_positions < min_scored]
+
+    sort_key_map = {
+        "decayed": lambda b: b.decayed_brier,
+        "mean": lambda b: b.mean_brier,
+        "stake_weighted": lambda b: b.stake_weighted_brier,
+    }
+    sort_key = sort_key_map[sort_by]
+
+    eligible_sorted = sorted(
+        eligible,
+        key=lambda b: (sort_key(b) is None, sort_key(b) if sort_key(b) is not None else 1.0),
+    )
+
+    if getattr(args, "json", False):
+        out = {
+            "store_dir": str(base_dir),
+            "window_days": window_days,
+            "half_life_days": half_life_days,
+            "min_scored": min_scored,
+            "sort_by": sort_by,
+            "now": now.isoformat(),
+            "leaderboard": [_breakdown_to_dict(b) for b in eligible_sorted],
+            "excluded_below_floor": [_breakdown_to_dict(b) for b in excluded],
+        }
+        print(json.dumps(out, sort_keys=True, indent=2))
+        return 0
+
+    if not eligible_sorted:
+        print(
+            f"No agents meet the minimum-scored floor "
+            f"(min_scored={min_scored}, window={window_days:.0f}d, "
+            f"store={base_dir}).",
+        )
+        if excluded:
+            print(f"  {len(excluded)} agent(s) below the floor — see --json for detail.")
+        return 0
+
+    print(
+        f"Calibration leaderboard (sort={sort_by}, window={window_days:.0f}d, "
+        f"half_life={half_life_days}d, min_scored={min_scored}, store={base_dir}):"
+    )
+    print(
+        f"  {'rank':>4s}  {'agent':<24s} {'scored':>7s} {'mean':>9s} "
+        f"{'stake_wt':>10s} {'decayed':>9s}"
+    )
+    for rank, breakdown in enumerate(eligible_sorted, start=1):
+        print(
+            f"  {rank:>4d}  {breakdown.agent_id:<24s} {breakdown.scored_positions:>7d} "
+            f"{_format_brier(breakdown.mean_brier):>9s} "
+            f"{_format_brier(breakdown.stake_weighted_brier):>10s} "
+            f"{_format_brier(breakdown.decayed_brier):>9s}"
+        )
+    if excluded:
+        print(
+            f"  ({len(excluded)} agent(s) below min_scored={min_scored} "
+            f"floor — see --json for detail.)"
+        )
+    return 0
+
+
+__all__ = ["cmd_calibration_report", "cmd_calibration_leaderboard"]

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -209,6 +209,7 @@ Examples:
     # AGT-* operator surfaces (read-only)
     _add_metrics_parser(subparsers)
     _add_markets_parser(subparsers)
+    _add_calibration_parser(subparsers)
     _add_cruxset_parser(subparsers)
 
     return parser
@@ -283,6 +284,99 @@ def _add_markets_parser(subparsers) -> None:
     )
     lst.add_argument("--json", action="store_true", help="Emit the listing as JSON")
     lst.set_defaults(func=_lazy("aragora.cli.commands.agt_markets", "cmd_markets_list"))
+
+
+def _add_calibration_parser(subparsers) -> None:
+    """Add the 'calibration' subcommand group.
+
+    AGT-03.3 calibration consumer surface: reads positions and
+    resolutions from the synthetic-market store and reports per-agent
+    rolling-window Brier scores.
+    """
+    calib_parser = subparsers.add_parser(
+        "calibration",
+        help="AGT-03.3: per-agent rolling-window Brier reports from market data",
+        description=(
+            "Read-only operator surface for prediction-market calibration. "
+            "Computes per-agent Brier scores (mean, stake-weighted, "
+            "time-decayed) over a rolling window using positions and "
+            "resolutions recorded in the synthetic-market store."
+        ),
+    )
+    calib_sub = calib_parser.add_subparsers(dest="calibration_cmd")
+
+    report = calib_sub.add_parser(
+        "report",
+        help="Print per-agent Brier breakdown over a rolling window",
+    )
+    report.add_argument(
+        "--store-dir",
+        default=".aragora_markets",
+        help="Path to the synthetic-market JSONL store directory (default: .aragora_markets)",
+    )
+    report.add_argument(
+        "--agent",
+        default=None,
+        help="Restrict the report to a single agent_id (default: all agents)",
+    )
+    report.add_argument(
+        "--window-days",
+        type=float,
+        default=90.0,
+        help="Rolling window in days (default: 90 per the AGT-03 plan)",
+    )
+    report.add_argument(
+        "--half-life-days",
+        type=float,
+        default=30.0,
+        help="Exponential time-decay half-life in days (default: 30)",
+    )
+    report.add_argument("--json", action="store_true", help="Emit the report as JSON")
+    report.set_defaults(
+        func=_lazy("aragora.cli.commands.agt_calibration", "cmd_calibration_report")
+    )
+
+    leaderboard = calib_sub.add_parser(
+        "leaderboard",
+        help="Rank agents by Brier score (lower = better calibrated)",
+    )
+    leaderboard.add_argument(
+        "--store-dir",
+        default=".aragora_markets",
+        help="Path to the synthetic-market JSONL store directory (default: .aragora_markets)",
+    )
+    leaderboard.add_argument(
+        "--window-days",
+        type=float,
+        default=90.0,
+        help="Rolling window in days (default: 90 per the AGT-03 plan)",
+    )
+    leaderboard.add_argument(
+        "--half-life-days",
+        type=float,
+        default=30.0,
+        help="Exponential time-decay half-life in days (default: 30)",
+    )
+    leaderboard.add_argument(
+        "--min-scored",
+        type=int,
+        default=5,
+        help=(
+            "Minimum scored positions required to appear on the leaderboard "
+            "(default: 5; agents below the floor are excluded but visible "
+            "in --json output)"
+        ),
+    )
+    leaderboard.add_argument(
+        "--sort-by",
+        choices=("decayed", "mean", "stake_weighted"),
+        default="decayed",
+        help="Brier flavor used for ranking (default: decayed)",
+    )
+    leaderboard.add_argument("--json", action="store_true", help="Emit the leaderboard as JSON")
+    leaderboard.set_defaults(
+        func=_lazy("aragora.cli.commands.agt_calibration", "cmd_calibration_leaderboard")
+    )
 
 
 def _add_cruxset_parser(subparsers) -> None:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference
@@ -11,8 +11,8 @@ description: Aragora CLI Reference
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **94**
-- Total top-level invocations (including aliases): **95**
+- Canonical top-level commands: **95**
+- Total top-level invocations (including aliases): **96**
 
 ## Installation
 
@@ -54,6 +54,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `bench` | - | Benchmark agents | - |
 | `billing` | - | Manage billing, usage, and subscriptions | `invoices`, `portal`, `status`, `subscribe`, `usage` |
 | `build` | - | Turn a vague idea into executed, reviewed, merged code | - |
+| `calibration` | - | AGT-03.3: per-agent rolling-window Brier reports from market data | `leaderboard`, `report` |
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 95 commands | 43.2% |
+| **CLI** | 96 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 95 commands | 43.2% |
+| **CLI** | 96 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **94**
-- Total top-level invocations (including aliases): **95**
+- Canonical top-level commands: **95**
+- Total top-level invocations (including aliases): **96**
 
 ## Installation
 
@@ -49,6 +49,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `bench` | - | Benchmark agents | - |
 | `billing` | - | Manage billing, usage, and subscriptions | `invoices`, `portal`, `status`, `subscribe`, `usage` |
 | `build` | - | Turn a vague idea into executed, reviewed, merged code | - |
+| `calibration` | - | AGT-03.3: per-agent rolling-window Brier reports from market data | `leaderboard`, `report` |
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |

--- a/tests/cli/test_agt_calibration.py
+++ b/tests/cli/test_agt_calibration.py
@@ -1,0 +1,287 @@
+"""Tests for the AGT-03.3 calibration consumer CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.agt_calibration import (
+    cmd_calibration_leaderboard,
+    cmd_calibration_report,
+)
+from aragora.markets.store import MarketStore
+from aragora.markets.types import Market, MarketPosition, ResolutionEvent
+
+
+def _make_args(**kwargs) -> argparse.Namespace:
+    """Build an argparse.Namespace with sensible defaults for the calibration CLI."""
+    defaults: dict = {
+        "store_dir": kwargs["store_dir"],
+        "agent": None,
+        "window_days": 90.0,
+        "half_life_days": 30.0,
+        "min_scored": 5,
+        "sort_by": "decayed",
+        "json": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+_market_counter = 0
+
+
+def _seed_position_pair(
+    store: MarketStore,
+    *,
+    agent_id: str,
+    probability: float,
+    yes_outcome: bool,
+    resolved_at: datetime,
+    stake: int = 10,
+) -> tuple[Market, MarketPosition, ResolutionEvent]:
+    """Seed one market + one position + one resolution into the store.
+
+    Uses a monotonic counter so repeated calls always produce a fresh
+    market_id (Market.market_id is deterministically derived from the
+    target dict).
+    """
+    global _market_counter
+    _market_counter += 1
+    market = Market.create(
+        question_kind="ci_pass",
+        target={
+            "repo": "synaptent/aragora",
+            "ref": f"sha_{agent_id}_{_market_counter}_{int(probability * 1000)}",
+        },
+        description="will ci pass",
+        resolution_window_days=14,
+    )
+    store.add_market(market)
+    position = MarketPosition.create(
+        market_id=market.market_id,
+        agent_id=agent_id,
+        probability=probability,
+        stake=stake,
+    )
+    store.add_position(position)
+    if yes_outcome:
+        event = ResolutionEvent.yes(
+            market_id=market.market_id,
+            resolution_source="github_ci",
+            resolved_at=resolved_at,
+        )
+    else:
+        event = ResolutionEvent.no(
+            market_id=market.market_id,
+            resolution_source="github_ci",
+            resolved_at=resolved_at,
+        )
+    store.record_resolution(event)
+    return market, position, event
+
+
+# ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationReport:
+    def test_empty_store_prints_no_positions_and_returns_zero(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        store.list_markets()  # force layout init
+        args = _make_args(store_dir=str(store.layout.base_dir))
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No positions found" in out
+
+    def test_single_well_calibrated_agent(self, tmp_path: Path, capsys) -> None:
+        """A perfectly-confident correct prediction yields Brier 0."""
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="oracle",
+            probability=1.0,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=10),
+        )
+        args = _make_args(store_dir=str(store.layout.base_dir))
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "oracle" in out
+        # Mean Brier should be 0.0000 for a P=1, outcome=YES position.
+        assert "0.0000" in out
+
+    def test_single_miscalibrated_agent_brier_1(self, tmp_path: Path, capsys) -> None:
+        """A perfectly-wrong prediction yields Brier 1."""
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="badcaller",
+            probability=1.0,
+            yes_outcome=False,  # predicted YES, got NO
+            resolved_at=now - timedelta(days=5),
+        )
+        args = _make_args(store_dir=str(store.layout.base_dir))
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "badcaller" in out
+        assert "1.0000" in out
+
+    def test_window_filter_excludes_old_resolutions(self, tmp_path: Path, capsys) -> None:
+        """A resolution older than the window should not appear in the report."""
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="ancient",
+            probability=0.5,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=180),  # well outside 90d window
+        )
+        args = _make_args(store_dir=str(store.layout.base_dir), window_days=90.0)
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No positions found" in out
+
+    def test_agent_filter_restricts_output(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="alice",
+            probability=0.7,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=2),
+        )
+        _seed_position_pair(
+            store,
+            agent_id="bob",
+            probability=0.3,
+            yes_outcome=False,
+            resolved_at=now - timedelta(days=2),
+        )
+        args = _make_args(store_dir=str(store.layout.base_dir), agent="alice")
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "alice" in out
+        assert "bob" not in out
+
+    def test_json_mode_emits_full_breakdown(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="alice",
+            probability=0.6,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=1),
+        )
+        args = _make_args(store_dir=str(store.layout.base_dir), json=True)
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["window_days"] == 90.0
+        assert payload["half_life_days"] == 30.0
+        assert len(payload["agents"]) == 1
+        agent_record = payload["agents"][0]
+        assert agent_record["agent_id"] == "alice"
+        assert agent_record["scored_positions"] == 1
+        # P(YES)=0.6, outcome=YES → Brier = (0.6 - 1.0)^2 = 0.16
+        assert agent_record["mean_brier"] == pytest.approx(0.16, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# leaderboard
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationLeaderboard:
+    def test_floor_excludes_low_sample_agents(self, tmp_path: Path, capsys) -> None:
+        """min_scored=5 should hide agents with fewer scored positions."""
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        # Single position only — below the default floor of 5.
+        _seed_position_pair(
+            store,
+            agent_id="rookie",
+            probability=0.5,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=1),
+        )
+        args = _make_args(store_dir=str(store.layout.base_dir), min_scored=5)
+        rc = cmd_calibration_leaderboard(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No agents meet the minimum-scored floor" in out
+
+    def test_ranks_eligible_agents_ascending_by_decayed_brier(self, tmp_path: Path, capsys) -> None:
+        """Better-calibrated agents (lower Brier) appear first."""
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        # Seed 5 perfect predictions for "oracle" → Brier 0.
+        for i in range(5):
+            _seed_position_pair(
+                store,
+                agent_id="oracle",
+                probability=1.0,
+                yes_outcome=True,
+                resolved_at=now - timedelta(days=i + 1),
+            )
+        # Seed 5 maximally-wrong predictions for "wrongbot" → Brier 1.
+        for i in range(5):
+            _seed_position_pair(
+                store,
+                agent_id="wrongbot",
+                probability=1.0,
+                yes_outcome=False,
+                resolved_at=now - timedelta(days=i + 1),
+            )
+        args = _make_args(store_dir=str(store.layout.base_dir), min_scored=5)
+        rc = cmd_calibration_leaderboard(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        oracle_pos = out.find("oracle")
+        wrongbot_pos = out.find("wrongbot")
+        assert oracle_pos != -1
+        assert wrongbot_pos != -1
+        assert oracle_pos < wrongbot_pos  # oracle ranks first
+
+    def test_invalid_sort_by_returns_2(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        store.list_markets()
+        args = _make_args(store_dir=str(store.layout.base_dir), sort_by="bogus")
+        rc = cmd_calibration_leaderboard(args)
+        assert rc == 2
+        out = capsys.readouterr().out
+        assert "Invalid --sort-by" in out
+
+    def test_json_includes_excluded_below_floor(self, tmp_path: Path, capsys) -> None:
+        """Agents below the floor must still be visible in the JSON output."""
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="rookie",
+            probability=0.5,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=1),
+        )
+        args = _make_args(store_dir=str(store.layout.base_dir), min_scored=5, json=True)
+        rc = cmd_calibration_leaderboard(args)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["leaderboard"] == []
+        assert len(payload["excluded_below_floor"]) == 1
+        assert payload["excluded_below_floor"][0]["agent_id"] == "rookie"


### PR DESCRIPTION
## Summary

Adds the **AGT-03.3 calibration consumer surface**: \`aragora calibration report\` and \`aragora calibration leaderboard\`. Closes the prediction-market loop (positions + resolutions in, per-agent Brier scores out) for operator inspection.

This is the first operator surface that consumes calibration data emitted by AGT-03 (Manifold), AGT-04 (synthetic GitHub markets), and downstream venues. It pairs naturally with the existing \`aragora markets list\` (AGT-04 inspection) and \`aragora metrics viah\` (AGT-06 operator metrics) verbs.

## CLI

\`\`\`
aragora calibration report [--store-dir DIR] [--agent ID] [--window-days N]
                           [--half-life-days N] [--json]
aragora calibration leaderboard [--store-dir DIR] [--window-days N]
                                [--half-life-days N] [--min-scored N]
                                [--sort-by {decayed,mean,stake_weighted}] [--json]
\`\`\`

**\`report\`** prints per-agent Brier breakdown (mean / stake-weighted / time-decayed), scored vs inconclusive position counts, and total stake over a rolling window. Defaults: 90-day window, 30-day half-life (matches the AGT-03 plan). Optional \`--agent\` restricts to one agent_id; \`--json\` emits machine-readable output.

**\`leaderboard\`** ranks agents by Brier ascending (lower = better calibrated). \`--min-scored\` floor (default 5) prevents low-sample agents from dominating; agents below the floor stay visible in \`--json\` output via \`excluded_below_floor\`. \`--sort-by\` chooses among \`decayed\` (default), \`mean\`, \`stake_weighted\`.

## Implementation

- New module \`aragora/cli/commands/agt_calibration.py\` (~240 LOC). Pure consumer surface; reuses \`aragora.markets.scoring.aggregate_brier\` — no new scoring logic.
- Parser wiring in \`aragora/cli/parser.py\` (\`_add_calibration_parser\` + slot under \`build_parser\`).
- Read-only against the synthetic-market JSONL store (\`.aragora_markets\` by default).
- Rolling-window filter at the CLI layer drops resolutions older than \`--window-days\`; unresolved positions pass through untouched (\`aggregate_brier\` skips them).

## Tests

10 cases, all green:

\`\`\`
tests/cli/test_agt_calibration.py::TestCalibrationReport
  - empty store prints no-positions and returns 0
  - perfectly-confident correct prediction -> Brier 0
  - perfectly-confident wrong prediction   -> Brier 1
  - resolution older than window is filtered out
  - --agent flag restricts to one agent_id
  - --json mode emits full breakdown with mean_brier == 0.16 (P=0.6, YES outcome)

tests/cli/test_agt_calibration.py::TestCalibrationLeaderboard
  - --min-scored=5 excludes single-position agents
  - 5 perfect predictions rank above 5 maximally-wrong predictions
  - invalid --sort-by returns exit code 2
  - --json includes excluded_below_floor entries
\`\`\`

\`\`\`
38 passed in 1.42s
\`\`\`

(38 = 10 new + 28 cohort from \`tests/cli/test_agt_commands.py\` + \`tests/cli/test_main.py\`.)

## Verification

- ruff check + ruff format: clean on all 3 changed files.
- mypy on \`agt_calibration.py\`: clean.
- preflight (\`scripts/automation_pr_preflight.sh\`): ok.
- gitleaks pre-commit: clean.

## Provenance

Phase D of approved Refined Round 2026-04-29 Full Scope (Phases A-G). Sibling PRs:
- #6805 (Phase A: B1 grok default model + B3 gauntlet imports + plan docs)
- #6806 (Phase B: B2/B4 debate-rounds resilience)

Tier 1: additive only, new CLI command surface, read-only consumer of existing data, no public-API breakage. Standing rule applies — I will not merge; awaiting non-Claude (Codex) signal + CI green.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>