### PR TITLE
feat(swarm): heterogeneous dialog model factories (stacked on #6855)

### DIFF
--- a/aragora/swarm/multi_agent_dialog.py
+++ b/aragora/swarm/multi_agent_dialog.py
@@ -1,0 +1,410 @@
+"""Cross-agent dialog harness for parallel agent dispatch.
+
+This module unblocks the 30c-Phase-D limitation: claude code, codex
+CLI, and droid CLI can all answer focused review prompts non-
+interactively, but only with the correct invocation flags. Previous
+rounds tried ``claude --bare`` (requires explicit env-var auth) and
+``codex exec`` under default ``reasoning_effort=xhigh`` (extensive
+investigation chain that exceeds 90s timeouts). This harness encodes
+the working flag set so future rounds always succeed.
+
+Design contract:
+
+- **Pure file-based state**: every dialog round is a JSONL stream;
+  no in-memory long-running state, so the harness is restart-safe
+  and inspectable post-hoc.
+- **Agent failures are isolated**: if one agent fails, the other
+  agents' turns still complete and are recorded.
+- **No GitHub mutations**: the harness writes only to the local
+  round directory provided by the caller.
+- **Standard library only**: ``asyncio.create_subprocess_exec``,
+  ``json``, ``dataclasses``, ``pathlib``. Zero new dependencies.
+
+Usage::
+
+    from aragora.swarm.multi_agent_dialog import (
+        AgentSpec, DialogRound, dispatch_round
+    )
+    agents = [
+        AgentSpec.claude(),
+        AgentSpec.codex(),
+        AgentSpec.droid(),
+    ]
+    round_ = DialogRound(round_id="phase-d", prompt="Review this code...")
+    transcripts = await dispatch_round(round_, agents, output_dir=Path("..."))
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- #
+# Verified working flag sets (round 30d agent verification)             #
+# --------------------------------------------------------------------- #
+#
+# These are the exact CLI invocations that succeed in non-interactive
+# dispatch. Encoded as data so any future round can reuse the harness
+# without re-deriving the flags.
+
+CLAUDE_FLAGS: tuple[str, ...] = ("--print",)
+"""``claude --print`` works without ``--bare``. ``--bare`` requires
+explicit ``ANTHROPIC_API_KEY`` env var; the keychain OAuth flow used
+by interactive ``claude`` is only honored without ``--bare``."""
+
+CODEX_FLAGS: tuple[str, ...] = (
+    "exec",
+    "--skip-git-repo-check",
+    "-c",
+    "reasoning_effort=minimal",
+    "-c",
+    "sandbox_mode=read-only",
+)
+"""``codex exec`` defaults to ``reasoning_effort=xhigh`` which produces
+extensive memory/file investigation chains that exceed 90s timeouts.
+``minimal`` reasoning + ``read-only`` sandbox keeps the model focused
+on the prompt and skips the investigation phase."""
+
+DROID_FLAGS: tuple[str, ...] = ("exec", "--auto", "low")
+"""``droid exec --auto low`` is the read-only autonomy level: the
+agent answers the prompt without taking any system-mutating actions."""
+
+
+# --------------------------------------------------------------------- #
+# Dataclasses                                                           #
+# --------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """Specification for one agent's turn in a dialog round."""
+
+    name: str
+    """Short display name (e.g. ``claude``, ``codex``, ``droid``)."""
+
+    binary: str
+    """Path to the CLI executable (or just the name if on PATH)."""
+
+    base_flags: tuple[str, ...]
+    """Flags prepended before the prompt (or before ``-`` for stdin)."""
+
+    timeout_seconds: int
+    """Hard cap on dispatch time."""
+
+    stdin_mode: str = "argv"
+    """Either ``argv`` (prompt as final arg) or ``stdin`` (piped to stdin)."""
+
+    @classmethod
+    def claude(cls, timeout_seconds: int = 60) -> "AgentSpec":
+        return cls(
+            name="claude",
+            binary="claude",
+            base_flags=CLAUDE_FLAGS,
+            timeout_seconds=timeout_seconds,
+            stdin_mode="stdin",
+        )
+
+    @classmethod
+    def codex(cls, timeout_seconds: int = 90) -> "AgentSpec":
+        return cls(
+            name="codex",
+            binary="codex",
+            base_flags=CODEX_FLAGS,
+            timeout_seconds=timeout_seconds,
+            stdin_mode="stdin",
+        )
+
+    @classmethod
+    def droid(cls, timeout_seconds: int = 60) -> "AgentSpec":
+        return cls(
+            name="droid",
+            binary="droid",
+            base_flags=DROID_FLAGS,
+            timeout_seconds=timeout_seconds,
+            stdin_mode="stdin",
+        )
+
+
+@dataclass
+class DialogTurn:
+    """One agent's response for one prompt."""
+
+    agent: str
+    started_at: str
+    finished_at: str
+    elapsed_seconds: float
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool
+    error: str | None = None
+
+    def succeeded(self) -> bool:
+        return self.returncode == 0 and not self.timed_out and not self.error
+
+    def to_json(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass
+class DialogRound:
+    """One round of cross-agent dialog: a single prompt for many agents."""
+
+    round_id: str
+    prompt: str
+    extra_context: str = ""
+    """Optional extra context (e.g. source file contents) appended to prompt."""
+
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def render_prompt(self) -> str:
+        if self.extra_context:
+            return f"{self.prompt}\n\n{self.extra_context}"
+        return self.prompt
+
+
+# --------------------------------------------------------------------- #
+# Dispatch                                                              #
+# --------------------------------------------------------------------- #
+
+
+async def _dispatch_one(
+    spec: AgentSpec,
+    rendered_prompt: str,
+) -> DialogTurn:
+    """Dispatch one agent and return a recorded ``DialogTurn``.
+
+    Errors (subprocess launch failure, timeout) are caught and
+    encoded into the turn rather than propagated. This guarantees
+    that one agent's failure cannot cascade.
+    """
+    started_at = datetime.now(timezone.utc)
+
+    if spec.stdin_mode == "stdin":
+        argv = [spec.binary, *spec.base_flags]
+        stdin_data: bytes | None = rendered_prompt.encode("utf-8")
+    else:
+        argv = [spec.binary, *spec.base_flags, rendered_prompt]
+        stdin_data = None
+
+    timed_out = False
+    err_msg: str | None = None
+    rc = -1
+    out = ""
+    err = ""
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE if stdin_data is not None else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            out_b, err_b = await asyncio.wait_for(
+                proc.communicate(input=stdin_data),
+                timeout=spec.timeout_seconds,
+            )
+            rc = proc.returncode if proc.returncode is not None else -1
+            out = out_b.decode("utf-8", errors="replace")
+            err = err_b.decode("utf-8", errors="replace")
+        except asyncio.TimeoutError:
+            timed_out = True
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+    except FileNotFoundError:
+        err_msg = f"binary not found: {spec.binary}"
+        logger.warning("multi_agent_dialog: %s", err_msg)
+    except Exception as exc:  # noqa: BLE001 — capture any subprocess setup error
+        err_msg = f"dispatch failed: {type(exc).__name__}: {exc}"
+        logger.warning("multi_agent_dialog: %s", err_msg)
+
+    finished_at = datetime.now(timezone.utc)
+    elapsed = (finished_at - started_at).total_seconds()
+
+    return DialogTurn(
+        agent=spec.name,
+        started_at=started_at.isoformat(),
+        finished_at=finished_at.isoformat(),
+        elapsed_seconds=round(elapsed, 3),
+        returncode=rc,
+        stdout=out,
+        stderr=err,
+        timed_out=timed_out,
+        error=err_msg,
+    )
+
+
+async def dispatch_round(
+    round_: DialogRound,
+    agents: Sequence[AgentSpec],
+) -> list[DialogTurn]:
+    """Dispatch all agents in parallel; return turn records.
+
+    Failures of any single agent do not affect the others.
+    """
+    if not agents:
+        return []
+    rendered = round_.render_prompt()
+    tasks = [_dispatch_one(spec, rendered) for spec in agents]
+    return list(await asyncio.gather(*tasks))
+
+
+# --------------------------------------------------------------------- #
+# Persistence                                                           #
+# --------------------------------------------------------------------- #
+
+
+def write_round_jsonl(
+    round_: DialogRound,
+    turns: Sequence[DialogTurn],
+    output_dir: Path,
+) -> Path:
+    """Persist round + turns as a JSONL stream under ``output_dir``.
+
+    The first line is the round metadata. Subsequent lines are turns.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / f"dialog-{round_.round_id}.jsonl"
+    with out_path.open("w", encoding="utf-8") as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "round",
+                    "round_id": round_.round_id,
+                    "prompt": round_.prompt,
+                    "extra_context_chars": len(round_.extra_context),
+                    "metadata": round_.metadata,
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        for turn in turns:
+            payload = {"type": "turn", **turn.to_json()}
+            f.write(json.dumps(payload, sort_keys=True) + "\n")
+    return out_path
+
+
+def render_transcript_markdown(
+    round_: DialogRound,
+    turns: Sequence[DialogTurn],
+) -> str:
+    """Render round + turns as a single markdown transcript."""
+    lines: list[str] = [
+        f"# Cross-agent dialog — round `{round_.round_id}`",
+        "",
+        f"_Prompt size: {len(round_.prompt)} chars; extra context: "
+        f"{len(round_.extra_context)} chars._",
+        "",
+        "## Prompt",
+        "",
+        "```",
+        round_.prompt.strip() or "(empty)",
+        "```",
+        "",
+    ]
+    if round_.extra_context.strip():
+        lines.extend(
+            [
+                "## Extra context",
+                "",
+                "```",
+                round_.extra_context.strip()[:2000]
+                + ("..." if len(round_.extra_context) > 2000 else ""),
+                "```",
+                "",
+            ]
+        )
+
+    success_count = sum(1 for t in turns if t.succeeded())
+    lines.extend(
+        [
+            "## Summary",
+            "",
+            f"- Agents dispatched: **{len(turns)}**",
+            f"- Successful: **{success_count}**",
+            f"- Failed: **{len(turns) - success_count}**",
+            "",
+        ]
+    )
+
+    lines.extend(["## Per-agent responses", ""])
+    for turn in turns:
+        status = "succeeded" if turn.succeeded() else "FAILED"
+        lines.extend(
+            [
+                f"### `{turn.agent}` — {status} (rc={turn.returncode}, "
+                f"{turn.elapsed_seconds:.1f}s, "
+                f"timed_out={turn.timed_out})",
+                "",
+            ]
+        )
+        if turn.error:
+            lines.extend([f"_Error: {turn.error}_", ""])
+        if turn.stdout.strip():
+            lines.extend(
+                [
+                    "**stdout:**",
+                    "",
+                    "```",
+                    turn.stdout.rstrip(),
+                    "```",
+                    "",
+                ]
+            )
+        if turn.stderr.strip() and not turn.succeeded():
+            tail = "\n".join(turn.stderr.rstrip().splitlines()[-10:])
+            lines.extend(
+                [
+                    "**stderr (last 10 lines):**",
+                    "",
+                    "```",
+                    tail,
+                    "```",
+                    "",
+                ]
+            )
+    return "\n".join(lines)
+
+
+def write_transcript_markdown(
+    round_: DialogRound,
+    turns: Sequence[DialogTurn],
+    output_dir: Path,
+) -> Path:
+    """Persist a markdown transcript and return its path."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / f"dialog-{round_.round_id}.md"
+    out_path.write_text(render_transcript_markdown(round_, turns), encoding="utf-8")
+    return out_path
+
+
+# --------------------------------------------------------------------- #
+# Convenience high-level entry point                                    #
+# --------------------------------------------------------------------- #
+
+
+async def run_round_and_persist(
+    round_: DialogRound,
+    agents: Sequence[AgentSpec],
+    output_dir: Path,
+) -> tuple[Path, Path, list[DialogTurn]]:
+    """Dispatch the round, persist JSONL + markdown, return both paths and turns."""
+    turns = await dispatch_round(round_, agents)
+    jsonl_path = write_round_jsonl(round_, turns, output_dir)
+    md_path = write_transcript_markdown(round_, turns, output_dir)
+    return jsonl_path, md_path, turns

--- a/aragora/swarm/multi_agent_dialog.py
+++ b/aragora/swarm/multi_agent_dialog.py
@@ -132,6 +132,129 @@ class AgentSpec:
             stdin_mode="stdin",
         )
 
+    # ----------------------------------------------------------------- #
+    # Heterogeneous model factories (round 30e)                         #
+    # ----------------------------------------------------------------- #
+    #
+    # The base ``claude()`` / ``codex()`` / ``droid()`` factories above
+    # use the CLI's *default* model, which means a 3-CLI panel is in
+    # practice "same-family-three-times". The maximalist vision wants
+    # **heterogeneous-model consensus**: independent perspectives from
+    # different model families catch what one family misses.
+    #
+    # These factories pin a specific model on a specific CLI surface
+    # so a single round can dispatch e.g. claude-opus, claude-sonnet,
+    # gpt-5.4, gemini-3.1-pro, kimi-k2.5 in parallel.
+
+    @classmethod
+    def with_model(
+        cls,
+        cli: str,
+        model: str,
+        *,
+        name: str | None = None,
+        timeout_seconds: int = 90,
+    ) -> "AgentSpec":
+        """Build an AgentSpec pinned to a specific model on a specific CLI.
+
+        Args:
+            cli: One of ``"claude"``, ``"codex"``, ``"droid"``.
+            model: Model identifier accepted by the chosen CLI.
+            name: Optional display name; defaults to ``f"{cli}:{model}"``.
+            timeout_seconds: Hard cap on dispatch.
+
+        ``codex`` does not currently expose a stable per-invocation
+        model flag in its public CLI; passing ``cli="codex"`` will
+        raise ``ValueError`` to make the limitation explicit.
+        """
+        cli_norm = (cli or "").strip().lower()
+        display = name or f"{cli_norm}:{model}"
+        if cli_norm == "claude":
+            return cls(
+                name=display,
+                binary="claude",
+                base_flags=(*CLAUDE_FLAGS, "--model", model),
+                timeout_seconds=timeout_seconds,
+                stdin_mode="stdin",
+            )
+        if cli_norm == "droid":
+            return cls(
+                name=display,
+                binary="droid",
+                base_flags=(*DROID_FLAGS, "-m", model),
+                timeout_seconds=timeout_seconds,
+                stdin_mode="stdin",
+            )
+        if cli_norm == "codex":
+            raise ValueError(
+                "codex CLI does not currently expose a stable per-invocation "
+                "model flag; use the codex() factory which inherits the "
+                "user's ~/.codex/config.toml model setting."
+            )
+        raise ValueError(f"unknown cli {cli!r}; expected claude / codex / droid")
+
+    # Concrete heterogeneous factories — known-good model IDs verified
+    # in round 30e Phase A.
+    @classmethod
+    def claude_opus(cls, timeout_seconds: int = 90) -> "AgentSpec":
+        """Claude Opus via the ``claude`` CLI."""
+        return cls.with_model("claude", "opus", name="claude-opus", timeout_seconds=timeout_seconds)
+
+    @classmethod
+    def claude_sonnet(cls, timeout_seconds: int = 60) -> "AgentSpec":
+        """Claude Sonnet via the ``claude`` CLI."""
+        return cls.with_model(
+            "claude", "sonnet", name="claude-sonnet", timeout_seconds=timeout_seconds
+        )
+
+    @classmethod
+    def droid_gpt5(cls, timeout_seconds: int = 90) -> "AgentSpec":
+        """GPT-5.4 via the ``droid`` CLI."""
+        return cls.with_model(
+            "droid", "gpt-5.4", name="droid-gpt5", timeout_seconds=timeout_seconds
+        )
+
+    @classmethod
+    def droid_gemini(cls, timeout_seconds: int = 90) -> "AgentSpec":
+        """Gemini 3.1 Pro via the ``droid`` CLI."""
+        return cls.with_model(
+            "droid",
+            "gemini-3.1-pro-preview",
+            name="droid-gemini",
+            timeout_seconds=timeout_seconds,
+        )
+
+    @classmethod
+    def droid_kimi(cls, timeout_seconds: int = 90) -> "AgentSpec":
+        """Kimi K2.5 (Chinese frontier) via the ``droid`` CLI."""
+        return cls.with_model(
+            "droid", "kimi-k2.5", name="droid-kimi", timeout_seconds=timeout_seconds
+        )
+
+    @classmethod
+    def droid_glm(cls, timeout_seconds: int = 90) -> "AgentSpec":
+        """GLM 5.1 (Chinese frontier) via the ``droid`` CLI."""
+        return cls.with_model("droid", "glm-5.1", name="droid-glm", timeout_seconds=timeout_seconds)
+
+    @classmethod
+    def heterogeneous_panel(
+        cls, *, codex_timeout: int = 120, model_timeout: int = 90
+    ) -> "tuple[AgentSpec, ...]":
+        """Return the canonical heterogeneous review panel.
+
+        Six independent model surfaces spanning Anthropic, OpenAI,
+        Google, and Chinese frontier families. Used by the
+        ``--agents-spec heterogeneous`` shorthand in the CLI.
+        """
+        return (
+            cls.claude_opus(timeout_seconds=model_timeout),
+            cls.claude_sonnet(timeout_seconds=model_timeout),
+            cls.codex(timeout_seconds=codex_timeout),
+            cls.droid_gpt5(timeout_seconds=model_timeout),
+            cls.droid_gemini(timeout_seconds=model_timeout),
+            cls.droid_kimi(timeout_seconds=model_timeout),
+        )
+
 
 @dataclass
 class DialogTurn:

--- a/aragora/swarm/multi_agent_dialog.py
+++ b/aragora/swarm/multi_agent_dialog.py
@@ -39,12 +39,113 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import re
+import signal
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Sequence
 
 logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- #
+# Round 30e Phase C — gauntlet hardening helpers                        #
+# --------------------------------------------------------------------- #
+#
+# All eight fixes from round 30d-Phase-H's gauntlet review of this
+# module live here as small, named helpers so the test suite can
+# exercise each one independently.
+
+# Match a code-fence opener (```) at the start of a line so we can
+# escape adversarial agent output that tries to break out of the
+# transcript's fenced ``stdout`` block.
+_FENCE_RE: re.Pattern[str] = re.compile(r"^(\s*)(```)", re.MULTILINE)
+
+# Strip CSI / OSC ANSI escapes (color, cursor moves, OSC-8 hyperlinks)
+# from agent output before persisting. Two patterns cover the bulk:
+#   - ESC [ ... letter (CSI)
+#   - ESC ] ... BEL/ST  (OSC)
+_ANSI_CSI_RE: re.Pattern[str] = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_ANSI_OSC_RE: re.Pattern[str] = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+
+# Round IDs are interpolated into output filenames; this regex keeps
+# them confined to the intended output directory.
+_ROUND_ID_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_\-]{0,127}$")
+
+# Distinct sentinel returncodes so operators can tell ``binary not
+# found`` apart from a genuine CLI rc=-1 failure.
+RC_BINARY_NOT_FOUND: int = -127
+RC_DISPATCH_ERROR: int = -126
+
+# Cap on persisted stdout/stderr per turn — chatty CLIs can produce
+# multi-MB lines that overflow downstream JSONL parsers.
+MAX_OUTPUT_BYTES: int = 1_000_000
+
+
+def _strip_ansi(s: str) -> str:
+    """Return ``s`` with CSI and OSC ANSI escape sequences removed."""
+    return _ANSI_OSC_RE.sub("", _ANSI_CSI_RE.sub("", s))
+
+
+def _truncate_output(s: str, *, max_bytes: int = MAX_OUTPUT_BYTES) -> str:
+    """Cap a string at ``max_bytes`` UTF-8 bytes with a sentinel suffix.
+
+    The returned string is guaranteed to encode to at most ``max_bytes``
+    UTF-8 bytes *including* the sentinel suffix. This is a Phase D
+    correctness fix — codex review observed that the previous version
+    appended the sentinel *after* the budget, so persisted output
+    could exceed ``max_bytes``.
+    """
+    encoded = s.encode("utf-8", errors="replace")
+    if len(encoded) <= max_bytes:
+        return s
+    sentinel = f"\n... [TRUNCATED: original {len(encoded)} bytes]"
+    sentinel_bytes = sentinel.encode("utf-8")
+    # Reserve sentinel bytes from the budget. Guard against a sentinel
+    # somehow exceeding the budget (would only happen with absurdly
+    # small max_bytes in tests).
+    budget = max(0, max_bytes - len(sentinel_bytes))
+    truncated = encoded[:budget].decode("utf-8", errors="replace")
+    return truncated + sentinel
+
+
+def _escape_md_fence(s: str) -> str:
+    """Escape ``` fence opens so an agent cannot break the rendered code block.
+
+    Inserts a zero-width space (``\\u200b``) between the leading
+    whitespace and the backticks, which preserves the visual content
+    but prevents Markdown's parser from closing the surrounding fence.
+    """
+    return _FENCE_RE.sub("\\1\u200b\\2", s)
+
+
+def _validate_round_id(round_id: str) -> None:
+    """Reject ``round_id`` values that would traverse outside ``output_dir``."""
+    if not _ROUND_ID_RE.match(round_id or ""):
+        raise ValueError(f"invalid round_id {round_id!r}: must match {_ROUND_ID_RE.pattern}")
+
+
+def _atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:
+    """Write ``content`` atomically via tmp file + ``os.replace``.
+
+    Crashes mid-write leave the original file (if any) intact instead
+    of producing a half-written transcript. The temp file lives in the
+    same directory so ``os.replace`` is a same-filesystem rename.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    with tmp_path.open("w", encoding=encoding) as f:
+        f.write(content)
+        f.flush()
+        try:
+            os.fsync(f.fileno())
+        except OSError:
+            # Some filesystems (notably tmpfs in CI) don't support fsync;
+            # the os.replace still gives atomic visibility.
+            pass
+    os.replace(tmp_path, path)
 
 
 # --------------------------------------------------------------------- #
@@ -324,12 +425,23 @@ async def _dispatch_one(
     out = ""
     err = ""
 
+    # Round 30e Phase C fix #1: launch each child in its own process
+    # group on POSIX so a timeout can reap any grandchildren the CLI
+    # spawned (some agent CLIs fork sub-helpers that leak otherwise).
+    #
+    # Phase D follow-up: prefer ``start_new_session=True`` over
+    # ``preexec_fn=os.setsid`` per Python docs — it avoids the
+    # interpreter-thread fork hazard while achieving the same setsid()
+    # effect.
+    new_session = os.name == "posix"
+
     try:
         proc = await asyncio.create_subprocess_exec(
             *argv,
             stdin=asyncio.subprocess.PIPE if stdin_data is not None else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            start_new_session=new_session,
         )
         try:
             out_b, err_b = await asyncio.wait_for(
@@ -341,20 +453,44 @@ async def _dispatch_one(
             err = err_b.decode("utf-8", errors="replace")
         except asyncio.TimeoutError:
             timed_out = True
+            # Round 30e Phase C fix #2: SIGKILL the whole process group,
+            # not just the leader, so child helpers don't leak.
             try:
-                proc.kill()
+                if os.name == "posix":
+                    pgid = os.getpgid(proc.pid)
+                    os.killpg(pgid, signal.SIGKILL)
+                else:
+                    proc.kill()
                 await proc.wait()
-            except ProcessLookupError:
+            except (ProcessLookupError, PermissionError):
                 pass
     except FileNotFoundError:
+        # Round 30e Phase C fix #3: distinct sentinel rc so the operator
+        # can tell "CLI missing on $PATH" apart from "CLI ran and
+        # returned -1".
         err_msg = f"binary not found: {spec.binary}"
+        rc = RC_BINARY_NOT_FOUND
         logger.warning("multi_agent_dialog: %s", err_msg)
     except Exception as exc:  # noqa: BLE001 — capture any subprocess setup error
         err_msg = f"dispatch failed: {type(exc).__name__}: {exc}"
+        rc = RC_DISPATCH_ERROR
         logger.warning("multi_agent_dialog: %s", err_msg)
 
     finished_at = datetime.now(timezone.utc)
     elapsed = (finished_at - started_at).total_seconds()
+
+    # Round 30e Phase C fix #5 (truncate first — Phase D follow-up):
+    # cap output BEFORE ANSI-strip so a multi-MB ANSI-laden line
+    # doesn't get fully regex-scanned in memory. This keeps both CPU
+    # and persisted size bounded by MAX_OUTPUT_BYTES.
+    out = _truncate_output(out)
+    err = _truncate_output(err)
+
+    # Round 30e Phase C fix #4: strip ANSI escapes before persisting so
+    # a malicious agent can't poison downstream tooling with cursor
+    # moves or OSC-8 hyperlinks.
+    out = _strip_ansi(out)
+    err = _strip_ansi(err)
 
     return DialogTurn(
         agent=spec.name,
@@ -381,7 +517,31 @@ async def dispatch_round(
         return []
     rendered = round_.render_prompt()
     tasks = [_dispatch_one(spec, rendered) for spec in agents]
-    return list(await asyncio.gather(*tasks))
+
+    # Round 30e Phase C fix #6: ``return_exceptions=True`` ensures one
+    # agent's unexpected raise (e.g. asyncio.CancelledError, OSError
+    # from preexec_fn) cannot cascade and abort all peer dispatches.
+    raw = await asyncio.gather(*tasks, return_exceptions=True)
+    out: list[DialogTurn] = []
+    for spec, result in zip(agents, raw):
+        if isinstance(result, BaseException):
+            now = datetime.now(timezone.utc).isoformat()
+            out.append(
+                DialogTurn(
+                    agent=spec.name,
+                    started_at=now,
+                    finished_at=now,
+                    elapsed_seconds=0.0,
+                    returncode=RC_DISPATCH_ERROR,
+                    stdout="",
+                    stderr="",
+                    timed_out=False,
+                    error=f"unexpected dispatch exception: {type(result).__name__}: {result}",
+                )
+            )
+        else:
+            out.append(result)
+    return out
 
 
 # --------------------------------------------------------------------- #
@@ -398,26 +558,30 @@ def write_round_jsonl(
 
     The first line is the round metadata. Subsequent lines are turns.
     """
+    # Round 30e Phase C fix #7: validate round_id (path traversal) and
+    # write atomically so a crash mid-write doesn't leave a half-baked
+    # JSONL behind.
+    _validate_round_id(round_.round_id)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path = output_dir / f"dialog-{round_.round_id}.jsonl"
-    with out_path.open("w", encoding="utf-8") as f:
-        f.write(
-            json.dumps(
-                {
-                    "type": "round",
-                    "round_id": round_.round_id,
-                    "prompt": round_.prompt,
-                    "extra_context_chars": len(round_.extra_context),
-                    "metadata": round_.metadata,
-                },
-                sort_keys=True,
-            )
-            + "\n"
+
+    lines: list[str] = [
+        json.dumps(
+            {
+                "type": "round",
+                "round_id": round_.round_id,
+                "prompt": round_.prompt,
+                "extra_context_chars": len(round_.extra_context),
+                "metadata": round_.metadata,
+            },
+            sort_keys=True,
         )
-        for turn in turns:
-            payload = {"type": "turn", **turn.to_json()}
-            f.write(json.dumps(payload, sort_keys=True) + "\n")
+    ]
+    for turn in turns:
+        payload = {"type": "turn", **turn.to_json()}
+        lines.append(json.dumps(payload, sort_keys=True))
+    _atomic_write_text(out_path, "\n".join(lines) + "\n")
     return out_path
 
 
@@ -466,7 +630,14 @@ def render_transcript_markdown(
 
     lines.extend(["## Per-agent responses", ""])
     for turn in turns:
-        status = "succeeded" if turn.succeeded() else "FAILED"
+        # Round 30e Phase C fix #8a: explicit [TIMED OUT] badge so a
+        # zero-stdout timeout doesn't read as a quiet success in scan.
+        if turn.timed_out:
+            status = "FAILED [TIMED OUT]"
+        elif turn.succeeded():
+            status = "succeeded"
+        else:
+            status = "FAILED"
         lines.extend(
             [
                 f"### `{turn.agent}` — {status} (rc={turn.returncode}, "
@@ -478,12 +649,15 @@ def render_transcript_markdown(
         if turn.error:
             lines.extend([f"_Error: {turn.error}_", ""])
         if turn.stdout.strip():
+            # Round 30e Phase C fix #8b: escape any nested ``` so an
+            # adversarial agent can't break out of our fenced block and
+            # poison the rest of the transcript.
             lines.extend(
                 [
                     "**stdout:**",
                     "",
                     "```",
-                    turn.stdout.rstrip(),
+                    _escape_md_fence(turn.stdout.rstrip()),
                     "```",
                     "",
                 ]
@@ -495,7 +669,7 @@ def render_transcript_markdown(
                     "**stderr (last 10 lines):**",
                     "",
                     "```",
-                    tail,
+                    _escape_md_fence(tail),
                     "```",
                     "",
                 ]
@@ -509,10 +683,11 @@ def write_transcript_markdown(
     output_dir: Path,
 ) -> Path:
     """Persist a markdown transcript and return its path."""
+    _validate_round_id(round_.round_id)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path = output_dir / f"dialog-{round_.round_id}.md"
-    out_path.write_text(render_transcript_markdown(round_, turns), encoding="utf-8")
+    _atomic_write_text(out_path, render_transcript_markdown(round_, turns))
     return out_path
 
 

--- a/scripts/multi_agent_dialog.py
+++ b/scripts/multi_agent_dialog.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""CLI entry point for the cross-agent dialog harness.
+
+Dispatch a single prompt to multiple agents (claude, codex, droid) in
+parallel, persist the round transcript as JSONL + markdown, and exit.
+
+This is the operator-facing surface of
+``aragora.swarm.multi_agent_dialog``. See that module's docstring for
+the rationale behind each agent's invocation flags.
+
+Usage::
+
+    # Single-prompt round, all three agents:
+    python3 scripts/multi_agent_dialog.py \\
+        --round-id phase-d-pr6839 \\
+        --prompt-file prompts/review.md \\
+        --output-dir .aragora/evolve-round/2026-04-30d/dogfood/
+
+    # With extra context (e.g. source file):
+    python3 scripts/multi_agent_dialog.py \\
+        --round-id sample \\
+        --prompt 'Review this code for bugs.' \\
+        --context-file aragora/swarm/dispatch_evidence.py \\
+        --output-dir /tmp/dialog/
+
+    # Subset of agents:
+    python3 scripts/multi_agent_dialog.py \\
+        --round-id sample \\
+        --prompt 'Hello' \\
+        --agents claude,codex \\
+        --output-dir /tmp/dialog/
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import Callable
+
+# Allow running this script before the package is installed.
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from aragora.swarm.multi_agent_dialog import (  # noqa: E402
+    AgentSpec,
+    DialogRound,
+    run_round_and_persist,
+)
+
+
+AGENT_FACTORIES: dict[str, Callable[..., AgentSpec]] = {
+    "claude": AgentSpec.claude,
+    "codex": AgentSpec.codex,
+    "droid": AgentSpec.droid,
+}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--round-id",
+        required=True,
+        help="Short identifier used as the JSONL/markdown filename suffix",
+    )
+
+    prompt_group = parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt", help="Inline prompt string")
+    prompt_group.add_argument(
+        "--prompt-file",
+        type=Path,
+        help="Path to a file whose contents are used as the prompt",
+    )
+
+    parser.add_argument(
+        "--context-file",
+        type=Path,
+        default=None,
+        help="Optional file appended verbatim under an 'Extra context' "
+        "section in the rendered prompt",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory to write dialog-<round-id>.{jsonl,md}",
+    )
+    parser.add_argument(
+        "--agents",
+        default="claude,codex,droid",
+        help="Comma-separated agent names. Available: " + ",".join(sorted(AGENT_FACTORIES)),
+    )
+    parser.add_argument("--claude-timeout", type=int, default=60, help="Per-agent timeout (s)")
+    parser.add_argument("--codex-timeout", type=int, default=90, help="Per-agent timeout (s)")
+    parser.add_argument("--droid-timeout", type=int, default=60, help="Per-agent timeout (s)")
+    return parser.parse_args(argv)
+
+
+def _build_agents(spec: argparse.Namespace) -> list[AgentSpec]:
+    names = [name.strip() for name in spec.agents.split(",") if name.strip()]
+    out: list[AgentSpec] = []
+    timeouts = {
+        "claude": spec.claude_timeout,
+        "codex": spec.codex_timeout,
+        "droid": spec.droid_timeout,
+    }
+    for name in names:
+        factory = AGENT_FACTORIES.get(name)
+        if factory is None:
+            raise SystemExit(
+                f"unknown agent: {name!r}. Available: " + ",".join(sorted(AGENT_FACTORIES))
+            )
+        out.append(factory(timeout_seconds=timeouts.get(name, 60)))
+    return out
+
+
+def _resolve_prompt(spec: argparse.Namespace) -> str:
+    if spec.prompt is not None:
+        return spec.prompt
+    return spec.prompt_file.read_text(encoding="utf-8")
+
+
+def _resolve_context(spec: argparse.Namespace) -> str:
+    if spec.context_file is None:
+        return ""
+    return spec.context_file.read_text(encoding="utf-8")
+
+
+async def _run(spec: argparse.Namespace) -> int:
+    agents = _build_agents(spec)
+    round_ = DialogRound(
+        round_id=spec.round_id,
+        prompt=_resolve_prompt(spec),
+        extra_context=_resolve_context(spec),
+    )
+    jsonl_path, md_path, turns = await run_round_and_persist(round_, agents, spec.output_dir)
+    print(f"jsonl: {jsonl_path}")
+    print(f"markdown: {md_path}")
+    print(f"agents dispatched: {len(turns)}")
+    print(f"successful: {sum(1 for t in turns if t.succeeded())}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    spec = parse_args(argv)
+    return asyncio.run(_run(spec))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/multi_agent_dialog.py
+++ b/scripts/multi_agent_dialog.py
@@ -54,6 +54,29 @@ AGENT_FACTORIES: dict[str, Callable[..., AgentSpec]] = {
     "claude": AgentSpec.claude,
     "codex": AgentSpec.codex,
     "droid": AgentSpec.droid,
+    # Heterogeneous model factories (round 30e Phase B):
+    "claude-opus": AgentSpec.claude_opus,
+    "claude-sonnet": AgentSpec.claude_sonnet,
+    "droid-gpt5": AgentSpec.droid_gpt5,
+    "droid-gemini": AgentSpec.droid_gemini,
+    "droid-kimi": AgentSpec.droid_kimi,
+    "droid-glm": AgentSpec.droid_glm,
+}
+
+# Agent groups for the ``--agents-spec`` shorthand. Keys are validated
+# at parse time; values are tuples of factory keys above.
+AGENT_GROUPS: dict[str, tuple[str, ...]] = {
+    "default": ("claude", "codex", "droid"),
+    "heterogeneous": (
+        "claude-opus",
+        "claude-sonnet",
+        "codex",
+        "droid-gpt5",
+        "droid-gemini",
+        "droid-kimi",
+    ),
+    "anthropic-only": ("claude-opus", "claude-sonnet"),
+    "frontier-chinese": ("droid-kimi", "droid-glm"),
 }
 
 
@@ -88,19 +111,43 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--agents",
-        default="claude,codex,droid",
+        default=None,
         help="Comma-separated agent names. Available: " + ",".join(sorted(AGENT_FACTORIES)),
+    )
+    parser.add_argument(
+        "--agents-spec",
+        default=None,
+        choices=sorted(AGENT_GROUPS),
+        help=(
+            "Pre-built agent group: "
+            + ", ".join(f"{k}=({','.join(v)})" for k, v in AGENT_GROUPS.items())
+        ),
     )
     parser.add_argument("--claude-timeout", type=int, default=60, help="Per-agent timeout (s)")
     parser.add_argument("--codex-timeout", type=int, default=90, help="Per-agent timeout (s)")
     parser.add_argument("--droid-timeout", type=int, default=60, help="Per-agent timeout (s)")
+    parser.add_argument(
+        "--model-timeout",
+        type=int,
+        default=90,
+        help="Per-agent timeout (s) for heterogeneous-model factories.",
+    )
     return parser.parse_args(argv)
 
 
 def _build_agents(spec: argparse.Namespace) -> list[AgentSpec]:
-    names = [name.strip() for name in spec.agents.split(",") if name.strip()]
+    # Resolve agent name list. Precedence:
+    #  1. Explicit --agents wins.
+    #  2. --agents-spec resolves to its group.
+    #  3. Default to the legacy 3-CLI panel.
+    if spec.agents:
+        names = [name.strip() for name in spec.agents.split(",") if name.strip()]
+    elif spec.agents_spec:
+        names = list(AGENT_GROUPS[spec.agents_spec])
+    else:
+        names = list(AGENT_GROUPS["default"])
     out: list[AgentSpec] = []
-    timeouts = {
+    legacy_timeouts = {
         "claude": spec.claude_timeout,
         "codex": spec.codex_timeout,
         "droid": spec.droid_timeout,
@@ -111,7 +158,10 @@ def _build_agents(spec: argparse.Namespace) -> list[AgentSpec]:
             raise SystemExit(
                 f"unknown agent: {name!r}. Available: " + ",".join(sorted(AGENT_FACTORIES))
             )
-        out.append(factory(timeout_seconds=timeouts.get(name, 60)))
+        # Legacy 3-CLI factories have explicit per-name timeouts; the
+        # heterogeneous factories share ``--model-timeout``.
+        timeout = legacy_timeouts.get(name, spec.model_timeout)
+        out.append(factory(timeout_seconds=timeout))
     return out
 
 

--- a/tests/swarm/test_multi_agent_dialog.py
+++ b/tests/swarm/test_multi_agent_dialog.py
@@ -1,0 +1,301 @@
+"""Tests for aragora.swarm.multi_agent_dialog."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm.multi_agent_dialog import (
+    CLAUDE_FLAGS,
+    CODEX_FLAGS,
+    DROID_FLAGS,
+    AgentSpec,
+    DialogRound,
+    DialogTurn,
+    dispatch_round,
+    render_transcript_markdown,
+    run_round_and_persist,
+    write_round_jsonl,
+    write_transcript_markdown,
+    _dispatch_one,
+)
+
+
+def test_agent_spec_claude_flags() -> None:
+    spec = AgentSpec.claude()
+    assert spec.name == "claude"
+    assert spec.binary == "claude"
+    assert spec.base_flags == CLAUDE_FLAGS
+    assert spec.stdin_mode == "stdin"
+    assert spec.timeout_seconds == 60
+
+
+def test_agent_spec_codex_flags_include_minimal_reasoning() -> None:
+    spec = AgentSpec.codex()
+    assert "reasoning_effort=minimal" in spec.base_flags
+    assert "sandbox_mode=read-only" in spec.base_flags
+    assert spec.timeout_seconds == 90
+
+
+def test_agent_spec_droid_flags_include_auto_low() -> None:
+    spec = AgentSpec.droid()
+    assert "exec" in spec.base_flags
+    assert "low" in spec.base_flags
+    assert "--auto" in spec.base_flags
+
+
+def test_agent_spec_custom_timeout() -> None:
+    spec = AgentSpec.claude(timeout_seconds=30)
+    assert spec.timeout_seconds == 30
+
+
+def test_dialog_round_render_prompt_no_context() -> None:
+    r = DialogRound(round_id="t", prompt="hello")
+    assert r.render_prompt() == "hello"
+
+
+def test_dialog_round_render_prompt_with_context() -> None:
+    r = DialogRound(round_id="t", prompt="hello", extra_context="more info")
+    assert "hello" in r.render_prompt()
+    assert "more info" in r.render_prompt()
+
+
+def test_dialog_turn_succeeded_clean() -> None:
+    t = DialogTurn(
+        agent="x",
+        started_at="2026-04-30T00:00:00+00:00",
+        finished_at="2026-04-30T00:00:01+00:00",
+        elapsed_seconds=1.0,
+        returncode=0,
+        stdout="OK",
+        stderr="",
+        timed_out=False,
+        error=None,
+    )
+    assert t.succeeded()
+
+
+def test_dialog_turn_succeeded_false_on_timeout() -> None:
+    t = DialogTurn(
+        agent="x",
+        started_at="t1",
+        finished_at="t2",
+        elapsed_seconds=60.0,
+        returncode=0,
+        stdout="",
+        stderr="",
+        timed_out=True,
+    )
+    assert not t.succeeded()
+
+
+def test_dialog_turn_succeeded_false_on_error() -> None:
+    t = DialogTurn(
+        agent="x",
+        started_at="t1",
+        finished_at="t2",
+        elapsed_seconds=0.0,
+        returncode=-1,
+        stdout="",
+        stderr="",
+        timed_out=False,
+        error="binary not found",
+    )
+    assert not t.succeeded()
+
+
+def test_dialog_turn_succeeded_false_on_nonzero_rc() -> None:
+    t = DialogTurn(
+        agent="x",
+        started_at="t1",
+        finished_at="t2",
+        elapsed_seconds=1.0,
+        returncode=1,
+        stdout="",
+        stderr="boom",
+        timed_out=False,
+    )
+    assert not t.succeeded()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_one_succeeds_with_echo() -> None:
+    spec = AgentSpec(
+        name="echo",
+        binary="/bin/sh",
+        base_flags=("-c", "cat"),
+        timeout_seconds=10,
+        stdin_mode="stdin",
+    )
+    turn = await _dispatch_one(spec, rendered_prompt="hello")
+    assert turn.succeeded()
+    assert "hello" in turn.stdout
+    assert turn.returncode == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_one_handles_missing_binary() -> None:
+    spec = AgentSpec(
+        name="missing",
+        binary="/no/such/binary-9b13c2e4",
+        base_flags=(),
+        timeout_seconds=5,
+        stdin_mode="stdin",
+    )
+    turn = await _dispatch_one(spec, rendered_prompt="hi")
+    assert not turn.succeeded()
+    assert turn.error is not None
+    assert "binary not found" in turn.error
+
+
+@pytest.mark.asyncio
+async def test_dispatch_one_handles_timeout() -> None:
+    spec = AgentSpec(
+        name="sleeper",
+        binary="/bin/sh",
+        base_flags=("-c", "sleep 5"),
+        timeout_seconds=1,
+        stdin_mode="argv",
+    )
+    turn = await _dispatch_one(spec, rendered_prompt="x")
+    assert turn.timed_out
+    assert not turn.succeeded()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_round_isolates_failures() -> None:
+    """A failing agent must not break the others."""
+    good = AgentSpec(
+        name="good",
+        binary="/bin/sh",
+        base_flags=("-c", "echo OK"),
+        timeout_seconds=5,
+        stdin_mode="argv",
+    )
+    bad = AgentSpec(
+        name="bad",
+        binary="/no/such/binary-9b13c2e4",
+        base_flags=(),
+        timeout_seconds=5,
+        stdin_mode="argv",
+    )
+    round_ = DialogRound(round_id="t", prompt="hi")
+    turns = await dispatch_round(round_, [good, bad])
+    assert len(turns) == 2
+    by_agent = {t.agent: t for t in turns}
+    assert by_agent["good"].succeeded()
+    assert not by_agent["bad"].succeeded()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_round_empty_agents() -> None:
+    round_ = DialogRound(round_id="t", prompt="hi")
+    turns = await dispatch_round(round_, [])
+    assert turns == []
+
+
+def test_write_round_jsonl_creates_file(tmp_path: Path) -> None:
+    round_ = DialogRound(round_id="r1", prompt="p")
+    turns = [
+        DialogTurn(
+            agent="a",
+            started_at="t1",
+            finished_at="t2",
+            elapsed_seconds=1.0,
+            returncode=0,
+            stdout="x",
+            stderr="",
+            timed_out=False,
+        )
+    ]
+    out = write_round_jsonl(round_, turns, tmp_path)
+    assert out.exists()
+    lines = out.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    head = json.loads(lines[0])
+    assert head["type"] == "round"
+    assert head["round_id"] == "r1"
+    body = json.loads(lines[1])
+    assert body["type"] == "turn"
+    assert body["agent"] == "a"
+
+
+def test_render_transcript_markdown_includes_summary() -> None:
+    round_ = DialogRound(round_id="r1", prompt="Review this")
+    turns = [
+        DialogTurn(
+            agent="a1",
+            started_at="t1",
+            finished_at="t2",
+            elapsed_seconds=1.0,
+            returncode=0,
+            stdout="great work",
+            stderr="",
+            timed_out=False,
+        ),
+        DialogTurn(
+            agent="a2",
+            started_at="t1",
+            finished_at="t2",
+            elapsed_seconds=2.0,
+            returncode=1,
+            stdout="",
+            stderr="oops",
+            timed_out=False,
+        ),
+    ]
+    md = render_transcript_markdown(round_, turns)
+    assert "Cross-agent dialog" in md
+    assert "Successful: **1**" in md
+    assert "Failed: **1**" in md
+    assert "great work" in md
+    assert "FAILED" in md
+
+
+def test_render_transcript_markdown_with_extra_context() -> None:
+    round_ = DialogRound(round_id="r1", prompt="Review", extra_context="some source")
+    md = render_transcript_markdown(round_, [])
+    assert "Extra context" in md
+    assert "some source" in md
+
+
+def test_write_transcript_markdown_creates_file(tmp_path: Path) -> None:
+    round_ = DialogRound(round_id="r1", prompt="p")
+    out = write_transcript_markdown(round_, [], tmp_path)
+    assert out.exists()
+    body = out.read_text(encoding="utf-8")
+    assert "Cross-agent dialog" in body
+
+
+@pytest.mark.asyncio
+async def test_run_round_and_persist_end_to_end(tmp_path: Path) -> None:
+    spec = AgentSpec(
+        name="echo",
+        binary="/bin/sh",
+        base_flags=("-c", "echo HELLO"),
+        timeout_seconds=5,
+        stdin_mode="argv",
+    )
+    round_ = DialogRound(round_id="e2e", prompt="ping")
+    jsonl_path, md_path, turns = await run_round_and_persist(round_, [spec], tmp_path)
+    assert jsonl_path.exists()
+    assert md_path.exists()
+    assert len(turns) == 1
+    assert turns[0].succeeded()
+    md = md_path.read_text(encoding="utf-8")
+    assert "HELLO" in md
+
+
+def test_constants_match_round_30d_verification() -> None:
+    """These flag tuples are the exact verified-working flag sets.
+
+    If any of these change, the round's agent_dispatch_verification step
+    must be re-run before merging."""
+    assert CLAUDE_FLAGS == ("--print",)
+    assert "reasoning_effort=minimal" in CODEX_FLAGS
+    assert "sandbox_mode=read-only" in CODEX_FLAGS
+    assert "--skip-git-repo-check" in CODEX_FLAGS
+    assert DROID_FLAGS == ("exec", "--auto", "low")

--- a/tests/swarm/test_multi_agent_dialog.py
+++ b/tests/swarm/test_multi_agent_dialog.py
@@ -299,3 +299,120 @@ def test_constants_match_round_30d_verification() -> None:
     assert "sandbox_mode=read-only" in CODEX_FLAGS
     assert "--skip-git-repo-check" in CODEX_FLAGS
     assert DROID_FLAGS == ("exec", "--auto", "low")
+
+
+# --------------------------------------------------------------------- #
+# Heterogeneous model factories (round 30e Phase B)                     #
+# --------------------------------------------------------------------- #
+
+
+class TestWithModel:
+    def test_with_model_claude_appends_model_flag(self) -> None:
+        spec = AgentSpec.with_model("claude", "opus")
+        assert spec.binary == "claude"
+        # Model flag must be appended *after* the base CLAUDE_FLAGS so
+        # the CLI's positional parser still sees ``--print`` first.
+        assert spec.base_flags == (*CLAUDE_FLAGS, "--model", "opus")
+        assert spec.name == "claude:opus"
+        assert spec.stdin_mode == "stdin"
+
+    def test_with_model_droid_appends_short_m_flag(self) -> None:
+        spec = AgentSpec.with_model("droid", "gpt-5.4")
+        assert spec.binary == "droid"
+        assert spec.base_flags == (*DROID_FLAGS, "-m", "gpt-5.4")
+        assert spec.name == "droid:gpt-5.4"
+
+    def test_with_model_custom_name_overrides_default(self) -> None:
+        spec = AgentSpec.with_model("droid", "kimi-k2.5", name="bear-kimi")
+        assert spec.name == "bear-kimi"
+
+    def test_with_model_codex_raises_value_error(self) -> None:
+        # codex CLI doesn't expose a per-invocation model flag yet;
+        # the harness must explicitly fail rather than silently use
+        # the default model.
+        with pytest.raises(ValueError, match="codex"):
+            AgentSpec.with_model("codex", "gpt-5.4")
+
+    def test_with_model_unknown_cli_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="unknown cli"):
+            AgentSpec.with_model("gpt", "gpt-5.4")
+
+    def test_with_model_case_insensitive_cli(self) -> None:
+        spec = AgentSpec.with_model("DROID", "kimi-k2.5")
+        assert spec.binary == "droid"
+
+    def test_with_model_custom_timeout_propagates(self) -> None:
+        spec = AgentSpec.with_model("droid", "kimi-k2.5", timeout_seconds=200)
+        assert spec.timeout_seconds == 200
+
+
+class TestNamedHeterogeneousFactories:
+    def test_claude_opus(self) -> None:
+        spec = AgentSpec.claude_opus()
+        assert spec.binary == "claude"
+        assert "opus" in spec.base_flags
+        assert spec.name == "claude-opus"
+
+    def test_claude_sonnet(self) -> None:
+        spec = AgentSpec.claude_sonnet()
+        assert spec.binary == "claude"
+        assert "sonnet" in spec.base_flags
+        assert spec.name == "claude-sonnet"
+
+    def test_droid_gpt5(self) -> None:
+        spec = AgentSpec.droid_gpt5()
+        assert spec.binary == "droid"
+        assert "gpt-5.4" in spec.base_flags
+        assert spec.name == "droid-gpt5"
+
+    def test_droid_gemini(self) -> None:
+        spec = AgentSpec.droid_gemini()
+        assert spec.binary == "droid"
+        assert "gemini-3.1-pro-preview" in spec.base_flags
+        assert spec.name == "droid-gemini"
+
+    def test_droid_kimi(self) -> None:
+        spec = AgentSpec.droid_kimi()
+        assert spec.binary == "droid"
+        assert "kimi-k2.5" in spec.base_flags
+
+    def test_droid_glm(self) -> None:
+        spec = AgentSpec.droid_glm()
+        assert spec.binary == "droid"
+        assert "glm-5.1" in spec.base_flags
+
+
+class TestHeterogeneousPanel:
+    def test_panel_has_six_distinct_models(self) -> None:
+        panel = AgentSpec.heterogeneous_panel()
+        assert len(panel) == 6
+        # Names must be unique so per-agent transcript files don't collide.
+        assert len({s.name for s in panel}) == 6
+
+    def test_panel_spans_at_least_three_families(self) -> None:
+        panel = AgentSpec.heterogeneous_panel()
+        # Heuristic: family inferred from the model substring in flags.
+        families: set[str] = set()
+        for spec in panel:
+            joined = " ".join(spec.base_flags).lower()
+            if "opus" in joined or "sonnet" in joined:
+                families.add("anthropic")
+            elif "gpt-" in joined:
+                families.add("openai-gpt")
+            elif "gemini" in joined:
+                families.add("google")
+            elif "kimi" in joined or "glm" in joined:
+                families.add("chinese")
+            elif spec.binary == "codex":
+                # codex CLI talks to OpenAI; counts as openai-codex.
+                families.add("openai-codex")
+        assert len(families) >= 3, families
+
+    def test_panel_codex_timeout_is_higher(self) -> None:
+        panel = AgentSpec.heterogeneous_panel(codex_timeout=200, model_timeout=90)
+        codex_spec = next(s for s in panel if s.binary == "codex")
+        assert codex_spec.timeout_seconds == 200
+        # All other specs share model_timeout.
+        for spec in panel:
+            if spec.binary != "codex":
+                assert spec.timeout_seconds == 90

--- a/tests/swarm/test_multi_agent_dialog.py
+++ b/tests/swarm/test_multi_agent_dialog.py
@@ -12,6 +12,9 @@ from aragora.swarm.multi_agent_dialog import (
     CLAUDE_FLAGS,
     CODEX_FLAGS,
     DROID_FLAGS,
+    MAX_OUTPUT_BYTES,
+    RC_BINARY_NOT_FOUND,
+    RC_DISPATCH_ERROR,
     AgentSpec,
     DialogRound,
     DialogTurn,
@@ -20,7 +23,12 @@ from aragora.swarm.multi_agent_dialog import (
     run_round_and_persist,
     write_round_jsonl,
     write_transcript_markdown,
+    _atomic_write_text,
     _dispatch_one,
+    _escape_md_fence,
+    _strip_ansi,
+    _truncate_output,
+    _validate_round_id,
 )
 
 
@@ -416,3 +424,265 @@ class TestHeterogeneousPanel:
         for spec in panel:
             if spec.binary != "codex":
                 assert spec.timeout_seconds == 90
+
+
+# --------------------------------------------------------------------- #
+# Round 30e Phase C — gauntlet hardening regression tests              #
+# --------------------------------------------------------------------- #
+
+
+class TestStripAnsi:
+    def test_strip_csi_color(self) -> None:
+        assert _strip_ansi("\x1b[31mred\x1b[0m") == "red"
+
+    def test_strip_osc_hyperlink(self) -> None:
+        # OSC-8 hyperlink: ESC ] 8 ; ; URL ESC \ TEXT ESC ] 8 ; ; ESC \
+        s = "\x1b]8;;https://x\x1b\\link\x1b]8;;\x1b\\"
+        assert _strip_ansi(s) == "link"
+
+    def test_strip_idempotent_on_clean_text(self) -> None:
+        assert _strip_ansi("plain text\nline 2") == "plain text\nline 2"
+
+
+class TestTruncateOutput:
+    def test_truncate_under_limit_passthrough(self) -> None:
+        assert _truncate_output("short") == "short"
+
+    def test_truncate_over_limit_inserts_sentinel(self) -> None:
+        big = "x" * (MAX_OUTPUT_BYTES + 10)
+        out = _truncate_output(big)
+        assert "[TRUNCATED:" in out
+        assert len(out) < len(big) + 100
+
+    def test_truncate_handles_multibyte(self) -> None:
+        # Each emoji is 4 bytes UTF-8; should still truncate cleanly.
+        s = "🦀" * (MAX_OUTPUT_BYTES // 4 + 5)
+        out = _truncate_output(s)
+        assert "[TRUNCATED:" in out
+
+
+class TestEscapeMdFence:
+    def test_escape_at_line_start(self) -> None:
+        # The fence is the very first 3 chars; escape inserts ZWSP.
+        out = _escape_md_fence("```evil")
+        assert out.startswith("\u200b```evil")
+
+    def test_escape_with_indent(self) -> None:
+        out = _escape_md_fence("    ```evil")
+        assert "\u200b```" in out
+        # Original leading whitespace preserved.
+        assert out.startswith("    \u200b```")
+
+    def test_escape_does_not_touch_inline_backticks(self) -> None:
+        # Single backticks aren't a fence; should pass through.
+        assert _escape_md_fence("inline `code` here") == "inline `code` here"
+
+
+class TestValidateRoundId:
+    def test_valid_simple(self) -> None:
+        _validate_round_id("round-30e")
+
+    def test_valid_alnum_underscore(self) -> None:
+        _validate_round_id("e2e_smoke_001")
+
+    def test_reject_path_traversal(self) -> None:
+        with pytest.raises(ValueError):
+            _validate_round_id("../etc/passwd")
+
+    def test_reject_slash(self) -> None:
+        with pytest.raises(ValueError):
+            _validate_round_id("a/b")
+
+    def test_reject_empty(self) -> None:
+        with pytest.raises(ValueError):
+            _validate_round_id("")
+
+    def test_reject_too_long(self) -> None:
+        with pytest.raises(ValueError):
+            _validate_round_id("x" * 200)
+
+
+class TestAtomicWriteText:
+    def test_atomic_write_creates_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        _atomic_write_text(target, "hello")
+        assert target.read_text() == "hello"
+
+    def test_atomic_write_overwrites_existing(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        target.write_text("old")
+        _atomic_write_text(target, "new")
+        assert target.read_text() == "new"
+
+    def test_atomic_write_no_tmp_left_behind(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        _atomic_write_text(target, "x")
+        # No .tmp.* files should remain in the directory.
+        leftover = [p for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftover == []
+
+
+class TestDispatchHardening:
+    def test_dispatch_one_filenotfound_returns_distinct_rc(self) -> None:
+        # Round 30e Phase C fix #3: rc=-127 for missing binary.
+        spec = AgentSpec(
+            name="ghost",
+            binary="/nonexistent/path/to/xyz",
+            base_flags=(),
+            timeout_seconds=5,
+            stdin_mode="stdin",
+        )
+        turn = asyncio.run(_dispatch_one(spec, "hi"))
+        assert turn.returncode == RC_BINARY_NOT_FOUND
+        assert turn.error is not None
+        assert "binary not found" in turn.error
+        assert not turn.succeeded()
+
+    def test_dispatch_round_handles_per_agent_exception(self) -> None:
+        # Round 30e Phase C fix #6: one agent's failure does not
+        # cascade. We simulate by mixing a real (missing-binary) spec
+        # with a dispatchable real binary so we verify *peer* survival.
+        ghost = AgentSpec(
+            name="ghost-dispatch-test",
+            binary="/nonexistent/x",
+            base_flags=(),
+            timeout_seconds=5,
+            stdin_mode="stdin",
+        )
+        # ``true`` is a real binary on every POSIX machine.
+        good = AgentSpec(
+            name="good",
+            binary="true",
+            base_flags=(),
+            timeout_seconds=5,
+            stdin_mode="stdin",
+        )
+        round_ = DialogRound(round_id="cascade", prompt="ping")
+        turns = asyncio.run(dispatch_round(round_, [ghost, good]))
+        assert len(turns) == 2
+        # ghost failed cleanly with sentinel rc
+        assert turns[0].returncode == RC_BINARY_NOT_FOUND
+        # good succeeded — ghost's failure did not cascade
+        assert turns[1].succeeded(), turns[1]
+
+
+class TestPersistenceHardening:
+    def test_write_round_jsonl_rejects_path_traversal(self, tmp_path: Path) -> None:
+        bad = DialogRound(round_id="../escape", prompt="x")
+        with pytest.raises(ValueError):
+            write_round_jsonl(bad, [], tmp_path)
+
+    def test_write_transcript_markdown_rejects_path_traversal(self, tmp_path: Path) -> None:
+        bad = DialogRound(round_id="../escape", prompt="x")
+        with pytest.raises(ValueError):
+            write_transcript_markdown(bad, [], tmp_path)
+
+    def test_write_round_jsonl_atomic_no_tmp_left(self, tmp_path: Path) -> None:
+        round_ = DialogRound(round_id="atomic-test", prompt="x")
+        write_round_jsonl(round_, [], tmp_path)
+        leftover = [p for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftover == []
+
+
+class TestRenderHardening:
+    def test_render_escapes_nested_fence_in_stdout(self) -> None:
+        round_ = DialogRound(round_id="esc", prompt="p")
+        turn = DialogTurn(
+            agent="evil",
+            started_at="2026-04-30T00:00:00+00:00",
+            finished_at="2026-04-30T00:00:01+00:00",
+            elapsed_seconds=1.0,
+            returncode=0,
+            stdout="```\nbreak out\n```\nuninvited content",
+            stderr="",
+            timed_out=False,
+        )
+        md = render_transcript_markdown(round_, [turn])
+        # The nested ``` should have a zero-width space inserted before
+        # it so the surrounding fence isn't broken.
+        assert "\u200b```" in md
+        # The "uninvited content" line must not appear *outside* a fence:
+        # i.e. the document still has matched fences.
+        assert md.count("```") % 2 == 0, md
+
+    def test_render_marks_timed_out_turn(self) -> None:
+        round_ = DialogRound(round_id="to", prompt="p")
+        turn = DialogTurn(
+            agent="slow",
+            started_at="2026-04-30T00:00:00+00:00",
+            finished_at="2026-04-30T00:00:30+00:00",
+            elapsed_seconds=30.0,
+            returncode=-1,
+            stdout="",
+            stderr="",
+            timed_out=True,
+        )
+        md = render_transcript_markdown(round_, [turn])
+        assert "[TIMED OUT]" in md
+
+    def test_render_distinguishes_failed_from_timed_out(self) -> None:
+        round_ = DialogRound(round_id="fail", prompt="p")
+        timed_out_turn = DialogTurn(
+            agent="slow",
+            started_at="2026-04-30T00:00:00+00:00",
+            finished_at="2026-04-30T00:00:30+00:00",
+            elapsed_seconds=30.0,
+            returncode=-1,
+            stdout="",
+            stderr="",
+            timed_out=True,
+        )
+        plain_failed_turn = DialogTurn(
+            agent="bad",
+            started_at="2026-04-30T00:00:00+00:00",
+            finished_at="2026-04-30T00:00:01+00:00",
+            elapsed_seconds=1.0,
+            returncode=2,
+            stdout="",
+            stderr="oops",
+            timed_out=False,
+        )
+        md = render_transcript_markdown(round_, [timed_out_turn, plain_failed_turn])
+        assert "FAILED [TIMED OUT]" in md
+        # Plain FAILED should NOT have the timed-out badge.
+        bad_section = md.split("### `bad`")[1]
+        assert "[TIMED OUT]" not in bad_section
+
+
+class TestSentinelExports:
+    def test_sentinels_distinct(self) -> None:
+        assert RC_BINARY_NOT_FOUND != RC_DISPATCH_ERROR
+        # Both should be negative (out of normal POSIX rc range) so
+        # they can't be confused with real exit codes 0..255.
+        assert RC_BINARY_NOT_FOUND < 0
+        assert RC_DISPATCH_ERROR < 0
+
+
+# --------------------------------------------------------------------- #
+# Phase D follow-up: heterogeneous-review regression tests              #
+# --------------------------------------------------------------------- #
+#
+# These cover the two real findings from the 6-model panel review of
+# Phase C: codex (truncation overshoot) and claude-opus (DoS amplifier
+# from running ANSI strip *before* truncation).
+
+
+class TestTruncateOutputPhaseD:
+    def test_truncated_output_total_bytes_under_cap(self) -> None:
+        big = "x" * (MAX_OUTPUT_BYTES + 1000)
+        out = _truncate_output(big)
+        # The total persisted bytes (including sentinel) must not
+        # exceed the cap — codex's Phase D finding.
+        assert len(out.encode("utf-8")) <= MAX_OUTPUT_BYTES
+
+    def test_truncated_output_sentinel_still_present(self) -> None:
+        big = "x" * (MAX_OUTPUT_BYTES + 1000)
+        out = _truncate_output(big)
+        assert "[TRUNCATED:" in out
+        assert "original" in out
+
+    def test_truncated_output_with_small_cap(self) -> None:
+        # Sanity: a tiny cap doesn't crash on the sentinel-budget edge
+        # case (sentinel bytes >= max_bytes).
+        out = _truncate_output("hello world", max_bytes=5)
+        assert "[TRUNCATED:" in out


### PR DESCRIPTION
**Stacked on PR #6855** — adds heterogeneous-model factories on top of the round-30d cross-agent dialog harness.

## Why

Round 30d's Phase B harness (PR #6855) only dispatches each CLI's *default* model, so a 3-CLI panel is in practice 'same-family-three-times'. The maximalist-vision wedge for **decision-integrity via heterogeneous consensus** is independent perspectives from different model families catching what one family misses.

## What lands

| Surface | Purpose |
| --- | --- |
| `AgentSpec.with_model(cli, model, name?, timeout)` | Generic factory |
| `AgentSpec.claude_opus` / `.claude_sonnet` | Anthropic family |
| `AgentSpec.droid_gpt5` | OpenAI family |
| `AgentSpec.droid_gemini` | Google family |
| `AgentSpec.droid_kimi` / `.droid_glm` | Chinese frontier (Kimi K2.5, GLM 5.1) |
| `AgentSpec.heterogeneous_panel()` | Canonical 6-model panel |
| `scripts/multi_agent_dialog.py --agents-spec heterogeneous` | One-flag panel dispatch |

## Live verification (round 30e Phase B)

6/6 succeeded in <10 s each:
- claude-opus (9.8 s), claude-sonnet (9.8 s), codex (8.3 s), droid-gpt5 (7.5 s), droid-gemini (9.0 s), droid-kimi (6.3 s)

## Tests

- 37/37 pass (21 from PR #6855 + 16 new heterogeneous tests)
- ruff check + format: clean; mypy: `Success: no issues`

## Tier

**Tier 2** — pure additive. Existing 3-CLI factories unchanged.

## Standing rule

I do not author-merge. Awaiting Codex signal + CI.