### PR TITLE
fix(status): auto-load H1 boss-harvest PR evidence

### DIFF
--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -26,9 +26,9 @@ thresholds:
 summary:
   core: 21
   integrated: 87
-  experimental: 25
+  experimental: 26
   deprecated: 2
-  total: 135
+  total: 136
 
 modules:
   # --- core (21) ---
@@ -45,9 +45,9 @@ modules:
     test_file_count: 118
   - name: cli
     tier: core
-    py_files: 97
+    py_files: 98
     importer_count: 5
-    test_file_count: 106
+    test_file_count: 108
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
@@ -57,14 +57,14 @@ modules:
     override_reason: "Pydantic settings + allowlist — load bearing"
   - name: connectors
     tier: core
-    py_files: 265
+    py_files: 266
     importer_count: 140
-    test_file_count: 255
+    test_file_count: 256
   - name: core
     tier: core
     py_files: 19
     importer_count: 207
-    test_file_count: 194
+    test_file_count: 195
     override_reason: "root type hierarchy + Agent base class"
   - name: db
     tier: core
@@ -76,7 +76,7 @@ modules:
     tier: core
     py_files: 263
     importer_count: 160
-    test_file_count: 594
+    test_file_count: 596
     override_reason: "Arena + DebateProtocol + consensus — mainline flow"
   - name: events
     tier: core
@@ -86,13 +86,13 @@ modules:
   - name: gauntlet
     tier: core
     py_files: 36
-    importer_count: 63
-    test_file_count: 97
+    importer_count: 64
+    test_file_count: 98
   - name: knowledge
     tier: core
-    py_files: 176
-    importer_count: 178
-    test_file_count: 224
+    py_files: 177
+    importer_count: 179
+    test_file_count: 227
   - name: memory
     tier: core
     py_files: 56
@@ -113,7 +113,7 @@ modules:
     tier: core
     py_files: 49
     importer_count: 71
-    test_file_count: 126
+    test_file_count: 125
   - name: ranking
     tier: core
     py_files: 25
@@ -127,9 +127,9 @@ modules:
     test_file_count: 201
   - name: reasoning
     tier: core
-    py_files: 18
-    importer_count: 119
-    test_file_count: 107
+    py_files: 19
+    importer_count: 120
+    test_file_count: 108
   - name: resilience
     tier: core
     py_files: 13
@@ -238,7 +238,7 @@ modules:
     tier: integrated
     py_files: 44
     importer_count: 46
-    test_file_count: 56
+    test_file_count: 57
   - name: coordination
     tier: integrated
     py_files: 11
@@ -256,9 +256,9 @@ modules:
     test_file_count: 11
   - name: epistemic
     tier: integrated
-    py_files: 18
-    importer_count: 1
-    test_file_count: 16
+    py_files: 21
+    importer_count: 2
+    test_file_count: 20
   - name: essay
     tier: integrated
     py_files: 6
@@ -373,8 +373,8 @@ modules:
   - name: markets
     tier: integrated
     py_files: 5
-    importer_count: 4
-    test_file_count: 7
+    importer_count: 6
+    test_file_count: 10
   - name: mcp
     tier: integrated
     py_files: 27
@@ -457,9 +457,9 @@ modules:
     test_file_count: 7
   - name: reputation
     tier: integrated
-    py_files: 7
-    importer_count: 1
-    test_file_count: 8
+    py_files: 10
+    importer_count: 2
+    test_file_count: 12
   - name: review
     tier: integrated
     py_files: 10
@@ -522,9 +522,9 @@ modules:
     test_file_count: 5
   - name: swarm
     tier: integrated
-    py_files: 93
+    py_files: 100
     importer_count: 28
-    test_file_count: 144
+    test_file_count: 153
   - name: templates
     tier: integrated
     py_files: 1
@@ -586,7 +586,7 @@ modules:
     importer_count: 15
     test_file_count: 11
 
-  # --- experimental (25) ---
+  # --- experimental (26) ---
   - name: approvals
     tier: experimental
     py_files: 5
@@ -612,6 +612,11 @@ modules:
     py_files: 1
     importer_count: 2
     test_file_count: 0
+  - name: heterogeneity
+    tier: experimental
+    py_files: 5
+    importer_count: 0
+    test_file_count: 4
   - name: maintenance
     tier: experimental
     py_files: 2
@@ -619,9 +624,9 @@ modules:
     test_file_count: 3
   - name: metrics
     tier: experimental
-    py_files: 2
+    py_files: 4
     importer_count: 1
-    test_file_count: 1
+    test_file_count: 3
   - name: moderation
     tier: experimental
     py_files: 2

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,11 +12,11 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4096` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1928113` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
-| Top-level modules under aragora/ | `135` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5136` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217250` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Python files under aragora/ | `4101` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1928729` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Top-level modules under aragora/ | `136` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
+| Test files (test_*.py under tests/) | `5141` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217270` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `662` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `61` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `816` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `820` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/status/H1_01_REV4_PROMOTION_READINESS.md
+++ b/docs/status/H1_01_REV4_PROMOTION_READINESS.md
@@ -1,6 +1,6 @@
 # H1-01 Rev-4 Promotion Readiness
 
-Last updated: 2026-04-30T18:57:38Z
+Last updated: 2026-04-30T19:54:46Z
 
 This is the operator-facing readiness surface for promoting the staged rev-4 benchmark corpus into the canonical B0 truth loop.
 
@@ -25,15 +25,15 @@ This is the operator-facing readiness surface for promoting the staged rev-4 ben
 | Metric | Value |
 | --- | --- |
 | Dispatch floor for first canonical slice | 15 |
-| Staged issues with dispatch evidence (any source) | 15 |
-| Staged issues still missing dispatch evidence | 18 |
+| Staged issues with dispatch evidence (any source) | 16 |
+| Staged issues still missing dispatch evidence | 17 |
 | Additional dispatches needed | 0 |
-| ...via metrics ledger only | 12 |
-| ...via merged/open boss-harvest PR only | 3 |
+| ...via metrics ledger only | 1 |
+| ...via merged/open boss-harvest PR only | 4 |
 
 ## Next Dispatch Targets
 
-`#5188`, `#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`
+`#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`
 
 ## Execution-Class Coverage
 
@@ -41,18 +41,18 @@ This is the operator-facing readiness surface for promoting the staged rev-4 ben
 | --- | ---: | ---: | ---: |
 | `docs_reconciliation` | 1 | 2 | 1 |
 | `exception_narrowing` | 0 | 8 | 8 |
-| `missing_test_coverage` | 9 | 10 | 1 |
+| `missing_test_coverage` | 10 | 10 | 0 |
 | `silent_exception_replacement` | 0 | 8 | 8 |
 | `small_refactor` | 3 | 3 | 0 |
 | `validation_tightening` | 2 | 2 | 0 |
 
 ## Dispatched Issues
 
-`#5126`, `#5128`, `#5130`, `#5176`, `#5180`, `#5185`, `#5187`, `#5197`, `#5198`, `#5426`, `#5427`, `#5428`, `#5764`, `#5765`, `#5844`
+`#5126`, `#5128`, `#5130`, `#5176`, `#5180`, `#5185`, `#5187`, `#5188`, `#5197`, `#5198`, `#5426`, `#5427`, `#5428`, `#5764`, `#5765`, `#5844`
 
 ## Missing Evidence
 
-`#5188`, `#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`, `#5810`, `#5811`, `#5812`, `#5821`, `#5823`, `#5825`, `#5883`
+`#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`, `#5810`, `#5811`, `#5812`, `#5821`, `#5823`, `#5825`, `#5883`
 
 ## Promotion Rule
 

--- a/scripts/render_rev4_promotion_readiness.py
+++ b/scripts/render_rev4_promotion_readiness.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import subprocess
 import sys
 from collections import Counter, defaultdict
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -297,6 +299,70 @@ def _load_pr_records(path: Path | None) -> list[dict[str, Any]]:
     return [item for item in payload if isinstance(item, dict)]
 
 
+def fetch_boss_harvest_pr_records(
+    issue_ids: Iterable[int],
+    *,
+    repo: str | None = None,
+    per_issue_limit: int = 10,
+    timeout_seconds: int = 15,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    seen_prs: set[int] = set()
+    for issue_id in sorted({int(issue_id) for issue_id in issue_ids if int(issue_id) > 0}):
+        cmd = [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            str(max(int(per_issue_limit), 1)),
+            "--search",
+            f"head:aragora/boss-harvest/issue-{issue_id}",
+            "--json",
+            "number,state,headRefName",
+        ]
+        if repo:
+            cmd.extend(["--repo", repo])
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=REPO_ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if proc.returncode != 0:
+            continue
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, list):
+            continue
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            number = item.get("number")
+            if isinstance(number, int):
+                if number in seen_prs:
+                    continue
+                seen_prs.add(number)
+            records.append(item)
+    return records
+
+
+def _corpus_issue_ids(corpus: dict[str, Any]) -> list[int]:
+    return [
+        _issue_id(issue)
+        for issue in corpus.get("issues", [])
+        if isinstance(issue, dict) and _issue_id(issue) > 0
+    ]
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS_PATH)
@@ -316,6 +382,25 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--no-gh-pr-records",
+        action="store_true",
+        help=(
+            "Disable the default non-fatal gh lookup for boss-harvest PR evidence "
+            "when --pr-records is omitted."
+        ),
+    )
+    parser.add_argument(
+        "--gh-repo",
+        default=None,
+        help="Optional owner/repo passed to gh when auto-loading boss-harvest PR evidence.",
+    )
+    parser.add_argument(
+        "--gh-per-issue-limit",
+        type=int,
+        default=10,
+        help="Maximum PR records to fetch per staged issue during the default gh lookup.",
+    )
+    parser.add_argument(
         "--json", action="store_true", help="Emit readiness JSON instead of Markdown"
     )
     parser.add_argument(
@@ -332,6 +417,12 @@ def main(argv: list[str] | None = None) -> int:
     metrics_path = resolve_metrics_path(args.metrics)
     corpus = load_corpus(corpus_path)
     pr_records = _load_pr_records(args.pr_records)
+    if args.pr_records is None and not args.no_gh_pr_records:
+        pr_records = fetch_boss_harvest_pr_records(
+            _corpus_issue_ids(corpus),
+            repo=args.gh_repo,
+            per_issue_limit=args.gh_per_issue_limit,
+        )
     readiness = build_readiness(
         corpus=corpus,
         metrics_rows=load_metrics(metrics_path),

--- a/tests/scripts/test_render_rev4_promotion_readiness.py
+++ b/tests/scripts/test_render_rev4_promotion_readiness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -105,6 +106,7 @@ def test_main_writes_markdown_readiness(tmp_path: Path) -> None:
             str(output_path),
             "--min-dispatched",
             "2",
+            "--no-gh-pr-records",
             "--generated-at",
             "2026-04-25T00:00:00Z",
         ]
@@ -114,7 +116,7 @@ def test_main_writes_markdown_readiness(tmp_path: Path) -> None:
     assert exit_code == 0
     assert "Last updated: 2026-04-25T00:00:00Z" in markdown
     assert "Status: `manifest_below_h1_floor`" in markdown
-    assert "| Staged issues with metrics evidence | 1 |" in markdown
+    assert "| Staged issues with dispatch evidence (any source) | 1 |" in markdown
     assert "`#1002`" in markdown
 
 
@@ -133,6 +135,7 @@ def test_main_json_mode_emits_readiness(tmp_path: Path, capsys) -> None:
             str(metrics_path),
             "--min-dispatched",
             "1",
+            "--no-gh-pr-records",
             "--json",
         ]
     )
@@ -141,3 +144,78 @@ def test_main_json_mode_emits_readiness(tmp_path: Path, capsys) -> None:
     assert exit_code == 0
     assert payload["status"] == "promotion_ready"
     assert payload["dispatch"]["dispatched_issue_count"] == 1
+
+
+def test_fetch_boss_harvest_pr_records_uses_targeted_branch_search(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        search = cmd[cmd.index("--search") + 1]
+        stdout = "[]"
+        if search.endswith("issue-1002"):
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 4242,
+                        "state": "MERGED",
+                        "headRefName": "aragora/boss-harvest/issue-1002-boss-abcd",
+                    }
+                ]
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    records = mod.fetch_boss_harvest_pr_records([1002, 1001, 1002], repo="owner/repo")
+
+    assert records == [
+        {
+            "number": 4242,
+            "state": "MERGED",
+            "headRefName": "aragora/boss-harvest/issue-1002-boss-abcd",
+        }
+    ]
+    assert [cmd[cmd.index("--search") + 1] for cmd in calls] == [
+        "head:aragora/boss-harvest/issue-1001",
+        "head:aragora/boss-harvest/issue-1002",
+    ]
+    assert all(cmd[-2:] == ["--repo", "owner/repo"] for cmd in calls)
+
+
+def test_main_json_mode_auto_loads_gh_pr_evidence(tmp_path: Path, capsys, monkeypatch) -> None:
+    corpus_path = _write_json(tmp_path / "corpus.json", _corpus(list(range(1001, 1031))))
+    metrics_path = _write_metrics(
+        tmp_path / "boss_metrics.jsonl",
+        [{"issue_number": 1001, "terminal_class": "deliverable_pr_created"}],
+    )
+
+    def fake_fetch(issue_ids, **kwargs):
+        assert 1002 in issue_ids
+        return [
+            {
+                "number": 4242,
+                "state": "MERGED",
+                "headRefName": "aragora/boss-harvest/issue-1002-boss-abcd",
+            }
+        ]
+
+    monkeypatch.setattr(mod, "fetch_boss_harvest_pr_records", fake_fetch)
+
+    exit_code = mod.main(
+        [
+            "--corpus",
+            str(corpus_path),
+            "--metrics",
+            str(metrics_path),
+            "--min-dispatched",
+            "2",
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["status"] == "promotion_ready"
+    assert payload["dispatch"]["dispatched_issue_count"] == 2
+    assert payload["dispatch"]["dispatch_source_by_issue"]["1002"] == "pr"


### PR DESCRIPTION
## Summary
- auto-load boss-harvest PR evidence through targeted gh lookups when H1 readiness is rendered without --pr-records
- keep offline/CI behavior non-fatal with --no-gh-pr-records escape hatch
- refresh H1 readiness status to promotion_ready with 16 dispatched issues / 0 needed

## Validation
- python3 -m pytest tests/scripts/test_render_rev4_promotion_readiness.py tests/swarm/test_dispatch_evidence.py -q
- python3 scripts/render_rev4_promotion_readiness.py --json
- bash scripts/automation_pr_preflight.sh origin/main HEAD