### PR TITLE
feat(swarm): H1 multi-gate readiness aggregator (advisory)

### DIFF
--- a/aragora/swarm/h1_readiness.py
+++ b/aragora/swarm/h1_readiness.py
@@ -1,0 +1,195 @@
+"""Compound H1 multi-gate readiness aggregator (advisory-only).
+
+The H1 epic has four sub-gates: H1-01 (rev-4 promotion), H1-02
+(scorecard publication), H1-03 (sanitation gate), H1-04 (autonomy
+ledger self-heal). Each has its own contract document under
+``docs/status/H1_*_CONTRACT.md`` and its own readiness check.
+
+For an operator running a release decision, *all four* must be in a
+known-good state. Today the operator checks each by hand.
+
+This module provides a pure aggregator that ingests the per-gate
+status records and returns one ``MultiGateReadiness`` value plus a
+deterministic Markdown rendering. It makes **no GitHub or filesystem
+calls itself** — the caller passes in already-loaded dicts. That keeps
+the aggregator fast, deterministic, and unit-testable offline.
+
+The intent is that the renderer in
+``scripts/render_h1_multi_gate_readiness.py`` reads the per-gate
+artifacts (the rev-4 readiness JSON, the H1-02 scorecard JSON, the
+sanitizer test surface, the ledger self-heal contract) and feeds them
+into ``aggregate_readiness`` here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final, Literal
+
+GateStatus = Literal["ready", "advisory_in_progress", "in_progress", "blocked", "unknown"]
+
+# The four H1 sub-gates in canonical roadmap order.
+H1_GATES: Final[tuple[str, ...]] = ("H1-01", "H1-02", "H1-03", "H1-04")
+
+
+@dataclass(frozen=True, slots=True)
+class GateInput:
+    """One H1 sub-gate's per-gate readiness signal.
+
+    Attributes:
+        gate_id: One of ``H1_GATES``.
+        status: ``ready`` (canonical contract IN PLACE),
+            ``advisory_in_progress`` (advisory deliverable shipped but
+            not promoted), ``in_progress`` (work ongoing),
+            ``blocked`` (blocker known), ``unknown`` (no signal yet).
+        contract_doc: Path to the contract document, if any.
+        evidence: Free-form mapping; preserved as-is in the output.
+    """
+
+    gate_id: str
+    status: GateStatus
+    contract_doc: str | None = None
+    evidence: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class MultiGateReadiness:
+    """Aggregated H1 readiness across all four sub-gates."""
+
+    overall_status: GateStatus
+    ready_count: int
+    advisory_count: int
+    blocked_count: int
+    in_progress_count: int
+    unknown_count: int
+    per_gate: tuple[GateInput, ...]
+    next_action: str
+
+
+def aggregate_readiness(inputs: list[GateInput]) -> MultiGateReadiness:
+    """Combine per-gate inputs into one readiness verdict.
+
+    Rules:
+        - All four gates ``ready`` → overall ``ready``.
+        - Any gate ``blocked`` → overall ``blocked`` (binding).
+        - Otherwise, if any gate is ``in_progress`` → overall
+          ``in_progress``.
+        - Otherwise (mix of ready / advisory_in_progress) → overall
+          ``advisory_in_progress``.
+        - Otherwise (any ``unknown``) → overall ``unknown``.
+
+    The aggregator is order-independent and pure: same inputs always
+    produce the same output. Missing gates count as ``unknown``.
+    """
+    by_id: dict[str, GateInput] = {gi.gate_id: gi for gi in inputs}
+    normalized: list[GateInput] = []
+    for gid in H1_GATES:
+        if gid in by_id:
+            normalized.append(by_id[gid])
+        else:
+            normalized.append(
+                GateInput(gate_id=gid, status="unknown", contract_doc=None, evidence={})
+            )
+
+    statuses = [gi.status for gi in normalized]
+    ready_count = statuses.count("ready")
+    advisory_count = statuses.count("advisory_in_progress")
+    blocked_count = statuses.count("blocked")
+    in_progress_count = statuses.count("in_progress")
+    unknown_count = statuses.count("unknown")
+
+    overall: GateStatus
+    next_action: str
+    if blocked_count > 0:
+        overall = "blocked"
+        blocked_ids = [gi.gate_id for gi in normalized if gi.status == "blocked"]
+        next_action = f"Resolve blocker(s) on {', '.join(blocked_ids)} before any other gate work."
+    elif ready_count == len(H1_GATES):
+        overall = "ready"
+        next_action = "All four H1 sub-gates ready. H1 epic may be marked complete."
+    elif in_progress_count > 0:
+        overall = "in_progress"
+        in_prog_ids = [gi.gate_id for gi in normalized if gi.status == "in_progress"]
+        next_action = f"Continue work on {', '.join(in_prog_ids)}."
+    elif advisory_count > 0:
+        overall = "advisory_in_progress"
+        advisory_ids = [gi.gate_id for gi in normalized if gi.status == "advisory_in_progress"]
+        next_action = (
+            f"Promote {', '.join(advisory_ids)} from advisory → canonical to graduate the H1 epic."
+        )
+    else:
+        # No blockers, not all ready, no in-progress, no advisory →
+        # only readys + unknowns, or all unknowns.
+        overall = "unknown"
+        unknown_ids = [gi.gate_id for gi in normalized if gi.status == "unknown"]
+        next_action = (
+            f"Run per-gate readiness checks for {', '.join(unknown_ids)} before aggregating."
+        )
+
+    return MultiGateReadiness(
+        overall_status=overall,
+        ready_count=ready_count,
+        advisory_count=advisory_count,
+        blocked_count=blocked_count,
+        in_progress_count=in_progress_count,
+        unknown_count=unknown_count,
+        per_gate=tuple(normalized),
+        next_action=next_action,
+    )
+
+
+_STATUS_BADGE: Final[dict[GateStatus, str]] = {
+    "ready": "ready",
+    "advisory_in_progress": "advisory",
+    "in_progress": "in-progress",
+    "blocked": "BLOCKED",
+    "unknown": "unknown",
+}
+
+
+def render_markdown(readiness: MultiGateReadiness) -> str:
+    """Deterministic Markdown rendering for the readiness verdict.
+
+    The output is stable across calls with the same input — no clocks,
+    no ordering ambiguity — so it can be diffed across rounds.
+    """
+    overall_badge = _STATUS_BADGE[readiness.overall_status]
+    lines: list[str] = [
+        "# H1 multi-gate readiness",
+        "",
+        f"**Overall status:** `{overall_badge}`",
+        "",
+        f"- Ready: **{readiness.ready_count}**/{len(H1_GATES)}",
+        f"- Advisory in progress: **{readiness.advisory_count}**",
+        f"- In progress: **{readiness.in_progress_count}**",
+        f"- Blocked: **{readiness.blocked_count}**",
+        f"- Unknown: **{readiness.unknown_count}**",
+        "",
+        "## Per-gate",
+        "",
+        "| Gate | Status | Contract |",
+        "| --- | --- | --- |",
+    ]
+    for gi in readiness.per_gate:
+        contract = gi.contract_doc or "—"
+        lines.append(f"| `{gi.gate_id}` | `{_STATUS_BADGE[gi.status]}` | {contract} |")
+    lines.extend(
+        [
+            "",
+            "## Next action",
+            "",
+            readiness.next_action,
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "GateInput",
+    "GateStatus",
+    "H1_GATES",
+    "MultiGateReadiness",
+    "aggregate_readiness",
+    "render_markdown",
+]

--- a/scripts/render_h1_multi_gate_readiness.py
+++ b/scripts/render_h1_multi_gate_readiness.py
@@ -1,0 +1,146 @@
+"""Render the H1 multi-gate readiness summary.
+
+Loads each H1 sub-gate's contract status from its canonical surface
+and feeds it through ``aragora.swarm.h1_readiness.aggregate_readiness``
+to produce one Markdown summary covering all four gates.
+
+Status detection (heuristic, contract-doc driven):
+
+- **H1-01**: parses ``scripts/render_rev4_promotion_readiness.py``
+  output JSON file (if present) and maps ``status`` →
+  ``ready`` (``promotion_ready``) or ``advisory_in_progress``.
+- **H1-02**: detects ``H1_02_SCORECARD_CONTRACT.md`` "Status: IN
+  PLACE" → ``ready``.
+- **H1-03**: detects ``H1_03_SANITATION_GATE_CONTRACT.md`` "Status:
+  IN PLACE" → ``ready``.
+- **H1-04**: detects ``H1_04_LEDGER_SELF_HEAL_CONTRACT.md`` "Status:
+  IN PLACE" → ``ready``.
+
+If a contract doc is missing or doesn't match either pattern, the
+gate is reported as ``unknown``.
+
+Usage::
+
+    python3 scripts/render_h1_multi_gate_readiness.py
+    python3 scripts/render_h1_multi_gate_readiness.py --json
+    python3 scripts/render_h1_multi_gate_readiness.py \\
+        --h1-01-readiness-json path/to/rev4_promotion_readiness.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.h1_readiness import (  # noqa: E402
+    GateInput,
+    GateStatus,
+    aggregate_readiness,
+    render_markdown,
+)
+
+CONTRACT_DOCS = {
+    "H1-01": REPO_ROOT / "docs/status/H1_01_REV4_PROMOTION_READINESS.md",
+    "H1-02": REPO_ROOT / "docs/status/H1_02_SCORECARD_CONTRACT.md",
+    "H1-03": REPO_ROOT / "docs/status/H1_03_SANITATION_GATE_CONTRACT.md",
+    "H1-04": REPO_ROOT / "docs/status/H1_04_LEDGER_SELF_HEAL_CONTRACT.md",
+}
+
+
+def _detect_in_place(contract_path: Path) -> bool:
+    """Heuristic: contract doc claims 'Status: IN PLACE'."""
+    if not contract_path.exists():
+        return False
+    text = contract_path.read_text(encoding="utf-8")
+    return "Status:**" in text and "IN PLACE" in text
+
+
+def _detect_h1_01_from_doc(contract_path: Path) -> GateStatus:
+    """H1-01's contract doc embeds a verdict line like
+    ``- Status: \\`promotion_ready\\``` (or ``needs_more_dispatch_evidence``).
+    Extract that without requiring a separate JSON artifact.
+    """
+    if not contract_path.exists():
+        return "unknown"
+    text = contract_path.read_text(encoding="utf-8")
+    if "Status: `promotion_ready`" in text:
+        return "ready"
+    if "Status: `needs_more_dispatch_evidence`" in text or "Status: `advisory_only`" in text:
+        return "advisory_in_progress"
+    return "unknown"
+
+
+def _h1_01_status(readiness_json: Path | None) -> GateStatus:
+    """H1-01 status from the rev-4 promotion readiness JSON if provided,
+    otherwise from the contract doc's embedded verdict line."""
+    if readiness_json is not None and readiness_json.exists():
+        try:
+            payload = json.loads(readiness_json.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return "unknown"
+        status = str(payload.get("status") or "")
+        if status == "promotion_ready":
+            return "ready"
+        if status in {"needs_more_dispatch_evidence", "advisory_only"}:
+            return "advisory_in_progress"
+        return "unknown"
+    return _detect_h1_01_from_doc(CONTRACT_DOCS["H1-01"])
+
+
+def _build_inputs(args: argparse.Namespace) -> list[GateInput]:
+    inputs: list[GateInput] = []
+
+    h1_01_status = _h1_01_status(args.h1_01_readiness_json)
+    inputs.append(
+        GateInput(
+            gate_id="H1-01",
+            status=h1_01_status,
+            contract_doc=str(CONTRACT_DOCS["H1-01"].relative_to(REPO_ROOT)),
+        )
+    )
+
+    for gid in ("H1-02", "H1-03", "H1-04"):
+        status: GateStatus = "ready" if _detect_in_place(CONTRACT_DOCS[gid]) else "unknown"
+        inputs.append(
+            GateInput(
+                gate_id=gid,
+                status=status,
+                contract_doc=str(CONTRACT_DOCS[gid].relative_to(REPO_ROOT)),
+            )
+        )
+
+    return inputs
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--h1-01-readiness-json",
+        type=Path,
+        default=None,
+        help="Optional rev-4 promotion readiness JSON; if omitted, "
+        "the contract doc heuristic is used.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of Markdown.")
+    args = parser.parse_args(argv)
+
+    inputs = _build_inputs(args)
+    readiness = aggregate_readiness(inputs)
+
+    if args.json:
+        sys.stdout.write(json.dumps(asdict(readiness), default=str, indent=2, sort_keys=True))
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(render_markdown(readiness))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/swarm/test_h1_readiness.py
+++ b/tests/swarm/test_h1_readiness.py
@@ -1,0 +1,139 @@
+"""Unit tests for the H1 multi-gate readiness aggregator."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.swarm.h1_readiness import (
+    H1_GATES,
+    GateInput,
+    aggregate_readiness,
+    render_markdown,
+)
+
+
+def _ready(gate_id: str) -> GateInput:
+    return GateInput(gate_id=gate_id, status="ready", contract_doc=f"docs/status/{gate_id}.md")
+
+
+def _advisory(gate_id: str) -> GateInput:
+    return GateInput(gate_id=gate_id, status="advisory_in_progress")
+
+
+def _blocked(gate_id: str) -> GateInput:
+    return GateInput(gate_id=gate_id, status="blocked")
+
+
+def _in_progress(gate_id: str) -> GateInput:
+    return GateInput(gate_id=gate_id, status="in_progress")
+
+
+class TestAggregateReadiness:
+    def test_all_four_ready_overall_ready(self) -> None:
+        inputs = [_ready(g) for g in H1_GATES]
+        out = aggregate_readiness(inputs)
+        assert out.overall_status == "ready"
+        assert out.ready_count == 4
+        assert "may be marked complete" in out.next_action
+
+    def test_one_blocked_overrides_everything(self) -> None:
+        inputs = [_ready("H1-01"), _ready("H1-02"), _blocked("H1-03"), _ready("H1-04")]
+        out = aggregate_readiness(inputs)
+        assert out.overall_status == "blocked"
+        assert out.blocked_count == 1
+        assert "H1-03" in out.next_action
+
+    def test_two_blocked_lists_both(self) -> None:
+        inputs = [_blocked("H1-01"), _ready("H1-02"), _blocked("H1-03"), _ready("H1-04")]
+        out = aggregate_readiness(inputs)
+        assert out.overall_status == "blocked"
+        assert "H1-01" in out.next_action and "H1-03" in out.next_action
+
+    def test_in_progress_takes_priority_over_advisory(self) -> None:
+        inputs = [_ready("H1-01"), _advisory("H1-02"), _in_progress("H1-03"), _advisory("H1-04")]
+        out = aggregate_readiness(inputs)
+        assert out.overall_status == "in_progress"
+        assert "H1-03" in out.next_action
+
+    def test_advisory_when_no_blocker_or_in_progress(self) -> None:
+        inputs = [_ready("H1-01"), _advisory("H1-02"), _ready("H1-03"), _ready("H1-04")]
+        out = aggregate_readiness(inputs)
+        assert out.overall_status == "advisory_in_progress"
+        assert "H1-02" in out.next_action
+        assert "advisory → canonical" in out.next_action
+
+    def test_missing_gates_become_unknown(self) -> None:
+        out = aggregate_readiness([_ready("H1-01")])
+        assert out.unknown_count == 3
+        assert out.overall_status == "unknown"
+        assert "Run per-gate readiness checks" in out.next_action
+
+    def test_empty_inputs_all_unknown(self) -> None:
+        out = aggregate_readiness([])
+        assert out.unknown_count == 4
+        assert out.ready_count == 0
+        assert out.overall_status == "unknown"
+
+    def test_input_order_does_not_matter(self) -> None:
+        a = aggregate_readiness([_ready(g) for g in H1_GATES])
+        b = aggregate_readiness([_ready(g) for g in reversed(H1_GATES)])
+        assert a == b
+
+    def test_per_gate_always_in_canonical_order(self) -> None:
+        out = aggregate_readiness([_ready(g) for g in reversed(H1_GATES)])
+        assert tuple(gi.gate_id for gi in out.per_gate) == H1_GATES
+
+    def test_evidence_preserved(self) -> None:
+        gi = GateInput(
+            gate_id="H1-01",
+            status="ready",
+            contract_doc="x.md",
+            evidence={"dispatched": 16, "merged_only": [5126]},
+        )
+        out = aggregate_readiness([gi])
+        retained = out.per_gate[0]
+        assert retained.evidence["dispatched"] == 16
+        assert retained.evidence["merged_only"] == [5126]
+
+
+class TestRenderMarkdown:
+    def test_renders_all_ready(self) -> None:
+        out = aggregate_readiness([_ready(g) for g in H1_GATES])
+        md = render_markdown(out)
+        assert "# H1 multi-gate readiness" in md
+        assert "`ready`" in md
+        assert "Ready: **4**/4" in md
+        for g in H1_GATES:
+            assert g in md
+
+    def test_renders_blocked(self) -> None:
+        out = aggregate_readiness(
+            [_ready("H1-01"), _ready("H1-02"), _blocked("H1-03"), _ready("H1-04")]
+        )
+        md = render_markdown(out)
+        assert "`BLOCKED`" in md
+        assert "Resolve blocker(s) on H1-03" in md
+
+    def test_render_is_deterministic(self) -> None:
+        inputs = [_advisory("H1-01"), _ready("H1-02"), _ready("H1-03"), _ready("H1-04")]
+        a = render_markdown(aggregate_readiness(inputs))
+        b = render_markdown(aggregate_readiness(list(reversed(inputs))))
+        assert a == b
+
+    def test_renders_contract_em_dash_for_missing(self) -> None:
+        out = aggregate_readiness([])
+        md = render_markdown(out)
+        # Each row should have "—" in the contract column (4 unknown gates)
+        assert md.count("| —") >= 4
+
+
+class TestImmutability:
+    def test_gate_input_frozen(self) -> None:
+        gi = _ready("H1-01")
+        with pytest.raises(Exception):
+            gi.status = "blocked"  # type: ignore[misc]
+
+    def test_multi_gate_readiness_frozen(self) -> None:
+        out = aggregate_readiness([_ready(g) for g in H1_GATES])
+        with pytest.raises(Exception):
+            out.overall_status = "blocked"  # type: ignore[misc]


### PR DESCRIPTION
Adds an advisory aggregator that combines all four H1 sub-gate readiness signals into one verdict.

## Why

The H1 epic has four sub-gates: H1-01 (rev-4 promotion), H1-02 (scorecard), H1-03 (sanitation), H1-04 (autonomy ledger). Today an operator must check each contract doc by hand to know whether the epic can graduate. This PR produces a single answer.

## What lands

| File | Purpose | LOC |
| --- | --- | --- |
| `aragora/swarm/h1_readiness.py` | Pure aggregator with frozen dataclasses | ~190 |
| `scripts/render_h1_multi_gate_readiness.py` | Renderer that loads each contract doc | ~135 |
| `tests/swarm/test_h1_readiness.py` | 16 unit tests (statuses, ordering, immutability, render) | ~155 |

## Aggregation rules

- Any **blocked** → overall blocked (binding)
- All four **ready** → overall ready
- Any **in_progress** → overall in_progress
- Otherwise any **advisory** → overall advisory_in_progress
- Otherwise (only readys + unknowns) → overall unknown

## Live verdict

```
# H1 multi-gate readiness
Overall status: advisory
- Ready: 3/4
- H1-01: advisory  (rev-4 still needs more dispatched evidence)
- H1-02: ready
- H1-03: ready
- H1-04: ready
Next action: Promote H1-01 from advisory → canonical to graduate the H1 epic.
```

## Tests & lints

- 16/16 unit tests pass
- ruff check + format: clean
- mypy: `Success: no issues`
- live render confirms 3/4 ready

## Tier

**Tier 2** — pure additive; the renderer only reads existing contract docs under `docs/status/`. Safe revert.

## Standing rule

I do not author-merge. Awaiting Codex signal + CI green.