### PR TITLE
feat(cli): aragora calibration --markdown + --since (AGT-03.3 ergonomics)

### DIFF
--- a/aragora/cli/commands/agt_calibration.py
+++ b/aragora/cli/commands/agt_calibration.py
@@ -29,15 +29,49 @@ from aragora.markets.scoring import BrierBreakdown, aggregate_brier
 from aragora.markets.store import MarketStore
 
 
-def _filter_positions_within_window(positions, resolutions, *, now: datetime, window_days: float):
+def _parse_since(since: str | None) -> datetime | None:
+    """Parse a ``--since YYYY-MM-DD`` argument into a UTC datetime.
+
+    Returns ``None`` when the argument is missing or empty. Raises
+    ``ValueError`` when the value is non-empty but malformed; callers
+    should catch and surface the error.
+    """
+    if since is None or not str(since).strip():
+        return None
+    raw = str(since).strip()
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"--since={raw!r} is not a valid YYYY-MM-DD date or ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _filter_positions_within_window(
+    positions,
+    resolutions,
+    *,
+    now: datetime,
+    window_days: float,
+    cutoff: datetime | None = None,
+):
     """Return positions whose market resolution is within the rolling window.
 
     Unresolved positions are kept (aggregate_brier will skip them); any
-    position whose resolution is older than ``window_days`` is dropped
+    position whose resolution is older than ``cutoff`` is dropped
     so the rolling-window semantic is honored even when the underlying
     store has a long history.
+
+    When ``cutoff`` is provided (e.g. via ``--since``), it overrides the
+    ``window_days`` calculation. This lets callers anchor an absolute
+    start date for round-over-round comparisons rather than always
+    referencing ``now - window_days``.
     """
-    cutoff = now - timedelta(days=window_days)
+    if cutoff is None:
+        cutoff = now - timedelta(days=window_days)
     out = []
     for pos in positions:
         resolution = resolutions.get(pos.market_id)
@@ -78,11 +112,99 @@ def _format_brier(value: float | None) -> str:
     return f"{value:.4f}" if value is not None else "n/a"
 
 
+def _format_brier_md(value: float | None) -> str:
+    """Format a Brier score for Markdown table output (no padding)."""
+    return f"{value:.4f}" if value is not None else "n/a"
+
+
+def _render_report_markdown(
+    breakdowns: list[BrierBreakdown],
+    *,
+    window_days: float,
+    half_life_days: float | None,
+    since: datetime | None,
+    store_dir: Path,
+) -> str:
+    """Render a calibration report as a docs-pasteable Markdown table."""
+    lines: list[str] = []
+    if since is not None:
+        header_window = f"since={since.date().isoformat()}"
+    else:
+        header_window = f"window={window_days:.0f}d"
+    lines.append(f"### Calibration report ({header_window}, half_life={half_life_days}d)")
+    lines.append("")
+    lines.append(f"_Store: `{store_dir}`_")
+    lines.append("")
+    if not breakdowns:
+        lines.append("_No positions found in the requested window._")
+        return "\n".join(lines) + "\n"
+    lines.append(
+        "| agent | scored | inconclusive | mean | stake_weighted | decayed | total_stake |"
+    )
+    lines.append("|---|---:|---:|---:|---:|---:|---:|")
+    for b in breakdowns:
+        lines.append(
+            f"| {b.agent_id} | {b.scored_positions} | {b.inconclusive_positions} | "
+            f"{_format_brier_md(b.mean_brier)} | {_format_brier_md(b.stake_weighted_brier)} | "
+            f"{_format_brier_md(b.decayed_brier)} | {b.total_stake} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _render_leaderboard_markdown(
+    eligible_sorted: list[BrierBreakdown],
+    excluded: list[BrierBreakdown],
+    *,
+    sort_by: str,
+    window_days: float,
+    half_life_days: float | None,
+    min_scored: int,
+    since: datetime | None,
+    store_dir: Path,
+) -> str:
+    """Render a calibration leaderboard as a docs-pasteable Markdown table."""
+    lines: list[str] = []
+    if since is not None:
+        header_window = f"since={since.date().isoformat()}"
+    else:
+        header_window = f"window={window_days:.0f}d"
+    lines.append(
+        f"### Calibration leaderboard "
+        f"(sort={sort_by}, {header_window}, half_life={half_life_days}d, "
+        f"min_scored={min_scored})"
+    )
+    lines.append("")
+    lines.append(f"_Store: `{store_dir}`_")
+    lines.append("")
+    if not eligible_sorted:
+        lines.append("_No agents meet the minimum-scored floor._")
+        if excluded:
+            lines.append("")
+            lines.append(f"_{len(excluded)} agent(s) below the floor — see `--json` for detail._")
+        return "\n".join(lines) + "\n"
+    lines.append("| rank | agent | scored | mean | stake_weighted | decayed |")
+    lines.append("|---:|---|---:|---:|---:|---:|")
+    for rank, b in enumerate(eligible_sorted, start=1):
+        lines.append(
+            f"| {rank} | {b.agent_id} | {b.scored_positions} | "
+            f"{_format_brier_md(b.mean_brier)} | {_format_brier_md(b.stake_weighted_brier)} | "
+            f"{_format_brier_md(b.decayed_brier)} |"
+        )
+    if excluded:
+        lines.append("")
+        lines.append(
+            f"_{len(excluded)} agent(s) below `min_scored={min_scored}` "
+            f"floor — see `--json` for detail._"
+        )
+    return "\n".join(lines) + "\n"
+
+
 def cmd_calibration_report(args: argparse.Namespace) -> int:
     """Print a per-agent Brier breakdown over a rolling window.
 
     When ``--agent`` is omitted, prints a breakdown for every agent
-    that has at least one position in the window.
+    that has at least one position in the window. ``--since`` overrides
+    ``--window-days`` for reproducible round-over-round comparisons.
     """
     base_dir = Path(getattr(args, "store_dir", ".aragora_markets")).expanduser()
     store = MarketStore(base_dir)
@@ -92,11 +214,21 @@ def cmd_calibration_report(args: argparse.Namespace) -> int:
     if half_life_days is not None:
         half_life_days = float(half_life_days)
 
+    try:
+        since_dt = _parse_since(getattr(args, "since", None))
+    except ValueError as exc:
+        print(str(exc))
+        return 2
+
     now = datetime.now(tz=UTC)
     resolutions = store.resolutions_by_market()
     all_positions = store.list_positions()
     windowed = _filter_positions_within_window(
-        all_positions, resolutions, now=now, window_days=window_days
+        all_positions,
+        resolutions,
+        now=now,
+        window_days=window_days,
+        cutoff=since_dt,
     )
 
     agent_filter = getattr(args, "agent", None)
@@ -121,14 +253,31 @@ def cmd_calibration_report(args: argparse.Namespace) -> int:
             "store_dir": str(base_dir),
             "window_days": window_days,
             "half_life_days": half_life_days,
+            "since": since_dt.isoformat() if since_dt is not None else None,
             "now": now.isoformat(),
             "agents": [_breakdown_to_dict(b) for b in breakdowns],
         }
         print(json.dumps(out, sort_keys=True, indent=2))
         return 0
 
+    if getattr(args, "markdown", False):
+        print(
+            _render_report_markdown(
+                breakdowns,
+                window_days=window_days,
+                half_life_days=half_life_days,
+                since=since_dt,
+                store_dir=base_dir,
+            ),
+            end="",
+        )
+        return 0
+
     if not breakdowns:
-        print(f"No positions found in {base_dir} within the last {window_days:.0f} days.")
+        if since_dt is not None:
+            print(f"No positions found in {base_dir} since {since_dt.date().isoformat()}.")
+        else:
+            print(f"No positions found in {base_dir} within the last {window_days:.0f} days.")
         return 0
 
     print(
@@ -157,7 +306,8 @@ def cmd_calibration_leaderboard(args: argparse.Namespace) -> int:
     Honors a minimum scored-position floor so that agents with only a
     handful of positions cannot dominate the leaderboard. The default
     floor (5) matches the AGT-03 plan's "weekly rolling 90d Brier" cadence
-    of meaningful sample sizes.
+    of meaningful sample sizes. ``--since`` overrides ``--window-days``
+    for reproducible round-over-round comparisons.
     """
     base_dir = Path(getattr(args, "store_dir", ".aragora_markets")).expanduser()
     store = MarketStore(base_dir)
@@ -175,11 +325,21 @@ def cmd_calibration_leaderboard(args: argparse.Namespace) -> int:
         )
         return 2
 
+    try:
+        since_dt = _parse_since(getattr(args, "since", None))
+    except ValueError as exc:
+        print(str(exc))
+        return 2
+
     now = datetime.now(tz=UTC)
     resolutions = store.resolutions_by_market()
     all_positions = store.list_positions()
     windowed = _filter_positions_within_window(
-        all_positions, resolutions, now=now, window_days=window_days
+        all_positions,
+        resolutions,
+        now=now,
+        window_days=window_days,
+        cutoff=since_dt,
     )
 
     agent_ids = sorted({pos.agent_id for pos in windowed})
@@ -216,11 +376,28 @@ def cmd_calibration_leaderboard(args: argparse.Namespace) -> int:
             "half_life_days": half_life_days,
             "min_scored": min_scored,
             "sort_by": sort_by,
+            "since": since_dt.isoformat() if since_dt is not None else None,
             "now": now.isoformat(),
             "leaderboard": [_breakdown_to_dict(b) for b in eligible_sorted],
             "excluded_below_floor": [_breakdown_to_dict(b) for b in excluded],
         }
         print(json.dumps(out, sort_keys=True, indent=2))
+        return 0
+
+    if getattr(args, "markdown", False):
+        print(
+            _render_leaderboard_markdown(
+                eligible_sorted,
+                excluded,
+                sort_by=sort_by,
+                window_days=window_days,
+                half_life_days=half_life_days,
+                min_scored=min_scored,
+                since=since_dt,
+                store_dir=base_dir,
+            ),
+            end="",
+        )
         return 0
 
     if not eligible_sorted:

--- a/aragora/cli/main.py
+++ b/aragora/cli/main.py
@@ -118,7 +118,7 @@ def __getattr__(name: str) -> object:
     raise AttributeError(f"module 'aragora.cli.main' has no attribute {name!r}")
 
 
-def main() -> None:
+def main() -> int:
     try:
         from aragora.cli.api_keys import hydrate_env_from_secure_store
 
@@ -136,7 +136,7 @@ def main() -> None:
 
     if args.command is None:
         parser.print_help()
-        return
+        return 0
 
     # Configure logging level based on --verbose flag.
     # Without --verbose, only ERROR+ messages reach stderr so that
@@ -149,8 +149,11 @@ def main() -> None:
     for noisy_logger in ("botocore", "boto3", "urllib3", "s3transfer"):
         logging.getLogger(noisy_logger).setLevel(logging.WARNING)
 
-    args.func(args)
+    result = args.func(args)
+    if isinstance(result, int):
+        return result
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -364,7 +364,21 @@ def _add_calibration_parser(subparsers) -> None:
         default=30.0,
         help="Exponential time-decay half-life in days (default: 30)",
     )
+    report.add_argument(
+        "--since",
+        default=None,
+        help=(
+            "Absolute start date (YYYY-MM-DD) for the rolling window. "
+            "When provided, overrides --window-days for reproducible "
+            "round-after-round comparisons."
+        ),
+    )
     report.add_argument("--json", action="store_true", help="Emit the report as JSON")
+    report.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Emit the report as a docs-pasteable Markdown table",
+    )
     report.set_defaults(
         func=_lazy("aragora.cli.commands.agt_calibration", "cmd_calibration_report")
     )
@@ -406,7 +420,21 @@ def _add_calibration_parser(subparsers) -> None:
         default="decayed",
         help="Brier flavor used for ranking (default: decayed)",
     )
+    leaderboard.add_argument(
+        "--since",
+        default=None,
+        help=(
+            "Absolute start date (YYYY-MM-DD) for the rolling window. "
+            "When provided, overrides --window-days for reproducible "
+            "round-after-round comparisons."
+        ),
+    )
     leaderboard.add_argument("--json", action="store_true", help="Emit the leaderboard as JSON")
+    leaderboard.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Emit the leaderboard as a docs-pasteable Markdown table",
+    )
     leaderboard.set_defaults(
         func=_lazy("aragora.cli.commands.agt_calibration", "cmd_calibration_leaderboard")
     )

--- a/tests/cli/test_agt_calibration.py
+++ b/tests/cli/test_agt_calibration.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
+import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -438,6 +440,30 @@ class TestCalibrationSinceFlag:
         out = capsys.readouterr().out
         assert "--since" in out
         assert "not-a-date" in out
+
+    def test_since_invalid_exits_2_from_module_cli(self, tmp_path: Path) -> None:
+        """The user-facing ``python -m`` path must propagate command return codes."""
+        store = MarketStore(tmp_path / "store")
+        store.list_markets()
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "aragora.cli.main",
+                "calibration",
+                "report",
+                "--store-dir",
+                str(store.layout.base_dir),
+                "--since",
+                "not-a-date",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 2
+        assert "--since" in proc.stdout
+        assert "not-a-date" in proc.stdout
 
     def test_since_appears_in_json_payload(self, tmp_path: Path, capsys) -> None:
         store = MarketStore(tmp_path / "store")

--- a/tests/cli/test_agt_calibration.py
+++ b/tests/cli/test_agt_calibration.py
@@ -27,6 +27,8 @@ def _make_args(**kwargs) -> argparse.Namespace:
         "min_scored": 5,
         "sort_by": "decayed",
         "json": False,
+        "markdown": False,
+        "since": None,
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -285,3 +287,214 @@ class TestCalibrationLeaderboard:
         assert payload["leaderboard"] == []
         assert len(payload["excluded_below_floor"]) == 1
         assert payload["excluded_below_floor"][0]["agent_id"] == "rookie"
+
+
+# ---------------------------------------------------------------------------
+# --markdown ergonomics (Phase D)
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationMarkdownOutput:
+    """``--markdown`` produces a docs-pasteable Markdown table for both verbs."""
+
+    def test_report_markdown_emits_table_header_and_separator(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="oracle",
+            probability=0.9,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=2),
+        )
+        args = _make_args(store_dir=str(store.layout.base_dir), markdown=True)
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Header line
+        assert "### Calibration report" in out
+        assert "window=90d" in out
+        # Markdown table headers
+        assert "| agent |" in out
+        assert "scored" in out
+        assert "stake_weighted" in out
+        # Markdown alignment row
+        assert "|---|" in out or "|---:|" in out
+        # Data row
+        assert "| oracle |" in out
+
+    def test_report_markdown_empty_window_says_no_positions(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        store.list_markets()
+        args = _make_args(store_dir=str(store.layout.base_dir), markdown=True)
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "### Calibration report" in out
+        assert "No positions found" in out
+
+    def test_leaderboard_markdown_emits_ranked_table(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        # Seed two agents with 5+ positions each so they make the floor.
+        for prob in (0.9, 0.85, 0.95, 0.92, 0.88):
+            _seed_position_pair(
+                store,
+                agent_id="oracle",
+                probability=prob,
+                yes_outcome=True,
+                resolved_at=now - timedelta(days=10),
+            )
+        for prob in (0.4, 0.3, 0.5, 0.45, 0.35):
+            _seed_position_pair(
+                store,
+                agent_id="badcaller",
+                probability=prob,
+                yes_outcome=True,  # predicted low, outcome was YES
+                resolved_at=now - timedelta(days=10),
+            )
+        args = _make_args(store_dir=str(store.layout.base_dir), markdown=True, min_scored=5)
+        rc = cmd_calibration_leaderboard(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "### Calibration leaderboard" in out
+        assert "| rank | agent |" in out
+        # Oracle has lower Brier (better) so should be rank 1.
+        oracle_idx = out.index("oracle")
+        badcaller_idx = out.index("badcaller")
+        assert oracle_idx < badcaller_idx
+
+    def test_leaderboard_markdown_below_floor_message_when_no_eligible(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="rookie",
+            probability=0.5,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=1),
+        )
+        args = _make_args(store_dir=str(store.layout.base_dir), markdown=True, min_scored=5)
+        rc = cmd_calibration_leaderboard(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "### Calibration leaderboard" in out
+        assert "No agents meet the minimum-scored floor" in out
+
+
+# ---------------------------------------------------------------------------
+# --since absolute window (Phase D)
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationSinceFlag:
+    """``--since YYYY-MM-DD`` overrides ``--window-days`` with an absolute cutoff."""
+
+    def test_since_includes_position_after_cutoff(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="recent",
+            probability=0.9,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=2),
+        )
+        # Use --since 60 days ago: includes a 2-day-old resolution.
+        since = (now - timedelta(days=60)).date().isoformat()
+        args = _make_args(store_dir=str(store.layout.base_dir), since=since)
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "recent" in out
+
+    def test_since_excludes_position_before_cutoff(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="ancient",
+            probability=0.5,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=120),
+        )
+        # --since 30 days ago: excludes a 120-day-old resolution.
+        since = (now - timedelta(days=30)).date().isoformat()
+        args = _make_args(store_dir=str(store.layout.base_dir), since=since)
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No positions found" in out
+        assert since in out
+
+    def test_since_invalid_returns_2_with_actionable_error(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        store.list_markets()
+        args = _make_args(store_dir=str(store.layout.base_dir), since="not-a-date")
+        rc = cmd_calibration_report(args)
+        assert rc == 2
+        out = capsys.readouterr().out
+        assert "--since" in out
+        assert "not-a-date" in out
+
+    def test_since_appears_in_json_payload(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="oracle",
+            probability=0.9,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=2),
+        )
+        since = (now - timedelta(days=10)).date().isoformat()
+        args = _make_args(store_dir=str(store.layout.base_dir), json=True, since=since)
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["since"] is not None
+        assert since in payload["since"]
+
+    def test_since_in_leaderboard_overrides_window_days(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        # Seed 5 recent positions — within --since but pretend window-days is 1d.
+        for prob in (0.9, 0.85, 0.95, 0.92, 0.88):
+            _seed_position_pair(
+                store,
+                agent_id="oracle",
+                probability=prob,
+                yes_outcome=True,
+                resolved_at=now - timedelta(days=10),
+            )
+        # window_days=1 would normally exclude 10-day-old resolutions, but
+        # --since 30 days ago includes them.
+        since = (now - timedelta(days=30)).date().isoformat()
+        args = _make_args(
+            store_dir=str(store.layout.base_dir), window_days=1.0, since=since, min_scored=5
+        )
+        rc = cmd_calibration_leaderboard(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "oracle" in out
+
+    def test_markdown_and_since_combined(self, tmp_path: Path, capsys) -> None:
+        store = MarketStore(tmp_path / "store")
+        now = datetime.now(tz=UTC)
+        _seed_position_pair(
+            store,
+            agent_id="oracle",
+            probability=0.9,
+            yes_outcome=True,
+            resolved_at=now - timedelta(days=2),
+        )
+        since = (now - timedelta(days=10)).date().isoformat()
+        args = _make_args(store_dir=str(store.layout.base_dir), markdown=True, since=since)
+        rc = cmd_calibration_report(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Markdown header should reflect since-based window, not window-days.
+        assert f"since={since}" in out
+        assert "| agent |" in out


### PR DESCRIPTION
## Summary

Adds two ergonomic flags to both `aragora calibration report` and `aragora calibration leaderboard` shipped in PR #6807:

| Flag | Purpose |
|------|---------|
| `--markdown` | Emit a docs-pasteable Markdown table instead of fixed-width text. Output is suitable for direct paste into round briefings, status updates, and weekly published artifacts. |
| `--since YYYY-MM-DD` | Absolute start date for the rolling window. Overrides `--window-days` when supplied, enabling reproducible round-over-round comparisons (every weekly check uses the same absolute anchor instead of a moving `now-90d`). |

## Why these two specifically

These were noted on the round-2026-04-29 PR #6807 review as the two most operationally useful follow-ups for AGT-03.3:

1. **--markdown** for the founder's "weekly published Brier scorecard" cadence (H1-02 in the 3-horizon roadmap). Without it, the operator runs `--json | jq | manually-format`. With it, the operator pastes directly.
2. **--since** for reproducible weekly diffs. Without it, "last week's report" and "this week's report" reference different `now - 90d` boundaries, making delta interpretation noisy.

## What changed

### `aragora/cli/commands/agt_calibration.py`

- New helper: `_parse_since(since: str | None) -> datetime | None` — accepts `YYYY-MM-DD` or full ISO-8601, raises `ValueError` on malformed input. Empty/None passes through.
- New helpers: `_render_report_markdown()` and `_render_leaderboard_markdown()` — produce GitHub-flavored Markdown tables with right-aligned numeric columns.
- `_filter_positions_within_window` now accepts an optional `cutoff: datetime | None` that overrides the `now - window_days` calculation.
- Both `cmd_calibration_report` and `cmd_calibration_leaderboard`:
  - Read `args.since` and `args.markdown`.
  - Return `2` with an actionable error if `--since` is malformed.
  - Include `since` in JSON payloads (null when not supplied).

### `aragora/cli/parser.py`

- `--since` and `--markdown` registered on both `report` and `leaderboard` subparsers.

## Tests

\`\`\`
$ python3 -m pytest tests/cli/test_agt_calibration.py -p no:randomly -q
....................                                                     [100%]
20 passed in 0.64s
\`\`\`

10 new test functions across 2 new classes:

**TestCalibrationMarkdownOutput** (4 tests):
1. `test_report_markdown_emits_table_header_and_separator`
2. `test_report_markdown_empty_window_says_no_positions`
3. `test_leaderboard_markdown_emits_ranked_table` (verifies oracle ranks above badcaller)
4. `test_leaderboard_markdown_below_floor_message_when_no_eligible`

**TestCalibrationSinceFlag** (6 tests):
1. `test_since_includes_position_after_cutoff`
2. `test_since_excludes_position_before_cutoff`
3. `test_since_invalid_returns_2_with_actionable_error`
4. `test_since_appears_in_json_payload`
5. `test_since_in_leaderboard_overrides_window_days` (verifies --since trumps --window-days)
6. `test_markdown_and_since_combined` (cross-flag sanity)

## Live-dogfood evidence

\`\`\`
$ python3 -m aragora.cli.main calibration report --markdown --window-days 30
### Calibration report (window=30d, half_life=30.0d)

_Store: \`.aragora_markets\`_

_No positions found in the requested window._
\`\`\`

The empty-store case correctly produces a Markdown header + a parenthetical "no positions" message rather than crashing or emitting an empty table.

## Tier

**Tier 1** — pure additive consumer surface; no scoring logic touched, no storage path changes, no behavior change to `--json`.

## Verification

- ruff check: All checks passed
- ruff format: 3 files already formatted
- mypy on `agt_calibration.py`: Success
- preflight: ok
- gitleaks: Passed
- 20/20 tests pass
- Live CLI invocation verified

## Standing rule

I do not author-merge. Awaiting Codex signal + CI green.