### PR TITLE
feat(epistemic): wire gauntlet bridge end-to-end via ingest_gauntlet_receipt

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -88,6 +88,7 @@ from .crux_receipt import (
 )
 from .gauntlet_crux_bridge import (
     from_gauntlet_receipt,
+    ingest_gauntlet_receipt,
     km_crux_ingestion_enabled,
 )
 from .decay_monitor import DecayReason, DecaySignal, evaluate_unit
@@ -230,6 +231,7 @@ __all__ = [
     "crux_receipt_enabled",
     "enable_crux_receipt",
     "from_gauntlet_receipt",
+    "ingest_gauntlet_receipt",
     "km_crux_ingestion_enabled",
     "enable_epistemic_followup",
     "enable_repair_pipeline",

--- a/aragora/epistemic/gauntlet_crux_bridge.py
+++ b/aragora/epistemic/gauntlet_crux_bridge.py
@@ -190,7 +190,83 @@ def from_gauntlet_receipt(
     )
 
 
+async def ingest_gauntlet_receipt(
+    gauntlet: "GauntletCruxReceipt",
+    adapter: Any,
+    *,
+    require_enabled: bool = True,
+    preserve_receipt_id: bool = False,
+) -> Any:
+    """End-to-end: convert a gauntlet ``CruxReceipt`` and ingest into the Knowledge Mound.
+
+    The bridge converter (:func:`from_gauntlet_receipt`) is always safe to call;
+    this thin wrapper adds the **side-effecting** Knowledge Mound ingestion step
+    via the provided :class:`~aragora.knowledge.mound.adapters.crux_receipt_adapter.CruxReceiptAdapter`.
+
+    Default off: ``require_enabled=True`` forces a check of
+    ``ARAGORA_KM_CRUX_INGESTION_ENABLED``.  When the flag is off, returns the
+    same skipped-ingestion result the adapter would produce, without invoking
+    the conversion at all (so a malformed gauntlet receipt is also a no-op
+    when the flag is off — defense-in-depth).
+
+    Round 2026-04-30d follow-up to #6849: gives downstream callers a single-
+    function path ``gauntlet receipt -> KM ingestion`` so the caller does not
+    have to compose the converter + adapter explicitly.  The bridge converter
+    remains the supported lower-level API for callers that need the
+    intermediate epistemic receipt for other purposes.
+
+    Parameters
+    ----------
+    gauntlet:
+        Gauntlet :class:`~aragora.gauntlet.receipt_models.CruxReceipt` to
+        convert and ingest.
+    adapter:
+        A :class:`CruxReceiptAdapter` instance (typed loosely as ``Any`` to
+        avoid a circular import; the adapter exposes
+        ``async ingest_crux_receipt(receipt, *, require_enabled)``).
+    require_enabled:
+        When ``True`` (default), check ``ARAGORA_KM_CRUX_INGESTION_ENABLED``
+        before performing the conversion or invoking the adapter.  When
+        ``False``, always run the conversion and pass ``require_enabled=False``
+        to the adapter (test-only escape hatch).
+    preserve_receipt_id:
+        Forwarded to :func:`from_gauntlet_receipt`.
+
+    Returns
+    -------
+    Whatever the adapter's ``ingest_crux_receipt`` returns — typically a
+    :class:`~aragora.knowledge.mound.adapters.crux_receipt_adapter.CruxIngestionResult`.
+    When the flag is off, returns the adapter's "skipped" shape (zero
+    items ingested, same receipt_id surfaced).
+    """
+    if require_enabled and not km_crux_ingestion_enabled():
+        # Fast-skip without invoking conversion: produces an adapter-shape
+        # result that downstream consumers can introspect identically to a
+        # real "skipped because flag off" path.
+        from aragora.knowledge.mound.adapters.crux_receipt_adapter import (
+            CruxIngestionResult,
+        )
+
+        return CruxIngestionResult(
+            receipt_id=gauntlet.receipt_id,
+            cruxes_ingested=0,
+            knowledge_item_ids=[],
+            skipped=len(gauntlet.cruxes or []),
+        )
+
+    epistemic_receipt = from_gauntlet_receipt(gauntlet, preserve_receipt_id=preserve_receipt_id)
+    return await adapter.ingest_crux_receipt(
+        epistemic_receipt,
+        # If require_enabled was True at our level and the flag is on, we
+        # already verified enablement; pass require_enabled=False so the
+        # adapter doesn't double-check.  If our caller passed
+        # require_enabled=False, we forward that intent.
+        require_enabled=False,
+    )
+
+
 __all__ = [
     "from_gauntlet_receipt",
+    "ingest_gauntlet_receipt",
     "km_crux_ingestion_enabled",
 ]

--- a/tests/epistemic/test_gauntlet_crux_bridge.py
+++ b/tests/epistemic/test_gauntlet_crux_bridge.py
@@ -324,3 +324,122 @@ class TestKmAdapterCompatibility:
         d = e.to_dict()
         assert d["debate_id"] == "debate.42"
         assert len(d["cruxes"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# ingest_gauntlet_receipt — end-to-end wrapper (Round 2026-04-30d follow-up to #6849)
+# ---------------------------------------------------------------------------
+
+
+class _StubAdapter:
+    """Minimal CruxReceiptAdapter stand-in for testing.
+
+    Records what was passed to ingest_crux_receipt + the require_enabled flag.
+    """
+
+    def __init__(self, *, raise_on_call: bool = False):
+        self.calls: list[tuple] = []
+        self.raise_on_call = raise_on_call
+
+    async def ingest_crux_receipt(self, receipt, *, require_enabled: bool = True):
+        self.calls.append((receipt, require_enabled))
+        if self.raise_on_call:
+            raise RuntimeError("adapter forced failure")
+        from aragora.knowledge.mound.adapters.crux_receipt_adapter import (
+            CruxIngestionResult,
+        )
+
+        return CruxIngestionResult(
+            receipt_id=receipt.receipt_id,
+            cruxes_ingested=len(receipt.cruxes),
+            knowledge_item_ids=[f"item_{i}" for i in range(len(receipt.cruxes))],
+        )
+
+
+class TestIngestGauntletReceipt:
+    """End-to-end: gauntlet receipt -> conversion -> KM adapter."""
+
+    @pytest.mark.asyncio
+    async def test_flag_off_returns_skipped_without_calling_adapter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from aragora.epistemic.gauntlet_crux_bridge import ingest_gauntlet_receipt
+
+        monkeypatch.delenv("ARAGORA_KM_CRUX_INGESTION_ENABLED", raising=False)
+        adapter = _StubAdapter()
+        g = _gauntlet_receipt()
+        result = await ingest_gauntlet_receipt(g, adapter)
+
+        assert adapter.calls == []
+        assert result.cruxes_ingested == 0
+        assert result.skipped == 1
+        assert result.knowledge_item_ids == []
+        # receipt_id is the gauntlet's verbatim (no conversion ran).
+        assert result.receipt_id == "crux-deadbeef"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_runs_full_conversion_and_adapter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from aragora.epistemic.gauntlet_crux_bridge import ingest_gauntlet_receipt
+
+        monkeypatch.setenv("ARAGORA_KM_CRUX_INGESTION_ENABLED", "1")
+        adapter = _StubAdapter()
+        g = _gauntlet_receipt()
+        result = await ingest_gauntlet_receipt(g, adapter)
+
+        assert len(adapter.calls) == 1
+        passed_receipt, passed_require = adapter.calls[0]
+        # Adapter is called with require_enabled=False (we already checked
+        # at the wrapper level; adapter doesn't need to double-check).
+        assert passed_require is False
+        from aragora.epistemic.crux_receipt import CruxReceipt as Target
+
+        assert isinstance(passed_receipt, Target)
+        assert passed_receipt.debate_id == "debate.42"
+        assert result.cruxes_ingested == 1
+        assert len(result.knowledge_item_ids) == 1
+
+    @pytest.mark.asyncio
+    async def test_require_enabled_false_bypasses_flag_check(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``require_enabled=False`` is the test-harness escape hatch."""
+        from aragora.epistemic.gauntlet_crux_bridge import ingest_gauntlet_receipt
+
+        monkeypatch.delenv("ARAGORA_KM_CRUX_INGESTION_ENABLED", raising=False)
+        adapter = _StubAdapter()
+        g = _gauntlet_receipt()
+        result = await ingest_gauntlet_receipt(g, adapter, require_enabled=False)
+
+        assert len(adapter.calls) == 1
+        assert result.cruxes_ingested == 1
+
+    @pytest.mark.asyncio
+    async def test_preserve_receipt_id_forwarded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from aragora.epistemic.gauntlet_crux_bridge import ingest_gauntlet_receipt
+
+        monkeypatch.setenv("ARAGORA_KM_CRUX_INGESTION_ENABLED", "1")
+        adapter = _StubAdapter()
+        g = _gauntlet_receipt()
+        await ingest_gauntlet_receipt(g, adapter, preserve_receipt_id=True)
+
+        passed_receipt, _ = adapter.calls[0]
+        assert passed_receipt.receipt_id == "crux-deadbeef"
+
+    @pytest.mark.asyncio
+    async def test_adapter_failure_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Adapter failures are not silently swallowed."""
+        from aragora.epistemic.gauntlet_crux_bridge import ingest_gauntlet_receipt
+
+        monkeypatch.setenv("ARAGORA_KM_CRUX_INGESTION_ENABLED", "1")
+        adapter = _StubAdapter(raise_on_call=True)
+        g = _gauntlet_receipt()
+        with pytest.raises(RuntimeError, match="adapter forced failure"):
+            await ingest_gauntlet_receipt(g, adapter)
+
+    def test_exported_from_aragora_epistemic(self) -> None:
+        import aragora.epistemic as ep
+
+        assert hasattr(ep, "ingest_gauntlet_receipt")
+        assert "ingest_gauntlet_receipt" in ep.__all__


### PR DESCRIPTION
Round 2026-04-30d follow-up to #6849 — Tier 2 (additive default-off)

Closes the wiring step the prior round briefing called out: now that
#6849 (Gauntlet -> Epistemic CruxReceipt bridge) is on main, give
downstream callers a single-function path:

    gauntlet CruxReceipt -> conversion -> KM ingestion

without forcing them to compose `from_gauntlet_receipt` + the adapter
explicitly.

New API: aragora.epistemic.gauntlet_crux_bridge.ingest_gauntlet_receipt

  async def ingest_gauntlet_receipt(
      gauntlet: GauntletCruxReceipt,
      adapter: CruxReceiptAdapter,
      *,
      require_enabled: bool = True,
      preserve_receipt_id: bool = False,
  ) -> CruxIngestionResult: ...

- `require_enabled=True` (default): checks
  `ARAGORA_KM_CRUX_INGESTION_ENABLED` and fast-skips without invoking
  conversion when off (defense-in-depth — malformed gauntlet receipt is
  also a no-op when flag off).
- `require_enabled=False`: test-harness escape hatch; always run.
- `preserve_receipt_id`: forwarded to `from_gauntlet_receipt`.

Returns the adapter's `CruxIngestionResult`. When the flag is off and
ingestion is skipped, returns an adapter-shape "skipped" result so
downstream consumers can introspect identically.

Public surface: exported from `aragora.epistemic.__all__`.

Tests (6 new):
- flag-off returns skipped without calling adapter
- flag-on runs full conversion + adapter (verifies require_enabled=False
  passed to adapter to avoid double-check)
- require_enabled=False bypasses flag check
- preserve_receipt_id forwarded correctly
- adapter failure propagates (not silently swallowed)
- exported from aragora.epistemic.__all__

Verification:
- 30/30 tests pass (was 24; +6 new)
- ruff check + format clean
- mypy clean on gauntlet_crux_bridge.py
- preflight ok

Pure addition; no caller migration. The lower-level
`from_gauntlet_receipt` remains supported for callers that need the
intermediate epistemic receipt.

Standing rule: I do not author-merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
