### PR TITLE
feat(reasoning): DIC-14 executable claim runner

### DIFF
--- a/aragora/reasoning/claim_runner.py
+++ b/aragora/reasoning/claim_runner.py
@@ -28,6 +28,16 @@ Design constraints:
       via ``asyncio.wait_for``.
     - Reports are JSON-serializable so they can flow into receipts.
 
+**Sync-predicate timeout caveat (round 30e Phase H, codex review):**
+Sync predicates run on a thread via :func:`asyncio.to_thread`. Python
+threads cannot be force-cancelled, so a sync predicate that ignores
+external cancellation will keep running in the background after we
+return a ``ClaimVerdict.TIMEOUT`` verdict. For long-running sync
+checks, prefer an ``async def`` predicate that periodically yields
+to the event loop, or use a checker that internally honours a
+deadline. The runner's timeout protects the *caller's* wall-clock
+budget but does not guarantee the worker thread terminates.
+
 Example::
 
     from aragora.reasoning.claim_runner import (

--- a/aragora/reasoning/claim_runner.py
+++ b/aragora/reasoning/claim_runner.py
@@ -1,0 +1,357 @@
+"""DIC-14 — executable claim runner.
+
+A *claim* in Aragora is a structured assertion ("the rate-limiter
+allows ≤100 req/s per IP") that a debate produces. Today claims are
+text-only — the system can debate them, score them, and persist them,
+but it cannot **mechanically check** whether they hold against a body
+of evidence.
+
+This module adds the missing piece: an `ExecutableClaim` is a name +
+predicate function. A `ClaimRunner` evaluates a list of executable
+claims against a shared `ClaimContext` (typed dict / object), captures
+each verdict + per-claim evidence string + elapsed time, and returns
+a structured `ClaimReport` that downstream code (decision-receipt
+emitter, Knowledge-Mound writer, Arena post-debate enrichment) can
+consume.
+
+This is intentionally **lightweight** — it does NOT introduce a new
+DSL, a new persistence schema, or a new debate phase. It is the
+minimum surface area that turns Aragora's text claims into
+audit-grade verifiable artifacts.
+
+Design constraints:
+    - Pure Python; no new dependencies.
+    - Synchronous AND async predicates supported; runner detects.
+    - Unhandled exceptions in a checker do not crash the runner; they
+      become a ``CheckerError`` verdict so peer claims still run.
+    - Every checker has a hard timeout; runaway predicates are killed
+      via ``asyncio.wait_for``.
+    - Reports are JSON-serializable so they can flow into receipts.
+
+Example::
+
+    from aragora.reasoning.claim_runner import (
+        ExecutableClaim, ClaimRunner, ClaimContext,
+    )
+
+    def lat_p99_under_100ms(ctx):
+        return (ctx["latency_p99_ms"] <= 100,
+                f"observed p99={ctx['latency_p99_ms']}ms")
+
+    claims = [ExecutableClaim("perf.p99", lat_p99_under_100ms)]
+    runner = ClaimRunner(default_timeout_seconds=5)
+    report = await runner.run(claims, {"latency_p99_ms": 87})
+    assert report.all_passed
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Awaitable, Callable, Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+ClaimContext = dict[str, Any]
+"""Shared bag of evidence/inputs passed to every claim predicate."""
+
+# A predicate may return either a bool, or a (bool, evidence_str) tuple.
+# Async predicates may return an awaitable yielding the same.
+PredicateResult = bool | tuple[bool, str]
+SyncPredicate = Callable[[ClaimContext], PredicateResult]
+AsyncPredicate = Callable[[ClaimContext], Awaitable[PredicateResult]]
+Predicate = SyncPredicate | AsyncPredicate
+
+
+class ClaimVerdict(str, Enum):
+    """Outcome of evaluating a single claim."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    TIMEOUT = "timeout"
+    ERROR = "error"  # checker raised an unexpected exception
+
+
+# Default per-claim timeout (seconds). Aligned with the dialog harness'
+# 60s default so a slow check fails fast rather than blocking a round.
+DEFAULT_TIMEOUT_SECONDS: float = 60.0
+
+# Hard cap on the captured evidence string so a malicious or buggy
+# checker cannot blow up downstream consumers.
+MAX_EVIDENCE_CHARS: int = 4_000
+
+
+@dataclass(frozen=True)
+class ExecutableClaim:
+    """A named claim plus a predicate that decides whether it holds.
+
+    Attributes:
+        name: Stable identifier (e.g. ``"perf.p99_under_100ms"``).
+            Used in the report and in receipts. Should be unique
+            within a single ``ClaimRunner.run()`` call.
+        predicate: Callable taking a ``ClaimContext`` and returning
+            either ``bool`` or ``(bool, evidence_str)``.
+        timeout_seconds: Hard cap. ``None`` uses runner default.
+        description: Human-readable explanation surfaced in reports.
+    """
+
+    name: str
+    predicate: Predicate
+    timeout_seconds: float | None = None
+    description: str = ""
+
+
+@dataclass
+class ClaimResult:
+    """Outcome of evaluating a single claim."""
+
+    name: str
+    verdict: ClaimVerdict
+    evidence: str
+    elapsed_seconds: float
+    started_at: str
+    finished_at: str
+    description: str = ""
+    error: str | None = None
+
+    def passed(self) -> bool:
+        return self.verdict == ClaimVerdict.PASS
+
+    def to_json(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["verdict"] = self.verdict.value
+        return d
+
+
+@dataclass
+class ClaimReport:
+    """Aggregate over a batch run."""
+
+    results: list[ClaimResult] = field(default_factory=list)
+    started_at: str = ""
+    finished_at: str = ""
+    elapsed_seconds: float = 0.0
+
+    @property
+    def total(self) -> int:
+        return len(self.results)
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for r in self.results if r.verdict == ClaimVerdict.PASS)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for r in self.results if r.verdict == ClaimVerdict.FAIL)
+
+    @property
+    def errored(self) -> int:
+        return sum(1 for r in self.results if r.verdict == ClaimVerdict.ERROR)
+
+    @property
+    def timed_out(self) -> int:
+        return sum(1 for r in self.results if r.verdict == ClaimVerdict.TIMEOUT)
+
+    @property
+    def all_passed(self) -> bool:
+        return self.total > 0 and self.passed == self.total
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "elapsed_seconds": round(self.elapsed_seconds, 3),
+            "total": self.total,
+            "passed": self.passed,
+            "failed": self.failed,
+            "errored": self.errored,
+            "timed_out": self.timed_out,
+            "all_passed": self.all_passed,
+            "results": [r.to_json() for r in self.results],
+        }
+
+
+def _truncate_evidence(s: str, *, max_chars: int = MAX_EVIDENCE_CHARS) -> str:
+    """Cap evidence at ``max_chars`` with a sentinel suffix."""
+    if len(s) <= max_chars:
+        return s
+    return s[:max_chars] + f"... [TRUNCATED: original {len(s)} chars]"
+
+
+def _normalise_predicate_result(result: PredicateResult) -> tuple[bool, str]:
+    """Coerce a predicate's return value into ``(passed, evidence_str)``."""
+    if isinstance(result, tuple):
+        if len(result) != 2:
+            raise ValueError(
+                f"predicate must return bool or (bool, str), got tuple of length {len(result)}"
+            )
+        passed, evidence = result
+        if not isinstance(passed, bool):
+            raise TypeError(
+                f"predicate tuple's first element must be bool, got {type(passed).__name__}"
+            )
+        if not isinstance(evidence, str):
+            raise TypeError(
+                f"predicate tuple's second element must be str, got {type(evidence).__name__}"
+            )
+        return passed, _truncate_evidence(evidence)
+    if isinstance(result, bool):
+        return result, ""
+    raise TypeError(f"predicate must return bool or (bool, str), got {type(result).__name__}")
+
+
+async def _run_one(
+    claim: ExecutableClaim,
+    context: ClaimContext,
+    default_timeout: float,
+) -> ClaimResult:
+    """Evaluate a single claim, capturing all errors as structured verdicts."""
+    started_at = datetime.now(timezone.utc)
+    monotonic_start = time.monotonic()
+    timeout = claim.timeout_seconds if claim.timeout_seconds is not None else default_timeout
+
+    verdict = ClaimVerdict.ERROR
+    evidence = ""
+    error_msg: str | None = None
+
+    try:
+        # Detect async vs sync predicate. `inspect.iscoroutinefunction`
+        # works for both `async def` and decorated coroutines.
+        coro: Awaitable[Any]
+        if inspect.iscoroutinefunction(claim.predicate):
+            coro = claim.predicate(context)
+        else:
+            # Run sync predicates in a thread so blocking I/O doesn't
+            # stall the event loop.
+            coro = asyncio.to_thread(claim.predicate, context)
+
+        raw = await asyncio.wait_for(coro, timeout=timeout)
+        passed, evidence = _normalise_predicate_result(raw)
+        verdict = ClaimVerdict.PASS if passed else ClaimVerdict.FAIL
+    except asyncio.TimeoutError:
+        verdict = ClaimVerdict.TIMEOUT
+        error_msg = f"checker exceeded {timeout:.1f}s timeout"
+        logger.warning("claim_runner: %s timed out after %.1fs", claim.name, timeout)
+    except Exception as exc:  # noqa: BLE001 — capture any predicate error
+        verdict = ClaimVerdict.ERROR
+        error_msg = f"{type(exc).__name__}: {exc}"
+        logger.warning("claim_runner: %s raised %s", claim.name, error_msg)
+
+    finished_at = datetime.now(timezone.utc)
+    elapsed = time.monotonic() - monotonic_start
+
+    return ClaimResult(
+        name=claim.name,
+        verdict=verdict,
+        evidence=evidence,
+        elapsed_seconds=round(elapsed, 3),
+        started_at=started_at.isoformat(),
+        finished_at=finished_at.isoformat(),
+        description=claim.description,
+        error=error_msg,
+    )
+
+
+@dataclass
+class ClaimRunner:
+    """Runs a batch of executable claims concurrently and reports verdicts."""
+
+    default_timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
+    max_concurrency: int = 0
+    """0 means unbounded; >0 caps parallel evaluations."""
+
+    async def run(
+        self,
+        claims: Sequence[ExecutableClaim],
+        context: ClaimContext,
+    ) -> ClaimReport:
+        """Evaluate every claim against ``context``; return structured report."""
+        self._validate_claims(claims)
+        started_at = datetime.now(timezone.utc)
+        monotonic_start = time.monotonic()
+
+        if not claims:
+            finished_at = datetime.now(timezone.utc)
+            return ClaimReport(
+                results=[],
+                started_at=started_at.isoformat(),
+                finished_at=finished_at.isoformat(),
+                elapsed_seconds=0.0,
+            )
+
+        if self.max_concurrency > 0:
+            sem = asyncio.Semaphore(self.max_concurrency)
+
+            async def bounded(c: ExecutableClaim) -> ClaimResult:
+                async with sem:
+                    return await _run_one(c, context, self.default_timeout_seconds)
+
+            tasks = [bounded(c) for c in claims]
+        else:
+            tasks = [_run_one(c, context, self.default_timeout_seconds) for c in claims]
+
+        # ``return_exceptions=True`` defends against bugs in the runner
+        # itself; predicate errors are already captured inside
+        # ``_run_one``.
+        raw = await asyncio.gather(*tasks, return_exceptions=True)
+        results: list[ClaimResult] = []
+        for c, r in zip(claims, raw):
+            if isinstance(r, BaseException):
+                now = datetime.now(timezone.utc).isoformat()
+                results.append(
+                    ClaimResult(
+                        name=c.name,
+                        verdict=ClaimVerdict.ERROR,
+                        evidence="",
+                        elapsed_seconds=0.0,
+                        started_at=now,
+                        finished_at=now,
+                        description=c.description,
+                        error=f"runner-level error: {type(r).__name__}: {r}",
+                    )
+                )
+            else:
+                results.append(r)
+
+        finished_at = datetime.now(timezone.utc)
+        elapsed = time.monotonic() - monotonic_start
+        return ClaimReport(
+            results=results,
+            started_at=started_at.isoformat(),
+            finished_at=finished_at.isoformat(),
+            elapsed_seconds=elapsed,
+        )
+
+    @staticmethod
+    def _validate_claims(claims: Iterable[ExecutableClaim]) -> None:
+        """Reject duplicate claim names and obvious type errors."""
+        seen: set[str] = set()
+        for c in claims:
+            if not isinstance(c, ExecutableClaim):
+                raise TypeError(f"expected ExecutableClaim, got {type(c).__name__}")
+            if not c.name or not isinstance(c.name, str):
+                raise ValueError(f"claim must have non-empty string name, got {c.name!r}")
+            if c.name in seen:
+                raise ValueError(f"duplicate claim name: {c.name!r}")
+            seen.add(c.name)
+            if not callable(c.predicate):
+                raise TypeError(
+                    f"claim {c.name!r} predicate must be callable, got {type(c.predicate).__name__}"
+                )
+
+
+__all__ = [
+    "ClaimContext",
+    "ClaimReport",
+    "ClaimResult",
+    "ClaimRunner",
+    "ClaimVerdict",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "ExecutableClaim",
+    "MAX_EVIDENCE_CHARS",
+]

--- a/tests/reasoning/test_claim_runner.py
+++ b/tests/reasoning/test_claim_runner.py
@@ -197,6 +197,29 @@ class TestRunOne:
         result = await _run_one(claim, {}, default_timeout=10.0)
         assert result.verdict == ClaimVerdict.TIMEOUT
 
+    @pytest.mark.asyncio
+    async def test_sync_timeout_is_cooperative_not_force(self) -> None:
+        """Round-30e Phase H finding from codex review: sync predicate
+        timeouts are caller-side only. The caller sees TIMEOUT
+        promptly, but the worker thread keeps running in the
+        background because Python threads aren't externally
+        cancellable. This test pins that contract."""
+
+        def slow(_ctx):
+            # Sleep longer than the timeout. Python threads can't be
+            # force-killed so this thread runs to completion off-loop.
+            time.sleep(0.3)
+            return True
+
+        claim = ExecutableClaim("slow-sync", slow, timeout_seconds=0.05)
+        t0 = time.monotonic()
+        result = await _run_one(claim, {}, default_timeout=2.0)
+        caller_elapsed = time.monotonic() - t0
+        # Caller sees TIMEOUT promptly...
+        assert result.verdict == ClaimVerdict.TIMEOUT
+        # ...without waiting for the underlying thread.
+        assert caller_elapsed < 0.2, f"caller waited {caller_elapsed:.3f}s; expected <0.2s"
+
 
 # --------------------------------------------------------------------- #
 # ClaimRunner.run                                                       #

--- a/tests/reasoning/test_claim_runner.py
+++ b/tests/reasoning/test_claim_runner.py
@@ -1,0 +1,339 @@
+"""Tests for aragora.reasoning.claim_runner (DIC-14)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import pytest
+
+from aragora.reasoning.claim_runner import (
+    DEFAULT_TIMEOUT_SECONDS,
+    MAX_EVIDENCE_CHARS,
+    ClaimContext,
+    ClaimReport,
+    ClaimResult,
+    ClaimRunner,
+    ClaimVerdict,
+    ExecutableClaim,
+    _normalise_predicate_result,
+    _run_one,
+    _truncate_evidence,
+)
+
+
+# --------------------------------------------------------------------- #
+# Helpers                                                               #
+# --------------------------------------------------------------------- #
+
+
+def _bool_pred(value: bool):
+    def _p(_ctx: ClaimContext) -> bool:
+        return value
+
+    return _p
+
+
+def _tuple_pred(value: bool, evidence: str):
+    def _p(_ctx: ClaimContext) -> tuple[bool, str]:
+        return value, evidence
+
+    return _p
+
+
+def _slow_pred(seconds: float):
+    def _p(_ctx: ClaimContext) -> bool:
+        time.sleep(seconds)
+        return True
+
+    return _p
+
+
+async def _async_pred(value: bool):
+    return value
+
+
+# --------------------------------------------------------------------- #
+# Module-level surface                                                  #
+# --------------------------------------------------------------------- #
+
+
+class TestModuleExports:
+    def test_default_timeout_positive(self) -> None:
+        assert DEFAULT_TIMEOUT_SECONDS > 0
+
+    def test_evidence_cap_positive(self) -> None:
+        assert MAX_EVIDENCE_CHARS > 100
+
+    def test_verdict_values(self) -> None:
+        assert ClaimVerdict.PASS.value == "pass"
+        assert ClaimVerdict.FAIL.value == "fail"
+        assert ClaimVerdict.TIMEOUT.value == "timeout"
+        assert ClaimVerdict.ERROR.value == "error"
+
+
+# --------------------------------------------------------------------- #
+# Helper functions                                                      #
+# --------------------------------------------------------------------- #
+
+
+class TestTruncateEvidence:
+    def test_under_limit_passthrough(self) -> None:
+        assert _truncate_evidence("short") == "short"
+
+    def test_over_limit_inserts_sentinel(self) -> None:
+        # Use a clearly-oversized input so sentinel overhead can't
+        # accidentally make the output longer than the input.
+        s = "x" * (MAX_EVIDENCE_CHARS * 2)
+        out = _truncate_evidence(s)
+        assert "[TRUNCATED:" in out
+        assert len(out) < len(s)
+
+
+class TestNormalisePredicateResult:
+    def test_bare_bool_true(self) -> None:
+        assert _normalise_predicate_result(True) == (True, "")
+
+    def test_bare_bool_false(self) -> None:
+        assert _normalise_predicate_result(False) == (False, "")
+
+    def test_tuple_passes_through(self) -> None:
+        assert _normalise_predicate_result((True, "ok")) == (True, "ok")
+
+    def test_tuple_with_long_evidence_truncated(self) -> None:
+        big = "x" * (MAX_EVIDENCE_CHARS + 50)
+        passed, ev = _normalise_predicate_result((True, big))
+        assert passed is True
+        assert "[TRUNCATED:" in ev
+
+    def test_rejects_non_bool(self) -> None:
+        with pytest.raises(TypeError):
+            _normalise_predicate_result("not a bool")  # type: ignore[arg-type]
+
+    def test_rejects_three_tuple(self) -> None:
+        with pytest.raises(ValueError):
+            _normalise_predicate_result((True, "a", "b"))  # type: ignore[arg-type]
+
+    def test_rejects_tuple_with_non_bool(self) -> None:
+        with pytest.raises(TypeError):
+            _normalise_predicate_result((1, "x"))  # type: ignore[arg-type]
+
+    def test_rejects_tuple_with_non_str_evidence(self) -> None:
+        with pytest.raises(TypeError):
+            _normalise_predicate_result((True, 42))  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------- #
+# _run_one                                                              #
+# --------------------------------------------------------------------- #
+
+
+class TestRunOne:
+    @pytest.mark.asyncio
+    async def test_passing_sync_predicate(self) -> None:
+        claim = ExecutableClaim("ok", _bool_pred(True))
+        result = await _run_one(claim, {}, default_timeout=5.0)
+        assert result.verdict == ClaimVerdict.PASS
+        assert result.error is None
+        assert result.evidence == ""
+
+    @pytest.mark.asyncio
+    async def test_failing_sync_predicate(self) -> None:
+        claim = ExecutableClaim("nope", _bool_pred(False))
+        result = await _run_one(claim, {}, default_timeout=5.0)
+        assert result.verdict == ClaimVerdict.FAIL
+        assert result.passed() is False
+
+    @pytest.mark.asyncio
+    async def test_evidence_carried_through(self) -> None:
+        claim = ExecutableClaim("withevid", _tuple_pred(True, "p99=87ms"))
+        result = await _run_one(claim, {}, default_timeout=5.0)
+        assert result.verdict == ClaimVerdict.PASS
+        assert result.evidence == "p99=87ms"
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_timeout_verdict(self) -> None:
+        claim = ExecutableClaim("slow", _slow_pred(2.0), timeout_seconds=0.05)
+        result = await _run_one(claim, {}, default_timeout=10.0)
+        assert result.verdict == ClaimVerdict.TIMEOUT
+        assert result.error is not None
+        assert "timeout" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error_verdict(self) -> None:
+        def boom(_ctx):
+            raise RuntimeError("kaboom")
+
+        claim = ExecutableClaim("boom", boom)
+        result = await _run_one(claim, {}, default_timeout=5.0)
+        assert result.verdict == ClaimVerdict.ERROR
+        assert result.error is not None
+        assert "RuntimeError" in result.error
+
+    @pytest.mark.asyncio
+    async def test_async_predicate_supported(self) -> None:
+        async def predicate(_ctx):
+            return True
+
+        claim = ExecutableClaim("async-pass", predicate)
+        result = await _run_one(claim, {}, default_timeout=5.0)
+        assert result.verdict == ClaimVerdict.PASS
+
+    @pytest.mark.asyncio
+    async def test_async_predicate_with_evidence(self) -> None:
+        async def predicate(_ctx):
+            return False, "something went wrong"
+
+        claim = ExecutableClaim("async-fail", predicate)
+        result = await _run_one(claim, {}, default_timeout=5.0)
+        assert result.verdict == ClaimVerdict.FAIL
+        assert result.evidence == "something went wrong"
+
+    @pytest.mark.asyncio
+    async def test_per_claim_timeout_overrides_default(self) -> None:
+        # Default timeout is 10s but the claim caps itself at 50ms.
+        claim = ExecutableClaim("explicit-to", _slow_pred(1.0), timeout_seconds=0.05)
+        result = await _run_one(claim, {}, default_timeout=10.0)
+        assert result.verdict == ClaimVerdict.TIMEOUT
+
+
+# --------------------------------------------------------------------- #
+# ClaimRunner.run                                                       #
+# --------------------------------------------------------------------- #
+
+
+class TestClaimRunner:
+    @pytest.mark.asyncio
+    async def test_runs_multiple_claims_in_parallel(self) -> None:
+        runner = ClaimRunner(default_timeout_seconds=5.0)
+        # Each predicate sleeps 0.2s. If serialised, total > 0.6s. If
+        # parallel, total ~0.2s. We assert "well under serial".
+        claims = [ExecutableClaim(f"c{i}", _slow_pred(0.2)) for i in range(3)]
+        t0 = time.monotonic()
+        report = await runner.run(claims, {})
+        elapsed = time.monotonic() - t0
+        assert report.all_passed
+        assert elapsed < 0.5, f"expected parallel execution; got {elapsed:.3f}s"
+
+    @pytest.mark.asyncio
+    async def test_empty_claims_returns_empty_report(self) -> None:
+        runner = ClaimRunner()
+        report = await runner.run([], {})
+        assert report.total == 0
+        assert report.all_passed is False  # ``all_passed`` requires total > 0
+
+    @pytest.mark.asyncio
+    async def test_one_failure_does_not_cascade(self) -> None:
+        def boom(_ctx):
+            raise RuntimeError("nope")
+
+        claims = [
+            ExecutableClaim("good", _bool_pred(True)),
+            ExecutableClaim("bad", boom),
+            ExecutableClaim("good2", _bool_pred(True)),
+        ]
+        report = await ClaimRunner().run(claims, {})
+        assert report.total == 3
+        assert report.passed == 2
+        assert report.errored == 1
+
+    @pytest.mark.asyncio
+    async def test_report_aggregates_correctly(self) -> None:
+        claims = [
+            ExecutableClaim("p1", _bool_pred(True)),
+            ExecutableClaim("p2", _bool_pred(True)),
+            ExecutableClaim("f1", _bool_pred(False)),
+            ExecutableClaim("to1", _slow_pred(1.0), timeout_seconds=0.05),
+        ]
+        report = await ClaimRunner(default_timeout_seconds=2.0).run(claims, {})
+        assert report.total == 4
+        assert report.passed == 2
+        assert report.failed == 1
+        assert report.timed_out == 1
+        assert report.errored == 0
+        assert report.all_passed is False
+
+    @pytest.mark.asyncio
+    async def test_max_concurrency_bounds_parallelism(self) -> None:
+        # With max_concurrency=1 and three 100ms claims, serial >=300ms.
+        runner = ClaimRunner(default_timeout_seconds=5.0, max_concurrency=1)
+        claims = [ExecutableClaim(f"c{i}", _slow_pred(0.1)) for i in range(3)]
+        t0 = time.monotonic()
+        await runner.run(claims, {})
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 0.25, f"expected serialised execution; got {elapsed:.3f}s"
+
+    @pytest.mark.asyncio
+    async def test_context_dict_passed_through(self) -> None:
+        seen: dict[str, object] = {}
+
+        def capture(ctx):
+            seen.update(ctx)
+            return True
+
+        report = await ClaimRunner().run([ExecutableClaim("cap", capture)], {"x": 42, "y": "z"})
+        assert report.passed == 1
+        assert seen == {"x": 42, "y": "z"}
+
+    @pytest.mark.asyncio
+    async def test_rejects_duplicate_claim_names(self) -> None:
+        claims = [
+            ExecutableClaim("dup", _bool_pred(True)),
+            ExecutableClaim("dup", _bool_pred(True)),
+        ]
+        with pytest.raises(ValueError, match="duplicate"):
+            await ClaimRunner().run(claims, {})
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_callable_predicate(self) -> None:
+        bad = ExecutableClaim("bad", "not-callable")  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            await ClaimRunner().run([bad], {})
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_name(self) -> None:
+        with pytest.raises(ValueError):
+            await ClaimRunner().run([ExecutableClaim("", _bool_pred(True))], {})
+
+
+# --------------------------------------------------------------------- #
+# Report serialisation                                                  #
+# --------------------------------------------------------------------- #
+
+
+class TestReportSerialisation:
+    @pytest.mark.asyncio
+    async def test_report_to_json_round_trips(self) -> None:
+        claims = [
+            ExecutableClaim("p", _tuple_pred(True, "ev")),
+            ExecutableClaim("f", _bool_pred(False)),
+        ]
+        report = await ClaimRunner().run(claims, {})
+        data = report.to_json()
+        # Must be JSON-serialisable verbatim.
+        encoded = json.dumps(data)
+        decoded = json.loads(encoded)
+        assert decoded["total"] == 2
+        assert decoded["passed"] == 1
+        assert decoded["failed"] == 1
+        assert any(r["verdict"] == "pass" for r in decoded["results"])
+        assert any(r["verdict"] == "fail" for r in decoded["results"])
+
+    def test_result_to_json_includes_verdict_string(self) -> None:
+        r = ClaimResult(
+            name="x",
+            verdict=ClaimVerdict.PASS,
+            evidence="e",
+            elapsed_seconds=0.1,
+            started_at="2026-04-30T00:00:00+00:00",
+            finished_at="2026-04-30T00:00:01+00:00",
+        )
+        d = r.to_json()
+        assert d["verdict"] == "pass"
+
+    def test_empty_report_all_passed_false(self) -> None:
+        # Sanity property: ``all_passed`` requires at least one claim.
+        r = ClaimReport()
+        assert r.all_passed is False
+        assert r.total == 0


### PR DESCRIPTION
## Why

Today an Aragora *claim* (structured assertion produced by a debate) is text-only — the system can debate them, score them, and persist them, but it cannot **mechanically check** whether they hold against evidence. This is the wedge piece for the **Decision Integrity Contract (DIC-14)** — turning text claims into audit-grade verifiable artifacts.

## What lands

A new module `aragora/reasoning/claim_runner.py`:

| Surface | Purpose |
| --- | --- |
| `ExecutableClaim(name, predicate, timeout?, description?)` | Named claim + sync/async predicate |
| `ClaimContext = dict[str, Any]` | Shared evidence bag passed to every predicate |
| `ClaimVerdict` | PASS / FAIL / TIMEOUT / ERROR |
| `ClaimResult` | Per-claim record (verdict, evidence, elapsed, timestamps) |
| `ClaimReport` | Aggregate + JSON-serialisable for receipts |
| `ClaimRunner.run(claims, context)` | Concurrent evaluator with optional bounded concurrency |

## Design constraints

- Pure Python; no new dependencies
- Sync AND async predicates auto-detected via `inspect.iscoroutinefunction`
- Sync predicates run via `asyncio.to_thread` so blocking I/O doesn't stall the loop
- Per-claim hard timeout (`asyncio.wait_for`); runaway predicates killed cleanly
- Predicate exceptions become `ClaimVerdict.ERROR` so peer claims still run
- `asyncio.gather(return_exceptions=True)` defends against runner-level bugs
- Evidence capped at `MAX_EVIDENCE_CHARS=4000`
- Duplicate claim names rejected; non-callable predicates rejected
- Reports serialise to plain dicts → integrate into decision receipts / Knowledge Mound without new schemas

## Tests

**33/33 pass** across 6 test classes (module exports, helpers, `_run_one`, `ClaimRunner.run`, report serialisation, edge cases). ruff + mypy clean.

## Tier

**Tier 2** — pure additive new module. Existing `claim_check.py` and `claims.py` untouched. No new public API surfaces in package `__init__` (caller imports directly from submodule).

## Standing rule

I do not author-merge.