### PR TITLE
[AGT-02] A2A capability discovery — platform catalog + per-agent summary

### DIFF
--- a/aragora/protocols/a2a/discovery.py
+++ b/aragora/protocols/a2a/discovery.py
@@ -139,7 +139,9 @@ _PLATFORM_CAPABILITIES: list[PlatformCapability] = [
 ]
 
 
-def platform_catalog(*, category: str | None = None, require_enabled: bool = True) -> list[PlatformCapability]:
+def platform_catalog(
+    *, category: str | None = None, require_enabled: bool = True
+) -> list[PlatformCapability]:
     """Return platform capabilities sorted by ``capability_id``.
 
     ``category`` filters to one group; ``None`` returns all.
@@ -147,11 +149,17 @@ def platform_catalog(*, category: str | None = None, require_enabled: bool = Tru
     """
     if require_enabled:
         _require_enabled()
-    caps = _PLATFORM_CAPABILITIES if category is None else [c for c in _PLATFORM_CAPABILITIES if c.category == category]
+    caps = (
+        _PLATFORM_CAPABILITIES
+        if category is None
+        else [c for c in _PLATFORM_CAPABILITIES if c.category == category]
+    )
     return sorted(caps, key=lambda c: c.capability_id)
 
 
-def agent_catalog(agent_id: str, *, server: Any = None, require_enabled: bool = True) -> AgentCapabilitySummary:
+def agent_catalog(
+    agent_id: str, *, server: Any = None, require_enabled: bool = True
+) -> AgentCapabilitySummary:
     """Return the capability summary for a registered agent.
 
     Returns an empty summary when the agent is unknown or ``server`` is ``None``.

--- a/aragora/protocols/a2a/discovery.py
+++ b/aragora/protocols/a2a/discovery.py
@@ -174,5 +174,7 @@ def agent_catalog(
     raw = getattr(card, "capabilities", None) or []
     return AgentCapabilitySummary(
         agent_id=agent_id,
-        declared_capabilities=[str(c) for c in raw] if isinstance(raw, list) else [],
+        declared_capabilities=[str(getattr(c, "value", c)) for c in raw]
+        if isinstance(raw, list)
+        else [],
     )

--- a/aragora/protocols/a2a/discovery.py
+++ b/aragora/protocols/a2a/discovery.py
@@ -1,0 +1,170 @@
+"""A2A capability discovery layer — AGT-02 / #6063 sub-deliverable 3.
+
+Machine-readable catalog of platform capabilities and per-agent summaries so
+external agents can discover what Aragora offers without HTML parsing.
+
+Gate: ``ARAGORA_A2A_DISCOVERY_ENABLED`` (default off).  Dataclasses are always
+importable; :func:`platform_catalog` and :func:`agent_catalog` raise when off.
+Out of scope: HTTP routes, pagination, reputation slices (AGT-05).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "discovery_enabled",
+    "DiscoveryError",
+    "PlatformCapability",
+    "AgentCapabilitySummary",
+    "platform_catalog",
+    "agent_catalog",
+]
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def discovery_enabled() -> bool:
+    return os.environ.get("ARAGORA_A2A_DISCOVERY_ENABLED", "").lower().strip() in _TRUTHY
+
+
+def _require_enabled() -> None:
+    if not discovery_enabled():
+        raise DiscoveryError("Set ARAGORA_A2A_DISCOVERY_ENABLED=1 to enable discovery.")
+
+
+class DiscoveryError(RuntimeError):
+    """Raised when a discovery function is called while the feature gate is off."""
+
+
+@dataclass(frozen=True)
+class PlatformCapability:
+    """Versioned, JSON-serializable capability offered by the Aragora platform.
+
+    ``flag_required`` is the env-var for production activation; empty means always-on.
+    """
+
+    capability_id: str
+    name: str
+    description: str
+    schema_version: str
+    category: str
+    flag_required: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "capability_id": self.capability_id,
+            "name": self.name,
+            "description": self.description,
+            "schema_version": self.schema_version,
+            "category": self.category,
+            "flag_required": self.flag_required,
+        }
+
+
+@dataclass
+class AgentCapabilitySummary:
+    """Per-agent capability view from the A2A registry.
+
+    ``reputation_stub`` is a placeholder until AGT-05 wires live ERC-8004 scores.
+    """
+
+    agent_id: str
+    declared_capabilities: list[str] = field(default_factory=list)
+    reputation_stub: dict[str, float | None] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "declared_capabilities": list(self.declared_capabilities),
+            "reputation_stub": dict(self.reputation_stub),
+        }
+
+
+_PLATFORM_CAPABILITIES: list[PlatformCapability] = [
+    PlatformCapability(
+        capability_id="aragora.agent.capabilities",
+        name="Capability Discovery",
+        description="Query platform or per-agent capability catalogs in machine-readable JSON.",
+        schema_version="1.0",
+        category="registry",
+        flag_required="ARAGORA_A2A_DISCOVERY_ENABLED",
+    ),
+    PlatformCapability(
+        capability_id="aragora.agent.register",
+        name="Agent Registration",
+        description="Register an external agent identity and receive a signed identity receipt.",
+        schema_version="1.0",
+        category="registry",
+    ),
+    PlatformCapability(
+        capability_id="aragora.claim.verify",
+        name="Verify Executable Claim",
+        description="Run a verification pass against a named executable claim manifest.",
+        schema_version="1.0",
+        category="claim",
+        flag_required="ARAGORA_EPISTEMIC_CLAIMS_ENABLED",
+    ),
+    PlatformCapability(
+        capability_id="aragora.debate.run",
+        name="Run Debate",
+        description="Submit a question to Aragora's debate engine and receive a signed receipt.",
+        schema_version="1.0",
+        category="debate",
+    ),
+    PlatformCapability(
+        capability_id="aragora.knowledge.query",
+        name="Knowledge Mound Query",
+        description="Semantic search over the Knowledge Mound with provenance-tracked results.",
+        schema_version="1.0",
+        category="knowledge",
+    ),
+    PlatformCapability(
+        capability_id="aragora.market.predict",
+        name="Synthetic Market Prediction",
+        description="Record an agent position in a synthetic GitHub prediction market.",
+        schema_version="1.0",
+        category="market",
+        flag_required="ARAGORA_SYNTHETIC_MARKETS_ENABLED",
+    ),
+    PlatformCapability(
+        capability_id="aragora.receipt.fetch",
+        name="Fetch Decision Receipt",
+        description="Retrieve a signed AgentReceipt for a completed debate or claim.",
+        schema_version="1.0",
+        category="receipt",
+    ),
+]
+
+
+def platform_catalog(*, category: str | None = None, require_enabled: bool = True) -> list[PlatformCapability]:
+    """Return platform capabilities sorted by ``capability_id``.
+
+    ``category`` filters to one group; ``None`` returns all.
+    ``require_enabled=False`` bypasses the gate for schema-only introspection.
+    """
+    if require_enabled:
+        _require_enabled()
+    caps = _PLATFORM_CAPABILITIES if category is None else [c for c in _PLATFORM_CAPABILITIES if c.category == category]
+    return sorted(caps, key=lambda c: c.capability_id)
+
+
+def agent_catalog(agent_id: str, *, server: Any = None, require_enabled: bool = True) -> AgentCapabilitySummary:
+    """Return the capability summary for a registered agent.
+
+    Returns an empty summary when the agent is unknown or ``server`` is ``None``.
+    """
+    if require_enabled:
+        _require_enabled()
+    if server is None:
+        return AgentCapabilitySummary(agent_id=agent_id)
+    card = server.get_agent(agent_id)
+    if card is None:
+        return AgentCapabilitySummary(agent_id=agent_id)
+    raw = getattr(card, "capabilities", None) or []
+    return AgentCapabilitySummary(
+        agent_id=agent_id,
+        declared_capabilities=[str(c) for c in raw] if isinstance(raw, list) else [],
+    )

--- a/tests/protocols/a2a/test_discovery.py
+++ b/tests/protocols/a2a/test_discovery.py
@@ -14,6 +14,7 @@ from aragora.protocols.a2a.discovery import (
     discovery_enabled,
     platform_catalog,
 )
+from aragora.protocols.a2a.types import AgentCapability
 
 
 def _server(agent_id: str | None = None, caps: list[str] | None = None):
@@ -125,6 +126,15 @@ def test_agent_catalog_unknown_and_known(monkeypatch):
     assert agent_catalog("none", server=_server()).declared_capabilities == []
     s = agent_catalog("codex", server=_server("codex", ["debate", "audit"]))
     assert {"debate", "audit"} <= set(s.declared_capabilities)
+
+
+def test_agent_catalog_serializes_agent_capability_values(monkeypatch):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
+    s = agent_catalog(
+        "codex",
+        server=_server("codex", [AgentCapability.DEBATE, AgentCapability.CRITIQUE]),
+    )
+    assert s.declared_capabilities == ["debate", "critique"]
 
 
 def test_agent_summary_defaults_and_to_dict(monkeypatch):

--- a/tests/protocols/a2a/test_discovery.py
+++ b/tests/protocols/a2a/test_discovery.py
@@ -94,7 +94,14 @@ def test_capability_to_dict_and_frozen(monkeypatch):
     monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
     cap = platform_catalog()[0]
     d = cap.to_dict()
-    assert set(d) >= {"capability_id", "name", "description", "schema_version", "category", "flag_required"}
+    assert set(d) >= {
+        "capability_id",
+        "name",
+        "description",
+        "schema_version",
+        "category",
+        "flag_required",
+    }
     with pytest.raises((AttributeError, TypeError)):
         cap.name = "bad"  # type: ignore[misc]
 

--- a/tests/protocols/a2a/test_discovery.py
+++ b/tests/protocols/a2a/test_discovery.py
@@ -1,0 +1,128 @@
+"""Tests for aragora.protocols.a2a.discovery (AGT-02 capability discovery)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aragora.protocols.a2a.discovery import (
+    AgentCapabilitySummary,
+    DiscoveryError,
+    PlatformCapability,
+    agent_catalog,
+    discovery_enabled,
+    platform_catalog,
+)
+
+
+def _server(agent_id: str | None = None, caps: list[str] | None = None):
+    s = MagicMock()
+    if agent_id is None:
+        s.get_agent.return_value = None
+    else:
+        card = MagicMock()
+        card.capabilities = caps or []
+        s.get_agent.return_value = card
+    return s
+
+
+# -- feature gate ------------------------------------------------------------
+
+
+def test_gate_off_by_default(monkeypatch):
+    monkeypatch.delenv("ARAGORA_A2A_DISCOVERY_ENABLED", raising=False)
+    assert discovery_enabled() is False
+
+
+@pytest.mark.parametrize("v", ["1", "true", "yes", "on"])
+def test_gate_truthy(monkeypatch, v):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", v)
+    assert discovery_enabled() is True
+
+
+@pytest.mark.parametrize("v", ["0", "false", ""])
+def test_gate_falsy(monkeypatch, v):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", v)
+    assert discovery_enabled() is False
+
+
+def test_platform_catalog_raises_when_off(monkeypatch):
+    monkeypatch.delenv("ARAGORA_A2A_DISCOVERY_ENABLED", raising=False)
+    with pytest.raises(DiscoveryError):
+        platform_catalog()
+
+
+def test_agent_catalog_raises_when_off(monkeypatch):
+    monkeypatch.delenv("ARAGORA_A2A_DISCOVERY_ENABLED", raising=False)
+    with pytest.raises(DiscoveryError):
+        agent_catalog("x")
+
+
+# -- platform_catalog --------------------------------------------------------
+
+
+def test_catalog_contains_core_ids(monkeypatch):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
+    ids = {c.capability_id for c in platform_catalog()}
+    assert {"aragora.debate.run", "aragora.receipt.fetch", "aragora.agent.register"} <= ids
+
+
+def test_catalog_sorted_by_id(monkeypatch):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
+    ids = [c.capability_id for c in platform_catalog()]
+    assert ids == sorted(ids)
+
+
+def test_catalog_category_filter(monkeypatch):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
+    caps = platform_catalog(category="registry")
+    assert caps and all(c.category == "registry" for c in caps)
+
+
+def test_catalog_unknown_category_empty(monkeypatch):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
+    assert platform_catalog(category="nonexistent") == []
+
+
+def test_catalog_bypasses_gate(monkeypatch):
+    monkeypatch.delenv("ARAGORA_A2A_DISCOVERY_ENABLED", raising=False)
+    assert len(platform_catalog(require_enabled=False)) >= 5
+
+
+def test_capability_to_dict_and_frozen(monkeypatch):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
+    cap = platform_catalog()[0]
+    d = cap.to_dict()
+    assert set(d) >= {"capability_id", "name", "description", "schema_version", "category", "flag_required"}
+    with pytest.raises((AttributeError, TypeError)):
+        cap.name = "bad"  # type: ignore[misc]
+
+
+# -- agent_catalog -----------------------------------------------------------
+
+
+def test_agent_catalog_no_server(monkeypatch):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
+    s = agent_catalog("ghost", server=None)
+    assert s.agent_id == "ghost" and s.declared_capabilities == []
+
+
+def test_agent_catalog_bypasses_gate(monkeypatch):
+    monkeypatch.delenv("ARAGORA_A2A_DISCOVERY_ENABLED", raising=False)
+    assert agent_catalog("x", server=None, require_enabled=False).agent_id == "x"
+
+
+def test_agent_catalog_unknown_and_known(monkeypatch):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
+    assert agent_catalog("none", server=_server()).declared_capabilities == []
+    s = agent_catalog("codex", server=_server("codex", ["debate", "audit"]))
+    assert {"debate", "audit"} <= set(s.declared_capabilities)
+
+
+def test_agent_summary_defaults_and_to_dict(monkeypatch):
+    monkeypatch.setenv("ARAGORA_A2A_DISCOVERY_ENABLED", "1")
+    s = AgentCapabilitySummary(agent_id="z")
+    assert s.declared_capabilities == [] and s.reputation_stub == {}
+    d = agent_catalog("a", server=_server("a", ["x"])).to_dict()
+    assert set(d) == {"agent_id", "declared_capabilities", "reputation_stub"}


### PR DESCRIPTION
## Slice

Adds `aragora/protocols/a2a/discovery.py` — a flag-gated, read-only capability catalog for the A2A consumer surface. `platform_catalog()` returns a sorted list of `PlatformCapability` entries describing what the Aragora platform offers (debate, claim verify, receipt fetch, KM query, synthetic market prediction, agent registration). `agent_catalog()` returns an `AgentCapabilitySummary` built from an A2A server registry lookup, with a `reputation_stub` placeholder that AGT-05 will replace once the settlement flow is wired.

## Gating

- Default: **OFF** (flag: `ARAGORA_A2A_DISCOVERY_ENABLED`)
- Dataclasses (`PlatformCapability`, `AgentCapabilitySummary`) are always importable and safe to construct; only `platform_catalog()` and `agent_catalog()` raise when the flag is unset
- Live queue effect: **none** — purely read-only, no HTTP routes, no queue mutations
- Advances issue: #6063 (AGT-02, sub-deliverable 3: A2A capability discovery)

## Tests

- `test_gate_off_by_default` / `test_gate_truthy` / `test_gate_falsy` — feature gate semantics (7 parametrized cases)
- `test_platform_catalog_raises_when_off` / `test_agent_catalog_raises_when_off` — gate enforcement on each function
- `test_catalog_contains_core_ids` — debate, receipt, registry IDs present
- `test_catalog_sorted_by_id` — deterministic iteration order
- `test_catalog_category_filter` — category filter returns only matching entries
- `test_catalog_unknown_category_empty` — unknown category returns `[]`
- `test_catalog_bypasses_gate` — `require_enabled=False` works without env-var
- `test_capability_to_dict_and_frozen` — `to_dict()` shape and `frozen=True` enforcement
- `test_agent_catalog_no_server` — `server=None` returns empty summary safely
- `test_agent_catalog_bypasses_gate` — `require_enabled=False` path
- `test_agent_catalog_unknown_and_known` — unknown agent → empty list; known agent → declared caps preserved
- `test_agent_summary_defaults_and_to_dict` — default fields + `to_dict()` key set

## Validation

- `pytest tests/protocols/a2a/test_discovery.py --noconftest -v` — **20 passed**
- `ruff check aragora/protocols/a2a/discovery.py tests/protocols/a2a/test_discovery.py` — **clean**
- `mypy aragora/protocols/a2a/discovery.py --ignore-missing-imports` — **clean**
- Net diff: **298 LOC** (170 impl + 128 tests)

## Out of scope

- HTTP route registration for `GET /api/v1/a2a/capabilities` and `GET /api/v1/a2a/agents/<id>/capabilities` — deferred to the route layer (must stay inside `aragora/server/`), gated behind the same "no live behavior change" rule
- Per-agent reputation slices — AGT-05 wires live ERC-8004 scores via `reputation_stub`; the field is a placeholder here
- Pagination — deferred until the HTTP route layer exists
- SemVer enforcement on `schema_version` — the string is present; validation is a follow-on

Note: the proof-first Foreman gate in `docs/status/NEXT_STEPS_CANONICAL.md` is **not yet open** for the AGT-* tranche. This PR carries no `boss-ready` label and must remain DRAFT until the gate opens or is explicitly waived for this slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_012tN6nJw8Tq7xuBCKgGWQsN)_