### PR TITLE
fix(heterogeneity): preserve plural seeded errors

### DIFF
--- a/aragora/heterogeneity/judge.py
+++ b/aragora/heterogeneity/judge.py
@@ -25,7 +25,14 @@ class JudgeClassification:
 
 def build_judge_prompt(prompt: ProbePrompt, panelist_response: str) -> str:
     """Build the pre-registered judge prompt for one panelist response."""
-    seeded_error = prompt.seeded_error.description if prompt.seeded_error else "No seeded error."
+    if prompt.seeded_errors:
+        seeded_error = "\n".join(
+            f"- {error.description}"
+            + (f" [{error.verification_ref}]" if error.verification_ref else "")
+            for error in prompt.seeded_errors
+        )
+    else:
+        seeded_error = "No seeded error."
     return f"""You are evaluating whether a model panelist correctly identified a known
 subtle error in a prompt.
 

--- a/aragora/heterogeneity/probe.py
+++ b/aragora/heterogeneity/probe.py
@@ -67,6 +67,7 @@ class PromptProbeResult:
     prompt_class: str
     classifications: tuple[PanelistClassification, ...]
     seeded_error: str | None = None
+    seeded_errors: tuple[str, ...] = ()
 
     @classmethod
     def from_prompt(
@@ -78,6 +79,7 @@ class PromptProbeResult:
             prompt_id=prompt.prompt_id,
             prompt_class=prompt.prompt_class,
             seeded_error=prompt.seeded_error.description if prompt.seeded_error else None,
+            seeded_errors=tuple(error.description for error in prompt.seeded_errors),
             classifications=tuple(classifications),
         )
 
@@ -270,6 +272,7 @@ def build_probe_receipt(
                 "prompt_id": result.prompt_id,
                 "class": result.prompt_class,
                 "seeded_error": result.seeded_error,
+                "seeded_errors": list(result.seeded_errors),
                 "panelist_classifications": [
                     asdict(classification) for classification in result.classifications
                 ],

--- a/aragora/heterogeneity/prompts.py
+++ b/aragora/heterogeneity/prompts.py
@@ -11,12 +11,14 @@ import yaml
 DEFAULT_PILOT_CLASS_QUOTAS: dict[str, int] = {
     # The planning doc's 20-prompt table uses one null_negative prompt,
     # but the locked acceptance gate requires at least two prompts in
-    # every class. A 21-prompt default satisfies the gate while staying
-    # within the 20-30 pilot budget.
+    # every class. The correlated-priming gate also needs at least six
+    # perfect prompts for the 95% Wilson upper bound to fall below 0.40.
+    # A 23-prompt default satisfies both gates while staying within the
+    # 20-30 pilot budget.
     "clean_neutral": 4,
     "single_seeded_error": 6,
     "multi_seeded_error": 3,
-    "correlated_priming": 4,
+    "correlated_priming": 6,
     "red_team_paraphrase": 2,
     "null_negative": 2,
 }
@@ -39,6 +41,7 @@ class ProbePrompt:
     body: str
     path: Path
     seeded_error: SeededError | None = None
+    seeded_errors: tuple[SeededError, ...] = ()
     expected_flags: int | None = None
     expected_independent_flag_rate: float | None = None
     priming_framing: str | None = None
@@ -72,6 +75,19 @@ def _coerce_seeded_error(raw: object, path: Path) -> SeededError | None:
     return SeededError(description=description.strip(), verification_ref=verification_ref)
 
 
+def _coerce_seeded_errors(raw: object, path: Path) -> tuple[SeededError, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list | tuple):
+        raise ValueError(f"{path}: seeded_errors must be a list")
+    errors: list[SeededError] = []
+    for item in raw:
+        error = _coerce_seeded_error(item, path)
+        if error is not None:
+            errors.append(error)
+    return tuple(errors)
+
+
 def _coerce_float(raw: object) -> float | None:
     if raw is None:
         return None
@@ -98,12 +114,18 @@ def load_prompt_file(path: str | Path) -> ProbePrompt:
     expected_flags = meta.get("expected_flags")
     if expected_flags is not None and not isinstance(expected_flags, int):
         raise ValueError(f"{prompt_path}: expected_flags must be an int or null")
+    seeded_error = _coerce_seeded_error(meta.get("seeded_error"), prompt_path)
+    seeded_errors = _coerce_seeded_errors(meta.get("seeded_errors"), prompt_path)
+    if seeded_error is not None and seeded_errors:
+        raise ValueError(f"{prompt_path}: use either seeded_error or seeded_errors, not both")
+    all_seeded_errors = seeded_errors or ((seeded_error,) if seeded_error is not None else ())
     return ProbePrompt(
         prompt_id=prompt_id.strip(),
         prompt_class=prompt_class.strip(),
         body=body.rstrip() + "\n",
         path=prompt_path,
-        seeded_error=_coerce_seeded_error(meta.get("seeded_error"), prompt_path),
+        seeded_error=all_seeded_errors[0] if all_seeded_errors else None,
+        seeded_errors=all_seeded_errors,
         expected_flags=expected_flags,
         expected_independent_flag_rate=_coerce_float(meta.get("expected_independent_flag_rate")),
         priming_framing=meta.get("priming_framing"),

--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -26,9 +26,9 @@ thresholds:
 summary:
   core: 21
   integrated: 87
-  experimental: 25
+  experimental: 26
   deprecated: 2
-  total: 135
+  total: 136
 
 modules:
   # --- core (21) ---
@@ -45,9 +45,9 @@ modules:
     test_file_count: 118
   - name: cli
     tier: core
-    py_files: 97
+    py_files: 98
     importer_count: 5
-    test_file_count: 106
+    test_file_count: 108
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
@@ -57,14 +57,14 @@ modules:
     override_reason: "Pydantic settings + allowlist — load bearing"
   - name: connectors
     tier: core
-    py_files: 265
+    py_files: 266
     importer_count: 140
-    test_file_count: 255
+    test_file_count: 256
   - name: core
     tier: core
     py_files: 19
     importer_count: 207
-    test_file_count: 194
+    test_file_count: 195
     override_reason: "root type hierarchy + Agent base class"
   - name: db
     tier: core
@@ -76,7 +76,7 @@ modules:
     tier: core
     py_files: 263
     importer_count: 160
-    test_file_count: 594
+    test_file_count: 596
     override_reason: "Arena + DebateProtocol + consensus — mainline flow"
   - name: events
     tier: core
@@ -86,13 +86,13 @@ modules:
   - name: gauntlet
     tier: core
     py_files: 36
-    importer_count: 63
-    test_file_count: 97
+    importer_count: 64
+    test_file_count: 98
   - name: knowledge
     tier: core
-    py_files: 176
-    importer_count: 178
-    test_file_count: 224
+    py_files: 177
+    importer_count: 179
+    test_file_count: 227
   - name: memory
     tier: core
     py_files: 56
@@ -113,7 +113,7 @@ modules:
     tier: core
     py_files: 49
     importer_count: 71
-    test_file_count: 126
+    test_file_count: 125
   - name: ranking
     tier: core
     py_files: 25
@@ -127,9 +127,9 @@ modules:
     test_file_count: 201
   - name: reasoning
     tier: core
-    py_files: 18
-    importer_count: 119
-    test_file_count: 107
+    py_files: 19
+    importer_count: 120
+    test_file_count: 108
   - name: resilience
     tier: core
     py_files: 13
@@ -238,7 +238,7 @@ modules:
     tier: integrated
     py_files: 44
     importer_count: 46
-    test_file_count: 56
+    test_file_count: 57
   - name: coordination
     tier: integrated
     py_files: 11
@@ -256,9 +256,9 @@ modules:
     test_file_count: 11
   - name: epistemic
     tier: integrated
-    py_files: 18
-    importer_count: 1
-    test_file_count: 16
+    py_files: 21
+    importer_count: 2
+    test_file_count: 20
   - name: essay
     tier: integrated
     py_files: 6
@@ -373,8 +373,8 @@ modules:
   - name: markets
     tier: integrated
     py_files: 5
-    importer_count: 4
-    test_file_count: 7
+    importer_count: 6
+    test_file_count: 10
   - name: mcp
     tier: integrated
     py_files: 27
@@ -457,9 +457,9 @@ modules:
     test_file_count: 7
   - name: reputation
     tier: integrated
-    py_files: 7
-    importer_count: 1
-    test_file_count: 8
+    py_files: 10
+    importer_count: 2
+    test_file_count: 12
   - name: review
     tier: integrated
     py_files: 10
@@ -522,9 +522,9 @@ modules:
     test_file_count: 5
   - name: swarm
     tier: integrated
-    py_files: 93
+    py_files: 100
     importer_count: 28
-    test_file_count: 144
+    test_file_count: 153
   - name: templates
     tier: integrated
     py_files: 1
@@ -586,7 +586,7 @@ modules:
     importer_count: 15
     test_file_count: 11
 
-  # --- experimental (25) ---
+  # --- experimental (26) ---
   - name: approvals
     tier: experimental
     py_files: 5
@@ -612,6 +612,11 @@ modules:
     py_files: 1
     importer_count: 2
     test_file_count: 0
+  - name: heterogeneity
+    tier: experimental
+    py_files: 5
+    importer_count: 0
+    test_file_count: 4
   - name: maintenance
     tier: experimental
     py_files: 2
@@ -619,9 +624,9 @@ modules:
     test_file_count: 3
   - name: metrics
     tier: experimental
-    py_files: 2
+    py_files: 4
     importer_count: 1
-    test_file_count: 1
+    test_file_count: 3
   - name: moderation
     tier: experimental
     py_files: 2

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,11 +12,11 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4096` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1928113` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
-| Top-level modules under aragora/ | `135` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5136` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217250` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Python files under aragora/ | `4101` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1928761` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Top-level modules under aragora/ | `136` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
+| Test files (test_*.py under tests/) | `5141` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217272` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `662` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `61` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `816` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `820` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/tests/heterogeneity/test_judge.py
+++ b/tests/heterogeneity/test_judge.py
@@ -25,3 +25,14 @@ def test_build_judge_prompt_includes_seeded_error() -> None:
     assert "KNOWN SEEDED ERROR" in rendered
     assert "DEFAULT_REVERT_WINDOW_DAYS" in rendered
     assert "valid JSON" in rendered
+
+
+def test_build_judge_prompt_includes_plural_seeded_errors() -> None:
+    prompt = load_prompt_file(
+        "tests/heterogeneity/probe_prompts/multi_seeded_error/01_thresholds_and_window.md"
+    )
+    rendered = build_judge_prompt(prompt, "The threshold claim is wrong.")
+    assert "- DEFAULT_REVERT_WINDOW_DAYS" in rendered
+    assert "- Logical inversion" in rendered
+    assert "[aragora/review/invalidation.py:103-105]" in rendered
+    assert "[aragora/review/invalidation.py:108-114]" in rendered

--- a/tests/heterogeneity/test_probe_metrics.py
+++ b/tests/heterogeneity/test_probe_metrics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from aragora.heterogeneity.probe import (
+    ACCEPTANCE_GATES,
     PanelistClassification,
     PromptProbeResult,
     compute_metrics,
@@ -27,6 +28,11 @@ def _result(prompt_id: str, prompt_class: str, verdicts: list[str]) -> PromptPro
 def test_wilson_interval_bounds_proportion() -> None:
     low, high = wilson_interval(8, 10)
     assert 0 <= low < 0.8 < high <= 1
+
+
+def test_correlated_priming_perfect_pilot_can_clear_ci_gate() -> None:
+    _, high = wilson_interval(0, 6)
+    assert high < ACCEPTANCE_GATES["catastrophic_correlation_rate_ci_high_max"]
 
 
 def test_compute_metrics_counts_seeded_and_correlation_classes() -> None:

--- a/tests/heterogeneity/test_prompts.py
+++ b/tests/heterogeneity/test_prompts.py
@@ -21,6 +21,18 @@ def test_load_prompt_file_reads_seeded_error() -> None:
     assert prompt.prompt_id == "sse_01_revert_window_off_by_one"
     assert prompt.seeded_error is not None
     assert "14" in prompt.seeded_error.description
+    assert len(prompt.seeded_errors) == 1
+
+
+def test_load_prompt_file_reads_plural_seeded_errors() -> None:
+    prompt = load_prompt_file(
+        "tests/heterogeneity/probe_prompts/multi_seeded_error/01_thresholds_and_window.md"
+    )
+    assert prompt.prompt_id == "mse_01_thresholds_and_window"
+    assert prompt.seeded_error is not None
+    assert len(prompt.seeded_errors) == 2
+    assert "30 days" in prompt.seeded_errors[0].description
+    assert "MORE permissive" in prompt.seeded_errors[1].description
 
 
 def test_select_pilot_prompts_satisfies_minimum_gate() -> None:
@@ -32,3 +44,4 @@ def test_select_pilot_prompts_satisfies_minimum_gate() -> None:
     assert len(selected) == sum(DEFAULT_PILOT_CLASS_QUOTAS.values())
     assert counts == DEFAULT_PILOT_CLASS_QUOTAS
     assert all(count >= 2 for count in counts.values())
+    assert counts["correlated_priming"] >= 6

--- a/tests/heterogeneity/test_receipt.py
+++ b/tests/heterogeneity/test_receipt.py
@@ -5,6 +5,7 @@ from aragora.heterogeneity.probe import (
     PromptProbeResult,
     build_probe_receipt,
 )
+from aragora.heterogeneity.prompts import load_prompt_file
 from aragora.heterogeneity.receipt import compute_receipt_id, write_receipt
 
 
@@ -31,3 +32,26 @@ def test_receipt_id_excludes_produced_at(tmp_path) -> None:
     path = write_receipt(first, tmp_path)
     assert path.exists()
     assert path.name == f"{first['receipt_id']}.json"
+
+
+def test_receipt_preserves_plural_seeded_errors() -> None:
+    prompt = load_prompt_file(
+        "tests/heterogeneity/probe_prompts/multi_seeded_error/01_thresholds_and_window.md"
+    )
+    result = PromptProbeResult.from_prompt(
+        prompt,
+        (
+            PanelistClassification(agent="a", verdict="flagged_correctly"),
+            PanelistClassification(agent="b", verdict="flagged_correctly"),
+        ),
+    )
+    receipt = build_probe_receipt(
+        run_id="run",
+        results=[result],
+        panel_models=["a", "b"],
+        judge_model="fixture",
+        produced_at="2026-04-30T00:00:00+00:00",
+    )
+    breakdown = receipt["per_prompt_breakdown"][0]
+    assert len(breakdown["seeded_errors"]) == 2
+    assert breakdown["seeded_error"] == breakdown["seeded_errors"][0]

--- a/tests/scripts/test_run_heterogeneity_probe.py
+++ b/tests/scripts/test_run_heterogeneity_probe.py
@@ -19,7 +19,7 @@ def test_probe_script_dry_run_selects_pilot_subset() -> None:
         capture_output=True,
     )
     payload = json.loads(proc.stdout)
-    assert payload["prompt_count"] == 21
+    assert payload["prompt_count"] == 23
     assert payload["class_counts"]["null_negative"] == 2
 
 


### PR DESCRIPTION
## Summary

Fixes two reliability defects surfaced by the 2026-04-30g heterogeneous dialog dogfood after #6902 merged:

- Preserve plural `seeded_errors` metadata for multi-seeded prompts through loading, judge prompts, and probe receipts.
- Raise the default `correlated_priming` pilot quota from 4 to 6 so a perfect pilot can satisfy the pre-registered Wilson upper-CI gate (`0.390 < 0.40`).

## Why

The merged probe was operationally safe, but dialog review found it could produce misleading settlement evidence:

- Multi-seeded prompts used `seeded_errors`, while the loader only read singular `seeded_error`, causing judge prompts to omit ground truth for that class.
- With only 4 correlated-priming prompts, `wilson_interval(0, 4)[1] ~= 0.49`, so the `catastrophic_correlation_rate_ci_high_max=0.40` gate could not pass even with zero catastrophic failures.

## Validation

```bash
python3 -m pytest tests/heterogeneity tests/scripts/test_run_heterogeneity_probe.py -p no:randomly -q
python3 -m ruff check aragora/heterogeneity scripts/run_heterogeneity_probe.py tests/heterogeneity tests/scripts/test_run_heterogeneity_probe.py
python3 -m ruff format --check aragora/heterogeneity scripts/run_heterogeneity_probe.py tests/heterogeneity tests/scripts/test_run_heterogeneity_probe.py
python3 -m mypy aragora/heterogeneity
bash scripts/automation_pr_preflight.sh origin/main HEAD
python3 scripts/run_heterogeneity_probe.py --json
```

## Scope

Bounded to the local heterogeneity probe surface. No production dispatch, market, reputation, GitHub mutation, or settlement automation is enabled.