### PR TITLE
fix(automation): anchor publisher bridge substrate

### DIFF
--- a/scripts/install_codex_automation_publisher_launchd.sh
+++ b/scripts/install_codex_automation_publisher_launchd.sh
@@ -3,7 +3,22 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+first_worktree_root() {
+    git -C "${SCRIPT_REPO_ROOT}" worktree list --porcelain 2>/dev/null \
+        | awk 'NR == 1 && $1 == "worktree" { sub(/^worktree /, ""); print; exit }'
+}
+
+REPO_ROOT="${ARAGORA_AUTOMATION_PUBLISHER_REPO_ROOT:-}"
+if [[ -z "${REPO_ROOT}" ]]; then
+    CANONICAL_REPO_ROOT="$(first_worktree_root || true)"
+    if [[ -n "${CANONICAL_REPO_ROOT}" && -f "${CANONICAL_REPO_ROOT}/scripts/run_codex_automation_publisher.sh" ]]; then
+        REPO_ROOT="${CANONICAL_REPO_ROOT}"
+    else
+        REPO_ROOT="${SCRIPT_REPO_ROOT}"
+    fi
+fi
 LABEL="com.aragora.codex-automation-publisher"
 LAUNCHD_DOMAIN="gui/$(id -u)"
 INTERVAL_SECONDS=300

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -84,6 +84,7 @@ BLOCK_TIMESTAMP_PATTERN = re.compile(
     r"(?m)(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)"
 )
 PR_REFERENCE_PATTERN = re.compile(r"(?i)\b(?:PR|pull request)\s*#(\d+)\b")
+PR_SLUG_REFERENCE_PATTERN = re.compile(r"(?i)(?:^|[\\/_-])pr[-_]?(\d{3,})(?:\b|[\\/_-])")
 STOPWORDS = {
     "a",
     "an",
@@ -880,7 +881,11 @@ def _existing_pr(repo_root: Path, repo: str, title: str) -> dict[str, Any] | Non
 def _referenced_pr_numbers(handoff: Handoff) -> list[int]:
     seen: set[int] = set()
     numbers: list[int] = []
-    for match in PR_REFERENCE_PATTERN.finditer(f"{handoff.task_title}\n{handoff.body}"):
+    text = f"{handoff.task_title}\n{handoff.body}"
+    matches = list(PR_REFERENCE_PATTERN.finditer(text)) + list(
+        PR_SLUG_REFERENCE_PATTERN.finditer(text)
+    )
+    for match in matches:
         try:
             number = int(match.group(1))
         except (TypeError, ValueError):
@@ -954,6 +959,14 @@ def _target_open_pr(repo_root: Path, repo: str, handoff: Handoff) -> dict[str, A
     for number in _referenced_pr_numbers(handoff):
         pr = _pr_by_number(repo_root, repo, number)
         if isinstance(pr, dict) and str(pr.get("state") or "").upper() == "OPEN":
+            return pr
+    return None
+
+
+def _referenced_pr(repo_root: Path, repo: str, handoff: Handoff) -> dict[str, Any] | None:
+    for number in _referenced_pr_numbers(handoff):
+        pr = _pr_by_number(repo_root, repo, number)
+        if isinstance(pr, dict):
             return pr
     return None
 
@@ -1073,6 +1086,18 @@ def decide_handoffs(
                     eligible=False,
                     reason="target_open_pr",
                     existing_pr_url=str(target_pr.get("url") or ""),
+                )
+            )
+            continue
+        referenced_pr = _referenced_pr(repo_root, repo, handoff)
+        if referenced_pr:
+            decisions.append(
+                PublishDecision(
+                    task_title=handoff.task_title,
+                    source_file=handoff.source_file,
+                    eligible=False,
+                    reason="existing_pr",
+                    existing_pr_url=str(referenced_pr.get("url") or ""),
                 )
             )
             continue

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -22,6 +22,10 @@ STAMP() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
+repo_root_available() {
+  [[ -d "${REPO_ROOT}" && ( -d "${REPO_ROOT}/.git" || -f "${REPO_ROOT}/.git" ) ]]
+}
+
 if ! mkdir "$LOCK_DIR" 2>/dev/null; then
   echo "$(STAMP) [codex-automation-publisher] already running; exiting"
   exit 0
@@ -72,12 +76,19 @@ if ! git fetch --no-write-fetch-head --prune origin '+refs/heads/*:refs/remotes/
 fi
 
 echo "$(STAMP) [codex-automation-publisher] starting branch publish pass"
+if ! repo_root_available; then
+  echo "$(STAMP) [codex-automation-publisher] repo root unavailable; skipping branch publish pass"
+  echo "$(STAMP) [codex-automation-publisher] publish pass complete"
+  exit 0
+fi
 BRANCH_PUBLISH_ARGS=(
+  --repo "${REPO_ROOT}" \
   --base origin/main \
   --apply \
   --limit "${BRANCH_LIMIT}" \
   --max-open-prs "${MAX_OPEN_PRS}" \
   --scan-limit "${BRANCH_SCAN_LIMIT}" \
+  --outbox-dir "${HANDOFF_OUTBOX_DIR}" \
   --json
 )
 if [[ "${ALLOW_UNHEALTHY_QUEUE_PUBLISH}" == "1" || "${ALLOW_UNHEALTHY_QUEUE_PUBLISH}" == "true" || "${ALLOW_UNHEALTHY_QUEUE_PUBLISH}" == "yes" ]]; then

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1023,6 +1023,79 @@ def test_referenced_pr_numbers_deduplicates_multiple_mentions(tmp_path: Path) ->
     assert mod._referenced_pr_numbers(handoff) == [6288]
 
 
+def test_referenced_pr_numbers_extracts_review_branch_slug(tmp_path: Path) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / "outbox.json"),
+        task_title="Open or update PR for AGT-04 markets predict CLI",
+        priority="HIGH",
+        body=(
+            "Branch: codex/review-pr6808\n"
+            "Worktree: /private/tmp/aragora-pr6808\n"
+            "Compare: https://github.com/synaptent/aragora/compare/main...codex/review-pr6808\n"
+        ),
+        labels={},
+        expires_at=None,
+    )
+
+    assert mod._referenced_pr_numbers(handoff) == [6808]
+
+
+def test_decide_handoffs_skips_merged_referenced_pr_slug(monkeypatch: Any, tmp_path: Path) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / "outbox.json"),
+        task_title="Open or update PR for AGT-04 markets predict CLI",
+        priority="HIGH",
+        body="Requested branch: codex/review-pr6808\n",
+        labels={},
+        expires_at=None,
+        source_kind="outbox",
+        branch="codex/review-pr6808",
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 6808,
+                        "title": "[AGT-04] aragora markets predict",
+                        "url": "https://github.com/synaptent/aragora/pull/6808",
+                        "state": "MERGED",
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="existing_pr",
+            existing_pr_url="https://github.com/synaptent/aragora/pull/6808",
+        )
+    ]
+
+
 def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: Path) -> None:
     handoff = Handoff(
         source_file=str(tmp_path / "memory.md"),

--- a/tests/scripts/test_run_codex_automation_publisher.py
+++ b/tests/scripts/test_run_codex_automation_publisher.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_publisher_wrapper_passes_shared_outbox_to_branch_publisher() -> None:
+    script = (REPO_ROOT / "scripts" / "run_codex_automation_publisher.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "repo_root_available()" in script
+    assert '--repo "${REPO_ROOT}"' in script
+    assert '--outbox-dir "${HANDOFF_OUTBOX_DIR}"' in script
+
+
+def test_launchd_installer_prefers_canonical_git_worktree_root() -> None:
+    script = (REPO_ROOT / "scripts" / "install_codex_automation_publisher_launchd.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "ARAGORA_AUTOMATION_PUBLISHER_REPO_ROOT" in script
+    assert 'git -C "${SCRIPT_REPO_ROOT}" worktree list --porcelain' in script
+    assert 'REPO_ROOT="${CANONICAL_REPO_ROOT}"' in script
+    assert 'LOG_PATH="${REPO_ROOT}/.aragora/overnight/codex-automation-publisher.log"' in script


### PR DESCRIPTION
## Summary
- make the publisher launchd installer prefer the canonical git worktree root, with an explicit ARAGORA_AUTOMATION_PUBLISHER_REPO_ROOT override
- make the publisher wrapper skip safely when the repo root is unavailable and pass explicit repo/outbox paths into branch publishing
- dedupe handoff publication when handoff text references a PR branch slug such as codex/review-pr6808

## Validation
- bash -n scripts/install_codex_automation_publisher_launchd.sh && bash -n scripts/run_codex_automation_publisher.sh
- python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py tests/scripts/test_run_codex_automation_publisher.py
- python3 -m pytest -q tests/scripts/test_run_codex_automation_publisher.py tests/scripts/test_publish_automation_handoffs.py -q