### PR TITLE
[DIC-24] GenealogyReport multi-unit aggregate + epistemic package exports

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -33,6 +33,13 @@ Exposes:
   :class:`DialecticalRuntimeError`, :func:`run_dialectical_loop`,
   :func:`dialectical_runtime_enabled`)
   Flag gate: ``ARAGORA_DIALECTICAL_RUNTIME_ENABLED`` (default off).
+- DIC-24: epistemic genealogy ledger — lineage view across decision, decay,
+  crux, and repair (:class:`CodeUnitGenealogy`, :class:`GenealogyEntry`,
+  :class:`GenealogyUnitSummary`, :class:`GenealogyReport`,
+  :func:`get_genealogy`, :func:`build_genealogy_report`,
+  :class:`InMemoryGenealogyStore`)
+  Flag gate: ``ARAGORA_GENEALOGY_ENABLED`` (default off; data classes and
+  store are always importable).
 - DIC-26: belief coherence monitor (:class:`BeliefEntry`,
   :class:`CoherenceReport`, :func:`scan_coherence`)
 - DIC-28: proactive crux gardening (:class:`GardeningConfig`,
@@ -145,6 +152,18 @@ from .proof_unit import (
     proof_unit_scan_enabled,
     reset_proof_unit_scan,
 )
+from .genealogy import (
+    CodeUnitGenealogy,
+    GenealogyEntry,
+    GenealogyStore,
+    InMemoryGenealogyStore,
+    get_genealogy,
+)
+from .genealogy_report import (
+    GenealogyReport,
+    GenealogyUnitSummary,
+    build_genealogy_report,
+)
 from .truth_map import (
     OrgTruthMapReport,
     build_truth_map,
@@ -218,6 +237,14 @@ __all__ = [
     "run_gardening_pass",
     "build_truth_map",
     "build_truth_map_from_manifests",
+    "CodeUnitGenealogy",
+    "GenealogyEntry",
+    "GenealogyReport",
+    "GenealogyStore",
+    "GenealogyUnitSummary",
+    "InMemoryGenealogyStore",
+    "build_genealogy_report",
+    "get_genealogy",
     "coherence_monitor_enabled",
     "crux_receipt_enabled",
     "enable_crux_receipt",

--- a/aragora/epistemic/genealogy_report.py
+++ b/aragora/epistemic/genealogy_report.py
@@ -1,0 +1,130 @@
+"""Multi-unit genealogy report — DIC-24 / #6218.
+
+Aggregates CodeUnitGenealogy records into a GenealogyReport for operator
+display or receipt-path ingestion.  Flag: ARAGORA_GENEALOGY_ENABLED (off
+by default).  Default OFF; data classes importable without the flag.
+Live queue effect: none.  Gate: same as DIC-23..28.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Iterable
+
+from aragora.epistemic.genealogy import CodeUnitGenealogy, GenealogyStore, get_genealogy
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class GenealogyUnitSummary:
+    """Compact lineage summary for one proof-carrying code unit.
+
+    ``entry_kinds`` is a sorted tuple of distinct entry_kind values present.
+    ``oldest_timestamp`` / ``newest_timestamp`` are None for empty chains.
+    """
+
+    code_unit_id: str
+    entry_count: int
+    entry_kinds: tuple[str, ...]
+    oldest_timestamp: str | None
+    newest_timestamp: str | None
+    chain_checksum: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code_unit_id": self.code_unit_id,
+            "entry_count": self.entry_count,
+            "entry_kinds": list(self.entry_kinds),
+            "oldest_timestamp": self.oldest_timestamp,
+            "newest_timestamp": self.newest_timestamp,
+            "chain_checksum": self.chain_checksum,
+        }
+
+    @classmethod
+    def from_genealogy(cls, genealogy: CodeUnitGenealogy) -> "GenealogyUnitSummary":
+        entries = genealogy.entries
+        if not entries:
+            return cls(
+                code_unit_id=genealogy.code_unit_id,
+                entry_count=0,
+                entry_kinds=(),
+                oldest_timestamp=None,
+                newest_timestamp=None,
+                chain_checksum=genealogy.chain_checksum,
+            )
+        kinds: tuple[str, ...] = tuple(sorted({e.entry_kind for e in entries}))
+        timestamps = [e.timestamp for e in entries]
+        return cls(
+            code_unit_id=genealogy.code_unit_id,
+            entry_count=len(entries),
+            entry_kinds=kinds,
+            oldest_timestamp=min(timestamps),
+            newest_timestamp=max(timestamps),
+            chain_checksum=genealogy.chain_checksum,
+        )
+
+
+@dataclass(frozen=True)
+class GenealogyReport:
+    """Aggregate lineage report across multiple proof-carrying code units.
+
+    ``summaries`` is sorted by code_unit_id for deterministic output.
+    """
+
+    unit_count: int
+    total_entries: int
+    summaries: tuple[GenealogyUnitSummary, ...]
+    generated_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "unit_count": self.unit_count,
+            "total_entries": self.total_entries,
+            "summaries": [s.to_dict() for s in self.summaries],
+            "generated_at": self.generated_at,
+        }
+
+    def units_by_activity(self) -> list[GenealogyUnitSummary]:
+        """Return summaries sorted by entry_count descending."""
+        return sorted(self.summaries, key=lambda s: s.entry_count, reverse=True)
+
+    def units_with_kind(self, kind: str) -> list[GenealogyUnitSummary]:
+        """Return summaries that contain at least one entry of *kind*."""
+        return [s for s in self.summaries if kind in s.entry_kinds]
+
+
+def build_genealogy_report(
+    code_unit_ids: Iterable[str],
+    store: GenealogyStore,
+    *,
+    require_enabled: bool = True,
+) -> GenealogyReport:
+    """Build a GenealogyReport from *store* for *code_unit_ids*.
+
+    Empty *code_unit_ids* returns an empty report without touching the flag.
+    Pass ``require_enabled=False`` in tests; the flag check is in get_genealogy.
+    """
+    ids = list(code_unit_ids)
+    if not ids:
+        return GenealogyReport(
+            unit_count=0, total_entries=0, summaries=(), generated_at=_utc_now_iso()
+        )
+    summaries = sorted(
+        [
+            GenealogyUnitSummary.from_genealogy(
+                get_genealogy(uid, store, require_enabled=require_enabled)
+            )
+            for uid in ids
+        ],
+        key=lambda s: s.code_unit_id,
+    )
+    return GenealogyReport(
+        unit_count=len(summaries),
+        total_entries=sum(s.entry_count for s in summaries),
+        summaries=tuple(summaries),
+        generated_at=_utc_now_iso(),
+    )

--- a/tests/epistemic/test_genealogy_report.py
+++ b/tests/epistemic/test_genealogy_report.py
@@ -1,0 +1,143 @@
+"""Tests for aragora.epistemic.genealogy_report (DIC-24 / #6218).
+
+Imports directly from modules (not aragora.epistemic) to avoid the yaml
+transitive dependency when running with --noconftest.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.genealogy import (
+    CodeUnitGenealogy,
+    GenealogyEntry,
+    InMemoryGenealogyStore,
+)
+from aragora.epistemic.genealogy_report import (
+    GenealogyReport,
+    GenealogyUnitSummary,
+    build_genealogy_report,
+)
+
+
+def _e(kind: str = "decay_signal", eid: str = "e1", ts: str = "2026-04-01T10:00:00Z") -> GenealogyEntry:
+    return GenealogyEntry(entry_kind=kind, entry_id=eid, checksum="x", timestamp=ts)  # type: ignore[arg-type]
+
+
+def _store(data: dict[str, list[GenealogyEntry]]) -> InMemoryGenealogyStore:
+    s = InMemoryGenealogyStore()
+    for uid, entries in data.items():
+        for e in entries:
+            s.add(uid, e)
+    return s
+
+
+# -- GenealogyUnitSummary.from_genealogy --
+
+
+def test_summary_empty_chain() -> None:
+    s = GenealogyUnitSummary.from_genealogy(CodeUnitGenealogy.build("u", []))
+    assert s.entry_count == 0 and s.entry_kinds == () and s.oldest_timestamp is None
+
+
+def test_summary_multiple_kinds_sorted() -> None:
+    g = CodeUnitGenealogy.build(
+        "u",
+        [
+            _e("decay_signal", "d1", "2026-04-01T00:00:00Z"),
+            _e("repair_proposal", "r1", "2026-04-02T00:00:00Z"),
+            _e("crux_receipt", "c1", "2026-04-03T00:00:00Z"),
+        ],
+    )
+    s = GenealogyUnitSummary.from_genealogy(g)
+    assert s.entry_count == 3
+    assert s.entry_kinds == ("crux_receipt", "decay_signal", "repair_proposal")
+    assert s.oldest_timestamp < s.newest_timestamp  # type: ignore[operator]
+
+
+def test_summary_chain_checksum_preserved() -> None:
+    g = CodeUnitGenealogy.build("u", [_e()])
+    assert GenealogyUnitSummary.from_genealogy(g).chain_checksum == g.chain_checksum
+
+
+# -- build_genealogy_report: empty and flag gate --
+
+
+def test_empty_ids_skips_flag() -> None:
+    r = build_genealogy_report([], InMemoryGenealogyStore(), require_enabled=True)
+    assert r.unit_count == 0 and r.summaries == ()
+
+
+def test_flag_off_raises() -> None:
+    with pytest.raises(RuntimeError, match="ARAGORA_GENEALOGY_ENABLED"):
+        build_genealogy_report(["u"], _store({"u": [_e()]}), require_enabled=True)
+
+
+def test_require_disabled_passes() -> None:
+    assert build_genealogy_report(["u"], _store({"u": [_e()]}), require_enabled=False).unit_count == 1
+
+# -- build_genealogy_report: content --
+
+
+def test_multiple_units_sorted_by_id() -> None:
+    r = build_genealogy_report(
+        ["u.beta", "u.alpha", "u.gamma"],
+        _store({
+            "u.beta": [_e(eid="b")],
+            "u.alpha": [_e(eid="a1"), _e(eid="a2", ts="2026-04-02T00:00:00Z")],
+            "u.gamma": [],
+        }),
+        require_enabled=False,
+    )
+    assert [s.code_unit_id for s in r.summaries] == ["u.alpha", "u.beta", "u.gamma"]
+    assert r.total_entries == 3
+
+
+def test_unknown_unit_empty_summary() -> None:
+    r = build_genealogy_report(["ghost"], InMemoryGenealogyStore(), require_enabled=False)
+    assert r.unit_count == 1 and r.total_entries == 0
+
+
+# -- GenealogyReport helpers --
+
+
+def _multi() -> GenealogyReport:
+    return build_genealogy_report(
+        ["u.a", "u.b", "u.c"],
+        _store({
+            "u.a": [_e("decay_signal", "d1"), _e("decay_signal", "d2", "2026-04-02T00:00:00Z"),
+                    _e("crux_receipt", "c1", "2026-04-03T00:00:00Z")],
+            "u.b": [_e("repair_proposal", "r1")],
+            "u.c": [],
+        }),
+        require_enabled=False,
+    )
+
+
+def test_units_by_activity_order() -> None:
+    ranked = _multi().units_by_activity()
+    assert ranked[0].code_unit_id == "u.a" and ranked[-1].entry_count == 0
+
+
+def test_units_with_kind_match_and_miss() -> None:
+    r = _multi()
+    assert [s.code_unit_id for s in r.units_with_kind("crux_receipt")] == ["u.a"]
+    assert r.units_with_kind("decision_receipt") == []
+
+
+def test_to_dict_structure() -> None:
+    d = _multi().to_dict()
+    assert set(d.keys()) == {"unit_count", "total_entries", "summaries", "generated_at"}
+    assert d["unit_count"] == 3 and d["total_entries"] == 4
+
+
+# -- __init__.py __all__ coverage (file-based, no yaml needed) --
+
+
+def test_init_all_contains_genealogy_symbols() -> None:
+    init_path = __file__.split("tests/epistemic/")[0] + "aragora/epistemic/__init__.py"
+    source = open(init_path).read()
+    for sym in ("GenealogyReport", "GenealogyUnitSummary", "build_genealogy_report",
+                "CodeUnitGenealogy", "GenealogyEntry", "GenealogyStore",
+                "InMemoryGenealogyStore", "get_genealogy"):
+        assert f'"{sym}"' in source, f"{sym!r} missing from aragora.epistemic.__all__"

--- a/tests/epistemic/test_genealogy_report.py
+++ b/tests/epistemic/test_genealogy_report.py
@@ -20,7 +20,9 @@ from aragora.epistemic.genealogy_report import (
 )
 
 
-def _e(kind: str = "decay_signal", eid: str = "e1", ts: str = "2026-04-01T10:00:00Z") -> GenealogyEntry:
+def _e(
+    kind: str = "decay_signal", eid: str = "e1", ts: str = "2026-04-01T10:00:00Z"
+) -> GenealogyEntry:
     return GenealogyEntry(entry_kind=kind, entry_id=eid, checksum="x", timestamp=ts)  # type: ignore[arg-type]
 
 
@@ -74,7 +76,10 @@ def test_flag_off_raises() -> None:
 
 
 def test_require_disabled_passes() -> None:
-    assert build_genealogy_report(["u"], _store({"u": [_e()]}), require_enabled=False).unit_count == 1
+    assert (
+        build_genealogy_report(["u"], _store({"u": [_e()]}), require_enabled=False).unit_count == 1
+    )
+
 
 # -- build_genealogy_report: content --
 
@@ -82,11 +87,13 @@ def test_require_disabled_passes() -> None:
 def test_multiple_units_sorted_by_id() -> None:
     r = build_genealogy_report(
         ["u.beta", "u.alpha", "u.gamma"],
-        _store({
-            "u.beta": [_e(eid="b")],
-            "u.alpha": [_e(eid="a1"), _e(eid="a2", ts="2026-04-02T00:00:00Z")],
-            "u.gamma": [],
-        }),
+        _store(
+            {
+                "u.beta": [_e(eid="b")],
+                "u.alpha": [_e(eid="a1"), _e(eid="a2", ts="2026-04-02T00:00:00Z")],
+                "u.gamma": [],
+            }
+        ),
         require_enabled=False,
     )
     assert [s.code_unit_id for s in r.summaries] == ["u.alpha", "u.beta", "u.gamma"]
@@ -104,12 +111,17 @@ def test_unknown_unit_empty_summary() -> None:
 def _multi() -> GenealogyReport:
     return build_genealogy_report(
         ["u.a", "u.b", "u.c"],
-        _store({
-            "u.a": [_e("decay_signal", "d1"), _e("decay_signal", "d2", "2026-04-02T00:00:00Z"),
-                    _e("crux_receipt", "c1", "2026-04-03T00:00:00Z")],
-            "u.b": [_e("repair_proposal", "r1")],
-            "u.c": [],
-        }),
+        _store(
+            {
+                "u.a": [
+                    _e("decay_signal", "d1"),
+                    _e("decay_signal", "d2", "2026-04-02T00:00:00Z"),
+                    _e("crux_receipt", "c1", "2026-04-03T00:00:00Z"),
+                ],
+                "u.b": [_e("repair_proposal", "r1")],
+                "u.c": [],
+            }
+        ),
         require_enabled=False,
     )
 
@@ -137,7 +149,14 @@ def test_to_dict_structure() -> None:
 def test_init_all_contains_genealogy_symbols() -> None:
     init_path = __file__.split("tests/epistemic/")[0] + "aragora/epistemic/__init__.py"
     source = open(init_path).read()
-    for sym in ("GenealogyReport", "GenealogyUnitSummary", "build_genealogy_report",
-                "CodeUnitGenealogy", "GenealogyEntry", "GenealogyStore",
-                "InMemoryGenealogyStore", "get_genealogy"):
+    for sym in (
+        "GenealogyReport",
+        "GenealogyUnitSummary",
+        "build_genealogy_report",
+        "CodeUnitGenealogy",
+        "GenealogyEntry",
+        "GenealogyStore",
+        "InMemoryGenealogyStore",
+        "get_genealogy",
+    ):
         assert f'"{sym}"' in source, f"{sym!r} missing from aragora.epistemic.__all__"


### PR DESCRIPTION
## Slice

Adds `GenealogyReport` — a multi-unit aggregate view over `CodeUnitGenealogy` records — to `aragora/epistemic/genealogy_report.py`. Also wires `aragora.epistemic.genealogy` (previously a private module with no package-level exports) into `aragora/epistemic/__init__.py` for the first time, making all genealogy types accessible via the public API.

## Gating

- Default: **OFF** (flag: `ARAGORA_GENEALOGY_ENABLED`; empty-id fast path bypasses the flag)
- Live queue effect: **none**
- Advances issue: #6218 (DIC-24)

## What this adds

**`aragora/epistemic/genealogy_report.py`** (130 LOC)
- `GenealogyUnitSummary` — compact per-unit summary: `entry_count`, `entry_kinds` (sorted unique kinds), `oldest_timestamp`, `newest_timestamp`, `chain_checksum`
- `GenealogyReport` — aggregate across N units: `unit_count`, `total_entries`, sorted `summaries` tuple, `generated_at`; helper methods `units_by_activity()` and `units_with_kind(kind)`
- `build_genealogy_report(code_unit_ids, store, *, require_enabled=True)` — calls `get_genealogy` per unit, returns sorted `GenealogyReport`

**`aragora/epistemic/__init__.py`** (27 LOC added)
- Imports and exports `CodeUnitGenealogy`, `GenealogyEntry`, `GenealogyStore`, `InMemoryGenealogyStore`, `get_genealogy` from `genealogy.py`
- Imports and exports `GenealogyReport`, `GenealogyUnitSummary`, `build_genealogy_report` from `genealogy_report.py`
- Updates module docstring to list DIC-24 in the coverage table

## Tests

- `test_summary_empty_chain` — empty genealogy → zero entries, None timestamps, empty kinds tuple
- `test_summary_multiple_kinds_sorted` — 3 entries of 3 kinds → sorted `entry_kinds`, `oldest < newest`
- `test_summary_chain_checksum_preserved` — checksum from `CodeUnitGenealogy` flows through
- `test_empty_ids_skips_flag` — empty ID list returns empty report without touching flag gate
- `test_flag_off_raises` — non-empty IDs with `require_enabled=True` and no env var raises `RuntimeError`
- `test_require_disabled_passes` — `require_enabled=False` bypasses flag gate
- `test_multiple_units_sorted_by_id` — 3 units returned alphabetically regardless of input order
- `test_unknown_unit_empty_summary` — missing store ID → unit_count=1, total_entries=0
- `test_units_by_activity_order` — busiest chain sorts first, empty chain sorts last
- `test_units_with_kind_match_and_miss` — filter by `entry_kind` present and absent
- `test_to_dict_structure` — `to_dict()` returns correct keys and values
- `test_init_all_contains_genealogy_symbols` — file-based check that all 8 genealogy symbols appear in `__all__`

## Validation

- `python3 -m pytest tests/epistemic/test_genealogy_report.py --noconftest -q` — **12 passed**
- `ruff check aragora/epistemic/genealogy_report.py aragora/epistemic/__init__.py tests/epistemic/test_genealogy_report.py` — **clean**
- `mypy aragora/epistemic/genealogy_report.py aragora/epistemic/genealogy.py --ignore-missing-imports` — **clean**
- Net diff: **300 LOC** (130 insertions impl + 143 insertions tests + 27 insertions `__init__.py`)

## Out of scope

- Persistence of `GenealogyReport` to disk or KM: callers own the store and can serialize via `to_dict()`
- Wiring `GenealogyReport` into the DIC-23 runtime loop or DIC-18 truth-map report: deferred to the DIC-23..28 activation gate
- On-disk serialization format: `to_dict()` is JSON-serializable; callers choose their output path

Note: the proof-first Foreman gate in `docs/status/NEXT_STEPS_CANONICAL.md` is **not yet open** for the DIC-23..28 tranche. This PR carries no `boss-ready` label and must remain DRAFT until the gate opens or is explicitly waived for this slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hXLV1mUovorWTvFFD6SoX)_