### PR TITLE
feat(automation): launch Droid lanes through agent bridge

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -6,6 +6,7 @@ inventory from agent_bridge_sessions.py (PR #5306).
 
 Usage:
   python3 scripts/agent_bridge.py sessions [--json]
+  python3 scripts/agent_bridge.py launch --name codex-review --agent codex --file /tmp/prompt.md
   python3 scripts/agent_bridge.py send <name> "Fix the LOC ratchet"
   python3 scripts/agent_bridge.py send <name> --file /tmp/prompt.md
   python3 scripts/agent_bridge.py approve <name>
@@ -539,6 +540,61 @@ def cmd_sessions(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_launch(args: argparse.Namespace) -> int:
+    """Launch a tmux-managed harness lane, then let send/read manage it."""
+    if not args.name:
+        print("No session name. Use --name", file=sys.stderr)
+        return 1
+    agent = str(args.agent or "codex").strip()
+    if agent not in {"codex", "claude", "droid", "factory"}:
+        print("Unsupported agent. Use codex, claude, droid, or factory.", file=sys.stderr)
+        return 1
+
+    launcher = CANONICAL_REPO_ROOT / "scripts" / "tmux_session_launcher.sh"
+    cmd = ["bash", str(launcher), "--name", args.name, "--agent", agent]
+    if getattr(args, "autonomous", False):
+        cmd.append("--autonomous")
+    if args.file:
+        cmd.extend(["--prompt-file", args.file])
+    elif args.prompt:
+        cmd.extend(["--prompt", " ".join(args.prompt)])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(CANONICAL_REPO_ROOT),
+            capture_output=bool(args.json),
+            text=True,
+            timeout=max(30, int(args.timeout_seconds)),
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        print(f"Launch failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": result.returncode == 0,
+                    "name": args.name,
+                    "agent": agent,
+                    "returncode": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                },
+                indent=2,
+            )
+        )
+    else:
+        if result.stdout:
+            print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="", file=sys.stderr)
+
+    return result.returncode
+
+
 def cmd_send(args: argparse.Namespace) -> int:
     sessions = discover()
     _enrich_prs(sessions)
@@ -843,6 +899,22 @@ def main() -> int:
 
     sub.add_parser("sessions", parents=[json_parent], help="List sessions")
 
+    launch_p = sub.add_parser(
+        "launch",
+        parents=[json_parent],
+        help="Launch a tmux-managed agent session",
+    )
+    launch_p.add_argument("--name", required=True)
+    launch_p.add_argument(
+        "--agent", default="codex", choices=("codex", "claude", "droid", "factory")
+    )
+    launch_p.add_argument("prompt", nargs="*")
+    launch_p.add_argument("--file", help="Prompt file")
+    launch_p.add_argument(
+        "--autonomous", action="store_true", help="Grant launcher autonomy where supported"
+    )
+    launch_p.add_argument("--timeout-seconds", type=int, default=120)
+
     send_p = sub.add_parser("send", parents=[json_parent], help="Send prompt to session")
     send_p.add_argument("name")
     send_p.add_argument("prompt", nargs="*")
@@ -886,6 +958,7 @@ def main() -> int:
 
     cmds = {
         "sessions": cmd_sessions,
+        "launch": cmd_launch,
         "send": cmd_send,
         "approve": cmd_approve,
         "read": cmd_read,

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -411,18 +411,23 @@ def _find_session(sessions: list[Session], target: str) -> Session | None:
 def _send_tmux(target: str, prompt: str) -> bool:
     try:
         if "\n" in prompt:
-            subprocess.run(["tmux", "set-buffer", "-b", "bridge", prompt], check=True, timeout=5)
             subprocess.run(
-                ["tmux", "paste-buffer", "-b", "bridge", "-t", target],
+                ["tmux", "load-buffer", "-"],
+                input=prompt,
+                text=True,
                 check=True,
                 timeout=5,
             )
             subprocess.run(
-                ["tmux", "send-keys", "-t", target, "", "Enter"],
+                ["tmux", "paste-buffer", "-d", "-t", target],
                 check=True,
                 timeout=5,
             )
-            subprocess.run(["tmux", "delete-buffer", "-b", "bridge"], check=False, timeout=5)
+            subprocess.run(
+                ["tmux", "send-keys", "-t", target, "Enter"],
+                check=True,
+                timeout=5,
+            )
         else:
             subprocess.run(
                 ["tmux", "send-keys", "-t", target, prompt, "Enter"],
@@ -647,9 +652,10 @@ def cmd_approve(args: argparse.Namespace) -> int:
     target = _resolve_tmux_target(session)
     if not target:
         target = f"{TMUX_SESSION}:{session.name}"
+    keys = ["Enter"] if session.agent in {"droid", "factory"} else ["y", "Enter"]
     try:
         subprocess.run(
-            ["tmux", "send-keys", "-t", target, "y", "Enter"],
+            ["tmux", "send-keys", "-t", target, *keys],
             check=True,
             timeout=5,
         )

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -26,6 +26,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from dataclasses import asdict, dataclass
 from datetime import UTC
 from datetime import datetime
@@ -423,6 +424,7 @@ def _send_tmux(target: str, prompt: str) -> bool:
                 check=True,
                 timeout=5,
             )
+            time.sleep(float(os.environ.get("ARAGORA_TMUX_PASTE_SETTLE_SECONDS", "0.2")))
             subprocess.run(
                 ["tmux", "send-keys", "-t", target, "Enter"],
                 check=True,

--- a/scripts/tmux_send_prompt.sh
+++ b/scripts/tmux_send_prompt.sh
@@ -182,6 +182,7 @@ fi
 if [[ "${LINE_COUNT}" -gt 1 ]]; then
     printf '%s' "${PROMPT}" | tmux load-buffer -
     tmux paste-buffer -d -t "${TARGET}"
+    sleep "${ARAGORA_TMUX_PASTE_SETTLE_SECONDS:-0.2}"
     tmux send-keys -t "${TARGET}" Enter
     DISPATCH_METHOD="paste-buffer"
 else

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Launch a Codex or Claude session inside a named tmux pane.
+# Launch a Codex, Claude, or Droid session inside a named tmux pane.
 #
 # Usage:
 #   ./scripts/tmux_session_launcher.sh --name codex-conductor --agent codex --prompt-file /tmp/prompt.md
 #   ./scripts/tmux_session_launcher.sh --name claude-worker --agent claude --autonomous --prompt "Fix tests"
+#   ./scripts/tmux_session_launcher.sh --name factory-review --agent droid --prompt "Review PR #6811"
 #   ./scripts/tmux_session_launcher.sh --name codex-qa --agent codex --autonomous --prompt "Fix the tests"
 #   ./scripts/tmux_session_launcher.sh --list
 #   ./scripts/tmux_session_launcher.sh --kill codex-conductor
@@ -96,6 +97,9 @@ wait_for_agent_ready() {
         claude)
             pattern='Claude Code|ctrl\+g to edit in VS Code|don'"'"'t ask on'
             ;;
+        droid|factory)
+            pattern='Droid|Factory|AI coding agent|Type your message'
+            ;;
     esac
 
     if [[ -z "${pattern}" ]]; then
@@ -120,6 +124,9 @@ default_init_wait_seconds() {
             echo "60"
             ;;
         claude)
+            echo "30"
+            ;;
+        droid|factory)
             echo "30"
             ;;
         *)
@@ -224,8 +231,13 @@ elif [[ "${AGENT}" == "claude" ]]; then
     else
         LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/claude-wt"
     fi
+elif [[ "${AGENT}" == "droid" || "${AGENT}" == "factory" ]]; then
+    # Droid interactive sessions do their own permission gating. Mission/exec
+    # mode is intentionally not used here so the pane remains interactive for
+    # later agent_bridge.py send/read cycles.
+    LAUNCH_CMD="cd '${REPO_ROOT}' && droid --cwd '${REPO_ROOT}'"
 else
-    echo "Unknown agent: ${AGENT}. Use 'codex' or 'claude'." >&2
+    echo "Unknown agent: ${AGENT}. Use 'codex', 'claude', or 'droid'." >&2
     exit 1
 fi
 

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -43,6 +43,7 @@ send_prompt_to_target() {
     if [[ "${line_count}" -gt 1 ]]; then
         printf '%s' "${prompt}" | tmux load-buffer -
         tmux paste-buffer -d -t "${target}"
+        sleep "${ARAGORA_TMUX_PASTE_SETTLE_SECONDS:-0.2}"
         tmux send-keys -t "${target}" Enter
         method="paste-buffer"
     else

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -92,7 +92,7 @@ wait_for_agent_ready() {
 
     case "${agent}" in
         codex)
-            pattern='OpenAI Codex|Use /skills to list available skills|Improve documentation in @filename|Find and fix a bug in @filename|Explain this codebase|Use /rename to rename your threads'
+            pattern='Use /skills to list available skills|Improve documentation in @filename|Find and fix a bug in @filename|Explain this codebase|Use /rename to rename your threads'
             ;;
         claude)
             pattern='Claude Code|ctrl\+g to edit in VS Code|don'"'"'t ask on'

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -24,6 +25,63 @@ def _patch_bridge_paths(mod, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(mod, "AGENT_BRIDGE_DIR", bridge_dir)
     monkeypatch.setattr(mod, "SESSION_SNAPSHOT_FILE", bridge_dir / "sessions.json")
     monkeypatch.setattr(mod, "LANE_REGISTRY_FILE", bridge_dir / "lanes.json")
+
+
+def test_send_tmux_multiline_uses_delete_on_paste_buffer_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bridge as mod
+
+    calls: list[tuple[list[str], str | None]] = []
+
+    def _fake_run(
+        args: list[str],
+        *,
+        input: str | None = None,
+        text: bool | None = None,
+        check: bool | None = None,
+        timeout: int | None = None,
+        **_kwargs,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append((args, input))
+        assert check is True
+        assert timeout == 5
+        if args == ["tmux", "load-buffer", "-"]:
+            assert text is True
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+
+    assert mod._send_tmux("aragora:codex-review", "line one\nline two") is True
+    assert calls == [
+        (["tmux", "load-buffer", "-"], "line one\nline two"),
+        (["tmux", "paste-buffer", "-d", "-t", "aragora:codex-review"], None),
+        (["tmux", "send-keys", "-t", "aragora:codex-review", "Enter"], None),
+    ]
+
+
+def test_cmd_approve_droid_uses_enter_menu_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bridge as mod
+
+    session = mod.Session(
+        name="factory-review",
+        agent="droid",
+        status="alive",
+        tmux_target="aragora:factory-review",
+    )
+    calls: list[list[str]] = []
+
+    def _fake_run(args: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(mod, "discover", lambda: [session])
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+
+    rc = mod.cmd_approve(argparse.Namespace(name="factory-review", json=False))
+
+    assert rc == 0
+    assert calls == [["tmux", "send-keys", "-t", "aragora:factory-review", "Enter"]]
 
 
 def test_cmd_send_persists_lane_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -33,6 +33,7 @@ def test_send_tmux_multiline_uses_delete_on_paste_buffer_transport(
     import agent_bridge as mod
 
     calls: list[tuple[list[str], str | None]] = []
+    sleeps: list[float] = []
 
     def _fake_run(
         args: list[str],
@@ -51,8 +52,11 @@ def test_send_tmux_multiline_uses_delete_on_paste_buffer_transport(
         return subprocess.CompletedProcess(args, 0)
 
     monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    monkeypatch.setenv("ARAGORA_TMUX_PASTE_SETTLE_SECONDS", "0.01")
+    monkeypatch.setattr(mod.time, "sleep", lambda seconds: sleeps.append(seconds))
 
     assert mod._send_tmux("aragora:codex-review", "line one\nline two") is True
+    assert sleeps == [0.01]
     assert calls == [
         (["tmux", "load-buffer", "-"], "line one\nline two"),
         (["tmux", "paste-buffer", "-d", "-t", "aragora:codex-review"], None),

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -265,6 +265,67 @@ def test_main_accepts_json_after_subcommand(
     assert json.loads(capsys.readouterr().out) == []
 
 
+def test_cmd_launch_invokes_tmux_launcher_for_droid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    repo_root = tmp_path / "repo"
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    launcher = scripts_dir / "tmux_session_launcher.sh"
+    launcher.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("review only\n", encoding="utf-8")
+    monkeypatch.setattr(mod, "CANONICAL_REPO_ROOT", repo_root)
+
+    calls = []
+
+    def _fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return argparse.Namespace(returncode=0, stdout="launched\n", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+
+    rc = mod.cmd_launch(
+        argparse.Namespace(
+            name="factory-review",
+            agent="droid",
+            prompt=[],
+            file=str(prompt_file),
+            autonomous=False,
+            timeout_seconds=10,
+            json=False,
+        )
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == "launched\n"
+    assert calls == [
+        (
+            [
+                "bash",
+                str(launcher),
+                "--name",
+                "factory-review",
+                "--agent",
+                "droid",
+                "--prompt-file",
+                str(prompt_file),
+            ],
+            {
+                "cwd": str(repo_root),
+                "capture_output": False,
+                "text": True,
+                "timeout": 30,
+                "check": False,
+            },
+        )
+    ]
+
+
 def test_write_session_snapshot_falls_back_to_state_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -34,9 +34,15 @@ if cmd[:2] == ["list-panes", "-t"]:
 if cmd[:2] == ["new-window", "-P"]:
     print("@17")
     raise SystemExit(0)
-if cmd[:2] in (["new-session", "-d"], ["pipe-pane", "-t"]):
+if cmd[:2] in (["new-session", "-d"], ["pipe-pane", "-t"], ["load-buffer", "-"]):
     raise SystemExit(0)
-if cmd[:2] in (["send-keys", "-t"], ["set-buffer", "-b"], ["paste-buffer", "-b"], ["delete-buffer", "-b"]):
+if cmd[:2] in (
+    ["send-keys", "-t"],
+    ["set-buffer", "-b"],
+    ["paste-buffer", "-b"],
+    ["paste-buffer", "-d"],
+    ["delete-buffer", "-b"],
+):
     raise SystemExit(0)
 
 print(f"unexpected tmux command: {{cmd}}", file=sys.stderr)
@@ -65,7 +71,7 @@ def _load_tmux_calls(env: dict[str, str]) -> list[list[str]]:
     ]
 
 
-def test_tmux_send_prompt_uses_unique_buffer_for_multiline_prompt(tmp_path: Path) -> None:
+def test_tmux_send_prompt_uses_load_buffer_for_multiline_prompt(tmp_path: Path) -> None:
     _write_fake_tmux(tmp_path)
     env = _fake_tmux_env(tmp_path)
     prompt_file = tmp_path / "prompt.md"
@@ -89,14 +95,9 @@ def test_tmux_send_prompt_uses_unique_buffer_for_multiline_prompt(tmp_path: Path
 
     assert "Prompt sent to 'testpane'" in result.stdout
     calls = _load_tmux_calls(env)
-    set_buffer_call = next(call for call in calls if call[:2] == ["set-buffer", "-b"])
-    paste_buffer_call = next(call for call in calls if call[:2] == ["paste-buffer", "-b"])
-    delete_buffer_call = next(call for call in calls if call[:2] == ["delete-buffer", "-b"])
-
-    buffer_name = set_buffer_call[2]
-    assert buffer_name == paste_buffer_call[2] == delete_buffer_call[2]
-    assert buffer_name.startswith("aragora-prompt-testpane-")
-    assert buffer_name != "aragora-prompt"
+    assert any(call[:2] == ["load-buffer", "-"] for call in calls)
+    assert any(call[:2] == ["paste-buffer", "-d"] for call in calls)
+    assert not any(call[:2] == ["set-buffer", "-b"] for call in calls)
 
 
 def test_tmux_session_launcher_waits_for_readiness_marker_before_prompt_send(
@@ -182,6 +183,46 @@ def test_tmux_session_launcher_accepts_new_codex_readiness_markers(tmp_path: Pat
     )
 
     assert "Readiness markers detected for testpane." in result.stdout
+
+
+def test_tmux_session_launcher_supports_droid_agent(tmp_path: Path) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+
+    log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
+    log_dir.mkdir(parents=True)
+    (log_dir / "factory-review.log").write_text("boot\nDroid\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "factory-review",
+            "--agent",
+            "droid",
+            "--prompt",
+            "review only",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Readiness markers detected for factory-review." in result.stdout
+    calls = _load_tmux_calls(env)
+    assert any(
+        call[:2] == ["send-keys", "-t"] and call[2] == "@17" and "droid --cwd" in call[3]
+        for call in calls
+    )
+    assert any(
+        call[:2] == ["send-keys", "-t"] and call[2] == "@17" and "review only" in call
+        for call in calls
+    )
 
 
 def test_tmux_session_launcher_does_not_send_prompt_before_readiness_by_default(

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -59,6 +59,7 @@ def _fake_tmux_env(tmp_path: Path) -> dict[str, str]:
     env["FAKE_TMUX_LOG"] = str(tmp_path / "tmux-calls.jsonl")
     env["PATH"] = f"{tmp_path}:{env['PATH']}"
     env["HOME"] = str(tmp_path / "home")
+    env["ARAGORA_TMUX_PASTE_SETTLE_SECONDS"] = "0"
     return env
 
 

--- a/tests/scripts/test_tmux_transport_scripts.py
+++ b/tests/scripts/test_tmux_transport_scripts.py
@@ -110,7 +110,10 @@ def test_tmux_session_launcher_waits_for_readiness_marker_before_prompt_send(
 
     log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
     log_dir.mkdir(parents=True)
-    (log_dir / "testpane.log").write_text("boot\nOpenAI Codex\n", encoding="utf-8")
+    (log_dir / "testpane.log").write_text(
+        "boot\nFind and fix a bug in @filename\n",
+        encoding="utf-8",
+    )
 
     result = subprocess.run(
         [
@@ -183,6 +186,42 @@ def test_tmux_session_launcher_accepts_new_codex_readiness_markers(tmp_path: Pat
     )
 
     assert "Readiness markers detected for testpane." in result.stdout
+
+
+def test_tmux_session_launcher_does_not_treat_codex_banner_as_ready(tmp_path: Path) -> None:
+    _write_fake_tmux(tmp_path)
+    env = _fake_tmux_env(tmp_path)
+    env["ARAGORA_TMUX_INIT_WAIT_SECONDS"] = "1"
+    env["ARAGORA_TMUX_REGISTRY_REPO_ROOT"] = str(tmp_path)
+
+    log_dir = Path(env["HOME"]) / ".aragora" / "tmux-sessions"
+    log_dir.mkdir(parents=True)
+    (log_dir / "testpane.log").write_text(
+        "boot\nOpenAI Codex (v0.125.0)\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "tmux_session_launcher.sh"),
+            "--name",
+            "testpane",
+            "--agent",
+            "codex",
+            "--prompt",
+            "hello from launcher",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Timed out waiting for readiness markers for testpane; prompt not sent." in result.stdout
+    calls = _load_tmux_calls(env)
+    assert ["load-buffer", "-"] not in calls
 
 
 def test_tmux_session_launcher_supports_droid_agent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Makes the Aragora agent bridge useful for the current multi-harness workflow by letting operators launch tmux-managed lanes directly through `scripts/agent_bridge.py`, and by adding Droid/Factory support to the existing tmux launcher.

## Changes

- Adds `python3 scripts/agent_bridge.py launch --name <name> --agent {codex,claude,droid,factory}` as the single bridge entrypoint for creating tmux-managed harness lanes.
- Adds `droid` / `factory` support to `scripts/tmux_session_launcher.sh`, including readiness markers and metadata registration through the existing tmux/session-mux path.
- Keeps Droid interactive rather than forcing `droid exec`, so follow-up `agent_bridge.py send/read` cycles remain possible.
- Updates tmux transport tests to match the current `load-buffer -` multiline prompt transport contract.

## Validation

- `python3 -m pytest -q tests/scripts/test_agent_bridge.py tests/scripts/test_tmux_transport_scripts.py -p no:randomly` -> 15 passed
- `python3 -m ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py tests/scripts/test_tmux_transport_scripts.py` -> pass
- `python3 -m ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py tests/scripts/test_tmux_transport_scripts.py` -> pass
- `bash -n scripts/tmux_session_launcher.sh scripts/tmux_send_prompt.sh` -> pass
- `python3 -m py_compile scripts/agent_bridge.py` -> pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> pass

## Notes

#6811 merged before this PR was opened. Current queue also has #6812 as a draft DIC PR; this branch is intentionally scoped to bridge/operator tooling only.
