### PR TITLE
fix(markets,swarm): two 1-line bugs from round 30c follow-ups

### DIFF
--- a/aragora/markets/resolver.py
+++ b/aragora/markets/resolver.py
@@ -113,8 +113,15 @@ class GitHubMarketResolver:
     ) -> ResolutionEvent:
         repo = str(market.target.get("repo") or "")
         number = int(market.target.get("number") or 0)
+        # NOTE: ``merged`` is NOT a valid ``gh pr view --json`` field. The
+        # only related field gh exposes is ``mergedAt``. Previous versions
+        # of this resolver included ``merged`` in the field list, which
+        # silently produced stdout *without* a ``merged`` key, so the
+        # downstream ``bool(payload.get("merged"))`` always evaluated to
+        # False — meaning a successfully-merged PR could never resolve YES.
+        # We derive ``merged`` from ``state == "MERGED"`` instead.
         result = self._runner(
-            ["pr", "view", str(number), "--repo", repo, "--json", "state,merged,mergedAt,closedAt"],
+            ["pr", "view", str(number), "--repo", repo, "--json", "state,mergedAt,closedAt"],
             timeout=30,
         )
         if result.returncode != 0:
@@ -124,7 +131,7 @@ class GitHubMarketResolver:
         except json.JSONDecodeError as exc:
             raise ResolutionError(f"gh pr view returned non-JSON: {exc}") from exc
         state = str(payload.get("state") or "").upper()
-        merged = bool(payload.get("merged"))
+        merged = state == "MERGED"
         evidence = {
             "repo": repo,
             "number": number,

--- a/aragora/swarm/shift_ledger.py
+++ b/aragora/swarm/shift_ledger.py
@@ -66,8 +66,12 @@ class ShiftLedger:
         publication_failure — benchmark PR publication failure
     """
 
-    def __init__(self, path: Path | None = None):
-        self._path = path or Path(DEFAULT_LEDGER_PATH)
+    def __init__(self, path: Path | str | None = None):
+        # Coerce strings (and ``None``) to ``Path`` so callers using the
+        # default ``DEFAULT_LEDGER_PATH`` string or ad-hoc string paths
+        # don't crash on ``self._path.parent.mkdir(...)``. Round 30c-Phase-I
+        # discovered this when invoking ``ShiftLedger(path=DEFAULT_LEDGER_PATH)``.
+        self._path = Path(path) if path is not None else Path(DEFAULT_LEDGER_PATH)
         self._path.parent.mkdir(parents=True, exist_ok=True)
 
     @property

--- a/tests/markets/test_resolver.py
+++ b/tests/markets/test_resolver.py
@@ -131,6 +131,54 @@ class TestPrMergeResolution:
         with pytest.raises(ResolutionError):
             resolve_market(market, gh_runner=_runner)
 
+    def test_real_world_gh_payload_no_merged_field_resolves_yes(self) -> None:
+        """Regression: round 30c-Phase-E discovered that ``gh pr view --json``
+        does NOT expose a ``merged`` field — only ``mergedAt`` and ``state``.
+
+        Previous resolver versions queried ``state,merged,...`` and read
+        ``bool(payload.get("merged"))``, which always evaluated to False for
+        real ``gh`` output. Live MERGED PRs would never resolve YES.
+
+        This test pins the fix: even when ``merged`` is absent from the
+        payload, ``state == "MERGED"`` still produces the YES outcome."""
+        market = _expired_pr_market(number=6828)
+        captured: list[list[str]] = []
+
+        def _runner(args, **kwargs):
+            captured.append(list(args))
+            # Real gh output — note ``merged`` is NOT present.
+            return _completed(
+                json.dumps(
+                    {
+                        "state": "MERGED",
+                        "mergedAt": "2026-04-30T03:16:56Z",
+                        "closedAt": "2026-04-30T03:16:56Z",
+                    }
+                )
+            )
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "yes"
+        assert event.evidence["merged"] is True
+        # And the field-list arg must NOT include the invalid ``merged`` field.
+        json_arg_idx = captured[0].index("--json")
+        fields = captured[0][json_arg_idx + 1].split(",")
+        assert "merged" not in fields, (
+            f"`merged` is not a valid gh JSON field — found in {fields!r}"
+        )
+
+    def test_real_world_gh_payload_no_merged_field_open_pr(self) -> None:
+        """Companion regression: an OPEN PR with no ``merged`` key still
+        resolves to inconclusive (not YES) under the fixed logic."""
+        market = _expired_pr_market(number=99)
+
+        def _runner(args, **kwargs):
+            return _completed(json.dumps({"state": "OPEN"}))
+
+        event = resolve_market(market, gh_runner=_runner)
+        assert event.outcome == "inconclusive"
+        assert event.evidence["merged"] is False
+
 
 class TestIssueResolution:
     def test_closed_issue_resolves_yes(self) -> None:

--- a/tests/swarm/test_shift_ledger.py
+++ b/tests/swarm/test_shift_ledger.py
@@ -34,6 +34,31 @@ class TestLedgerEntry:
         assert entry.payload == {}
 
 
+class TestShiftLedgerInit:
+    """Regression tests for round 30c-Phase-I bug: __init__ did not
+    coerce string paths to Path."""
+
+    def test_init_accepts_str_path(self, tmp_path: Path) -> None:
+        """Passing a str path must not raise AttributeError on .parent.mkdir."""
+        path_str = str(tmp_path / "ledger.jsonl")
+        sl = ShiftLedger(path=path_str)
+        assert sl.path == Path(path_str)
+        # And the parent directory must exist after init.
+        assert sl.path.parent.exists()
+
+    def test_init_accepts_path_object(self, tmp_path: Path) -> None:
+        path_obj = tmp_path / "ledger.jsonl"
+        sl = ShiftLedger(path=path_obj)
+        assert sl.path == path_obj
+
+    def test_init_with_none_uses_default(self, tmp_path: Path, monkeypatch) -> None:
+        """When path is None, the default must still be coerced cleanly."""
+        # Avoid touching the real default path — chdir into tmp.
+        monkeypatch.chdir(tmp_path)
+        sl = ShiftLedger(path=None)
+        assert isinstance(sl.path, Path)
+
+
 class TestShiftLedger:
     def test_append_and_read_all(self, ledger: ShiftLedger) -> None:
         ledger.append("shift_start", shift_id="s1")


### PR DESCRIPTION
Two real bugs discovered (not introduced) during round 30c dogfooding.

## 1. `aragora/markets/resolver.py:_resolve_pr_merge` — invalid `gh` JSON field

The resolver queried `gh pr view --json state,merged,mergedAt,closedAt`, but **`merged` is NOT a valid `gh` JSON field** — only `mergedAt` is. This silently produced output without a `merged` key, so the downstream `bool(payload.get('merged'))` always evaluated to False.

**Result**: a successfully MERGED PR could never resolve YES.

Round 30c-Phase-E worked around this with a custom runner; this PR fixes it permanently:
- Drop `merged` from the field list (one fewer round-trip)
- Derive `merged` from `state == 'MERGED'` instead

Regression test (`test_real_world_gh_payload_no_merged_field_resolves_yes`) pins the fix using a real-world payload with no `merged` key — the test would have failed against the old code.

## 2. `aragora/swarm/shift_ledger.py:71` — missing Path coercion

`ShiftLedger.__init__` accepted `path: Path | None` but did not coerce a passed string to `Path`, raising `AttributeError` on `self._path.parent.mkdir(...)` when the caller passed `DEFAULT_LEDGER_PATH` (a string) directly.

Fix: `self._path = Path(path) if path is not None else Path(DEFAULT_LEDGER_PATH)`. Annotation widened to `Path | str | None`.

Three regression tests cover str / Path object / None paths.

## Tests

- 31/31 pass (26 existing + 5 new regression tests)
- ruff check + format: clean
- mypy on changed modules: `Success: no issues found`
- preflight: ok

## Why this is safe

- Both fixes are surgical: 30 LOC of source changes, 50 LOC of regression tests
- Existing test suite still passes — old tests used stub runners that included `merged: True` in payloads (correlated with `state: MERGED`), so the fixed logic produces the same outcome for them
- New regression tests prove the bugs are caught; `git revert` reproduces them

## Tier

**Tier 2** — bug fixes + regression tests; safe revert via `git revert`.

## Standing rule

I do not author-merge. Awaiting Codex signal + CI green.