### PR TITLE
docs(site): sync B0 status generated pages

### DIFF
--- a/docs-site/docs/contributing/b0-benchmark-truth-status.md
+++ b/docs-site/docs/contributing/b0-benchmark-truth-status.md
@@ -5,7 +5,7 @@ description: B0 Benchmark Truth Status
 
 # B0 Benchmark Truth Status
 
-Last updated: 2026-04-22T11:33:32Z
+Last updated: 2026-04-30T16:01:56Z
 
 This is the repo-tracked recurring `TW-02` publication surface for the fixed benchmark corpus.
 
@@ -13,69 +13,56 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 
 - Corpus manifest: `docs/benchmarks/corpus.json`
 - Corpus id: `tw-01-bounded-execution-v1`
-- Revision: `3`
-- Recorded on: `2026-04-17`
+- Revision: `4`
+- Recorded on: `2026-04-26`
 - Success contract: `mergeable_pr_or_merged_pr`
 - Verified expected issues: `0`
-- In-progress expected issues: `3`
+- In-progress expected issues: `1`
 - Coverage status: `complete`
-- Coverage: `3`/`3` issues attempted
+- Coverage: `1`/`1` issues attempted
 
 ## Published Paths
 
 - Latest truth artifact: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json`
 - Latest scorecard: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/latest.json`
-- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-3/latest.json`
-- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-3/latest.json`
+- Revision-scoped truth pointer: `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/rev-4/latest.json`
+- Revision-scoped scorecard pointer: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-4/latest.json`
 
 ## Truth Metrics
 
 | Metric | Value |
 | --- | --- |
 | Verified truth success rate (primary) | 0.0% |
-| Full-corpus truth success rate (legacy/context) | 33.3% |
-| No-rescue truth success rate | 33.3% |
-| Merged-only rate | 33.3% |
+| Full-corpus truth success rate (legacy/context) | 0.0% |
+| No-rescue truth success rate | 0.0% |
+| Merged-only rate | 0.0% |
 
 ## In-Flight Graduation Metrics
 
 | Metric | Value |
 | --- | --- |
-| In-progress expected issues | 3 |
-| In-progress attempted issues | 3 |
-| In-progress successful issues | 1 |
-| In-progress graduation rate | 33.3% |
-| In-progress issue numbers | `#5844`, `#5887`, `#5903` |
+| In-progress expected issues | 1 |
+| In-progress attempted issues | 1 |
+| In-progress successful issues | 0 |
+| In-progress graduation rate | 0.0% |
+| In-progress issue numbers | `#5839` |
 
 ## Proxy Metrics
 
 | Metric | Value |
 | --- | --- |
-| Proxy no-rescue success rate | 0.0% |
-| Unique issues attempted | 3 |
-| Unique issues succeeded | 0 |
-| Unique issues failed | 3 |
+| Proxy no-rescue success rate | 100.0% |
+| Unique issues attempted | 1 |
+| Unique issues succeeded | 1 |
+| Unique issues failed | 0 |
 | Unique issues neutral | 0 |
-| Total ticks | 9 |
+| Total ticks | 5 |
 
 ## Failure Class Distribution
 
-- `blocked_auth_failure`: 2
-- `blocked_not_dispatch_bounded`: 7
+- `blocked_auth_failure`: 3
+- `blocked_sanitation_failed`: 1
 
 ## Rescue Counts By Type
 
 - none
-
-## Previous Published Artifact
-
-- Previous artifact path: `docs/status/generated/benchmark_scorecards/tw-01-bounded-execution-v1/rev-3/scorecard-20260417T143309Z.json`
-- Previous generated_at: `2026-04-17T14:33:09Z`
-
-## Deltas
-
-- `merged_only_rate`: 0.3333
-- `no_rescue_truth_success_rate`: 0.3333
-- `proxy_no_rescue_success_rate`: 0.0000
-- `truth_success_rate`: 0.3333
-- `unique_issues_attempted`: 0.0000

--- a/docs-site/docs/contributing/tw03-rescue-productization-status.md
+++ b/docs-site/docs/contributing/tw03-rescue-productization-status.md
@@ -5,7 +5,7 @@ description: TW-03 Rescue Productization Status
 
 # TW-03 Rescue Productization Status
 
-Last updated: 2026-04-17T18:13:48Z
+Last updated: 2026-04-17T12:57:28Z
 
 This repo-tracked recurring `TW-03` status captures repeated rescue-class harvest, conversion, and ledger-consistency validation.
 


### PR DESCRIPTION
## Summary
- sync generated docs-site copies after the B0 rev-4 status update
- fixes the doc-build PR check failure seen after #6891 by committing the generated docs-site pages

## Validation
- python3 scripts/doc_stats.py --write
- node docs-site/scripts/sync-docs.js
- git diff --exit-code -- docs-site/docs/contributing/b0-benchmark-truth-status.md docs-site/docs/contributing/tw03-rescue-productization-status.md
- bash scripts/automation_pr_preflight.sh origin/main HEAD