### PR TITLE
[AGT-06] CP-* capability checkpoint registry (vision-layer)

### DIFF
--- a/aragora/metrics/capability_checkpoint.py
+++ b/aragora/metrics/capability_checkpoint.py
@@ -1,0 +1,166 @@
+"""Capability checkpoints for the booster-rocket thesis (AGT-06 / #6067).
+
+Five graduation gates from substrate to surface; see
+``docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md`` §5.
+
+Flag: ``ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED`` (default off).
+Dataclasses are always constructable; :meth:`CheckpointRegistry.record` is gated.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def capability_checkpoints_enabled() -> bool:
+    return os.environ.get("ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED", "").lower() in _TRUTHY
+
+
+class CheckpointCode(str, Enum):
+    CP1 = "CP-1"
+    CP2 = "CP-2"
+    CP3 = "CP-3"
+    CP4 = "CP-4"
+    CP5 = "CP-5"
+
+
+class CheckpointStatus(str, Enum):
+    PENDING = "pending"
+    PASS = "pass"
+    FAIL = "fail"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class CapabilityCheckpoint:
+    code: CheckpointCode
+    title: str
+    window_weeks: int
+    depends_on: CheckpointCode | None
+    pass_condition: str
+    action_if_not_met: str
+
+
+@dataclass
+class CheckpointRecord:
+    checkpoint_code: CheckpointCode
+    status: CheckpointStatus
+    evaluated_at: str
+    evaluator: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+    notes: str = ""
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        checkpoint_code: CheckpointCode,
+        status: CheckpointStatus,
+        evaluator: str,
+        evidence: dict[str, Any] | None = None,
+        notes: str = "",
+        evaluated_at: str | None = None,
+    ) -> "CheckpointRecord":
+        return cls(
+            checkpoint_code=checkpoint_code, status=status, evaluator=evaluator,
+            evidence=dict(evidence or {}), notes=notes,
+            evaluated_at=evaluated_at or datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "checkpoint_code": self.checkpoint_code.value, "status": self.status.value,
+            "evaluated_at": self.evaluated_at, "evaluator": self.evaluator,
+            "evidence": self.evidence, "notes": self.notes,
+        }
+
+
+class CheckpointRegistryError(RuntimeError):
+    pass
+
+
+class CheckpointRegistry:
+    """In-memory registry; reads always allowed, writes are flag-gated."""
+
+    def __init__(self, checkpoints: list[CapabilityCheckpoint]) -> None:
+        if not checkpoints:
+            raise CheckpointRegistryError("checkpoints must be non-empty")
+        self._cps: dict[CheckpointCode, CapabilityCheckpoint] = {cp.code: cp for cp in checkpoints}
+        self._records: list[CheckpointRecord] = []
+
+    def checkpoint(self, code: CheckpointCode) -> CapabilityCheckpoint:
+        try:
+            return self._cps[code]
+        except KeyError as exc:
+            raise CheckpointRegistryError(f"unknown checkpoint: {code!r}") from exc
+
+    def all_checkpoints(self) -> list[CapabilityCheckpoint]:
+        return [self._cps[c] for c in sorted(self._cps, key=lambda c: c.value)]
+
+    def status_of(self, code: CheckpointCode) -> CheckpointStatus:
+        hits = [r for r in self._records if r.checkpoint_code == code]
+        return hits[-1].status if hits else CheckpointStatus.PENDING
+
+    def latest_record(self, code: CheckpointCode) -> CheckpointRecord | None:
+        hits = [r for r in self._records if r.checkpoint_code == code]
+        return hits[-1] if hits else None
+
+    def record(self, rec: CheckpointRecord) -> CheckpointRecord:
+        """Append *rec* (flag-gated). Raises if disabled or code unknown."""
+        if not capability_checkpoints_enabled():
+            raise CheckpointRegistryError(
+                "capability-checkpoint recording is disabled; "
+                "set ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED=1 to enable"
+            )
+        if rec.checkpoint_code not in self._cps:
+            raise CheckpointRegistryError(f"unknown checkpoint code: {rec.checkpoint_code!r}")
+        self._records.append(rec)
+        return rec
+
+
+_DEFAULTS = [
+    ("CP-1", "Sustained substrate", 4, None,
+     "3 consecutive green BC-12 soaks (1 idle + 2 productive); "
+     "no LaunchAgent respawn-failure incidents requiring human kickstart",
+     "Pause AGT-* planning work; debug substrate self-healing"),
+    ("CP-2", "Live crux activation", 4, "CP-1",
+     "CruxDetector emits ranked CruxSet on >=20 real debates per week; "
+     "at least one CruxSet linked to a follow-up issue or claim",
+     "Reduce AGT scope to crux-only and re-evaluate"),
+    ("CP-3", "External truth signal", 4, "CP-2",
+     "Manifold + Metaculus integration produces >=100 resolved predictions "
+     "per agent per week; calibration curve is stable",
+     "Defer reputation wiring; debug prediction pipeline"),
+    ("CP-4", "Reputation flow live", 4, "CP-3",
+     "At least one agent has reputation delta drive a real "
+     "dispatch-eligibility change in production",
+     "Reduce to read-only reputation surface; revisit policy"),
+    ("CP-5", "Productivity-positive", 4, "CP-4",
+     "VIAH trends positive over rolling 4-week window without operator rescue spike",
+     "Pause new boosters; consolidate existing layers"),
+]
+
+
+def build_default_registry() -> CheckpointRegistry:
+    """Return a registry with all 5 checkpoints (all start PENDING, no records)."""
+    return CheckpointRegistry([
+        CapabilityCheckpoint(
+            code=CheckpointCode(code), title=title, window_weeks=weeks,
+            depends_on=CheckpointCode(dep) if dep else None,
+            pass_condition=pass_cond, action_if_not_met=action,
+        )
+        for code, title, weeks, dep, pass_cond, action in _DEFAULTS
+    ])
+
+
+__all__ = [
+    "CapabilityCheckpoint", "CheckpointCode", "CheckpointRecord",
+    "CheckpointRegistry", "CheckpointRegistryError", "CheckpointStatus",
+    "build_default_registry", "capability_checkpoints_enabled",
+]

--- a/aragora/metrics/capability_checkpoint.py
+++ b/aragora/metrics/capability_checkpoint.py
@@ -68,16 +68,22 @@ class CheckpointRecord:
         evaluated_at: str | None = None,
     ) -> "CheckpointRecord":
         return cls(
-            checkpoint_code=checkpoint_code, status=status, evaluator=evaluator,
-            evidence=dict(evidence or {}), notes=notes,
+            checkpoint_code=checkpoint_code,
+            status=status,
+            evaluator=evaluator,
+            evidence=dict(evidence or {}),
+            notes=notes,
             evaluated_at=evaluated_at or datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
         )
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "checkpoint_code": self.checkpoint_code.value, "status": self.status.value,
-            "evaluated_at": self.evaluated_at, "evaluator": self.evaluator,
-            "evidence": self.evidence, "notes": self.notes,
+            "checkpoint_code": self.checkpoint_code.value,
+            "status": self.status.value,
+            "evaluated_at": self.evaluated_at,
+            "evaluator": self.evaluator,
+            "evidence": self.evidence,
+            "notes": self.notes,
         }
 
 
@@ -125,42 +131,77 @@ class CheckpointRegistry:
 
 
 _DEFAULTS = [
-    ("CP-1", "Sustained substrate", 4, None,
-     "3 consecutive green BC-12 soaks (1 idle + 2 productive); "
-     "no LaunchAgent respawn-failure incidents requiring human kickstart",
-     "Pause AGT-* planning work; debug substrate self-healing"),
-    ("CP-2", "Live crux activation", 4, "CP-1",
-     "CruxDetector emits ranked CruxSet on >=20 real debates per week; "
-     "at least one CruxSet linked to a follow-up issue or claim",
-     "Reduce AGT scope to crux-only and re-evaluate"),
-    ("CP-3", "External truth signal", 4, "CP-2",
-     "Manifold + Metaculus integration produces >=100 resolved predictions "
-     "per agent per week; calibration curve is stable",
-     "Defer reputation wiring; debug prediction pipeline"),
-    ("CP-4", "Reputation flow live", 4, "CP-3",
-     "At least one agent has reputation delta drive a real "
-     "dispatch-eligibility change in production",
-     "Reduce to read-only reputation surface; revisit policy"),
-    ("CP-5", "Productivity-positive", 4, "CP-4",
-     "VIAH trends positive over rolling 4-week window without operator rescue spike",
-     "Pause new boosters; consolidate existing layers"),
+    (
+        "CP-1",
+        "Sustained substrate",
+        4,
+        None,
+        "3 consecutive green BC-12 soaks (1 idle + 2 productive); "
+        "no LaunchAgent respawn-failure incidents requiring human kickstart",
+        "Pause AGT-* planning work; debug substrate self-healing",
+    ),
+    (
+        "CP-2",
+        "Live crux activation",
+        4,
+        "CP-1",
+        "CruxDetector emits ranked CruxSet on >=20 real debates per week; "
+        "at least one CruxSet linked to a follow-up issue or claim",
+        "Reduce AGT scope to crux-only and re-evaluate",
+    ),
+    (
+        "CP-3",
+        "External truth signal",
+        4,
+        "CP-2",
+        "Manifold + Metaculus integration produces >=100 resolved predictions "
+        "per agent per week; calibration curve is stable",
+        "Defer reputation wiring; debug prediction pipeline",
+    ),
+    (
+        "CP-4",
+        "Reputation flow live",
+        4,
+        "CP-3",
+        "At least one agent has reputation delta drive a real "
+        "dispatch-eligibility change in production",
+        "Reduce to read-only reputation surface; revisit policy",
+    ),
+    (
+        "CP-5",
+        "Productivity-positive",
+        4,
+        "CP-4",
+        "VIAH trends positive over rolling 4-week window without operator rescue spike",
+        "Pause new boosters; consolidate existing layers",
+    ),
 ]
 
 
 def build_default_registry() -> CheckpointRegistry:
     """Return a registry with all 5 checkpoints (all start PENDING, no records)."""
-    return CheckpointRegistry([
-        CapabilityCheckpoint(
-            code=CheckpointCode(code), title=title, window_weeks=weeks,
-            depends_on=CheckpointCode(dep) if dep else None,
-            pass_condition=pass_cond, action_if_not_met=action,
-        )
-        for code, title, weeks, dep, pass_cond, action in _DEFAULTS
-    ])
+    return CheckpointRegistry(
+        [
+            CapabilityCheckpoint(
+                code=CheckpointCode(code),
+                title=title,
+                window_weeks=weeks,
+                depends_on=CheckpointCode(dep) if dep else None,
+                pass_condition=pass_cond,
+                action_if_not_met=action,
+            )
+            for code, title, weeks, dep, pass_cond, action in _DEFAULTS
+        ]
+    )
 
 
 __all__ = [
-    "CapabilityCheckpoint", "CheckpointCode", "CheckpointRecord",
-    "CheckpointRegistry", "CheckpointRegistryError", "CheckpointStatus",
-    "build_default_registry", "capability_checkpoints_enabled",
+    "CapabilityCheckpoint",
+    "CheckpointCode",
+    "CheckpointRecord",
+    "CheckpointRegistry",
+    "CheckpointRegistryError",
+    "CheckpointStatus",
+    "build_default_registry",
+    "capability_checkpoints_enabled",
 ]

--- a/tests/metrics/test_capability_checkpoint.py
+++ b/tests/metrics/test_capability_checkpoint.py
@@ -15,13 +15,16 @@ from aragora.metrics.capability_checkpoint import (
 )
 
 
-def _rec(code: CheckpointCode, status: CheckpointStatus = CheckpointStatus.PASS) -> CheckpointRecord:
+def _rec(
+    code: CheckpointCode, status: CheckpointStatus = CheckpointStatus.PASS
+) -> CheckpointRecord:
     return CheckpointRecord.create(checkpoint_code=code, status=status, evaluator="t")
 
 
 # ---------------------------------------------------------------------------
 # Feature flag
 # ---------------------------------------------------------------------------
+
 
 def test_flag_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED", raising=False)
@@ -38,6 +41,7 @@ def test_flag_enabled_truthy(monkeypatch: pytest.MonkeyPatch, val: str) -> None:
 # Default registry structure (mirrors AGENT_CIVILIZATION_SUBSTRATE.md §5)
 # ---------------------------------------------------------------------------
 
+
 def test_default_registry_has_five_checkpoints() -> None:
     assert len(build_default_registry().all_checkpoints()) == 5
 
@@ -50,8 +54,12 @@ def test_all_checkpoints_start_pending() -> None:
 def test_dependency_chain() -> None:
     reg = build_default_registry()
     assert reg.checkpoint(CheckpointCode.CP1).depends_on is None
-    for code, dep in [(CheckpointCode.CP2, CheckpointCode.CP1), (CheckpointCode.CP3, CheckpointCode.CP2),
-                      (CheckpointCode.CP4, CheckpointCode.CP3), (CheckpointCode.CP5, CheckpointCode.CP4)]:
+    for code, dep in [
+        (CheckpointCode.CP2, CheckpointCode.CP1),
+        (CheckpointCode.CP3, CheckpointCode.CP2),
+        (CheckpointCode.CP4, CheckpointCode.CP3),
+        (CheckpointCode.CP5, CheckpointCode.CP4),
+    ]:
         assert reg.checkpoint(code).depends_on == dep
 
 
@@ -77,14 +85,17 @@ def test_unknown_code_raises() -> None:
 # CheckpointRecord
 # ---------------------------------------------------------------------------
 
+
 def test_record_create_auto_timestamp() -> None:
     assert _rec(CheckpointCode.CP1).evaluated_at.endswith("Z")
 
 
 def test_record_to_dict_shape() -> None:
     d = CheckpointRecord.create(
-        checkpoint_code=CheckpointCode.CP3, status=CheckpointStatus.SKIPPED,
-        evaluator="ci", notes="skip",
+        checkpoint_code=CheckpointCode.CP3,
+        status=CheckpointStatus.SKIPPED,
+        evaluator="ci",
+        notes="skip",
     ).to_dict()
     assert d["checkpoint_code"] == "CP-3" and d["status"] == "skipped" and d["notes"] == "skip"
 
@@ -92,8 +103,10 @@ def test_record_to_dict_shape() -> None:
 def test_record_evidence_preserved() -> None:
     ev = {"shift_entry": "abc"}
     rec = CheckpointRecord.create(
-        checkpoint_code=CheckpointCode.CP1, status=CheckpointStatus.PASS,
-        evaluator="op", evidence=ev,
+        checkpoint_code=CheckpointCode.CP1,
+        status=CheckpointStatus.PASS,
+        evaluator="op",
+        evidence=ev,
     )
     assert rec.evidence == ev
 
@@ -101,6 +114,7 @@ def test_record_evidence_preserved() -> None:
 # ---------------------------------------------------------------------------
 # Registry write path (flag-gated)
 # ---------------------------------------------------------------------------
+
 
 def test_record_blocked_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED", raising=False)

--- a/tests/metrics/test_capability_checkpoint.py
+++ b/tests/metrics/test_capability_checkpoint.py
@@ -77,8 +77,9 @@ def test_checkpoints_sorted_by_code() -> None:
 
 
 def test_unknown_code_raises() -> None:
+    small = CheckpointRegistry([build_default_registry().checkpoint(CheckpointCode.CP1)])
     with pytest.raises(CheckpointRegistryError):
-        build_default_registry().checkpoint(CheckpointCode("CP-9"))  # type: ignore[arg-type]
+        small.checkpoint(CheckpointCode.CP2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/metrics/test_capability_checkpoint.py
+++ b/tests/metrics/test_capability_checkpoint.py
@@ -1,0 +1,130 @@
+"""Tests for aragora.metrics.capability_checkpoint — AGT-06 CP-* registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.metrics.capability_checkpoint import (
+    CheckpointCode,
+    CheckpointRecord,
+    CheckpointRegistry,
+    CheckpointRegistryError,
+    CheckpointStatus,
+    build_default_registry,
+    capability_checkpoints_enabled,
+)
+
+
+def _rec(code: CheckpointCode, status: CheckpointStatus = CheckpointStatus.PASS) -> CheckpointRecord:
+    return CheckpointRecord.create(checkpoint_code=code, status=status, evaluator="t")
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+def test_flag_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED", raising=False)
+    assert not capability_checkpoints_enabled()
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_flag_enabled_truthy(monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+    monkeypatch.setenv("ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED", val)
+    assert capability_checkpoints_enabled()
+
+
+# ---------------------------------------------------------------------------
+# Default registry structure (mirrors AGENT_CIVILIZATION_SUBSTRATE.md §5)
+# ---------------------------------------------------------------------------
+
+def test_default_registry_has_five_checkpoints() -> None:
+    assert len(build_default_registry().all_checkpoints()) == 5
+
+
+def test_all_checkpoints_start_pending() -> None:
+    reg = build_default_registry()
+    assert all(reg.status_of(cp.code) == CheckpointStatus.PENDING for cp in reg.all_checkpoints())
+
+
+def test_dependency_chain() -> None:
+    reg = build_default_registry()
+    assert reg.checkpoint(CheckpointCode.CP1).depends_on is None
+    for code, dep in [(CheckpointCode.CP2, CheckpointCode.CP1), (CheckpointCode.CP3, CheckpointCode.CP2),
+                      (CheckpointCode.CP4, CheckpointCode.CP3), (CheckpointCode.CP5, CheckpointCode.CP4)]:
+        assert reg.checkpoint(code).depends_on == dep
+
+
+def test_all_window_weeks_are_4() -> None:
+    assert all(cp.window_weeks == 4 for cp in build_default_registry().all_checkpoints())
+
+
+def test_cp5_pass_condition_mentions_viah() -> None:
+    assert "VIAH" in build_default_registry().checkpoint(CheckpointCode.CP5).pass_condition
+
+
+def test_checkpoints_sorted_by_code() -> None:
+    codes = [cp.code.value for cp in build_default_registry().all_checkpoints()]
+    assert codes == sorted(codes)
+
+
+def test_unknown_code_raises() -> None:
+    with pytest.raises(CheckpointRegistryError):
+        build_default_registry().checkpoint(CheckpointCode("CP-9"))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# CheckpointRecord
+# ---------------------------------------------------------------------------
+
+def test_record_create_auto_timestamp() -> None:
+    assert _rec(CheckpointCode.CP1).evaluated_at.endswith("Z")
+
+
+def test_record_to_dict_shape() -> None:
+    d = CheckpointRecord.create(
+        checkpoint_code=CheckpointCode.CP3, status=CheckpointStatus.SKIPPED,
+        evaluator="ci", notes="skip",
+    ).to_dict()
+    assert d["checkpoint_code"] == "CP-3" and d["status"] == "skipped" and d["notes"] == "skip"
+
+
+def test_record_evidence_preserved() -> None:
+    ev = {"shift_entry": "abc"}
+    rec = CheckpointRecord.create(
+        checkpoint_code=CheckpointCode.CP1, status=CheckpointStatus.PASS,
+        evaluator="op", evidence=ev,
+    )
+    assert rec.evidence == ev
+
+
+# ---------------------------------------------------------------------------
+# Registry write path (flag-gated)
+# ---------------------------------------------------------------------------
+
+def test_record_blocked_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED", raising=False)
+    with pytest.raises(CheckpointRegistryError, match="disabled"):
+        build_default_registry().record(_rec(CheckpointCode.CP1))
+
+
+def test_record_succeeds_and_updates_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED", "1")
+    reg = build_default_registry()
+    r1 = _rec(CheckpointCode.CP2, CheckpointStatus.FAIL)
+    r2 = _rec(CheckpointCode.CP2, CheckpointStatus.PASS)
+    assert reg.record(r1) is r1
+    reg.record(r2)
+    assert reg.status_of(CheckpointCode.CP2) == CheckpointStatus.PASS
+    assert reg.latest_record(CheckpointCode.CP2) is r2
+
+
+def test_record_unknown_code_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED", "1")
+    small = CheckpointRegistry([build_default_registry().checkpoint(CheckpointCode.CP1)])
+    with pytest.raises(CheckpointRegistryError, match="unknown checkpoint code"):
+        small.record(_rec(CheckpointCode.CP2))
+
+
+def test_latest_record_none_before_writes() -> None:
+    assert build_default_registry().latest_record(CheckpointCode.CP5) is None


### PR DESCRIPTION
## Slice

Adds `aragora/metrics/capability_checkpoint.py` — a flag-gated in-memory registry for the five booster-rocket capability checkpoints defined in `docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md` §5 (`CP-1: Sustained substrate` → `CP-2: Live crux activation` → `CP-3: External truth signal` → `CP-4: Reputation flow live` → `CP-5: Productivity-positive`). These checkpoints are the explicit graduation criteria for the AGT-* tranche but have had no implementation until now.

## Gating

- Default: **OFF** (flag: `ARAGORA_CAPABILITY_CHECKPOINTS_ENABLED`)
- `build_default_registry()` and all dataclasses are always constructable; only `CheckpointRegistry.record()` raises when the flag is unset
- Live queue effect: **none**
- Advances issue: #6067 (AGT-06)

## Tests

- `test_flag_disabled_by_default` / `test_flag_enabled_truthy` — env var gate semantics
- `test_default_registry_has_five_checkpoints` — five CP-* entries populate correctly
- `test_all_checkpoints_start_pending` — no evaluation history until first `record()` call
- `test_dependency_chain` — CP-1 has no parent; CP-2→CP-1, CP-3→CP-2, CP-4→CP-3, CP-5→CP-4
- `test_all_window_weeks_are_4` — 4-week window matches substrate doc
- `test_cp5_pass_condition_mentions_viah` — CP-5 tied to VIAH metric
- `test_checkpoints_sorted_by_code` — `all_checkpoints()` returns in deterministic order
- `test_unknown_code_raises` — `checkpoint()` raises `CheckpointRegistryError` for unknown code
- `test_record_create_auto_timestamp` / `test_record_to_dict_shape` / `test_record_evidence_preserved` — `CheckpointRecord` construction and serialization
- `test_record_blocked_when_disabled` — `record()` raises when flag is off
- `test_record_succeeds_and_updates_status` — two records for same code; `status_of()` and `latest_record()` track the most recent
- `test_record_unknown_code_raises` — `record()` raises for unknown code even when flag is on
- `test_latest_record_none_before_writes` — clean registry returns `None` for `latest_record()`

## Validation

- `python3 -c "import importlib.util..."` — 16/16 logic checks passed (pydantic not installed in bare env; same constraint affects all `tests/metrics/` tests)
- `ruff check aragora/metrics/capability_checkpoint.py tests/metrics/test_capability_checkpoint.py` — **clean**
- `mypy aragora/metrics/capability_checkpoint.py --ignore-missing-imports` — **clean**
- Net diff: **296 LOC** (166 impl + 130 tests)

## Out of scope

- Persistence / JSONL serialization of `CheckpointRecord` to disk: callers own persistence (same pattern as `CheckpointRegistry` in the debate module)
- Wiring CP-1 gate evaluation against live `ShiftLedger` data: deferred to the gate-open slice once the substrate-first Foreman gate permits the AGT-* tranche
- Automatic CP-* gate enforcement in the boss loop or dispatch path: explicitly out of scope per the "no live queue effect" guardrail

Note: the proof-first Foreman gate in `docs/status/NEXT_STEPS_CANONICAL.md` is **not yet open** for the AGT-* tranche. This PR carries no `boss-ready` label and must remain DRAFT until the gate opens or is explicitly waived for this slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMoMXsMCjfz2mZxUern5d8)_