### PR TITLE
fix(automation): match queue receipts by idempotency key

### DIFF
--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -80,6 +80,18 @@ def _json_files(path: Path) -> list[Path]:
     return sorted(item for item in path.glob("*.json") if item.is_file())
 
 
+def _queue_file_key(path: Path) -> str:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return path.stem
+    if isinstance(payload, dict):
+        key = str(payload.get("idempotency_key") or "").strip()
+        if key:
+            return key
+    return path.stem
+
+
 def _local_queue_state(
     *,
     repo_root: Path,
@@ -90,14 +102,14 @@ def _local_queue_state(
     receipts = _resolve_state_path(repo_root, receipt_dir, DEFAULT_RECEIPT_DIR)
     outbox_files = _json_files(outbox)
     receipt_files = _json_files(receipts)
-    receipt_names = {item.name for item in receipt_files}
+    receipt_keys = {_queue_file_key(item) for item in receipt_files}
     return {
         "outbox_dir": str(outbox),
         "receipt_dir": str(receipts),
         "outbox_count": len(outbox_files),
         "receipt_count": len(receipt_files),
         "unreceipted_outbox_count": sum(
-            1 for item in outbox_files if item.name not in receipt_names
+            1 for item in outbox_files if _queue_file_key(item) not in receipt_keys
         ),
     }
 

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -47,6 +47,32 @@ def test_build_status_uses_local_queue_when_github_unavailable(
     assert payload["local_queue"]["unreceipted_outbox_count"] == 1
 
 
+def test_local_queue_state_matches_receipts_by_idempotency_key(tmp_path: Path) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-example-abc123"
+    (outbox / "handoff-file-name.json").write_text(
+        f'{{"idempotency_key": "{key}"}}',
+        encoding="utf-8",
+    )
+    (receipts / "different-receipt-file.json").write_text(
+        f'{{"idempotency_key": "{key}", "status": "published"}}',
+        encoding="utf-8",
+    )
+
+    payload = mod._local_queue_state(
+        repo_root=tmp_path,
+        outbox_dir=None,
+        receipt_dir=None,
+    )
+
+    assert payload["outbox_count"] == 1
+    assert payload["receipt_count"] == 1
+    assert payload["unreceipted_outbox_count"] == 0
+
+
 def test_build_status_records_remote_pressure_when_github_available(
     monkeypatch: Any,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
Fixes local automation GitHub status cache queue-pressure counts so receipt matching uses `idempotency_key` in addition to filenames. This prevents stale/historically renamed outbox handoffs from being counted as unreceipted work when their terminal receipt exists under a different filename.

## Scope
- `scripts/cache_codex_automation_github_status.py`
- `tests/scripts/test_cache_codex_automation_github_status.py`

Tier 2 automation/cache surface. No branch deletion, cleanup, merge, market, reputation, DIC, or production dispatch path changes.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_cache_codex_automation_github_status.py -p no:rerunfailures -p no:cacheprovider` -> 3 passed
- `python3 -m ruff check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py` -> passed
- `python3 -m ruff format --check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

Standing rule: awaiting independent model review and CI before settlement.