### PR TITLE
fix(agent-bridge): compact operator snapshot output

### DIFF
--- a/docs/briefs/codex-desktop-automation-autonomy.md
+++ b/docs/briefs/codex-desktop-automation-autonomy.md
@@ -20,7 +20,7 @@ Every automation should start from live repo evidence, not prior narration:
 3. Run the relevant local status command before choosing a lane:
    - `python3 scripts/check_codex_desktop_automations.py --json --summary-only`
    - `python3 scripts/audit_codex_branch_backlog.py --max-branches 200 --json --summary-only --outbox-dir /Users/armand/Development/aragora/.aragora/automation-outbox --receipt-dir /Users/armand/Development/aragora/.aragora/automation-receipts`
-   - `python3 scripts/agent_bridge.py operator-snapshot --json`
+   - `python3 scripts/agent_bridge.py operator-snapshot --json --summary-only` for gating, or omit `--summary-only` when detailed session context is needed.
 4. Treat sandboxed GitHub failure as expected. Use local git, shared outbox files, and receipts as the primary automation substrate.
 
 ## Writer Lanes

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -15,7 +15,7 @@ Usage:
   python3 scripts/agent_bridge.py lanes [--json]
   python3 scripts/agent_bridge.py tmux-map
   python3 scripts/agent_bridge.py health [--json]
-  python3 scripts/agent_bridge.py operator-snapshot [--json]
+  python3 scripts/agent_bridge.py operator-snapshot [--json] [--summary-only]
 """
 
 from __future__ import annotations
@@ -819,8 +819,10 @@ def cmd_health(args: argparse.Namespace) -> int:
 
 def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     """Output a unified operator snapshot combining sessions, lanes, and health."""
+    summary_only = bool(getattr(args, "summary_only", False))
     sessions = discover()
-    _enrich_prs(sessions)
+    if not summary_only:
+        _enrich_prs(sessions)
     _write_session_snapshot(sessions)
     records = _sync_lane_records(_load_lane_registry(), sessions)
 
@@ -840,6 +842,10 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
             "health_issues": len(issues),
         },
     }
+    if summary_only:
+        snapshot.pop("sessions")
+        snapshot.pop("lanes")
+        snapshot["records_omitted"] = True
 
     if args.json:
         print(json.dumps(snapshot, indent=2))
@@ -855,7 +861,7 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     health_status = "OK" if snapshot["health"]["ok"] else f"{summary['health_issues']} issue(s)"
     print(f"Health:   {health_status}")
 
-    if sessions:
+    if sessions and not summary_only:
         print(f"\n{'NAME':<24} {'AGENT':<8} {'STATUS':<8} {'BRANCH':<28} SUMMARY")
         print("-" * 110)
         for s in sessions:
@@ -863,7 +869,7 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
             summary_text = (s.summary[:40] + "..." if len(s.summary) > 40 else s.summary) or "-"
             print(f"{s.name:<24} {s.agent:<8} {s.status:<8} {branch:<28} {summary_text}")
 
-    if records:
+    if records and not summary_only:
         print(f"\n{'LANE':<22} {'OWNER':<24} {'STATUS':<10} NEXT ACTION")
         print("-" * 90)
         for r in records:
@@ -979,10 +985,15 @@ def main() -> int:
     sub.add_parser(
         "health", parents=[json_parent], help="Check for stale worktrees and lane conflicts"
     )
-    sub.add_parser(
+    operator_snapshot_p = sub.add_parser(
         "operator-snapshot",
         parents=[json_parent],
         help="Unified operator snapshot (sessions + lanes + health)",
+    )
+    operator_snapshot_p.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Omit session and lane records from output for compact automation checks.",
     )
 
     args = parser.parse_args()

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -327,6 +327,47 @@ def test_main_accepts_json_after_subcommand(
     assert json.loads(capsys.readouterr().out) == []
 
 
+def test_operator_snapshot_summary_only_json_omits_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        mod,
+        "discover",
+        lambda: [
+            mod.Session(
+                name="codex-main",
+                agent="codex",
+                status="alive",
+                branch="codex/example",
+                worktree=str(tmp_path),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "_enrich_prs",
+        lambda _sessions: (_ for _ in ()).throw(
+            AssertionError("summary-only should not call GitHub PR enrichment")
+        ),
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "sessions" not in payload
+    assert "lanes" not in payload
+    assert payload["records_omitted"] is True
+    assert payload["summary"]["total_sessions"] == 1
+    assert payload["summary"]["alive_sessions"] == 1
+    assert payload["health"] == {"ok": True, "issues": []}
+
+
 def test_cmd_launch_invokes_tmux_launcher_for_droid(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add `operator-snapshot --summary-only` for compact automation gating output
- skip PR enrichment and omit session/lane records in summary mode
- update the desktop automation autonomy brief and add regression coverage

Supersedes the stale issue-only handoff for `codex/agent-bridge-operator-snapshot-summary` (#6863) by restacking the same improvement onto current `origin/main` without force-pushing the old branch.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_agent_bridge.py -p no:rerunfailures -p no:cacheprovider` (12 passed)
- `python3 -m ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py`
- `python3 -m ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py`
- `python3 scripts/agent_bridge.py operator-snapshot --json --summary-only`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`