### PR TITLE
[DIC-19] Proof-unit constraint graph — cross-reference index for ProofCarryingCodeUnits

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -23,12 +23,14 @@ Exposes:
   :class:`FragilityReport`, :class:`StressTestResult`,
   :func:`run_stress_test`, :func:`stress_test_enabled`)
   Flag gate: ``ARAGORA_STRESS_TEST_ENABLED`` (default off).
-- DIC-19: proof-carrying code unit schema and scanner
+- DIC-19: proof-carrying code unit schema, scanner, and constraint graph
   (:class:`ProofCarryingCodeUnit`, :class:`DecayPolicy`,
   :class:`FallbackPolicy`, :func:`load_proof_unit`,
-  :func:`load_proof_unit_from_yaml`, :func:`load_proof_units_from_dir`)
+  :func:`load_proof_unit_from_yaml`, :func:`load_proof_units_from_dir`,
+  :class:`ProofUnitConstraintGraph`)
   Flag gate: ``ARAGORA_PROOF_UNIT_SCAN_ENABLED`` (default off; dataclasses
-  are always importable).
+  and graph construction are always importable; the scanner that populates
+  the unit list is gated).
 - DIC-23: dialectical runtime loop orchestrator (:class:`DialecticalEvent`,
   :class:`DialecticalRuntimeError`, :func:`run_dialectical_loop`,
   :func:`dialectical_runtime_enabled`)
@@ -138,6 +140,7 @@ from .proof_unit import (
     DecayPolicy,
     FallbackPolicy,
     ProofCarryingCodeUnit,
+    ProofUnitConstraintGraph,
     enable_proof_unit_scan,
     load_proof_unit,
     load_proof_unit_from_yaml,
@@ -201,6 +204,7 @@ __all__ = [
     "DecayPolicy",
     "FallbackPolicy",
     "ProofCarryingCodeUnit",
+    "ProofUnitConstraintGraph",
     "StressPerturbation",
     "StressTestResult",
     "IncoherenceKind",

--- a/aragora/epistemic/constraint_graph.py
+++ b/aragora/epistemic/constraint_graph.py
@@ -1,0 +1,157 @@
+"""Proof-Carrying Code Unit constraint graph (DIC-19 / #6030).
+
+Builds a read-only dependency graph from a collection of
+:class:`aragora.epistemic.proof_unit_model.ProofCarryingCodeUnit` instances.
+
+The graph indexes each unit by its shared ``claims``, ``decision_receipts``,
+and ``linked_crux_ids`` so callers can answer in O(1):
+
+- "Which units depend on claim X?"
+- "Which units are tied to receipt R?"
+- "Which units reference crux C?"
+- "What is the full impact set if these claims become invalid?"
+
+Construction is explicit (``ProofUnitConstraintGraph(units)``); nothing in this
+module runs automatically.  The dataclass is always importable; the scanner that
+populates the unit list is gated by ``ARAGORA_PROOF_UNIT_SCAN_ENABLED``.
+
+Out of scope (deferred):
+- Multi-hop unit-to-unit dependency propagation (requires explicit edges).
+- Mutating units or triggering quarantine/repair — see DIC-21/DIC-22.
+- Persisting the graph — callers serialize via :meth:`to_dict`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Collection, Iterable
+
+from .proof_unit_model import ProofCarryingCodeUnit
+
+
+class ProofUnitConstraintGraph:
+    """Cross-reference index over a set of ProofCarryingCodeUnits.
+
+    After construction, the graph is immutable: the underlying dicts are
+    never modified. Call :meth:`to_dict` to obtain a JSON-serializable
+    snapshot for operator dashboards or debugging.
+    """
+
+    def __init__(self, units: Iterable[ProofCarryingCodeUnit]) -> None:
+        self._units: dict[str, ProofCarryingCodeUnit] = {}
+        self._by_claim: dict[str, set[str]] = defaultdict(set)
+        self._by_receipt: dict[str, set[str]] = defaultdict(set)
+        self._by_crux: dict[str, set[str]] = defaultdict(set)
+
+        for unit in units:
+            uid = unit.code_unit_id
+            if uid in self._units:
+                raise ValueError(
+                    f"duplicate code_unit_id {uid!r}; each unit must be unique within a graph"
+                )
+            self._units[uid] = unit
+            for claim in unit.claims:
+                self._by_claim[claim].add(uid)
+            for receipt in unit.decision_receipts:
+                self._by_receipt[receipt].add(uid)
+            for crux_id in unit.linked_crux_ids:
+                self._by_crux[crux_id].add(uid)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def unit_count(self) -> int:
+        """Number of proof units in the graph."""
+        return len(self._units)
+
+    @property
+    def claim_count(self) -> int:
+        """Number of distinct claim IDs referenced across all units."""
+        return len(self._by_claim)
+
+    @property
+    def receipt_count(self) -> int:
+        """Number of distinct decision receipt IDs referenced across all units."""
+        return len(self._by_receipt)
+
+    @property
+    def crux_count(self) -> int:
+        """Number of distinct crux IDs referenced across all units."""
+        return len(self._by_crux)
+
+    # ------------------------------------------------------------------
+    # Lookup helpers — all return deterministic sorted lists
+    # ------------------------------------------------------------------
+
+    def units_by_claim(self, claim_id: str) -> list[ProofCarryingCodeUnit]:
+        """Return units whose ``claims`` list contains *claim_id*."""
+        return [self._units[uid] for uid in sorted(self._by_claim.get(claim_id, set()))]
+
+    def units_by_receipt(self, receipt_id: str) -> list[ProofCarryingCodeUnit]:
+        """Return units whose ``decision_receipts`` list contains *receipt_id*."""
+        return [self._units[uid] for uid in sorted(self._by_receipt.get(receipt_id, set()))]
+
+    def units_by_crux(self, crux_id: str) -> list[ProofCarryingCodeUnit]:
+        """Return units whose ``linked_crux_ids`` list contains *crux_id*."""
+        return [self._units[uid] for uid in sorted(self._by_crux.get(crux_id, set()))]
+
+    # ------------------------------------------------------------------
+    # Impact analysis
+    # ------------------------------------------------------------------
+
+    def impact_set(self, claim_ids: Collection[str]) -> set[str]:
+        """Return ``code_unit_id``s of all units directly impacted by *claim_ids*.
+
+        A unit is impacted if at least one of the given claim IDs appears in
+        its ``claims`` list.  The result is a flat set of unit IDs — not unit
+        objects — so callers can log, diff, or feed into repair pipelines
+        without holding object references.
+
+        This is a single-hop query.  Multi-hop propagation (unit A relies on
+        unit B's proof) is deferred until explicit unit-to-unit dependency
+        edges are tracked in a future DIC-19 follow-on.
+        """
+        impacted: set[str] = set()
+        for claim_id in claim_ids:
+            impacted.update(self._by_claim.get(claim_id, set()))
+        return impacted
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable summary of the graph.
+
+        Suitable for operator dashboards, debug logging, or snapshotting
+        the state of the constraint graph at a point in time.
+        """
+        return {
+            "unit_count": self.unit_count,
+            "claim_count": self.claim_count,
+            "receipt_count": self.receipt_count,
+            "crux_count": self.crux_count,
+            "units": {
+                uid: {
+                    "symbol": u.symbol,
+                    "source_path": u.source_path,
+                    "owner": u.owner,
+                    "claims": u.claims,
+                    "decision_receipts": u.decision_receipts,
+                    "linked_crux_ids": u.linked_crux_ids,
+                    "freshness_sla_hours": u.freshness_sla_hours,
+                }
+                for uid, u in sorted(self._units.items())
+            },
+            "claim_index": {
+                claim: sorted(uids) for claim, uids in sorted(self._by_claim.items())
+            },
+            "receipt_index": {
+                receipt: sorted(uids) for receipt, uids in sorted(self._by_receipt.items())
+            },
+            "crux_index": {
+                crux_id: sorted(uids) for crux_id, uids in sorted(self._by_crux.items())
+            },
+        }

--- a/aragora/epistemic/constraint_graph.py
+++ b/aragora/epistemic/constraint_graph.py
@@ -145,9 +145,7 @@ class ProofUnitConstraintGraph:
                 }
                 for uid, u in sorted(self._units.items())
             },
-            "claim_index": {
-                claim: sorted(uids) for claim, uids in sorted(self._by_claim.items())
-            },
+            "claim_index": {claim: sorted(uids) for claim, uids in sorted(self._by_claim.items())},
             "receipt_index": {
                 receipt: sorted(uids) for receipt, uids in sorted(self._by_receipt.items())
             },

--- a/aragora/epistemic/proof_unit.py
+++ b/aragora/epistemic/proof_unit.py
@@ -2,12 +2,15 @@
 
 The pure schema/model lives in :mod:`aragora.epistemic.proof_unit_model`.
 Filesystem scanning and flag handling live in
-:mod:`aragora.epistemic.proof_unit_scanner`.  This facade preserves the
-original public import path while keeping dataclasses separate from I/O.
+:mod:`aragora.epistemic.proof_unit_scanner`.  The cross-reference index over
+multiple units lives in :mod:`aragora.epistemic.constraint_graph`.  This
+facade preserves the original public import path while keeping dataclasses
+separate from I/O and graph logic.
 """
 
 from __future__ import annotations
 
+from .constraint_graph import ProofUnitConstraintGraph
 from .proof_unit_model import (
     DecayPolicy,
     FallbackPolicy,
@@ -31,6 +34,7 @@ __all__ = [
     "InvalidProofUnitError",
     "MalformedProofUnitError",
     "ProofCarryingCodeUnit",
+    "ProofUnitConstraintGraph",
     "ProofUnitLoadError",
     "enable_proof_unit_scan",
     "load_proof_unit",

--- a/tests/epistemic/test_constraint_graph.py
+++ b/tests/epistemic/test_constraint_graph.py
@@ -17,8 +17,26 @@ from aragora.epistemic.proof_unit_model import (
 )
 
 
-def _unit(uid: str, claims: list[str] | None = None, receipts: list[str] | None = None, crux_ids: list[str] | None = None) -> ProofCarryingCodeUnit:
-    return ProofCarryingCodeUnit(code_unit_id=uid, symbol=f"aragora.epistemic.{uid}", source_path=f"aragora/{uid}.py", owner="test", decision_receipts=receipts or [], claims=claims or [], assumptions=[], verifiers=[], freshness_sla_hours=24, decay_policy=DecayPolicy(), fallback_policy=FallbackPolicy(), linked_crux_ids=crux_ids or [])
+def _unit(
+    uid: str,
+    claims: list[str] | None = None,
+    receipts: list[str] | None = None,
+    crux_ids: list[str] | None = None,
+) -> ProofCarryingCodeUnit:
+    return ProofCarryingCodeUnit(
+        code_unit_id=uid,
+        symbol=f"aragora.epistemic.{uid}",
+        source_path=f"aragora/{uid}.py",
+        owner="test",
+        decision_receipts=receipts or [],
+        claims=claims or [],
+        assumptions=[],
+        verifiers=[],
+        freshness_sla_hours=24,
+        decay_policy=DecayPolicy(),
+        fallback_policy=FallbackPolicy(),
+        linked_crux_ids=crux_ids or [],
+    )
 
 
 class TestBuild:
@@ -70,12 +88,20 @@ class TestUnitsByReceiptAndCrux:
     def test_by_receipt(self) -> None:
         u = _unit("alpha", receipts=["rcpt.001"])
         g = ProofUnitConstraintGraph([u])
-        assert g.units_by_receipt("rcpt.001") == [u] and g.units_by_receipt("missing") == [] and g.receipt_count == 1
+        assert (
+            g.units_by_receipt("rcpt.001") == [u]
+            and g.units_by_receipt("missing") == []
+            and g.receipt_count == 1
+        )
 
     def test_by_crux(self) -> None:
         u = _unit("alpha", crux_ids=["crux.42"])
         g = ProofUnitConstraintGraph([u])
-        assert g.units_by_crux("crux.42") == [u] and g.units_by_crux("missing") == [] and g.crux_count == 1
+        assert (
+            g.units_by_crux("crux.42") == [u]
+            and g.units_by_crux("missing") == []
+            and g.crux_count == 1
+        )
 
     def test_no_crux_ids_gives_zero_crux_count(self) -> None:
         assert ProofUnitConstraintGraph([_unit("alpha", claims=["c"])]).crux_count == 0
@@ -89,11 +115,13 @@ class TestImpactSet:
         assert g.impact_set({"a"}) == {"alpha"}
 
     def test_multiple_claims_union(self) -> None:
-        g = ProofUnitConstraintGraph([
-            _unit("alpha", claims=["a"]),
-            _unit("beta", claims=["b"]),
-            _unit("gamma", claims=["a", "b"]),
-        ])
+        g = ProofUnitConstraintGraph(
+            [
+                _unit("alpha", claims=["a"]),
+                _unit("beta", claims=["b"]),
+                _unit("gamma", claims=["a", "b"]),
+            ]
+        )
         assert g.impact_set({"a", "b"}) == {"alpha", "beta", "gamma"}
 
     def test_empty_input_returns_empty(self) -> None:

--- a/tests/epistemic/test_constraint_graph.py
+++ b/tests/epistemic/test_constraint_graph.py
@@ -1,0 +1,134 @@
+"""Tests for ProofUnitConstraintGraph (DIC-19 / #6030).
+
+Pure schema/logic — no network, no subprocess, no queue mutation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aragora.epistemic.constraint_graph import ProofUnitConstraintGraph
+from aragora.epistemic.proof_unit_model import (
+    DecayPolicy,
+    FallbackPolicy,
+    ProofCarryingCodeUnit,
+)
+
+
+def _unit(uid: str, claims: list[str] | None = None, receipts: list[str] | None = None, crux_ids: list[str] | None = None) -> ProofCarryingCodeUnit:
+    return ProofCarryingCodeUnit(code_unit_id=uid, symbol=f"aragora.epistemic.{uid}", source_path=f"aragora/{uid}.py", owner="test", decision_receipts=receipts or [], claims=claims or [], assumptions=[], verifiers=[], freshness_sla_hours=24, decay_policy=DecayPolicy(), fallback_policy=FallbackPolicy(), linked_crux_ids=crux_ids or [])
+
+
+class TestBuild:
+    def test_empty_graph(self) -> None:
+        g = ProofUnitConstraintGraph([])
+        assert g.unit_count == 0
+        assert g.claim_count == 0
+
+    def test_single_unit_indexed_by_claim(self) -> None:
+        u = _unit("alpha", claims=["claim.x"])
+        g = ProofUnitConstraintGraph([u])
+        assert g.unit_count == 1
+        assert g.units_by_claim("claim.x") == [u]
+
+    def test_duplicate_unit_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="duplicate code_unit_id"):
+            ProofUnitConstraintGraph([_unit("alpha"), _unit("alpha")])
+
+    def test_generator_input(self) -> None:
+        g = ProofUnitConstraintGraph(_unit(f"u{i}") for i in range(3))
+        assert g.unit_count == 3
+
+
+class TestUnitsByClaim:
+    def test_shared_claim_returns_all_owners(self) -> None:
+        u1 = _unit("alpha", claims=["shared"])
+        u2 = _unit("beta", claims=["shared"])
+        g = ProofUnitConstraintGraph([u1, u2])
+        assert {u.code_unit_id for u in g.units_by_claim("shared")} == {"alpha", "beta"}
+
+    def test_unknown_claim_empty(self) -> None:
+        g = ProofUnitConstraintGraph([_unit("alpha", claims=["x"])])
+        assert g.units_by_claim("missing") == []
+
+    def test_result_deterministically_sorted(self) -> None:
+        units = [_unit(f"unit{x}", claims=["shared"]) for x in ["zzz", "aaa", "mmm"]]
+        g = ProofUnitConstraintGraph(units)
+        ids = [u.code_unit_id for u in g.units_by_claim("shared")]
+        assert ids == sorted(ids)
+
+    def test_unit_with_many_claims_indexed_under_each(self) -> None:
+        u = _unit("alpha", claims=["a", "b", "c"])
+        g = ProofUnitConstraintGraph([u])
+        for c in ["a", "b", "c"]:
+            assert g.units_by_claim(c) == [u]
+
+
+class TestUnitsByReceiptAndCrux:
+    def test_by_receipt(self) -> None:
+        u = _unit("alpha", receipts=["rcpt.001"])
+        g = ProofUnitConstraintGraph([u])
+        assert g.units_by_receipt("rcpt.001") == [u] and g.units_by_receipt("missing") == [] and g.receipt_count == 1
+
+    def test_by_crux(self) -> None:
+        u = _unit("alpha", crux_ids=["crux.42"])
+        g = ProofUnitConstraintGraph([u])
+        assert g.units_by_crux("crux.42") == [u] and g.units_by_crux("missing") == [] and g.crux_count == 1
+
+    def test_no_crux_ids_gives_zero_crux_count(self) -> None:
+        assert ProofUnitConstraintGraph([_unit("alpha", claims=["c"])]).crux_count == 0
+
+
+class TestImpactSet:
+    def test_single_claim_impacts_direct_owners_only(self) -> None:
+        u1 = _unit("alpha", claims=["a"])
+        u2 = _unit("beta", claims=["b"])
+        g = ProofUnitConstraintGraph([u1, u2])
+        assert g.impact_set({"a"}) == {"alpha"}
+
+    def test_multiple_claims_union(self) -> None:
+        g = ProofUnitConstraintGraph([
+            _unit("alpha", claims=["a"]),
+            _unit("beta", claims=["b"]),
+            _unit("gamma", claims=["a", "b"]),
+        ])
+        assert g.impact_set({"a", "b"}) == {"alpha", "beta", "gamma"}
+
+    def test_empty_input_returns_empty(self) -> None:
+        g = ProofUnitConstraintGraph([_unit("alpha", claims=["a"])])
+        assert g.impact_set(set()) == set()
+        assert g.impact_set([]) == set()
+
+    def test_unknown_claims_are_ignored(self) -> None:
+        g = ProofUnitConstraintGraph([])
+        assert g.impact_set({"nonexistent"}) == set()
+
+
+class TestToDict:
+    def test_structure_and_json_round_trip(self) -> None:
+        u = _unit("alpha", claims=["c.x"], receipts=["r.1"], crux_ids=["crux.9"])
+        g = ProofUnitConstraintGraph([u])
+        d = g.to_dict()
+        assert d["unit_count"] == 1
+        assert d["claim_count"] == 1
+        assert d["receipt_count"] == 1
+        assert d["crux_count"] == 1
+        assert d["claim_index"]["c.x"] == ["alpha"]
+        assert d["receipt_index"]["r.1"] == ["alpha"]
+        assert d["crux_index"]["crux.9"] == ["alpha"]
+        # Must be JSON-serializable
+        reloaded = json.loads(json.dumps(d))
+        assert reloaded["unit_count"] == 1
+
+    def test_empty_graph_gives_empty_dicts(self) -> None:
+        d = ProofUnitConstraintGraph([]).to_dict()
+        assert d["units"] == {} and d["claim_index"] == {}
+
+    def test_units_and_claim_index_are_sorted(self) -> None:
+        units = [_unit(f"unit{x}", claims=["shared"]) for x in ["zzz", "aaa"]]
+        g = ProofUnitConstraintGraph(units)
+        d = g.to_dict()
+        assert list(d["units"].keys()) == sorted(d["units"].keys())
+        assert d["claim_index"]["shared"] == sorted(d["claim_index"]["shared"])


### PR DESCRIPTION
## Slice

Adds `ProofUnitConstraintGraph` — a read-only cross-reference index that takes a collection of `ProofCarryingCodeUnit` instances and builds O(1) lookup indexes over their `claims`, `decision_receipts`, and `linked_crux_ids`. The `impact_set(claim_ids)` method answers "which code units are directly impacted if these claims become invalid?" in a single set union, with no scanning.

This is the missing piece of DIC-19: the individual unit schema and filesystem scanner already existed (`proof_unit_model.py`, `proof_unit_scanner.py`); what was absent was the graph that joins units through their shared claims and receipts to enable downstream decay and quarantine tools (DIC-20/DIC-21) to query impact without iterating all units on every check.

## Gating

- Default: **OFF** — no live code constructs the graph; the dataclass is always importable (same pattern as `ProofCarryingCodeUnit` itself)
- Scanner gate: `ARAGORA_PROOF_UNIT_SCAN_ENABLED` (same existing flag as the directory scanner that populates the unit list)
- Live queue effect: **none**
- Advances issue: #6030

## Tests

- `TestBuild` — empty graph, single unit indexed, duplicate ID raises `ValueError`, generator input accepted
- `TestUnitsByClaim` — shared claim returns all owners, unknown claim returns empty, result is deterministically sorted, multi-claim unit indexed under each claim
- `TestUnitsByReceiptAndCrux` — lookup by receipt ID, lookup by crux ID, zero crux count when no crux IDs present
- `TestImpactSet` — single-claim impact, multi-claim union, empty input, unknown claims ignored
- `TestToDict` — full JSON-serializable structure, empty graph shape, sorted keys invariant

## Validation

- `python3 -m pytest tests/epistemic/test_constraint_graph.py --noconftest -q` — **18 passed** (pure stdlib; no pydantic/asyncio conftest needed)
- `ruff check aragora/epistemic/constraint_graph.py tests/epistemic/test_constraint_graph.py aragora/epistemic/proof_unit.py` — **clean**
- `mypy aragora/epistemic/constraint_graph.py aragora/epistemic/proof_unit.py --ignore-missing-imports` — **clean**
- Net diff: 299 LOC (304 insertions − 5 deletions)

## Out of scope

- Multi-hop propagation (unit A depends on unit B's proof): deferred until explicit unit-to-unit dependency edges are tracked in a future DIC-19 follow-on
- Persistence / serialization to disk: callers use `to_dict()` and own the store
- Integration with DIC-20 decay monitor or DIC-21 quarantine policy: those slices wire the graph in; this PR only ships the graph

Note: the proof-first Foreman gate in `docs/status/NEXT_STEPS_CANONICAL.md` is **not yet open** for the DIC-13..22 tranche. This PR carries no `boss-ready` label and must remain DRAFT until the gate opens or is explicitly waived for this slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Trs6vTnGBAPqWsfs3agsz)_