### PR TITLE
fix(automation): compact desktop automation check output

### DIFF
--- a/docs/briefs/codex-desktop-automation-autonomy.md
+++ b/docs/briefs/codex-desktop-automation-autonomy.md
@@ -18,8 +18,8 @@ Every automation should start from live repo evidence, not prior narration:
 1. Read its own memory at `/Users/armand/.codex/automations/<automation-id>/memory.md` if present.
 2. Inspect `/Users/armand/Development/aragora/.aragora/automation-outbox` and `.aragora/automation-receipts`.
 3. Run the relevant local status command before choosing a lane:
-   - `python3 scripts/check_codex_desktop_automations.py --json`
-   - `python3 scripts/audit_codex_branch_backlog.py --max-branches 200 --json --outbox-dir /Users/armand/Development/aragora/.aragora/automation-outbox --receipt-dir /Users/armand/Development/aragora/.aragora/automation-receipts`
+   - `python3 scripts/check_codex_desktop_automations.py --json --summary-only`
+   - `python3 scripts/audit_codex_branch_backlog.py --max-branches 200 --json --summary-only --outbox-dir /Users/armand/Development/aragora/.aragora/automation-outbox --receipt-dir /Users/armand/Development/aragora/.aragora/automation-receipts`
    - `python3 scripts/agent_bridge.py operator-snapshot --json`
 4. Treat sandboxed GitHub failure as expected. Use local git, shared outbox files, and receipts as the primary automation substrate.
 

--- a/scripts/check_codex_desktop_automations.py
+++ b/scripts/check_codex_desktop_automations.py
@@ -178,6 +178,26 @@ def build_payload(root: Path) -> dict[str, Any]:
     }
 
 
+def summary_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact payload suitable for recurring automation gates."""
+
+    compact = dict(payload)
+    compact["core_writers"] = {
+        writer_id: (
+            {
+                key: record[key]
+                for key in ("id", "name", "kind", "status", "path", "byminute", "role")
+                if key in record
+            }
+            if isinstance(record, dict)
+            else None
+        )
+        for writer_id, record in payload.get("core_writers", {}).items()
+    }
+    compact["prompt_details_omitted"] = True
+    return compact
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -187,9 +207,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Codex Desktop automation directory",
     )
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Omit full automation prompts from JSON output for compact startup gates.",
+    )
     args = parser.parse_args(argv)
 
     payload = build_payload(args.root.expanduser())
+    if args.summary_only:
+        payload = summary_only_payload(payload)
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:

--- a/tests/scripts/test_check_codex_desktop_automations.py
+++ b/tests/scripts/test_check_codex_desktop_automations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -80,6 +81,50 @@ def test_audit_accepts_staggered_writer_contracts(tmp_path: Path) -> None:
     payload = mod.build_payload(tmp_path)
 
     assert payload["summary"] == {"active_count": 4, "error_count": 0, "warning_count": 0}
+
+
+def test_summary_only_payload_omits_core_writer_prompts(tmp_path: Path) -> None:
+    import check_codex_desktop_automations as mod
+
+    prompt = "Read memory, repair one branch, validate locally, then refresh outbox."
+    for automation_id, minute in mod.CORE_WRITERS.items():
+        _write_automation(
+            tmp_path,
+            automation_id,
+            name=f"{automation_id} Writer",
+            prompt=prompt,
+            byminute=minute,
+        )
+
+    payload = mod.build_payload(tmp_path)
+    compact = mod.summary_only_payload(payload)
+
+    assert compact["summary"] == payload["summary"]
+    assert compact["prompt_details_omitted"] is True
+    assert "prompt" in payload["core_writers"]["engineering-autopilot"]
+    assert "prompt" not in compact["core_writers"]["engineering-autopilot"]
+    assert compact["core_writers"]["engineering-autopilot"]["byminute"] == 5
+
+
+def test_main_summary_only_json_omits_prompts(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import check_codex_desktop_automations as mod
+
+    prompt = "Read memory, repair one branch, validate locally, then refresh outbox."
+    for automation_id, minute in mod.CORE_WRITERS.items():
+        _write_automation(
+            tmp_path,
+            automation_id,
+            name=f"{automation_id} Writer",
+            prompt=prompt,
+            byminute=minute,
+        )
+
+    assert mod.main(["--root", str(tmp_path), "--json", "--summary-only"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["prompt_details_omitted"] is True
+    assert all("prompt" not in record for record in payload["core_writers"].values())
 
 
 def test_audit_warns_duplicate_writer_minutes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds `--summary-only` to `scripts/check_codex_desktop_automations.py` so recurring automation startup checks can report health without dumping full prompt/config details. Updates the automation autonomy brief to use the compact command.

## Scope
- `scripts/check_codex_desktop_automations.py`
- `tests/scripts/test_check_codex_desktop_automations.py`
- `docs/briefs/codex-desktop-automation-autonomy.md`

Tier 2 automation/observability surface. No branch deletion, cleanup, merge, market, reputation, DIC, or production dispatch path changes.

## Validation
- `python3 scripts/check_codex_desktop_automations.py --json --summary-only` -> valid compact JSON, `prompt_details_omitted=True`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_check_codex_desktop_automations.py -p no:rerunfailures -p no:cacheprovider` -> 5 passed
- `python3 -m ruff check scripts/check_codex_desktop_automations.py tests/scripts/test_check_codex_desktop_automations.py` -> passed
- `python3 -m ruff format --check scripts/check_codex_desktop_automations.py tests/scripts/test_check_codex_desktop_automations.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

Standing rule: awaiting independent model review and CI before settlement.