### PR TITLE
fix(worktree): protect status-failed autopilot cleanup

### DIFF
--- a/scripts/codex_worktree_autopilot.py
+++ b/scripts/codex_worktree_autopilot.py
@@ -539,7 +539,8 @@ def _ensure_fetched(repo_root: Path, base: str) -> None:
 
 def _worktree_status(repo_root: Path, worktree: Path, base: str) -> dict[str, Any]:
     status_proc = _run_git(repo_root, "status", "--porcelain", cwd=worktree)
-    dirty = bool(status_proc.stdout.strip())
+    status_lookup_failed = status_proc.returncode != 0
+    dirty = status_lookup_failed or bool(status_proc.stdout.strip())
 
     counts_proc = _run_git(
         repo_root, "rev-list", "--left-right", "--count", f"origin/{base}...HEAD", cwd=worktree
@@ -556,6 +557,7 @@ def _worktree_status(repo_root: Path, worktree: Path, base: str) -> dict[str, An
         "dirty": dirty,
         "ahead": ahead,
         "behind": behind,
+        "status_lookup_failed": status_lookup_failed,
     }
 
 
@@ -1229,6 +1231,7 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
     removed = 0
     archived = 0
     skipped_unmerged = 0
+    skipped_dirty_worktree = 0
     failed_worktree_removals = 0
     failed_branch_deletions = 0
     failed_archives = 0
@@ -1270,6 +1273,19 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
                     "branch": branch,
                     "path": str(path),
                     "status": "skipped_grace",
+                    "lifecycle_state": metadata["lifecycle_state"],
+                }
+            )
+            continue
+        if metadata["dirty"]:
+            kept.append(session)
+            skipped_dirty_worktree += 1
+            results.append(
+                {
+                    "session_id": session["session_id"],
+                    "branch": branch,
+                    "path": str(path),
+                    "status": "skipped_dirty_worktree",
                     "lifecycle_state": metadata["lifecycle_state"],
                 }
             )
@@ -1350,6 +1366,7 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
         "archived": archived,
         "kept": len(kept),
         "skipped_unmerged": skipped_unmerged,
+        "skipped_dirty_worktree": skipped_dirty_worktree,
         "skipped_active_session": skipped_active_session,
         "skipped_grace": skipped_grace,
         "failed_archives": failed_archives,
@@ -1364,6 +1381,7 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
             f"cleanup complete: removed={removed} kept={len(kept)} "
             f"archived={archived} "
             f"skipped_unmerged={skipped_unmerged} "
+            f"skipped_dirty_worktree={skipped_dirty_worktree} "
             f"skipped_active_session={skipped_active_session} "
             f"skipped_grace={skipped_grace} "
             f"failed_archives={failed_archives} "

--- a/tests/scripts/test_codex_worktree_autopilot.py
+++ b/tests/scripts/test_codex_worktree_autopilot.py
@@ -192,6 +192,45 @@ def test_maintain_parser_defaults_to_ff_only_strategy():
     assert args.strategy == "ff-only"
 
 
+def test_worktree_status_treats_status_failure_as_dirty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_autopilot as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    def _run_git(
+        _repo_root: Path, *args: str, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ("status", "--porcelain"):
+            return subprocess.CompletedProcess(
+                args=("git", *args),
+                returncode=128,
+                stdout="",
+                stderr="fatal: status unavailable",
+            )
+        if args[:3] == ("rev-list", "--left-right", "--count"):
+            return subprocess.CompletedProcess(
+                args=("git", *args),
+                returncode=0,
+                stdout="0 0\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected git args: {args}")
+
+    monkeypatch.setattr(mod, "_run_git", _run_git)
+
+    status = mod._worktree_status(repo_root, worktree, "main")
+
+    assert status["dirty"] is True
+    assert status["status_lookup_failed"] is True
+    assert status["ahead"] == 0
+    assert status["behind"] == 0
+
+
 def test_parse_ts_normalizes_naive_timestamp_to_utc():
     import codex_worktree_autopilot as mod
 
@@ -569,6 +608,97 @@ def test_cmd_cleanup_keeps_session_when_worktree_remove_fails(
     assert payload["failed_worktree_removals"] == 1
     assert payload["failed_branch_deletions"] == 0
     assert len(saved_state["sessions"]) == 1
+
+
+def test_cmd_cleanup_keeps_dirty_worktree_without_removal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import codex_worktree_autopilot as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    dirty_path = tmp_path / "dirty-wt"
+    dirty_path.mkdir()
+    state = {
+        "sessions": [
+            {
+                "session_id": "s-dirty",
+                "agent": "codex",
+                "branch": "codex/s-dirty",
+                "path": str(dirty_path),
+                "created_at": "2026-02-01T00:00:00+00:00",
+            }
+        ]
+    }
+    saved_state: dict[str, object] = {}
+
+    monkeypatch.setattr(mod, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(
+        mod,
+        "_get_worktree_entries",
+        lambda _repo: [mod.WorktreeEntry(path=dirty_path, branch="codex/s-dirty")],
+    )
+    monkeypatch.setattr(mod, "_load_state", lambda _state_file: state)
+    monkeypatch.setattr(mod, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(
+        mod,
+        "_lease_snapshot",
+        lambda *_args, **_kwargs: {
+            "lease_id": None,
+            "lease_status": None,
+            "last_heartbeat_at": None,
+            "lease_expires_at": None,
+            "owner_agent": None,
+            "owner_session_id": None,
+            "branch": None,
+            "title": None,
+            "has_live_lease": False,
+        },
+    )
+    monkeypatch.setattr(mod, "_worktree_status", lambda *_args, **_kwargs: {"dirty": True})
+    monkeypatch.setattr(mod, "_branch_ahead_count", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        mod,
+        "_archive_session",
+        lambda *_args, **_kwargs: pytest.fail("dirty sessions must not be archived"),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_remove_worktree",
+        lambda *_args, **_kwargs: pytest.fail("dirty worktrees must not be removed"),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_run_git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["git", "worktree", "prune"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr(
+        mod, "_save_state", lambda _state_file, payload: saved_state.update(payload)
+    )
+
+    args = argparse.Namespace(
+        repo=".",
+        managed_dir=".worktrees/codex-auto",
+        base="main",
+        ttl_hours=0,
+        force_unmerged=False,
+        delete_branches=True,
+        json=True,
+    )
+    rc = mod.cmd_cleanup(args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["removed"] == 0
+    assert payload["kept"] == 1
+    assert payload["skipped_dirty_worktree"] == 1
+    assert payload["results"][0]["status"] == "skipped_dirty_worktree"
+    assert saved_state["sessions"] == state["sessions"]
 
 
 def test_cmd_cleanup_reports_failed_branch_deletions(


### PR DESCRIPTION
## Summary
- Treat failed managed-worktree status probes as dirty so cleanup preserves ambiguous worktrees.
- Report and skip dirty/status-failed sessions before archive/remove in autopilot cleanup.
- Add targeted coverage for status lookup failure and cleanup preservation.

## Validation
- direct _worktree_status repro: status failure returns dirty=True and status_lookup_failed=True
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_codex_worktree_autopilot.py -p no:rerunfailures -p no:cacheprovider
- RUFF_CACHE_DIR=/tmp/ruff-cache-autopilot-status-failed python3 -m ruff check scripts/codex_worktree_autopilot.py tests/scripts/test_codex_worktree_autopilot.py
- RUFF_CACHE_DIR=/tmp/ruff-cache-autopilot-status-failed-format python3 -m ruff format --check scripts/codex_worktree_autopilot.py tests/scripts/test_codex_worktree_autopilot.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD