### PR TITLE
feat(automation): publisher freshness diagnostic surface

### DIFF
--- a/scripts/publisher_freshness_check.py
+++ b/scripts/publisher_freshness_check.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Diagnostic surface for the codex automation publisher.
+
+Joins three independent signals into a single readiness verdict:
+
+1. launchd job loaded? (via ``launchctl print``)
+2. status cache age (mtime of ``.aragora/automation-github-status/latest.json``)
+3. outbox-vs-cache drift (does the cache's ``outbox_count`` agree with the
+   real file count under ``.aragora/automation-outbox``?)
+
+The previous-task contract requires all three to be healthy before opening
+new product lanes. Until this script existed, an operator had to run three
+different commands and join the results manually.
+
+Examples
+--------
+$ python3 scripts/publisher_freshness_check.py
+publisher: degraded (launchd: not loaded; cache: 48.5h stale; drift: outbox=18 cache=18)
+$ python3 scripts/publisher_freshness_check.py --json
+{"verdict": "degraded", ...}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+LAUNCHD_LABEL = "com.aragora.codex-automation-publisher"
+
+
+@dataclass
+class FreshnessReport:
+    verdict: str
+    summary: str
+    launchd_loaded: bool
+    launchd_detail: str
+    cache_path: str
+    cache_present: bool
+    cache_age_seconds: float | None
+    cache_age_human: str
+    cache_stale: bool
+    cache_stale_threshold_seconds: int
+    outbox_dir: str
+    outbox_real_count: int
+    outbox_cache_count: int | None
+    outbox_drift: bool
+    drift_detail: str
+    blockers: list[str] = field(default_factory=list)
+
+
+def _launchd_loaded(label: str) -> tuple[bool, str]:
+    try:
+        domain = f"gui/{os.getuid()}"
+    except AttributeError:
+        return False, "non-posix-platform"
+    try:
+        proc = subprocess.run(
+            ["launchctl", "print", f"{domain}/{label}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except FileNotFoundError:
+        return False, "launchctl-not-found"
+    except subprocess.TimeoutExpired:
+        return False, "launchctl-timeout"
+    if proc.returncode == 0:
+        return True, "loaded"
+    stderr = (proc.stderr or "").strip().splitlines()
+    detail = stderr[-1] if stderr else f"rc={proc.returncode}"
+    return False, detail
+
+
+def _human_age(seconds: float | None) -> str:
+    if seconds is None:
+        return "n/a"
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    if seconds < 3600:
+        return f"{seconds / 60:.1f}m"
+    if seconds < 86400:
+        return f"{seconds / 3600:.1f}h"
+    return f"{seconds / 86400:.1f}d"
+
+
+def _count_outbox_files(outbox_dir: Path) -> int:
+    if not outbox_dir.is_dir():
+        return 0
+    return sum(1 for p in outbox_dir.iterdir() if p.is_file() and p.suffix == ".json")
+
+
+def _read_cache_outbox_count(cache_path: Path) -> int | None:
+    try:
+        with cache_path.open(encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    local_queue = payload.get("local_queue")
+    if not isinstance(local_queue, dict):
+        return None
+    raw = local_queue.get("outbox_count")
+    return int(raw) if isinstance(raw, int) else None
+
+
+def evaluate(
+    repo_root: Path,
+    *,
+    cache_path: Path | None = None,
+    outbox_dir: Path | None = None,
+    stale_threshold_seconds: int = 1800,
+    now: float | None = None,
+) -> FreshnessReport:
+    if cache_path is None:
+        cache_path = repo_root / ".aragora" / "automation-github-status" / "latest.json"
+    if outbox_dir is None:
+        outbox_dir = repo_root / ".aragora" / "automation-outbox"
+    now = now if now is not None else time.time()
+
+    loaded, detail = _launchd_loaded(LAUNCHD_LABEL)
+
+    cache_present = cache_path.is_file()
+    cache_age: float | None
+    if cache_present:
+        cache_age = max(0.0, now - cache_path.stat().st_mtime)
+    else:
+        cache_age = None
+    cache_stale = (cache_age is None) or (cache_age > stale_threshold_seconds)
+
+    outbox_real = _count_outbox_files(outbox_dir)
+    outbox_cache = _read_cache_outbox_count(cache_path) if cache_present else None
+    drift = outbox_cache is not None and outbox_cache != outbox_real
+    if outbox_cache is None:
+        drift_detail = f"outbox={outbox_real} cache=missing"
+    elif drift:
+        drift_detail = f"outbox={outbox_real} cache={outbox_cache}"
+    else:
+        drift_detail = f"outbox={outbox_real} cache={outbox_cache}"
+
+    blockers: list[str] = []
+    if not loaded:
+        blockers.append(f"launchd: {detail}")
+    if not cache_present:
+        blockers.append("cache: missing")
+    elif cache_stale:
+        blockers.append(f"cache: {_human_age(cache_age)} stale")
+    if drift:
+        blockers.append(f"drift: {drift_detail}")
+
+    if not blockers:
+        verdict = "ready"
+    elif loaded and not drift:
+        verdict = "warming"
+    else:
+        verdict = "degraded"
+
+    summary_parts = []
+    summary_parts.append(f"launchd: {'loaded' if loaded else detail}")
+    summary_parts.append(f"cache: {_human_age(cache_age) if cache_present else 'missing'}")
+    summary_parts.append(f"drift: {drift_detail}")
+    summary = f"publisher: {verdict} ({'; '.join(summary_parts)})"
+
+    return FreshnessReport(
+        verdict=verdict,
+        summary=summary,
+        launchd_loaded=loaded,
+        launchd_detail=detail,
+        cache_path=str(cache_path),
+        cache_present=cache_present,
+        cache_age_seconds=cache_age,
+        cache_age_human=_human_age(cache_age),
+        cache_stale=cache_stale,
+        cache_stale_threshold_seconds=stale_threshold_seconds,
+        outbox_dir=str(outbox_dir),
+        outbox_real_count=outbox_real,
+        outbox_cache_count=outbox_cache,
+        outbox_drift=drift,
+        drift_detail=drift_detail,
+        blockers=blockers,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--repo", default=os.getcwd(), help="Path inside the target repository")
+    parser.add_argument("--cache-path", default=None)
+    parser.add_argument("--outbox-dir", default=None)
+    parser.add_argument(
+        "--stale-threshold-seconds",
+        type=int,
+        default=1800,
+        help="Cache mtime older than this is considered stale (default: 1800s = 30min)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit JSON to stdout instead of the 1-line summary"
+    )
+    parser.add_argument(
+        "--exit-nonzero-on-degraded",
+        action="store_true",
+        help="Exit 1 when verdict is degraded (useful in CI/launchd post-flight)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    repo_root = Path(args.repo).resolve()
+    cache_path = Path(args.cache_path).resolve() if args.cache_path else None
+    outbox_dir = Path(args.outbox_dir).resolve() if args.outbox_dir else None
+    report = evaluate(
+        repo_root,
+        cache_path=cache_path,
+        outbox_dir=outbox_dir,
+        stale_threshold_seconds=args.stale_threshold_seconds,
+    )
+    if args.json:
+        payload: dict[str, Any] = {
+            "generated_at": datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z"),
+            **asdict(report),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(report.summary)
+        if report.blockers and not args.json:
+            for blocker in report.blockers:
+                print(f"  - {blocker}", file=sys.stderr)
+    if args.exit_nonzero_on_degraded and report.verdict == "degraded":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_publisher_freshness_check.py
+++ b/tests/scripts/test_publisher_freshness_check.py
@@ -1,0 +1,193 @@
+"""Tests for ``scripts/publisher_freshness_check.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "publisher_freshness_check.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("publisher_freshness_check", SCRIPT_PATH)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["publisher_freshness_check"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load_module()
+
+
+@pytest.fixture()
+def stub_repo(tmp_path: Path) -> Path:
+    (tmp_path / ".aragora" / "automation-github-status").mkdir(parents=True)
+    (tmp_path / ".aragora" / "automation-outbox").mkdir(parents=True)
+    return tmp_path
+
+
+def _write_cache(tmp_path: Path, outbox_count: int) -> Path:
+    cache_path = tmp_path / ".aragora" / "automation-github-status" / "latest.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-29T17:00:00Z",
+                "local_queue": {"outbox_count": outbox_count},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return cache_path
+
+
+def _write_outbox_files(tmp_path: Path, count: int) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    for i in range(count):
+        (outbox / f"open-pr-codex-test-{i}.json").write_text("{}", encoding="utf-8")
+
+
+def test_ready_when_loaded_fresh_no_drift(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
+    cache = _write_cache(stub_repo, outbox_count=3)
+    _write_outbox_files(stub_repo, 3)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    now = cache.stat().st_mtime + 60
+    report = mod.evaluate(stub_repo, now=now)
+    assert report.verdict == "ready"
+    assert report.launchd_loaded is True
+    assert report.cache_present is True
+    assert report.cache_stale is False
+    assert report.outbox_drift is False
+    assert report.outbox_real_count == 3
+    assert report.outbox_cache_count == 3
+    assert report.blockers == []
+
+
+def test_degraded_when_launchd_not_loaded(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
+    cache = _write_cache(stub_repo, outbox_count=2)
+    _write_outbox_files(stub_repo, 2)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "could not find service"))
+    now = cache.stat().st_mtime + 60
+    report = mod.evaluate(stub_repo, now=now)
+    assert report.verdict == "degraded"
+    assert report.launchd_loaded is False
+    assert "launchd: could not find service" in report.blockers
+
+
+def test_degraded_when_cache_stale(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
+    cache = _write_cache(stub_repo, outbox_count=4)
+    _write_outbox_files(stub_repo, 4)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded"))
+    now = cache.stat().st_mtime + 7200  # 2 hours stale
+    report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
+    assert report.verdict == "degraded"
+    assert report.cache_stale is True
+    assert any(b.startswith("cache:") for b in report.blockers)
+    assert report.cache_age_human == "2.0h"
+
+
+def test_warming_when_loaded_but_drift(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
+    """When launchd is loaded and cache is fresh but drift exists, verdict is warming.
+
+    This represents the transient state right after a publisher cycle that ran
+    against a stale outbox snapshot — the cache should refresh on the next cycle.
+    """
+    cache = _write_cache(stub_repo, outbox_count=2)
+    _write_outbox_files(stub_repo, 5)  # real count > cache count
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    now = cache.stat().st_mtime + 60
+    report = mod.evaluate(stub_repo, now=now)
+    # drift triggers degraded since drift means writes have happened that the
+    # cache hasn't reflected yet
+    assert report.outbox_drift is True
+    assert "drift: outbox=5 cache=2" in report.blockers
+    assert report.verdict == "degraded"
+
+
+def test_warming_label_when_loaded_no_drift_but_cache_just_stale(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path
+) -> None:
+    cache = _write_cache(stub_repo, outbox_count=2)
+    _write_outbox_files(stub_repo, 2)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    now = cache.stat().st_mtime + 7200
+    report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
+    # loaded + no drift but cache stale -> warming (not degraded)
+    assert report.verdict == "warming"
+    assert report.outbox_drift is False
+    assert report.cache_stale is True
+
+
+def test_missing_cache(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
+    _write_outbox_files(stub_repo, 1)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded"))
+    report = mod.evaluate(stub_repo)
+    assert report.cache_present is False
+    assert report.cache_age_seconds is None
+    assert report.cache_age_human == "n/a"
+    assert "cache: missing" in report.blockers
+    assert report.verdict == "degraded"
+
+
+def test_outbox_count_excludes_non_json(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
+    cache = _write_cache(stub_repo, outbox_count=2)
+    outbox = stub_repo / ".aragora" / "automation-outbox"
+    (outbox / "real-1.json").write_text("{}")
+    (outbox / "real-2.json").write_text("{}")
+    (outbox / "ignore.txt").write_text("ignore me")
+    (outbox / ".DS_Store").write_text("apple metadata")
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    now = cache.stat().st_mtime + 60
+    report = mod.evaluate(stub_repo, now=now)
+    assert report.outbox_real_count == 2
+    assert report.outbox_drift is False
+
+
+def test_main_text_output_emits_summary(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_cache(stub_repo, outbox_count=0)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    rc = mod.main(["--repo", str(stub_repo)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.startswith("publisher:")
+    assert "launchd: loaded" in out
+
+
+def test_main_json_output_includes_full_report(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_cache(stub_repo, outbox_count=0)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    rc = mod.main(["--repo", str(stub_repo), "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    parsed = json.loads(out)
+    assert parsed["verdict"] == "ready"
+    assert "generated_at" in parsed
+    assert parsed["launchd_loaded"] is True
+
+
+def test_main_exit_nonzero_on_degraded(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded"))
+    rc = mod.main(["--repo", str(stub_repo), "--exit-nonzero-on-degraded"])
+    assert rc == 1
+
+
+def test_main_exit_zero_on_degraded_without_flag(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded"))
+    rc = mod.main(["--repo", str(stub_repo)])
+    assert rc == 0


### PR DESCRIPTION
## Summary

Adds `scripts/publisher_freshness_check.py` — a single-call diagnostic that joins three independent signals into one readiness verdict:

1. **launchd job state** — is `com.aragora.codex-automation-publisher` loaded?
2. **status cache age** — mtime of `.aragora/automation-github-status/latest.json`
3. **outbox-vs-cache drift** — does the cache's `local_queue.outbox_count` match the real count of files under `.aragora/automation-outbox`?

## Why

The previous-task contract for the operator running #6811's freshly-anchored publisher said:

> Do not open new product lanes until the publisher status cache is fresh and the outbox count matches the real `.aragora/automation-outbox` count.

Before this PR the operator had to run **three separate commands** (`launchctl print`, `stat`, `jq`) and join the results manually. This is exactly the kind of manual stitching the operating contract calls out:

> every time humans intervene twice for the same failure class, the next system change should absorb that rescue as product behavior

## Live dogfood evidence

Running on the current repo at the time of this PR:

\`\`\`
$ python3 scripts/publisher_freshness_check.py
publisher: degraded (launchd: loaded; cache: 1.9d; drift: outbox=20 cache=0)
  - cache: 1.9d stale
  - drift: outbox=20 cache=0
\`\`\`

This immediately surfaces a real condition that was hidden until now: launchd just got loaded by the operator, but the cache is from 1.9 days ago AND the cached outbox count (\`0\`) is wildly out of date with the real count on disk (\`20\`). Without this script the operator would have had to discover the drift the hard way.

## Verdict semantics

| State | launchd | cache fresh | drift | Meaning |
|-------|---------|-------------|-------|---------|
| ready | loaded | yes | no | OK to open new product lanes |
| warming | loaded | no | no | Transient — next cycle should refresh |
| degraded | not loaded OR cache stale + drift OR cache missing | — | — | Block new product lanes |

## Surface

- \`--json\` for machine consumption
- \`--exit-nonzero-on-degraded\` for CI/launchd post-flight gates
- \`--repo\`, \`--cache-path\`, \`--outbox-dir\`, \`--stale-threshold-seconds\` for testing and overrides

## Tests

\`\`\`
$ python3 -m pytest tests/scripts/test_publisher_freshness_check.py -p no:randomly -q
..........                                                              [100%]
11 passed in 0.78s
\`\`\`

Coverage:
1. Ready when loaded + fresh + no drift
2. Degraded when launchd not loaded
3. Degraded when cache stale
4. Degraded when drift exists (even if loaded + fresh)
5. Warming when loaded + no drift but cache just stale
6. Missing cache handling
7. Non-JSON files in outbox dir excluded from count
8. Text output emits 1-line summary
9. JSON output includes \`generated_at\` + full report
10. \`--exit-nonzero-on-degraded\` returns 1
11. Default returns 0 even when degraded

## Tier

Tier 1 (additive consumer surface, no behavior change to existing publisher pipeline).

## Verification

- ruff check: All checks passed
- ruff format --check: 2 files already formatted
- mypy: Success: no issues found in 1 source file
- preflight: ok

## Standing rule

I do not author-merge. Awaiting Codex signal + CI green before any settlement consideration.