### PR TITLE
fix(heterogeneity): expose probe metric counts

### DIFF
--- a/aragora/heterogeneity/probe.py
+++ b/aragora/heterogeneity/probe.py
@@ -150,15 +150,23 @@ def compute_metrics(
         "n_panelists": panel_size,
         "n_prompts": len(results),
         "n_per_class": _class_counts(results),
+        "independent_flag_successes": seeded_successes,
+        "independent_flag_trials": seeded_trials,
         "independent_flag_rate": independent_rate,
         "independent_flag_rate_ci_95_wilson": list(
             wilson_interval(seeded_successes, seeded_trials)
         ),
+        "catastrophic_correlation_failures": catastrophic_count,
+        "catastrophic_correlation_trials": catastrophic_trials,
         "catastrophic_correlation_rate": catastrophic_rate,
         "catastrophic_correlation_rate_ci_95_wilson": list(
             wilson_interval(catastrophic_count, catastrophic_trials)
         ),
+        "clean_neutral_false_positives": clean_wrong,
+        "clean_neutral_false_positive_trials": clean_trials,
         "false_positive_rate_on_clean_neutral": clean_fpr,
+        "null_negative_false_positives": null_wrong,
+        "null_negative_false_positive_trials": null_trials,
         "false_positive_rate_on_null_negative": null_fpr,
     }
 

--- a/tests/heterogeneity/test_probe_metrics.py
+++ b/tests/heterogeneity/test_probe_metrics.py
@@ -45,9 +45,17 @@ def test_compute_metrics_counts_seeded_and_correlation_classes() -> None:
         _result("z1", "null_negative", ["missed"] * 6),
     ]
     metrics = compute_metrics(results, n_panelists=6)
+    assert metrics["independent_flag_successes"] == 13
+    assert metrics["independent_flag_trials"] == 18
     assert metrics["independent_flag_rate"] == 13 / 18
+    assert metrics["catastrophic_correlation_failures"] == 1
+    assert metrics["catastrophic_correlation_trials"] == 1
     assert metrics["catastrophic_correlation_rate"] == 1.0
+    assert metrics["clean_neutral_false_positives"] == 1
+    assert metrics["clean_neutral_false_positive_trials"] == 6
     assert metrics["false_positive_rate_on_clean_neutral"] == 1 / 6
+    assert metrics["null_negative_false_positives"] == 0
+    assert metrics["null_negative_false_positive_trials"] == 6
     assert metrics["false_positive_rate_on_null_negative"] == 0
 
 

--- a/tests/heterogeneity/test_receipt.py
+++ b/tests/heterogeneity/test_receipt.py
@@ -32,6 +32,8 @@ def test_receipt_id_excludes_produced_at(tmp_path) -> None:
     path = write_receipt(first, tmp_path)
     assert path.exists()
     assert path.name == f"{first['receipt_id']}.json"
+    assert first["metrics"]["independent_flag_successes"] == 1
+    assert first["metrics"]["independent_flag_trials"] == 2
 
 
 def test_receipt_preserves_plural_seeded_errors() -> None:


### PR DESCRIPTION
## Summary
- restacks the prior heterogeneity metric-count handoff onto current main
- exposes numerator/trial counts beside the existing heterogeneity probe rates and Wilson intervals
- adds regression coverage for metrics and receipt payloads

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/heterogeneity/test_probe_metrics.py tests/heterogeneity/test_receipt.py tests/scripts/test_run_heterogeneity_probe.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check aragora/heterogeneity/probe.py tests/heterogeneity/test_probe_metrics.py tests/heterogeneity/test_receipt.py
- python3 -m ruff format --check aragora/heterogeneity/probe.py tests/heterogeneity/test_probe_metrics.py tests/heterogeneity/test_receipt.py
- python3 scripts/run_heterogeneity_probe.py --json --synthetic-fixture --output-root /private/tmp/aragora-heterogeneity-metric-counts-fixture --run-id metric-counts-refresh
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Supersedes handoff issue #6917.