### PR TITLE
feat(review): emit invalidation threshold receipts

### DIFF
--- a/aragora/review/__init__.py
+++ b/aragora/review/__init__.py
@@ -82,6 +82,7 @@ from aragora.review.invalidation import (
     is_invalidated,
 )
 from aragora.review.invalidation_event_source import (
+    ReviewQueueInvalidationEventSource,
     count_decisions_from_settlement_receipts,
     iter_invalidations_from_calibration_store,
     iter_invalidations_from_settlement_receipts,
@@ -90,12 +91,19 @@ from aragora.review.invalidation_event_source import (
 )
 from aragora.review.threshold_recalibration import (
     DEFAULT_THRESHOLD_RECEIPT_DIR,
+    DEFAULT_SUPPORT_TARGETS,
+    INSUFFICIENCY_RECEIPT_SCHEMA_VERSION,
     THRESHOLD_UPDATE_RECEIPT_SCHEMA_VERSION,
+    InsufficiencyReceipt,
     InvalidationEventSource,
     InvalidationRecalibrationSample,
+    RecalibrationReceipt,
     ThresholdRecalibrationScheduler,
     ThresholdUpdateReceipt,
+    compute_insufficiency_receipt_id,
     compute_threshold_update_receipt_id,
+    write_insufficiency_receipt,
+    write_recalibration_receipt,
     write_threshold_update_receipt,
 )
 
@@ -111,6 +119,7 @@ __all__ = [
     "DEFAULT_MINIMUM_MEANINGFUL_RATE",
     "DEFAULT_REVERT_WINDOW_DAYS",
     "DEFAULT_SAFETY_MARGIN",
+    "DEFAULT_SUPPORT_TARGETS",
     "DEFAULT_THRESHOLD_RECEIPT_DIR",
     "DepthTrigger",
     "DissentingView",
@@ -125,6 +134,8 @@ __all__ = [
     "INVALIDATION_REVERT_WITHIN_WINDOW",
     "INVALIDATION_ROLLBACK",
     "INVALIDATION_SIGNALS",
+    "INSUFFICIENCY_RECEIPT_SCHEMA_VERSION",
+    "InsufficiencyReceipt",
     "InvalidationEventSource",
     "InvalidationRecalibrationSample",
     "InvalidatedDecision",
@@ -137,6 +148,7 @@ __all__ = [
     "PanelVote",
     "REVIEWER_OUTPUT_SCHEMA_VERSION",
     "Recommendation",
+    "RecalibrationReceipt",
     "ReviewBrief",
     "ReviewBudget",
     "ReviewDepth",
@@ -144,6 +156,7 @@ __all__ = [
     "ReviewerOutput",
     "ReviewPolicy",
     "ReviewPolicyDecision",
+    "ReviewQueueInvalidationEventSource",
     "ReviewRole",
     "RiskClass",
     "RoleFinding",
@@ -160,6 +173,7 @@ __all__ = [
     "build_brief",
     "classify_invalidation",
     "compute_baseline",
+    "compute_insufficiency_receipt_id",
     "compute_packet_sha",
     "compute_threshold_update_receipt_id",
     "count_decisions_from_settlement_receipts",
@@ -170,5 +184,7 @@ __all__ = [
     "measure_baseline_from_stores",
     "resolve_review_queue_root",
     "validate_reviewer_outputs",
+    "write_insufficiency_receipt",
+    "write_recalibration_receipt",
     "write_threshold_update_receipt",
 ]

--- a/aragora/review/invalidation_event_source.py
+++ b/aragora/review/invalidation_event_source.py
@@ -70,6 +70,7 @@ from aragora.review.invalidation import (
     InvalidatedDecision,
     compute_baseline,
 )
+from aragora.review.threshold_recalibration import InvalidationRecalibrationSample
 from aragora.triage.auto_handle_calibration import (
     AutoHandleCalibrationStore,
     OUTCOME_HUMAN_OVERRIDE,
@@ -81,6 +82,7 @@ from aragora.triage.auto_handle_calibration import (
 __all__ = [
     "DEFAULT_REVIEW_QUEUE_SUBDIR",
     "RECEIPTS_SUBDIR",
+    "ReviewQueueInvalidationEventSource",
     "iter_invalidations_from_calibration_store",
     "iter_invalidations_from_settlement_receipts",
     "count_decisions_from_settlement_receipts",
@@ -104,6 +106,91 @@ _OUTCOME_TO_SIGNAL: dict[str, str] = {
 }
 
 _FAILURE_OUTCOMES = frozenset(_OUTCOME_TO_SIGNAL.keys())
+
+
+class ReviewQueueInvalidationEventSource:
+    """Protocol adapter for the threshold recalibration scheduler.
+
+    This class keeps the event-source policy in one place: auto-handle
+    calibration rows provide auto-handled numerator + denominator data, while
+    settlement receipts provide the human-settled denominator and only provide
+    human numerator events when explicit future-schema invalidation fields are
+    present.
+    """
+
+    source_name = "aragora.review.invalidation_event_source"
+    source_version = "round30f.v1"
+
+    def __init__(
+        self,
+        *,
+        calibration_store: AutoHandleCalibrationStore,
+        review_queue_root: str | Path | None = None,
+        revert_window_days: int = DEFAULT_REVERT_WINDOW_DAYS,
+    ) -> None:
+        self.calibration_store = calibration_store
+        self.review_queue_root = review_queue_root
+        self.revert_window_days = int(revert_window_days)
+
+    def collect_recalibration_sample(
+        self,
+        *,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> InvalidationRecalibrationSample:
+        """Return denominator + invalidation data for one measurement window."""
+        window_start = _ensure_utc(window_start)
+        window_end = _ensure_utc(window_end)
+        if window_end <= window_start:
+            raise ValueError("window_end must be after window_start")
+        window_days = max(1, int((window_end - window_start).total_seconds() // 86400))
+
+        auto_invalidations = list(
+            iter_invalidations_from_calibration_store(
+                self.calibration_store,
+                window_end=window_end,
+                window_days=window_days,
+            )
+        )
+        auto_total = _count_calibration_decisions_in_window(
+            self.calibration_store,
+            window_end=window_end,
+            window_days=window_days,
+        )
+        human_invalidations = [
+            d
+            for d in iter_invalidations_from_settlement_receipts(
+                store_root=self.review_queue_root,
+                revert_window_days=self.revert_window_days,
+            )
+            if window_start <= d.settled_at <= window_end
+        ]
+        human_total = count_decisions_from_settlement_receipts(
+            store_root=self.review_queue_root,
+            window_end=window_end,
+            window_days=window_days,
+        )
+
+        notes: dict[str, str] = {
+            "human_denominator_source": "review-queue settlement receipts",
+            "auto_handle_source": "auto-handle calibration store",
+        }
+        if not human_invalidations:
+            notes["human_invalidations_source"] = (
+                "settlement-receipt schema does not yet record post-settlement "
+                "invalidation signals by default; human-side numerator is 0 by "
+                "data availability unless future-schema fields are present."
+            )
+
+        return InvalidationRecalibrationSample(
+            invalidations=tuple(auto_invalidations + human_invalidations),
+            total_human_settled=human_total,
+            total_auto_handled=auto_total,
+            source_name=self.source_name,
+            source_version=self.source_version,
+            collected_at=window_end,
+            notes=notes,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/aragora/review/threshold_recalibration.py
+++ b/aragora/review/threshold_recalibration.py
@@ -39,16 +39,25 @@ from aragora.review.invalidation import (
 UTC = timezone.utc
 
 THRESHOLD_UPDATE_RECEIPT_SCHEMA_VERSION = "threshold_update_receipt.v1"
+INSUFFICIENCY_RECEIPT_SCHEMA_VERSION = "insufficiency_receipt.v1"
 DEFAULT_THRESHOLD_RECEIPT_DIR = Path(".aragora") / "review-queue" / "thresholds"
+DEFAULT_SUPPORT_TARGETS: tuple[int, ...] = (5126, 5128, 5130)
 
 __all__ = [
     "DEFAULT_THRESHOLD_RECEIPT_DIR",
+    "DEFAULT_SUPPORT_TARGETS",
+    "INSUFFICIENCY_RECEIPT_SCHEMA_VERSION",
     "THRESHOLD_UPDATE_RECEIPT_SCHEMA_VERSION",
+    "InsufficiencyReceipt",
     "InvalidationEventSource",
     "InvalidationRecalibrationSample",
+    "RecalibrationReceipt",
     "ThresholdRecalibrationScheduler",
     "ThresholdUpdateReceipt",
+    "compute_insufficiency_receipt_id",
     "compute_threshold_update_receipt_id",
+    "write_recalibration_receipt",
+    "write_insufficiency_receipt",
     "write_threshold_update_receipt",
 ]
 
@@ -213,6 +222,89 @@ class ThresholdUpdateReceipt:
         return payload
 
 
+@dataclass(frozen=True, slots=True)
+class InsufficiencyReceipt:
+    """Receipt emitted when current data must not update the threshold."""
+
+    receipt_id: str
+    generated_at: datetime
+    source_name: str
+    source_version: str
+    measurement: BaselineMeasurement
+    proposal: ThresholdProposal
+    previous_threshold: float | None = None
+    previous_baseline_human_rate: float | None = None
+    insufficiency_reasons: tuple[str, ...] = ()
+    support_targets: tuple[int, ...] = DEFAULT_SUPPORT_TARGETS
+    additional_dispatches_needed: int = 0
+    notes: Mapping[str, str] = field(default_factory=dict)
+    schema_version: str = INSUFFICIENCY_RECEIPT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "generated_at", _ensure_utc(self.generated_at))
+        object.__setattr__(self, "insufficiency_reasons", tuple(self.insufficiency_reasons))
+        object.__setattr__(self, "support_targets", tuple(int(x) for x in self.support_targets))
+        object.__setattr__(
+            self, "additional_dispatches_needed", int(self.additional_dispatches_needed)
+        )
+        object.__setattr__(self, "notes", MappingProxyType(dict(self.notes)))
+        if self.schema_version != INSUFFICIENCY_RECEIPT_SCHEMA_VERSION:
+            raise ValueError(
+                "schema_version must be "
+                f"{INSUFFICIENCY_RECEIPT_SCHEMA_VERSION!r}; got {self.schema_version!r}"
+            )
+        if self.additional_dispatches_needed < 0:
+            raise ValueError("additional_dispatches_needed must be non-negative")
+        if not self.insufficiency_reasons:
+            raise ValueError("insufficiency_reasons must not be empty")
+        if (
+            not self.proposal.is_placeholder
+            and "schema_gap_human_numerator" not in self.insufficiency_reasons
+        ):
+            raise ValueError(
+                "InsufficiencyReceipt requires a placeholder proposal unless the "
+                "human invalidation numerator schema gap is the blocking reason"
+            )
+
+    @property
+    def sample_count(self) -> int:
+        return int(self.measurement.total_human_settled)
+
+    def to_dict(self, *, include_receipt_id: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "generated_at": self.generated_at.astimezone(UTC).isoformat(),
+            "source": {
+                "name": self.source_name,
+                "version": self.source_version,
+            },
+            "sample_count": int(self.sample_count),
+            "window": {
+                "start": self.measurement.window_start.astimezone(UTC).isoformat(),
+                "end": self.measurement.window_end.astimezone(UTC).isoformat(),
+                "days": self.measurement.window_days,
+            },
+            "measurement": self.measurement.to_dict(),
+            "proposal": self.proposal.to_dict(),
+            "previous": {
+                "threshold": _float_or_none(self.previous_threshold),
+                "baseline_human_rate": _float_or_none(self.previous_baseline_human_rate),
+            },
+            "insufficiency": {
+                "reasons": list(self.insufficiency_reasons),
+                "support_targets": list(self.support_targets),
+                "additional_dispatches_needed": int(self.additional_dispatches_needed),
+            },
+            "notes": dict(self.notes),
+        }
+        if include_receipt_id:
+            payload["receipt_id"] = self.receipt_id
+        return payload
+
+
+RecalibrationReceipt = ThresholdUpdateReceipt | InsufficiencyReceipt
+
+
 class ThresholdRecalibrationScheduler:
     """Runs one threshold recalibration cycle over a sampled window."""
 
@@ -263,6 +355,32 @@ class ThresholdRecalibrationScheduler:
             now=now,
         )
 
+    def run_receipt_from_source(
+        self,
+        source: InvalidationEventSource,
+        *,
+        previous_receipt: ThresholdUpdateReceipt | None = None,
+        previous_threshold: float | None = None,
+        previous_baseline_human_rate: float | None = None,
+        now: datetime | None = None,
+        support_targets: tuple[int, ...] = DEFAULT_SUPPORT_TARGETS,
+    ) -> RecalibrationReceipt:
+        """Collect a sample and emit either threshold or insufficiency receipt."""
+        now = _ensure_utc(now) if now is not None else datetime.now(UTC)
+        window_start = now - timedelta(days=self.window_days)
+        sample = source.collect_recalibration_sample(
+            window_start=window_start,
+            window_end=now,
+        )
+        return self.run_receipt_from_sample(
+            sample,
+            previous_receipt=previous_receipt,
+            previous_threshold=previous_threshold,
+            previous_baseline_human_rate=previous_baseline_human_rate,
+            now=now,
+            support_targets=support_targets,
+        )
+
     def run_from_sample(
         self,
         sample: InvalidationRecalibrationSample,
@@ -307,6 +425,50 @@ class ThresholdRecalibrationScheduler:
             notes=sample.notes,
         )
 
+    def run_receipt_from_sample(
+        self,
+        sample: InvalidationRecalibrationSample,
+        *,
+        previous_receipt: ThresholdUpdateReceipt | None = None,
+        previous_threshold: float | None = None,
+        previous_baseline_human_rate: float | None = None,
+        now: datetime | None = None,
+        support_targets: tuple[int, ...] = DEFAULT_SUPPORT_TARGETS,
+    ) -> RecalibrationReceipt:
+        """Emit a threshold receipt only when data is sufficient and usable.
+
+        ``run_from_sample()`` remains backward-compatible and always returns the
+        historic ``ThresholdUpdateReceipt`` shape. This method is the Round 30f
+        settlement surface: placeholder proposals, below-floor samples, and
+        known human-numerator schema gaps produce an ``InsufficiencyReceipt``.
+        """
+        threshold_receipt = self.run_from_sample(
+            sample,
+            previous_receipt=previous_receipt,
+            previous_threshold=previous_threshold,
+            previous_baseline_human_rate=previous_baseline_human_rate,
+            now=now,
+        )
+        reasons = _insufficiency_reasons(
+            threshold_receipt.measurement,
+            threshold_receipt.proposal,
+            notes=threshold_receipt.notes,
+        )
+        if not reasons:
+            return threshold_receipt
+        return _build_insufficiency_receipt(
+            generated_at=threshold_receipt.generated_at,
+            source_name=threshold_receipt.source_name,
+            source_version=threshold_receipt.source_version,
+            measurement=threshold_receipt.measurement,
+            proposal=threshold_receipt.proposal,
+            previous_threshold=threshold_receipt.previous_threshold,
+            previous_baseline_human_rate=threshold_receipt.previous_baseline_human_rate,
+            insufficiency_reasons=tuple(reasons),
+            support_targets=support_targets,
+            notes=threshold_receipt.notes,
+        )
+
 
 def compute_threshold_update_receipt_id(payload: Mapping[str, Any]) -> str:
     """Return the stable SHA-256 receipt ID for a receipt payload."""
@@ -319,6 +481,11 @@ def compute_threshold_update_receipt_id(payload: Mapping[str, Any]) -> str:
         ensure_ascii=False,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def compute_insufficiency_receipt_id(payload: Mapping[str, Any]) -> str:
+    """Return the stable SHA-256 receipt ID for an insufficiency receipt."""
+    return compute_threshold_update_receipt_id(payload)
 
 
 def write_threshold_update_receipt(
@@ -336,6 +503,35 @@ def write_threshold_update_receipt(
         encoding="utf-8",
     )
     return path
+
+
+def write_insufficiency_receipt(
+    receipt: InsufficiencyReceipt,
+    *,
+    repo_root: Path,
+    receipt_dir: Path = DEFAULT_THRESHOLD_RECEIPT_DIR,
+) -> Path:
+    """Write ``receipt`` to ``repo_root / receipt_dir`` and return the path."""
+    directory = repo_root / receipt_dir
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{receipt.receipt_id}.json"
+    path.write_text(
+        json.dumps(receipt.to_dict(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return path
+
+
+def write_recalibration_receipt(
+    receipt: RecalibrationReceipt,
+    *,
+    repo_root: Path,
+    receipt_dir: Path = DEFAULT_THRESHOLD_RECEIPT_DIR,
+) -> Path:
+    """Write either threshold-update or insufficiency receipt."""
+    if isinstance(receipt, InsufficiencyReceipt):
+        return write_insufficiency_receipt(receipt, repo_root=repo_root, receipt_dir=receipt_dir)
+    return write_threshold_update_receipt(receipt, repo_root=repo_root, receipt_dir=receipt_dir)
 
 
 def _build_receipt(
@@ -372,6 +568,81 @@ def _build_receipt(
         previous_baseline_human_rate=previous_baseline_human_rate,
         notes=notes,
     )
+
+
+def _build_insufficiency_receipt(
+    *,
+    generated_at: datetime,
+    source_name: str,
+    source_version: str,
+    measurement: BaselineMeasurement,
+    proposal: ThresholdProposal,
+    previous_threshold: float | None,
+    previous_baseline_human_rate: float | None,
+    insufficiency_reasons: tuple[str, ...],
+    support_targets: tuple[int, ...],
+    notes: Mapping[str, str],
+) -> InsufficiencyReceipt:
+    additional_dispatches_needed = max(
+        0,
+        int(measurement.min_samples_required) - int(measurement.total_human_settled),
+    )
+    enriched_notes = dict(notes)
+    enriched_notes.setdefault(
+        "threshold_action",
+        "docs/THESIS.md threshold replacement remains blocked until a non-insufficient "
+        "threshold_update_receipt.v1 exists and a human author accepts it.",
+    )
+    placeholder = InsufficiencyReceipt(
+        receipt_id="",
+        generated_at=generated_at,
+        source_name=source_name,
+        source_version=source_version,
+        measurement=measurement,
+        proposal=proposal,
+        previous_threshold=previous_threshold,
+        previous_baseline_human_rate=previous_baseline_human_rate,
+        insufficiency_reasons=insufficiency_reasons,
+        support_targets=support_targets,
+        additional_dispatches_needed=additional_dispatches_needed,
+        notes=enriched_notes,
+    )
+    receipt_id = compute_insufficiency_receipt_id(placeholder.to_dict(include_receipt_id=False))
+    return InsufficiencyReceipt(
+        receipt_id=receipt_id,
+        generated_at=generated_at,
+        source_name=source_name,
+        source_version=source_version,
+        measurement=measurement,
+        proposal=proposal,
+        previous_threshold=previous_threshold,
+        previous_baseline_human_rate=previous_baseline_human_rate,
+        insufficiency_reasons=insufficiency_reasons,
+        support_targets=support_targets,
+        additional_dispatches_needed=additional_dispatches_needed,
+        notes=enriched_notes,
+    )
+
+
+def _insufficiency_reasons(
+    measurement: BaselineMeasurement,
+    proposal: ThresholdProposal,
+    *,
+    notes: Mapping[str, str] | None = None,
+) -> list[str]:
+    reasons: list[str] = []
+    notes = notes or {}
+    if measurement.total_human_settled == 0:
+        reasons.append("no_human_settled_in_window")
+    if measurement.total_human_settled + measurement.total_auto_handled == 0:
+        reasons.append("no_decisions_in_window")
+    if measurement.total_human_settled < measurement.min_samples_required:
+        reasons.append("below_min_human_settled")
+    if "human_invalidations_source" in measurement.notes or "human_invalidations_source" in notes:
+        reasons.append("schema_gap_human_numerator")
+    if proposal.is_placeholder and "placeholder_threshold" not in reasons:
+        reasons.append("placeholder_threshold")
+    return reasons
 
 
 def _resolve_previous(

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4089` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1925455` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4096` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1928113` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `135` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5126` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `216989` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `661` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5136` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217250` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `662` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `61` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3398` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `811` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `816` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/scripts/measure_invalidation_baseline.py
+++ b/scripts/measure_invalidation_baseline.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Measure #6375 invalidation baseline and optionally persist a receipt.
+
+The default mode is read-only and prints the receipt payload that would be
+written. Passing ``--write-receipt`` is the only mutation path; it writes one
+JSON receipt under ``.aragora/review-queue/thresholds/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.review import (
+    DEFAULT_BASELINE_WINDOW_DAYS,
+    DEFAULT_MIN_BASELINE_SAMPLES,
+    DEFAULT_MINIMUM_MEANINGFUL_RATE,
+    DEFAULT_SAFETY_MARGIN,
+    DEFAULT_THRESHOLD_RECEIPT_DIR,
+    ReviewQueueInvalidationEventSource,
+    ThresholdRecalibrationScheduler,
+    write_recalibration_receipt,
+)
+from aragora.triage.auto_handle_calibration import AutoHandleCalibrationStore
+
+UTC = timezone.utc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure Aragora's empirical invalidation baseline (#6375) and "
+            "emit either a threshold_update_receipt.v1 or insufficiency_receipt.v1."
+        )
+    )
+    parser.add_argument("--window-days", type=int, default=DEFAULT_BASELINE_WINDOW_DAYS)
+    parser.add_argument("--min-samples", type=int, default=DEFAULT_MIN_BASELINE_SAMPLES)
+    parser.add_argument("--safety-margin", type=float, default=DEFAULT_SAFETY_MARGIN)
+    parser.add_argument(
+        "--minimum-meaningful-rate",
+        type=float,
+        default=DEFAULT_MINIMUM_MEANINGFUL_RATE,
+    )
+    parser.add_argument("--placeholder-value", type=float, default=0.05)
+    parser.add_argument("--calibration-db", default=None)
+    parser.add_argument("--review-queue-root", default=None)
+    parser.add_argument(
+        "--receipt-dir",
+        type=Path,
+        default=DEFAULT_THRESHOLD_RECEIPT_DIR,
+        help="Receipt directory relative to the repo root unless absolute.",
+    )
+    parser.add_argument(
+        "--write-receipt",
+        action="store_true",
+        help="Persist the emitted receipt JSON. Default is dry-run/read-only.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        _validate_args(args)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        store = AutoHandleCalibrationStore(db_path=args.calibration_db)
+        source = ReviewQueueInvalidationEventSource(
+            calibration_store=store,
+            review_queue_root=args.review_queue_root,
+        )
+        scheduler = ThresholdRecalibrationScheduler(
+            window_days=args.window_days,
+            min_samples=args.min_samples,
+            safety_margin=args.safety_margin,
+            minimum_meaningful_rate=args.minimum_meaningful_rate,
+            placeholder_value=args.placeholder_value,
+        )
+        receipt = scheduler.run_receipt_from_source(source, now=datetime.now(UTC))
+    except (OSError, RuntimeError, sqlite3.Error, ValueError, TypeError) as exc:
+        print(f"error: baseline measurement failed: {exc}", file=sys.stderr)
+        return 1
+
+    payload: dict[str, Any] = receipt.to_dict()
+    path: Path | None = None
+    if args.write_receipt:
+        repo_root = _resolve_repo_root(Path.cwd())
+        receipt_dir = args.receipt_dir
+        if receipt_dir.is_absolute():
+            try:
+                receipt_dir = receipt_dir.relative_to(repo_root)
+            except ValueError:
+                pass
+        path = write_recalibration_receipt(receipt, repo_root=repo_root, receipt_dir=receipt_dir)
+        payload["receipt_path"] = str(path)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _render_summary(payload, path=path)
+    return 0
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.window_days <= 0:
+        raise ValueError("--window-days must be positive")
+    if args.min_samples <= 0:
+        raise ValueError("--min-samples must be positive")
+    if not 0 < args.safety_margin <= 1:
+        raise ValueError("--safety-margin must be in (0, 1]")
+    if args.minimum_meaningful_rate <= 0:
+        raise ValueError("--minimum-meaningful-rate must be positive")
+    if not 0 < args.placeholder_value < 1:
+        raise ValueError("--placeholder-value must be in (0, 1)")
+
+
+def _resolve_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists() or (candidate / ".aragora").exists():
+            return candidate
+    return start
+
+
+def _render_summary(payload: dict[str, Any], *, path: Path | None) -> None:
+    schema = payload["schema_version"]
+    sample_count = payload["sample_count"]
+    threshold = payload["proposal"]["threshold"]
+    placeholder = payload["proposal"]["is_placeholder"]
+    print(f"schema: {schema}")
+    print(f"receipt_id: {payload['receipt_id']}")
+    print(f"sample_count: {sample_count}")
+    print(f"threshold: {threshold}")
+    print(f"placeholder: {placeholder}")
+    if schema == "insufficiency_receipt.v1":
+        reasons = ", ".join(payload["insufficiency"]["reasons"])
+        needed = payload["insufficiency"]["additional_dispatches_needed"]
+        print(f"insufficiency_reasons: {reasons}")
+        print(f"additional_dispatches_needed: {needed}")
+    if path is None:
+        print("receipt_path: (dry-run; pass --write-receipt to persist)")
+    else:
+        print(f"receipt_path: {path}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/review/test_invalidation_event_source.py
+++ b/tests/review/test_invalidation_event_source.py
@@ -22,6 +22,7 @@ from aragora.review import (
     InvalidatedDecision,
 )
 from aragora.review.invalidation_event_source import (
+    ReviewQueueInvalidationEventSource,
     count_decisions_from_settlement_receipts,
     iter_invalidations_from_calibration_store,
     iter_invalidations_from_settlement_receipts,
@@ -517,6 +518,33 @@ def test_measure_baseline_rejects_zero_window_days(tmp_path: Path) -> None:
             window_end=datetime.now(UTC),
             window_days=0,
         )
+
+
+def test_review_queue_event_source_collects_scheduler_sample(tmp_path: Path) -> None:
+    store = AutoHandleCalibrationStore(db_path=":memory:")
+    _seed_calibration_store(store, success=5, revert=2)
+
+    receipts = tmp_path / ".aragora" / "review-queue" / "receipts"
+    receipts.mkdir(parents=True)
+    now = datetime.now(UTC)
+    for i in range(3):
+        _write_receipt(receipts, pr_number=i, reviewed_at=now - timedelta(days=1))
+
+    source = ReviewQueueInvalidationEventSource(
+        calibration_store=store,
+        review_queue_root=tmp_path / ".aragora" / "review-queue",
+    )
+
+    sample = source.collect_recalibration_sample(
+        window_start=now - timedelta(days=30),
+        window_end=now,
+    )
+
+    assert sample.source_name == "aragora.review.invalidation_event_source"
+    assert sample.total_human_settled == 3
+    assert sample.total_auto_handled == 7
+    assert len(sample.invalidations) == 2
+    assert "human_invalidations_source" in sample.notes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/review/test_threshold_recalibration.py
+++ b/tests/review/test_threshold_recalibration.py
@@ -10,13 +10,17 @@ import pytest
 
 from aragora.review import (
     DEFAULT_THRESHOLD_RECEIPT_DIR,
+    INSUFFICIENCY_RECEIPT_SCHEMA_VERSION,
     THRESHOLD_UPDATE_RECEIPT_SCHEMA_VERSION,
+    InsufficiencyReceipt,
     INVALIDATION_REVERT_WITHIN_WINDOW,
     InvalidationRecalibrationSample,
     InvalidatedDecision,
     ThresholdRecalibrationScheduler,
     ThresholdUpdateReceipt,
+    compute_insufficiency_receipt_id,
     compute_threshold_update_receipt_id,
+    write_recalibration_receipt,
     write_threshold_update_receipt,
 )
 
@@ -65,6 +69,50 @@ def test_scheduler_emits_placeholder_receipt_below_sample_floor() -> None:
     assert payload["baseline"]["human_rate_ci"]["low"] is not None
     assert payload["threshold"]["derived"] == pytest.approx(0.05)
     assert payload["prior"] == {"threshold": None, "baseline_human_rate": None}
+
+
+def test_scheduler_emits_insufficiency_receipt_below_sample_floor() -> None:
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    scheduler = ThresholdRecalibrationScheduler(min_samples=50)
+    sample = InvalidationRecalibrationSample(
+        total_human_settled=10,
+        total_auto_handled=0,
+        source_name="fake-event-source",
+        source_version="test",
+    )
+
+    receipt = scheduler.run_receipt_from_sample(sample, now=now)
+
+    assert isinstance(receipt, InsufficiencyReceipt)
+    assert receipt.schema_version == INSUFFICIENCY_RECEIPT_SCHEMA_VERSION
+    assert receipt.sample_count == 10
+    assert receipt.additional_dispatches_needed == 40
+    assert "below_min_human_settled" in receipt.insufficiency_reasons
+    assert "placeholder_threshold" in receipt.insufficiency_reasons
+    payload = receipt.to_dict()
+    assert payload["insufficiency"]["additional_dispatches_needed"] == 40
+    assert payload["proposal"]["is_placeholder"] is True
+
+
+def test_scheduler_emits_insufficiency_receipt_for_schema_gap_even_above_floor() -> None:
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    scheduler = ThresholdRecalibrationScheduler(min_samples=50)
+    sample = InvalidationRecalibrationSample(
+        total_human_settled=60,
+        total_auto_handled=0,
+        source_name="fake-event-source",
+        source_version="test",
+        notes={"human_invalidations_source": "future receipt fields absent"},
+    )
+
+    receipt = scheduler.run_receipt_from_sample(sample, now=now)
+
+    assert isinstance(receipt, InsufficiencyReceipt)
+    assert receipt.proposal.is_placeholder is False
+    assert receipt.proposal.threshold == pytest.approx(0.01)
+    assert receipt.additional_dispatches_needed == 0
+    assert receipt.insufficiency_reasons == ("schema_gap_human_numerator",)
+    assert receipt.notes["human_invalidations_source"] == "future receipt fields absent"
 
 
 def test_scheduler_derives_threshold_and_deltas_from_previous_receipt() -> None:
@@ -128,6 +176,22 @@ def test_receipt_id_is_stable_and_excludes_receipt_id() -> None:
     assert compute_threshold_update_receipt_id(tampered) == receipt_a.receipt_id
 
 
+def test_insufficiency_receipt_id_is_stable_and_excludes_receipt_id() -> None:
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    scheduler = ThresholdRecalibrationScheduler(min_samples=50)
+    sample = InvalidationRecalibrationSample(total_human_settled=0, total_auto_handled=0)
+
+    receipt_a = scheduler.run_receipt_from_sample(sample, now=now)
+    receipt_b = scheduler.run_receipt_from_sample(sample, now=now)
+
+    assert isinstance(receipt_a, InsufficiencyReceipt)
+    assert isinstance(receipt_b, InsufficiencyReceipt)
+    assert receipt_a.receipt_id == receipt_b.receipt_id
+    tampered = receipt_a.to_dict()
+    tampered["receipt_id"] = "not-the-real-id"
+    assert compute_insufficiency_receipt_id(tampered) == receipt_a.receipt_id
+
+
 class _FakeEventSource:
     def __init__(self, sample: InvalidationRecalibrationSample) -> None:
         self.sample = sample
@@ -173,6 +237,22 @@ def test_write_threshold_update_receipt_uses_threshold_receipt_dir(tmp_path: Pat
 
     assert path.parent == tmp_path / DEFAULT_THRESHOLD_RECEIPT_DIR
     assert path.name == f"{receipt.receipt_id}.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload == receipt.to_dict()
+
+
+def test_write_recalibration_receipt_handles_insufficiency_receipt(tmp_path: Path) -> None:
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    scheduler = ThresholdRecalibrationScheduler(min_samples=50)
+    receipt = scheduler.run_receipt_from_sample(
+        InvalidationRecalibrationSample(total_human_settled=0, total_auto_handled=0),
+        now=now,
+    )
+
+    path = write_recalibration_receipt(receipt, repo_root=tmp_path)
+
+    assert isinstance(receipt, InsufficiencyReceipt)
+    assert path.parent == tmp_path / DEFAULT_THRESHOLD_RECEIPT_DIR
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload == receipt.to_dict()
 

--- a/tests/scripts/test_measure_invalidation_baseline.py
+++ b/tests/scripts/test_measure_invalidation_baseline.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/measure_invalidation_baseline.py")
+
+
+def test_measure_invalidation_baseline_dry_run_emits_insufficiency_json(tmp_path: Path) -> None:
+    review_queue_root = tmp_path / ".aragora" / "review-queue"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--calibration-db",
+            str(tmp_path / "calibration.db"),
+            "--review-queue-root",
+            str(review_queue_root),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "insufficiency_receipt.v1"
+    assert "below_min_human_settled" in payload["insufficiency"]["reasons"]
+    assert not (tmp_path / ".aragora" / "review-queue" / "thresholds").exists()
+
+
+def test_measure_invalidation_baseline_write_receipt(tmp_path: Path) -> None:
+    receipt_dir = tmp_path / ".aragora" / "review-queue" / "thresholds"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--calibration-db",
+            str(tmp_path / "calibration.db"),
+            "--review-queue-root",
+            str(tmp_path / ".aragora" / "review-queue"),
+            "--receipt-dir",
+            str(receipt_dir),
+            "--write-receipt",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    path = Path(payload["receipt_path"])
+    assert path.exists()
+    assert path.parent == receipt_dir
+    assert json.loads(path.read_text(encoding="utf-8"))["receipt_id"] == payload["receipt_id"]


### PR DESCRIPTION
## Summary
- adds `InsufficiencyReceipt.v1` alongside existing `ThresholdUpdateReceipt.v1` so #6375 baseline runs do not pretend below-floor or schema-gap measurements are settlement-ready threshold updates
- adds `ReviewQueueInvalidationEventSource`, a scheduler protocol adapter over the existing auto-handle calibration store and review-queue settlement receipts
- adds `scripts/measure_invalidation_baseline.py`, dry-run by default, with `--write-receipt` as the only mutation path under `.aragora/review-queue/thresholds/`

## Scope Boundary
- no `docs/THESIS.md` update
- no new invalidation signals
- no H2, DIC, AGT, marketplace, or receipt-API breadth
- no production mutation beyond an explicit local threshold receipt write

## Live Dry Run
`python3 scripts/measure_invalidation_baseline.py --write-receipt --json` emitted an ignored local `insufficiency_receipt.v1`:
- sample_count: 0
- reasons: `no_human_settled_in_window`, `no_decisions_in_window`, `below_min_human_settled`, `schema_gap_human_numerator`, `placeholder_threshold`
- additional_dispatches_needed: 50

## Validation
- `python3 -m pytest -q tests/review/test_threshold_recalibration.py tests/review/test_invalidation_event_source.py tests/scripts/test_measure_invalidation_baseline.py`
- `python3 -m ruff check aragora/review/threshold_recalibration.py aragora/review/invalidation_event_source.py aragora/review/__init__.py scripts/measure_invalidation_baseline.py tests/review/test_threshold_recalibration.py tests/review/test_invalidation_event_source.py tests/scripts/test_measure_invalidation_baseline.py`
- `python3 -m mypy aragora/review/threshold_recalibration.py aragora/review/invalidation_event_source.py scripts/measure_invalidation_baseline.py`
- `python3 -m compileall -q scripts/measure_invalidation_baseline.py aragora/review/threshold_recalibration.py aragora/review/invalidation_event_source.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`