### PR TITLE
fix(swarm): mark empty-prompt boss_metrics rows with dispatch_skip_reason

### DIFF
--- a/aragora/swarm/boss_loop_outcome.py
+++ b/aragora/swarm/boss_loop_outcome.py
@@ -168,12 +168,31 @@ def append_iteration_metrics(
             if not failure_reason:
                 failure_reason = str(needs_human_reasons[0]).strip()[:200]
 
+        # B0 honesty axis: when a dispatch never produced a real prompt
+        # (no work_orders, or the prompt accumulator stayed at 0), mark the
+        # row with a ``dispatch_skip_reason`` so downstream consumers can
+        # distinguish a *real* attempt with a 0-char prompt (rare; pathology)
+        # from a *no-op* row recording a sanitizer / dispatch rejection.
+        # This is non-invasive: ``prompt_chars`` itself stays 0 so existing
+        # filters in ``aragora.swarm.issue_scanner._load_metrics_rows``
+        # continue to drop these rows.
+        worker_status_text = str(worker_result.get("status", "")).strip() or "unknown"
+        worker_outcome_text = str(worker_result.get("outcome", "")).strip() or None
+        dispatch_skip_reason: str | None = None
+        if prompt_chars <= 0 and enriched_context_chars <= 0:
+            if worker_status_text == "needs_human":
+                dispatch_skip_reason = "needs_human_no_prompt"
+            elif worker_status_text in ("dropped", "skipped"):
+                dispatch_skip_reason = "dispatch_dropped_no_prompt"
+            else:
+                dispatch_skip_reason = "no_work_orders"
+
         payload: dict[str, Any] = {
             "iteration": int(iteration),
             "issue_number": issue_number,
             "issue_title": issue_title[:120] if issue_title else None,
-            "worker_status": str(worker_result.get("status", "")).strip() or "unknown",
-            "worker_outcome": str(worker_result.get("outcome", "")).strip() or None,
+            "worker_status": worker_status_text,
+            "worker_outcome": worker_outcome_text,
             "elapsed_seconds": float(elapsed_seconds or 0.0),
             "files_changed": files_changed,
             "tests_run": tests_run,
@@ -192,6 +211,7 @@ def append_iteration_metrics(
             "blocker_kind": blocker_kind,
             "blocker_evidence": blocker_evidence,
             "category_success_rates": category_success_rates,
+            "dispatch_skip_reason": dispatch_skip_reason,
         }
 
         try:

--- a/tests/swarm/test_boss_loop_outcome.py
+++ b/tests/swarm/test_boss_loop_outcome.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from aragora.swarm.boss_loop_outcome import (
+    append_iteration_metrics,
     extract_iteration_metrics,
     freshness_is_fresh,
     freshness_to_dict,
@@ -113,3 +117,95 @@ class TestFreshnessHelpers:
 
     def test_freshness_is_fresh_missing(self) -> None:
         assert freshness_is_fresh(None, {}) is False
+
+
+class TestDispatchSkipReason:
+    """Regression tests for the dispatch_skip_reason field.
+
+    The empty-prompt no-op pathology in
+    .aragora/overnight/boss_metrics.jsonl had 289/406 rows with
+    prompt_chars=0, hiding 35 retry-loop rows on a single closed/merged
+    issue. dispatch_skip_reason makes those rows immediately
+    distinguishable from real attempts that genuinely had a 0-char
+    prompt.
+    """
+
+    def _common_args(self, tmp_path: Path) -> dict:
+        return {
+            "metrics_jsonl_path": str(tmp_path / "boss_metrics.jsonl"),
+            "outcome_learner_window": 50,
+            "deferred_queue_depth": 0,
+            "iteration": 1,
+            "issue_number": 1,
+            "elapsed_seconds": 0.5,
+            "files_changed": 0,
+            "tests_run": 0,
+            "tests_passed": 0,
+        }
+
+    def _read_row(self, tmp_path: Path) -> dict:
+        path = tmp_path / "boss_metrics.jsonl"
+        assert path.exists(), "metrics file should be created"
+        lines = [line for line in path.read_text().splitlines() if line.strip()]
+        assert len(lines) == 1
+        return json.loads(lines[0])
+
+    def test_needs_human_no_prompt_marks_skip_reason(self, tmp_path: Path) -> None:
+        worker_result = {
+            "status": "needs_human",
+            "outcome": "blocked",
+            "failure_reason": "Approval required for merge.",
+            "run": {"work_orders": []},
+        }
+        append_iteration_metrics(
+            **self._common_args(tmp_path),
+            worker_result=worker_result,
+        )
+        row = self._read_row(tmp_path)
+        assert row["prompt_chars"] == 0
+        assert row["worker_status"] == "needs_human"
+        assert row["dispatch_skip_reason"] == "needs_human_no_prompt"
+
+    def test_dropped_no_prompt_marks_skip_reason(self, tmp_path: Path) -> None:
+        worker_result = {
+            "status": "dropped",
+            "outcome": "no_dispatch",
+            "run": {},
+        }
+        append_iteration_metrics(
+            **self._common_args(tmp_path),
+            worker_result=worker_result,
+        )
+        row = self._read_row(tmp_path)
+        assert row["dispatch_skip_reason"] == "dispatch_dropped_no_prompt"
+
+    def test_no_work_orders_marks_skip_reason(self, tmp_path: Path) -> None:
+        worker_result = {
+            "status": "completed",
+            "run": {"work_orders": []},
+        }
+        append_iteration_metrics(
+            **self._common_args(tmp_path),
+            worker_result=worker_result,
+        )
+        row = self._read_row(tmp_path)
+        assert row["dispatch_skip_reason"] == "no_work_orders"
+
+    def test_real_run_has_no_skip_reason(self, tmp_path: Path) -> None:
+        worker_result = {
+            "status": "completed",
+            "outcome": "merged",
+            "run": {
+                "work_orders": [
+                    {"prompt_chars": 1234, "enriched_context_chars": 4321},
+                ]
+            },
+        }
+        append_iteration_metrics(
+            **self._common_args(tmp_path),
+            worker_result=worker_result,
+        )
+        row = self._read_row(tmp_path)
+        assert row["prompt_chars"] == 1234
+        assert row["enriched_context_chars"] == 4321
+        assert row["dispatch_skip_reason"] is None


### PR DESCRIPTION
Adds a `dispatch_skip_reason` field to each row written by `aragora.swarm.boss_loop_outcome.append_iteration_metrics` so empty-prompt no-op rows are immediately distinguishable from real dispatch attempts.

## Why

Survey of `.aragora/overnight/boss_metrics.jsonl` on origin/main today:

```
total rows: 406
rows with prompt_chars==0: 289   (71%)
rows with prompt_chars>0:  117   (29%)
unique issue_numbers: 181; top 5: [(1, 35), (2, 16), (42, 13), (5899, 11), (5895, 9)]
```

35 rows are on **issue_number=1**, which is a closed, merged dependabot PR (`chore(deps): Bump the react group in /aragora/live with 4 updates`). The boss loop was retry-looping on the closed issue but each iteration's row was indistinguishable from a real dispatch attempt that happened to produce a 0-char prompt.

This obscures any real prompt-engineering bug:
- Looking at `prompt_chars=0` rows mixes retry-loop noise with genuine pathology.
- Looking at iteration counts can't tell you which issues are stuck in a no-op loop.

## What this PR changes

In `append_iteration_metrics`, the row payload now includes:

| status | accumulated prompt_chars | dispatch_skip_reason |
|---|---|---|
| `needs_human` | 0 and ec_chars==0 | `needs_human_no_prompt` |
| `dropped` / `skipped` | 0 and ec_chars==0 | `dispatch_dropped_no_prompt` |
| any other | 0 and ec_chars==0 | `no_work_orders` |
| anything | >0 (real prompt) | `None` |

## Why this is safe

- **Purely additive**: new optional field; the value is `None` in the common path. Existing readers never reference it.
- **No semantic change**: `prompt_chars` itself stays 0; the existing `issue_scanner._load_metrics_rows` filter (which drops rows with `prompt_chars<=0`) keeps working unchanged.
- **No new emissions**: rows that were emitted before are still emitted; rows that were not emitted before are still not emitted.

## Tests

- `tests/swarm/test_boss_loop_outcome.py` — **19/19 pass**, including 4 new `TestDispatchSkipReason` regressions for all three sentinel values plus the real-run no-marker case.
- `ruff check` + `ruff format`: clean
- preflight: ok

## Tier

**Tier 2** — additive single-field change in a single function plus tests; safe revert by reverting the commit.

## Standing rule

I do not author-merge. Awaiting Codex signal + CI green.