### PR TITLE
feat(reputation): AGT-05 stale-policy seed (shadow only)

### DIFF
--- a/aragora/reputation/stale_policy.py
+++ b/aragora/reputation/stale_policy.py
@@ -1,0 +1,175 @@
+"""AGT-05 stale-policy seed (shadow only).
+
+A *stale* claim is one whose resolution would still type-check but whose
+information value has decayed past a threshold. The settlement module
+already supports time-decay via ``decay_half_life_days``. This module
+adds an *explicit, named* policy surface that future settlement,
+leaderboard, and audit code can call without each call site rolling its
+own age math.
+
+This is shadow-only:
+
+- It defines :class:`StalePolicy` with conservative defaults that match
+  the existing 30-day settlement half-life.
+- It exposes :func:`is_stale` as the public predicate.
+- It returns a :class:`StaleDecision` carrying the reason, the age in
+  days, and the policy fingerprint, so audit trails are
+  machine-greppable.
+- No production code path calls into this module yet.
+
+A future PR can wire this into ``settle_claim``, the calibration
+leaderboard, and the rev-4 staging scorecard. Until then, this seed
+exists only so the policy surface is reviewable in isolation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Final
+
+# Default tuning. These mirror the half-life used in
+# ``aragora.reputation.settlement.settle_claim`` so a claim that is
+# materially decayed under the existing scoring rule is also flagged
+# stale by this predicate.
+DEFAULT_FRESH_DAYS: Final[float] = 7.0
+DEFAULT_STALE_DAYS: Final[float] = 30.0
+DEFAULT_HARD_LIMIT_DAYS: Final[float] = 180.0
+
+
+@dataclass(frozen=True)
+class StalePolicy:
+    """Bounds for the stale-claim predicate.
+
+    Attributes:
+        fresh_days: Claims younger than this are always fresh.
+        stale_days: Claims older than this are always stale.
+        hard_limit_days: Claims older than this are *expired* and
+            should not even be settled.
+    """
+
+    fresh_days: float = DEFAULT_FRESH_DAYS
+    stale_days: float = DEFAULT_STALE_DAYS
+    hard_limit_days: float = DEFAULT_HARD_LIMIT_DAYS
+
+    def __post_init__(self) -> None:
+        if not (0 < self.fresh_days <= self.stale_days <= self.hard_limit_days):
+            raise ValueError(
+                "StalePolicy bounds must satisfy "
+                "0 < fresh_days <= stale_days <= hard_limit_days; got "
+                f"fresh={self.fresh_days}, stale={self.stale_days}, "
+                f"hard_limit={self.hard_limit_days}"
+            )
+
+    def fingerprint(self) -> str:
+        """Stable 12-char hash of the policy parameters.
+
+        Useful for tagging audit rows so a future change in defaults can
+        be tracked in receipts without a schema migration.
+        """
+        material = json.dumps(
+            {
+                "fresh_days": self.fresh_days,
+                "stale_days": self.stale_days,
+                "hard_limit_days": self.hard_limit_days,
+            },
+            sort_keys=True,
+        )
+        return f"sp_{hashlib.sha256(material.encode('utf-8')).hexdigest()[:12]}"
+
+
+@dataclass(frozen=True)
+class StaleDecision:
+    """The outcome of a stale-policy evaluation.
+
+    Attributes:
+        is_stale: True iff the claim should be treated as stale.
+        is_expired: True iff the claim is past the hard-limit and
+            should not be settled at all.
+        age_days: Age of the claim in days at the evaluation moment.
+        bucket: One of ``"fresh"``, ``"stale"``, ``"expired"``.
+        policy_fingerprint: Stable hash of the policy parameters.
+    """
+
+    is_stale: bool
+    is_expired: bool
+    age_days: float
+    bucket: str
+    policy_fingerprint: str
+
+
+def _age_days(claim_iso: str, now_iso: str) -> float:
+    claim_at = datetime.fromisoformat(claim_iso.replace("Z", "+00:00"))
+    if claim_at.tzinfo is None:
+        claim_at = claim_at.replace(tzinfo=timezone.utc)
+    now = datetime.fromisoformat(now_iso.replace("Z", "+00:00"))
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    delta = (now - claim_at).total_seconds() / 86400.0
+    if delta < 0:
+        # Future-dated claims are treated as fresh; we never lie about age.
+        return 0.0
+    return delta
+
+
+def is_stale(
+    *,
+    claim_iso: str,
+    now_iso: str | None = None,
+    policy: StalePolicy | None = None,
+) -> StaleDecision:
+    """Decide whether a claim is fresh, stale, or expired.
+
+    Args:
+        claim_iso: ISO-8601 timestamp at which the claim was made.
+        now_iso: Optional override for the evaluation moment; defaults
+            to ``datetime.now(timezone.utc)``.
+        policy: Optional :class:`StalePolicy`; defaults to the
+            conservative module-level defaults.
+
+    Returns:
+        A :class:`StaleDecision`. The decision is *advisory* — call
+        sites are responsible for whatever action it implies (skip
+        settlement, mark a leaderboard cell, append to an audit row).
+    """
+    if not claim_iso:
+        raise ValueError("claim_iso must be a non-empty ISO-8601 string")
+    if now_iso is None:
+        now_iso = datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    p = policy or StalePolicy()
+    age = _age_days(claim_iso, now_iso)
+    if age > p.hard_limit_days:
+        return StaleDecision(
+            is_stale=True,
+            is_expired=True,
+            age_days=age,
+            bucket="expired",
+            policy_fingerprint=p.fingerprint(),
+        )
+    if age >= p.stale_days:
+        return StaleDecision(
+            is_stale=True,
+            is_expired=False,
+            age_days=age,
+            bucket="stale",
+            policy_fingerprint=p.fingerprint(),
+        )
+    return StaleDecision(
+        is_stale=False,
+        is_expired=False,
+        age_days=age,
+        bucket="fresh",
+        policy_fingerprint=p.fingerprint(),
+    )
+
+
+__all__ = [
+    "DEFAULT_FRESH_DAYS",
+    "DEFAULT_STALE_DAYS",
+    "DEFAULT_HARD_LIMIT_DAYS",
+    "StalePolicy",
+    "StaleDecision",
+    "is_stale",
+]

--- a/tests/reputation/test_stale_policy.py
+++ b/tests/reputation/test_stale_policy.py
@@ -1,0 +1,159 @@
+"""Unit tests for the AGT-05 stale-policy seed.
+
+These tests cover:
+
+- The fresh / stale / expired bucketing.
+- Bound validation in ``StalePolicy.__post_init__``.
+- Future-dated claims being treated as fresh.
+- ``policy_fingerprint`` stability and sensitivity to parameter changes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from aragora.reputation.stale_policy import (
+    DEFAULT_FRESH_DAYS,
+    DEFAULT_STALE_DAYS,
+    DEFAULT_HARD_LIMIT_DAYS,
+    StaleDecision,
+    StalePolicy,
+    is_stale,
+)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@pytest.fixture()
+def now() -> datetime:
+    # Pin the evaluation moment so tests are deterministic.
+    return datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestBucketing:
+    def test_fresh_just_made(self, now: datetime) -> None:
+        decision = is_stale(claim_iso=_iso(now - timedelta(hours=1)), now_iso=_iso(now))
+        assert decision.bucket == "fresh"
+        assert decision.is_stale is False
+        assert decision.is_expired is False
+
+    def test_fresh_under_default_fresh_days(self, now: datetime) -> None:
+        decision = is_stale(
+            claim_iso=_iso(now - timedelta(days=DEFAULT_FRESH_DAYS - 0.5)),
+            now_iso=_iso(now),
+        )
+        assert decision.bucket == "fresh"
+
+    def test_stale_at_default_stale_days(self, now: datetime) -> None:
+        # Age == stale_days hits the >= boundary.
+        decision = is_stale(
+            claim_iso=_iso(now - timedelta(days=DEFAULT_STALE_DAYS)),
+            now_iso=_iso(now),
+        )
+        assert decision.bucket == "stale"
+        assert decision.is_stale is True
+        assert decision.is_expired is False
+
+    def test_stale_between_stale_and_hard_limit(self, now: datetime) -> None:
+        decision = is_stale(
+            claim_iso=_iso(now - timedelta(days=90)),
+            now_iso=_iso(now),
+        )
+        assert decision.bucket == "stale"
+        assert decision.is_stale is True
+        assert decision.is_expired is False
+
+    def test_expired_past_hard_limit(self, now: datetime) -> None:
+        decision = is_stale(
+            claim_iso=_iso(now - timedelta(days=DEFAULT_HARD_LIMIT_DAYS + 1)),
+            now_iso=_iso(now),
+        )
+        assert decision.bucket == "expired"
+        assert decision.is_stale is True
+        assert decision.is_expired is True
+
+
+class TestFutureDated:
+    def test_future_claim_treated_as_fresh(self, now: datetime) -> None:
+        decision = is_stale(
+            claim_iso=_iso(now + timedelta(days=5)),
+            now_iso=_iso(now),
+        )
+        # Negative age is clamped to zero so the predicate is total.
+        assert decision.bucket == "fresh"
+        assert decision.age_days == 0.0
+
+
+class TestPolicyValidation:
+    def test_invalid_bounds_zero_fresh(self) -> None:
+        with pytest.raises(ValueError):
+            StalePolicy(fresh_days=0, stale_days=10, hard_limit_days=20)
+
+    def test_invalid_bounds_unordered(self) -> None:
+        with pytest.raises(ValueError):
+            StalePolicy(fresh_days=10, stale_days=5, hard_limit_days=20)
+
+    def test_invalid_bounds_hard_below_stale(self) -> None:
+        with pytest.raises(ValueError):
+            StalePolicy(fresh_days=1, stale_days=10, hard_limit_days=5)
+
+    def test_valid_bounds_equal_allowed(self) -> None:
+        # fresh == stale is allowed (immediate stale-on-creation policy)
+        p = StalePolicy(fresh_days=1.0, stale_days=1.0, hard_limit_days=10.0)
+        assert p.fresh_days == 1.0
+        assert p.stale_days == 1.0
+
+
+class TestFingerprint:
+    def test_fingerprint_stable(self) -> None:
+        p1 = StalePolicy()
+        p2 = StalePolicy()
+        assert p1.fingerprint() == p2.fingerprint()
+
+    def test_fingerprint_changes_with_param(self) -> None:
+        a = StalePolicy().fingerprint()
+        b = StalePolicy(stale_days=DEFAULT_STALE_DAYS + 1).fingerprint()
+        assert a != b
+
+    def test_fingerprint_format(self) -> None:
+        fp = StalePolicy().fingerprint()
+        assert fp.startswith("sp_")
+        assert len(fp) == 3 + 12  # "sp_" + 12 hex chars
+
+
+class TestCustomPolicy:
+    def test_custom_policy_applied(self, now: datetime) -> None:
+        custom = StalePolicy(fresh_days=1.0, stale_days=2.0, hard_limit_days=3.0)
+        decision = is_stale(
+            claim_iso=_iso(now - timedelta(days=2.5)),
+            now_iso=_iso(now),
+            policy=custom,
+        )
+        assert decision.bucket == "stale"
+        assert decision.policy_fingerprint == custom.fingerprint()
+
+
+class TestInvalidInput:
+    def test_empty_claim_iso_raises(self, now: datetime) -> None:
+        with pytest.raises(ValueError):
+            is_stale(claim_iso="", now_iso=_iso(now))
+
+    def test_now_iso_default_used(self) -> None:
+        # Just verify the function handles None now_iso without crashing
+        decision = is_stale(claim_iso="2026-04-29T00:00:00Z")
+        assert isinstance(decision, StaleDecision)
+        assert decision.age_days >= 0.0
+
+
+class TestReturnShape:
+    def test_decision_is_dataclass_with_expected_fields(self, now: datetime) -> None:
+        d = is_stale(claim_iso=_iso(now), now_iso=_iso(now))
+        assert hasattr(d, "is_stale")
+        assert hasattr(d, "is_expired")
+        assert hasattr(d, "age_days")
+        assert hasattr(d, "bucket")
+        assert hasattr(d, "policy_fingerprint")


### PR DESCRIPTION
Adds `aragora/reputation/stale_policy.py` — a named, reviewable surface for the AGT-05 stale-claim predicate.

## Why

The settlement module already supports time-decay via `decay_half_life_days`, but each call site that needs to ask 'is this claim too old to score?' currently rolls its own age math (or implicitly trusts the half-life to do the right thing). Naming the predicate makes it auditable, configurable per-deployment, and consistent across settlement / leaderboard / scorecard.

## What this PR adds

| File | Lines | Purpose |
|---|---:|---|
| `aragora/reputation/stale_policy.py` | 175 | Public predicate + dataclasses |
| `tests/reputation/test_stale_policy.py` | 159 | 17 unit tests |

## Public surface

```python
from aragora.reputation.stale_policy import is_stale, StalePolicy

decision = is_stale(claim_iso="2026-04-01T00:00:00Z")
# StaleDecision(is_stale=True, is_expired=False, age_days=29.5,
#               bucket='stale', policy_fingerprint='sp_a1b2c3d4e5f6')
```

Conservative defaults (7 / 30 / 180 days) mirror the existing 30-day half-life used by `settle_claim`.

## Why this is shadow-only

- **No production code path calls into this module yet.** A future PR can wire it into:
  - `aragora.reputation.settlement.settle_claim` (gate stale claims out of scoring)
  - `aragora.cli.calibration leaderboard` (mark stale rows in the table)
  - the rev-4 staging scorecard (filter expired entries)
- The seed exists so the policy surface can be reviewed in isolation, before any of those wirings.

## Tests

- 17/17 pass in `tests/reputation/test_stale_policy.py` covering:
  - fresh / stale / expired bucketing at the boundaries
  - future-dated claims clamped to fresh
  - bound validation (zero-fresh, unordered, hard < stale)
  - fingerprint stability and parameter sensitivity
  - custom policies and return shape
- ruff check + format: clean
- preflight: ok

## Tier

**Tier 2** — additive new module + tests; no existing code path touched; safe revert by deleting two files.

## Standing rule

I do not author-merge. Awaiting Codex signal + CI green.