### PR TITLE
feat(swarm): cross-round cadence aggregator

### DIFF
--- a/aragora/swarm/round_cadence.py
+++ b/aragora/swarm/round_cadence.py
@@ -1,0 +1,179 @@
+"""Cross-round cadence metrics for the autonomous evolve-round loop.
+
+Each evolve-round drops phase receipts into a directory like
+``.aragora/evolve-round/<round-id>/dogfood/phase-<letter>-receipt.json``.
+Over time, these receipts form an audit trail of how many phases each
+round completed, how many PRs each round opened, and what the
+phase-by-phase outcomes looked like.
+
+This module is a pure offline aggregator: given a list of receipt
+records (already loaded from disk by the caller), it returns one
+``RoundCadenceSummary`` with deterministic totals plus a per-round
+breakdown. No filesystem or GitHub calls are made here — the caller
+loads the JSON files via ``scripts/render_round_cadence.py``.
+
+The intent is so an operator can answer:
+
+- How many rounds have we run, total?
+- How many PRs did each round open?
+- What's the per-round phase completion rate?
+- Which rounds tripped a halt?
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Public phase status values we count.
+PHASE_STATUSES = ("complete", "in_progress", "blocked", "skipped", "unknown")
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseReceipt:
+    """One loaded phase-receipt.json from a round."""
+
+    round_id: str
+    phase: str
+    status: str
+    pr_number: int | None = None
+    halt_tripped: bool = False
+    name: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class RoundSummary:
+    """Per-round aggregation across all of a round's phase receipts."""
+
+    round_id: str
+    total_phases: int
+    complete_phases: int
+    blocked_phases: int
+    pr_numbers: tuple[int, ...]
+    halt_tripped: bool
+    phases_by_letter: tuple[PhaseReceipt, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RoundCadenceSummary:
+    """Aggregated cadence across all rounds."""
+
+    total_rounds: int
+    total_phases: int
+    total_complete_phases: int
+    total_blocked_phases: int
+    total_prs_opened: int
+    rounds_with_halt: int
+    per_round: tuple[RoundSummary, ...] = field(default_factory=tuple)
+
+
+def _normalize_phase(letter: str) -> str:
+    """Phase letters are case-insensitive single chars."""
+    s = (letter or "").strip().upper()
+    return s[:1] if s else "?"
+
+
+def aggregate_cadence(receipts: list[PhaseReceipt]) -> RoundCadenceSummary:
+    """Compute one cadence summary from a list of phase receipts.
+
+    Output is deterministic: rounds are sorted by ``round_id`` ascending,
+    phases within each round are sorted by their (uppercased) letter.
+    """
+    by_round: dict[str, list[PhaseReceipt]] = {}
+    for r in receipts:
+        by_round.setdefault(r.round_id, []).append(r)
+
+    per_round_list: list[RoundSummary] = []
+    total_phases = 0
+    total_complete = 0
+    total_blocked = 0
+    total_prs = 0
+    rounds_with_halt = 0
+
+    for round_id in sorted(by_round.keys()):
+        group = by_round[round_id]
+        group_sorted = tuple(sorted(group, key=lambda r: _normalize_phase(r.phase)))
+
+        complete = sum(1 for r in group_sorted if r.status == "complete")
+        blocked = sum(1 for r in group_sorted if r.status == "blocked")
+        pr_nums = tuple(sorted({r.pr_number for r in group_sorted if isinstance(r.pr_number, int)}))
+        any_halt = any(r.halt_tripped for r in group_sorted)
+
+        per_round_list.append(
+            RoundSummary(
+                round_id=round_id,
+                total_phases=len(group_sorted),
+                complete_phases=complete,
+                blocked_phases=blocked,
+                pr_numbers=pr_nums,
+                halt_tripped=any_halt,
+                phases_by_letter=group_sorted,
+            )
+        )
+
+        total_phases += len(group_sorted)
+        total_complete += complete
+        total_blocked += blocked
+        total_prs += len(pr_nums)
+        if any_halt:
+            rounds_with_halt += 1
+
+    return RoundCadenceSummary(
+        total_rounds=len(per_round_list),
+        total_phases=total_phases,
+        total_complete_phases=total_complete,
+        total_blocked_phases=total_blocked,
+        total_prs_opened=total_prs,
+        rounds_with_halt=rounds_with_halt,
+        per_round=tuple(per_round_list),
+    )
+
+
+def render_markdown(summary: RoundCadenceSummary) -> str:
+    """Deterministic Markdown rendering of the cadence summary.
+
+    No clocks, no platform-specific paths, no random ordering —
+    same input always produces the same output.
+    """
+    if summary.total_rounds == 0:
+        return "# Round cadence\n\nNo rounds found.\n"
+
+    completion_rate = (
+        100.0 * summary.total_complete_phases / summary.total_phases
+        if summary.total_phases > 0
+        else 0.0
+    )
+
+    lines: list[str] = [
+        "# Round cadence",
+        "",
+        f"**Total rounds:** {summary.total_rounds}",
+        f"**Total phases run:** {summary.total_phases}",
+        f"**Phases complete:** {summary.total_complete_phases} ({completion_rate:.1f}%)",
+        f"**Phases blocked:** {summary.total_blocked_phases}",
+        f"**Total PRs opened:** {summary.total_prs_opened}",
+        f"**Rounds with halt-trip:** {summary.rounds_with_halt}",
+        "",
+        "## Per-round",
+        "",
+        "| Round | Phases | Complete | Blocked | PRs | Halt |",
+        "| --- | ---: | ---: | ---: | ---: | :---: |",
+    ]
+    for rs in summary.per_round:
+        halt_marker = "**HALT**" if rs.halt_tripped else "—"
+        prs_str = ", ".join(f"#{n}" for n in rs.pr_numbers) or "—"
+        lines.append(
+            f"| `{rs.round_id}` | {rs.total_phases} | "
+            f"{rs.complete_phases} | {rs.blocked_phases} | {prs_str} | {halt_marker} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "PHASE_STATUSES",
+    "PhaseReceipt",
+    "RoundCadenceSummary",
+    "RoundSummary",
+    "aggregate_cadence",
+    "render_markdown",
+]

--- a/scripts/render_round_cadence.py
+++ b/scripts/render_round_cadence.py
@@ -1,0 +1,118 @@
+"""Render the cross-round cadence summary.
+
+Walks ``.aragora/evolve-round/<round-id>/dogfood/phase-*-receipt.json``
+across all rounds, loads each receipt into a ``PhaseReceipt``, and
+feeds them through ``aragora.swarm.round_cadence.aggregate_cadence``
+to produce a Markdown or JSON summary.
+
+Usage::
+
+    python3 scripts/render_round_cadence.py
+    python3 scripts/render_round_cadence.py --json
+    python3 scripts/render_round_cadence.py \\
+        --rounds-dir .aragora/evolve-round \\
+        --output round-cadence.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.round_cadence import (  # noqa: E402
+    PhaseReceipt,
+    aggregate_cadence,
+    render_markdown,
+)
+
+DEFAULT_ROUNDS_DIR = REPO_ROOT / ".aragora/evolve-round"
+RECEIPT_GLOB = "phase-*-receipt.json"
+PHASE_FROM_FILENAME = re.compile(r"phase-([a-zA-Z])-receipt\.json$")
+
+
+def _phase_from_path(path: Path) -> str:
+    m = PHASE_FROM_FILENAME.search(path.name)
+    return m.group(1).upper() if m else "?"
+
+
+def _load_receipt(round_id: str, path: Path) -> PhaseReceipt | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    phase = str(payload.get("phase") or _phase_from_path(path)).upper()[:1]
+    status = str(payload.get("status") or "unknown")
+    raw_pr = payload.get("pr_number")
+    pr_number: int | None = raw_pr if isinstance(raw_pr, int) else None
+    halt_tripped = bool(payload.get("halt_tripped", False))
+    name = str(payload.get("name") or "")
+    return PhaseReceipt(
+        round_id=round_id,
+        phase=phase,
+        status=status,
+        pr_number=pr_number,
+        halt_tripped=halt_tripped,
+        name=name,
+    )
+
+
+def _scan_rounds(rounds_dir: Path) -> list[PhaseReceipt]:
+    if not rounds_dir.is_dir():
+        return []
+    receipts: list[PhaseReceipt] = []
+    for round_dir in sorted(rounds_dir.iterdir()):
+        if not round_dir.is_dir():
+            continue
+        round_id = round_dir.name
+        dogfood = round_dir / "dogfood"
+        if not dogfood.is_dir():
+            continue
+        for receipt_path in sorted(dogfood.glob(RECEIPT_GLOB)):
+            r = _load_receipt(round_id, receipt_path)
+            if r is not None:
+                receipts.append(r)
+    return receipts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rounds-dir",
+        type=Path,
+        default=DEFAULT_ROUNDS_DIR,
+        help="Directory containing per-round subdirectories.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of Markdown.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write to this file instead of stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    receipts = _scan_rounds(args.rounds_dir)
+    summary = aggregate_cadence(receipts)
+    if args.json:
+        rendered = json.dumps(asdict(summary), default=str, indent=2, sort_keys=True) + "\n"
+    else:
+        rendered = render_markdown(summary)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/swarm/test_round_cadence.py
+++ b/tests/swarm/test_round_cadence.py
@@ -1,0 +1,165 @@
+"""Unit tests for round_cadence aggregator."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.swarm.round_cadence import (
+    PhaseReceipt,
+    aggregate_cadence,
+    render_markdown,
+)
+
+
+def _r(
+    round_id: str,
+    phase: str,
+    status: str = "complete",
+    pr_number: int | None = None,
+    halt_tripped: bool = False,
+) -> PhaseReceipt:
+    return PhaseReceipt(
+        round_id=round_id,
+        phase=phase,
+        status=status,
+        pr_number=pr_number,
+        halt_tripped=halt_tripped,
+    )
+
+
+class TestAggregateCadence:
+    def test_empty(self) -> None:
+        out = aggregate_cadence([])
+        assert out.total_rounds == 0
+        assert out.total_phases == 0
+        assert out.total_prs_opened == 0
+        assert out.per_round == ()
+
+    def test_single_round_single_phase(self) -> None:
+        out = aggregate_cadence([_r("2026-04-30", "A", pr_number=6800)])
+        assert out.total_rounds == 1
+        assert out.total_phases == 1
+        assert out.total_complete_phases == 1
+        assert out.total_prs_opened == 1
+        assert out.per_round[0].round_id == "2026-04-30"
+        assert out.per_round[0].pr_numbers == (6800,)
+
+    def test_round_phase_completion_rate(self) -> None:
+        receipts = [
+            _r("r1", "A", "complete"),
+            _r("r1", "B", "complete"),
+            _r("r1", "C", "blocked"),
+        ]
+        out = aggregate_cadence(receipts)
+        assert out.total_complete_phases == 2
+        assert out.total_blocked_phases == 1
+
+    def test_pr_dedup_per_round(self) -> None:
+        receipts = [
+            _r("r1", "A", pr_number=100),
+            _r("r1", "B", pr_number=100),  # same PR, doesn't double-count
+            _r("r1", "C", pr_number=101),
+        ]
+        out = aggregate_cadence(receipts)
+        assert out.per_round[0].pr_numbers == (100, 101)
+        assert out.total_prs_opened == 2
+
+    def test_pr_none_skipped(self) -> None:
+        receipts = [_r("r1", "A", pr_number=None), _r("r1", "B", pr_number=None)]
+        out = aggregate_cadence(receipts)
+        assert out.per_round[0].pr_numbers == ()
+        assert out.total_prs_opened == 0
+
+    def test_halt_tripped_propagates(self) -> None:
+        receipts = [_r("r1", "A"), _r("r1", "B", halt_tripped=True)]
+        out = aggregate_cadence(receipts)
+        assert out.per_round[0].halt_tripped is True
+        assert out.rounds_with_halt == 1
+
+    def test_rounds_sorted_alphabetically(self) -> None:
+        # Pass rounds in non-sorted order
+        receipts = [
+            _r("2026-04-30c", "A"),
+            _r("2026-04-30", "A"),
+            _r("2026-04-30b", "A"),
+        ]
+        out = aggregate_cadence(receipts)
+        assert tuple(rs.round_id for rs in out.per_round) == (
+            "2026-04-30",
+            "2026-04-30b",
+            "2026-04-30c",
+        )
+
+    def test_phases_sorted_within_round(self) -> None:
+        receipts = [
+            _r("r1", "C"),
+            _r("r1", "A"),
+            _r("r1", "B"),
+        ]
+        out = aggregate_cadence(receipts)
+        assert tuple(p.phase for p in out.per_round[0].phases_by_letter) == ("A", "B", "C")
+
+    def test_case_insensitive_phase_normalize(self) -> None:
+        receipts = [_r("r1", "a"), _r("r1", "B")]
+        out = aggregate_cadence(receipts)
+        # Both phases should be present, sorted as "A" "B"
+        assert len(out.per_round[0].phases_by_letter) == 2
+
+    def test_multi_round_totals(self) -> None:
+        receipts = [
+            _r("r1", "A", pr_number=10),
+            _r("r1", "B", "blocked"),
+            _r("r2", "A", pr_number=20),
+            _r("r2", "B", pr_number=21),
+        ]
+        out = aggregate_cadence(receipts)
+        assert out.total_rounds == 2
+        assert out.total_phases == 4
+        assert out.total_complete_phases == 3
+        assert out.total_blocked_phases == 1
+        assert out.total_prs_opened == 3
+
+
+class TestRenderMarkdown:
+    def test_empty(self) -> None:
+        out = aggregate_cadence([])
+        md = render_markdown(out)
+        assert "No rounds found" in md
+
+    def test_renders_header_and_rows(self) -> None:
+        receipts = [
+            _r("r1", "A", pr_number=100),
+            _r("r1", "B", "blocked"),
+            _r("r2", "A", pr_number=200, halt_tripped=True),
+        ]
+        out = aggregate_cadence(receipts)
+        md = render_markdown(out)
+        assert "Total rounds:** 2" in md
+        assert "`r1`" in md and "`r2`" in md
+        assert "**HALT**" in md
+        assert "#100" in md and "#200" in md
+
+    def test_completion_rate(self) -> None:
+        receipts = [_r("r1", "A"), _r("r1", "B"), _r("r1", "C", "blocked")]
+        out = aggregate_cadence(receipts)
+        md = render_markdown(out)
+        # 2/3 = 66.7%
+        assert "66.7%" in md
+
+    def test_render_is_deterministic(self) -> None:
+        receipts = [_r("r1", "A", pr_number=1), _r("r2", "A", pr_number=2)]
+        a = render_markdown(aggregate_cadence(receipts))
+        b = render_markdown(aggregate_cadence(list(reversed(receipts))))
+        assert a == b
+
+
+class TestImmutability:
+    def test_phase_receipt_frozen(self) -> None:
+        r = _r("r1", "A")
+        with pytest.raises(Exception):
+            r.status = "blocked"  # type: ignore[misc]
+
+    def test_round_summary_frozen(self) -> None:
+        out = aggregate_cadence([_r("r1", "A")])
+        with pytest.raises(Exception):
+            out.per_round[0].round_id = "x"  # type: ignore[misc]


### PR DESCRIPTION
Adds an offline aggregator that produces cross-round cadence metrics from the existing per-phase receipt files.

## Why

The autonomous evolve-round loop has run 5+ rounds. Each round drops phase receipts into `.aragora/evolve-round/<round-id>/dogfood/phase-*-receipt.json`. Today, computing cross-round metrics (PRs/round, completion rate, halt-trip count) requires hand-counting receipts. This PR produces them in one call.

## What lands

| File | Purpose | LOC |
| --- | --- | --- |
| `aragora/swarm/round_cadence.py` | Pure aggregator with frozen dataclasses | ~165 |
| `scripts/render_round_cadence.py` | Walks `.aragora/evolve-round/` and renders | ~115 |
| `tests/swarm/test_round_cadence.py` | 16 unit tests | ~180 |

## Live verdict (this PR's run)

```
Total rounds: 5
Total phases run: 43
Phases complete: 35 (81.4%)
Phases blocked: 0
Total PRs opened: 22
Rounds with halt-trip: 0
```

## Tests & lints

- 16/16 unit tests pass
- ruff check + format: clean
- mypy: `Success: no issues`

## Tier

**Tier 2** — pure additive; the renderer only reads existing receipt JSON files under `.aragora/evolve-round/` (already gitignored). Safe revert.

## Standing rule

I do not author-merge. Awaiting Codex signal + CI green.