### PR TITLE
fix(heterogeneity): repair clean control prompt

### DIFF
--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -26,9 +26,9 @@ thresholds:
 summary:
   core: 21
   integrated: 87
-  experimental: 25
+  experimental: 26
   deprecated: 2
-  total: 135
+  total: 136
 
 modules:
   # --- core (21) ---
@@ -45,9 +45,9 @@ modules:
     test_file_count: 118
   - name: cli
     tier: core
-    py_files: 97
+    py_files: 98
     importer_count: 5
-    test_file_count: 106
+    test_file_count: 108
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
@@ -57,14 +57,14 @@ modules:
     override_reason: "Pydantic settings + allowlist — load bearing"
   - name: connectors
     tier: core
-    py_files: 265
+    py_files: 266
     importer_count: 140
-    test_file_count: 255
+    test_file_count: 256
   - name: core
     tier: core
     py_files: 19
     importer_count: 207
-    test_file_count: 194
+    test_file_count: 195
     override_reason: "root type hierarchy + Agent base class"
   - name: db
     tier: core
@@ -76,7 +76,7 @@ modules:
     tier: core
     py_files: 263
     importer_count: 160
-    test_file_count: 594
+    test_file_count: 596
     override_reason: "Arena + DebateProtocol + consensus — mainline flow"
   - name: events
     tier: core
@@ -86,13 +86,13 @@ modules:
   - name: gauntlet
     tier: core
     py_files: 36
-    importer_count: 63
-    test_file_count: 97
+    importer_count: 64
+    test_file_count: 98
   - name: knowledge
     tier: core
-    py_files: 176
-    importer_count: 178
-    test_file_count: 224
+    py_files: 177
+    importer_count: 179
+    test_file_count: 227
   - name: memory
     tier: core
     py_files: 56
@@ -113,7 +113,7 @@ modules:
     tier: core
     py_files: 49
     importer_count: 71
-    test_file_count: 126
+    test_file_count: 125
   - name: ranking
     tier: core
     py_files: 25
@@ -127,9 +127,9 @@ modules:
     test_file_count: 201
   - name: reasoning
     tier: core
-    py_files: 18
-    importer_count: 119
-    test_file_count: 107
+    py_files: 19
+    importer_count: 120
+    test_file_count: 108
   - name: resilience
     tier: core
     py_files: 13
@@ -238,7 +238,7 @@ modules:
     tier: integrated
     py_files: 44
     importer_count: 46
-    test_file_count: 56
+    test_file_count: 57
   - name: coordination
     tier: integrated
     py_files: 11
@@ -256,9 +256,9 @@ modules:
     test_file_count: 11
   - name: epistemic
     tier: integrated
-    py_files: 18
-    importer_count: 1
-    test_file_count: 16
+    py_files: 21
+    importer_count: 2
+    test_file_count: 20
   - name: essay
     tier: integrated
     py_files: 6
@@ -373,8 +373,8 @@ modules:
   - name: markets
     tier: integrated
     py_files: 5
-    importer_count: 4
-    test_file_count: 7
+    importer_count: 6
+    test_file_count: 10
   - name: mcp
     tier: integrated
     py_files: 27
@@ -457,9 +457,9 @@ modules:
     test_file_count: 7
   - name: reputation
     tier: integrated
-    py_files: 7
-    importer_count: 1
-    test_file_count: 8
+    py_files: 10
+    importer_count: 2
+    test_file_count: 12
   - name: review
     tier: integrated
     py_files: 10
@@ -522,9 +522,9 @@ modules:
     test_file_count: 5
   - name: swarm
     tier: integrated
-    py_files: 93
+    py_files: 100
     importer_count: 28
-    test_file_count: 144
+    test_file_count: 153
   - name: templates
     tier: integrated
     py_files: 1
@@ -586,7 +586,7 @@ modules:
     importer_count: 15
     test_file_count: 11
 
-  # --- experimental (25) ---
+  # --- experimental (26) ---
   - name: approvals
     tier: experimental
     py_files: 5
@@ -612,6 +612,11 @@ modules:
     py_files: 1
     importer_count: 2
     test_file_count: 0
+  - name: heterogeneity
+    tier: experimental
+    py_files: 5
+    importer_count: 0
+    test_file_count: 4
   - name: maintenance
     tier: experimental
     py_files: 2
@@ -619,9 +624,9 @@ modules:
     test_file_count: 3
   - name: metrics
     tier: experimental
-    py_files: 2
+    py_files: 4
     importer_count: 1
-    test_file_count: 1
+    test_file_count: 3
   - name: moderation
     tier: experimental
     py_files: 2

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,11 +12,11 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4096` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1928113` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
-| Top-level modules under aragora/ | `135` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5136` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217250` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Python files under aragora/ | `4101` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1928729` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Top-level modules under aragora/ | `136` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
+| Test files (test_*.py under tests/) | `5141` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217268` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `662` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `61` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `816` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `820` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/tests/heterogeneity/probe_prompts/clean_neutral/01_invalidation_signals.md
+++ b/tests/heterogeneity/probe_prompts/clean_neutral/01_invalidation_signals.md
@@ -7,15 +7,16 @@ expected_independent_flag_rate: null
 priming_framing: null
 paraphrase_of: null
 verification_refs:
-  - "aragora/review/invalidation.py:130-148"
+  - "aragora/review/invalidation.py:50-61"
+  - "aragora/review/invalidation.py:141-150"
 ---
 
 The Aragora review-invalidation module declares five canonical signals that count an outcome as invalidated:
 
-1. `revert_within_window` — a `Revert "..."` commit references the merged change within a bounded window.
+1. `revert_within_window` — the merged change was reverted within a bounded window.
 2. `post_merge_incident` — a post-merge incident is attributed to the change.
-3. `human_override_redo` — a human override forced a redo (e.g., re-opened PR with substantive new commits).
-4. `rollback` — an explicit rollback was issued (e.g., feature-flag rollback, infra rollback).
+3. `human_override_redo` — a human override forced a redo (e.g., re-opened PR with substantive new commits, or a follow-up PR explicitly fixes the prior settlement).
+4. `rollback` — an explicit rollback was issued, separate from a clean revert (e.g., feature-flag rollback, infra rollback).
 5. `reopened_pr` — the same PR was reopened after settle.
 
 These signals are exposed as a `frozenset[str]` named `INVALIDATION_SIGNALS`. Tests pin this set so adding a new signal forces an explicit acknowledgement.


### PR DESCRIPTION
## Summary
- repair `cn_01_invalidation_signals`, which a live six-agent smoke found was not actually clean
- remove the over-specific `Revert \"...\"` commit parsing claim from the clean-neutral control prompt
- align verification refs and descriptions with `aragora/review/invalidation.py` docstring/constants

## Validation
- `python3 -m pytest -q tests/heterogeneity/test_prompts.py tests/scripts/test_run_heterogeneity_probe.py tests/heterogeneity/test_judge.py tests/heterogeneity/test_probe_metrics.py tests/heterogeneity/test_receipt.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 scripts/run_heterogeneity_probe.py --limit 1 --json`
- live smoke before patch: 6/6 agents succeeded, 5/6 flagged the control prompt as inaccurate
- live smoke after patch: 6/6 agents succeeded, visible outputs classified the prompt as accurate

## Scope
Prompt-seed repair only. No production code, markets, reputation, H2, or dispatch mutation.