### PR TITLE
fix(debate): narrow ctx.result via require_phase_result in debate_rounds

### DIFF
--- a/aragora/debate/phases/debate_rounds.py
+++ b/aragora/debate/phases/debate_rounds.py
@@ -23,6 +23,7 @@ from collections.abc import Callable
 from aragora.config import AGENT_TIMEOUT_SECONDS, MAX_CONCURRENT_CRITIQUES, MAX_CONCURRENT_REVISIONS
 from aragora.debate.complexity_governor import get_complexity_governor
 from aragora.debate.performance_monitor import get_debate_monitor
+from aragora.debate.phases._phase_invariant import require_phase_result
 from aragora.debate.phases.convergence_tracker import (
     DebateConvergenceTracker,
 )
@@ -440,7 +441,7 @@ class DebateRoundsPhase:
             ctx: The DebateContext with proposals and result
         """
 
-        result = ctx.result
+        result = require_phase_result(ctx)
         proposals = ctx.proposals
 
         # Determine rounds: use strategy if available, otherwise protocol
@@ -531,7 +532,7 @@ class DebateRoundsPhase:
         Returns:
             True if debate should continue to next round, False if converged/should stop.
         """
-        result = ctx.result
+        result = require_phase_result(ctx)
 
         # Record partial-round progress at round start so that DebateState
         # finalization, timeout recovery, and post-failure inspection all see
@@ -962,7 +963,7 @@ class DebateRoundsPhase:
         """Execute critique phase with parallel generation."""
         from aragora.core import Message
 
-        result = ctx.result
+        result = require_phase_result(ctx)
         proposals = ctx.proposals
         round_critiques: list[Critique] = []
 
@@ -1233,7 +1234,7 @@ class DebateRoundsPhase:
         """Execute revision phase with parallel generation."""
         from aragora.core import Message
 
-        result = ctx.result
+        result = require_phase_result(ctx)
         proposals = ctx.proposals
 
         if not self._generate_with_agent or not self._build_revision_prompt:

--- a/tests/debate/phases/test_debate_rounds_invariant.py
+++ b/tests/debate/phases/test_debate_rounds_invariant.py
@@ -1,0 +1,135 @@
+"""Regression tests for ``DebateRoundsExecutor`` phase-invariant narrowing.
+
+Before this round's refactor, ``debate_rounds.py`` had 11 mypy ``union-attr``
+errors of the form ``Item "None" of "DebateResult | None" has no attribute X``
+because each phase method assigned ``result = ctx.result`` (which is typed
+``Optional[DebateResult]``) and then dereferenced it unconditionally.
+
+The fix swapped each ``result = ctx.result`` to
+``result = require_phase_result(ctx)`` — the helper that already exists in
+``aragora.debate.phases._phase_invariant`` and is already used by
+``winner_selector.py`` and ``consensus_phase.py``.
+
+These tests pin the new contract:
+
+1. When ``ctx.result is None`` and one of the four phase methods is invoked,
+   a ``RuntimeError`` with the canonical "phase invariant violated" message
+   is raised at the entry-point — not deep inside the method where the
+   error would be cryptic.
+2. The fix does not regress the existing partial-rounds preservation
+   behavior shipped in PR #6806.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from aragora.debate.debate_state import DebateContext
+from aragora.debate.phases.debate_rounds import DebateRoundsPhase
+
+
+def _make_executor() -> DebateRoundsPhase:
+    """Build an executor with the minimum dependencies the phase methods need."""
+    return DebateRoundsPhase(
+        protocol=MagicMock(rounds=1, consensus_threshold=0.5, use_structured_phases=False),
+        circuit_breaker=None,
+        convergence_detector=None,
+        recorder=None,
+        hooks={},
+        novelty_tracker=None,
+        critique_with_agent=None,
+        build_revision_prompt=None,
+        generate_with_agent=None,
+        with_timeout=None,
+        record_grounded_position=None,
+        debate_strategy=None,
+        rhetorical_observer=None,
+        checkpoint_callback=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_runtime_error_when_result_uninitialized() -> None:
+    """The top-level ``execute`` must raise via ``require_phase_result`` on None."""
+    executor = _make_executor()
+    ctx = DebateContext()
+    ctx.proposals = {"alice": "draft"}
+    assert ctx.result is None
+
+    with pytest.raises(RuntimeError, match="phase invariant violated"):
+        await executor.execute(ctx)
+
+
+@pytest.mark.asyncio
+async def test_execute_round_raises_runtime_error_when_result_uninitialized() -> None:
+    """``_execute_round`` is the hot path that previously hid 3 of 11 mypy errors."""
+    executor = _make_executor()
+    ctx = DebateContext()
+    ctx.proposals = {"alice": "draft"}
+    ctx.proposers = []  # type: ignore[attr-defined]
+    assert ctx.result is None
+
+    perf_monitor = MagicMock()
+    with pytest.raises(RuntimeError, match="phase invariant violated"):
+        await executor._execute_round(ctx, perf_monitor, round_num=1, total_rounds=1)
+
+
+@pytest.mark.asyncio
+async def test_critique_phase_raises_runtime_error_when_result_uninitialized() -> None:
+    """``_critique_phase`` previously had 3 mypy errors all under the same root cause."""
+    executor = _make_executor()
+    ctx = DebateContext()
+    ctx.proposals = {"alice": "draft"}
+    assert ctx.result is None
+
+    with pytest.raises(RuntimeError, match="phase invariant violated"):
+        await executor._critique_phase(ctx, critics=[], round_num=1)
+
+
+@pytest.mark.asyncio
+async def test_revision_phase_raises_runtime_error_when_result_uninitialized() -> None:
+    """``_revision_phase`` previously had 3 mypy errors (1246, 1484, 1506)."""
+    executor = _make_executor()
+    ctx = DebateContext()
+    ctx.proposals = {"alice": "draft"}
+    assert ctx.result is None
+
+    with pytest.raises(RuntimeError, match="phase invariant violated"):
+        await executor._revision_phase(ctx, critics=[], round_num=1)
+
+
+def test_debate_rounds_imports_require_phase_result() -> None:
+    """Pin the import so a future regression of this fix shows up loudly.
+
+    Without this test, somebody could revert one of the four
+    ``require_phase_result`` calls back to ``ctx.result`` and the mypy
+    errors would silently come back. The import-level pin makes that
+    revert visible in test signal as well.
+    """
+    from aragora.debate.phases import debate_rounds
+
+    assert hasattr(debate_rounds, "require_phase_result"), (
+        "require_phase_result must remain imported in debate_rounds; "
+        "removing this import is the canary for a regression of the "
+        "phase-invariant narrowing fix."
+    )
+
+
+def test_invariant_helper_returns_same_object_as_ctx_result() -> None:
+    """Behavioural parity: the narrowed alias is identity-equal to ctx.result."""
+    from aragora.core import DebateResult, Environment
+
+    env = Environment(task="parity-test")
+    result = DebateResult(task=env.task)
+    ctx = DebateContext(env=env, result=result)
+
+    from aragora.debate.phases.debate_rounds import require_phase_result
+
+    narrowed = require_phase_result(ctx)
+    assert narrowed is result
+    # Mutations via narrowed alias propagate (no defensive copy).
+    narrowed.final_answer = "parity"
+    assert ctx.result is not None and ctx.result.final_answer == "parity"


### PR DESCRIPTION
## Summary

Closes 11 pre-existing mypy `union-attr` errors in `aragora/debate/phases/debate_rounds.py` at lines 467, 468, 610, 653, 702, 1153, 1170, 1222, 1246, 1484, 1506, 1730. All 11 share the same root cause:

> `result = ctx.result` is typed `Optional[DebateResult]` (per `aragora/debate/debate_state.py:175`) and then dereferenced unconditionally.

The pattern was carried over from the 2026-04-29 round briefing (`docs/plans/2026-04-29-refined-round-briefing.md`):

> **Pre-existing mypy errors in `aragora/debate/phases/debate_rounds.py:1153, 1170, 1222, 1246, 1484, 1506, 1730`. Out of scope for this round.**

## Why this is the right shape

The repo already has the canonical helper:

```
aragora/debate/phases/_phase_invariant.py:
  def require_phase_result(ctx: DebateContext) -> DebateResult: ...
```

It's already used by:
- `winner_selector.py` (5 sites)
- `consensus_phase.py` (16 sites)

`debate_rounds.py` was simply missed. This PR applies the same pattern.

## What changed

4 line-edits in `debate_rounds.py`:

| Function | Line | Before | After |
|----------|------|--------|-------|
| `execute` | 444 | `result = ctx.result` | `result = require_phase_result(ctx)` |
| `_execute_round` | 535 | `result = ctx.result` | `result = require_phase_result(ctx)` |
| `_critique_phase` | 966 | `result = ctx.result` | `result = require_phase_result(ctx)` |
| `_revision_phase` | 1237 | `result = ctx.result` | `result = require_phase_result(ctx)` |

Plus the import at line 24:
```python
from aragora.debate.phases._phase_invariant import require_phase_result
```

## Why narrow at the entry point and not at each access site?

mypy narrows through closures only when the binding type is non-optional at function-definition time. By narrowing at the function entry, the closures `_tagged_revision`, `generate_critique`, etc. inside `_critique_phase`/`_revision_phase` automatically inherit the narrowed type. This avoids 11 separate per-access narrowings.

## Tests

\`\`\`
$ python3 -m pytest tests/debate/phases/ tests/debate/test_debate_state.py -p no:randomly -q
1694 passed, 6 warnings in 176.05s
\`\`\`

Plus 6 new regression tests in \`tests/debate/phases/test_debate_rounds_invariant.py\`:

1. \`test_execute_raises_runtime_error_when_result_uninitialized\`
2. \`test_execute_round_raises_runtime_error_when_result_uninitialized\`
3. \`test_critique_phase_raises_runtime_error_when_result_uninitialized\`
4. \`test_revision_phase_raises_runtime_error_when_result_uninitialized\`
5. \`test_debate_rounds_imports_require_phase_result\` (canary against future regression)
6. \`test_invariant_helper_returns_same_object_as_ctx_result\` (parity with old behavior)

## Tier

**Tier 2** — touches the live debate orchestrator hot path. CI must run the full debate suite.

## Verification

- ruff check: All checks passed
- ruff format: 2 files already formatted
- mypy on `debate_rounds.py`: **Success: no issues found in 1 source file** (was 11 errors)
- preflight: ok

## Standing rule

I do not author-merge. Awaiting Codex signal + CI green before settlement.