### PR TITLE
fix(swarm): harden multi_agent_dialog (8 gauntlet fixes — stacked on #6883)

### DIFF
--- a/aragora/swarm/multi_agent_dialog.py
+++ b/aragora/swarm/multi_agent_dialog.py
@@ -39,12 +39,100 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import re
+import signal
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Sequence
 
 logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- #
+# Round 30e Phase C — gauntlet hardening helpers                        #
+# --------------------------------------------------------------------- #
+#
+# All eight fixes from round 30d-Phase-H's gauntlet review of this
+# module live here as small, named helpers so the test suite can
+# exercise each one independently.
+
+# Match a code-fence opener (```) at the start of a line so we can
+# escape adversarial agent output that tries to break out of the
+# transcript's fenced ``stdout`` block.
+_FENCE_RE: re.Pattern[str] = re.compile(r"^(\s*)(```)", re.MULTILINE)
+
+# Strip CSI / OSC ANSI escapes (color, cursor moves, OSC-8 hyperlinks)
+# from agent output before persisting. Two patterns cover the bulk:
+#   - ESC [ ... letter (CSI)
+#   - ESC ] ... BEL/ST  (OSC)
+_ANSI_CSI_RE: re.Pattern[str] = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_ANSI_OSC_RE: re.Pattern[str] = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+
+# Round IDs are interpolated into output filenames; this regex keeps
+# them confined to the intended output directory.
+_ROUND_ID_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_\-]{0,127}$")
+
+# Distinct sentinel returncodes so operators can tell ``binary not
+# found`` apart from a genuine CLI rc=-1 failure.
+RC_BINARY_NOT_FOUND: int = -127
+RC_DISPATCH_ERROR: int = -126
+
+# Cap on persisted stdout/stderr per turn — chatty CLIs can produce
+# multi-MB lines that overflow downstream JSONL parsers.
+MAX_OUTPUT_BYTES: int = 1_000_000
+
+
+def _strip_ansi(s: str) -> str:
+    """Return ``s`` with CSI and OSC ANSI escape sequences removed."""
+    return _ANSI_OSC_RE.sub("", _ANSI_CSI_RE.sub("", s))
+
+
+def _truncate_output(s: str, *, max_bytes: int = MAX_OUTPUT_BYTES) -> str:
+    """Cap a string at ``max_bytes`` UTF-8 bytes with a sentinel suffix."""
+    encoded = s.encode("utf-8", errors="replace")
+    if len(encoded) <= max_bytes:
+        return s
+    truncated = encoded[:max_bytes].decode("utf-8", errors="replace")
+    return truncated + f"\n... [TRUNCATED: original {len(encoded)} bytes]"
+
+
+def _escape_md_fence(s: str) -> str:
+    """Escape ``` fence opens so an agent cannot break the rendered code block.
+
+    Inserts a zero-width space (``\\u200b``) between the leading
+    whitespace and the backticks, which preserves the visual content
+    but prevents Markdown's parser from closing the surrounding fence.
+    """
+    return _FENCE_RE.sub("\\1\u200b\\2", s)
+
+
+def _validate_round_id(round_id: str) -> None:
+    """Reject ``round_id`` values that would traverse outside ``output_dir``."""
+    if not _ROUND_ID_RE.match(round_id or ""):
+        raise ValueError(f"invalid round_id {round_id!r}: must match {_ROUND_ID_RE.pattern}")
+
+
+def _atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:
+    """Write ``content`` atomically via tmp file + ``os.replace``.
+
+    Crashes mid-write leave the original file (if any) intact instead
+    of producing a half-written transcript. The temp file lives in the
+    same directory so ``os.replace`` is a same-filesystem rename.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    with tmp_path.open("w", encoding=encoding) as f:
+        f.write(content)
+        f.flush()
+        try:
+            os.fsync(f.fileno())
+        except OSError:
+            # Some filesystems (notably tmpfs in CI) don't support fsync;
+            # the os.replace still gives atomic visibility.
+            pass
+    os.replace(tmp_path, path)
 
 
 # --------------------------------------------------------------------- #
@@ -324,12 +412,18 @@ async def _dispatch_one(
     out = ""
     err = ""
 
+    # Round 30e Phase C fix #1: launch each child in its own process
+    # group on POSIX so a timeout can reap any grandchildren the CLI
+    # spawned (some agent CLIs fork sub-helpers that leak otherwise).
+    preexec = os.setsid if os.name == "posix" else None
+
     try:
         proc = await asyncio.create_subprocess_exec(
             *argv,
             stdin=asyncio.subprocess.PIPE if stdin_data is not None else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            preexec_fn=preexec,
         )
         try:
             out_b, err_b = await asyncio.wait_for(
@@ -341,20 +435,43 @@ async def _dispatch_one(
             err = err_b.decode("utf-8", errors="replace")
         except asyncio.TimeoutError:
             timed_out = True
+            # Round 30e Phase C fix #2: SIGKILL the whole process group,
+            # not just the leader, so child helpers don't leak.
             try:
-                proc.kill()
+                if os.name == "posix":
+                    pgid = os.getpgid(proc.pid)
+                    os.killpg(pgid, signal.SIGKILL)
+                else:
+                    proc.kill()
                 await proc.wait()
-            except ProcessLookupError:
+            except (ProcessLookupError, PermissionError):
                 pass
     except FileNotFoundError:
+        # Round 30e Phase C fix #3: distinct sentinel rc so the operator
+        # can tell "CLI missing on $PATH" apart from "CLI ran and
+        # returned -1".
         err_msg = f"binary not found: {spec.binary}"
+        rc = RC_BINARY_NOT_FOUND
         logger.warning("multi_agent_dialog: %s", err_msg)
     except Exception as exc:  # noqa: BLE001 — capture any subprocess setup error
         err_msg = f"dispatch failed: {type(exc).__name__}: {exc}"
+        rc = RC_DISPATCH_ERROR
         logger.warning("multi_agent_dialog: %s", err_msg)
 
     finished_at = datetime.now(timezone.utc)
     elapsed = (finished_at - started_at).total_seconds()
+
+    # Round 30e Phase C fix #4: strip ANSI escapes before persisting so
+    # a malicious agent can't poison downstream tooling with cursor
+    # moves or OSC-8 hyperlinks.
+    out = _strip_ansi(out)
+    err = _strip_ansi(err)
+
+    # Round 30e Phase C fix #5: cap output size to MAX_OUTPUT_BYTES so
+    # one chatty CLI cannot blow up the JSONL parser or the markdown
+    # transcript.
+    out = _truncate_output(out)
+    err = _truncate_output(err)
 
     return DialogTurn(
         agent=spec.name,
@@ -381,7 +498,31 @@ async def dispatch_round(
         return []
     rendered = round_.render_prompt()
     tasks = [_dispatch_one(spec, rendered) for spec in agents]
-    return list(await asyncio.gather(*tasks))
+
+    # Round 30e Phase C fix #6: ``return_exceptions=True`` ensures one
+    # agent's unexpected raise (e.g. asyncio.CancelledError, OSError
+    # from preexec_fn) cannot cascade and abort all peer dispatches.
+    raw = await asyncio.gather(*tasks, return_exceptions=True)
+    out: list[DialogTurn] = []
+    for spec, result in zip(agents, raw):
+        if isinstance(result, BaseException):
+            now = datetime.now(timezone.utc).isoformat()
+            out.append(
+                DialogTurn(
+                    agent=spec.name,
+                    started_at=now,
+                    finished_at=now,
+                    elapsed_seconds=0.0,
+                    returncode=RC_DISPATCH_ERROR,
+                    stdout="",
+                    stderr="",
+                    timed_out=False,
+                    error=f"unexpected dispatch exception: {type(result).__name__}: {result}",
+                )
+            )
+        else:
+            out.append(result)
+    return out
 
 
 # --------------------------------------------------------------------- #
@@ -398,26 +539,30 @@ def write_round_jsonl(
 
     The first line is the round metadata. Subsequent lines are turns.
     """
+    # Round 30e Phase C fix #7: validate round_id (path traversal) and
+    # write atomically so a crash mid-write doesn't leave a half-baked
+    # JSONL behind.
+    _validate_round_id(round_.round_id)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path = output_dir / f"dialog-{round_.round_id}.jsonl"
-    with out_path.open("w", encoding="utf-8") as f:
-        f.write(
-            json.dumps(
-                {
-                    "type": "round",
-                    "round_id": round_.round_id,
-                    "prompt": round_.prompt,
-                    "extra_context_chars": len(round_.extra_context),
-                    "metadata": round_.metadata,
-                },
-                sort_keys=True,
-            )
-            + "\n"
+
+    lines: list[str] = [
+        json.dumps(
+            {
+                "type": "round",
+                "round_id": round_.round_id,
+                "prompt": round_.prompt,
+                "extra_context_chars": len(round_.extra_context),
+                "metadata": round_.metadata,
+            },
+            sort_keys=True,
         )
-        for turn in turns:
-            payload = {"type": "turn", **turn.to_json()}
-            f.write(json.dumps(payload, sort_keys=True) + "\n")
+    ]
+    for turn in turns:
+        payload = {"type": "turn", **turn.to_json()}
+        lines.append(json.dumps(payload, sort_keys=True))
+    _atomic_write_text(out_path, "\n".join(lines) + "\n")
     return out_path
 
 
@@ -466,7 +611,14 @@ def render_transcript_markdown(
 
     lines.extend(["## Per-agent responses", ""])
     for turn in turns:
-        status = "succeeded" if turn.succeeded() else "FAILED"
+        # Round 30e Phase C fix #8a: explicit [TIMED OUT] badge so a
+        # zero-stdout timeout doesn't read as a quiet success in scan.
+        if turn.timed_out:
+            status = "FAILED [TIMED OUT]"
+        elif turn.succeeded():
+            status = "succeeded"
+        else:
+            status = "FAILED"
         lines.extend(
             [
                 f"### `{turn.agent}` — {status} (rc={turn.returncode}, "
@@ -478,12 +630,15 @@ def render_transcript_markdown(
         if turn.error:
             lines.extend([f"_Error: {turn.error}_", ""])
         if turn.stdout.strip():
+            # Round 30e Phase C fix #8b: escape any nested ``` so an
+            # adversarial agent can't break out of our fenced block and
+            # poison the rest of the transcript.
             lines.extend(
                 [
                     "**stdout:**",
                     "",
                     "```",
-                    turn.stdout.rstrip(),
+                    _escape_md_fence(turn.stdout.rstrip()),
                     "```",
                     "",
                 ]
@@ -495,7 +650,7 @@ def render_transcript_markdown(
                     "**stderr (last 10 lines):**",
                     "",
                     "```",
-                    tail,
+                    _escape_md_fence(tail),
                     "```",
                     "",
                 ]
@@ -509,10 +664,11 @@ def write_transcript_markdown(
     output_dir: Path,
 ) -> Path:
     """Persist a markdown transcript and return its path."""
+    _validate_round_id(round_.round_id)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path = output_dir / f"dialog-{round_.round_id}.md"
-    out_path.write_text(render_transcript_markdown(round_, turns), encoding="utf-8")
+    _atomic_write_text(out_path, render_transcript_markdown(round_, turns))
     return out_path
 
 

--- a/aragora/swarm/multi_agent_dialog.py
+++ b/aragora/swarm/multi_agent_dialog.py
@@ -90,12 +90,25 @@ def _strip_ansi(s: str) -> str:
 
 
 def _truncate_output(s: str, *, max_bytes: int = MAX_OUTPUT_BYTES) -> str:
-    """Cap a string at ``max_bytes`` UTF-8 bytes with a sentinel suffix."""
+    """Cap a string at ``max_bytes`` UTF-8 bytes with a sentinel suffix.
+
+    The returned string is guaranteed to encode to at most ``max_bytes``
+    UTF-8 bytes *including* the sentinel suffix. This is a Phase D
+    correctness fix — codex review observed that the previous version
+    appended the sentinel *after* the budget, so persisted output
+    could exceed ``max_bytes``.
+    """
     encoded = s.encode("utf-8", errors="replace")
     if len(encoded) <= max_bytes:
         return s
-    truncated = encoded[:max_bytes].decode("utf-8", errors="replace")
-    return truncated + f"\n... [TRUNCATED: original {len(encoded)} bytes]"
+    sentinel = f"\n... [TRUNCATED: original {len(encoded)} bytes]"
+    sentinel_bytes = sentinel.encode("utf-8")
+    # Reserve sentinel bytes from the budget. Guard against a sentinel
+    # somehow exceeding the budget (would only happen with absurdly
+    # small max_bytes in tests).
+    budget = max(0, max_bytes - len(sentinel_bytes))
+    truncated = encoded[:budget].decode("utf-8", errors="replace")
+    return truncated + sentinel
 
 
 def _escape_md_fence(s: str) -> str:
@@ -415,7 +428,12 @@ async def _dispatch_one(
     # Round 30e Phase C fix #1: launch each child in its own process
     # group on POSIX so a timeout can reap any grandchildren the CLI
     # spawned (some agent CLIs fork sub-helpers that leak otherwise).
-    preexec = os.setsid if os.name == "posix" else None
+    #
+    # Phase D follow-up: prefer ``start_new_session=True`` over
+    # ``preexec_fn=os.setsid`` per Python docs — it avoids the
+    # interpreter-thread fork hazard while achieving the same setsid()
+    # effect.
+    new_session = os.name == "posix"
 
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -423,7 +441,7 @@ async def _dispatch_one(
             stdin=asyncio.subprocess.PIPE if stdin_data is not None else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            preexec_fn=preexec,
+            start_new_session=new_session,
         )
         try:
             out_b, err_b = await asyncio.wait_for(
@@ -461,17 +479,18 @@ async def _dispatch_one(
     finished_at = datetime.now(timezone.utc)
     elapsed = (finished_at - started_at).total_seconds()
 
+    # Round 30e Phase C fix #5 (truncate first — Phase D follow-up):
+    # cap output BEFORE ANSI-strip so a multi-MB ANSI-laden line
+    # doesn't get fully regex-scanned in memory. This keeps both CPU
+    # and persisted size bounded by MAX_OUTPUT_BYTES.
+    out = _truncate_output(out)
+    err = _truncate_output(err)
+
     # Round 30e Phase C fix #4: strip ANSI escapes before persisting so
     # a malicious agent can't poison downstream tooling with cursor
     # moves or OSC-8 hyperlinks.
     out = _strip_ansi(out)
     err = _strip_ansi(err)
-
-    # Round 30e Phase C fix #5: cap output size to MAX_OUTPUT_BYTES so
-    # one chatty CLI cannot blow up the JSONL parser or the markdown
-    # transcript.
-    out = _truncate_output(out)
-    err = _truncate_output(err)
 
     return DialogTurn(
         agent=spec.name,

--- a/tests/swarm/test_multi_agent_dialog.py
+++ b/tests/swarm/test_multi_agent_dialog.py
@@ -12,6 +12,9 @@ from aragora.swarm.multi_agent_dialog import (
     CLAUDE_FLAGS,
     CODEX_FLAGS,
     DROID_FLAGS,
+    MAX_OUTPUT_BYTES,
+    RC_BINARY_NOT_FOUND,
+    RC_DISPATCH_ERROR,
     AgentSpec,
     DialogRound,
     DialogTurn,
@@ -20,7 +23,12 @@ from aragora.swarm.multi_agent_dialog import (
     run_round_and_persist,
     write_round_jsonl,
     write_transcript_markdown,
+    _atomic_write_text,
     _dispatch_one,
+    _escape_md_fence,
+    _strip_ansi,
+    _truncate_output,
+    _validate_round_id,
 )
 
 
@@ -416,3 +424,235 @@ class TestHeterogeneousPanel:
         for spec in panel:
             if spec.binary != "codex":
                 assert spec.timeout_seconds == 90
+
+
+# --------------------------------------------------------------------- #
+# Round 30e Phase C — gauntlet hardening regression tests              #
+# --------------------------------------------------------------------- #
+
+
+class TestStripAnsi:
+    def test_strip_csi_color(self) -> None:
+        assert _strip_ansi("\x1b[31mred\x1b[0m") == "red"
+
+    def test_strip_osc_hyperlink(self) -> None:
+        # OSC-8 hyperlink: ESC ] 8 ; ; URL ESC \ TEXT ESC ] 8 ; ; ESC \
+        s = "\x1b]8;;https://x\x1b\\link\x1b]8;;\x1b\\"
+        assert _strip_ansi(s) == "link"
+
+    def test_strip_idempotent_on_clean_text(self) -> None:
+        assert _strip_ansi("plain text\nline 2") == "plain text\nline 2"
+
+
+class TestTruncateOutput:
+    def test_truncate_under_limit_passthrough(self) -> None:
+        assert _truncate_output("short") == "short"
+
+    def test_truncate_over_limit_inserts_sentinel(self) -> None:
+        big = "x" * (MAX_OUTPUT_BYTES + 10)
+        out = _truncate_output(big)
+        assert "[TRUNCATED:" in out
+        assert len(out) < len(big) + 100
+
+    def test_truncate_handles_multibyte(self) -> None:
+        # Each emoji is 4 bytes UTF-8; should still truncate cleanly.
+        s = "🦀" * (MAX_OUTPUT_BYTES // 4 + 5)
+        out = _truncate_output(s)
+        assert "[TRUNCATED:" in out
+
+
+class TestEscapeMdFence:
+    def test_escape_at_line_start(self) -> None:
+        # The fence is the very first 3 chars; escape inserts ZWSP.
+        out = _escape_md_fence("```evil")
+        assert out.startswith("\u200b```evil")
+
+    def test_escape_with_indent(self) -> None:
+        out = _escape_md_fence("    ```evil")
+        assert "\u200b```" in out
+        # Original leading whitespace preserved.
+        assert out.startswith("    \u200b```")
+
+    def test_escape_does_not_touch_inline_backticks(self) -> None:
+        # Single backticks aren't a fence; should pass through.
+        assert _escape_md_fence("inline `code` here") == "inline `code` here"
+
+
+class TestValidateRoundId:
+    def test_valid_simple(self) -> None:
+        _validate_round_id("round-30e")
+
+    def test_valid_alnum_underscore(self) -> None:
+        _validate_round_id("e2e_smoke_001")
+
+    def test_reject_path_traversal(self) -> None:
+        with pytest.raises(ValueError):
+            _validate_round_id("../etc/passwd")
+
+    def test_reject_slash(self) -> None:
+        with pytest.raises(ValueError):
+            _validate_round_id("a/b")
+
+    def test_reject_empty(self) -> None:
+        with pytest.raises(ValueError):
+            _validate_round_id("")
+
+    def test_reject_too_long(self) -> None:
+        with pytest.raises(ValueError):
+            _validate_round_id("x" * 200)
+
+
+class TestAtomicWriteText:
+    def test_atomic_write_creates_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        _atomic_write_text(target, "hello")
+        assert target.read_text() == "hello"
+
+    def test_atomic_write_overwrites_existing(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        target.write_text("old")
+        _atomic_write_text(target, "new")
+        assert target.read_text() == "new"
+
+    def test_atomic_write_no_tmp_left_behind(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+        _atomic_write_text(target, "x")
+        # No .tmp.* files should remain in the directory.
+        leftover = [p for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftover == []
+
+
+class TestDispatchHardening:
+    def test_dispatch_one_filenotfound_returns_distinct_rc(self) -> None:
+        # Round 30e Phase C fix #3: rc=-127 for missing binary.
+        spec = AgentSpec(
+            name="ghost",
+            binary="/nonexistent/path/to/xyz",
+            base_flags=(),
+            timeout_seconds=5,
+            stdin_mode="stdin",
+        )
+        turn = asyncio.run(_dispatch_one(spec, "hi"))
+        assert turn.returncode == RC_BINARY_NOT_FOUND
+        assert turn.error is not None
+        assert "binary not found" in turn.error
+        assert not turn.succeeded()
+
+    def test_dispatch_round_handles_per_agent_exception(self) -> None:
+        # Round 30e Phase C fix #6: one agent's failure does not
+        # cascade. We simulate by mixing a real (missing-binary) spec
+        # with a dispatchable real binary so we verify *peer* survival.
+        ghost = AgentSpec(
+            name="ghost-dispatch-test",
+            binary="/nonexistent/x",
+            base_flags=(),
+            timeout_seconds=5,
+            stdin_mode="stdin",
+        )
+        # ``true`` is a real binary on every POSIX machine.
+        good = AgentSpec(
+            name="good",
+            binary="true",
+            base_flags=(),
+            timeout_seconds=5,
+            stdin_mode="stdin",
+        )
+        round_ = DialogRound(round_id="cascade", prompt="ping")
+        turns = asyncio.run(dispatch_round(round_, [ghost, good]))
+        assert len(turns) == 2
+        # ghost failed cleanly with sentinel rc
+        assert turns[0].returncode == RC_BINARY_NOT_FOUND
+        # good succeeded — ghost's failure did not cascade
+        assert turns[1].succeeded(), turns[1]
+
+
+class TestPersistenceHardening:
+    def test_write_round_jsonl_rejects_path_traversal(self, tmp_path: Path) -> None:
+        bad = DialogRound(round_id="../escape", prompt="x")
+        with pytest.raises(ValueError):
+            write_round_jsonl(bad, [], tmp_path)
+
+    def test_write_transcript_markdown_rejects_path_traversal(self, tmp_path: Path) -> None:
+        bad = DialogRound(round_id="../escape", prompt="x")
+        with pytest.raises(ValueError):
+            write_transcript_markdown(bad, [], tmp_path)
+
+    def test_write_round_jsonl_atomic_no_tmp_left(self, tmp_path: Path) -> None:
+        round_ = DialogRound(round_id="atomic-test", prompt="x")
+        write_round_jsonl(round_, [], tmp_path)
+        leftover = [p for p in tmp_path.iterdir() if ".tmp." in p.name]
+        assert leftover == []
+
+
+class TestRenderHardening:
+    def test_render_escapes_nested_fence_in_stdout(self) -> None:
+        round_ = DialogRound(round_id="esc", prompt="p")
+        turn = DialogTurn(
+            agent="evil",
+            started_at="2026-04-30T00:00:00+00:00",
+            finished_at="2026-04-30T00:00:01+00:00",
+            elapsed_seconds=1.0,
+            returncode=0,
+            stdout="```\nbreak out\n```\nuninvited content",
+            stderr="",
+            timed_out=False,
+        )
+        md = render_transcript_markdown(round_, [turn])
+        # The nested ``` should have a zero-width space inserted before
+        # it so the surrounding fence isn't broken.
+        assert "\u200b```" in md
+        # The "uninvited content" line must not appear *outside* a fence:
+        # i.e. the document still has matched fences.
+        assert md.count("```") % 2 == 0, md
+
+    def test_render_marks_timed_out_turn(self) -> None:
+        round_ = DialogRound(round_id="to", prompt="p")
+        turn = DialogTurn(
+            agent="slow",
+            started_at="2026-04-30T00:00:00+00:00",
+            finished_at="2026-04-30T00:00:30+00:00",
+            elapsed_seconds=30.0,
+            returncode=-1,
+            stdout="",
+            stderr="",
+            timed_out=True,
+        )
+        md = render_transcript_markdown(round_, [turn])
+        assert "[TIMED OUT]" in md
+
+    def test_render_distinguishes_failed_from_timed_out(self) -> None:
+        round_ = DialogRound(round_id="fail", prompt="p")
+        timed_out_turn = DialogTurn(
+            agent="slow",
+            started_at="2026-04-30T00:00:00+00:00",
+            finished_at="2026-04-30T00:00:30+00:00",
+            elapsed_seconds=30.0,
+            returncode=-1,
+            stdout="",
+            stderr="",
+            timed_out=True,
+        )
+        plain_failed_turn = DialogTurn(
+            agent="bad",
+            started_at="2026-04-30T00:00:00+00:00",
+            finished_at="2026-04-30T00:00:01+00:00",
+            elapsed_seconds=1.0,
+            returncode=2,
+            stdout="",
+            stderr="oops",
+            timed_out=False,
+        )
+        md = render_transcript_markdown(round_, [timed_out_turn, plain_failed_turn])
+        assert "FAILED [TIMED OUT]" in md
+        # Plain FAILED should NOT have the timed-out badge.
+        bad_section = md.split("### `bad`")[1]
+        assert "[TIMED OUT]" not in bad_section
+
+
+class TestSentinelExports:
+    def test_sentinels_distinct(self) -> None:
+        assert RC_BINARY_NOT_FOUND != RC_DISPATCH_ERROR
+        # Both should be negative (out of normal POSIX rc range) so
+        # they can't be confused with real exit codes 0..255.
+        assert RC_BINARY_NOT_FOUND < 0
+        assert RC_DISPATCH_ERROR < 0

--- a/tests/swarm/test_multi_agent_dialog.py
+++ b/tests/swarm/test_multi_agent_dialog.py
@@ -656,3 +656,33 @@ class TestSentinelExports:
         # they can't be confused with real exit codes 0..255.
         assert RC_BINARY_NOT_FOUND < 0
         assert RC_DISPATCH_ERROR < 0
+
+
+# --------------------------------------------------------------------- #
+# Phase D follow-up: heterogeneous-review regression tests              #
+# --------------------------------------------------------------------- #
+#
+# These cover the two real findings from the 6-model panel review of
+# Phase C: codex (truncation overshoot) and claude-opus (DoS amplifier
+# from running ANSI strip *before* truncation).
+
+
+class TestTruncateOutputPhaseD:
+    def test_truncated_output_total_bytes_under_cap(self) -> None:
+        big = "x" * (MAX_OUTPUT_BYTES + 1000)
+        out = _truncate_output(big)
+        # The total persisted bytes (including sentinel) must not
+        # exceed the cap — codex's Phase D finding.
+        assert len(out.encode("utf-8")) <= MAX_OUTPUT_BYTES
+
+    def test_truncated_output_sentinel_still_present(self) -> None:
+        big = "x" * (MAX_OUTPUT_BYTES + 1000)
+        out = _truncate_output(big)
+        assert "[TRUNCATED:" in out
+        assert "original" in out
+
+    def test_truncated_output_with_small_cap(self) -> None:
+        # Sanity: a tiny cap doesn't crash on the sentinel-budget edge
+        # case (sentinel bytes >= max_bytes).
+        out = _truncate_output("hello world", max_bytes=5)
+        assert "[TRUNCATED:" in out


### PR DESCRIPTION
**Stacked on PR #6883.** Applies the 8 hardening findings from round-30d-Phase-H's gauntlet review of `aragora/swarm/multi_agent_dialog.py`.

## Eight fixes (one regression test cluster each)

| # | Fix | Why |
| - | --- | --- |
| 1 | `os.setsid` preexec + `os.killpg` on timeout | Reap grandchildren from CLIs that fork sub-helpers |
| 2 | `rc=RC_BINARY_NOT_FOUND=-127` on `FileNotFoundError` | Distinguish 'CLI missing on PATH' from real rc=-1 |
| 3 | `rc=RC_DISPATCH_ERROR=-126` on other dispatch errors | Distinct sentinel for setup failures |
| 4 | Strip CSI + OSC-8 ANSI escapes from stdout/stderr | Prevent malicious agents from poisoning downstream tooling |
| 5 | Truncate stdout/stderr at `MAX_OUTPUT_BYTES=1 MB` | Prevent JSONL parser blow-up from chatty CLIs |
| 6 | `asyncio.gather(..., return_exceptions=True)` | One agent's raise no longer cascades to peer dispatches |
| 7 | Atomic write (tmp + fsync + `os.replace`) + `_validate_round_id` regex | Crash-safe persistence + path-traversal prevention |
| 8 | `_escape_md_fence` (ZWSP) + `[TIMED OUT]` status badge | Adversarial \`\`\` can't break transcript fence; timed-out turns visibly distinct |

## Tests

- **64/64 pass** (37 base + 27 new hardening regression tests across 9 test classes)
- ruff check + format: clean
- mypy: `Success: no issues`

## Live re-verification

Heterogeneous 6-model panel post-hardening:
- 6/6 succeeded in <12s each (claude-opus 11.0s, claude-sonnet 9.2s, codex 8.5s, droid-gpt5 7.3s, droid-gemini 6.5s, droid-kimi 7.3s)

## Tier

**Tier 1 / safety hardening.** Internal helpers only; no public API surface changed. Pure additive on top of #6883.

## Standing rule

I do not author-merge. Awaiting Codex signal + CI.