### PR TITLE
feat(server): surface B0 publication freshness in swarm-status FastAPI route

### DIFF
--- a/aragora/server/fastapi/routes/swarm_status.py
+++ b/aragora/server/fastapi/routes/swarm_status.py
@@ -13,6 +13,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.live_shift_status import _detect_benchmark_freshness
 from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH as DEFAULT_SHIFT_LEDGER_PATH
 from aragora.swarm.shift_ledger import ShiftLedger
 
@@ -85,12 +86,21 @@ def swarm_status_summary(
     rows = _tail_jsonl(path, window)
     ledger_status = _load_ledger_status(repo_root=root, ledger_path=ledger_path)
 
+    # B0 publication freshness — Round 2026-04-30c Phase C, additive surface
+    # for the Foreman-gate operability signal.  Reads `generated_at` from the
+    # canonical B0 truth artifact at
+    # docs/status/generated/benchmark_scorecards/.../latest.json and reports
+    # three keys: current_benchmark_fresh / _age_hours / _generated_at.
+    # All-None when the artifact is missing or unparseable; never errors.
+    benchmark_freshness = _detect_benchmark_freshness(root)
+
     if not rows and not ledger_status:
         return {
             "status": "no_data",
             "metrics_path": str(path),
             "window": window,
             "total_ticks": 0,
+            **benchmark_freshness,
         }
 
     terminal_classes: Counter[str] = Counter()
@@ -161,11 +171,17 @@ def swarm_status_summary(
         "merge_running": (
             ledger_status.get("current_merge_running") if isinstance(ledger_status, dict) else None
         ),
+        # ``benchmark_fresh`` (legacy) is the ledger's last-tick view.
+        # Round 2026-04-30c Phase C adds the on-disk artifact-driven view
+        # via ``current_benchmark_fresh`` / ``_age_hours`` /
+        # ``_generated_at`` — these reflect what's actually published on
+        # main, complementing the ledger's record.
         "benchmark_fresh": (
             ledger_status.get("current_benchmark_fresh")
             if isinstance(ledger_status, dict)
             else None
         ),
+        **benchmark_freshness,
         "last_stop_reason": (
             ledger_status.get("last_stop_reason") if isinstance(ledger_status, dict) else ""
         ),

--- a/tests/server/fastapi/routes/test_swarm_status.py
+++ b/tests/server/fastapi/routes/test_swarm_status.py
@@ -247,3 +247,122 @@ def test_register_routes_adds_swarm_status_endpoints() -> None:
     assert "/api/v1/swarm/status" in route_paths
     assert "/api/v1/swarm/preflight" in route_paths
     assert "/api/v1/swarm/preflight/receipts" in route_paths
+
+
+# ---------------------------------------------------------------------------
+# Round 2026-04-30c Phase C: B0 publication freshness fields surfaced to the
+# FastAPI swarm-status route.  Closes the Optional Fix C from the #6798
+# design note: dashboard consumers can now distinguish "ledger says fresh"
+# (the existing ``benchmark_fresh`` field, which reads from the ledger
+# last-tick payload) from "the on-disk artifact actually IS fresh"
+# (``current_benchmark_fresh`` populated by ``_detect_benchmark_freshness``).
+# ---------------------------------------------------------------------------
+
+
+def _write_b0_artifact(repo_root: Path, generated_at: str | None) -> Path:
+    """Write a stub B0 truth artifact at the canonical relative path."""
+    target = (
+        repo_root
+        / "docs"
+        / "status"
+        / "generated"
+        / "benchmark_scorecards"
+        / "tw-01-bounded-execution-v1"
+        / "latest.json"
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, object] = {"corpus_id": "tw-01-bounded-execution-v1", "revision": 3}
+    if generated_at is not None:
+        payload["generated_at"] = generated_at
+    target.write_text(json.dumps(payload), encoding="utf-8")
+    return target
+
+
+def test_swarm_status_no_data_includes_benchmark_freshness_keys(tmp_path: Path) -> None:
+    """Even on the no-data path the three new keys must be present (None)."""
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path, repo_root=tmp_path)
+    assert summary["status"] == "no_data"
+    assert summary["current_benchmark_fresh"] is None
+    assert summary["current_benchmark_age_hours"] is None
+    assert summary["current_benchmark_generated_at"] is None
+
+
+def test_swarm_status_active_with_fresh_b0_artifact(tmp_path: Path) -> None:
+    """Active path with a recent B0 artifact reports current_benchmark_fresh=True."""
+    from datetime import datetime, timedelta, timezone
+
+    recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+    _write_b0_artifact(tmp_path, recent)
+
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    _write_jsonl(
+        metrics_path,
+        [{"timestamp": "2026-04-30T01:00:00Z", "terminal_class": "deliverable_pr_created"}],
+    )
+
+    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path, repo_root=tmp_path)
+    assert summary["status"] == "active"
+    assert summary["current_benchmark_fresh"] is True
+    assert summary["current_benchmark_age_hours"] is not None
+    assert 0 <= summary["current_benchmark_age_hours"] <= 2.0
+    assert summary["current_benchmark_generated_at"] == recent
+
+
+def test_swarm_status_active_with_stale_b0_artifact(tmp_path: Path) -> None:
+    """Active path with a stale B0 artifact reports current_benchmark_fresh=False."""
+    from datetime import datetime, timedelta, timezone
+
+    stale = (datetime.now(timezone.utc) - timedelta(hours=30)).isoformat().replace("+00:00", "Z")
+    _write_b0_artifact(tmp_path, stale)
+
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    _write_jsonl(
+        metrics_path,
+        [{"timestamp": "2026-04-30T01:00:00Z", "terminal_class": "deliverable_pr_created"}],
+    )
+
+    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path, repo_root=tmp_path)
+    assert summary["status"] == "active"
+    assert summary["current_benchmark_fresh"] is False
+    assert summary["current_benchmark_age_hours"] is not None
+    assert summary["current_benchmark_age_hours"] >= 24.0
+
+
+def test_swarm_status_active_with_missing_b0_artifact(tmp_path: Path) -> None:
+    """Active path with no B0 artifact at all reports None for all freshness keys.
+
+    A missing artifact is its own degraded state; we don't synthesise a
+    boolean from absent data.
+    """
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    _write_jsonl(
+        metrics_path,
+        [{"timestamp": "2026-04-30T01:00:00Z", "terminal_class": "deliverable_pr_created"}],
+    )
+
+    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path, repo_root=tmp_path)
+    assert summary["status"] == "active"
+    assert summary["current_benchmark_fresh"] is None
+    assert summary["current_benchmark_age_hours"] is None
+    assert summary["current_benchmark_generated_at"] is None
+
+
+def test_swarm_status_legacy_benchmark_fresh_field_preserved(tmp_path: Path) -> None:
+    """The legacy ``benchmark_fresh`` field (ledger-driven) is kept side-by-side
+    with the new artifact-driven fields. Callers that were reading
+    ``benchmark_fresh`` continue to work; callers that want artifact-grounded
+    truth read ``current_benchmark_fresh``.
+    """
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    _write_jsonl(
+        metrics_path,
+        [{"timestamp": "2026-04-30T01:00:00Z", "terminal_class": "deliverable_pr_created"}],
+    )
+
+    summary = swarm_status.swarm_status_summary(metrics_path=metrics_path, repo_root=tmp_path)
+    # Legacy field still in the payload, alongside the new ones.
+    assert "benchmark_fresh" in summary
+    assert "current_benchmark_fresh" in summary
+    assert "current_benchmark_age_hours" in summary
+    assert "current_benchmark_generated_at" in summary


### PR DESCRIPTION
## Summary

Round 2026-04-30c — Phase C (Tier 2). Closes Optional Fix C from the #6798 design note: extend the FastAPI swarm-status route to surface the on-disk B0 truth artifact's freshness fields, complementing the existing ledger-driven `benchmark_fresh` field.

## Why this matters

Two semantically different signals were collapsing into one operator surface:

| Field | Source | Meaning |
|---|---|---|
| `benchmark_fresh` (legacy) | `ShiftLedger.get_status_summary()` last-tick payload | What the boss-loop wrote when it last ticked |
| `current_benchmark_fresh` (new) | `_detect_benchmark_freshness` reads `latest.json` | What the publisher actually has on main right now |

Together they let dashboards distinguish "ledger says fresh" from "the artifact actually IS fresh" — the second is the signal the Foreman gate cares about.

## Implementation

- Import `_detect_benchmark_freshness` from `aragora.swarm.live_shift_status` (already on main from #6836).
- Call it once in `swarm_status_summary` and merge the three keys into BOTH the no-data response and the active response.
- Legacy `benchmark_fresh` field kept side-by-side; existing consumers continue to work unchanged.

## New response fields

```jsonc
{
  "current_benchmark_fresh": true | false | null,    // bool / None
  "current_benchmark_age_hours": 1.5 | null,          // float / None
  "current_benchmark_generated_at": "2026-04-30T03:00:00Z" | null
}
```

All-None when the artifact is missing or unparseable; never errors.

## Tests (5 new, 13 total)

- `test_swarm_status_no_data_includes_benchmark_freshness_keys` — schema invariant on no-data path
- `test_swarm_status_active_with_fresh_b0_artifact` — fresh → `current_benchmark_fresh=True`
- `test_swarm_status_active_with_stale_b0_artifact` — stale → `current_benchmark_fresh=False`
- `test_swarm_status_active_with_missing_b0_artifact` — missing → all-None
- `test_swarm_status_legacy_benchmark_fresh_field_preserved` — legacy field continues to work

## Verification

- 13/13 tests pass deterministically (was 8)
- ruff check + format clean
- mypy clean
- preflight ok

## Diff stat

```
 aragora/server/fastapi/routes/swarm_status.py            |  20 ++-
 tests/server/fastapi/routes/test_swarm_status.py         | 115 +++++++++++++++++++++
 2 files changed, 135 insertions(+)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)