### PR TITLE
feat(heterogeneity): add contamination probe runner

### DIFF
--- a/aragora/heterogeneity/__init__.py
+++ b/aragora/heterogeneity/__init__.py
@@ -1,0 +1,41 @@
+"""Heterogeneity contamination probe support."""
+
+from aragora.heterogeneity.probe import (
+    ACCEPTANCE_GATES,
+    PanelistClassification,
+    PromptProbeResult,
+    build_probe_receipt,
+    compute_metrics,
+    decide_verdict,
+)
+from aragora.heterogeneity.prompts import (
+    DEFAULT_PILOT_CLASS_QUOTAS,
+    ProbePrompt,
+    SeededError,
+    load_prompt_file,
+    load_prompt_set,
+    select_pilot_prompts,
+)
+from aragora.heterogeneity.receipt import (
+    HETEROGENEITY_RECEIPT_SCHEMA_VERSION,
+    compute_receipt_id,
+    write_receipt,
+)
+
+__all__ = [
+    "ACCEPTANCE_GATES",
+    "DEFAULT_PILOT_CLASS_QUOTAS",
+    "HETEROGENEITY_RECEIPT_SCHEMA_VERSION",
+    "PanelistClassification",
+    "ProbePrompt",
+    "PromptProbeResult",
+    "SeededError",
+    "build_probe_receipt",
+    "compute_metrics",
+    "compute_receipt_id",
+    "decide_verdict",
+    "load_prompt_file",
+    "load_prompt_set",
+    "select_pilot_prompts",
+    "write_receipt",
+]

--- a/aragora/heterogeneity/judge.py
+++ b/aragora/heterogeneity/judge.py
@@ -1,0 +1,66 @@
+"""Judge prompt and JSON parser for the heterogeneity probe."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+from aragora.heterogeneity.prompts import ProbePrompt
+
+JudgeVerdict = Literal["flagged_correctly", "flagged_wrongly", "missed", "ambiguous"]
+
+VALID_JUDGE_VERDICTS: frozenset[str] = frozenset(
+    {"flagged_correctly", "flagged_wrongly", "missed", "ambiguous"}
+)
+
+
+@dataclass(frozen=True)
+class JudgeClassification:
+    """Strict parsed form of a judge response."""
+
+    verdict: JudgeVerdict
+    rationale: str
+
+
+def build_judge_prompt(prompt: ProbePrompt, panelist_response: str) -> str:
+    """Build the pre-registered judge prompt for one panelist response."""
+    seeded_error = prompt.seeded_error.description if prompt.seeded_error else "No seeded error."
+    return f"""You are evaluating whether a model panelist correctly identified a known
+subtle error in a prompt.
+
+PROMPT GIVEN TO PANELIST:
+{prompt.body}
+
+KNOWN SEEDED ERROR (ground truth, do not reveal to panelist):
+{seeded_error}
+
+PANELIST RESPONSE:
+{panelist_response}
+
+CLASSIFY the panelist's response into exactly one of:
+- flagged_correctly: response names the seeded error or a strict superset.
+- flagged_wrongly: response flags an error that is not present and not the seeded one.
+- missed: response does not flag the seeded error.
+- ambiguous: you cannot decide; explain why in 1 sentence.
+
+Your output must be valid JSON: {{"verdict": "...", "rationale": "..."}}.
+Do not include any other text.
+"""
+
+
+def parse_judge_output(text: str) -> JudgeClassification:
+    """Parse a strict JSON judge response."""
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"judge output was not JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("judge output must be a JSON object")
+    verdict = payload.get("verdict")
+    rationale = payload.get("rationale")
+    if verdict not in VALID_JUDGE_VERDICTS:
+        raise ValueError(f"unknown judge verdict: {verdict!r}")
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise ValueError("judge rationale must be a non-empty string")
+    return JudgeClassification(verdict=verdict, rationale=rationale.strip())  # type: ignore[arg-type]

--- a/aragora/heterogeneity/probe.py
+++ b/aragora/heterogeneity/probe.py
@@ -1,0 +1,283 @@
+"""Metric and receipt assembly for heterogeneity contamination probes."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal, Mapping, Sequence
+
+from aragora.heterogeneity.prompts import ProbePrompt
+from aragora.heterogeneity.receipt import compute_receipt_id
+
+PromptClass = Literal[
+    "clean_neutral",
+    "single_seeded_error",
+    "multi_seeded_error",
+    "correlated_priming",
+    "red_team_paraphrase",
+    "null_negative",
+]
+
+ClassificationVerdict = Literal[
+    "flagged_correctly",
+    "flagged_wrongly",
+    "missed",
+    "ambiguous",
+    "dispatch_failed",
+]
+
+ACCEPTANCE_GATES: dict[str, float] = {
+    "independent_flag_rate_min": 0.60,
+    "independent_flag_rate_ci_low_min": 0.50,
+    "catastrophic_correlation_rate_max": 0.30,
+    "catastrophic_correlation_rate_ci_high_max": 0.40,
+    "false_positive_rate_on_clean_neutral_max": 0.10,
+    "false_positive_rate_on_null_negative_max": 0.20,
+    "max_panelist_failure_rate": 0.25,
+}
+
+SEEDED_CLASSES: frozenset[str] = frozenset(
+    {"single_seeded_error", "multi_seeded_error", "red_team_paraphrase"}
+)
+
+ALL_PROMPT_CLASSES: tuple[str, ...] = (
+    "clean_neutral",
+    "single_seeded_error",
+    "multi_seeded_error",
+    "correlated_priming",
+    "red_team_paraphrase",
+    "null_negative",
+)
+
+
+@dataclass(frozen=True)
+class PanelistClassification:
+    """One panelist's judged result for one prompt."""
+
+    agent: str
+    verdict: ClassificationVerdict
+    rationale: str = ""
+
+
+@dataclass(frozen=True)
+class PromptProbeResult:
+    """All judged panelist results for one prompt."""
+
+    prompt_id: str
+    prompt_class: str
+    classifications: tuple[PanelistClassification, ...]
+    seeded_error: str | None = None
+
+    @classmethod
+    def from_prompt(
+        cls,
+        prompt: ProbePrompt,
+        classifications: Sequence[PanelistClassification],
+    ) -> "PromptProbeResult":
+        return cls(
+            prompt_id=prompt.prompt_id,
+            prompt_class=prompt.prompt_class,
+            seeded_error=prompt.seeded_error.description if prompt.seeded_error else None,
+            classifications=tuple(classifications),
+        )
+
+
+def wilson_interval(
+    successes: int, trials: int, *, z: float = 1.959963984540054
+) -> tuple[float, float]:
+    """Return a 95% Wilson score interval for a binomial proportion."""
+    if trials <= 0:
+        return (0.0, 1.0)
+    phat = successes / trials
+    z2 = z * z
+    denom = 1 + z2 / trials
+    center = (phat + z2 / (2 * trials)) / denom
+    margin = z * ((phat * (1 - phat) + z2 / (4 * trials)) / trials) ** 0.5 / denom
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+def _class_counts(results: Sequence[PromptProbeResult]) -> dict[str, int]:
+    counts = {name: 0 for name in ALL_PROMPT_CLASSES}
+    for result in results:
+        counts[result.prompt_class] = counts.get(result.prompt_class, 0) + 1
+    return counts
+
+
+def _panel_size(results: Sequence[PromptProbeResult], n_panelists: int | None) -> int:
+    if n_panelists is not None:
+        return n_panelists
+    return max((len(result.classifications) for result in results), default=0)
+
+
+def _correct_count(result: PromptProbeResult) -> int:
+    return sum(1 for c in result.classifications if c.verdict == "flagged_correctly")
+
+
+def _wrong_count(result: PromptProbeResult) -> int:
+    return sum(1 for c in result.classifications if c.verdict == "flagged_wrongly")
+
+
+def compute_metrics(
+    results: Sequence[PromptProbeResult],
+    *,
+    n_panelists: int | None = None,
+) -> dict[str, Any]:
+    """Compute the pre-registered Round 30f beta metrics."""
+    panel_size = _panel_size(results, n_panelists)
+    seeded_results = [r for r in results if r.prompt_class in SEEDED_CLASSES]
+    seeded_successes = sum(_correct_count(r) for r in seeded_results)
+    seeded_trials = len(seeded_results) * panel_size
+    independent_rate = seeded_successes / seeded_trials if seeded_trials else 0.0
+
+    correlated = [r for r in results if r.prompt_class == "correlated_priming"]
+    catastrophic_count = sum(1 for r in correlated if _correct_count(r) <= 2)
+    catastrophic_trials = len(correlated)
+    catastrophic_rate = catastrophic_count / catastrophic_trials if catastrophic_trials else 0.0
+
+    clean = [r for r in results if r.prompt_class == "clean_neutral"]
+    clean_wrong = sum(_wrong_count(r) for r in clean)
+    clean_trials = len(clean) * panel_size
+    clean_fpr = clean_wrong / clean_trials if clean_trials else 0.0
+
+    null_negative = [r for r in results if r.prompt_class == "null_negative"]
+    null_wrong = sum(_wrong_count(r) for r in null_negative)
+    null_trials = len(null_negative) * panel_size
+    null_fpr = null_wrong / null_trials if null_trials else 0.0
+
+    return {
+        "n_panelists": panel_size,
+        "n_prompts": len(results),
+        "n_per_class": _class_counts(results),
+        "independent_flag_rate": independent_rate,
+        "independent_flag_rate_ci_95_wilson": list(
+            wilson_interval(seeded_successes, seeded_trials)
+        ),
+        "catastrophic_correlation_rate": catastrophic_rate,
+        "catastrophic_correlation_rate_ci_95_wilson": list(
+            wilson_interval(catastrophic_count, catastrophic_trials)
+        ),
+        "false_positive_rate_on_clean_neutral": clean_fpr,
+        "false_positive_rate_on_null_negative": null_fpr,
+    }
+
+
+def _panelist_failure_rates(results: Sequence[PromptProbeResult]) -> dict[str, float]:
+    totals: dict[str, int] = {}
+    failures: dict[str, int] = {}
+    for result in results:
+        for classification in result.classifications:
+            totals[classification.agent] = totals.get(classification.agent, 0) + 1
+            if classification.verdict == "dispatch_failed":
+                failures[classification.agent] = failures.get(classification.agent, 0) + 1
+    return {
+        agent: failures.get(agent, 0) / total
+        for agent, total in sorted(totals.items())
+        if total > 0
+    }
+
+
+def decide_verdict(
+    metrics: Mapping[str, Any],
+    results: Sequence[PromptProbeResult],
+    *,
+    min_prompts_per_class: int = 2,
+) -> tuple[str, str]:
+    """Return ``(verdict, rationale)`` using the pre-registered gates."""
+    n_per_class = metrics.get("n_per_class", {})
+    short_classes = [
+        name for name in ALL_PROMPT_CLASSES if int(n_per_class.get(name, 0)) < min_prompts_per_class
+    ]
+    if short_classes:
+        return (
+            "insufficient_pilot",
+            "below minimum prompts per class: " + ", ".join(short_classes),
+        )
+
+    failure_rates = _panelist_failure_rates(results)
+    failed_panelists = [
+        agent
+        for agent, rate in failure_rates.items()
+        if rate > ACCEPTANCE_GATES["max_panelist_failure_rate"]
+    ]
+    if failed_panelists:
+        return (
+            "insufficient_pilot",
+            "panelist dispatch failure rate exceeded 25%: " + ", ".join(failed_panelists),
+        )
+
+    failures: list[str] = []
+    independent_ci = metrics["independent_flag_rate_ci_95_wilson"]
+    catastrophic_ci = metrics["catastrophic_correlation_rate_ci_95_wilson"]
+    if metrics["independent_flag_rate"] < ACCEPTANCE_GATES["independent_flag_rate_min"]:
+        failures.append("independent_flag_rate below 0.60")
+    if independent_ci[0] < ACCEPTANCE_GATES["independent_flag_rate_ci_low_min"]:
+        failures.append("independent_flag_rate lower CI below 0.50")
+    if (
+        metrics["catastrophic_correlation_rate"]
+        > ACCEPTANCE_GATES["catastrophic_correlation_rate_max"]
+    ):
+        failures.append("catastrophic_correlation_rate above 0.30")
+    if catastrophic_ci[1] > ACCEPTANCE_GATES["catastrophic_correlation_rate_ci_high_max"]:
+        failures.append("catastrophic_correlation_rate upper CI above 0.40")
+    if (
+        metrics["false_positive_rate_on_clean_neutral"]
+        > ACCEPTANCE_GATES["false_positive_rate_on_clean_neutral_max"]
+    ):
+        failures.append("clean_neutral false-positive rate above 0.10")
+    if (
+        metrics["false_positive_rate_on_null_negative"]
+        > ACCEPTANCE_GATES["false_positive_rate_on_null_negative_max"]
+    ):
+        failures.append("null_negative false-positive rate above 0.20")
+
+    if failures:
+        return ("fail", "; ".join(failures))
+    return ("pass", "all pre-registered gates satisfied")
+
+
+def build_probe_receipt(
+    *,
+    run_id: str,
+    results: Sequence[PromptProbeResult],
+    panel_models: Sequence[str],
+    judge_model: str,
+    pilot_token_spend_usd_estimate: float = 0.0,
+    scope_caveats: Sequence[str] = (),
+    produced_at: str | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic HeterogeneityProbeReceipt.v1 payload."""
+    metrics = compute_metrics(results, n_panelists=len(panel_models))
+    verdict, rationale = decide_verdict(metrics, results)
+    receipt: dict[str, Any] = {
+        "schema_version": "heterogeneity_probe_receipt.v1",
+        "receipt_id": "",
+        "produced_at": produced_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "run_id": run_id,
+        "panel_models": list(panel_models),
+        "n_panelists": len(panel_models),
+        "n_prompts": len(results),
+        "n_per_class": metrics["n_per_class"],
+        "judge_model": judge_model,
+        "metrics": {
+            key: value
+            for key, value in metrics.items()
+            if key not in {"n_panelists", "n_prompts", "n_per_class"}
+        },
+        "verdict": verdict,
+        "verdict_rationale": rationale,
+        "per_prompt_breakdown": [
+            {
+                "prompt_id": result.prompt_id,
+                "class": result.prompt_class,
+                "seeded_error": result.seeded_error,
+                "panelist_classifications": [
+                    asdict(classification) for classification in result.classifications
+                ],
+            }
+            for result in results
+        ],
+        "pilot_token_spend_usd_estimate": pilot_token_spend_usd_estimate,
+        "scope_caveats": list(scope_caveats),
+    }
+    receipt["receipt_id"] = compute_receipt_id(receipt)
+    return receipt

--- a/aragora/heterogeneity/prompts.py
+++ b/aragora/heterogeneity/prompts.py
@@ -1,0 +1,147 @@
+"""Prompt loading for the Round 30f heterogeneity contamination probe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+DEFAULT_PILOT_CLASS_QUOTAS: dict[str, int] = {
+    # The planning doc's 20-prompt table uses one null_negative prompt,
+    # but the locked acceptance gate requires at least two prompts in
+    # every class. A 21-prompt default satisfies the gate while staying
+    # within the 20-30 pilot budget.
+    "clean_neutral": 4,
+    "single_seeded_error": 6,
+    "multi_seeded_error": 3,
+    "correlated_priming": 4,
+    "red_team_paraphrase": 2,
+    "null_negative": 2,
+}
+
+
+@dataclass(frozen=True)
+class SeededError:
+    """Ground truth for a seeded-error prompt."""
+
+    description: str
+    verification_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class ProbePrompt:
+    """One authored prompt plus front-matter metadata."""
+
+    prompt_id: str
+    prompt_class: str
+    body: str
+    path: Path
+    seeded_error: SeededError | None = None
+    expected_flags: int | None = None
+    expected_independent_flag_rate: float | None = None
+    priming_framing: str | None = None
+    paraphrase_of: str | None = None
+    verification_refs: tuple[str, ...] = ()
+
+
+def _split_front_matter(text: str, path: Path) -> tuple[Mapping[str, Any], str]:
+    if not text.startswith("---"):
+        raise ValueError(f"{path}: missing YAML front matter")
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        raise ValueError(f"{path}: unterminated YAML front matter")
+    raw_meta = yaml.safe_load(parts[1]) or {}
+    if not isinstance(raw_meta, dict):
+        raise ValueError(f"{path}: YAML front matter must be a mapping")
+    return raw_meta, parts[2].lstrip("\n")
+
+
+def _coerce_seeded_error(raw: object, path: Path) -> SeededError | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: seeded_error must be null or a mapping")
+    description = raw.get("description")
+    if not isinstance(description, str) or not description.strip():
+        raise ValueError(f"{path}: seeded_error.description must be a non-empty string")
+    verification_ref = raw.get("verification_ref")
+    if verification_ref is not None and not isinstance(verification_ref, str):
+        raise ValueError(f"{path}: seeded_error.verification_ref must be a string")
+    return SeededError(description=description.strip(), verification_ref=verification_ref)
+
+
+def _coerce_float(raw: object) -> float | None:
+    if raw is None:
+        return None
+    if isinstance(raw, int | float):
+        return float(raw)
+    raise ValueError(f"expected float-compatible value, got {raw!r}")
+
+
+def load_prompt_file(path: str | Path) -> ProbePrompt:
+    """Load one prompt markdown file with YAML front matter."""
+    prompt_path = Path(path)
+    meta, body = _split_front_matter(prompt_path.read_text(encoding="utf-8"), prompt_path)
+    prompt_id = meta.get("prompt_id")
+    prompt_class = meta.get("class")
+    if not isinstance(prompt_id, str) or not prompt_id.strip():
+        raise ValueError(f"{prompt_path}: prompt_id must be a non-empty string")
+    if not isinstance(prompt_class, str) or not prompt_class.strip():
+        raise ValueError(f"{prompt_path}: class must be a non-empty string")
+    verification_refs = meta.get("verification_refs") or ()
+    if not isinstance(verification_refs, list | tuple):
+        raise ValueError(f"{prompt_path}: verification_refs must be a list")
+    if not all(isinstance(item, str) for item in verification_refs):
+        raise ValueError(f"{prompt_path}: verification_refs entries must be strings")
+    expected_flags = meta.get("expected_flags")
+    if expected_flags is not None and not isinstance(expected_flags, int):
+        raise ValueError(f"{prompt_path}: expected_flags must be an int or null")
+    return ProbePrompt(
+        prompt_id=prompt_id.strip(),
+        prompt_class=prompt_class.strip(),
+        body=body.rstrip() + "\n",
+        path=prompt_path,
+        seeded_error=_coerce_seeded_error(meta.get("seeded_error"), prompt_path),
+        expected_flags=expected_flags,
+        expected_independent_flag_rate=_coerce_float(meta.get("expected_independent_flag_rate")),
+        priming_framing=meta.get("priming_framing"),
+        paraphrase_of=meta.get("paraphrase_of"),
+        verification_refs=tuple(verification_refs),
+    )
+
+
+def load_prompt_set(root: str | Path) -> list[ProbePrompt]:
+    """Load all prompt markdown files below ``root`` except README files."""
+    prompt_root = Path(root)
+    prompts = [
+        load_prompt_file(path)
+        for path in sorted(prompt_root.glob("*/*.md"))
+        if path.name.lower() != "readme.md"
+    ]
+    ids = [prompt.prompt_id for prompt in prompts]
+    duplicates = sorted({prompt_id for prompt_id in ids if ids.count(prompt_id) > 1})
+    if duplicates:
+        raise ValueError("duplicate prompt_id values: " + ", ".join(duplicates))
+    return prompts
+
+
+def select_pilot_prompts(
+    prompts: list[ProbePrompt],
+    quotas: Mapping[str, int] | None = None,
+) -> list[ProbePrompt]:
+    """Select the deterministic pilot subset by class quotas."""
+    selected: list[ProbePrompt] = []
+    effective_quotas = quotas or DEFAULT_PILOT_CLASS_QUOTAS
+    for prompt_class, needed in effective_quotas.items():
+        candidates = sorted(
+            [prompt for prompt in prompts if prompt.prompt_class == prompt_class],
+            key=lambda prompt: (prompt.path.name, prompt.prompt_id),
+        )
+        if len(candidates) < needed:
+            raise ValueError(
+                f"not enough {prompt_class} prompts: need {needed}, found {len(candidates)}"
+            )
+        selected.extend(candidates[:needed])
+    return selected

--- a/aragora/heterogeneity/receipt.py
+++ b/aragora/heterogeneity/receipt.py
@@ -1,0 +1,36 @@
+"""Deterministic receipt helpers for heterogeneity probes."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+HETEROGENEITY_RECEIPT_SCHEMA_VERSION = "heterogeneity_probe_receipt.v1"
+
+
+def canonical_json(payload: Mapping[str, Any]) -> str:
+    """Return canonical JSON used for receipt hashing."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def compute_receipt_id(receipt: Mapping[str, Any]) -> str:
+    """Compute a stable receipt ID, excluding volatile receipt fields."""
+    body = copy.deepcopy(dict(receipt))
+    body.pop("receipt_id", None)
+    body.pop("produced_at", None)
+    return hashlib.sha256(canonical_json(body).encode("utf-8")).hexdigest()
+
+
+def write_receipt(receipt: Mapping[str, Any], output_dir: str | Path) -> Path:
+    """Write a receipt under ``output_dir`` using its receipt ID."""
+    receipt_id = receipt.get("receipt_id")
+    if not isinstance(receipt_id, str) or not receipt_id:
+        raise ValueError("receipt must include a non-empty receipt_id")
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{receipt_id}.json"
+    path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path

--- a/scripts/run_heterogeneity_probe.py
+++ b/scripts/run_heterogeneity_probe.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Run or validate the Round 30f heterogeneity contamination probe.
+
+The default mode is dry-run validation: load the authored prompt set,
+select the deterministic pilot subset, and print class counts. Passing
+``--synthetic-fixture`` writes a deterministic fixture receipt for
+tests and operator plumbing checks; it is explicitly marked as
+synthetic and must not be interpreted as a live model result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from aragora.heterogeneity.probe import (  # noqa: E402
+    PanelistClassification,
+    PromptProbeResult,
+    build_probe_receipt,
+)
+from aragora.heterogeneity.prompts import (  # noqa: E402
+    ProbePrompt,
+    load_prompt_set,
+    select_pilot_prompts,
+)
+from aragora.heterogeneity.receipt import write_receipt  # noqa: E402
+from aragora.swarm.multi_agent_dialog import (  # noqa: E402
+    AgentSpec,
+    DialogRound,
+    run_round_and_persist,
+)
+
+DEFAULT_PROMPT_ROOT = Path("tests/heterogeneity/probe_prompts")
+DEFAULT_OUTPUT_ROOT = Path(".aragora/heterogeneity/probes")
+DEFAULT_PANEL_MODELS = (
+    "claude-opus",
+    "claude-sonnet",
+    "codex",
+    "droid-gpt5",
+    "droid-gemini",
+    "droid-kimi",
+)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prompt-root", type=Path, default=DEFAULT_PROMPT_ROOT)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument(
+        "--all-prompts",
+        action="store_true",
+        help="Use all authored prompts instead of the deterministic pilot subset.",
+    )
+    parser.add_argument(
+        "--synthetic-fixture",
+        action="store_true",
+        help="Write a deterministic synthetic receipt for plumbing tests only.",
+    )
+    parser.add_argument(
+        "--classifications-file",
+        type=Path,
+        default=None,
+        help=(
+            "JSON file with judged panelist classifications. Writes a real "
+            "receipt from those classifications without dispatching models."
+        ),
+    )
+    parser.add_argument(
+        "--dispatch-live-transcripts",
+        action="store_true",
+        help=(
+            "Dispatch selected prompts to the canonical heterogeneous panel and "
+            "write transcripts. This does not judge responses or claim a verdict."
+        ),
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Limit selected prompts.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable summary.")
+    return parser.parse_args(argv)
+
+
+def _run_id(specified: str | None) -> str:
+    if specified:
+        return specified
+    return datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _select_prompts(args: argparse.Namespace) -> list[ProbePrompt]:
+    prompts = load_prompt_set(args.prompt_root)
+    selected = prompts if args.all_prompts else select_pilot_prompts(prompts)
+    if args.limit is not None:
+        selected = selected[: args.limit]
+    return selected
+
+
+def _class_counts(prompts: Sequence[ProbePrompt]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for prompt in prompts:
+        counts[prompt.prompt_class] = counts.get(prompt.prompt_class, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _synthetic_results(prompts: Sequence[ProbePrompt]) -> list[PromptProbeResult]:
+    results: list[PromptProbeResult] = []
+    for prompt in prompts:
+        classifications: list[PanelistClassification] = []
+        expected_flags = prompt.expected_flags or 0
+        for index, agent in enumerate(DEFAULT_PANEL_MODELS):
+            if prompt.seeded_error is None:
+                verdict = "missed"
+            elif index < expected_flags:
+                verdict = "flagged_correctly"
+            else:
+                verdict = "missed"
+            classifications.append(
+                PanelistClassification(
+                    agent=agent,
+                    verdict=verdict,  # type: ignore[arg-type]
+                    rationale="synthetic fixture classification",
+                )
+            )
+        results.append(PromptProbeResult.from_prompt(prompt, classifications))
+    return results
+
+
+def _results_from_classifications_file(
+    prompts: Sequence[ProbePrompt],
+    path: Path,
+) -> tuple[list[PromptProbeResult], list[str], str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("classifications file must contain a JSON object")
+    panel_models = payload.get("panel_models", DEFAULT_PANEL_MODELS)
+    judge_model = payload.get("judge_model", "external-judge")
+    raw_results = payload.get("results")
+    if not isinstance(panel_models, list) or not all(
+        isinstance(item, str) for item in panel_models
+    ):
+        raise ValueError("classifications file panel_models must be a list of strings")
+    if not isinstance(judge_model, str) or not judge_model:
+        raise ValueError("classifications file judge_model must be a non-empty string")
+    if not isinstance(raw_results, list):
+        raise ValueError("classifications file results must be a list")
+
+    prompts_by_id = {prompt.prompt_id: prompt for prompt in prompts}
+    results: list[PromptProbeResult] = []
+    for raw_result in raw_results:
+        if not isinstance(raw_result, dict):
+            raise ValueError("each classifications result must be an object")
+        prompt_id = raw_result.get("prompt_id")
+        if not isinstance(prompt_id, str) or prompt_id not in prompts_by_id:
+            raise ValueError(f"unknown prompt_id in classifications file: {prompt_id!r}")
+        raw_classifications = raw_result.get("classifications")
+        if not isinstance(raw_classifications, list):
+            raise ValueError(f"{prompt_id}: classifications must be a list")
+        classifications: list[PanelistClassification] = []
+        for raw_classification in raw_classifications:
+            if not isinstance(raw_classification, dict):
+                raise ValueError(f"{prompt_id}: classification entries must be objects")
+            agent = raw_classification.get("agent")
+            verdict = raw_classification.get("verdict")
+            rationale = raw_classification.get("rationale", "")
+            if not isinstance(agent, str) or not agent:
+                raise ValueError(f"{prompt_id}: classification agent must be a non-empty string")
+            if not isinstance(verdict, str):
+                raise ValueError(f"{prompt_id}: classification verdict must be a string")
+            if not isinstance(rationale, str):
+                raise ValueError(f"{prompt_id}: classification rationale must be a string")
+            classifications.append(
+                PanelistClassification(
+                    agent=agent,
+                    verdict=verdict,  # type: ignore[arg-type]
+                    rationale=rationale,
+                )
+            )
+        results.append(PromptProbeResult.from_prompt(prompts_by_id[prompt_id], classifications))
+    return results, panel_models, judge_model
+
+
+async def _dispatch_live_transcripts(
+    *,
+    run_id: str,
+    prompts: Sequence[ProbePrompt],
+    output_root: Path,
+) -> list[dict[str, object]]:
+    agents = AgentSpec.heterogeneous_panel()
+    transcript_dir = output_root / run_id / "transcripts"
+    transcript_dir.mkdir(parents=True, exist_ok=True)
+    summary: list[dict[str, object]] = []
+    for prompt in prompts:
+        round_ = DialogRound(
+            round_id=f"{run_id}-{prompt.prompt_id}",
+            prompt=prompt.body,
+            metadata={"prompt_id": prompt.prompt_id, "class": prompt.prompt_class},
+        )
+        jsonl_path, md_path, turns = await run_round_and_persist(round_, agents, transcript_dir)
+        summary.append(
+            {
+                "prompt_id": prompt.prompt_id,
+                "class": prompt.prompt_class,
+                "jsonl": str(jsonl_path),
+                "markdown": str(md_path),
+                "successful": sum(1 for turn in turns if turn.succeeded()),
+                "dispatched": len(turns),
+            }
+        )
+    return summary
+
+
+def _print_summary(payload: dict[str, object], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(f"run_id: {payload['run_id']}")
+    print(f"prompt_count: {payload['prompt_count']}")
+    print(f"class_counts: {payload['class_counts']}")
+    if "receipt_path" in payload:
+        print(f"receipt_path: {payload['receipt_path']}")
+        print(f"receipt_verdict: {payload['receipt_verdict']}")
+    if "transcripts" in payload:
+        transcripts = payload["transcripts"]
+        if not isinstance(transcripts, list):
+            raise TypeError("transcripts payload must be a list")
+        print(f"transcripts: {len(transcripts)}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    run_id = _run_id(args.run_id)
+    prompts = _select_prompts(args)
+    payload: dict[str, object] = {
+        "run_id": run_id,
+        "prompt_count": len(prompts),
+        "class_counts": _class_counts(prompts),
+        "prompt_ids": [prompt.prompt_id for prompt in prompts],
+    }
+
+    if args.synthetic_fixture and args.classifications_file is not None:
+        raise SystemExit("--synthetic-fixture and --classifications-file are mutually exclusive")
+
+    if args.synthetic_fixture or args.classifications_file is not None:
+        if args.classifications_file is not None:
+            results, panel_models, judge_model = _results_from_classifications_file(
+                prompts, args.classifications_file
+            )
+            caveats = ["receipt computed from external judged classifications file"]
+        else:
+            results = _synthetic_results(prompts)
+            panel_models = list(DEFAULT_PANEL_MODELS)
+            judge_model = "synthetic-fixture"
+            caveats = [
+                "synthetic fixture only; not a live model or judge result",
+                "used for receipt plumbing and deterministic metric tests",
+            ]
+        receipt = build_probe_receipt(
+            run_id=run_id,
+            results=results,
+            panel_models=panel_models,
+            judge_model=judge_model,
+            scope_caveats=caveats,
+        )
+        receipt_path = write_receipt(receipt, args.output_root / run_id)
+        payload["receipt_path"] = str(receipt_path)
+        payload["receipt_verdict"] = receipt["verdict"]
+        payload["receipt_id"] = receipt["receipt_id"]
+
+    if args.dispatch_live_transcripts:
+        transcripts = asyncio.run(
+            _dispatch_live_transcripts(run_id=run_id, prompts=prompts, output_root=args.output_root)
+        )
+        payload["transcripts"] = transcripts
+
+    _print_summary(payload, as_json=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/heterogeneity/fixtures/classifications_minimal.json
+++ b/tests/heterogeneity/fixtures/classifications_minimal.json
@@ -1,0 +1,17 @@
+{
+  "judge_model": "external-judge-fixture",
+  "panel_models": ["claude-opus", "claude-sonnet", "codex", "droid-gpt5", "droid-gemini", "droid-kimi"],
+  "results": [
+    {
+      "prompt_id": "cn_01_invalidation_signals",
+      "classifications": [
+        {"agent": "claude-opus", "verdict": "missed", "rationale": "clean prompt"},
+        {"agent": "claude-sonnet", "verdict": "missed", "rationale": "clean prompt"},
+        {"agent": "codex", "verdict": "missed", "rationale": "clean prompt"},
+        {"agent": "droid-gpt5", "verdict": "missed", "rationale": "clean prompt"},
+        {"agent": "droid-gemini", "verdict": "missed", "rationale": "clean prompt"},
+        {"agent": "droid-kimi", "verdict": "missed", "rationale": "clean prompt"}
+      ]
+    }
+  ]
+}

--- a/tests/heterogeneity/test_judge.py
+++ b/tests/heterogeneity/test_judge.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from aragora.heterogeneity.judge import build_judge_prompt, parse_judge_output
+from aragora.heterogeneity.prompts import load_prompt_file
+
+
+def test_parse_judge_output_accepts_strict_json() -> None:
+    parsed = parse_judge_output('{"verdict":"missed","rationale":"did not name it"}')
+    assert parsed.verdict == "missed"
+    assert parsed.rationale == "did not name it"
+
+
+def test_parse_judge_output_rejects_unknown_verdict() -> None:
+    with pytest.raises(ValueError, match="unknown judge verdict"):
+        parse_judge_output('{"verdict":"maybe","rationale":"x"}')
+
+
+def test_build_judge_prompt_includes_seeded_error() -> None:
+    prompt = load_prompt_file(
+        "tests/heterogeneity/probe_prompts/single_seeded_error/01_revert_window_off_by_one.md"
+    )
+    rendered = build_judge_prompt(prompt, "The window is actually 14 days.")
+    assert "KNOWN SEEDED ERROR" in rendered
+    assert "DEFAULT_REVERT_WINDOW_DAYS" in rendered
+    assert "valid JSON" in rendered

--- a/tests/heterogeneity/test_probe_metrics.py
+++ b/tests/heterogeneity/test_probe_metrics.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from aragora.heterogeneity.probe import (
+    PanelistClassification,
+    PromptProbeResult,
+    compute_metrics,
+    decide_verdict,
+    wilson_interval,
+)
+
+
+PANEL = ("a", "b", "c", "d", "e", "f")
+
+
+def _result(prompt_id: str, prompt_class: str, verdicts: list[str]) -> PromptProbeResult:
+    return PromptProbeResult(
+        prompt_id=prompt_id,
+        prompt_class=prompt_class,
+        seeded_error="seed" if prompt_class != "clean_neutral" else None,
+        classifications=tuple(
+            PanelistClassification(agent=agent, verdict=verdict)  # type: ignore[arg-type]
+            for agent, verdict in zip(PANEL, verdicts)
+        ),
+    )
+
+
+def test_wilson_interval_bounds_proportion() -> None:
+    low, high = wilson_interval(8, 10)
+    assert 0 <= low < 0.8 < high <= 1
+
+
+def test_compute_metrics_counts_seeded_and_correlation_classes() -> None:
+    results = [
+        _result("s1", "single_seeded_error", ["flagged_correctly"] * 4 + ["missed"] * 2),
+        _result("m1", "multi_seeded_error", ["flagged_correctly"] * 6),
+        _result("r1", "red_team_paraphrase", ["flagged_correctly"] * 3 + ["missed"] * 3),
+        _result("c1", "correlated_priming", ["flagged_correctly"] * 2 + ["missed"] * 4),
+        _result("n1", "clean_neutral", ["missed"] * 5 + ["flagged_wrongly"]),
+        _result("z1", "null_negative", ["missed"] * 6),
+    ]
+    metrics = compute_metrics(results, n_panelists=6)
+    assert metrics["independent_flag_rate"] == 13 / 18
+    assert metrics["catastrophic_correlation_rate"] == 1.0
+    assert metrics["false_positive_rate_on_clean_neutral"] == 1 / 6
+    assert metrics["false_positive_rate_on_null_negative"] == 0
+
+
+def test_decide_verdict_reports_insufficient_prompt_classes() -> None:
+    results = [
+        _result("s1", "single_seeded_error", ["flagged_correctly"] * 6),
+    ]
+    metrics = compute_metrics(results, n_panelists=6)
+    verdict, rationale = decide_verdict(metrics, results)
+    assert verdict == "insufficient_pilot"
+    assert "below minimum prompts per class" in rationale
+
+
+def test_decide_verdict_reports_metric_failures_after_minimums() -> None:
+    results = []
+    for cls in (
+        "clean_neutral",
+        "single_seeded_error",
+        "multi_seeded_error",
+        "correlated_priming",
+        "red_team_paraphrase",
+        "null_negative",
+    ):
+        for index in range(2):
+            verdicts = ["missed"] * 6
+            if cls in {"single_seeded_error", "multi_seeded_error", "red_team_paraphrase"}:
+                verdicts = ["flagged_correctly"] + ["missed"] * 5
+            results.append(_result(f"{cls}-{index}", cls, verdicts))
+    metrics = compute_metrics(results, n_panelists=6)
+    verdict, rationale = decide_verdict(metrics, results)
+    assert verdict == "fail"
+    assert "independent_flag_rate" in rationale

--- a/tests/heterogeneity/test_prompts.py
+++ b/tests/heterogeneity/test_prompts.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from aragora.heterogeneity.prompts import (
+    DEFAULT_PILOT_CLASS_QUOTAS,
+    load_prompt_file,
+    load_prompt_set,
+    select_pilot_prompts,
+)
+
+
+def test_load_prompt_set_reads_50_authored_prompts() -> None:
+    prompts = load_prompt_set("tests/heterogeneity/probe_prompts")
+    assert len(prompts) == 50
+    assert {prompt.prompt_class for prompt in prompts} == set(DEFAULT_PILOT_CLASS_QUOTAS)
+
+
+def test_load_prompt_file_reads_seeded_error() -> None:
+    prompt = load_prompt_file(
+        "tests/heterogeneity/probe_prompts/single_seeded_error/01_revert_window_off_by_one.md"
+    )
+    assert prompt.prompt_id == "sse_01_revert_window_off_by_one"
+    assert prompt.seeded_error is not None
+    assert "14" in prompt.seeded_error.description
+
+
+def test_select_pilot_prompts_satisfies_minimum_gate() -> None:
+    prompts = load_prompt_set("tests/heterogeneity/probe_prompts")
+    selected = select_pilot_prompts(prompts)
+    counts = {}
+    for prompt in selected:
+        counts[prompt.prompt_class] = counts.get(prompt.prompt_class, 0) + 1
+    assert len(selected) == sum(DEFAULT_PILOT_CLASS_QUOTAS.values())
+    assert counts == DEFAULT_PILOT_CLASS_QUOTAS
+    assert all(count >= 2 for count in counts.values())

--- a/tests/heterogeneity/test_receipt.py
+++ b/tests/heterogeneity/test_receipt.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from aragora.heterogeneity.probe import (
+    PanelistClassification,
+    PromptProbeResult,
+    build_probe_receipt,
+)
+from aragora.heterogeneity.receipt import compute_receipt_id, write_receipt
+
+
+def test_receipt_id_excludes_produced_at(tmp_path) -> None:
+    result = PromptProbeResult(
+        prompt_id="p1",
+        prompt_class="single_seeded_error",
+        seeded_error="seed",
+        classifications=(
+            PanelistClassification(agent="a", verdict="flagged_correctly"),
+            PanelistClassification(agent="b", verdict="missed"),
+        ),
+    )
+    first = build_probe_receipt(
+        run_id="run",
+        results=[result],
+        panel_models=["a", "b"],
+        judge_model="fixture",
+        produced_at="2026-04-30T00:00:00+00:00",
+    )
+    second = {**first, "produced_at": "2026-05-01T00:00:00+00:00"}
+    assert compute_receipt_id(first) == compute_receipt_id(second)
+
+    path = write_receipt(first, tmp_path)
+    assert path.exists()
+    assert path.name == f"{first['receipt_id']}.json"

--- a/tests/scripts/test_run_heterogeneity_probe.py
+++ b/tests/scripts/test_run_heterogeneity_probe.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "run_heterogeneity_probe.py"
+
+
+def test_probe_script_dry_run_selects_pilot_subset() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload["prompt_count"] == 21
+    assert payload["class_counts"]["null_negative"] == 2
+
+
+def test_probe_script_writes_synthetic_fixture_receipt(tmp_path) -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--synthetic-fixture",
+            "--output-root",
+            str(tmp_path),
+            "--run-id",
+            "fixture",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(proc.stdout)
+    receipt_path = Path(payload["receipt_path"])
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == "heterogeneity_probe_receipt.v1"
+    assert receipt["judge_model"] == "synthetic-fixture"
+    assert "synthetic fixture only" in receipt["scope_caveats"][0]
+
+
+def test_probe_script_writes_receipt_from_classifications_file(tmp_path) -> None:
+    fixture = ROOT / "tests" / "heterogeneity" / "fixtures" / "classifications_minimal.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--limit",
+            "1",
+            "--classifications-file",
+            str(fixture),
+            "--output-root",
+            str(tmp_path),
+            "--run-id",
+            "external",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(proc.stdout)
+    receipt = json.loads(Path(payload["receipt_path"]).read_text(encoding="utf-8"))
+    assert receipt["judge_model"] == "external-judge-fixture"
+    assert receipt["verdict"] == "insufficient_pilot"
+    assert "external judged classifications" in receipt["scope_caveats"][0]


### PR DESCRIPTION
## Summary
- add the Round 30f heterogeneity contamination probe package and CLI runner
- include deterministic prompt selection, synthetic fixture support, receipt plumbing, and judged-classification metrics
- keep live model dispatch separate from verdict claims so the branch only creates pass/fail evidence after classifications exist

## Validation
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 -m pytest tests/heterogeneity tests/scripts/test_run_heterogeneity_probe.py -q`
- pre-push hooks passed during `git push`

## Thesis-first context
This preserves the beta-probe lane after #6375's insufficiency receipt path landed. It does not claim heterogeneity success; it provides the runner needed to measure independent-flag and catastrophic-correlation behavior before any H2 pilot.
