### PR TITLE
docs(status): refresh H1 threshold and promotion readiness

### DIFF
--- a/docs/status/H1_01_REV4_PROMOTION_READINESS.md
+++ b/docs/status/H1_01_REV4_PROMOTION_READINESS.md
@@ -1,13 +1,13 @@
 # H1-01 Rev-4 Promotion Readiness
 
-Last updated: 2026-04-30T16:01:46Z
+Last updated: 2026-04-30T18:57:38Z
 
 This is the operator-facing readiness surface for promoting the staged rev-4 benchmark corpus into the canonical B0 truth loop.
 
 ## Verdict
 
-- Status: `needs_more_dispatch_evidence`
-- Decision: Not ready: needs 3 more dispatched issue(s) to reach the 15-issue promotion floor.
+- Status: `promotion_ready`
+- Decision: Ready to promote the first canonical rev-4 slice.
 - Staging corpus: `tests/benchmarks/corpus_rev4.json`
 - Metrics source: `.aragora/overnight/boss_metrics.jsonl`
 - Promotion target: `docs/benchmarks/corpus.json`
@@ -25,15 +25,15 @@ This is the operator-facing readiness surface for promoting the staged rev-4 ben
 | Metric | Value |
 | --- | --- |
 | Dispatch floor for first canonical slice | 15 |
-| Staged issues with dispatch evidence (any source) | 12 |
-| Staged issues still missing dispatch evidence | 21 |
-| Additional dispatches needed | 3 |
+| Staged issues with dispatch evidence (any source) | 15 |
+| Staged issues still missing dispatch evidence | 18 |
+| Additional dispatches needed | 0 |
 | ...via metrics ledger only | 12 |
-| ...via merged/open boss-harvest PR only | 0 |
+| ...via merged/open boss-harvest PR only | 3 |
 
 ## Next Dispatch Targets
 
-`#5126`, `#5128`, `#5130`
+`#5188`, `#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`
 
 ## Execution-Class Coverage
 
@@ -41,18 +41,18 @@ This is the operator-facing readiness surface for promoting the staged rev-4 ben
 | --- | ---: | ---: | ---: |
 | `docs_reconciliation` | 1 | 2 | 1 |
 | `exception_narrowing` | 0 | 8 | 8 |
-| `missing_test_coverage` | 6 | 10 | 4 |
+| `missing_test_coverage` | 9 | 10 | 1 |
 | `silent_exception_replacement` | 0 | 8 | 8 |
 | `small_refactor` | 3 | 3 | 0 |
 | `validation_tightening` | 2 | 2 | 0 |
 
 ## Dispatched Issues
 
-`#5176`, `#5180`, `#5185`, `#5187`, `#5197`, `#5198`, `#5426`, `#5427`, `#5428`, `#5764`, `#5765`, `#5844`
+`#5126`, `#5128`, `#5130`, `#5176`, `#5180`, `#5185`, `#5187`, `#5197`, `#5198`, `#5426`, `#5427`, `#5428`, `#5764`, `#5765`, `#5844`
 
 ## Missing Evidence
 
-`#5126`, `#5128`, `#5130`, `#5188`, `#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`, `#5810`, `#5811`, `#5812`, `#5821`, `#5823`, `#5825`, `#5883`
+`#5188`, `#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`, `#5810`, `#5811`, `#5812`, `#5821`, `#5823`, `#5825`, `#5883`
 
 ## Promotion Rule
 

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -67,7 +67,7 @@ Readiness receipt: [2026-04-25-rc1-to-stable-receipt.md](2026-04-25-rc1-to-stabl
   - [#6372](https://github.com/synaptent/aragora/issues/6372) auto-handle calibration + drift gating — **CLOSED**
   - [#6373](https://github.com/synaptent/aragora/issues/6373) rolling-window triage metrics — **CLOSED**
   - [#6374](https://github.com/synaptent/aragora/issues/6374) source-of-truth alignment on PR-review path — **CLOSED**
-  - [#6375](https://github.com/synaptent/aragora/issues/6375) empirical threshold grounding — **OPEN** (sole remaining H1 gap)
+  - [#6375](https://github.com/synaptent/aragora/issues/6375) empirical threshold grounding — **CLOSED with insufficiency receipt** (threshold remains placeholder until enough settled decisions accumulate)
 
 ### What Recently Landed On `main`
 
@@ -85,9 +85,9 @@ The April merge stream maps directly to the thesis and review-queue execution pa
 
 ### Current Frontier
 
-The frontier is now (updated 2026-04-25 after #6372/#6373/#6374 closed):
+The frontier is now (updated 2026-04-30 after #6375's insufficiency receipt path landed):
 
-- **ground threshold claims empirically** — close [#6375](https://github.com/synaptent/aragora/issues/6375); this is the sole remaining H1 implementation gap. Per thesis Commitment 3, the 5% auto-handle invalidation cap must move from placeholder to a measured baseline + safety margin from accumulated settlement data.
+- **collect enough settlement evidence to ground threshold claims empirically** — [#6375](https://github.com/synaptent/aragora/issues/6375) is closed as an implementation gap because the event-source adapter, scheduler, CLI, and receipt path landed, but the latest receipt is `insufficiency_receipt.v1` with `sample_count=0`. Per thesis Commitment 3, the 5% auto-handle invalidation cap remains a placeholder until a future non-insufficient receipt measures baseline + safety margin from accumulated settlement data.
 - **keep queue growth bounded** — continue the single-slice cadence in the PDB lane rather than opening large successor chains in parallel
 - **continue post-v2.9.0 threshold grounding** — v2.9.0 was tagged on 2026-04-25 after the empirical threshold framework substrate landed; #6375 remains the post-release work to convert that substrate into measured baselines and operating thresholds.
 
@@ -96,7 +96,7 @@ The frontier is now (updated 2026-04-25 after #6372/#6373/#6374 closed):
 The current bounded queue (updated 2026-04-25):
 
 1. ~~merge [#6448](https://github.com/synaptent/aragora/pull/6448) to close [#6372](https://github.com/synaptent/aragora/issues/6372)~~ — **DONE**
-2. close [#6375](https://github.com/synaptent/aragora/issues/6375) using the metrics and calibration substrates above — **active work**
+2. ~~close [#6375](https://github.com/synaptent/aragora/issues/6375) using the metrics and calibration substrates above~~ — **DONE as an insufficiency path; measurement still sample-blocked**
 3. ~~narrow and then close [#6374](https://github.com/synaptent/aragora/issues/6374)~~ — **DONE**
 4. ~~keep refining [#6373](https://github.com/synaptent/aragora/issues/6373) from rolling-window metrics~~ — **DONE** (rolling-window endpoint live)
 5. keep the agent-bridge lane scoped to bounded, observable increments rather than a parallel subsystem explosion
@@ -107,9 +107,9 @@ The strategy document is now [docs/THESIS.md](../THESIS.md).
 The short version on April 21, 2026:
 
 - the project is executing on the thesis in real code, especially in the PDB lane
-- three of four named H1 implementation gaps closed on 2026-04-25; only [#6375](https://github.com/synaptent/aragora/issues/6375) (empirical threshold grounding) remains open
+- the four named H1 implementation gaps are closed, but [#6375](https://github.com/synaptent/aragora/issues/6375) closed truthfully with an insufficiency receipt rather than a measured threshold
 - human settlement remains the controlling boundary
-- the next wins come from closing #6375 (empirical baseline grounding for the 5% auto-handle invalidation cap) and from the bounded-slice discipline that produced the H1 closure burst
+- the next wins come from accumulating settled review-queue receipts until the 5% auto-handle invalidation cap can be replaced by a measured baseline + safety margin, and from the bounded-slice discipline that produced the H1 closure burst
 
 ## March 2026 Sprint — Closed-Loop Backbone, Trust Wedge & Infrastructure
 


### PR DESCRIPTION
## Summary
- refresh H1-01 rev-4 readiness with existing merged boss-harvest PR evidence for #5126/#5128/#5130
- mark the first canonical rev-4 slice as promotion-ready at 15/15 dispatch evidence
- correct status wording for #6375: the implementation gap is closed with an insufficiency receipt, but the 5% threshold remains a placeholder until settled review-queue samples exist

## Validation
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 scripts/render_rev4_promotion_readiness.py --pr-records /tmp/h1-pr-records-5126-5128-5130.json --json` → `promotion_ready 15 0`
- `python3 scripts/measure_invalidation_baseline.py --json` → `insufficiency_receipt.v1 sample_count=0 is_placeholder=true`
- `python3 -m pytest tests/review/test_invalidation_event_source.py tests/review/test_threshold_recalibration.py tests/scripts/test_measure_invalidation_baseline.py -q`

## Notes
This is a status-truth PR only. It does not claim #6375 empirically grounded the threshold; it preserves the current thesis boundary that the threshold remains sample-blocked.
