### PR TITLE
fix(dialog): widen timeouts and guard droid reviews

### DIFF
--- a/aragora/swarm/multi_agent_dialog.py
+++ b/aragora/swarm/multi_agent_dialog.py
@@ -156,6 +156,28 @@ def _atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> 
 # dispatch. Encoded as data so any future round can reuse the harness
 # without re-deriving the flags.
 
+DEFAULT_CLAUDE_TIMEOUT: int = 180
+"""Default Claude CLI budget.
+
+Live 30f dogfood showed Claude Sonnet needs roughly two minutes for
+repo-grounded review prompts, so the old 60s budget was too short for
+quality work.
+"""
+
+DEFAULT_CODEX_TIMEOUT: int = 420
+"""Default Codex CLI budget.
+
+Live 30f dogfood completed a high-quality Codex review in ~273s; this
+keeps enough margin for normal GitHub/repo inspection variance without
+making hung subprocesses unbounded.
+"""
+
+DEFAULT_DROID_TIMEOUT: int = 300
+"""Default Droid CLI budget for read/search-only review prompts."""
+
+DEFAULT_MODEL_TIMEOUT: int = 360
+"""Default heterogeneous-model budget for non-Codex model lanes."""
+
 CLAUDE_FLAGS: tuple[str, ...] = ("--print",)
 """``claude --print`` works without ``--bare``. ``--bare`` requires
 explicit ``ANTHROPIC_API_KEY`` env var; the keychain OAuth flow used
@@ -174,9 +196,27 @@ extensive memory/file investigation chains that exceed 90s timeouts.
 ``minimal`` reasoning + ``read-only`` sandbox keeps the model focused
 on the prompt and skips the investigation phase."""
 
-DROID_FLAGS: tuple[str, ...] = ("exec", "--auto", "low")
-"""``droid exec --auto low`` is the read-only autonomy level: the
-agent answers the prompt without taking any system-mutating actions."""
+DROID_REVIEW_SYSTEM_PROMPT: str = (
+    "Do not run shell commands or modify files. Use read/search tools only "
+    "and return a concise text answer."
+)
+"""Additional Droid guardrail for local-only dialog review turns."""
+
+DROID_FLAGS: tuple[str, ...] = (
+    "exec",
+    "--disabled-tools",
+    "Execute",
+    "--append-system-prompt",
+    DROID_REVIEW_SYSTEM_PROMPT,
+)
+"""``droid exec`` defaults to read-only mode; disabling ``Execute``
+keeps dialog turns on file/read/search tools only.
+
+Round 30f dogfood showed that repo-review prompts under the previous
+``--auto low`` setting could fail with a permission/autonomy error
+instead of timing out. The read/search-only guardrail produced usable
+output in ~183s while preserving the local-only contract.
+"""
 
 
 # --------------------------------------------------------------------- #
@@ -204,7 +244,7 @@ class AgentSpec:
     """Either ``argv`` (prompt as final arg) or ``stdin`` (piped to stdin)."""
 
     @classmethod
-    def claude(cls, timeout_seconds: int = 60) -> "AgentSpec":
+    def claude(cls, timeout_seconds: int = DEFAULT_CLAUDE_TIMEOUT) -> "AgentSpec":
         return cls(
             name="claude",
             binary="claude",
@@ -214,7 +254,7 @@ class AgentSpec:
         )
 
     @classmethod
-    def codex(cls, timeout_seconds: int = 90) -> "AgentSpec":
+    def codex(cls, timeout_seconds: int = DEFAULT_CODEX_TIMEOUT) -> "AgentSpec":
         return cls(
             name="codex",
             binary="codex",
@@ -224,7 +264,7 @@ class AgentSpec:
         )
 
     @classmethod
-    def droid(cls, timeout_seconds: int = 60) -> "AgentSpec":
+    def droid(cls, timeout_seconds: int = DEFAULT_DROID_TIMEOUT) -> "AgentSpec":
         return cls(
             name="droid",
             binary="droid",
@@ -254,7 +294,7 @@ class AgentSpec:
         model: str,
         *,
         name: str | None = None,
-        timeout_seconds: int = 90,
+        timeout_seconds: int = DEFAULT_MODEL_TIMEOUT,
     ) -> "AgentSpec":
         """Build an AgentSpec pinned to a specific model on a specific CLI.
 
@@ -297,26 +337,26 @@ class AgentSpec:
     # Concrete heterogeneous factories — known-good model IDs verified
     # in round 30e Phase A.
     @classmethod
-    def claude_opus(cls, timeout_seconds: int = 90) -> "AgentSpec":
+    def claude_opus(cls, timeout_seconds: int = DEFAULT_MODEL_TIMEOUT) -> "AgentSpec":
         """Claude Opus via the ``claude`` CLI."""
         return cls.with_model("claude", "opus", name="claude-opus", timeout_seconds=timeout_seconds)
 
     @classmethod
-    def claude_sonnet(cls, timeout_seconds: int = 60) -> "AgentSpec":
+    def claude_sonnet(cls, timeout_seconds: int = DEFAULT_MODEL_TIMEOUT) -> "AgentSpec":
         """Claude Sonnet via the ``claude`` CLI."""
         return cls.with_model(
             "claude", "sonnet", name="claude-sonnet", timeout_seconds=timeout_seconds
         )
 
     @classmethod
-    def droid_gpt5(cls, timeout_seconds: int = 90) -> "AgentSpec":
+    def droid_gpt5(cls, timeout_seconds: int = DEFAULT_MODEL_TIMEOUT) -> "AgentSpec":
         """GPT-5.4 via the ``droid`` CLI."""
         return cls.with_model(
             "droid", "gpt-5.4", name="droid-gpt5", timeout_seconds=timeout_seconds
         )
 
     @classmethod
-    def droid_gemini(cls, timeout_seconds: int = 90) -> "AgentSpec":
+    def droid_gemini(cls, timeout_seconds: int = DEFAULT_MODEL_TIMEOUT) -> "AgentSpec":
         """Gemini 3.1 Pro via the ``droid`` CLI."""
         return cls.with_model(
             "droid",
@@ -326,20 +366,23 @@ class AgentSpec:
         )
 
     @classmethod
-    def droid_kimi(cls, timeout_seconds: int = 90) -> "AgentSpec":
+    def droid_kimi(cls, timeout_seconds: int = DEFAULT_MODEL_TIMEOUT) -> "AgentSpec":
         """Kimi K2.5 (Chinese frontier) via the ``droid`` CLI."""
         return cls.with_model(
             "droid", "kimi-k2.5", name="droid-kimi", timeout_seconds=timeout_seconds
         )
 
     @classmethod
-    def droid_glm(cls, timeout_seconds: int = 90) -> "AgentSpec":
+    def droid_glm(cls, timeout_seconds: int = DEFAULT_MODEL_TIMEOUT) -> "AgentSpec":
         """GLM 5.1 (Chinese frontier) via the ``droid`` CLI."""
         return cls.with_model("droid", "glm-5.1", name="droid-glm", timeout_seconds=timeout_seconds)
 
     @classmethod
     def heterogeneous_panel(
-        cls, *, codex_timeout: int = 120, model_timeout: int = 90
+        cls,
+        *,
+        codex_timeout: int = DEFAULT_CODEX_TIMEOUT,
+        model_timeout: int = DEFAULT_MODEL_TIMEOUT,
     ) -> "tuple[AgentSpec, ...]":
         """Return the canonical heterogeneous review panel.
 

--- a/scripts/multi_agent_dialog.py
+++ b/scripts/multi_agent_dialog.py
@@ -45,6 +45,10 @@ sys.path.insert(0, str(ROOT))
 
 from aragora.swarm.multi_agent_dialog import (  # noqa: E402
     AgentSpec,
+    DEFAULT_CLAUDE_TIMEOUT,
+    DEFAULT_CODEX_TIMEOUT,
+    DEFAULT_DROID_TIMEOUT,
+    DEFAULT_MODEL_TIMEOUT,
     DialogRound,
     run_round_and_persist,
 )
@@ -123,13 +127,28 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             + ", ".join(f"{k}=({','.join(v)})" for k, v in AGENT_GROUPS.items())
         ),
     )
-    parser.add_argument("--claude-timeout", type=int, default=60, help="Per-agent timeout (s)")
-    parser.add_argument("--codex-timeout", type=int, default=90, help="Per-agent timeout (s)")
-    parser.add_argument("--droid-timeout", type=int, default=60, help="Per-agent timeout (s)")
+    parser.add_argument(
+        "--claude-timeout",
+        type=int,
+        default=DEFAULT_CLAUDE_TIMEOUT,
+        help="Per-agent timeout (s)",
+    )
+    parser.add_argument(
+        "--codex-timeout",
+        type=int,
+        default=DEFAULT_CODEX_TIMEOUT,
+        help="Per-agent timeout (s)",
+    )
+    parser.add_argument(
+        "--droid-timeout",
+        type=int,
+        default=DEFAULT_DROID_TIMEOUT,
+        help="Per-agent timeout (s)",
+    )
     parser.add_argument(
         "--model-timeout",
         type=int,
-        default=90,
+        default=DEFAULT_MODEL_TIMEOUT,
         help="Per-agent timeout (s) for heterogeneous-model factories.",
     )
     return parser.parse_args(argv)

--- a/tests/swarm/test_multi_agent_dialog.py
+++ b/tests/swarm/test_multi_agent_dialog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import json
 from pathlib import Path
 
@@ -12,6 +13,11 @@ from aragora.swarm.multi_agent_dialog import (
     CLAUDE_FLAGS,
     CODEX_FLAGS,
     DROID_FLAGS,
+    DROID_REVIEW_SYSTEM_PROMPT,
+    DEFAULT_CLAUDE_TIMEOUT,
+    DEFAULT_CODEX_TIMEOUT,
+    DEFAULT_DROID_TIMEOUT,
+    DEFAULT_MODEL_TIMEOUT,
     MAX_OUTPUT_BYTES,
     RC_BINARY_NOT_FOUND,
     RC_DISPATCH_ERROR,
@@ -38,21 +44,24 @@ def test_agent_spec_claude_flags() -> None:
     assert spec.binary == "claude"
     assert spec.base_flags == CLAUDE_FLAGS
     assert spec.stdin_mode == "stdin"
-    assert spec.timeout_seconds == 60
+    assert spec.timeout_seconds == DEFAULT_CLAUDE_TIMEOUT
 
 
 def test_agent_spec_codex_flags_include_minimal_reasoning() -> None:
     spec = AgentSpec.codex()
     assert "reasoning_effort=minimal" in spec.base_flags
     assert "sandbox_mode=read-only" in spec.base_flags
-    assert spec.timeout_seconds == 90
+    assert spec.timeout_seconds == DEFAULT_CODEX_TIMEOUT
 
 
-def test_agent_spec_droid_flags_include_auto_low() -> None:
+def test_agent_spec_droid_flags_are_read_search_only() -> None:
     spec = AgentSpec.droid()
     assert "exec" in spec.base_flags
-    assert "low" in spec.base_flags
-    assert "--auto" in spec.base_flags
+    assert "--auto" not in spec.base_flags
+    assert "--disabled-tools" in spec.base_flags
+    assert "Execute" in spec.base_flags
+    assert DROID_REVIEW_SYSTEM_PROMPT in spec.base_flags
+    assert spec.timeout_seconds == DEFAULT_DROID_TIMEOUT
 
 
 def test_agent_spec_custom_timeout() -> None:
@@ -306,7 +315,13 @@ def test_constants_match_round_30d_verification() -> None:
     assert "reasoning_effort=minimal" in CODEX_FLAGS
     assert "sandbox_mode=read-only" in CODEX_FLAGS
     assert "--skip-git-repo-check" in CODEX_FLAGS
-    assert DROID_FLAGS == ("exec", "--auto", "low")
+    assert DROID_FLAGS == (
+        "exec",
+        "--disabled-tools",
+        "Execute",
+        "--append-system-prompt",
+        DROID_REVIEW_SYSTEM_PROMPT,
+    )
 
 
 # --------------------------------------------------------------------- #
@@ -424,6 +439,38 @@ class TestHeterogeneousPanel:
         for spec in panel:
             if spec.binary != "codex":
                 assert spec.timeout_seconds == 90
+
+    def test_panel_defaults_use_quality_budgets(self) -> None:
+        panel = AgentSpec.heterogeneous_panel()
+        codex_spec = next(s for s in panel if s.binary == "codex")
+        assert codex_spec.timeout_seconds == DEFAULT_CODEX_TIMEOUT
+        for spec in panel:
+            if spec.binary != "codex":
+                assert spec.timeout_seconds == DEFAULT_MODEL_TIMEOUT
+
+
+def test_cli_parse_args_uses_quality_timeout_defaults() -> None:
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "multi_agent_dialog.py"
+    spec = importlib.util.spec_from_file_location("multi_agent_dialog_script", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    args = module.parse_args(
+        [
+            "--round-id",
+            "r",
+            "--prompt",
+            "p",
+            "--output-dir",
+            "/tmp/dialog",
+        ]
+    )
+    assert args.claude_timeout == DEFAULT_CLAUDE_TIMEOUT
+    assert args.codex_timeout == DEFAULT_CODEX_TIMEOUT
+    assert args.droid_timeout == DEFAULT_DROID_TIMEOUT
+    assert args.model_timeout == DEFAULT_MODEL_TIMEOUT
 
 
 # --------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Fixes the cross-agent dialog harness reliability issue found during 30f dogfood.

The dogfood showed two distinct failure modes:

- The process was sound, but the old 60/90/180s budgets were too short for high-quality repo-grounded review. A Codex lane completed successfully only after 272.7s under a 480s probe.
- The Droid failure was not a timeout. Droid GPT-5.4 failed quickly with an autonomy permission error under the existing `droid exec --auto low` harness flags. A read/search-only configuration with `Execute` disabled completed successfully and returned a useful review.

## Changes

- Raises default dialog timeouts to quality-oriented budgets:
  - Claude: 180s
  - Codex: 420s
  - Droid: 300s
  - Heterogeneous model lanes: 360s
- Replaces Droid `--auto low` with default read-only `droid exec` plus `--disabled-tools Execute` and a no-shell/no-mutation appended system prompt.
- Keeps the dialog contract local-only: no GitHub mutation, no repo-tracked writes from agents, file/read/search-oriented Droid reviews only.
- Adds regression coverage for the new timeout defaults and Droid guardrails, including the operator CLI parser defaults.

## Validation

- `python3 -m pytest tests/swarm/test_multi_agent_dialog.py tests/swarm/agent_bridge/test_harnesses_codex.py tests/swarm/agent_bridge/test_harnesses_droid.py -p no:randomly -q` -> 75 passed
- `python3 -m ruff check scripts/multi_agent_dialog.py aragora/swarm/multi_agent_dialog.py tests/swarm/test_multi_agent_dialog.py` -> pass
- `python3 -m ruff format --check scripts/multi_agent_dialog.py aragora/swarm/multi_agent_dialog.py tests/swarm/test_multi_agent_dialog.py` -> pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok
- Live harness dogfood:
  - `python3 scripts/multi_agent_dialog.py --round-id timeout-postfix-droid-gpt5-readonly --prompt-file /Users/armand/Development/aragora/.aragora/evolve-round/2026-04-30f/prompts/h1-b0-truth-surface.md --output-dir /Users/armand/Development/aragora/.aragora/evolve-round/2026-04-30f/dialog --agents droid-gpt5`
  - Result: 1 agent dispatched, 1 successful, elapsed 167.354s, rc=0, non-empty stdout, empty stderr.

## Tier

Tier 2: touches live automation / CLI orchestration surface.

Standing rule: I do not author-merge.
