### PR TITLE
test(epistemic): fix _probe_event helper short-circuit on probe_result=None

### DIFF
--- a/tests/epistemic/test_runtime_loop.py
+++ b/tests/epistemic/test_runtime_loop.py
@@ -281,16 +281,30 @@ _FAKE_PROBE = {
 }
 
 
+# Sentinel for distinguishing "use the default fake probe" from "explicitly
+# pass this value (including None)". Without this, ``probe_result or dict(_FAKE_PROBE)``
+# short-circuited the ``probe_result=None`` case to the fake dict, making
+# ``test_skipped_when_attempt_returns_none`` impossible to express truthfully.
+_NO_PROBE_OVERRIDE: object = object()
+
+
 def _probe_event(
     signal: DecaySignal | None = None,
     *,
-    probe_result: dict | None = None,
+    probe_result: dict | None | object = _NO_PROBE_OVERRIDE,
     extra_metadata: dict | None = None,
     question: str = "Is the proof still valid?",
 ) -> DialecticalEvent:
     import aragora.epistemic.runtime_loop as _m
 
-    with patch.object(_m, "_attempt_crux_probe", return_value=probe_result or dict(_FAKE_PROBE)):
+    if probe_result is _NO_PROBE_OVERRIDE:
+        patched_return: dict | None = dict(_FAKE_PROBE)
+    else:
+        # Explicit override (including ``probe_result=None``) is passed through
+        # verbatim so callers can assert behaviour when the patched probe
+        # returns ``None``.
+        patched_return = probe_result  # type: ignore[assignment]
+    with patch.object(_m, "_attempt_crux_probe", return_value=patched_return):
         return run_dialectical_loop(
             signal or _signal(),
             enable_crux_probe=True,


### PR DESCRIPTION
## Summary

Round 2026-04-30b — Phase C (Tier 1, tests-only). Fixes a pre-existing test failure that was confirmed to fail on `origin/main` independently of any other PR.

## Root cause

`_probe_event` helper in `tests/epistemic/test_runtime_loop.py` used:

```python
with patch.object(_m, "_attempt_crux_probe", return_value=probe_result or dict(_FAKE_PROBE)):
```

When called with `probe_result=None`, the `or` short-circuited to `dict(_FAKE_PROBE)`, so the patched function returned a real dict instead of `None`.

This made `test_skipped_when_attempt_returns_none` un-expressible: the test asserted `crux_probe_skipped is True` (i.e., the production code correctly handles a None probe result), but the helper never actually let `None` reach the production path. The test failed against `crux_probe_skipped=False` because the fake probe data ended up populating `metadata["crux_probe"]`.

**This is a pure test-fixture bug. The production code in `aragora/epistemic/runtime_loop.py` is correct.** Verified by reading the production skip logic at lines 301–311.

## Fix

Introduce a sentinel `_NO_PROBE_OVERRIDE` so the helper can distinguish "use default fake probe" from "explicitly pass this value (including None)":

```python
if probe_result is _NO_PROBE_OVERRIDE:
    patched_return = dict(_FAKE_PROBE)
else:
    patched_return = probe_result  # passed verbatim
```

## Verification

- Previously-failing `test_skipped_when_attempt_returns_none` now **PASSES**
- Full `TestCruxProbe` class: 10/10 pass
- Full `tests/epistemic/` suite: **353/353 pass** (was 352/1)
- ruff check + format clean
- No production code changes (1 file changed, +16/-2 in tests only)

## Diff stat

```
 tests/epistemic/test_runtime_loop.py | 18 ++++++++++++++++--
 1 file changed, 16 insertions(+), 2 deletions(-)
```

## How this was discovered

While doing the focused dogfood review on PR #6812 (DIC-19 constraint graph), running the broader `tests/epistemic/` suite surfaced this single pre-existing failure. I cross-checked against a fresh `origin/main` clone and confirmed it failed there too — so the failure pre-dated #6812 and was unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)