### PR TITLE
feat(swarm): harness health registry + fallback ladder + harness-status CLI (Round 30f Phase 2)

### DIFF
--- a/aragora/cli/commands/harness_status.py
+++ b/aragora/cli/commands/harness_status.py
@@ -21,7 +21,10 @@ from aragora.swarm.harness_health import (
 )
 
 
-_KNOWN_HARNESSES = ("claude-code", "codex", "aider")
+# Round 30g: only harnesses with a real shipping implementation in
+# aragora.harnesses are listed. Re-add 'aider' here when an actual
+# AiderHarness lands; do not list a name we can't dispatch to.
+_KNOWN_HARNESSES = ("claude-code", "codex")
 
 
 def _format_outcome(outcome: str | None) -> str:

--- a/aragora/cli/commands/harness_status.py
+++ b/aragora/cli/commands/harness_status.py
@@ -1,0 +1,100 @@
+"""``aragora swarm harness-status`` — render harness health for the operator.
+
+Pure read-only; never mutates the registry. Takes a snapshot of the
+process-wide :class:`HarnessHealthRegistry` and prints either a table
+(default) or JSON (``--json``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Iterable
+
+from aragora.swarm.harness_fallback import (
+    default_implementation_ladder,
+    default_review_ladder,
+)
+from aragora.swarm.harness_health import (
+    HarnessHealthSnapshot,
+    get_harness_health_registry,
+)
+
+
+_KNOWN_HARNESSES = ("claude-code", "codex", "aider")
+
+
+def _format_outcome(outcome: str | None) -> str:
+    if outcome is None:
+        return "never invoked"
+    return outcome
+
+
+def _format_pin(snap: HarnessHealthSnapshot) -> str:
+    if snap.permanent_pin_reason is None:
+        return ""
+    return snap.permanent_pin_reason
+
+
+def _render_table(snaps: Iterable[HarnessHealthSnapshot]) -> str:
+    rows = list(snaps)
+    if not rows:
+        return "(no harnesses recorded)"
+    header = (
+        f"{'harness':<14} {'available':<10} {'transient':<10} "
+        f"{'last_outcome':<14} {'pin_reason':<40}"
+    )
+    out = [header, "-" * len(header)]
+    for snap in rows:
+        out.append(
+            f"{snap.harness:<14} "
+            f"{('yes' if snap.available else 'no'):<10} "
+            f"{snap.transient_failure_count_in_window:<10} "
+            f"{_format_outcome(snap.last_outcome):<14} "
+            f"{_format_pin(snap):<40}"
+        )
+    return "\n".join(out)
+
+
+def _render_ladders(*, registry) -> str:
+    ladders = [default_implementation_ladder(), default_review_ladder()]
+    out = ["", "Fallback ladders:"]
+    for ladder in ladders:
+        resolution = ladder.next_available(registry=registry)
+        chosen = resolution.chosen or "(none available)"
+        skipped = f" skipped={list(resolution.skipped)}" if resolution.skipped else ""
+        out.append(f"  {ladder.name}: {' -> '.join(ladder.steps)} -> chosen={chosen}{skipped}")
+    return "\n".join(out)
+
+
+def cmd_harness_status(args: argparse.Namespace) -> None:
+    """Handle ``aragora swarm harness-status``.
+
+    Args available on ``args``:
+      - ``as_json`` (bool): print JSON instead of table.
+      - ``status_limit`` (int): unused, kept for arg-parser uniformity.
+    """
+    registry = get_harness_health_registry()
+    snaps = registry.snapshot_all(harnesses=list(_KNOWN_HARNESSES))
+    as_json = bool(getattr(args, "as_json", False))
+    if as_json:
+        ladders_payload = []
+        for ladder in (default_implementation_ladder(), default_review_ladder()):
+            resolution = ladder.next_available(registry=registry)
+            ladders_payload.append(
+                {
+                    "ladder": ladder.name,
+                    "steps": list(ladder.steps),
+                    "chosen": resolution.chosen,
+                    "skipped": list(resolution.skipped),
+                    "reasons": dict(resolution.reasons),
+                }
+            )
+        payload = {
+            "harnesses": [snap.to_dict() for snap in snaps],
+            "ladders": ladders_payload,
+        }
+        print(json.dumps(payload, indent=2))
+        return
+    print(_render_table(snaps))
+    print(_render_ladders(registry=registry))

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -77,6 +77,7 @@ def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | Non
         "runner",
         "status",
         "shift-status",
+        "harness-status",
         "reconcile",
         "initiative",
         "campaign",
@@ -3301,6 +3302,12 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         from aragora.cli.commands.shift_status import cmd_shift_status
 
         cmd_shift_status(args)
+        return
+
+    if action == "harness-status":
+        from aragora.cli.commands.harness_status import cmd_harness_status
+
+        cmd_harness_status(args)
         return
 
     if action == "reconcile":

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2760,9 +2760,9 @@ def _add_swarm_parser(subparsers) -> None:
         "swarm_action_or_goal",
         nargs="?",
         help=(
-            "Action (run/preflight/status/shift-status/reconcile/campaign/initiative/integrator/"
-            "tranche/coord/assign/claim-pr/report/findings/merge-arbiter/dispatch) or your goal "
-            "in plain language"
+            "Action (run/preflight/status/shift-status/harness-status/reconcile/campaign/initiative/"
+            "integrator/tranche/coord/assign/claim-pr/report/findings/merge-arbiter/dispatch) or "
+            "your goal in plain language"
         ),
     )
     swarm_parser.add_argument(

--- a/aragora/harnesses/claude_code.py
+++ b/aragora/harnesses/claude_code.py
@@ -39,6 +39,10 @@ from aragora.harnesses.base import (
     SessionResult,
 )
 from aragora.pipeline.execution_mode import ExecutionMode
+from aragora.swarm.harness_health import (
+    get_harness_health_registry,
+    record_harness_result,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -225,6 +229,8 @@ class ClaudeCodeHarness(CodeAnalysisHarness):
         error_message = None
         success = False
 
+        get_harness_health_registry().record_attempt(self.name)
+
         try:
             # Build the prompt
             analysis_prompt = prompt or self.config.analysis_prompts.get(
@@ -282,6 +288,13 @@ Respond with a JSON array of findings. Each finding should have:
 
         completed_at = datetime.now(timezone.utc)
 
+        record_harness_result(
+            harness=self.name,
+            success=success,
+            error_message=error_message,
+            error_output=error_output,
+        )
+
         return HarnessResult(
             harness=self.name,
             analysis_type=analysis_type,
@@ -309,6 +322,13 @@ Respond with a JSON array of findings. Each finding should have:
     ) -> HarnessResult:
         """Analyze specific files using Claude Code."""
         if not files:
+            # Caller bug rather than harness failure; do not pin the
+            # harness, but record the no-op so observability shows it.
+            record_harness_result(
+                harness=self.name,
+                success=False,
+                error_message="caller passed no files",
+            )
             return HarnessResult(
                 harness=self.name,
                 analysis_type=analysis_type,
@@ -317,7 +337,8 @@ Respond with a JSON array of findings. Each finding should have:
                 error_message="No files provided",
             )
 
-        # Use parent of first file as working directory
+        # Use parent of first file as working directory.
+        # analyze_repository records its own outcome, so we don't double-record here.
         cwd = files[0].parent
         return await self.analyze_repository(
             repo_path=cwd,

--- a/aragora/harnesses/codex.py
+++ b/aragora/harnesses/codex.py
@@ -26,6 +26,10 @@ from aragora.harnesses.base import (
     SessionContext,
     SessionResult,
 )
+from aragora.swarm.harness_health import (
+    get_harness_health_registry,
+    record_harness_result,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +201,8 @@ class CodexHarness(CodeAnalysisHarness):
         options = options or {}
         started_at = datetime.now(timezone.utc)
 
+        get_harness_health_registry().record_attempt(self.name)
+
         try:
             # Gather code files
             file_patterns = options.get("file_patterns", ["**/*.py", "**/*.js", "**/*.ts"])
@@ -210,6 +216,10 @@ class CodexHarness(CodeAnalysisHarness):
             )
 
             if not files_content:
+                # No-op success — caller produced an empty work surface,
+                # not a harness failure. Record success to keep the
+                # health registry honest.
+                record_harness_result(harness=self.name, success=True)
                 return HarnessResult(
                     harness="codex",
                     analysis_type=analysis_type,
@@ -230,6 +240,8 @@ class CodexHarness(CodeAnalysisHarness):
 
             duration = (datetime.now(timezone.utc) - started_at).total_seconds()
 
+            record_harness_result(harness=self.name, success=True)
+
             return HarnessResult(
                 harness="codex",
                 analysis_type=analysis_type,
@@ -246,6 +258,11 @@ class CodexHarness(CodeAnalysisHarness):
 
         except (OSError, ValueError, TypeError, RuntimeError) as e:
             logger.exception("Codex analysis failed: %s", e)
+            record_harness_result(
+                harness=self.name,
+                success=False,
+                error_message=str(e),
+            )
             return HarnessResult(
                 harness="codex",
                 analysis_type=analysis_type,
@@ -267,6 +284,8 @@ class CodexHarness(CodeAnalysisHarness):
         options = options or {}
         started_at = datetime.now(timezone.utc)
 
+        get_harness_health_registry().record_attempt(self.name)
+
         try:
             # Read file contents
             files_content: dict[str, str] = {}
@@ -279,6 +298,8 @@ class CodexHarness(CodeAnalysisHarness):
                         logger.warning("Failed to read %s: %s", file_path, e)
 
             if not files_content:
+                # Empty work surface — not a harness failure.
+                record_harness_result(harness=self.name, success=True)
                 return HarnessResult(
                     harness="codex",
                     analysis_type=analysis_type,
@@ -295,6 +316,8 @@ class CodexHarness(CodeAnalysisHarness):
 
             duration = (datetime.now(timezone.utc) - started_at).total_seconds()
 
+            record_harness_result(harness=self.name, success=True)
+
             return HarnessResult(
                 harness="codex",
                 analysis_type=analysis_type,
@@ -310,6 +333,11 @@ class CodexHarness(CodeAnalysisHarness):
 
         except (OSError, ValueError, TypeError, RuntimeError) as e:
             logger.exception("Codex file analysis failed: %s", e)
+            record_harness_result(
+                harness=self.name,
+                success=False,
+                error_message=str(e),
+            )
             return HarnessResult(
                 harness="codex",
                 analysis_type=analysis_type,

--- a/aragora/swarm/harness_fallback.py
+++ b/aragora/swarm/harness_fallback.py
@@ -1,0 +1,151 @@
+"""Declarative fallback ladders for harness selection.
+
+A :class:`FallbackLadder` is an ordered list of harness names. Calling
+:meth:`FallbackLadder.next_available` consults
+:class:`aragora.swarm.harness_health.HarnessHealthRegistry` and returns
+the first non-pinned harness in order, or ``None`` if every step in the
+ladder has been pinned.
+
+Why a separate module
+---------------------
+
+The health registry must stay free of *policy* (which harness to prefer
+when several are healthy). The ladder owns that policy. Spawn sites that
+just want "give me whichever harness is alive" call into the ladder; the
+registry just records and reports.
+
+Usage
+-----
+
+>>> from aragora.swarm.harness_fallback import FallbackLadder
+>>> ladder = FallbackLadder.default_implementation_ladder()
+>>> chosen = ladder.next_available()
+>>> if chosen is None:
+...     raise RuntimeError("no implementation harness available")
+
+Default ladders
+---------------
+
+Two ladders are provided:
+
+  - ``default_implementation_ladder`` — for "implement this change"
+    style work. Order: ``claude-code -> codex -> aider``.
+  - ``default_review_ladder`` — for "review/critique this change"
+    style work. Order: ``claude-code -> codex``.
+
+These mirror today's call sites; new ladders can be constructed by
+callers or registered as named ladders later.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Sequence
+
+from aragora.swarm.harness_health import (
+    HarnessHealthRegistry,
+    get_harness_health_registry,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "FallbackLadder",
+    "FallbackResolution",
+    "default_implementation_ladder",
+    "default_review_ladder",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackResolution:
+    """Result of resolving a ladder against the registry."""
+
+    chosen: str | None
+    skipped: tuple[str, ...]
+    reasons: dict[str, str] = field(default_factory=dict)
+
+    def is_resolved(self) -> bool:
+        return self.chosen is not None
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackLadder:
+    """An ordered list of harnesses to try in turn."""
+
+    name: str
+    steps: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.steps:
+            raise ValueError(f"FallbackLadder({self.name!r}) requires at least one step")
+        seen: set[str] = set()
+        for step in self.steps:
+            if not isinstance(step, str) or not step:
+                raise ValueError(
+                    f"FallbackLadder({self.name!r}) steps must be non-empty strings; got {step!r}"
+                )
+            if step in seen:
+                raise ValueError(f"FallbackLadder({self.name!r}) has duplicate step {step!r}")
+            seen.add(step)
+
+    def next_available(
+        self,
+        *,
+        registry: HarnessHealthRegistry | None = None,
+    ) -> FallbackResolution:
+        """Return the first available harness in the ladder.
+
+        ``registry`` defaults to the process-wide singleton. Pass an
+        explicit instance in tests.
+        """
+        reg = registry or get_harness_health_registry()
+        skipped: list[str] = []
+        reasons: dict[str, str] = {}
+        for step in self.steps:
+            if reg.is_available(step):
+                return FallbackResolution(
+                    chosen=step,
+                    skipped=tuple(skipped),
+                    reasons=reasons,
+                )
+            skipped.append(step)
+            reason = reg.permanent_pin_reason(step) or "pinned"
+            reasons[step] = reason
+            logger.info(
+                "harness_fallback: %s skipping %s (%s)",
+                self.name,
+                step,
+                reason,
+            )
+        return FallbackResolution(chosen=None, skipped=tuple(skipped), reasons=reasons)
+
+    @classmethod
+    def from_steps(cls, name: str, steps: Sequence[str]) -> "FallbackLadder":
+        """Construct from a sequence (validated)."""
+        return cls(name=name, steps=tuple(steps))
+
+
+def default_implementation_ladder() -> FallbackLadder:
+    """Order tuned for code-implementation work today.
+
+    Rationale:
+      - claude-code is preferred for repo-wide reasoning + edit volume.
+      - codex is the second-best fallback (matches existing
+        cli_agents.py preference order).
+      - aider is a known-working but lower-throughput option used today
+        when the others are degraded.
+    """
+    return FallbackLadder(
+        name="implementation",
+        steps=("claude-code", "codex", "aider"),
+    )
+
+
+def default_review_ladder() -> FallbackLadder:
+    """Order tuned for code-review work today."""
+    return FallbackLadder(
+        name="review",
+        steps=("claude-code", "codex"),
+    )

--- a/aragora/swarm/harness_fallback.py
+++ b/aragora/swarm/harness_fallback.py
@@ -29,9 +29,16 @@ Default ladders
 Two ladders are provided:
 
   - ``default_implementation_ladder`` — for "implement this change"
-    style work. Order: ``claude-code -> codex -> aider``.
+    style work. Order: ``claude-code -> codex``.
   - ``default_review_ladder`` — for "review/critique this change"
     style work. Order: ``claude-code -> codex``.
+
+Note: Earlier drafts included ``aider`` as a third implementation
+step, but no real ``AiderHarness`` is wired into this codebase
+(``aragora.harnesses`` only ships ``ClaudeCodeHarness`` and
+``CodexHarness``). Round 30g removes the dangling reference rather
+than ship a stub: a ladder must only name harnesses that can actually
+run. Add ``aider`` back when an honest harness implementation lands.
 
 These mirror today's call sites; new ladders can be constructed by
 callers or registered as named ladders later.
@@ -134,12 +141,15 @@ def default_implementation_ladder() -> FallbackLadder:
       - claude-code is preferred for repo-wide reasoning + edit volume.
       - codex is the second-best fallback (matches existing
         cli_agents.py preference order).
-      - aider is a known-working but lower-throughput option used today
-        when the others are degraded.
+
+    ``aider`` was removed in Round 30g: there is no real
+    ``AiderHarness`` shipped in :mod:`aragora.harnesses`, and the
+    contract is that a ladder must name only harnesses that can
+    actually run. Re-add when a real harness lands.
     """
     return FallbackLadder(
         name="implementation",
-        steps=("claude-code", "codex", "aider"),
+        steps=("claude-code", "codex"),
     )
 
 

--- a/aragora/swarm/harness_health.py
+++ b/aragora/swarm/harness_health.py
@@ -1,0 +1,365 @@
+"""Session-scoped health registry for harnesses.
+
+Mirrors the design of :mod:`aragora.routing.session_circuit_breaker` but at
+the *harness* layer (Claude Code, Codex, Aider, agent-bridge, etc.) rather
+than the *provider* layer (Anthropic, OpenAI, etc.).
+
+Why this exists
+---------------
+
+The Round 30f plan calls out harness reliability as Phase 2. The boss-loop
+and supervisor today launch external CLIs without a single source of truth
+for "is harness X currently healthy?". Each spawn site decides on its own
+whether to retry, fall back, or give up. This module gives us:
+
+  - One in-memory registry, thread-safe, that any caller can consult.
+  - Three failure categories with separate pinning rules:
+      * AUTH failures (401/403/missing API key) — permanent for the
+        session; do not retry, escalate to fallback.
+      * QUOTA failures (429/rate-limit/budget-exhausted) — permanent for
+        the session.
+      * TRANSIENT failures (timeouts, 5xx, exit-code != 0 on a single
+        run) — sliding window; only pin after a threshold of failures
+        within a window.
+  - A snapshot API (:meth:`HarnessHealthRegistry.snapshot`) suitable for
+    rendering by ``aragora swarm harness-status``.
+
+Pinning is *opt-in advice*. Callers must consult
+:meth:`HarnessHealthRegistry.is_available` before invoking and treat a
+``False`` result as "use the fallback ladder". This module does not block
+calls; it just records and reports.
+
+Scope (Phase 2)
+---------------
+
+This is the **registry + snapshot** layer. The fallback ladder that
+*consumes* this registry lives in :mod:`aragora.swarm.harness_fallback`.
+The CLI surface lives in :mod:`aragora.cli.commands.harness_status`.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "AUTH_FAILURE_CODES",
+    "FailureCategory",
+    "HarnessAttempt",
+    "HarnessFailure",
+    "HarnessHealthRegistry",
+    "HarnessHealthSnapshot",
+    "PERMANENT_FAILURE_CODES",
+    "QUOTA_FAILURE_CODES",
+    "TRANSIENT_FAILURE_CODES",
+    "TRANSIENT_FAILURE_THRESHOLD",
+    "TRANSIENT_WINDOW_SECONDS",
+    "classify_failure",
+    "get_harness_health_registry",
+    "reset_harness_health_registry",
+]
+
+
+# Failure-classification thresholds. Pinned to match
+# session_circuit_breaker so harness-level and provider-level operators see
+# consistent behavior.
+AUTH_FAILURE_CODES: frozenset[int] = frozenset({401, 403})
+QUOTA_FAILURE_CODES: frozenset[int] = frozenset({429})
+PERMANENT_FAILURE_CODES: frozenset[int] = AUTH_FAILURE_CODES | QUOTA_FAILURE_CODES
+TRANSIENT_FAILURE_CODES: frozenset[int] = frozenset({500, 502, 503, 504})
+
+TRANSIENT_FAILURE_THRESHOLD: int = 3
+TRANSIENT_WINDOW_SECONDS: float = 300.0
+
+
+class FailureCategory(Enum):
+    """Classification of a harness failure."""
+
+    AUTH = "auth"
+    QUOTA = "quota"
+    TRANSIENT = "transient"
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessFailure:
+    """One failure event for a harness."""
+
+    harness: str
+    category: FailureCategory
+    reason: str
+    status_code: int | None = None
+    at: float = field(default_factory=time.monotonic)
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessAttempt:
+    """One attempt event (success or failure) for a harness.
+
+    Used for the snapshot's ``last_attempt_at`` / ``last_outcome`` fields
+    so operators can tell at a glance whether a harness is *idle* or
+    *actively failing*.
+    """
+
+    harness: str
+    success: bool
+    at: float = field(default_factory=time.monotonic)
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessHealthSnapshot:
+    """Read-only view of a single harness's health.
+
+    Rendered by ``aragora swarm harness-status``.
+    """
+
+    harness: str
+    available: bool
+    permanent_pin_reason: str | None
+    transient_failure_count_in_window: int
+    last_attempt_at_monotonic: float | None
+    last_outcome: str | None  # "success" | "failure" | None
+    last_failure_reason: str | None
+    last_failure_category: str | None  # FailureCategory.value or None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "harness": self.harness,
+            "available": self.available,
+            "permanent_pin_reason": self.permanent_pin_reason,
+            "transient_failure_count_in_window": self.transient_failure_count_in_window,
+            "last_attempt_at_monotonic": self.last_attempt_at_monotonic,
+            "last_outcome": self.last_outcome,
+            "last_failure_reason": self.last_failure_reason,
+            "last_failure_category": self.last_failure_category,
+        }
+
+
+def classify_failure(
+    *,
+    status_code: int | None,
+    reason: str,
+) -> FailureCategory:
+    """Classify a failure into one of three categories.
+
+    Heuristics:
+      - status_code in :data:`AUTH_FAILURE_CODES` -> AUTH.
+      - status_code in :data:`QUOTA_FAILURE_CODES` -> QUOTA.
+      - reason mentions ``api key``/``unauthorized``/``forbidden`` -> AUTH.
+      - reason mentions ``rate limit``/``quota``/``budget`` -> QUOTA.
+      - everything else -> TRANSIENT.
+
+    The string heuristics let CLI harnesses (which don't return HTTP
+    codes) signal auth/quota pinning by including the right phrase in
+    their stderr.
+    """
+    if status_code is not None:
+        if status_code in AUTH_FAILURE_CODES:
+            return FailureCategory.AUTH
+        if status_code in QUOTA_FAILURE_CODES:
+            return FailureCategory.QUOTA
+    lower = reason.lower()
+    if any(
+        marker in lower for marker in ("unauthorized", "forbidden", "api key", "missing credential")
+    ):
+        return FailureCategory.AUTH
+    if any(
+        marker in lower for marker in ("rate limit", "quota", "budget", "429", "too many request")
+    ):
+        return FailureCategory.QUOTA
+    return FailureCategory.TRANSIENT
+
+
+class HarnessHealthRegistry:
+    """In-memory, session-scoped registry of harness health.
+
+    Thread-safe; resets only on process restart (or via
+    :func:`reset_harness_health_registry`, intended for tests).
+    """
+
+    def __init__(
+        self,
+        *,
+        transient_threshold: int = TRANSIENT_FAILURE_THRESHOLD,
+        transient_window_seconds: float = TRANSIENT_WINDOW_SECONDS,
+    ) -> None:
+        if transient_threshold < 1:
+            raise ValueError("transient_threshold must be >= 1")
+        if transient_window_seconds <= 0:
+            raise ValueError("transient_window_seconds must be > 0")
+        self._lock = threading.RLock()
+        self._transient_threshold = transient_threshold
+        self._transient_window = transient_window_seconds
+        # harness -> list[HarnessFailure] (rolling)
+        self._failures: dict[str, list[HarnessFailure]] = {}
+        # harness -> permanent pin reason (None == not pinned)
+        self._permanent_pins: dict[str, str] = {}
+        # harness -> last attempt
+        self._last_attempts: dict[str, HarnessAttempt] = {}
+
+    # -- recording API -------------------------------------------------
+
+    def record_attempt(self, harness: str) -> None:
+        """Record that an invocation of ``harness`` is being attempted.
+
+        Lets the snapshot show "tried recently, no outcome yet". Most
+        callers won't need this; record_success / record_failure imply
+        an attempt.
+        """
+        with self._lock:
+            self._last_attempts[harness] = HarnessAttempt(
+                harness=harness, success=False, detail="in_progress"
+            )
+
+    def record_success(self, harness: str, *, detail: str = "") -> None:
+        """Record a successful invocation. Resets the transient-failure window."""
+        with self._lock:
+            self._failures.pop(harness, None)
+            self._last_attempts[harness] = HarnessAttempt(
+                harness=harness, success=True, detail=detail
+            )
+
+    def record_failure(
+        self,
+        harness: str,
+        *,
+        reason: str,
+        status_code: int | None = None,
+    ) -> FailureCategory:
+        """Record a failed invocation. Returns the classified category.
+
+        AUTH and QUOTA failures pin the harness permanently for the
+        session. TRANSIENT failures accumulate; once
+        ``transient_threshold`` is reached within
+        ``transient_window_seconds``, the harness is pinned with the
+        reason ``"too many transient failures"``.
+        """
+        category = classify_failure(status_code=status_code, reason=reason)
+        failure = HarnessFailure(
+            harness=harness,
+            category=category,
+            reason=reason,
+            status_code=status_code,
+        )
+        with self._lock:
+            self._last_attempts[harness] = HarnessAttempt(
+                harness=harness, success=False, detail=reason
+            )
+            if category in (FailureCategory.AUTH, FailureCategory.QUOTA):
+                self._permanent_pins[harness] = (
+                    f"{category.value}: {reason}" if reason else f"{category.value} failure"
+                )
+                logger.warning(
+                    "harness_health: pinning %s permanently (%s): %s",
+                    harness,
+                    category.value,
+                    reason,
+                )
+                return category
+            # Transient: prune old, append, check threshold.
+            now = time.monotonic()
+            window = self._failures.setdefault(harness, [])
+            cutoff = now - self._transient_window
+            window[:] = [f for f in window if f.at >= cutoff]
+            window.append(failure)
+            if len(window) >= self._transient_threshold:
+                self._permanent_pins[harness] = (
+                    f"transient threshold ({self._transient_threshold}) reached "
+                    f"in {int(self._transient_window)}s window"
+                )
+                logger.warning(
+                    "harness_health: pinning %s after %d transient failures",
+                    harness,
+                    len(window),
+                )
+            return category
+
+    # -- query API -----------------------------------------------------
+
+    def is_available(self, harness: str) -> bool:
+        """Return True iff the harness is not permanently pinned."""
+        with self._lock:
+            return harness not in self._permanent_pins
+
+    def permanent_pin_reason(self, harness: str) -> str | None:
+        with self._lock:
+            return self._permanent_pins.get(harness)
+
+    def transient_failures_in_window(self, harness: str) -> int:
+        """Number of transient failures within the rolling window."""
+        with self._lock:
+            window = self._failures.get(harness, [])
+            cutoff = time.monotonic() - self._transient_window
+            return sum(1 for f in window if f.at >= cutoff)
+
+    def snapshot(self, harness: str) -> HarnessHealthSnapshot:
+        """Read-only snapshot for one harness."""
+        with self._lock:
+            pin = self._permanent_pins.get(harness)
+            last = self._last_attempts.get(harness)
+            window = self._failures.get(harness, [])
+            cutoff = time.monotonic() - self._transient_window
+            transient_count = sum(1 for f in window if f.at >= cutoff)
+            last_failure = window[-1] if window else None
+            last_outcome: str | None
+            if last is None:
+                last_outcome = None
+            elif last.detail == "in_progress":
+                last_outcome = "in_progress"
+            elif last.success:
+                last_outcome = "success"
+            else:
+                last_outcome = "failure"
+            return HarnessHealthSnapshot(
+                harness=harness,
+                available=pin is None,
+                permanent_pin_reason=pin,
+                transient_failure_count_in_window=transient_count,
+                last_attempt_at_monotonic=last.at if last else None,
+                last_outcome=last_outcome,
+                last_failure_reason=last_failure.reason if last_failure else None,
+                last_failure_category=(last_failure.category.value if last_failure else None),
+            )
+
+    def snapshot_all(self, *, harnesses: list[str] | None = None) -> list[HarnessHealthSnapshot]:
+        """Snapshots for all known harnesses, plus any explicitly requested.
+
+        ``harnesses`` lets callers force a snapshot for harnesses that
+        haven't been touched yet (so the CLI can show "claude-code:
+        never invoked" rather than omitting it).
+        """
+        with self._lock:
+            seen: set[str] = set()
+            seen.update(self._failures.keys())
+            seen.update(self._permanent_pins.keys())
+            seen.update(self._last_attempts.keys())
+            if harnesses:
+                seen.update(harnesses)
+        return [self.snapshot(name) for name in sorted(seen)]
+
+
+_SINGLETON_LOCK = threading.Lock()
+_SINGLETON: HarnessHealthRegistry | None = None
+
+
+def get_harness_health_registry() -> HarnessHealthRegistry:
+    """Return the process-wide harness health registry, lazily created."""
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        if _SINGLETON is None:
+            _SINGLETON = HarnessHealthRegistry()
+        return _SINGLETON
+
+
+def reset_harness_health_registry() -> None:
+    """Reset the singleton. Intended for tests only."""
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        _SINGLETON = None

--- a/aragora/swarm/harness_health.py
+++ b/aragora/swarm/harness_health.py
@@ -63,6 +63,7 @@ __all__ = [
     "TRANSIENT_WINDOW_SECONDS",
     "classify_failure",
     "get_harness_health_registry",
+    "record_harness_result",
     "reset_harness_health_registry",
 ]
 
@@ -363,3 +364,38 @@ def reset_harness_health_registry() -> None:
     global _SINGLETON
     with _SINGLETON_LOCK:
         _SINGLETON = None
+
+
+def record_harness_result(
+    *,
+    harness: str,
+    success: bool,
+    error_message: str | None = None,
+    error_output: str | None = None,
+    status_code: int | None = None,
+) -> None:
+    """Convenience: record a harness call outcome on the singleton.
+
+    This is the single helper that real harness call sites
+    (:class:`aragora.harnesses.claude_code.ClaudeCodeHarness`,
+    :class:`aragora.harnesses.codex.CodexHarness`) should use after
+    each call. It does the right thing regardless of whether the
+    harness has been touched before in this process.
+
+    Failure reason is composed from ``error_message`` (preferred) and
+    falls back to a tail of ``error_output`` so stderr-only signals
+    (e.g., a CLI's ``Unauthorized: invalid API key`` printed without
+    an HTTP code) feed cleanly into :func:`classify_failure`.
+    """
+    registry = get_harness_health_registry()
+    if success:
+        registry.record_success(harness)
+        return
+    reason = (error_message or "").strip()
+    if not reason and error_output:
+        # Take the tail (last 240 chars) so we keep the most diagnostic
+        # bit of stderr without flooding the registry.
+        reason = error_output.strip()[-240:]
+    if not reason:
+        reason = "harness call failed (no error message captured)"
+    registry.record_failure(harness, reason=reason, status_code=status_code)

--- a/tests/cli/test_harness_status_cmd.py
+++ b/tests/cli/test_harness_status_cmd.py
@@ -31,7 +31,8 @@ class TestTableRendering:
         out = capsys.readouterr().out
         assert "claude-code" in out
         assert "codex" in out
-        assert "aider" in out
+        # Round 30g: aider intentionally absent; no real harness yet.
+        assert "aider" not in out
         assert "Fallback ladders:" in out
         assert "implementation" in out
         assert "review" in out

--- a/tests/cli/test_harness_status_cmd.py
+++ b/tests/cli/test_harness_status_cmd.py
@@ -1,0 +1,85 @@
+"""Tests for ``aragora swarm harness-status`` (Round 30f phase 2)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from aragora.cli.commands.harness_status import cmd_harness_status
+from aragora.swarm.harness_health import (
+    get_harness_health_registry,
+    reset_harness_health_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    reset_harness_health_registry()
+    yield
+    reset_harness_health_registry()
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+class TestTableRendering:
+    def test_renders_known_harnesses_when_idle(self, capsys) -> None:
+        cmd_harness_status(_ns(as_json=False))
+        out = capsys.readouterr().out
+        assert "claude-code" in out
+        assert "codex" in out
+        assert "aider" in out
+        assert "Fallback ladders:" in out
+        assert "implementation" in out
+        assert "review" in out
+
+    def test_shows_pin_reason_after_auth_failure(self, capsys) -> None:
+        reg = get_harness_health_registry()
+        reg.record_failure("claude-code", reason="api key invalid", status_code=401)
+        cmd_harness_status(_ns(as_json=False))
+        out = capsys.readouterr().out
+        assert "claude-code" in out
+        assert "no" in out  # not available
+        assert "auth" in out
+
+    def test_shows_chosen_fallback_when_primary_pinned(self, capsys) -> None:
+        reg = get_harness_health_registry()
+        reg.record_failure("claude-code", reason="api key invalid", status_code=401)
+        cmd_harness_status(_ns(as_json=False))
+        out = capsys.readouterr().out
+        # implementation ladder should now skip claude-code -> codex
+        assert "chosen=codex" in out
+
+
+class TestJsonRendering:
+    def test_emits_valid_json(self, capsys) -> None:
+        cmd_harness_status(_ns(as_json=True))
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert "harnesses" in payload
+        assert "ladders" in payload
+
+    def test_json_shape(self, capsys) -> None:
+        reg = get_harness_health_registry()
+        reg.record_success("claude-code")
+        cmd_harness_status(_ns(as_json=True))
+        payload = json.loads(capsys.readouterr().out)
+        names = {h["harness"] for h in payload["harnesses"]}
+        assert "claude-code" in names
+        cc = next(h for h in payload["harnesses"] if h["harness"] == "claude-code")
+        assert cc["available"] is True
+        assert cc["last_outcome"] == "success"
+        ladder_names = {ladder["ladder"] for ladder in payload["ladders"]}
+        assert ladder_names == {"implementation", "review"}
+
+    def test_json_pin_propagates(self, capsys) -> None:
+        reg = get_harness_health_registry()
+        reg.record_failure("codex", reason="rate limit", status_code=429)
+        cmd_harness_status(_ns(as_json=True))
+        payload = json.loads(capsys.readouterr().out)
+        codex_entry = next(h for h in payload["harnesses"] if h["harness"] == "codex")
+        assert codex_entry["available"] is False
+        assert "quota" in (codex_entry["permanent_pin_reason"] or "")

--- a/tests/harnesses/test_harness_health_wiring.py
+++ b/tests/harnesses/test_harness_health_wiring.py
@@ -1,0 +1,318 @@
+"""End-to-end tests proving HarnessHealthRegistry wiring at real harness call sites.
+
+Round 30g (#6922 continuation). These tests exercise
+:class:`aragora.harnesses.claude_code.ClaudeCodeHarness` and
+:class:`aragora.harnesses.codex.CodexHarness` with their underlying
+subprocess / OpenAI calls mocked. The goal is to demonstrate that:
+
+  1. ``record_attempt`` fires when ``analyze_repository`` /
+     ``analyze_files`` runs.
+  2. On success, the registry records a success outcome.
+  3. On auth-style failures (401-equivalent), the harness pins
+     permanently with ``last_failure_category == "auth"``.
+  4. On quota-style failures (429-equivalent), the harness pins
+     permanently with ``last_failure_category == "quota"``.
+  5. On transient failures (5xx-equivalent), a single failure does
+     not pin, but enough transient failures within the rolling window
+     do trip the pin.
+
+These tests do **not** call the real Claude Code or OpenAI API. The
+boundary that's mocked is the lowest-level subprocess/HTTP wrapper
+on each harness; everything between that wrapper and the registry is
+real production code.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aragora.harnesses.base import AnalysisType
+from aragora.harnesses.claude_code import ClaudeCodeConfig, ClaudeCodeHarness
+from aragora.harnesses.codex import CodexConfig, CodexHarness
+from aragora.swarm.harness_health import (
+    TRANSIENT_FAILURE_THRESHOLD,
+    get_harness_health_registry,
+    reset_harness_health_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> None:
+    reset_harness_health_registry()
+    yield
+    reset_harness_health_registry()
+
+
+@pytest.fixture
+def temp_repo() -> Path:
+    with tempfile.TemporaryDirectory() as d:
+        repo = Path(d)
+        (repo / "a.py").write_text("print('a')\n")
+        (repo / "b.py").write_text("print('b')\n")
+        yield repo
+
+
+# =============================================================================
+# ClaudeCodeHarness (subprocess-mocked)
+# =============================================================================
+
+
+class TestClaudeCodeHarnessWiring:
+    @pytest.mark.asyncio
+    async def test_success_records_success(self, temp_repo: Path) -> None:
+        harness = ClaudeCodeHarness(ClaudeCodeConfig())
+        with patch.object(
+            harness,
+            "_run_claude_code",
+            new=AsyncMock(return_value=("[]", "")),
+        ):
+            result = await harness.analyze_repository(
+                repo_path=temp_repo,
+                analysis_type=AnalysisType.GENERAL,
+            )
+        assert result.success is True
+        snap = get_harness_health_registry().snapshot("claude-code")
+        assert snap.last_outcome == "success"
+        assert snap.available is True
+        assert snap.permanent_pin_reason is None
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_pins_with_auth_category(self, temp_repo: Path) -> None:
+        harness = ClaudeCodeHarness(ClaudeCodeConfig())
+        # Simulate an auth-flavoured failure surfacing through the
+        # generic exception path. The registry classifies on the
+        # textual reason; HTTP status code is not always reachable.
+        with patch.object(
+            harness,
+            "_run_claude_code",
+            new=AsyncMock(side_effect=RuntimeError("Unauthorized: invalid API key")),
+        ):
+            result = await harness.analyze_repository(
+                repo_path=temp_repo,
+                analysis_type=AnalysisType.GENERAL,
+            )
+        assert result.success is False
+        snap = get_harness_health_registry().snapshot("claude-code")
+        assert snap.available is False
+        assert snap.last_outcome == "failure"
+        # AUTH/QUOTA failures pin permanently; the canonical signal is
+        # permanent_pin_reason. The registry stores the category as a
+        # prefix in that string and does not also append to the
+        # transient _failures window.
+        assert snap.permanent_pin_reason is not None
+        assert snap.permanent_pin_reason.startswith("auth:")
+
+    @pytest.mark.asyncio
+    async def test_quota_failure_pins_with_quota_category(self, temp_repo: Path) -> None:
+        harness = ClaudeCodeHarness(ClaudeCodeConfig())
+        with patch.object(
+            harness,
+            "_run_claude_code",
+            new=AsyncMock(side_effect=RuntimeError("rate limit exceeded (429)")),
+        ):
+            result = await harness.analyze_repository(
+                repo_path=temp_repo,
+                analysis_type=AnalysisType.GENERAL,
+            )
+        assert result.success is False
+        snap = get_harness_health_registry().snapshot("claude-code")
+        assert snap.available is False
+        assert snap.permanent_pin_reason is not None
+        assert snap.permanent_pin_reason.startswith("quota:")
+
+    @pytest.mark.asyncio
+    async def test_single_transient_does_not_pin(self, temp_repo: Path) -> None:
+        harness = ClaudeCodeHarness(ClaudeCodeConfig())
+        with patch.object(
+            harness,
+            "_run_claude_code",
+            new=AsyncMock(side_effect=RuntimeError("connection reset by peer")),
+        ):
+            await harness.analyze_repository(
+                repo_path=temp_repo,
+                analysis_type=AnalysisType.GENERAL,
+            )
+        snap = get_harness_health_registry().snapshot("claude-code")
+        # A single transient failure must not pin permanently.
+        assert snap.available is True
+        assert snap.last_outcome == "failure"
+        assert snap.last_failure_category == "transient"
+        assert snap.transient_failure_count_in_window == 1
+
+    @pytest.mark.asyncio
+    async def test_repeated_transient_eventually_pins(self, temp_repo: Path) -> None:
+        harness = ClaudeCodeHarness(ClaudeCodeConfig())
+        with patch.object(
+            harness,
+            "_run_claude_code",
+            new=AsyncMock(side_effect=RuntimeError("connection reset by peer")),
+        ):
+            for _ in range(TRANSIENT_FAILURE_THRESHOLD):
+                await harness.analyze_repository(
+                    repo_path=temp_repo,
+                    analysis_type=AnalysisType.GENERAL,
+                )
+        snap = get_harness_health_registry().snapshot("claude-code")
+        # After enough transients in the rolling window, harness pins.
+        assert snap.available is False
+        assert snap.permanent_pin_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_empty_files_no_op_records_failure_without_pin(self) -> None:
+        harness = ClaudeCodeHarness(ClaudeCodeConfig())
+        result = await harness.analyze_files(
+            files=[],
+            analysis_type=AnalysisType.GENERAL,
+        )
+        # Caller-side bug: no files. The harness records the no-op
+        # but treats it as a single failure (not enough to pin).
+        assert result.success is False
+        snap = get_harness_health_registry().snapshot("claude-code")
+        assert snap.last_outcome == "failure"
+        assert snap.available is True
+
+
+# =============================================================================
+# CodexHarness (OpenAI-call mocked)
+# =============================================================================
+
+
+class TestCodexHarnessWiring:
+    @pytest.mark.asyncio
+    async def test_success_records_success(self, temp_repo: Path) -> None:
+        harness = CodexHarness(CodexConfig(api_key="test"))
+        with patch.object(
+            harness,
+            "_call_openai",
+            new=AsyncMock(return_value="[]"),
+        ):
+            result = await harness.analyze_repository(
+                repo_path=temp_repo,
+                analysis_type=AnalysisType.GENERAL,
+            )
+        assert result.success is True
+        snap = get_harness_health_registry().snapshot("codex")
+        assert snap.last_outcome == "success"
+        assert snap.available is True
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_pins(self, temp_repo: Path) -> None:
+        harness = CodexHarness(CodexConfig(api_key="test"))
+        with patch.object(
+            harness,
+            "_call_openai",
+            new=AsyncMock(side_effect=ValueError("Unauthorized: invalid API key")),
+        ):
+            result = await harness.analyze_repository(
+                repo_path=temp_repo,
+                analysis_type=AnalysisType.GENERAL,
+            )
+        assert result.success is False
+        snap = get_harness_health_registry().snapshot("codex")
+        assert snap.available is False
+        assert snap.permanent_pin_reason is not None
+        assert snap.permanent_pin_reason.startswith("auth:")
+
+    @pytest.mark.asyncio
+    async def test_quota_failure_pins(self, temp_repo: Path) -> None:
+        harness = CodexHarness(CodexConfig(api_key="test"))
+        with patch.object(
+            harness,
+            "_call_openai",
+            new=AsyncMock(side_effect=RuntimeError("rate limit exceeded (429)")),
+        ):
+            result = await harness.analyze_repository(
+                repo_path=temp_repo,
+                analysis_type=AnalysisType.GENERAL,
+            )
+        assert result.success is False
+        snap = get_harness_health_registry().snapshot("codex")
+        assert snap.available is False
+        assert snap.permanent_pin_reason is not None
+        assert snap.permanent_pin_reason.startswith("quota:")
+
+    @pytest.mark.asyncio
+    async def test_single_transient_does_not_pin(self, temp_repo: Path) -> None:
+        harness = CodexHarness(CodexConfig(api_key="test"))
+        with patch.object(
+            harness,
+            "_call_openai",
+            new=AsyncMock(side_effect=RuntimeError("upstream returned 503")),
+        ):
+            result = await harness.analyze_repository(
+                repo_path=temp_repo,
+                analysis_type=AnalysisType.GENERAL,
+            )
+        assert result.success is False
+        snap = get_harness_health_registry().snapshot("codex")
+        assert snap.available is True
+        assert snap.last_failure_category == "transient"
+
+    @pytest.mark.asyncio
+    async def test_no_files_records_success_without_pin(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            empty = Path(d)
+            harness = CodexHarness(CodexConfig(api_key="test"))
+            result = await harness.analyze_repository(
+                repo_path=empty,
+                analysis_type=AnalysisType.GENERAL,
+            )
+        assert result.success is True
+        snap = get_harness_health_registry().snapshot("codex")
+        # Empty work surface is success, not failure.
+        assert snap.last_outcome == "success"
+        assert snap.available is True
+
+
+# =============================================================================
+# record_harness_result helper edge cases
+# =============================================================================
+
+
+class TestRecordHarnessResultHelper:
+    def test_success_path(self) -> None:
+        from aragora.swarm.harness_health import record_harness_result
+
+        record_harness_result(harness="x", success=True)
+        snap = get_harness_health_registry().snapshot("x")
+        assert snap.last_outcome == "success"
+
+    def test_failure_uses_error_message_when_present(self) -> None:
+        from aragora.swarm.harness_health import record_harness_result
+
+        record_harness_result(
+            harness="x",
+            success=False,
+            error_message="Unauthorized: invalid API key",
+            status_code=401,
+        )
+        snap = get_harness_health_registry().snapshot("x")
+        assert snap.available is False
+        # AUTH classification surfaces as a 'auth:' permanent pin.
+        assert snap.permanent_pin_reason is not None
+        assert snap.permanent_pin_reason.startswith("auth:")
+
+    def test_failure_falls_back_to_error_output_tail(self) -> None:
+        from aragora.swarm.harness_health import record_harness_result
+
+        record_harness_result(
+            harness="x",
+            success=False,
+            error_output="some\nlong\nstderr\nUnauthorized at line 42",
+        )
+        snap = get_harness_health_registry().snapshot("x")
+        assert snap.permanent_pin_reason is not None
+        assert snap.permanent_pin_reason.startswith("auth:")
+
+    def test_failure_with_no_signal_records_transient(self) -> None:
+        from aragora.swarm.harness_health import record_harness_result
+
+        record_harness_result(harness="x", success=False)
+        snap = get_harness_health_registry().snapshot("x")
+        assert snap.last_outcome == "failure"
+        # Unknown reason classifies as transient (not pinning).
+        assert snap.available is True

--- a/tests/swarm/test_harness_fallback.py
+++ b/tests/swarm/test_harness_fallback.py
@@ -81,7 +81,10 @@ class TestDefaultLadders:
     def test_default_implementation_order(self) -> None:
         ladder = default_implementation_ladder()
         assert ladder.name == "implementation"
-        assert ladder.steps == ("claude-code", "codex", "aider")
+        # Round 30g: aider removed — no real AiderHarness ships in
+        # aragora.harnesses, so the ladder must only list harnesses
+        # that can actually run.
+        assert ladder.steps == ("claude-code", "codex")
 
     def test_default_review_order(self) -> None:
         ladder = default_review_ladder()

--- a/tests/swarm/test_harness_fallback.py
+++ b/tests/swarm/test_harness_fallback.py
@@ -1,0 +1,105 @@
+"""Tests for aragora.swarm.harness_fallback (Round 30f phase 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.swarm.harness_fallback import (
+    FallbackLadder,
+    FallbackResolution,
+    default_implementation_ladder,
+    default_review_ladder,
+)
+from aragora.swarm.harness_health import HarnessHealthRegistry
+
+
+class TestFallbackLadderConstruction:
+    def test_simple_construction(self) -> None:
+        ladder = FallbackLadder(name="test", steps=("a", "b", "c"))
+        assert ladder.name == "test"
+        assert ladder.steps == ("a", "b", "c")
+
+    def test_rejects_empty_steps(self) -> None:
+        with pytest.raises(ValueError, match="at least one step"):
+            FallbackLadder(name="test", steps=())
+
+    def test_rejects_duplicate_steps(self) -> None:
+        with pytest.raises(ValueError, match="duplicate"):
+            FallbackLadder(name="test", steps=("a", "b", "a"))
+
+    def test_rejects_empty_string_step(self) -> None:
+        with pytest.raises(ValueError, match="non-empty strings"):
+            FallbackLadder(name="test", steps=("a", ""))
+
+    def test_from_steps_builder(self) -> None:
+        ladder = FallbackLadder.from_steps("review", ["claude-code", "codex"])
+        assert ladder.steps == ("claude-code", "codex")
+
+
+class TestFallbackResolution:
+    def test_first_step_is_chosen_when_available(self) -> None:
+        reg = HarnessHealthRegistry()
+        ladder = FallbackLadder(name="t", steps=("a", "b", "c"))
+        result = ladder.next_available(registry=reg)
+        assert result.chosen == "a"
+        assert result.skipped == ()
+        assert result.reasons == {}
+        assert result.is_resolved() is True
+
+    def test_skips_pinned_first_step(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_failure("a", reason="api key", status_code=401)
+        ladder = FallbackLadder(name="t", steps=("a", "b", "c"))
+        result = ladder.next_available(registry=reg)
+        assert result.chosen == "b"
+        assert result.skipped == ("a",)
+        assert "auth" in result.reasons["a"]
+
+    def test_returns_none_when_all_pinned(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_failure("a", reason="auth", status_code=401)
+        reg.record_failure("b", reason="auth", status_code=401)
+        reg.record_failure("c", reason="auth", status_code=401)
+        ladder = FallbackLadder(name="t", steps=("a", "b", "c"))
+        result = ladder.next_available(registry=reg)
+        assert result.chosen is None
+        assert result.skipped == ("a", "b", "c")
+        assert result.is_resolved() is False
+
+    def test_uses_singleton_when_no_registry_passed(self, monkeypatch) -> None:
+        # next_available without registry should consult the global singleton.
+        from aragora.swarm import harness_health as hh
+
+        hh.reset_harness_health_registry()
+        ladder = FallbackLadder(name="t", steps=("a", "b"))
+        result = ladder.next_available()
+        # Singleton is fresh => "a" available
+        assert result.chosen == "a"
+
+
+class TestDefaultLadders:
+    def test_default_implementation_order(self) -> None:
+        ladder = default_implementation_ladder()
+        assert ladder.name == "implementation"
+        assert ladder.steps == ("claude-code", "codex", "aider")
+
+    def test_default_review_order(self) -> None:
+        ladder = default_review_ladder()
+        assert ladder.name == "review"
+        assert ladder.steps == ("claude-code", "codex")
+
+    def test_implementation_falls_back_when_claude_pinned(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_failure("claude-code", reason="auth", status_code=401)
+        ladder = default_implementation_ladder()
+        result = ladder.next_available(registry=reg)
+        assert result.chosen == "codex"
+
+    def test_review_returns_none_when_both_pinned(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_failure("claude-code", reason="auth", status_code=401)
+        reg.record_failure("codex", reason="auth", status_code=401)
+        ladder = default_review_ladder()
+        result = ladder.next_available(registry=reg)
+        assert result.chosen is None
+        assert result.skipped == ("claude-code", "codex")

--- a/tests/swarm/test_harness_health.py
+++ b/tests/swarm/test_harness_health.py
@@ -1,0 +1,206 @@
+"""Tests for aragora.swarm.harness_health (Round 30f phase 2)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from aragora.swarm.harness_health import (
+    AUTH_FAILURE_CODES,
+    PERMANENT_FAILURE_CODES,
+    QUOTA_FAILURE_CODES,
+    TRANSIENT_FAILURE_CODES,
+    FailureCategory,
+    HarnessHealthRegistry,
+    classify_failure,
+    get_harness_health_registry,
+    reset_harness_health_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> None:
+    reset_harness_health_registry()
+    yield
+    reset_harness_health_registry()
+
+
+# --- classify_failure --------------------------------------------------
+
+
+class TestClassifyFailure:
+    def test_auth_status_codes(self) -> None:
+        for code in AUTH_FAILURE_CODES:
+            assert classify_failure(status_code=code, reason="") is FailureCategory.AUTH
+
+    def test_quota_status_code(self) -> None:
+        for code in QUOTA_FAILURE_CODES:
+            assert classify_failure(status_code=code, reason="") is FailureCategory.QUOTA
+
+    def test_transient_default(self) -> None:
+        assert classify_failure(status_code=500, reason="server error") is FailureCategory.TRANSIENT
+
+    def test_no_status_unauthorized_phrase(self) -> None:
+        assert (
+            classify_failure(status_code=None, reason="Error: Unauthorized API key")
+            is FailureCategory.AUTH
+        )
+
+    def test_no_status_quota_phrase(self) -> None:
+        assert (
+            classify_failure(status_code=None, reason="Rate limit exceeded")
+            is FailureCategory.QUOTA
+        )
+
+    def test_no_status_unknown_is_transient(self) -> None:
+        assert (
+            classify_failure(status_code=None, reason="connection reset")
+            is FailureCategory.TRANSIENT
+        )
+
+
+class TestPermanentCodesUnion:
+    def test_union_is_correct(self) -> None:
+        assert PERMANENT_FAILURE_CODES == AUTH_FAILURE_CODES | QUOTA_FAILURE_CODES
+
+    def test_transient_codes_disjoint_from_permanent(self) -> None:
+        assert PERMANENT_FAILURE_CODES.isdisjoint(TRANSIENT_FAILURE_CODES)
+
+
+# --- HarnessHealthRegistry --------------------------------------------
+
+
+class TestRegistryInit:
+    def test_default_construction(self) -> None:
+        reg = HarnessHealthRegistry()
+        assert reg.is_available("any-harness") is True
+
+    def test_rejects_invalid_threshold(self) -> None:
+        with pytest.raises(ValueError, match=">= 1"):
+            HarnessHealthRegistry(transient_threshold=0)
+
+    def test_rejects_invalid_window(self) -> None:
+        with pytest.raises(ValueError, match="> 0"):
+            HarnessHealthRegistry(transient_window_seconds=0)
+
+
+class TestRecordSuccessFailure:
+    def test_success_recorded(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_success("claude-code", detail="ok")
+        snap = reg.snapshot("claude-code")
+        assert snap.last_outcome == "success"
+        assert snap.available is True
+
+    def test_failure_recorded_transient_below_threshold(self) -> None:
+        reg = HarnessHealthRegistry()
+        cat = reg.record_failure("claude-code", reason="timeout")
+        assert cat is FailureCategory.TRANSIENT
+        assert reg.is_available("claude-code") is True
+        assert reg.transient_failures_in_window("claude-code") == 1
+
+    def test_transient_threshold_pins_harness(self) -> None:
+        reg = HarnessHealthRegistry(transient_threshold=3)
+        for _ in range(3):
+            reg.record_failure("claude-code", reason="timeout")
+        assert reg.is_available("claude-code") is False
+        reason = reg.permanent_pin_reason("claude-code")
+        assert reason is not None
+        assert "transient" in reason
+
+    def test_auth_failure_pins_immediately(self) -> None:
+        reg = HarnessHealthRegistry()
+        cat = reg.record_failure("claude-code", reason="missing credential", status_code=401)
+        assert cat is FailureCategory.AUTH
+        assert reg.is_available("claude-code") is False
+        assert "auth" in reg.permanent_pin_reason("claude-code")
+
+    def test_quota_failure_pins_immediately(self) -> None:
+        reg = HarnessHealthRegistry()
+        cat = reg.record_failure("claude-code", reason="rate limit", status_code=429)
+        assert cat is FailureCategory.QUOTA
+        assert reg.is_available("claude-code") is False
+
+    def test_success_resets_transient_window(self) -> None:
+        reg = HarnessHealthRegistry(transient_threshold=3)
+        reg.record_failure("claude-code", reason="timeout")
+        reg.record_failure("claude-code", reason="timeout")
+        reg.record_success("claude-code")
+        assert reg.transient_failures_in_window("claude-code") == 0
+        # And accumulating again starts from zero
+        reg.record_failure("claude-code", reason="timeout")
+        assert reg.is_available("claude-code") is True
+
+    def test_success_does_not_lift_permanent_pin(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_failure("claude-code", reason="api key invalid", status_code=401)
+        reg.record_success("claude-code")  # bizarre but valid call
+        # Permanent pin survives — auth pin is for the session.
+        assert reg.is_available("claude-code") is False
+
+    def test_other_harnesses_unaffected_by_pin(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_failure("claude-code", reason="api key", status_code=401)
+        assert reg.is_available("codex") is True
+        assert reg.is_available("aider") is True
+
+
+class TestSnapshot:
+    def test_snapshot_for_unknown_harness_is_available(self) -> None:
+        reg = HarnessHealthRegistry()
+        snap = reg.snapshot("never-touched")
+        assert snap.available is True
+        assert snap.permanent_pin_reason is None
+        assert snap.last_outcome is None
+        assert snap.transient_failure_count_in_window == 0
+
+    def test_snapshot_after_failure(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_failure("claude-code", reason="boom", status_code=500)
+        snap = reg.snapshot("claude-code")
+        assert snap.last_outcome == "failure"
+        assert snap.last_failure_reason == "boom"
+        assert snap.last_failure_category == "transient"
+
+    def test_snapshot_to_dict_round_trip(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_success("claude-code")
+        snap = reg.snapshot("claude-code")
+        d = snap.to_dict()
+        assert d["harness"] == "claude-code"
+        assert d["available"] is True
+        assert d["last_outcome"] == "success"
+
+    def test_snapshot_all_includes_explicitly_requested(self) -> None:
+        reg = HarnessHealthRegistry()
+        reg.record_success("claude-code")
+        snaps = reg.snapshot_all(harnesses=["codex", "aider"])
+        names = {snap.harness for snap in snaps}
+        assert {"claude-code", "codex", "aider"}.issubset(names)
+
+
+class TestSingleton:
+    def test_get_returns_same_instance(self) -> None:
+        a = get_harness_health_registry()
+        b = get_harness_health_registry()
+        assert a is b
+
+    def test_reset_creates_new_instance(self) -> None:
+        a = get_harness_health_registry()
+        reset_harness_health_registry()
+        b = get_harness_health_registry()
+        assert a is not b
+
+
+class TestSlidingWindow:
+    def test_old_failures_pruned_from_count(self) -> None:
+        reg = HarnessHealthRegistry(transient_threshold=3, transient_window_seconds=0.1)
+        reg.record_failure("claude-code", reason="t1")
+        reg.record_failure("claude-code", reason="t2")
+        time.sleep(0.15)
+        # Window expired; count should be 0 even though 2 failures occurred
+        assert reg.transient_failures_in_window("claude-code") == 0
+        # And new failure must restart accumulation, not pin yet
+        reg.record_failure("claude-code", reason="t3")
+        assert reg.is_available("claude-code") is True


### PR DESCRIPTION
## Summary

Phase 2 of the approved Round 30f plan: harness reliability primitives. Mirrors the design of `aragora.routing.session_circuit_breaker` but at the *harness* layer (Claude Code, Codex, Aider) rather than the *provider* layer.

This PR is **infrastructure + CLI surface only**. It adds the building blocks without wiring them into the boss-loop or supervisor — that wiring is intentionally deferred so this PR stays under the Tier-2 cap and can be reviewed in isolation.

## Changes

1. **`aragora/swarm/harness_health.py` (NEW, ~370 LOC)**
   - `HarnessHealthRegistry`: thread-safe, session-scoped registry. Auth (401/403) and quota (429) failures pin permanently for the session; transient failures (5xx, timeouts, exit-code != 0) pin after 3 failures in a 300s sliding window.
   - `classify_failure`: status-code + reason-string heuristic. Lets CLI harnesses signal auth/quota pinning by including the right phrase in stderr.
   - `HarnessHealthSnapshot`: read-only view, `to_dict()` round-trip.
   - `get_harness_health_registry` / `reset_harness_health_registry` (test helper).

2. **`aragora/swarm/harness_fallback.py` (NEW, ~155 LOC)**
   - `FallbackLadder`: declarative ordered list of harnesses, validates uniqueness + non-empty steps. `next_available()` consults the registry and returns the first non-pinned step or `None`.
   - `default_implementation_ladder()` -> `claude-code -> codex -> aider`.
   - `default_review_ladder()` -> `claude-code -> codex`.

3. **`aragora/cli/commands/harness_status.py` (NEW, ~104 LOC)** + parser/swarm.py wiring
   - `aragora swarm harness-status` (table mode by default, `--json` for structured output).
   - Shows known harnesses (`claude-code`, `codex`, `aider`) even if they've never been invoked, plus the resolved fallback ladders so the operator sees the chosen step.

4. **45 new tests** across `tests/swarm/test_harness_health.py`, `tests/swarm/test_harness_fallback.py`, `tests/cli/test_harness_status_cmd.py`. All 167 tests in `tests/cli/commands/` pass; all 45 new tests pass.

## Why this is Tier-2 and not author-merged

Adds new public API in `aragora.swarm` and a new CLI subcommand under `aragora swarm`. Even though this PR doesn't change any existing call site's behavior, the API shapes here will be consumed by Phase 3 wiring; reviewer eyes on the contracts now save churn later.

## What this PR is NOT

- Does not wire the registry/ladder into `worker_launcher.py`, `supervisor.py`, or `boss_loop.py` — that's a separate stacked PR that requires looking at every spawn site individually.
- Does not change any existing harness or provider behavior; the registry is opt-in advice.
- Does not introduce any new external dependencies.

## Test plan

- `pytest tests/swarm/test_harness_health.py tests/swarm/test_harness_fallback.py tests/cli/test_harness_status_cmd.py -v` -> 45 passed
- `pytest tests/cli/commands/ -q` -> 167 passed
- Pre-commit: ruff + ruff-format + gitleaks all pass
- Manual smoke: `python3 -c "from aragora.cli.parser import build_parser; print(build_parser().parse_args(['swarm', 'harness-status', '--json']))"` -> parses cleanly