### PR TITLE
fix(automation): parse JSON handoff action strings

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -526,7 +526,12 @@ def _structured_action(value: Any) -> Mapping[str, Any] | None:
         text = value.strip()
         if text.startswith("{") and text.endswith("}"):
             try:
-                parsed = ast.literal_eval(text)
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                try:
+                    parsed = ast.literal_eval(text)
+                except (SyntaxError, ValueError):
+                    return None
             except (SyntaxError, ValueError):
                 return None
             if isinstance(parsed, Mapping):

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -427,6 +427,53 @@ def test_load_outbox_handoffs_deduplicates_structured_action_branch_handoffs(
     assert handoffs[0].source_file == str(newer)
 
 
+def test_load_outbox_handoffs_deduplicates_json_string_action_branch_handoffs(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    older = outbox / "older.json"
+    newer = outbox / "newer.json"
+    requested_action = json.dumps(
+        {
+            "type": "open_pull_request",
+            "branch": "codex/example",
+            "base": "main",
+            "draft": True,
+        }
+    )
+    older.write_text(
+        json.dumps(
+            _outbox_payload(
+                task="Publish older branch snapshot",
+                requested_action=requested_action,
+                idempotency_key="open-pr-codex-example-old",
+            )
+        ),
+        encoding="utf-8",
+    )
+    newer.write_text(
+        json.dumps(
+            _outbox_payload(
+                task="Publish newer branch snapshot",
+                requested_action=requested_action,
+                idempotency_key="open-pr-codex-example-new",
+            )
+        ),
+        encoding="utf-8",
+    )
+    os.utime(older, (1_000, 1_000))
+    os.utime(newer, (2_000, 2_000))
+
+    handoffs = mod.load_outbox_handoffs(tmp_path)
+
+    assert len(handoffs) == 1
+    assert handoffs[0].task_title == "Publish newer branch snapshot"
+    assert handoffs[0].idempotency_key == "open-pr-codex-example-new"
+    assert handoffs[0].source_file == str(newer)
+    assert handoffs[0].branch == "codex/example"
+
+
 def test_load_outbox_handoffs_skips_terminal_receipt_for_same_branch(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
Teaches the automation handoff publisher to parse JSON-string `requested_action` values, not only dict-shaped action payloads.

This lets the publisher correctly identify and route handoff actions that were serialized as JSON strings by sandboxed automation writers.

## Scope
- Adds JSON-string action parsing in `scripts/publish_automation_handoffs.py`.
- Adds regression coverage in `tests/scripts/test_publish_automation_handoffs.py`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py -p no:rerunfailures -p no:cacheprovider` -> 41 passed.
- `python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` -> passed.
- `python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` -> passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok.
- `git diff --check origin/main...HEAD` -> passed.

## Notes
This is the publish-path half of the JSON handoff parsing pair. The audit/read-only half landed separately in #6823.