### PR TITLE
docs(cli): salvage generated site description

### DIFF
--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference

--- a/docs-site/scripts/sync-docs.js
+++ b/docs-site/scripts/sync-docs.js
@@ -598,8 +598,13 @@ function processFile(srcRelPath, destPath) {
   const isAdr = relSrcPath.startsWith('ADR' + path.sep);
   const slug = isAdr && baseName !== 'README' ? baseName : null;
 
+  const description =
+    relSrcPath.replace(/\\/g, '/') === 'reference/CLI_REFERENCE.md'
+      ? 'Generated Aragora CLI command catalog from live parser'
+      : undefined;
+
   // Add frontmatter
-  content = addFrontmatter(content, title, undefined, slug);
+  content = addFrontmatter(content, title, description, slug);
 
   // Fix content for compatibility (pass relative dest path)
   const relDestPath = destPath.replace(DEST_DIR + '/', '');

--- a/tests/scripts/test_docs_site_sync_links.py
+++ b/tests/scripts/test_docs_site_sync_links.py
@@ -117,3 +117,10 @@ def test_docs_site_sync_creates_linked_status_and_planning_pages() -> None:
 
     for page in expected_pages:
         assert page.exists(), f"Expected synced docs-site page missing: {page}"
+
+
+def test_cli_reference_preserves_generated_catalog_description() -> None:
+    content = _read_docs_site("api/cli.md")
+
+    assert "title: Aragora CLI Reference" in content
+    assert "description: Generated Aragora CLI command catalog from live parser" in content


### PR DESCRIPTION
## Summary

Repairs the generated CLI reference docs-site description salvage and the docs sync source that was rewriting it.

The original one-line docs-site change restored:

```yaml
description: Generated Aragora CLI command catalog from live parser
```

CI showed this was incomplete: `node docs-site/scripts/sync-docs.js` rewrote `docs-site/docs/api/cli.md` back to `description: Aragora CLI Reference` during the docs build. This PR now patches the sync layer so the generated CLI reference keeps the generator's richer provenance description, and adds a regression assertion for the synced docs-site frontmatter.

## Validation

- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok
- `python3 scripts/generate_cli_reference.py --check --check-site` -> CLI reference files are up to date
- `python3 -m pytest tests/scripts/test_generate_cli_reference.py tests/scripts/test_docs_site_sync_links.py -p no:randomly -q` -> 6 passed
- `python3 -m ruff check tests/scripts/test_docs_site_sync_links.py` -> pass
- `python3 -m ruff format --check tests/scripts/test_docs_site_sync_links.py` -> pass
- `node docs-site/scripts/sync-docs.js` -> no diff after the sync-layer fix

## Scope

- `docs-site/docs/api/cli.md`: generated frontmatter description
- `docs-site/scripts/sync-docs.js`: narrow CLI reference description preservation
- `tests/scripts/test_docs_site_sync_links.py`: regression assertion

No runtime code, routes, SDKs, or release flow touched.
