### PR TITLE
fix(automation): surface launchd last-exit-code in publisher freshness check

### DIFF
--- a/scripts/publisher_freshness_check.py
+++ b/scripts/publisher_freshness_check.py
@@ -42,6 +42,7 @@ class FreshnessReport:
     summary: str
     launchd_loaded: bool
     launchd_detail: str
+    launchd_last_exit_code: int | None
     cache_path: str
     cache_present: bool
     cache_age_seconds: float | None
@@ -56,11 +57,66 @@ class FreshnessReport:
     blockers: list[str] = field(default_factory=list)
 
 
-def _launchd_loaded(label: str) -> tuple[bool, str]:
+# Map of common launchd exit codes to human-readable labels (sysexits.h subset).
+# Reported alongside the raw integer so the operator surface explains *why*
+# `last exit code = 78` is bad without requiring them to know sysexits.h.
+_LAUNCHD_EXIT_CODE_NAMES: dict[int, str] = {
+    64: "EX_USAGE",
+    65: "EX_DATAERR",
+    66: "EX_NOINPUT",
+    67: "EX_NOUSER",
+    68: "EX_NOHOST",
+    69: "EX_UNAVAILABLE",
+    70: "EX_SOFTWARE",
+    71: "EX_OSERR",
+    72: "EX_OSFILE",
+    73: "EX_CANTCREAT",
+    74: "EX_IOERR",
+    75: "EX_TEMPFAIL",
+    76: "EX_PROTOCOL",
+    77: "EX_NOPERM",
+    78: "EX_CONFIG",
+    127: "command-not-found",
+    137: "SIGKILL",
+}
+
+
+def _parse_last_exit_code(launchctl_print_stdout: str) -> int | None:
+    """Extract ``last exit code = N`` from ``launchctl print`` output.
+
+    Returns ``None`` when the field is absent (e.g., the job has never run, or
+    the launchctl output format changes).  Robust to whitespace and surrounding
+    fields.
+    """
+    for line in launchctl_print_stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("last exit code"):
+            # Form: "last exit code = N: NAME" or "last exit code = N".
+            _, _, rest = stripped.partition("=")
+            rest = rest.strip()
+            if not rest:
+                return None
+            num_str = rest.split(":", 1)[0].strip()
+            try:
+                return int(num_str)
+            except ValueError:
+                return None
+    return None
+
+
+def _launchd_loaded(label: str) -> tuple[bool, str, int | None]:
+    """Return (loaded, detail, last_exit_code).
+
+    A launchd job that is *loaded* may still be persistently failing — the
+    plist on disk can hard-code a missing WorkingDirectory or a bad command.
+    Surfacing the last-known exit code lets the caller distinguish "loaded
+    and healthy" from "loaded but persistently exit-code-failing" — the
+    latter is strictly more degraded.
+    """
     try:
         domain = f"gui/{os.getuid()}"
     except AttributeError:
-        return False, "non-posix-platform"
+        return False, "non-posix-platform", None
     try:
         proc = subprocess.run(
             ["launchctl", "print", f"{domain}/{label}"],
@@ -70,14 +126,15 @@ def _launchd_loaded(label: str) -> tuple[bool, str]:
             timeout=5,
         )
     except FileNotFoundError:
-        return False, "launchctl-not-found"
+        return False, "launchctl-not-found", None
     except subprocess.TimeoutExpired:
-        return False, "launchctl-timeout"
+        return False, "launchctl-timeout", None
+    last_exit = _parse_last_exit_code(proc.stdout or "")
     if proc.returncode == 0:
-        return True, "loaded"
+        return True, "loaded", last_exit
     stderr = (proc.stderr or "").strip().splitlines()
     detail = stderr[-1] if stderr else f"rc={proc.returncode}"
-    return False, detail
+    return False, detail, last_exit
 
 
 def _human_age(seconds: float | None) -> str:
@@ -125,7 +182,13 @@ def evaluate(
         outbox_dir = repo_root / ".aragora" / "automation-outbox"
     now = now if now is not None else time.time()
 
-    loaded, detail = _launchd_loaded(LAUNCHD_LABEL)
+    loaded, detail, last_exit_code = _launchd_loaded(LAUNCHD_LABEL)
+    # A non-zero last exit code on a *loaded* job is a strictly worse state
+    # than "loaded healthy": the plist is installed but the program is
+    # consistently failing.  Caught in Round 2026-04-30c Phase B (launchd
+    # plist pointing at a missing WorkingDirectory after a worktree rename
+    # caused 375 consecutive EX_CONFIG=78 fires before being noticed).
+    launchd_failing = loaded and last_exit_code is not None and last_exit_code != 0
 
     cache_present = cache_path.is_file()
     cache_age: float | None
@@ -155,6 +218,10 @@ def evaluate(
     blockers: list[str] = []
     if not loaded:
         blockers.append(f"launchd: {detail}")
+    elif launchd_failing:
+        # Loaded but persistently failing: surface the exit code with name.
+        name = _LAUNCHD_EXIT_CODE_NAMES.get(last_exit_code or -1, "unknown")
+        blockers.append(f"launchd: exit_code={last_exit_code} ({name})")
     if not cache_present:
         blockers.append("cache: missing")
     elif cache_stale:
@@ -164,16 +231,22 @@ def evaluate(
 
     if not blockers:
         verdict = "ready"
-    elif loaded and not drift_meaningful:
-        # cache-stale alone (without meaningful drift) is "warming": the
-        # next publisher run will refresh the cache and the operator
-        # signal will resolve without intervention.
+    elif loaded and not launchd_failing and not drift_meaningful:
+        # cache-stale alone (without meaningful drift, with healthy launchd)
+        # is "warming": the next publisher run will refresh the cache and
+        # the operator signal will resolve without intervention.
         verdict = "warming"
     else:
         verdict = "degraded"
 
     summary_parts = []
-    summary_parts.append(f"launchd: {'loaded' if loaded else detail}")
+    if loaded and not launchd_failing:
+        summary_parts.append("launchd: loaded")
+    elif loaded and launchd_failing:
+        name = _LAUNCHD_EXIT_CODE_NAMES.get(last_exit_code or -1, "unknown")
+        summary_parts.append(f"launchd: loaded but failing exit_code={last_exit_code} ({name})")
+    else:
+        summary_parts.append(f"launchd: {detail}")
     summary_parts.append(f"cache: {_human_age(cache_age) if cache_present else 'missing'}")
     summary_parts.append(f"drift: {drift_detail}")
     summary = f"publisher: {verdict} ({'; '.join(summary_parts)})"
@@ -183,6 +256,7 @@ def evaluate(
         summary=summary,
         launchd_loaded=loaded,
         launchd_detail=detail,
+        launchd_last_exit_code=last_exit_code,
         cache_path=str(cache_path),
         cache_present=cache_present,
         cache_age_seconds=cache_age,

--- a/tests/scripts/test_publisher_freshness_check.py
+++ b/tests/scripts/test_publisher_freshness_check.py
@@ -58,7 +58,7 @@ def _write_outbox_files(tmp_path: Path, count: int) -> None:
 def test_ready_when_loaded_fresh_no_drift(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
     cache = _write_cache(stub_repo, outbox_count=3)
     _write_outbox_files(stub_repo, 3)
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     now = cache.stat().st_mtime + 60
     report = mod.evaluate(stub_repo, now=now)
     assert report.verdict == "ready"
@@ -74,7 +74,9 @@ def test_ready_when_loaded_fresh_no_drift(monkeypatch: pytest.MonkeyPatch, stub_
 def test_degraded_when_launchd_not_loaded(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
     cache = _write_cache(stub_repo, outbox_count=2)
     _write_outbox_files(stub_repo, 2)
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "could not find service"))
+    monkeypatch.setattr(
+        mod, "_launchd_loaded", lambda label: (False, "could not find service", None)
+    )
     now = cache.stat().st_mtime + 60
     report = mod.evaluate(stub_repo, now=now)
     assert report.verdict == "degraded"
@@ -85,7 +87,7 @@ def test_degraded_when_launchd_not_loaded(monkeypatch: pytest.MonkeyPatch, stub_
 def test_degraded_when_cache_stale(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
     cache = _write_cache(stub_repo, outbox_count=4)
     _write_outbox_files(stub_repo, 4)
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded", None))
     now = cache.stat().st_mtime + 7200  # 2 hours stale
     report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
     assert report.verdict == "degraded"
@@ -102,7 +104,7 @@ def test_warming_when_loaded_but_drift(monkeypatch: pytest.MonkeyPatch, stub_rep
     """
     cache = _write_cache(stub_repo, outbox_count=2)
     _write_outbox_files(stub_repo, 5)  # real count > cache count
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     now = cache.stat().st_mtime + 60
     report = mod.evaluate(stub_repo, now=now)
     # drift triggers degraded since drift means writes have happened that the
@@ -117,7 +119,7 @@ def test_warming_label_when_loaded_no_drift_but_cache_just_stale(
 ) -> None:
     cache = _write_cache(stub_repo, outbox_count=2)
     _write_outbox_files(stub_repo, 2)
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     now = cache.stat().st_mtime + 7200
     report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
     # loaded + no drift but cache stale -> warming (not degraded)
@@ -128,7 +130,7 @@ def test_warming_label_when_loaded_no_drift_but_cache_just_stale(
 
 def test_missing_cache(monkeypatch: pytest.MonkeyPatch, stub_repo: Path) -> None:
     _write_outbox_files(stub_repo, 1)
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded", None))
     report = mod.evaluate(stub_repo)
     assert report.cache_present is False
     assert report.cache_age_seconds is None
@@ -144,7 +146,7 @@ def test_outbox_count_excludes_non_json(monkeypatch: pytest.MonkeyPatch, stub_re
     (outbox / "real-2.json").write_text("{}")
     (outbox / "ignore.txt").write_text("ignore me")
     (outbox / ".DS_Store").write_text("apple metadata")
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     now = cache.stat().st_mtime + 60
     report = mod.evaluate(stub_repo, now=now)
     assert report.outbox_real_count == 2
@@ -155,7 +157,7 @@ def test_main_text_output_emits_summary(
     monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _write_cache(stub_repo, outbox_count=0)
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     rc = mod.main(["--repo", str(stub_repo)])
     out = capsys.readouterr().out
     assert rc == 0
@@ -167,7 +169,7 @@ def test_main_json_output_includes_full_report(
     monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _write_cache(stub_repo, outbox_count=0)
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     rc = mod.main(["--repo", str(stub_repo), "--json"])
     out = capsys.readouterr().out
     assert rc == 0
@@ -180,7 +182,7 @@ def test_main_json_output_includes_full_report(
 def test_main_exit_nonzero_on_degraded(
     monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded", None))
     rc = mod.main(["--repo", str(stub_repo), "--exit-nonzero-on-degraded"])
     assert rc == 1
 
@@ -188,7 +190,7 @@ def test_main_exit_nonzero_on_degraded(
 def test_main_exit_zero_on_degraded_without_flag(
     monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (False, "not loaded", None))
     rc = mod.main(["--repo", str(stub_repo)])
     assert rc == 0
 
@@ -213,7 +215,7 @@ def test_stale_cache_with_count_disagreement_does_not_double_flag_drift(
     """
     cache = _write_cache(stub_repo, outbox_count=20)
     _write_outbox_files(stub_repo, 17)  # real count != cache count
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     # Cache is 4 hours stale at default 1800s threshold.
     now = cache.stat().st_mtime + 4 * 3600
     report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
@@ -252,7 +254,7 @@ def test_fresh_cache_with_count_disagreement_still_flags_drift(
     """
     cache = _write_cache(stub_repo, outbox_count=2)
     _write_outbox_files(stub_repo, 5)
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     # Cache is 60s old → fresh at default 1800s threshold.
     now = cache.stat().st_mtime + 60
     report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
@@ -274,9 +276,113 @@ def test_stale_cache_with_matching_counts_warming_only(
     """
     cache = _write_cache(stub_repo, outbox_count=3)
     _write_outbox_files(stub_repo, 3)
-    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded"))
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
     now = cache.stat().st_mtime + 4 * 3600
     report = mod.evaluate(stub_repo, now=now, stale_threshold_seconds=1800)
     assert report.cache_stale is True
     assert report.outbox_drift is False
     assert report.verdict == "warming"
+
+
+# ---------------------------------------------------------------------------
+# Round 2026-04-30c Phase B: surface launchd last-exit-code in the report.
+# Catches the EX_CONFIG=78 silent-fail class that ate ~9.6h of cache freshness
+# (375 consecutive failed runs against a missing WorkingDirectory).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_last_exit_code_canonical_form() -> None:
+    sample = "\tactive count = 0\n\tlast exit code = 78: EX_CONFIG\n\truns = 375\n"
+    assert mod._parse_last_exit_code(sample) == 78
+
+
+def test_parse_last_exit_code_no_name_suffix() -> None:
+    assert mod._parse_last_exit_code("\tlast exit code = 0\n") == 0
+
+
+def test_parse_last_exit_code_absent_field() -> None:
+    assert mod._parse_last_exit_code("\truns = 0\n\tactive count = 0\n") is None
+
+
+def test_parse_last_exit_code_unparseable_value() -> None:
+    assert mod._parse_last_exit_code("\tlast exit code = (none)\n") is None
+
+
+def test_loaded_with_persistent_failure_is_degraded(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path
+) -> None:
+    """A loaded launchd job with last_exit_code != 0 must trigger 'degraded'.
+
+    Regression for the Round 2026-04-30c Phase B RCA: launchd plist pointed at
+    a missing WorkingDirectory, every fire exited EX_CONFIG=78, but the
+    diagnostic still reported "launchd: loaded" and gave a misleading
+    'warming' verdict.
+    """
+    cache = _write_cache(stub_repo, outbox_count=3)
+    _write_outbox_files(stub_repo, 3)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", 78))
+    now = cache.stat().st_mtime + 60
+    report = mod.evaluate(stub_repo, now=now)
+    assert report.launchd_loaded is True
+    assert report.launchd_last_exit_code == 78
+    assert report.verdict == "degraded"
+    launchd_blockers = [b for b in report.blockers if b.startswith("launchd:")]
+    assert launchd_blockers, report.blockers
+    assert "exit_code=78" in launchd_blockers[0]
+    assert "EX_CONFIG" in launchd_blockers[0]
+
+
+def test_loaded_with_zero_exit_code_is_healthy(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path
+) -> None:
+    """Loaded with last_exit_code=0 is healthy — no launchd blocker."""
+    cache = _write_cache(stub_repo, outbox_count=3)
+    _write_outbox_files(stub_repo, 3)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", 0))
+    now = cache.stat().st_mtime + 60
+    report = mod.evaluate(stub_repo, now=now)
+    assert report.verdict == "ready"
+    assert all(not b.startswith("launchd:") for b in report.blockers), report.blockers
+
+
+def test_loaded_with_no_recorded_exit_code_treated_as_healthy(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path
+) -> None:
+    """A job that has never run (last_exit_code=None) must NOT be flagged as
+    failing — absence of a record is not a failure."""
+    cache = _write_cache(stub_repo, outbox_count=3)
+    _write_outbox_files(stub_repo, 3)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", None))
+    now = cache.stat().st_mtime + 60
+    report = mod.evaluate(stub_repo, now=now)
+    assert report.verdict == "ready"
+    assert report.launchd_last_exit_code is None
+    assert all(not b.startswith("launchd:") for b in report.blockers)
+
+
+def test_summary_string_calls_out_failing_state(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path
+) -> None:
+    """The 1-line summary string must call out the failing state explicitly."""
+    cache = _write_cache(stub_repo, outbox_count=2)
+    _write_outbox_files(stub_repo, 2)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", 78))
+    now = cache.stat().st_mtime + 60
+    report = mod.evaluate(stub_repo, now=now)
+    assert "exit_code=78" in report.summary
+    assert "EX_CONFIG" in report.summary
+    assert report.summary.startswith("publisher: degraded")
+
+
+def test_full_report_serializes_exit_code(
+    monkeypatch: pytest.MonkeyPatch, stub_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """JSON output includes ``launchd_last_exit_code`` for downstream consumers."""
+    _write_cache(stub_repo, outbox_count=0)
+    monkeypatch.setattr(mod, "_launchd_loaded", lambda label: (True, "loaded", 78))
+    rc = mod.main(["--repo", str(stub_repo), "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    parsed = json.loads(out)
+    assert parsed["launchd_last_exit_code"] == 78
+    assert parsed["verdict"] == "degraded"


### PR DESCRIPTION
## Summary

Round 2026-04-30c — Phase B (Tier 2). Closes the silent-fail class found via Phase B RCA: a launchd plist with a missing WorkingDirectory had been firing every 5 minutes for ~1.3 days (375 consecutive runs), exiting `EX_CONFIG=78` on every fire — yet the freshness diagnostic only reported `launchd: loaded` because the plist was loaded.

The cache aged 9.6h with no operator-visible cause until I dug through `launchctl print` and found:

```
state = not running
runs = 375
last exit code = 78: EX_CONFIG
WorkingDirectory = /Users/armand/Development/aragora/.worktrees/publisher-bridge-main  ← missing on disk
```

## Fix

Extend `_launchd_loaded` to parse the `last exit code` field from `launchctl print` output. Add `launchd_last_exit_code: int | None` to `FreshnessReport`. A loaded-but-failing job is now a distinct degraded state.

Common `sysexits.h` codes (EX_USAGE..EX_NOPERM..EX_CONFIG, plus 127 and 137) are mapped to human-readable names so operators don't need to memorise the table.

## Verdict semantics

| Loaded? | Last exit | Verdict |
|---|---|---|
| ✅ | 0 or absent | depends on cache state (`ready` / `warming`) |
| ✅ | non-zero | **`degraded`** (new behavior) |
| ❌ | (any) | `degraded` |

## Live dogfood

```text
Before: publisher: degraded (launchd: loaded; cache: 9.6h; drift: outbox=16 cache=20)
After:  publisher: degraded (launchd: loaded but failing exit_code=78 (EX_CONFIG); cache: ...)
```

The actual repair of the broken installed plist requires `bash scripts/install_codex_automation_publisher_launchd.sh` (operator action; out of scope for this PR per round invariants on author-merge and install runs).

## Tests (8 new, 23 total)

- `_parse_last_exit_code`: 4 cases (canonical form, no name suffix, absent field, unparseable value)
- `evaluate()`: 4 cases (loaded+exit78=degraded, loaded+exit0=ready, loaded+no-record=ready, summary string + JSON output serialisation)

## Verification

- 23/23 tests pass deterministically (was 14)
- ruff check + format clean
- mypy clean on `publisher_freshness_check.py`
- Live dogfood confirms the new diagnostic surface

## Diff stat

```
 scripts/publisher_freshness_check.py            |  56 ++++++--
 tests/scripts/test_publisher_freshness_check.py | 176 ++++++++++++++++++++--
 2 files changed, 206 insertions(+), 26 deletions(-)
```

## Why now

I found this while running my own `publisher_freshness_check.py` (#6814) in this round's Phase A baseline. The previous-round drift-suppression fix (#6837) made the verdict accurate for "stale cache only", but the launchd-failing-but-loaded class was still invisible. This PR adds the missing observability and is bounded enough to ship in the same round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)