### PR TITLE
fix(automation): suppress publisher drift signal when cache is already stale

### DIFF
--- a/scripts/publisher_freshness_check.py
+++ b/scripts/publisher_freshness_check.py
@@ -137,6 +137,13 @@ def evaluate(
 
     outbox_real = _count_outbox_files(outbox_dir)
     outbox_cache = _read_cache_outbox_count(cache_path) if cache_present else None
+    # A stale cache will *necessarily* disagree with the live outbox (the
+    # outbox has changed since the snapshot was taken). Reporting drift in
+    # that case is double-flagging: ``cache: Nh stale`` already explains the
+    # disagreement. Only treat drift as a real signal when the cache is
+    # fresh and the counts still don't match — that is the actual operator-
+    # actionable case (e.g. publisher writing the wrong count).
+    drift_meaningful = outbox_cache is not None and outbox_cache != outbox_real and not cache_stale
     drift = outbox_cache is not None and outbox_cache != outbox_real
     if outbox_cache is None:
         drift_detail = f"outbox={outbox_real} cache=missing"
@@ -152,12 +159,15 @@ def evaluate(
         blockers.append("cache: missing")
     elif cache_stale:
         blockers.append(f"cache: {_human_age(cache_age)} stale")
-    if drift:
+    if drift_meaningful:
         blockers.append(f"drift: {drift_detail}")
 
     if not blockers:
         verdict = "ready"
-    elif loaded and not drift:
+    elif loaded and not drift_meaningful:
+        # cache-stale alone (without meaningful drift) is "warming": the
+        # next publisher run will refresh the cache and the operator
+        # signal will resolve without intervention.
         verdict = "warming"
     else:
         verdict = "degraded"

--- a/tests/scripts/test_publisher_freshness_check.py
+++ b/tests/scripts/test_publisher_freshness_check.py
@@ -191,3 +191,92 @@ def test_main_exit_zero_on_degraded_without_flag(
     monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded"))
     rc = mod.main(["--repo", str(stub_repo)])
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Drift-suppression on stale cache (Round 2026-04-30b Phase E)
+# ---------------------------------------------------------------------------
+
+
+def test_stale_cache_with_count_disagreement_does_not_double_flag_drift(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path
+) -> None:
+    """A stale cache will *necessarily* disagree with the live outbox.
+
+    Previously this surfaced both "cache: stale" and "drift: outbox=N cache=M"
+    as separate blockers, double-flagging the same root cause. After the
+    Phase E fix the drift signal is suppressed when the cache is already
+    flagged stale; only "cache: stale" remains as the blocker.
+
+    The raw ``outbox_drift`` field on the report is still True so consumers
+    that want the unfiltered observability signal can still see it.
+    """
+    cache = _write_cache(stub_repo, outbox_count=20)
+    _write_outbox_files(stub_repo, 17)  # real count != cache count
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    # Cache is 4 hours stale at default 1800s threshold.
+    now = cache.stat().st_mtime + 4 * 3600
+    report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
+
+    # Cache is stale.
+    assert report.cache_stale is True
+    cache_blockers = [b for b in report.blockers if b.startswith("cache:")]
+    assert cache_blockers and "stale" in cache_blockers[0]
+
+    # Drift is NOT a blocker (suppressed because cache is stale).
+    drift_blockers = [b for b in report.blockers if b.startswith("drift:")]
+    assert drift_blockers == [], (
+        f"drift should be suppressed when cache is stale; got {drift_blockers}"
+    )
+
+    # But raw observability fields are preserved.
+    assert report.outbox_drift is True
+    assert report.outbox_real_count == 17
+    assert report.outbox_cache_count == 20
+    assert report.drift_detail == "outbox=17 cache=20"
+
+    # Verdict is "warming" not "degraded" — operator action is just
+    # waiting for the next publisher cycle, which is exactly what
+    # `warming` semantics communicate.
+    assert report.verdict == "warming"
+
+
+def test_fresh_cache_with_count_disagreement_still_flags_drift(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path
+) -> None:
+    """Drift signal is meaningful only when the cache is fresh.
+
+    Confirms the inverse of the suppression rule: when the cache is fresh
+    AND counts disagree, drift IS a real blocker (the publisher wrote
+    inconsistent data).
+    """
+    cache = _write_cache(stub_repo, outbox_count=2)
+    _write_outbox_files(stub_repo, 5)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    # Cache is 60s old → fresh at default 1800s threshold.
+    now = cache.stat().st_mtime + 60
+    report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
+
+    assert report.cache_stale is False
+    assert report.outbox_drift is True
+    drift_blockers = [b for b in report.blockers if b.startswith("drift:")]
+    assert drift_blockers == ["drift: outbox=5 cache=2"]
+    assert report.verdict == "degraded"
+
+
+def test_stale_cache_with_matching_counts_warming_only(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path
+) -> None:
+    """Sanity: stale cache without drift is still 'warming', not 'degraded'.
+
+    Companion to the existing ``test_warming_label_when_loaded_no_drift_but_cache_just_stale``;
+    this version also exercises the new suppression code path at the same time.
+    """
+    cache = _write_cache(stub_repo, outbox_count=3)
+    _write_outbox_files(stub_repo, 3)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    now = cache.stat().st_mtime + 4 * 3600
+    report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
+    assert report.cache_stale is True
+    assert report.outbox_drift is False
+    assert report.verdict == "warming"


### PR DESCRIPTION
## Summary

Round 2026-04-30b — Phase E (Tier 2). Fixes a self-discovered double-flag bug in `publisher_freshness_check.py` (#6814) found while dogfooding it in this round.

## Bug

`drift = outbox_cache is not None and outbox_cache != outbox_real`

A stale cache will **necessarily** disagree with the live outbox (the outbox has changed since the snapshot was taken). Reporting drift in that case double-flags the same root cause: the cache is stale.

Operator surfaces saw both blockers stacked:

```
publisher: degraded (launchd: loaded; cache: 8.9h; drift: outbox=17 cache=20)
```

This signaled "two problems" when there's only one (a stale cache will resolve itself on the next publisher cycle).

## Fix

Drift is only flagged when the cache is **fresh** and counts disagree — the actual operator-actionable case (publisher wrote the wrong count). Stale-cache-only state correctly collapses to verdict=warming:

```
publisher: warming (launchd: loaded; cache: 9.2h; drift: outbox=16 cache=20)
```

The raw `outbox_drift` field on `FreshnessReport` is still set so downstream consumers can see the unfiltered observability signal; only the `blockers` list and `verdict` semantics change.

## Tests (3 new)

- `test_stale_cache_with_count_disagreement_does_not_double_flag_drift` — canonical regression
- `test_fresh_cache_with_count_disagreement_still_flags_drift` — inverse, confirms drift is still flagged when cache is fresh
- `test_stale_cache_with_matching_counts_warming_only` — sanity, doesn't break the existing warming path

## Verification

- 14/14 tests pass deterministically (was 11; +3 new)
- ruff check + format clean
- mypy clean
- Live dogfood confirms verdict transitions correctly:
  - **Before:** `publisher: degraded (... cache: 8.9h; drift: outbox=17 cache=20)`
  - **After:** `publisher: warming (... cache: 9.2h; drift: outbox=16 cache=20)`

## Diff stat

```
 scripts/publisher_freshness_check.py            | 16 ++++-
 tests/scripts/test_publisher_freshness_check.py | 89 +++++++++++++++++++++++++
 2 files changed, 103 insertions(+), 2 deletions(-)
```

## Discovery

This was found by self-dogfooding #6814 in this round's Phase E. The plan was an investigation; the inline fix met the round's `<30 LOC + high-confidence` halt-class for fix-vs-investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)