### PR TITLE
fix(debate): floor adaptive rounds at 1 to preserve rounds_completed honesty

### DIFF
--- a/aragora/debate/phases/debate_rounds.py
+++ b/aragora/debate/phases/debate_rounds.py
@@ -463,7 +463,24 @@ class DebateRoundsPhase:
                         strategy_rec.reasoning[:50],
                     )
                     _record_adaptive_round(direction)
-                    rounds = strategy_rec.estimated_rounds
+                    # Floor adaptive recommendation at 1: a recommendation of 0
+                    # (interpreted as "the proposal already produced consensus, no
+                    # critique-revision rounds needed") would skip the round loop
+                    # entirely and report rounds_completed=0 to downstream consumers,
+                    # making a real debate look like one that never ran. We honour
+                    # the strategy's signal in metadata but always run at least one
+                    # round so the metric is honest. See
+                    # docs/plans/2026-04-30-rounds-floor-rca.md
+                    # (or .aragora/evolve-round/2026-04-30/dogfood/phase-e-rounds-zero-rca.md
+                    # in repos that carry the round receipts).
+                    if strategy_rec.estimated_rounds < 1:
+                        logger.info(
+                            "[strategy] estimate=%s < 1; flooring at 1 to preserve rounds_completed honesty",
+                            strategy_rec.estimated_rounds,
+                        )
+                        rounds = max(1, rounds)
+                    else:
+                        rounds = strategy_rec.estimated_rounds
                     # Store strategy recommendation in result metadata
                     if hasattr(result, "metadata") and result.metadata is not None:
                         result.metadata["strategy_recommendation"] = {
@@ -471,6 +488,7 @@ class DebateRoundsPhase:
                             "confidence": strategy_rec.confidence,
                             "reasoning": strategy_rec.reasoning,
                             "relevant_memories": strategy_rec.relevant_memories[:3],
+                            "floored_to_one": strategy_rec.estimated_rounds < 1,
                         }
             except (RuntimeError, AttributeError, TypeError) as e:  # noqa: BLE001
                 logger.debug("[strategy] Round estimation failed, using protocol default: %s", e)

--- a/tests/debate/phases/test_debate_rounds.py
+++ b/tests/debate/phases/test_debate_rounds.py
@@ -1513,6 +1513,125 @@ class TestStrategyBasedRounds:
         # Default rounds should be used
         assert ctx.result.rounds_used == 1
 
+    @pytest.mark.asyncio
+    async def test_strategy_zero_rounds_falls_back_to_protocol_default(self):
+        """Strategy returning estimated_rounds=0 must not skip the round loop.
+
+        Regression for the rounds_completed=0 RCA in
+        .aragora/evolve-round/2026-04-30/dogfood/phase-e-rounds-zero-rca.md.
+        Previously, an `estimated_rounds=0` recommendation was passed through
+        verbatim; the for-loop never iterated, and downstream consumers saw
+        rounds_completed=0 even when a winner was extracted.
+        """
+        protocol = MockProtocol(rounds=2)
+        strategy = MagicMock()
+        strategy_rec = MagicMock()
+        strategy_rec.estimated_rounds = 0  # The pathological case.
+        strategy_rec.confidence = 0.9
+        strategy_rec.reasoning = "Proposal already consensus-shaped"
+        strategy_rec.relevant_memories = []
+        strategy.estimate_rounds_async = AsyncMock(return_value=strategy_rec)
+
+        agent1 = MockAgent(name="agent-1", role="proposer")
+        ctx = MockDebateContext(
+            agents=[agent1],
+            proposers=[agent1],
+            proposals={"agent-1": "proposal"},
+            result=MockResult(critiques=[], metadata={}),
+        )
+
+        convergence_tracker = MagicMock()
+        convergence_tracker.check_convergence.return_value = MockConvergenceResult(
+            converged=True, blocked_by_trickster=False
+        )
+        convergence_tracker.track_novelty = MagicMock()
+        convergence_tracker.check_rlm_ready_quorum.return_value = False
+
+        phase = DebateRoundsPhase(
+            protocol=protocol,
+            debate_strategy=strategy,
+            critique_with_agent=AsyncMock(return_value=None),
+        )
+        phase._convergence_tracker = convergence_tracker
+
+        with (
+            patch("aragora.debate.phases.debate_rounds.get_debate_monitor") as mock_mon,
+            patch("aragora.debate.phases.debate_rounds.get_complexity_governor") as mock_gov,
+        ):
+            mock_perf = MagicMock()
+            mock_perf.track_round = MagicMock(side_effect=lambda *a, **kw: _noop_cm())
+            mock_perf.track_phase = MagicMock(side_effect=lambda *a, **kw: _noop_cm())
+            mock_perf.slow_round_threshold = 60.0
+            mock_mon.return_value = mock_perf
+            mock_gov.return_value.get_scaled_timeout.return_value = 30.0
+
+            await phase.execute(ctx)
+
+        # Round loop must have iterated at least once — rounds_used >= 1.
+        assert ctx.result.rounds_used >= 1, (
+            "estimated_rounds=0 must be floored; round loop must iterate at least once"
+        )
+        # Recommendation surfaced in metadata, including the floored_to_one flag.
+        rec = ctx.result.metadata.get("strategy_recommendation")
+        assert rec is not None, "strategy_recommendation must be recorded"
+        assert rec["estimated_rounds"] == 0, "raw strategy estimate preserved in metadata"
+        assert rec["floored_to_one"] is True, "floored_to_one flag must be set"
+
+    @pytest.mark.asyncio
+    async def test_strategy_negative_rounds_falls_back_to_protocol_default(self):
+        """Defensive: a negative estimated_rounds (mistake or bug) must also floor.
+
+        Companion regression for the strategy floor.
+        """
+        protocol = MockProtocol(rounds=2)
+        strategy = MagicMock()
+        strategy_rec = MagicMock()
+        strategy_rec.estimated_rounds = -1
+        strategy_rec.confidence = 0.5
+        strategy_rec.reasoning = "negative recommendation (defensive case)"
+        strategy_rec.relevant_memories = []
+        strategy.estimate_rounds_async = AsyncMock(return_value=strategy_rec)
+
+        agent1 = MockAgent(name="agent-1", role="proposer")
+        ctx = MockDebateContext(
+            agents=[agent1],
+            proposers=[agent1],
+            proposals={"agent-1": "proposal"},
+            result=MockResult(critiques=[], metadata={}),
+        )
+
+        convergence_tracker = MagicMock()
+        convergence_tracker.check_convergence.return_value = MockConvergenceResult(
+            converged=True, blocked_by_trickster=False
+        )
+        convergence_tracker.track_novelty = MagicMock()
+        convergence_tracker.check_rlm_ready_quorum.return_value = False
+
+        phase = DebateRoundsPhase(
+            protocol=protocol,
+            debate_strategy=strategy,
+            critique_with_agent=AsyncMock(return_value=None),
+        )
+        phase._convergence_tracker = convergence_tracker
+
+        with (
+            patch("aragora.debate.phases.debate_rounds.get_debate_monitor") as mock_mon,
+            patch("aragora.debate.phases.debate_rounds.get_complexity_governor") as mock_gov,
+        ):
+            mock_perf = MagicMock()
+            mock_perf.track_round = MagicMock(side_effect=lambda *a, **kw: _noop_cm())
+            mock_perf.track_phase = MagicMock(side_effect=lambda *a, **kw: _noop_cm())
+            mock_perf.slow_round_threshold = 60.0
+            mock_mon.return_value = mock_perf
+            mock_gov.return_value.get_scaled_timeout.return_value = 30.0
+
+            await phase.execute(ctx)
+
+        assert ctx.result.rounds_used >= 1
+        rec = ctx.result.metadata.get("strategy_recommendation")
+        assert rec is not None
+        assert rec["floored_to_one"] is True
+
 
 # =============================================================================
 # Additional Coverage: Propulsion Events Tests


### PR DESCRIPTION
## Summary

Round 2026-04-30b — Phase B (Tier 2). Closes the `rounds_completed=0` bug root-caused in 2026-04-30 Phase E (`.aragora/evolve-round/2026-04-30/dogfood/phase-e-rounds-zero-rca.md`).

## Bug

`DebateStrategy.estimate_rounds_async()` could return `estimated_rounds=0` (interpreted as "proposal already produced consensus, no critique-revision rounds needed"). The previous code passed this through verbatim, and the round-loop in `DebateRoundsPhase.execute()` would skip entirely:

```python
for round_num in range(1, rounds + 1):  # range(1, 1) yields nothing
```

Downstream consumers saw `rounds_completed=0` and inferred "no debate happened" — even when a winner was extracted from the proposal. This was a metric/observability bug, not a correctness bug on the proposal path.

PR #6806's `partial_rounds`-at-round-start fix is correct but doesn't fire in this scenario because `_execute_round` is never entered.

## Fix

Option I from the RCA: floor the strategy recommendation at 1. The strategy's signal is preserved verbatim in `result.metadata["strategy_recommendation"]["estimated_rounds"]`, plus a new `floored_to_one` bool that downstream consumers can filter on.

## Tests

- `test_strategy_zero_rounds_falls_back_to_protocol_default` — regression for the literal RCA scenario: `estimated_rounds=0` must produce `rounds_used >= 1` + `floored_to_one=True` in metadata
- `test_strategy_negative_rounds_falls_back_to_protocol_default` — defensive case for a future strategy bug

## Verification

- 101/101 tests pass on `test_debate_rounds.py` + `test_debate_rounds_invariant.py`
- ruff check + format clean
- mypy clean on `debate_rounds.py`
- preflight ok

## Diff stat

```
 aragora/debate/phases/debate_rounds.py   |  19 ++--
 tests/debate/phases/test_debate_rounds.py | 120 +++++++++++++++++++++++++++++++
 2 files changed, 138 insertions(+), 1 deletion(-)
```

## Round invariants

- Tier 2 (debate orchestrator hot path)
- No author-merge, no draft-flip, no GitHub review-state set
- 101 tests pass deterministically

🤖 Generated with [Claude Code](https://claude.com/claude-code)