### PR TITLE
[AGT-04] aragora markets predict — position-taking CLI verb

### DIFF
--- a/aragora/cli/commands/agt_markets.py
+++ b/aragora/cli/commands/agt_markets.py
@@ -1,20 +1,25 @@
-"""CLI command: ``aragora markets list``.
+"""CLI commands: ``aragora markets list`` and ``aragora markets predict``.
 
-Reads a synthetic-market store and prints a one-line summary per market.
+Reads a synthetic-market store and prints a one-line summary per market,
+or records a new agent position against an open market.
+
 See aragora.markets for the AGT-04 substrate (issue #6065).
 
-This is read-only. Creating markets, taking positions, and resolving
-markets are deferred to follow-up CLI verbs once the substrate-first
-gate opens for AGT-04 production use.
+``predict`` is the first write-path verb: it records a :class:`MarketPosition`
+in the local JSONL store.  It is flag-free and default-off by virtue of being
+an explicit CLI invocation rather than an automated path.  Creating markets and
+resolving them are deferred to follow-up CLI verbs.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
-from aragora.markets.store import MarketStore
+from aragora.markets.store import MarketStore, MarketStoreError
+from aragora.markets.types import MarketPosition
 
 
 def cmd_markets_list(args: argparse.Namespace) -> int:
@@ -53,4 +58,70 @@ def cmd_markets_list(args: argparse.Namespace) -> int:
     return 0
 
 
-__all__ = ["cmd_markets_list"]
+def cmd_markets_predict(args: argparse.Namespace) -> int:
+    """Record an agent position on an open market.
+
+    Writes a :class:`~aragora.markets.types.MarketPosition` to the local
+    JSONL store.  The market must exist in the store and must not yet be
+    resolved.  Exits non-zero on any validation or store error.
+    """
+    base_dir = Path(getattr(args, "store_dir", ".aragora_markets")).expanduser()
+    market_id: str = args.market_id
+    agent_id: str = args.agent
+    probability: float = args.probability
+    stake: int = args.stake
+    rationale: str = getattr(args, "rationale", "") or ""
+    emit_json: bool = getattr(args, "json", False)
+
+    store = MarketStore(base_dir)
+
+    market = store.get_market(market_id)
+    if market is None:
+        print(f"error: market {market_id!r} not found in {base_dir}", file=sys.stderr)
+        return 1
+
+    resolutions = store.resolutions_by_market()
+    if market_id in resolutions:
+        resolution = resolutions[market_id]
+        print(
+            f"error: market {market_id!r} is already resolved "
+            f"(outcome={resolution.outcome}); cannot add positions",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        position = MarketPosition.create(
+            market_id=market_id,
+            agent_id=agent_id,
+            probability=probability,
+            stake=stake,
+            rationale=rationale,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        saved = store.add_position(position)
+    except MarketStoreError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if emit_json:
+        print(json.dumps(saved.to_json(), sort_keys=True, indent=2))
+    else:
+        print(
+            f"position recorded: {saved.position_id}\n"
+            f"  market  : {saved.market_id}\n"
+            f"  agent   : {saved.agent_id}\n"
+            f"  P(YES)  : {saved.probability:.4f}\n"
+            f"  stake   : {saved.stake}\n"
+            f"  at      : {saved.submitted_at}"
+        )
+        if saved.rationale:
+            print(f"  rationale: {saved.rationale}")
+    return 0
+
+
+__all__ = ["cmd_markets_list", "cmd_markets_predict"]

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -265,11 +265,11 @@ def _add_metrics_parser(subparsers) -> None:
 
 
 def _add_markets_parser(subparsers) -> None:
-    """Add the 'markets' subcommand group with a 'list' verb."""
+    """Add the 'markets' subcommand group with 'list' and 'predict' verbs."""
     markets_parser = subparsers.add_parser(
         "markets",
-        help="AGT-04: inspect synthetic GitHub prediction markets",
-        description="Read-only operator surface for the synthetic-market store.",
+        help="AGT-04: inspect and interact with synthetic GitHub prediction markets",
+        description="Operator surface for the synthetic-market store.",
     )
     markets_sub = markets_parser.add_subparsers(dest="markets_cmd")
     lst = markets_sub.add_parser(
@@ -283,6 +283,39 @@ def _add_markets_parser(subparsers) -> None:
     )
     lst.add_argument("--json", action="store_true", help="Emit the listing as JSON")
     lst.set_defaults(func=_lazy("aragora.cli.commands.agt_markets", "cmd_markets_list"))
+
+    pred = markets_sub.add_parser(
+        "predict",
+        help="Record an agent prediction (position) on an open market",
+        description=(
+            "Write a MarketPosition to the store for the given market. "
+            "The market must exist and must not yet be resolved."
+        ),
+    )
+    pred.add_argument("--market-id", required=True, help="Market ID to predict on")
+    pred.add_argument("--agent", required=True, help="Agent ID making the prediction")
+    pred.add_argument(
+        "--probability",
+        required=True,
+        type=float,
+        metavar="FLOAT",
+        help="Predicted P(YES) in [0, 1]",
+    )
+    pred.add_argument(
+        "--stake",
+        required=True,
+        type=int,
+        metavar="INT",
+        help="Stake in internal credits [1..100]",
+    )
+    pred.add_argument("--rationale", default="", help="Optional free-text rationale")
+    pred.add_argument(
+        "--store-dir",
+        default=".aragora_markets",
+        help="Path to the synthetic-market JSONL store directory (default: .aragora_markets)",
+    )
+    pred.add_argument("--json", action="store_true", help="Emit the saved position as JSON")
+    pred.set_defaults(func=_lazy("aragora.cli.commands.agt_markets", "cmd_markets_predict"))
 
 
 def _add_cruxset_parser(subparsers) -> None:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Generated Aragora CLI command catalog from live parser
+description: Aragora CLI Reference
 ---
 
 # Aragora CLI Reference

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference
@@ -88,7 +88,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `km` | - | Knowledge Mound management commands | `query`, `stats`, `store` |
 | `knowledge` | - | Knowledge base operations | `facts`, `jobs`, `process`, `query`, `search`, `stats` |
 | `marketplace` | - | Manage agent template marketplace | - |
-| `markets` | - | AGT-04: inspect synthetic GitHub prediction markets | `list` |
+| `markets` | - | AGT-04: inspect and interact with synthetic GitHub prediction markets | `list`, `predict` |
 | `mcp-server` | - | Run the MCP (Model Context Protocol) server | - |
 | `memory` | - | Memory management commands | `promote`, `query`, `stats`, `store` |
 | `metrics` | - | AGT-06: read VIAH and other operator metrics | `viah` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4084` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1923630` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1923778` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `135` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5114` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `216748` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5115` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `216767` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `659` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `60` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `800` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `802` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4084` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1923630` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4085` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1924178` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `135` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5114` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `216748` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5116` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `216782` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `659` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `60` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| CLI top-level command modules | `61` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3398` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `800` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `803` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -83,7 +83,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `km` | - | Knowledge Mound management commands | `query`, `stats`, `store` |
 | `knowledge` | - | Knowledge base operations | `facts`, `jobs`, `process`, `query`, `search`, `stats` |
 | `marketplace` | - | Manage agent template marketplace | - |
-| `markets` | - | AGT-04: inspect synthetic GitHub prediction markets | `list` |
+| `markets` | - | AGT-04: inspect and interact with synthetic GitHub prediction markets | `list`, `predict` |
 | `mcp-server` | - | Run the MCP (Model Context Protocol) server | - |
 | `memory` | - | Memory management commands | `promote`, `query`, `stats`, `store` |
 | `metrics` | - | AGT-06: read VIAH and other operator metrics | `viah` |

--- a/tests/cli/test_agt_markets_predict.py
+++ b/tests/cli/test_agt_markets_predict.py
@@ -22,6 +22,7 @@ from aragora.markets.types import Market, ResolutionEvent
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 def _make_market(tmp_path, *, number: int = 42) -> Market:
     store = MarketStore(tmp_path)
     market = Market.create(
@@ -59,6 +60,7 @@ def _args(
 # ---------------------------------------------------------------------------
 # Happy-path tests
 # ---------------------------------------------------------------------------
+
 
 class TestPredictHappyPath:
     def test_records_position_in_store(self, tmp_path) -> None:
@@ -116,6 +118,7 @@ class TestPredictHappyPath:
 # ---------------------------------------------------------------------------
 # Error-path tests
 # ---------------------------------------------------------------------------
+
 
 class TestPredictErrorPath:
     def test_unknown_market_returns_nonzero(self, tmp_path) -> None:

--- a/tests/cli/test_agt_markets_predict.py
+++ b/tests/cli/test_agt_markets_predict.py
@@ -1,0 +1,162 @@
+"""Tests for ``aragora markets predict`` CLI verb (AGT-04, issue #6065).
+
+All tests are fully hermetic: they use a ``tmp_path`` store and deterministic
+market/position fixtures.  No network calls, no live dispatch, no queue
+mutations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from aragora.cli.commands.agt_markets import cmd_markets_predict
+from aragora.markets.store import MarketStore
+from aragora.markets.types import Market, ResolutionEvent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_market(tmp_path, *, number: int = 42) -> Market:
+    store = MarketStore(tmp_path)
+    market = Market.create(
+        question_kind="pr_merge",
+        target={"repo": "synaptent/aragora", "number": number},
+        description=f"will PR #{number} merge",
+        resolution_window_days=30,
+        created_at=datetime(2026, 4, 17, tzinfo=UTC),
+    )
+    store.add_market(market)
+    return market
+
+
+def _args(
+    *,
+    store_dir,
+    market_id: str,
+    agent: str = "claude-sonnet",
+    probability: float = 0.75,
+    stake: int = 10,
+    rationale: str = "",
+    emit_json: bool = False,
+) -> argparse.Namespace:
+    ns = argparse.Namespace()
+    ns.store_dir = str(store_dir)
+    ns.market_id = market_id
+    ns.agent = agent
+    ns.probability = probability
+    ns.stake = stake
+    ns.rationale = rationale
+    ns.json = emit_json
+    return ns
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests
+# ---------------------------------------------------------------------------
+
+class TestPredictHappyPath:
+    def test_records_position_in_store(self, tmp_path) -> None:
+        market = _make_market(tmp_path)
+        args = _args(store_dir=tmp_path, market_id=market.market_id)
+        rc = cmd_markets_predict(args)
+        assert rc == 0
+        store = MarketStore(tmp_path)
+        positions = store.list_positions(market_id=market.market_id)
+        assert len(positions) == 1
+        pos = positions[0]
+        assert pos.agent_id == "claude-sonnet"
+        assert pos.probability == pytest.approx(0.75)
+        assert pos.stake == 10
+
+    def test_json_output_roundtrips(self, tmp_path, capsys) -> None:
+        market = _make_market(tmp_path)
+        args = _args(store_dir=tmp_path, market_id=market.market_id, emit_json=True)
+        rc = cmd_markets_predict(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["market_id"] == market.market_id
+        assert payload["agent_id"] == "claude-sonnet"
+        assert payload["probability"] == pytest.approx(0.75)
+        assert payload["stake"] == 10
+
+    def test_rationale_preserved(self, tmp_path) -> None:
+        market = _make_market(tmp_path)
+        args = _args(
+            store_dir=tmp_path,
+            market_id=market.market_id,
+            rationale="CI is green and two approvals are in",
+        )
+        rc = cmd_markets_predict(args)
+        assert rc == 0
+        store = MarketStore(tmp_path)
+        pos = store.list_positions(market_id=market.market_id)[0]
+        assert pos.rationale == "CI is green and two approvals are in"
+
+    def test_multiple_agents_can_predict_same_market(self, tmp_path) -> None:
+        market = _make_market(tmp_path)
+        for agent, prob in [("agent-a", 0.6), ("agent-b", 0.9)]:
+            rc = cmd_markets_predict(
+                _args(store_dir=tmp_path, market_id=market.market_id, agent=agent, probability=prob)
+            )
+            assert rc == 0
+        store = MarketStore(tmp_path)
+        positions = store.list_positions(market_id=market.market_id)
+        assert len(positions) == 2
+        agents = {p.agent_id for p in positions}
+        assert agents == {"agent-a", "agent-b"}
+
+
+# ---------------------------------------------------------------------------
+# Error-path tests
+# ---------------------------------------------------------------------------
+
+class TestPredictErrorPath:
+    def test_unknown_market_returns_nonzero(self, tmp_path) -> None:
+        args = _args(store_dir=tmp_path, market_id="mkt_nonexistent_abc123")
+        rc = cmd_markets_predict(args)
+        assert rc != 0
+
+    def test_resolved_market_returns_nonzero(self, tmp_path) -> None:
+        market = _make_market(tmp_path)
+        store = MarketStore(tmp_path)
+        store.record_resolution(
+            ResolutionEvent.yes(
+                market_id=market.market_id,
+                resolution_source="test",
+                evidence={"merged": True},
+            )
+        )
+        args = _args(store_dir=tmp_path, market_id=market.market_id)
+        rc = cmd_markets_predict(args)
+        assert rc != 0
+
+    def test_probability_out_of_range_returns_nonzero(self, tmp_path) -> None:
+        market = _make_market(tmp_path)
+        args = _args(store_dir=tmp_path, market_id=market.market_id, probability=1.5)
+        rc = cmd_markets_predict(args)
+        assert rc != 0
+
+    def test_stake_exceeds_cap_returns_nonzero(self, tmp_path) -> None:
+        market = _make_market(tmp_path)
+        args = _args(store_dir=tmp_path, market_id=market.market_id, stake=101)
+        rc = cmd_markets_predict(args)
+        assert rc != 0
+
+    def test_zero_stake_returns_nonzero(self, tmp_path) -> None:
+        market = _make_market(tmp_path)
+        args = _args(store_dir=tmp_path, market_id=market.market_id, stake=0)
+        rc = cmd_markets_predict(args)
+        assert rc != 0
+
+    def test_error_message_to_stderr(self, tmp_path, capsys) -> None:
+        args = _args(store_dir=tmp_path, market_id="mkt_missing_xyz")
+        cmd_markets_predict(args)
+        err = capsys.readouterr().err
+        assert "mkt_missing_xyz" in err


### PR DESCRIPTION
## Slice

Adds `aragora markets predict` as the first write-path verb for the AGT-04 synthetic-market substrate. An agent can now record a `MarketPosition` (agent ID, P(YES), stake, optional rationale) against any open market in the local JSONL store, completing the basic predict → list → calibrate loop started by the earlier read-only `markets list` verb.

## Gating

- Default: OFF — explicit CLI invocation; no automated path calls this
- Live queue effect: none (writes only to the operator's local `.aragora_markets` JSONL store)
- Advances issue: #6065

## Tests

`tests/cli/test_agt_markets_predict.py` — 10 cases:

**Happy path (4)**
- `test_records_position_in_store` — position is persisted and readable via `MarketStore`
- `test_json_output_roundtrips` — `--json` flag emits valid JSON with correct fields
- `test_rationale_preserved` — free-text rationale survives the store round-trip
- `test_multiple_agents_can_predict_same_market` — two agents produce two distinct positions

**Error path (6)**
- `test_unknown_market_returns_nonzero` — exit 1 + stderr on missing market
- `test_resolved_market_returns_nonzero` — exit 1 when market already has a resolution
- `test_probability_out_of_range_returns_nonzero` — probability > 1 rejected
- `test_stake_exceeds_cap_returns_nonzero` — stake > 100 rejected
- `test_zero_stake_returns_nonzero` — stake = 0 rejected
- `test_error_message_to_stderr` — stderr contains the offending market ID

## Validation

- `pytest tests/cli/test_agt_markets_predict.py` — **10 passed**
- `ruff check aragora/cli/commands/agt_markets.py aragora/cli/parser.py tests/cli/test_agt_markets_predict.py` — clean
- `mypy aragora/cli/commands/agt_markets.py aragora/cli/parser.py --ignore-missing-imports` — clean

## Out of scope

- `aragora markets create` (programmatic market creation CLI) — deferred to follow-up slice
- `aragora markets resolve` (trigger GitHub-event resolution) — deferred; requires gh runner wiring
- AGT-05 reputation delta wiring — depends on this slice landing first
- No changes to live queue, dispatch, swarm supervisor, or boss loop

https://claude.ai/code/session_016aKKoVyykgBRZ4yYewDCMU

---
_Generated by [Claude Code](https://claude.ai/code/session_016aKKoVyykgBRZ4yYewDCMU)_