### PR TITLE
fix(automation): parse JSON action handoff branches

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -329,6 +329,12 @@ def _structured_action(value: Any) -> Mapping[str, Any] | None:
         text = value.strip()
         if text.startswith("{") and text.endswith("}"):
             try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, Mapping):
+                return parsed
+            try:
                 parsed = ast.literal_eval(text)
             except (SyntaxError, ValueError):
                 return None

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -598,6 +598,75 @@ def test_audit_protects_structured_action_branch_handoffs(tmp_path: Path, monkey
     assert payload["summary"]["publishable_branch_backlog"] == 1
 
 
+def test_audit_protects_json_string_action_branch_handoffs(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    now = datetime.now(timezone.utc)
+    rows = [
+        _branch_row("codex/json-action", committed_at=now),
+        _branch_row("codex/new-work", committed_at=now),
+    ]
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "json-action.json").write_text(
+        json.dumps(
+            {
+                "task": "Publish JSON-string action branch",
+                "requires_github": True,
+                "requested_action": json.dumps(
+                    {
+                        "type": "push_branch_and_open_pr",
+                        "branch": "codex/json-action",
+                        "requires_github": True,
+                    }
+                ),
+                "repo": "synaptent/aragora",
+                "local_evidence": {},
+                "validation": ["pytest tests/example.py -q"],
+                "idempotency_key": "open-pr-codex-json-action-abc123",
+                "created_at": "2026-04-29T12:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "local_branches", lambda _root, _prefix, _base: rows)
+    monkeypatch.setattr(mod, "remote_branch_names", lambda _root, _prefix: set())
+    monkeypatch.setattr(mod, "merged_branch_names", lambda _root, _base, _prefix: set())
+    monkeypatch.setattr(mod, "worktree_map", lambda _root: {})
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=2,
+    )
+
+    by_category = payload["summary"]["by_category"]
+    assert by_category["protected_handoff_outbox"] == 1
+    assert by_category["salvage_recent_unique"] == 1
+    protected = next(
+        record for record in payload["records"] if record["name"] == "codex/json-action"
+    )
+    assert protected["handoff_outbox_exists"] is True
+    assert protected["category"] == "protected_handoff_outbox"
+
+
 def test_audit_protects_patch_equivalent_unresolved_handoff_branches(
     tmp_path: Path, monkeypatch: Any
 ) -> None:


### PR DESCRIPTION
## Summary
Teaches the branch-backlog audit to extract branch names from JSON-string `requested_action` payloads, not only dict-shaped action payloads.

This prevents unresolved automation handoffs with serialized JSON action strings from being missed by branch protection/backlog classification.

## Scope
- Adds JSON-string action parsing in `scripts/audit_codex_branch_backlog.py`.
- Adds regression coverage for JSON-string handoff actions in `tests/scripts/test_audit_codex_branch_backlog.py`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py -p no:rerunfailures -p no:cacheprovider` -> 28 passed.
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed.
- `python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok.
- `git diff --check origin/main...HEAD` -> passed.

## Notes
This is the audit/read-only half of the JSON handoff parsing pair. It is intentionally separate from the publish-path branch (`codex/publish-json-action-handoff-parsing`), which touches different files and will be handled after this PR settles.