### PR TITLE
fix(automation): unblock publisher queue health false positives

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -115,7 +115,7 @@ def local_branches(root: Path, prefix: str, base: str) -> list[dict[str, str]]:
     proc = run_git(
         [
             "for-each-ref",
-            f"--format=%(refname:short)|%(upstream:short)|%(objectname:short)|%(committerdate:iso8601)|%(ahead-behind:{base})|%(subject)",
+            "--format=%(refname:short)|%(upstream:short)|%(objectname:short)|%(committerdate:iso8601)|%(subject)",
             ref_prefix,
         ],
         root,
@@ -127,16 +127,15 @@ def local_branches(root: Path, prefix: str, base: str) -> list[dict[str, str]]:
     for line in proc.stdout.splitlines():
         if not line.strip():
             continue
-        name, upstream, head_sha, committed_at, ahead_behind, subject = line.split("|", 5)
-        ahead_count, _, behind_count = ahead_behind.partition(" ")
+        name, upstream, head_sha, committed_at, subject = line.split("|", 4)
         rows.append(
             {
                 "name": name,
                 "upstream": upstream,
                 "head_sha": head_sha,
                 "committed_at": committed_at,
-                "ahead_count": ahead_count or "0",
-                "behind_count": behind_count or "0",
+                "ahead_count": "",
+                "behind_count": "",
                 "subject": subject,
             }
         )
@@ -480,13 +479,19 @@ def open_pr_heads(root: Path, repo: str, prefix: str) -> dict[str, int]:
 
 
 def count_ahead(root: Path, base: str, branch: str) -> int:
-    proc = run_git(["rev-list", "--count", f"{base}..{branch}"], root)
+    ahead_count, _behind_count = branch_divergence(root, base, branch)
+    return ahead_count
+
+
+def branch_divergence(root: Path, base: str, branch: str) -> tuple[int, int]:
+    proc = run_git(["rev-list", "--left-right", "--count", f"{base}...{branch}"], root)
     if proc.returncode != 0:
-        return 0
+        return (0, 0)
     try:
-        return int(proc.stdout.strip() or "0")
+        behind_count, ahead_count = (int(part) for part in proc.stdout.split())
+        return (ahead_count, behind_count)
     except ValueError:
-        return 0
+        return (0, 0)
 
 
 def is_merged(root: Path, base: str, branch: str) -> bool:
@@ -708,11 +713,12 @@ def audit(
         try:
             ahead_count = int(row["ahead_count"])
         except ValueError:
-            ahead_count = count_ahead(root, base, branch)
-        try:
-            behind_count = int(row.get("behind_count", "0"))
-        except ValueError:
-            behind_count = 0
+            ahead_count, behind_count = branch_divergence(root, base, branch)
+        else:
+            try:
+                behind_count = int(row.get("behind_count", "0"))
+            except ValueError:
+                _ahead_count, behind_count = branch_divergence(root, base, branch)
         merged_to_base = branch in merged_branches
         patch_equivalent = False
         patch_id = None

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -46,9 +46,15 @@ UNHEALTHY_CHECK_STATES = {
     "FAILED",
     "TIMED_OUT",
 }
+HEALTHY_CHECK_STATES = {
+    "SUCCESS",
+    "NEUTRAL",
+    "SKIPPED",
+}
 CANCELLED_ADVISORY_WORKFLOWS = {
     "Metrics Drift",
     "Module Tier Drift",
+    "PR Admission Controller",
 }
 STOPWORDS = {
     "and",
@@ -447,7 +453,7 @@ def _open_codex_prs(repo_root: Path, repo: str) -> list[dict[str, Any]]:
             "--limit",
             "200",
             "--json",
-            "headRefName,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup",
+            "number,title,headRefName,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup",
         ],
         cwd=repo_root,
     )
@@ -490,6 +496,62 @@ def _check_rollup_is_unhealthy(item: dict[str, Any]) -> bool:
     return workflow_name not in CANCELLED_ADVISORY_WORKFLOWS
 
 
+def _check_rollup_identity(item: dict[str, Any]) -> tuple[str, str]:
+    return (str(item.get("workflowName") or ""), str(item.get("name") or ""))
+
+
+def _check_rollup_label(item: dict[str, Any]) -> str:
+    workflow_name, check_name = _check_rollup_identity(item)
+    return "/".join(part for part in (workflow_name, check_name) if part) or "unknown-check"
+
+
+def _unhealthy_check_rollup_items(check_rollup: Any) -> list[dict[str, Any]]:
+    if not isinstance(check_rollup, list):
+        return []
+
+    checks = [check for check in check_rollup if isinstance(check, dict)]
+    healthy_identities = {
+        _check_rollup_identity(check)
+        for check in checks
+        if _rollup_state(check) in HEALTHY_CHECK_STATES
+    }
+    unhealthy: list[dict[str, Any]] = []
+    for check in checks:
+        if not _check_rollup_is_unhealthy(check):
+            continue
+        if (
+            _rollup_state(check) == "CANCELLED"
+            and _check_rollup_identity(check) in healthy_identities
+        ):
+            continue
+        unhealthy.append(check)
+    return unhealthy
+
+
+def _open_codex_pr_unhealthy_reasons(item: dict[str, Any]) -> list[str]:
+    merge_state = str(item.get("mergeStateStatus") or "UNKNOWN").upper()
+    if merge_state == "DIRTY":
+        return ["merge_state=DIRTY"]
+    if merge_state != "BLOCKED":
+        return []
+    if item.get("isDraft") is True:
+        return ["draft=true"]
+
+    unhealthy_checks = _unhealthy_check_rollup_items(item.get("statusCheckRollup") or [])
+    if unhealthy_checks:
+        return [
+            f"check={_check_rollup_label(check)}:{_rollup_state(check)}"
+            for check in unhealthy_checks
+        ]
+
+    review_decision = str(item.get("reviewDecision") or "").upper()
+    if review_decision == "REVIEW_REQUIRED":
+        return []
+    if review_decision == "CHANGES_REQUESTED":
+        return ["review_decision=CHANGES_REQUESTED"]
+    return [f"review_decision={review_decision or 'UNKNOWN'}"]
+
+
 def _open_codex_pr_is_unhealthy(item: dict[str, Any]) -> bool:
     """Return true only for PR states that should pause more automation publishing.
 
@@ -499,27 +561,7 @@ def _open_codex_pr_is_unhealthy(item: dict[str, Any]) -> bool:
     below budget.
     """
 
-    merge_state = str(item.get("mergeStateStatus") or "UNKNOWN").upper()
-    if merge_state == "DIRTY":
-        return True
-    if merge_state != "BLOCKED":
-        return False
-    if item.get("isDraft") is True:
-        return True
-
-    check_rollup = item.get("statusCheckRollup") or []
-    if isinstance(check_rollup, list):
-        if any(
-            _check_rollup_is_unhealthy(check) for check in check_rollup if isinstance(check, dict)
-        ):
-            return True
-
-    review_decision = str(item.get("reviewDecision") or "").upper()
-    if review_decision == "REVIEW_REQUIRED":
-        return False
-    if review_decision == "CHANGES_REQUESTED":
-        return True
-    return True
+    return bool(_open_codex_pr_unhealthy_reasons(item))
 
 
 def _branch_remote_head(repo_root: Path, branch: str) -> str | None:
@@ -1135,10 +1177,23 @@ def main(argv: list[str] | None = None) -> int:
         superseded_outbox_branches=superseded_outbox_lookup,
     )
     merge_state_counts: dict[str, int] = {}
+    unhealthy_open_prs: list[dict[str, Any]] = []
     for item in open_codex_prs:
         state = str(item.get("mergeStateStatus") or "UNKNOWN").upper()
         merge_state_counts[state] = merge_state_counts.get(state, 0) + 1
-    unhealthy_open_pr_count = sum(1 for item in open_codex_prs if _open_codex_pr_is_unhealthy(item))
+        unhealthy_reasons = _open_codex_pr_unhealthy_reasons(item)
+        if unhealthy_reasons:
+            unhealthy_open_prs.append(
+                {
+                    "number": item.get("number"),
+                    "title": item.get("title"),
+                    "headRefName": item.get("headRefName"),
+                    "mergeStateStatus": item.get("mergeStateStatus"),
+                    "reviewDecision": item.get("reviewDecision"),
+                    "reasons": unhealthy_reasons,
+                }
+            )
+    unhealthy_open_pr_count = len(unhealthy_open_prs)
     all_open_prs_unhealthy = bool(open_codex_prs) and unhealthy_open_pr_count == len(open_codex_prs)
 
     payload: dict[str, Any] = {
@@ -1153,6 +1208,7 @@ def main(argv: list[str] | None = None) -> int:
             "unhealthy_open_pr_count": unhealthy_open_pr_count,
             "merge_state_counts": merge_state_counts,
             "all_open_prs_unhealthy": all_open_prs_unhealthy,
+            "unhealthy_open_prs": unhealthy_open_prs,
         },
         "github_health": github_health.to_dict(),
         "decisions": [asdict(decision) for decision in decisions],

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -38,6 +38,45 @@ def _stub_git_inventory(monkeypatch: Any, row: dict[str, str]) -> None:
     monkeypatch.setattr(mod, "worktree_map", lambda _root: {})
 
 
+def test_local_branches_defers_expensive_divergence_lookup(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run_git(
+        args: list[str], cwd: Path, *, timeout: int = 60
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout="codex/example||abc1234|2026-04-30 00:00:00 +0000|test branch\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+
+    rows = mod.local_branches(tmp_path, "codex/", "origin/main")
+
+    assert "%(ahead-behind:" not in calls[0][1]
+    assert rows[0]["ahead_count"] == ""
+    assert rows[0]["behind_count"] == ""
+
+
+def test_branch_divergence_parses_rev_list_left_right_counts(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    def fake_run_git(
+        args: list[str], cwd: Path, *, timeout: int = 60
+    ) -> subprocess.CompletedProcess[str]:
+        assert args == ["rev-list", "--left-right", "--count", "origin/main...codex/example"]
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="3\t7\n", stderr="")
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+
+    assert mod.branch_divergence(tmp_path, "origin/main", "codex/example") == (7, 3)
+
+
 def test_summary_only_payload_omits_records_without_mutating_source() -> None:
     payload = {
         "branch_count": 2,

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -765,6 +765,8 @@ def test_main_pauses_apply_when_open_codex_queue_is_unhealthy(
     assert publish_called is False
     out = capsys.readouterr().out
     assert '"publish_paused_reason": "open_pr_queue_unhealthy"' in out
+    assert '"unhealthy_open_prs": [' in out
+    assert '"headRefName": "codex/b"' in out
 
 
 def test_main_can_override_unhealthy_queue_pause_for_preflighted_branch(
@@ -922,8 +924,39 @@ def test_review_required_inflight_pr_does_not_pause_for_pending_or_advisory_canc
                 "statusCheckRollup": [
                     {"conclusion": "CANCELLED", "workflowName": "Metrics Drift"},
                     {"conclusion": "CANCELLED", "workflowName": "Module Tier Drift"},
+                    {
+                        "conclusion": "CANCELLED",
+                        "workflowName": "PR Admission Controller",
+                        "name": "PR Admission Signal (Advisory)",
+                    },
                     {"status": "IN_PROGRESS", "workflowName": "Tests"},
                     {"status": "QUEUED", "workflowName": "Aragora Code Review"},
+                ],
+            }
+        )
+        is False
+    )
+
+
+def test_review_required_pr_ignores_superseded_cancelled_check() -> None:
+    assert (
+        mod._open_codex_pr_is_unhealthy(
+            {
+                "headRefName": "codex/superseded-cancel",
+                "isDraft": False,
+                "mergeStateStatus": "BLOCKED",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "statusCheckRollup": [
+                    {
+                        "conclusion": "CANCELLED",
+                        "workflowName": "Tests",
+                        "name": "Baseline Determinism",
+                    },
+                    {
+                        "conclusion": "SUCCESS",
+                        "workflowName": "Tests",
+                        "name": "Baseline Determinism",
+                    },
                 ],
             }
         )


### PR DESCRIPTION
## Summary
- ignore cancelled advisory PR Admission checks in the codex publisher queue-health gate
- ignore stale cancelled check runs when a healthy run for the same workflow/check identity exists
- expose unhealthy open codex PR details in publisher dry-run payloads
- make branch backlog audits avoid expensive ahead/behind lookup during initial ref enumeration

## Validation
- python3 -m pytest tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_audit_codex_branch_backlog.py -q
- python3 -m ruff check scripts/publish_codex_automation_branches.py scripts/audit_codex_branch_backlog.py tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_audit_codex_branch_backlog.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- publisher dry-run: queue_health.unhealthy_open_pr_count=0, all_open_prs_unhealthy=false
- backlog audit dry-run completed with branch_count=300, publishable_branch_backlog=1, safe_cleanup_candidates=30