### PR TITLE
fix(agent-airlock): resolve shared metrics path

### DIFF
--- a/aragora/agents/airlock.py
+++ b/aragora/agents/airlock.py
@@ -16,6 +16,7 @@ __all__ = [
     "AirlockMetrics",
     "AirlockConfig",
     "AirlockProxy",
+    "resolve_metrics_path",
     "wrap_agent",
     "wrap_agents",
 ]
@@ -24,8 +25,10 @@ import asyncio
 import json
 import logging
 import re
+import subprocess
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from collections.abc import Awaitable, Callable
 
@@ -33,6 +36,46 @@ if TYPE_CHECKING:
     from aragora.core import Agent, Critique, Message, Vote
 
 logger = logging.getLogger(__name__)
+
+
+OVERNIGHT_METRICS_PATH = Path(".aragora/overnight/boss_metrics.jsonl")
+
+
+def resolve_metrics_path(
+    metrics_path: str | Path = OVERNIGHT_METRICS_PATH,
+    *,
+    start: str | Path | None = None,
+) -> Path:
+    """Resolve overnight metrics across managed worktrees.
+
+    Managed Codex worktrees usually do not have their own `.aragora` state;
+    Git's common dir points back to the shared checkout where overnight
+    benchmark metrics are written.
+    """
+    path = Path(metrics_path)
+    base = Path(start) if start is not None else Path.cwd()
+    candidate = path if path.is_absolute() else base / path
+    if candidate.exists() or path.is_absolute():
+        return candidate
+
+    try:
+        common_dir_output = subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=base,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return candidate
+
+    common_dir = Path(common_dir_output)
+    if not common_dir.is_absolute():
+        common_dir = base / common_dir
+    shared_root = common_dir.parent if common_dir.name == ".git" else common_dir
+    shared_candidate = shared_root / path
+    if shared_candidate.exists():
+        return shared_candidate
+    return candidate
 
 
 @dataclass

--- a/tests/test_airlock.py
+++ b/tests/test_airlock.py
@@ -9,14 +9,18 @@ Tests cover:
 """
 
 import asyncio
+import subprocess
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import aragora.agents.airlock as airlock
 from aragora.agents.airlock import (
     AirlockConfig,
     AirlockMetrics,
     AirlockProxy,
+    resolve_metrics_path,
     wrap_agent,
     wrap_agents,
 )
@@ -161,6 +165,53 @@ class TestAirlockMetrics:
         result = metrics.to_dict()
         assert result["success_rate"] == 33.33
         assert result["avg_latency_ms"] == 333.33
+
+
+# === Metrics Path Resolution Tests ===
+
+
+class TestResolveMetricsPath:
+    """Tests for resolving overnight metrics from managed worktrees."""
+
+    def test_returns_absolute_path(self, tmp_path):
+        metrics_path = tmp_path / "metrics.jsonl"
+        assert resolve_metrics_path(metrics_path) == metrics_path
+
+    def test_prefers_existing_local_candidate(self, tmp_path):
+        metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+        metrics_path.parent.mkdir(parents=True)
+        metrics_path.write_text("{}\n", encoding="utf-8")
+
+        assert resolve_metrics_path(start=tmp_path) == metrics_path
+
+    def test_resolves_shared_repo_root_from_git_common_dir(self, tmp_path, monkeypatch):
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        shared_root = tmp_path / "shared"
+        shared_git = shared_root / ".git"
+        shared_metrics = shared_root / ".aragora" / "overnight" / "boss_metrics.jsonl"
+        shared_git.mkdir(parents=True)
+        shared_metrics.parent.mkdir(parents=True)
+        shared_metrics.write_text("{}\n", encoding="utf-8")
+
+        def fake_check_output(args, *, cwd, stderr, text):
+            assert args == ["git", "rev-parse", "--git-common-dir"]
+            assert Path(cwd) == worktree
+            assert stderr is subprocess.DEVNULL
+            assert text is True
+            return str(shared_git)
+
+        monkeypatch.setattr(airlock.subprocess, "check_output", fake_check_output)
+
+        assert resolve_metrics_path(start=worktree) == shared_metrics
+
+    def test_returns_local_candidate_when_git_lookup_fails(self, tmp_path, monkeypatch):
+        def fake_check_output(*args, **kwargs):
+            raise subprocess.CalledProcessError(128, args[0])
+
+        monkeypatch.setattr(airlock.subprocess, "check_output", fake_check_output)
+
+        assert resolve_metrics_path("missing.jsonl", start=tmp_path) == tmp_path / "missing.jsonl"
 
 
 # === AirlockConfig Tests ===


### PR DESCRIPTION
## Summary
- add Airlock metrics path resolution that falls back through the Git common-dir/shared checkout
- cover managed worktree metrics resolution in Airlock tests

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/test_airlock.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check aragora/agents/airlock.py tests/test_airlock.py
- python3 -m ruff format --check aragora/agents/airlock.py tests/test_airlock.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD