### PR TITLE
fix(cli): aragora crux ImportError on get_default_agents (use get_agents_by_names)

### DIFF
--- a/aragora/cli/commands/crux.py
+++ b/aragora/cli/commands/crux.py
@@ -37,7 +37,7 @@ async def _run_crux_debate(
 ) -> Any:
     """Run a crux-finder debate and return the Arena ``DebateResult``."""
     from aragora import Arena, Environment
-    from aragora.agents import get_default_agents
+    from aragora.agents import get_agents_by_names
     from aragora.debate.protocol import DebateProtocol
 
     protocol = DebateProtocol(
@@ -49,7 +49,15 @@ async def _run_crux_debate(
         use_structured_phases=False,
     )
 
-    resolved_agents = get_default_agents(agent_names=agents) if agents else get_default_agents()
+    # Resolve agent names to instances.  ``get_default_agents`` (the symbol
+    # this CLI originally referenced) does not exist on
+    # ``aragora.agents``; the exported helper is ``get_agents_by_names``.
+    # Found via Phase F end-to-end dogfood in Round 2026-04-30c — the
+    # ``aragora crux`` CLI raised ``ImportError`` for any invocation that
+    # was not ``--dry-run``.
+    resolved_agents = (
+        get_agents_by_names(agents) if agents else get_agents_by_names(["claude", "codex"])
+    )
 
     env = Environment(task=question)
     arena = Arena(env, resolved_agents, protocol)

--- a/tests/cli/test_crux_command.py
+++ b/tests/cli/test_crux_command.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -290,3 +290,43 @@ def test_cmd_crux_rejects_non_crux_proof(capsys) -> None:
             crux_cmd.cmd_crux(args)
     assert exc_info.value.code == 1
     assert "crux-finder" in capsys.readouterr().err
+
+
+def test_run_crux_debate_imports_resolve_without_error() -> None:
+    """Regression: the inner imports must resolve without raising.
+
+    The CLI used to import a non-existent ``get_default_agents`` from
+    ``aragora.agents`` (Phase F dogfood finding, Round 2026-04-30c). The
+    existing test bank patches ``_run_crux_debate`` directly so it never
+    executed the inner import path, allowing the break to live undetected.
+
+    This test exercises the import path by invoking the function with all
+    its collaborators stubbed; if the import fails the test fails with
+    ImportError before any stub is reached.
+    """
+    import asyncio
+
+    mock_arena = MagicMock()
+
+    async def _fake_arena_run() -> SimpleNamespace:
+        return SimpleNamespace(consensus_proof=None, proposals={})
+
+    mock_arena.run = _fake_arena_run
+
+    with (
+        patch("aragora.Arena", return_value=mock_arena),
+        patch("aragora.Environment", return_value=MagicMock()),
+        patch("aragora.agents.get_agents_by_names", return_value=[]),
+    ):
+        # Smoke-test only: passes as long as no ImportError is raised.
+        result = asyncio.run(
+            crux_cmd._run_crux_debate(
+                "Sample question?",
+                agents=["demo"],
+                rounds=1,
+                top_k=3,
+                min_score=0.3,
+                counterfactual_validation=False,
+            )
+        )
+    assert result is not None  # the mock returns a SimpleNamespace


### PR DESCRIPTION
## Summary

Round 2026-04-30c — Phase F (Tier 2). The `aragora crux` CLI imported `get_default_agents` from `aragora.agents` — but that symbol does not exist. The exported helper is `get_agents_by_names`. Any non-dry-run invocation of `aragora crux <question>` raised:

```
ImportError: cannot import name 'get_default_agents' from 'aragora.agents'
```

Found via Phase F end-to-end dogfood. The CLI's existing test bank patched `_run_crux_debate` directly and never exercised the inner import path, allowing this break to live undetected.

## Fix

Replace `get_default_agents(agent_names=agents)` with `get_agents_by_names(agents)`. Default agents when no `--agents` flag is passed are kept identical to the CLI help documentation: `["claude", "codex"]`.

## Tests

- **New** `test_run_crux_debate_imports_resolve_without_error` — exercises the inner import path with all collaborators stubbed. This would have caught the bug before it shipped.
- All 9 existing crux-command tests continue to pass.

## Verification

- 10/10 tests pass deterministically (was 9)
- ruff check + format clean
- mypy clean on `crux.py`
- preflight ok
- Live import probe confirms inner path resolves without ImportError

## Diff stat

```
 aragora/cli/commands/crux.py     | 12 +++++++++--
 tests/cli/test_crux_command.py   | 42 +++++++++++++++++++++++++++++++++++++++-
 2 files changed, 51 insertions(+), 3 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)