### PR TITLE
fix(agent-bridge): protect unavailable supervisor worktrees

### DIFF
--- a/scripts/agent_bridge_supervise.py
+++ b/scripts/agent_bridge_supervise.py
@@ -144,13 +144,27 @@ def _session_text(session: agent_bridge.Session | None) -> str:
 
 
 def _run_git(worktree: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git", "-C", str(worktree), *args],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        check=False,
-    )
+    cmd = ["git", "-C", str(worktree), *args]
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        message = stderr or f"command timed out after 10s: {' '.join(cmd)}"
+        return subprocess.CompletedProcess(cmd, 124, stdout, message)
+    except OSError as exc:
+        return subprocess.CompletedProcess(cmd, 127, "", str(exc))
+
+
+def _git_failure_detail(proc: subprocess.CompletedProcess[str]) -> str:
+    detail = (proc.stderr or proc.stdout or f"rc={proc.returncode}").strip()
+    return f" ({detail})" if detail else ""
 
 
 def _inspect_worktree(worktree_path: str) -> WorktreeStatus:
@@ -172,7 +186,8 @@ def _inspect_worktree(worktree_path: str) -> WorktreeStatus:
         if dirty:
             evidence.append("worktree has local changes")
     else:
-        evidence.append("git status unavailable")
+        dirty = True
+        evidence.append(f"git status unavailable{_git_failure_detail(status_proc)}")
 
     counts_proc = _run_git(worktree, "rev-list", "--left-right", "--count", "origin/main...HEAD")
     if counts_proc.returncode == 0:
@@ -411,6 +426,25 @@ def _decide_lane(
             source=record.source,
             branch=branch,
             worktree=worktree,
+            evidence=evidence,
+        )
+
+    if worktree_status.dirty:
+        return LaneDecision(
+            lane_id=record.lane_id,
+            owner_session=record.owner_session,
+            status=record.status,
+            next_action="send_followup",
+            reason=(
+                "lane worktree has local changes or unavailable git status; "
+                "owner needs a bounded reconciliation prompt"
+            ),
+            source=record.source,
+            branch=branch,
+            worktree=worktree,
+            pr_number=pr_truth.number if pr_truth else None,
+            pr_url=pr_truth.url if pr_truth else "",
+            pr_checks_bucket=pr_truth.checks_bucket if pr_truth else "",
             evidence=evidence,
         )
 

--- a/tests/scripts/test_agent_bridge_supervise.py
+++ b/tests/scripts/test_agent_bridge_supervise.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -175,6 +176,85 @@ def test_decide_lane_ready_for_review_when_checks_pass() -> None:
 
     assert decision.next_action == "ready_for_review"
     assert "checks passed" in decision.reason
+
+
+def test_decide_lane_followup_when_worktree_dirty_even_if_checks_pass() -> None:
+    import agent_bridge_supervise as mod
+
+    record = mod.agent_bridge.LaneRecord(
+        lane_id="bridge-hardening",
+        owner_session="codex-bridge",
+        status="active",
+        branch="codex/issue-5322",
+        worktree="/tmp/bridge",
+    )
+    session = mod.agent_bridge.Session(
+        name="codex-bridge",
+        agent="codex",
+        status="alive",
+        branch="codex/issue-5322",
+        worktree="/tmp/bridge",
+        summary="PR is green and ready for review",
+    )
+    pr_truth = mod.PRTruth(
+        branch="codex/issue-5322",
+        number=5402,
+        url="https://github.com/synaptent/aragora/pull/5402",
+        checks_bucket="pass",
+    )
+
+    decision = mod._decide_lane(
+        record,
+        session,
+        session.summary,
+        mod.WorktreeStatus(
+            state="dirty",
+            dirty=True,
+            evidence=["git status unavailable (command timed out)"],
+        ),
+        pr_truth,
+    )
+
+    assert decision.next_action == "send_followup"
+    assert "worktree has local changes" in decision.reason
+    assert decision.pr_number == 5402
+
+
+def test_inspect_worktree_treats_git_status_failure_as_dirty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge_supervise as mod
+
+    def fake_run_git(_worktree: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        if args == ("status", "--short"):
+            return subprocess.CompletedProcess(["git", "status"], 128, "", "fatal: bad index")
+        if args == ("rev-list", "--left-right", "--count", "origin/main...HEAD"):
+            return subprocess.CompletedProcess(["git", "rev-list"], 0, "0 0\n", "")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(mod, "_run_git", fake_run_git)
+
+    status = mod._inspect_worktree(str(tmp_path))
+
+    assert status.dirty is True
+    assert status.state == "dirty"
+    assert status.evidence == ["git status unavailable (fatal: bad index)"]
+
+
+def test_run_git_returns_degraded_process_on_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge_supervise as mod
+
+    def raise_timeout(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=["git", "status"], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(mod.subprocess, "run", raise_timeout)
+
+    proc = mod._run_git(tmp_path, "status")
+
+    assert proc.returncode == 124
+    assert "command timed out after 10s" in proc.stderr
 
 
 def test_main_once_json_renders_snapshot(


### PR DESCRIPTION
## Summary
- Treat failed or timed-out git status checks as dirty in the agent bridge supervisor.
- Route lanes with unavailable worktree status to bounded follow-up instead of ready-for-review decisions.
- Add focused regression coverage for dirty/unavailable worktree handling and git timeout degradation.

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_agent_bridge_supervise.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/agent_bridge_supervise.py tests/scripts/test_agent_bridge_supervise.py
- python3 -m ruff format --check scripts/agent_bridge_supervise.py tests/scripts/test_agent_bridge_supervise.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/agent_bridge_supervise.py --once --json