### PR TITLE
feat(swarm): boss-loop unstick planning surface (dry-run only)

### DIFF
--- a/aragora/swarm/unstick.py
+++ b/aragora/swarm/unstick.py
@@ -1,0 +1,258 @@
+"""Boss-loop ``unstick`` planning surface.
+
+The boss-loop emits the ``boss-stuck`` label when it cannot make
+progress on an issue. Once labeled, the loop's own ``skip_labels`` set
+filters the issue out forever — even if the underlying work has since
+been delivered by a different path (a peer agent's PR, a manual fix,
+a related issue's PR, etc.).
+
+This module gives operators a **planning** surface that says, for each
+``boss-stuck`` issue:
+
+- whether the issue's deterministic boss-harvest branch already has a
+  merged PR (i.e. the work is done);
+- whether the issue itself has been closed/merged outside the boss-loop;
+- whether to recommend ``unstick`` (relabel + post a closure comment),
+  ``close`` (the issue is already fully resolved), or ``hold`` (still
+  truly stuck).
+
+This module is **dry-run only**: it produces a JSON plan that the
+operator (or a future PR) can act on. It performs **no** GitHub
+mutations itself.
+
+Wire-up: a CLI entry point lives in
+``scripts/boss_loop_unstick_plan.py`` and emits the plan as JSON or
+markdown. It accepts already-fetched issue and PR records, just like
+:mod:`aragora.swarm.dispatch_evidence`, so this module remains pure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Iterable
+
+from aragora.swarm.dispatch_evidence import is_issue_dispatched_via_pr
+
+STUCK_LABEL: Final[str] = "boss-stuck"
+
+
+@dataclass(frozen=True)
+class UnstickRecommendation:
+    """Per-issue recommendation produced by :func:`plan_unstick`.
+
+    Attributes:
+        issue_number: The numeric issue identifier.
+        action: One of ``"unstick"``, ``"close"``, ``"hold"``.
+        rationale: Operator-readable explanation.
+        evidence: Dict carrying the dispatch verdict and any merged
+            PR numbers, suitable for embedding in a comment.
+    """
+
+    issue_number: int
+    action: str
+    rationale: str
+    evidence: dict[str, object]
+
+
+_VALID_ACTIONS: Final[frozenset[str]] = frozenset({"unstick", "close", "hold"})
+
+
+@dataclass(frozen=True)
+class _NormalizedIssue:
+    number: int
+    state: str
+    labels: list[str]
+
+
+def _normalize_issue_record(record: object) -> _NormalizedIssue | None:
+    if not isinstance(record, dict):
+        return None
+    raw_number = record.get("number")
+    if not isinstance(raw_number, int) or raw_number <= 0:
+        return None
+    state = str(record.get("state") or "").strip().upper()
+    labels_raw = record.get("labels") or []
+    labels: list[str] = []
+    if isinstance(labels_raw, list):
+        for entry in labels_raw:
+            if isinstance(entry, dict):
+                name = entry.get("name")
+                if isinstance(name, str) and name:
+                    labels.append(name)
+            elif isinstance(entry, str) and entry:
+                labels.append(entry)
+    return _NormalizedIssue(number=raw_number, state=state, labels=labels)
+
+
+def plan_unstick(
+    *,
+    stuck_issue_records: Iterable[dict[str, object]],
+    pr_records: Iterable[dict[str, object]],
+) -> list[UnstickRecommendation]:
+    """Build per-issue unstick recommendations.
+
+    Args:
+        stuck_issue_records: Iterable of dicts with at least
+            ``number``, ``state`` (e.g. ``"OPEN"`` or ``"CLOSED"``),
+            and ``labels`` (list of dicts with ``name`` or list of
+            strings). Only issues carrying the ``boss-stuck`` label
+            will appear in the output.
+        pr_records: Iterable of dicts with at least ``number``,
+            ``state``, and ``headRefName`` (the shape from
+            ``gh pr list --json number,state,headRefName``).
+
+    Returns:
+        A list of :class:`UnstickRecommendation`, one per stuck issue,
+        sorted by ``issue_number``.
+    """
+    pr_list = list(pr_records or [])
+    out: list[UnstickRecommendation] = []
+    seen: set[int] = set()
+    for raw in stuck_issue_records or []:
+        record = _normalize_issue_record(raw)
+        if record is None:
+            continue
+        issue_number = record.number
+        if issue_number in seen:
+            continue
+        if STUCK_LABEL not in record.labels:
+            continue
+        seen.add(issue_number)
+        verdict = is_issue_dispatched_via_pr(issue_number, pr_records=pr_list)
+        state = record.state
+
+        merged_raw = verdict.get("pr_numbers_merged")
+        open_raw = verdict.get("pr_numbers_open")
+        merged_prs: list[int] = list(merged_raw) if isinstance(merged_raw, list) else []
+        open_prs: list[int] = list(open_raw) if isinstance(open_raw, list) else []
+
+        if state in {"CLOSED", "MERGED"}:
+            action = "close"
+            rationale = (
+                f"Issue is already {state.lower()} on GitHub; the boss-stuck label "
+                f"is stale. Recommend removing the label so future scans treat the "
+                f"issue as resolved."
+            )
+        elif merged_prs:
+            action = "unstick"
+            rationale = (
+                f"Boss-harvest PR(s) {merged_prs} merged to main. The work is "
+                f"shipped; remove the boss-stuck label and post a closure comment "
+                f"linking the merged PR. Operator may also close the issue."
+            )
+        elif open_prs:
+            action = "hold"
+            rationale = (
+                f"Boss-harvest PR(s) {open_prs} are open and in-flight. Hold the "
+                f"boss-stuck label until the PR merges or closes."
+            )
+        else:
+            action = "hold"
+            rationale = (
+                "No merged or open boss-harvest PR found for this issue. The "
+                "stuck label correctly reflects current state."
+            )
+
+        evidence = {
+            "issue_state": state,
+            "best_pr_state": verdict.get("best_state"),
+            "merged_pr_numbers": merged_prs,
+            "open_pr_numbers": open_prs,
+        }
+        out.append(
+            UnstickRecommendation(
+                issue_number=issue_number,
+                action=action,
+                rationale=rationale,
+                evidence=evidence,
+            )
+        )
+
+    out.sort(key=lambda r: r.issue_number)
+    return out
+
+
+def summarize_plan(recommendations: Iterable[UnstickRecommendation]) -> dict[str, object]:
+    """Summarize a plan into operator-friendly counts.
+
+    Returns a dict with ``total``, ``by_action`` (counts), and
+    ``by_action_issue_numbers`` (sorted issue lists per action).
+    """
+    by_action: dict[str, int] = {a: 0 for a in _VALID_ACTIONS}
+    by_action_issue_numbers: dict[str, list[int]] = {a: [] for a in _VALID_ACTIONS}
+    total = 0
+    for rec in recommendations or []:
+        if not isinstance(rec, UnstickRecommendation):
+            continue
+        if rec.action not in _VALID_ACTIONS:
+            continue
+        total += 1
+        by_action[rec.action] += 1
+        by_action_issue_numbers[rec.action].append(rec.issue_number)
+    for k in by_action_issue_numbers:
+        by_action_issue_numbers[k].sort()
+    return {
+        "total": total,
+        "by_action": by_action,
+        "by_action_issue_numbers": by_action_issue_numbers,
+    }
+
+
+def render_markdown(recommendations: Iterable[UnstickRecommendation]) -> str:
+    """Render a markdown report for the unstick plan."""
+    rows = list(recommendations or [])
+    summary = summarize_plan(rows)
+    total = summary["total"] if isinstance(summary["total"], int) else 0
+    by_action_obj = summary["by_action"]
+    by_action_ids_obj = summary["by_action_issue_numbers"]
+    by_action: dict[str, int] = by_action_obj if isinstance(by_action_obj, dict) else {}
+    by_action_ids: dict[str, list[int]] = (
+        by_action_ids_obj if isinstance(by_action_ids_obj, dict) else {}
+    )
+
+    lines = [
+        "# Boss-loop unstick plan (dry-run)",
+        "",
+        f"Total stuck issues considered: **{total}**",
+        "",
+        "## Counts by action",
+        "",
+        "| Action | Count | Issue numbers |",
+        "| --- | ---: | --- |",
+    ]
+    for action in ("unstick", "close", "hold"):
+        ids: list[int] = by_action_ids.get(action) or []
+        ids_str = ", ".join(f"#{n}" for n in ids) if ids else "—"
+        lines.append(f"| `{action}` | {by_action.get(action, 0)} | {ids_str} |")
+
+    lines.extend(
+        [
+            "",
+            "## Per-issue recommendations",
+            "",
+            "| Issue | Action | Issue state | Best PR state | Merged PRs | Rationale |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for rec in rows:
+        merged_raw = rec.evidence.get("merged_pr_numbers", [])
+        merged_list: list[int] = list(merged_raw) if isinstance(merged_raw, list) else []
+        merged = ", ".join(f"#{n}" for n in merged_list)
+        lines.append(
+            f"| #{rec.issue_number} | `{rec.action}` | "
+            f"{rec.evidence.get('issue_state', '?')} | "
+            f"{rec.evidence.get('best_pr_state') or '—'} | "
+            f"{merged or '—'} | "
+            f"{rec.rationale} |"
+        )
+    lines.extend(["", "_This plan is dry-run only; no GitHub mutations performed._", ""])
+    return "\n".join(lines)
+
+
+__all__ = [
+    "STUCK_LABEL",
+    "UnstickRecommendation",
+    "plan_unstick",
+    "summarize_plan",
+    "render_markdown",
+]

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4085` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1924178` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4089` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1925455` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `135` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5116` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `216782` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `659` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5126` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `216989` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `661` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `61` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3398` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `806` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `811` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/scripts/boss_loop_unstick_plan.py
+++ b/scripts/boss_loop_unstick_plan.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Boss-loop ``unstick`` planning CLI (dry-run only).
+
+Reads two JSON files (the shape returned by ``gh issue list`` and
+``gh pr list``) and writes an ``UnstickRecommendation`` plan to
+stdout (JSON or markdown) for operator review.
+
+This script performs **no** GitHub mutations.
+
+Example
+-------
+
+::
+
+    gh issue list --state open --label boss-stuck --limit 200 \\
+        --json number,state,labels > /tmp/stuck-issues.json
+    gh pr list --state all --limit 500 \\
+        --search 'head:aragora/boss-harvest/' \\
+        --json number,state,headRefName > /tmp/pr-records.json
+
+    python3 scripts/boss_loop_unstick_plan.py \\
+        --issues /tmp/stuck-issues.json \\
+        --pr-records /tmp/pr-records.json \\
+        --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.unstick import (  # noqa: E402
+    plan_unstick,
+    render_markdown,
+    summarize_plan,
+)
+
+
+def _load_json_list(path: Path | None) -> list[dict[str, Any]]:
+    if path is None or not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--issues",
+        type=Path,
+        required=True,
+        help="JSON file with `gh issue list ... --json number,state,labels` output",
+    )
+    parser.add_argument(
+        "--pr-records",
+        type=Path,
+        required=True,
+        help="JSON file with `gh pr list ... --json number,state,headRefName` output",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "md"),
+        default="json",
+        help="Output format (default: json)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional output path; default writes to stdout",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    issues = _load_json_list(args.issues)
+    pr_records = _load_json_list(args.pr_records)
+    plan = plan_unstick(stuck_issue_records=issues, pr_records=pr_records)
+    if args.format == "md":
+        text = render_markdown(plan)
+    else:
+        payload = {
+            "summary": summarize_plan(plan),
+            "recommendations": [asdict(r) for r in plan],
+        }
+        text = json.dumps(payload, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + ("\n" if not text.endswith("\n") else ""))
+        print(str(args.output))
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/swarm/test_unstick.py
+++ b/tests/swarm/test_unstick.py
@@ -1,0 +1,218 @@
+"""Unit tests for ``aragora.swarm.unstick``.
+
+Tests cover:
+
+- The three actions: ``unstick`` (merged PR exists, issue still open),
+  ``close`` (issue already closed/merged on GitHub), and ``hold``
+  (truly stuck or only open in-flight PRs).
+- Robustness against malformed records.
+- The summary helper and the markdown renderer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aragora.swarm.unstick import (
+    STUCK_LABEL,
+    UnstickRecommendation,
+    plan_unstick,
+    render_markdown,
+    summarize_plan,
+)
+
+
+def _issue(
+    number: int,
+    *,
+    state: str = "OPEN",
+    labels: list[str] | None = None,
+) -> dict:
+    return {
+        "number": number,
+        "state": state,
+        "labels": [{"name": n} for n in (labels or [STUCK_LABEL])],
+    }
+
+
+def _pr(number: int, *, state: str, branch: str) -> dict:
+    return {"number": number, "state": state, "headRefName": branch}
+
+
+class TestPlanUnstickActions:
+    def test_merged_pr_open_issue_yields_unstick(self) -> None:
+        issues = [_issue(5126)]
+        prs = [_pr(5163, state="MERGED", branch="aragora/boss-harvest/issue-5126-boss-x")]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=prs)
+        assert len(plan) == 1
+        assert plan[0].issue_number == 5126
+        assert plan[0].action == "unstick"
+        assert plan[0].evidence["merged_pr_numbers"] == [5163]
+
+    def test_closed_issue_yields_close(self) -> None:
+        issues = [_issue(7, state="CLOSED")]
+        prs = []
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=prs)
+        assert plan[0].action == "close"
+
+    def test_merged_issue_state_yields_close(self) -> None:
+        issues = [_issue(7, state="MERGED")]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=[])
+        assert plan[0].action == "close"
+
+    def test_open_pr_only_yields_hold(self) -> None:
+        issues = [_issue(8)]
+        prs = [_pr(101, state="OPEN", branch="aragora/boss-harvest/issue-8-foo")]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=prs)
+        assert plan[0].action == "hold"
+        assert plan[0].evidence["open_pr_numbers"] == [101]
+
+    def test_no_pr_evidence_yields_hold(self) -> None:
+        issues = [_issue(9)]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=[])
+        assert plan[0].action == "hold"
+        assert plan[0].evidence["best_pr_state"] is None
+
+    def test_closed_unmerged_pr_does_not_unstick(self) -> None:
+        issues = [_issue(10)]
+        prs = [_pr(102, state="CLOSED", branch="aragora/boss-harvest/issue-10-foo")]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=prs)
+        assert plan[0].action == "hold"
+
+
+class TestPlanUnstickFiltering:
+    def test_issue_without_stuck_label_excluded(self) -> None:
+        issues = [_issue(11, labels=["enhancement"]), _issue(12)]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=[])
+        assert len(plan) == 1
+        assert plan[0].issue_number == 12
+
+    def test_duplicate_issue_records_deduped(self) -> None:
+        issues = [_issue(13), _issue(13)]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=[])
+        assert len(plan) == 1
+
+    def test_malformed_records_skipped(self) -> None:
+        issues = [
+            "not-a-dict",
+            None,
+            {"number": "abc", "state": "OPEN", "labels": [{"name": STUCK_LABEL}]},
+            {"number": -5, "state": "OPEN", "labels": [{"name": STUCK_LABEL}]},
+            _issue(14),
+        ]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=[])
+        assert len(plan) == 1
+        assert plan[0].issue_number == 14
+
+    def test_string_labels_accepted(self) -> None:
+        issues = [{"number": 15, "state": "OPEN", "labels": [STUCK_LABEL, "other"]}]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=[])
+        assert len(plan) == 1
+        assert plan[0].issue_number == 15
+
+    def test_results_sorted_by_issue_number(self) -> None:
+        issues = [_issue(20), _issue(10), _issue(15)]
+        plan = plan_unstick(stuck_issue_records=issues, pr_records=[])
+        assert [r.issue_number for r in plan] == [10, 15, 20]
+
+
+class TestSummarizePlan:
+    def test_summary_counts(self) -> None:
+        plan = [
+            UnstickRecommendation(1, "unstick", "x", {}),
+            UnstickRecommendation(2, "unstick", "x", {}),
+            UnstickRecommendation(3, "close", "x", {}),
+            UnstickRecommendation(4, "hold", "x", {}),
+        ]
+        s = summarize_plan(plan)
+        assert s["total"] == 4
+        assert s["by_action"] == {"unstick": 2, "close": 1, "hold": 1}
+        assert s["by_action_issue_numbers"]["unstick"] == [1, 2]
+
+    def test_summary_empty(self) -> None:
+        s = summarize_plan([])
+        assert s["total"] == 0
+
+    def test_summary_skips_invalid(self) -> None:
+        plan = [
+            UnstickRecommendation(1, "unstick", "x", {}),
+            UnstickRecommendation(2, "bogus", "x", {}),
+        ]
+        s = summarize_plan(plan)
+        assert s["total"] == 1
+
+
+class TestRenderMarkdown:
+    def test_renders_summary_and_rows(self) -> None:
+        plan = [
+            UnstickRecommendation(
+                1,
+                "unstick",
+                "merged PR #100",
+                {
+                    "issue_state": "OPEN",
+                    "best_pr_state": "MERGED",
+                    "merged_pr_numbers": [100],
+                    "open_pr_numbers": [],
+                },
+            ),
+            UnstickRecommendation(
+                2,
+                "hold",
+                "no PR",
+                {
+                    "issue_state": "OPEN",
+                    "best_pr_state": None,
+                    "merged_pr_numbers": [],
+                    "open_pr_numbers": [],
+                },
+            ),
+        ]
+        md = render_markdown(plan)
+        assert "Boss-loop unstick plan (dry-run)" in md
+        assert "Total stuck issues considered: **2**" in md
+        assert "| #1 | `unstick` |" in md
+        assert "| #2 | `hold` |" in md
+        assert "_This plan is dry-run only" in md
+
+    def test_renders_empty_plan(self) -> None:
+        md = render_markdown([])
+        assert "Total stuck issues considered: **0**" in md
+
+
+class TestEndToEndCli:
+    def test_cli_emits_expected_json(self, tmp_path: Path) -> None:
+        # Just verify the script's main() returns 0 and produces parseable JSON.
+        import sys
+
+        repo_root = Path(__file__).resolve().parents[2]
+        sys.path.insert(0, str(repo_root / "scripts"))
+        try:
+            import boss_loop_unstick_plan as cli  # type: ignore[import-not-found]
+        finally:
+            sys.path.pop(0)
+
+        issues_path = tmp_path / "issues.json"
+        prs_path = tmp_path / "prs.json"
+        out_path = tmp_path / "out.json"
+        issues_path.write_text(json.dumps([_issue(99)]))
+        prs_path.write_text(
+            json.dumps([_pr(101, state="MERGED", branch="aragora/boss-harvest/issue-99-x")])
+        )
+        rc = cli.main(
+            [
+                "--issues",
+                str(issues_path),
+                "--pr-records",
+                str(prs_path),
+                "--format",
+                "json",
+                "--output",
+                str(out_path),
+            ]
+        )
+        assert rc == 0
+        payload = json.loads(out_path.read_text())
+        assert payload["summary"]["total"] == 1
+        assert payload["recommendations"][0]["action"] == "unstick"


### PR DESCRIPTION
Stacked on #6839. Adds a planning surface that, given fetched issue and PR records, decides per-issue whether to unstick / close / hold a `boss-stuck`-labeled issue.

## Why

The boss-loop emits the `boss-stuck` label when it cannot make progress. Once labeled, the loop's own `skip_labels` set filters the issue out forever — even if the underlying work has since been delivered (a peer agent's PR, a manual fix, a related issue's PR, etc.).

A live scan of origin/main reveals **84 of the 200 currently `boss-stuck` issues already have merged boss-harvest PRs**. Those are false-stuck — they're shipped work that the boss-loop is hiding.

## What this PR adds

| File | Lines | Purpose |
|---|---:|---|
| `aragora/swarm/unstick.py` | 246 | Pure offline planning module |
| `scripts/boss_loop_unstick_plan.py` | 110 | CLI entry point |
| `tests/swarm/test_unstick.py` | 218 | 17 unit tests |

The module is **dry-run only**: it produces a JSON plan that the operator (or a future PR) can act on. It performs **no** GitHub mutations itself.

## Recommendation taxonomy

- **`unstick`**: boss-harvest PR(s) merged but the label persists. Recommend removing the label and posting a closure comment linking the merged PR.
- **`close`**: the issue itself is already closed/merged on GitHub. Recommend removing the label so future scans treat it as resolved.
- **`hold`**: no merged PR found. The label correctly reflects current state.

## Live verification

```bash
gh issue list --state open --label boss-stuck --limit 200 \
    --json number,state,labels > /tmp/stuck-issues.json
gh pr list --state all --limit 500 \
    --search 'head:aragora/boss-harvest/' \
    --json number,state,headRefName > /tmp/pr-records.json

python3 scripts/boss_loop_unstick_plan.py \
    --issues /tmp/stuck-issues.json \
    --pr-records /tmp/pr-records.json --format json | jq .summary
```

```
{
  "by_action": { "unstick": 84, "close": 0, "hold": 116 },
  "total": 200
}
```

## Why this is safe

- **Dry-run only**: no GitHub writes, ever. The action is just a string in the JSON output.
- **Conservative branch matching**: relies on PR #6839's strict regex `^aragora/boss-harvest/issue-(\d+)(?:[-/].*)?$`.
- **CLOSED-without-merge → hold**: abandoned work doesn't trigger unstick.
- **Open-PR → hold**: in-flight work isn't unstuck prematurely.

## Tests

- 17/17 pass in `tests/swarm/test_unstick.py` covering all three actions, malformed-record robustness, dedup, summary helper, markdown rendering, and end-to-end CLI smoke.
- ruff check + format: clean
- mypy-baseline pre-commit: passes (no new errors)
- preflight: ok

## Tier

**Tier 2** — additive new module + CLI + tests; zero GitHub writes; safe revert by deleting three files.

## Standing rule

I do not author-merge. Awaiting Codex signal + CI green.