### PR TITLE
fix(agent-bridge): preserve launch cwd for tmux harnesses

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -6,7 +6,7 @@ inventory from agent_bridge_sessions.py (PR #5306).
 
 Usage:
   python3 scripts/agent_bridge.py sessions [--json]
-  python3 scripts/agent_bridge.py launch --name codex-review --agent codex --file /tmp/prompt.md
+  python3 scripts/agent_bridge.py launch --name codex-review --agent codex --cwd .worktrees/review --file /tmp/prompt.md
   python3 scripts/agent_bridge.py send <name> "Fix the LOC ratchet"
   python3 scripts/agent_bridge.py send <name> --file /tmp/prompt.md
   python3 scripts/agent_bridge.py approve <name>
@@ -556,9 +556,27 @@ def cmd_launch(args: argparse.Namespace) -> int:
     if agent not in {"codex", "claude", "droid", "factory"}:
         print("Unsupported agent. Use codex, claude, droid, or factory.", file=sys.stderr)
         return 1
+    launch_cwd = Path(args.cwd).expanduser() if args.cwd else Path.cwd()
+    try:
+        launch_cwd = launch_cwd.resolve()
+    except OSError as exc:
+        print(f"Invalid launch cwd: {exc}", file=sys.stderr)
+        return 1
+    if not launch_cwd.is_dir():
+        print(f"Launch cwd does not exist or is not a directory: {launch_cwd}", file=sys.stderr)
+        return 1
 
     launcher = CANONICAL_REPO_ROOT / "scripts" / "tmux_session_launcher.sh"
-    cmd = ["bash", str(launcher), "--name", args.name, "--agent", agent]
+    cmd = [
+        "bash",
+        str(launcher),
+        "--name",
+        args.name,
+        "--agent",
+        agent,
+        "--cwd",
+        str(launch_cwd),
+    ]
     if getattr(args, "autonomous", False):
         cmd.append("--autonomous")
     if args.file:
@@ -586,6 +604,7 @@ def cmd_launch(args: argparse.Namespace) -> int:
                     "ok": result.returncode == 0,
                     "name": args.name,
                     "agent": agent,
+                    "cwd": str(launch_cwd),
                     "returncode": result.returncode,
                     "stdout": result.stdout,
                     "stderr": result.stderr,
@@ -915,6 +934,13 @@ def main() -> int:
     launch_p.add_argument("--name", required=True)
     launch_p.add_argument(
         "--agent", default="codex", choices=("codex", "claude", "droid", "factory")
+    )
+    launch_p.add_argument(
+        "--cwd",
+        help=(
+            "Working directory/worktree for the launched harness "
+            "(defaults to the caller's current directory)"
+        ),
     )
     launch_p.add_argument("prompt", nargs="*")
     launch_p.add_argument("--file", help="Prompt file")

--- a/scripts/agent_bridge_sessions.py
+++ b/scripts/agent_bridge_sessions.py
@@ -348,6 +348,16 @@ def load_tmux_sessions(*, repo_root: Path, tmux_dir: Path) -> list[SessionRecord
         candidate_root = _safe_repo_root(str(meta.get("repo_root", "") or ""))
         if not _repo_match(candidate_root, repo_root):
             continue
+        raw_cwd = meta.get("cwd") or meta.get("worktree")
+        display_cwd = str(candidate_root) if candidate_root else None
+        if isinstance(raw_cwd, str) and raw_cwd.strip():
+            cwd_path = Path(raw_cwd).expanduser()
+            try:
+                resolved_cwd = cwd_path.resolve()
+            except OSError:
+                resolved_cwd = cwd_path
+            if _repo_match(_safe_repo_root(str(resolved_cwd)), repo_root):
+                display_cwd = str(resolved_cwd)
 
         name = meta_path.stem.removesuffix(".meta")
         log_file = Path(str(meta.get("log_file", "") or "")).expanduser()
@@ -373,7 +383,7 @@ def load_tmux_sessions(*, repo_root: Path, tmux_dir: Path) -> list[SessionRecord
                 status=status,
                 updated_at=updated_at,
                 branch=None,
-                cwd=str(candidate_root) if candidate_root else None,
+                cwd=display_cwd,
                 prompt_file=str(meta.get("prompt_file", "") or "") or None,
                 summary=summary,
                 log_file=str(log_file) if log_file else None,

--- a/scripts/tmux_session_launcher.sh
+++ b/scripts/tmux_session_launcher.sh
@@ -5,6 +5,7 @@
 #   ./scripts/tmux_session_launcher.sh --name codex-conductor --agent codex --prompt-file /tmp/prompt.md
 #   ./scripts/tmux_session_launcher.sh --name claude-worker --agent claude --autonomous --prompt "Fix tests"
 #   ./scripts/tmux_session_launcher.sh --name factory-review --agent droid --prompt "Review PR #6811"
+#   ./scripts/tmux_session_launcher.sh --name factory-review --agent factory --cwd /tmp/pr-review --prompt "Review PR #6811"
 #   ./scripts/tmux_session_launcher.sh --name codex-qa --agent codex --autonomous --prompt "Fix the tests"
 #   ./scripts/tmux_session_launcher.sh --list
 #   ./scripts/tmux_session_launcher.sh --kill codex-conductor
@@ -143,11 +144,13 @@ PROMPT=""
 PROMPT_FILE=""
 ACTION="launch"
 AUTONOMOUS="0"
+WORKDIR=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --name)     NAME="$2"; shift 2 ;;
         --agent)    AGENT="$2"; shift 2 ;;
+        --cwd)      WORKDIR="$2"; shift 2 ;;
         --prompt)   PROMPT="$2"; shift 2 ;;
         --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
         --autonomous) AUTONOMOUS="1"; shift ;;
@@ -206,6 +209,16 @@ if [[ -z "${NAME}" ]]; then
     NAME="${AGENT}-$(date +%H%M%S)"
 fi
 
+if [[ -n "${WORKDIR}" ]]; then
+    if [[ ! -d "${WORKDIR}" ]]; then
+        echo "Launch cwd does not exist or is not a directory: ${WORKDIR}" >&2
+        exit 1
+    fi
+    WORKDIR="$(cd "${WORKDIR}" && pwd)"
+else
+    WORKDIR="${REPO_ROOT}"
+fi
+
 LOG_FILE="${LOG_DIR}/${NAME}.log"
 META_FILE="${LOG_DIR}/${NAME}.meta.json"
 REGISTRY_REPO_ROOT="${ARAGORA_TMUX_REGISTRY_REPO_ROOT:-${REPO_ROOT}}"
@@ -222,23 +235,23 @@ fi
 #   - Codex gets --full-auto approval mode
 if [[ "${AGENT}" == "codex" ]]; then
     if [[ "${AUTONOMOUS}" == "1" ]]; then
-        LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/codex_session.sh --agent '${NAME}' --base main --full-auto"
+        LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh --agent '${NAME}' --base main --full-auto"
     else
-        LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/codex_session.sh --agent '${NAME}' --base main"
+        LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/codex_session.sh --agent '${NAME}' --base main"
     fi
 elif [[ "${AGENT}" == "claude" ]]; then
     if [[ "${AUTONOMOUS}" == "1" ]]; then
-        LAUNCH_CMD="cd '${REPO_ROOT}' && ARAGORA_ADMIN_APPROVED=1 ./scripts/claude-wt"
+        LAUNCH_CMD="cd '${WORKDIR}' && ARAGORA_ADMIN_APPROVED=1 ./scripts/claude-wt"
     else
-        LAUNCH_CMD="cd '${REPO_ROOT}' && ./scripts/claude-wt"
+        LAUNCH_CMD="cd '${WORKDIR}' && ./scripts/claude-wt"
     fi
 elif [[ "${AGENT}" == "droid" || "${AGENT}" == "factory" ]]; then
     # Droid interactive sessions do their own permission gating. Mission/exec
     # mode is intentionally not used here so the pane remains interactive for
     # later agent_bridge.py send/read cycles.
-    LAUNCH_CMD="cd '${REPO_ROOT}' && droid --cwd '${REPO_ROOT}'"
+    LAUNCH_CMD="cd '${WORKDIR}' && droid --cwd '${WORKDIR}'"
 else
-    echo "Unknown agent: ${AGENT}. Use 'codex', 'claude', or 'droid'." >&2
+    echo "Unknown agent: ${AGENT}. Use 'codex', 'claude', 'droid', or 'factory'." >&2
     exit 1
 fi
 
@@ -256,14 +269,14 @@ tmux pipe-pane -t "${WINDOW_TARGET}" -o "cat >> '${LOG_FILE}'"
 tmux send-keys -t "${WINDOW_TARGET}" "${LAUNCH_CMD}" Enter
 
 # Write metadata (avoid embedding prompt content in Python literal)
-python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" "${TMUX_SESSION}" "${PANE_INDEX}" "${LAUNCH_CMD}" "${REGISTRY_REPO_ROOT}" <<'PYEOF'
+python3 - "${NAME}" "${AGENT}" "${LOG_FILE}" "${REPO_ROOT}" "${WORKDIR}" "${PROMPT_FILE}" "${META_FILE}" "${PROMPT:+yes}" "${WINDOW_TARGET}" "${TMUX_SESSION}" "${PANE_INDEX}" "${LAUNCH_CMD}" "${REGISTRY_REPO_ROOT}" <<'PYEOF'
 import datetime
 import importlib.util
 import json
 from pathlib import Path
 import sys
 
-name, agent, log_file, repo_root, prompt_file, meta_file, has_prompt, window_target, tmux_session, pane_index, launch_cmd, registry_repo_root = sys.argv[1:13]
+name, agent, log_file, repo_root, workdir, prompt_file, meta_file, has_prompt, window_target, tmux_session, pane_index, launch_cmd, registry_repo_root = sys.argv[1:14]
 started_at = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 meta = {
     "name": name,
@@ -271,6 +284,8 @@ meta = {
     "started": started_at,
     "log_file": log_file,
     "repo_root": repo_root,
+    "cwd": workdir,
+    "worktree": workdir,
     "tmux_session": tmux_session,
     "tmux_window_target": window_target,
     "tmux_pane_index": pane_index,
@@ -304,6 +319,7 @@ except Exception as exc:  # pragma: no cover - launcher should still succeed if 
 PYEOF
 
 echo "Launched '${NAME}' (${AGENT}) in tmux session '${TMUX_SESSION}'"
+echo "  Cwd: ${WORKDIR}"
 echo "  Log: ${LOG_FILE}"
 echo "  Meta: ${META_FILE}"
 

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -339,6 +339,8 @@ def test_cmd_launch_invokes_tmux_launcher_for_droid(
     scripts_dir.mkdir(parents=True)
     launcher = scripts_dir / "tmux_session_launcher.sh"
     launcher.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    review_worktree = tmp_path / "review-worktree"
+    review_worktree.mkdir()
     prompt_file = tmp_path / "prompt.md"
     prompt_file.write_text("review only\n", encoding="utf-8")
     monkeypatch.setattr(mod, "CANONICAL_REPO_ROOT", repo_root)
@@ -357,6 +359,7 @@ def test_cmd_launch_invokes_tmux_launcher_for_droid(
             agent="droid",
             prompt=[],
             file=str(prompt_file),
+            cwd=str(review_worktree),
             autonomous=False,
             timeout_seconds=10,
             json=False,
@@ -374,6 +377,8 @@ def test_cmd_launch_invokes_tmux_launcher_for_droid(
                 "factory-review",
                 "--agent",
                 "droid",
+                "--cwd",
+                str(review_worktree),
                 "--prompt-file",
                 str(prompt_file),
             ],

--- a/tests/scripts/test_agent_bridge_sessions.py
+++ b/tests/scripts/test_agent_bridge_sessions.py
@@ -32,6 +32,8 @@ def test_collect_sessions_merges_tmux_and_claude_sources(
 
     repo_root = tmp_path / "aragora"
     repo_root.mkdir()
+    review_worktree = repo_root / ".worktrees" / "review-6818"
+    review_worktree.mkdir(parents=True)
     tmux_dir = tmp_path / "tmux"
     tmux_dir.mkdir()
     claude_projects_root = tmp_path / "claude-projects"
@@ -48,6 +50,7 @@ def test_collect_sessions_merges_tmux_and_claude_sources(
                 "started": "2026-04-13T18:00:00Z",
                 "log_file": str(log_file),
                 "repo_root": str(repo_root),
+                "cwd": str(review_worktree),
                 "prompt_file": "/tmp/5282.md",
                 "has_prompt": True,
             }
@@ -117,6 +120,7 @@ def test_collect_sessions_merges_tmux_and_claude_sources(
     assert tmux_session.status == "alive"
     assert tmux_session.summary == "PR #5297 opened"
     assert tmux_session.prompt_file == "/tmp/5282.md"
+    assert tmux_session.cwd == str(review_worktree)
 
     claude_session = next(item for item in sessions if item.source == "claude_jsonl")
     assert claude_session.name == "claude-1431bd39"


### PR DESCRIPTION
## Summary
Fixes the bridge usability issue observed during #6818 review: `scripts/agent_bridge.py launch` invoked the tmux launcher from the canonical repo root and did not pass the intended worktree/cwd, so Factory/Droid sessions could open in root and fail to read PR-specific files.

## Changes
- Add `--cwd` to `agent_bridge.py launch` and default it to the caller's current directory.
- Pass `--cwd` through to `scripts/tmux_session_launcher.sh`.
- Start Codex/Claude/Droid/Factory harnesses from the requested worktree/cwd.
- Persist `cwd`/`worktree` in tmux metadata.
- Teach `agent_bridge_sessions.py` to report the actual launched cwd when it belongs to this repo.

## Validation
- `python3 -m pytest -q tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_sessions.py` -> 18 passed.
- `bash -n scripts/tmux_session_launcher.sh` -> pass.
- `python3 -m py_compile scripts/agent_bridge.py scripts/agent_bridge_sessions.py` -> pass.
- `python3 -m ruff check scripts/agent_bridge.py scripts/agent_bridge_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_sessions.py` -> pass.
- `python3 -m ruff format --check scripts/agent_bridge.py scripts/agent_bridge_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_sessions.py` -> pass.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok.
- git pre-push hook -> passed including baseline-filtered mypy and gitleaks.

## Risk
Tier 2 automation bridge change. It does not alter production runtime behavior, reputation flow, or dispatch semantics. It only makes interactive tmux harness launches honor their intended working directory and report that cwd in bridge inventory.