### PR TITLE
fix(automation): preserve ambiguous outbox handoffs

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -38,6 +38,7 @@ from audit_codex_branch_backlog import (  # noqa: E402
     open_pr_heads,
     run_git,
 )
+from github_cli_health import check_github_cli_health  # noqa: E402
 
 UTC = timezone.utc
 
@@ -163,6 +164,25 @@ def _write_synthetic_receipt(
     return path
 
 
+def _github_open_pr_state(root: Path, repo_name: str) -> tuple[dict[str, int], bool, str]:
+    """Return open codex PR heads when GitHub is healthy enough to trust."""
+
+    try:
+        health = check_github_cli_health(root)
+    except Exception as exc:
+        return {}, False, f"GitHub health check failed ({exc})"
+
+    if not health.ready:
+        detail = f"GitHub unavailable [{health.mode}] {health.error}".strip()
+        return {}, False, detail
+
+    try:
+        open_prs = open_pr_heads(root, repo_name, "codex/")
+    except Exception as exc:
+        return {}, False, f"open PR fetch failed ({exc})"
+    return open_prs, True, f"{len(open_prs)} open codex/* PRs"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -211,13 +231,21 @@ def main(argv: list[str] | None = None) -> int:
     outbox_files = _list_json(outbox_dir)
     print(f"  {len(outbox_files)} outbox files\n")
 
-    print("loading open PR state from GitHub (one bulk call)...")
-    try:
-        open_prs = open_pr_heads(root, args.repo_name, "codex/")
-        print(f"  {len(open_prs)} open codex/* PRs\n")
-    except Exception as exc:
-        print(f"  WARN: open PR fetch failed ({exc}); proceeding without open-PR check\n")
-        open_prs = {}
+    open_prs_cache: dict[str, int] | None = None
+    open_pr_state_available = False
+
+    def load_open_pr_state() -> tuple[dict[str, int], bool]:
+        nonlocal open_prs_cache, open_pr_state_available
+        if open_prs_cache is None:
+            print("loading open PR state from GitHub (one bulk call)...")
+            open_prs_cache, open_pr_state_available, message = _github_open_pr_state(
+                root, args.repo_name
+            )
+            if open_pr_state_available:
+                print(f"  {message}\n")
+            else:
+                print(f"  WARN: {message}; preserving ambiguous handoffs without open-PR truth\n")
+        return open_prs_cache, open_pr_state_available
 
     counts = {
         "satisfied_by_existing_receipt": 0,
@@ -225,6 +253,7 @@ def main(argv: list[str] | None = None) -> int:
         "satisfied_by_open_pr_merged": 0,  # placeholder; we only know open PRs
         "still_protecting_active_work": 0,
         "missing_branch": 0,
+        "blocked_missing_branch_open_pr_unknown": 0,
         "skipped_unparseable": 0,
     }
 
@@ -262,6 +291,34 @@ def main(argv: list[str] | None = None) -> int:
         except Exception:
             ref_proc = None
         if ref_proc is None or ref_proc.returncode != 0:
+            open_prs, open_pr_state_available = load_open_pr_state()
+            if branch in open_prs:
+                counts["still_protecting_active_work"] += 1
+                actions.append(
+                    {
+                        "path": str(path),
+                        "branch": branch,
+                        "decision": "keep",
+                        "reason": f"branch missing locally but has open PR #{open_prs[branch]}",
+                        "synthetic_receipt": False,
+                    }
+                )
+                continue
+            if not open_pr_state_available:
+                counts["blocked_missing_branch_open_pr_unknown"] += 1
+                actions.append(
+                    {
+                        "path": str(path),
+                        "branch": branch,
+                        "decision": "keep",
+                        "reason": (
+                            "branch no longer exists locally, but open PR state is unavailable"
+                        ),
+                        "synthetic_receipt": False,
+                    }
+                )
+                continue
+
             counts["missing_branch"] += 1
             actions.append(
                 {
@@ -283,6 +340,7 @@ def main(argv: list[str] | None = None) -> int:
                 shutil.move(str(path), str(archive_dir / path.name))
             continue
 
+        open_prs, _open_pr_state_available = load_open_pr_state()
         if branch in open_prs:
             counts["still_protecting_active_work"] += 1
             actions.append(

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -1,10 +1,42 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import scripts.reconcile_automation_outbox as mod
+
+
+def _unhealthy_github() -> SimpleNamespace:
+    return SimpleNamespace(
+        ready=False,
+        mode="connectivity_failed",
+        error="error connecting to api.github.com",
+    )
+
+
+def _ready_github() -> SimpleNamespace:
+    return SimpleNamespace(ready=True, mode="ready", error="")
+
+
+def _write_outbox_handoff(outbox_dir: Path, *, branch: str, key: str) -> Path:
+    outbox_dir.mkdir(parents=True, exist_ok=True)
+    path = outbox_dir / f"{key}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "task": f"Publish {branch}",
+                "requires_github": True,
+                "requested_action": {"type": "open_pr", "branch": branch},
+                "repo": "synaptent/aragora",
+                "idempotency_key": key,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
 
 
 def test_terminal_receipt_keys_falls_back_to_receipt_filename(tmp_path: Path) -> None:
@@ -108,3 +140,70 @@ def test_reconcile_existing_receipt_uses_structured_requested_action_branch(
     assert payload["counts"]["satisfied_by_existing_receipt"] == 1
     assert payload["counts"]["skipped_unparseable"] == 0
     assert payload["actions"][0]["branch"] == "codex/structured-action"
+
+
+def test_apply_preserves_missing_branch_when_open_pr_state_unavailable(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "open-pr-codex-missing-abc123"
+    handoff = _write_outbox_handoff(outbox_dir, branch="codex/missing", key=key)
+    receipt_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _unhealthy_github())
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("open PR fetch should be skipped when GitHub is unhealthy")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["git"], returncode=128, stdout="", stderr="missing ref"
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--apply"]) == 0
+
+    reports = sorted((tmp_path / ".aragora" / "cleanup-state").glob("*.json"))
+    payload = json.loads(reports[-1].read_text(encoding="utf-8"))
+    assert payload["counts"]["blocked_missing_branch_open_pr_unknown"] == 1
+    assert payload["counts"]["missing_branch"] == 0
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "open PR state is unavailable" in payload["actions"][0]["reason"]
+    assert handoff.exists()
+    assert not (receipt_dir / f"{key}.json").exists()
+    assert not list((tmp_path / ".aragora" / "automation-outbox-archive").glob("*.json"))
+
+
+def test_missing_branch_archives_when_open_pr_state_is_available(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    key = "open-pr-codex-missing-abc123"
+    _write_outbox_handoff(outbox_dir, branch="codex/missing", key=key)
+
+    monkeypatch.setattr(mod, "check_github_cli_health", lambda _root: _ready_github())
+    monkeypatch.setattr(mod, "open_pr_heads", lambda *_args: {})
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["git"], returncode=128, stdout="", stderr="missing ref"
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--write-report"]) == 0
+
+    reports = sorted((tmp_path / ".aragora" / "cleanup-state").glob("*.json"))
+    payload = json.loads(reports[-1].read_text(encoding="utf-8"))
+    assert payload["counts"]["missing_branch"] == 1
+    assert payload["counts"]["blocked_missing_branch_open_pr_unknown"] == 0
+    assert payload["actions"][0]["decision"] == "archive"
+    assert payload["actions"][0]["reason"] == "branch no longer exists"


### PR DESCRIPTION
## Summary
Fixes the automation outbox reconciler so missing local branches are not archived when GitHub PR truth is unavailable or ambiguous.

This preserves unresolved outbox handoffs instead of treating a missing local branch as cleanup permission when the open-PR lookup cannot be trusted.

## Scope
- Adds GitHub health gating before the reconciler relies on open PR state.
- Keeps handoffs for missing local branches when open-PR truth is unavailable.
- Adds regression coverage for the ambiguous missing-branch case.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py -p no:rerunfailures -p no:cacheprovider` -> 8 passed.
- `python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py` -> passed.
- `python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py` -> passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok.
- `python3 scripts/reconcile_automation_outbox.py --repo /Users/armand/Development/aragora --base origin/main` -> dry-run kept all 21 current outbox files, 0 archived.

## Notes
Restacked onto current `origin/main` before publishing. This is an automation-substrate repair; it does not mutate outbox state by default and requires `--apply` for archival actions.