### PR TITLE
[AGT-03] Per-agent rolling Brier scorer (sub-deliverables 3 & 4)

### DIFF
--- a/aragora/metrics/__init__.py
+++ b/aragora/metrics/__init__.py
@@ -1,12 +1,69 @@
 """Aragora metrics package.
 
-Currently exposes the AGT-06 VIAH (verifiable improvements per agent-hour)
-helper. See ``docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md`` §4 and
-issue #6067 for the rationale.
+Exposes:
+- AGT-06 VIAH (verifiable improvements per agent-hour): :class:`ViahReport`,
+  :func:`compute_viah`, :func:`viah_score`.
+- AGT-03 Manifold Brier scorer: :class:`ManifoldBrierScorer`,
+  :class:`ManifoldPrediction`, :class:`BrierWindowSummary`,
+  :class:`CalibrationBin`, :func:`brier_score`, :func:`manifold_brier_enabled`.
+
+Imports are lazy (PEP 562 ``__getattr__``) so importing
+``aragora.metrics.manifold_brier`` does not trigger the heavy transitive
+dependency chain in ``aragora.metrics.viah``.
 """
 
 from __future__ import annotations
 
-from aragora.metrics.viah import ViahReport, compute_viah, viah_score
+__all__ = [
+    # AGT-06
+    "ViahReport",
+    "compute_viah",
+    "viah_score",
+    # AGT-03
+    "ManifoldBrierScorer",
+    "ManifoldPrediction",
+    "BrierWindowSummary",
+    "CalibrationBin",
+    "brier_score",
+    "manifold_brier_enabled",
+]
 
-__all__ = ["ViahReport", "compute_viah", "viah_score"]
+_VIAH_NAMES = {"ViahReport", "compute_viah", "viah_score"}
+_BRIER_NAMES = {
+    "ManifoldBrierScorer",
+    "ManifoldPrediction",
+    "BrierWindowSummary",
+    "CalibrationBin",
+    "brier_score",
+    "manifold_brier_enabled",
+}
+
+
+def __getattr__(name: str):  # noqa: ANN001, ANN201 — PEP 562 module __getattr__
+    if name in _VIAH_NAMES:
+        from aragora.metrics.viah import ViahReport, compute_viah, viah_score
+
+        _globals = globals()
+        _globals["ViahReport"] = ViahReport
+        _globals["compute_viah"] = compute_viah
+        _globals["viah_score"] = viah_score
+        return _globals[name]
+    if name in _BRIER_NAMES:
+        from aragora.metrics.manifold_brier import (
+            BrierWindowSummary,
+            CalibrationBin,
+            ManifoldBrierScorer,
+            ManifoldPrediction,
+            brier_score,
+            manifold_brier_enabled,
+        )
+
+        _globals = globals()
+        _globals["BrierWindowSummary"] = BrierWindowSummary
+        _globals["CalibrationBin"] = CalibrationBin
+        _globals["ManifoldBrierScorer"] = ManifoldBrierScorer
+        _globals["ManifoldPrediction"] = ManifoldPrediction
+        _globals["brier_score"] = brier_score
+        _globals["manifold_brier_enabled"] = manifold_brier_enabled
+        return _globals[name]
+    raise AttributeError(f"module 'aragora.metrics' has no attribute {name!r}")

--- a/aragora/metrics/manifold_brier.py
+++ b/aragora/metrics/manifold_brier.py
@@ -280,6 +280,88 @@ class ManifoldBrierScorer:
             window_end=now,
         )
 
+    def agents(self) -> list[str]:
+        """Sorted list of distinct non-empty agent_ids with stored predictions."""
+        _require_enabled()
+        return sorted({p.agent_id for p in self._predictions if p.agent_id})
+
+    def rolling_score_for_agent(
+        self,
+        agent_id: str,
+        *,
+        window_days: int = 90,
+        reference_time: Optional[datetime] = None,
+    ) -> BrierWindowSummary:
+        """Per-agent rolling Brier score (AGT-03 sub-deliverable 3).
+
+        Like :meth:`rolling_score` but filtered to ``agent_id``.  Default
+        *window_days* is 90 per the AGT-03 plan.
+        """
+        _require_enabled()
+        if window_days < 1:
+            raise ValueError(f"window_days must be >= 1; got {window_days}")
+        if not agent_id:
+            raise ValueError("agent_id must be a non-empty string")
+        now = reference_time if reference_time is not None else datetime.now(UTC)
+        cutoff = now - timedelta(days=window_days)
+        in_window = [
+            p
+            for p in self._predictions
+            if p.agent_id == agent_id and cutoff <= p.predicted_at <= now
+        ]
+        scores = [p.score for p in in_window]
+        return BrierWindowSummary(
+            window_days=window_days,
+            n_predictions=len(scores),
+            mean_brier=statistics.mean(scores) if scores else None,
+            median_brier=statistics.median(scores) if scores else None,
+            window_start=cutoff,
+            window_end=now,
+        )
+
+    def calibration_curve_for_agent(
+        self,
+        agent_id: str,
+        *,
+        n_bins: int = 10,
+    ) -> list[CalibrationBin]:
+        """Calibration curve filtered to one agent (AGT-03 sub-deliverable 4).
+
+        Like :meth:`calibration_curve` but restricted to ``agent_id``.
+        """
+        _require_enabled()
+        if not (2 <= n_bins <= 100):
+            raise ValueError(f"n_bins must be in [2, 100]; got {n_bins}")
+        if not agent_id:
+            raise ValueError("agent_id must be a non-empty string")
+        step = 1.0 / n_bins
+        counts_yes: list[int] = [0] * n_bins
+        counts_total: list[int] = [0] * n_bins
+        sum_predicted: list[float] = [0.0] * n_bins
+        for pred in self._predictions:
+            if pred.agent_id != agent_id:
+                continue
+            decimal_probability = Decimal(str(pred.predicted_probability))
+            idx = int((decimal_probability * n_bins).to_integral_value(rounding=ROUND_FLOOR))
+            idx = min(idx, n_bins - 1)
+            counts_total[idx] += 1
+            sum_predicted[idx] += pred.predicted_probability
+            if pred.outcome == 1:
+                counts_yes[idx] += 1
+        bins: list[CalibrationBin] = []
+        for i in range(n_bins):
+            n = counts_total[i]
+            bins.append(
+                CalibrationBin(
+                    low=round(i * step, 10),
+                    high=round((i + 1) * step, 10),
+                    count=n,
+                    fraction_yes=(counts_yes[i] / n) if n > 0 else None,
+                    mean_predicted=(sum_predicted[i] / n) if n > 0 else None,
+                )
+            )
+        return bins
+
     def calibration_curve(self, *, n_bins: int = 10) -> list[CalibrationBin]:
         """Compute a reliability diagram calibration curve over all stored predictions.
 

--- a/tests/metrics/test_manifold_brier_per_agent.py
+++ b/tests/metrics/test_manifold_brier_per_agent.py
@@ -1,0 +1,163 @@
+"""Tests for per-agent Brier scoring (AGT-03 sub-deliverable 3/4).
+
+Covers ManifoldBrierScorer.agents(), .rolling_score_for_agent(),
+and .calibration_curve_for_agent().
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.metrics.manifold_brier import (
+    ManifoldBrierScorer,
+    ManifoldPrediction,
+)
+
+
+def _pred(p: float, outcome: int, *, agent_id: str = "alpha", days_ago: float = 0,
+          question_id: str | None = None) -> ManifoldPrediction:
+    return ManifoldPrediction(
+        question_id=question_id or f"q_{agent_id}_{p}_{days_ago}",
+        predicted_probability=p,
+        outcome=outcome,
+        predicted_at=datetime.now(UTC) - timedelta(days=days_ago),
+        agent_id=agent_id,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+
+
+# ---------------------------------------------------------------------------
+# Feature-gate enforcement
+# ---------------------------------------------------------------------------
+
+class TestGate:
+    @pytest.mark.parametrize("method,args", [
+        ("agents", []),
+        ("rolling_score_for_agent", ["x"]),
+        ("calibration_curve_for_agent", ["x"]),
+    ])
+    def test_raises_when_disabled(self, monkeypatch: pytest.MonkeyPatch,
+                                   method: str, args: list) -> None:
+        monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)
+        scorer = ManifoldBrierScorer()
+        with pytest.raises(RuntimeError, match="disabled"):
+            getattr(scorer, method)(*args)
+
+
+# ---------------------------------------------------------------------------
+# agents()
+# ---------------------------------------------------------------------------
+
+class TestAgents:
+    def test_empty_scorer(self) -> None:
+        assert ManifoldBrierScorer().agents() == []
+
+    def test_sorted_and_deduplicated(self) -> None:
+        scorer = ManifoldBrierScorer()
+        for q in "abc":
+            scorer.add(_pred(0.5, 1, agent_id="zebra", question_id=f"z{q}"))
+        scorer.add(_pred(0.5, 1, agent_id="alpha", question_id="a1"))
+        assert scorer.agents() == ["alpha", "zebra"]
+
+    def test_blank_agent_id_excluded(self) -> None:
+        scorer = ManifoldBrierScorer()
+        scorer.add(ManifoldPrediction(
+            question_id="anon", predicted_probability=0.5, outcome=1,
+            predicted_at=datetime.now(UTC), agent_id="",
+        ))
+        scorer.add(_pred(0.7, 1, agent_id="alpha"))
+        assert scorer.agents() == ["alpha"]
+
+
+# ---------------------------------------------------------------------------
+# rolling_score_for_agent()
+# ---------------------------------------------------------------------------
+
+class TestRollingScoreForAgent:
+    def test_empty_returns_none_stats(self) -> None:
+        s = ManifoldBrierScorer()
+        r = s.rolling_score_for_agent("alpha")
+        assert r.n_predictions == 0
+        assert r.mean_brier is None
+
+    def test_default_window_90_days(self) -> None:
+        s = ManifoldBrierScorer()
+        s.add(_pred(0.8, 1, days_ago=89, question_id="in"))
+        s.add(_pred(0.8, 1, days_ago=91, question_id="out"))
+        r = s.rolling_score_for_agent("alpha")
+        assert r.window_days == 90
+        assert r.n_predictions == 1
+
+    def test_excludes_other_agents(self) -> None:
+        s = ManifoldBrierScorer()
+        s.add(_pred(1.0, 1, agent_id="alpha", question_id="a"))
+        s.add(_pred(0.0, 1, agent_id="beta",  question_id="b"))
+        assert s.rolling_score_for_agent("alpha").n_predictions == 1
+        assert s.rolling_score_for_agent("beta").n_predictions == 1
+
+    def test_two_agents_independent_scores(self) -> None:
+        s = ManifoldBrierScorer()
+        s.add(_pred(1.0, 1, agent_id="alpha", question_id="a"))  # BS=0.0
+        s.add(_pred(0.0, 1, agent_id="beta",  question_id="b"))  # BS=1.0
+        assert s.rolling_score_for_agent("alpha").mean_brier == pytest.approx(0.0)
+        assert s.rolling_score_for_agent("beta").mean_brier  == pytest.approx(1.0)
+
+    def test_empty_agent_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="agent_id"):
+            ManifoldBrierScorer().rolling_score_for_agent("")
+
+    def test_invalid_window_days_raises(self) -> None:
+        with pytest.raises(ValueError, match="window_days"):
+            ManifoldBrierScorer().rolling_score_for_agent("alpha", window_days=0)
+
+    def test_unknown_agent_returns_empty(self) -> None:
+        s = ManifoldBrierScorer()
+        s.add(_pred(0.7, 1, agent_id="alpha"))
+        assert s.rolling_score_for_agent("no-such-agent").n_predictions == 0
+
+
+# ---------------------------------------------------------------------------
+# calibration_curve_for_agent()
+# ---------------------------------------------------------------------------
+
+class TestCalibrationCurveForAgent:
+    def test_returns_n_bins(self) -> None:
+        assert len(ManifoldBrierScorer().calibration_curve_for_agent("x", n_bins=5)) == 5
+
+    def test_empty_scorer_all_empty_bins(self) -> None:
+        curve = ManifoldBrierScorer().calibration_curve_for_agent("x")
+        assert all(b.count == 0 and b.fraction_yes is None for b in curve)
+
+    def test_other_agent_excluded(self) -> None:
+        s = ManifoldBrierScorer()
+        s.add(_pred(0.75, 1, agent_id="beta"))
+        assert sum(b.count for b in s.calibration_curve_for_agent("alpha")) == 0
+
+    def test_fraction_yes_correct(self) -> None:
+        s = ManifoldBrierScorer()
+        s.add(_pred(0.25, 1, agent_id="x", question_id="y1"))
+        s.add(_pred(0.25, 0, agent_id="x", question_id="n1"))
+        curve = s.calibration_curve_for_agent("x", n_bins=10)
+        assert curve[2].count == 2
+        assert curve[2].fraction_yes == pytest.approx(0.5)
+
+    def test_p1_clamps_to_last_bin(self) -> None:
+        s = ManifoldBrierScorer()
+        s.add(_pred(1.0, 1, agent_id="x"))
+        curve = s.calibration_curve_for_agent("x", n_bins=10)
+        assert curve[-1].count == 1
+        assert sum(b.count for b in curve) == 1
+
+    def test_empty_agent_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="agent_id"):
+            ManifoldBrierScorer().calibration_curve_for_agent("")
+
+    def test_invalid_n_bins_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_bins"):
+            ManifoldBrierScorer().calibration_curve_for_agent("x", n_bins=1)

--- a/tests/metrics/test_manifold_brier_per_agent.py
+++ b/tests/metrics/test_manifold_brier_per_agent.py
@@ -16,8 +16,14 @@ from aragora.metrics.manifold_brier import (
 )
 
 
-def _pred(p: float, outcome: int, *, agent_id: str = "alpha", days_ago: float = 0,
-          question_id: str | None = None) -> ManifoldPrediction:
+def _pred(
+    p: float,
+    outcome: int,
+    *,
+    agent_id: str = "alpha",
+    days_ago: float = 0,
+    question_id: str | None = None,
+) -> ManifoldPrediction:
     return ManifoldPrediction(
         question_id=question_id or f"q_{agent_id}_{p}_{days_ago}",
         predicted_probability=p,
@@ -36,14 +42,19 @@ def _enable(monkeypatch: pytest.MonkeyPatch) -> None:
 # Feature-gate enforcement
 # ---------------------------------------------------------------------------
 
+
 class TestGate:
-    @pytest.mark.parametrize("method,args", [
-        ("agents", []),
-        ("rolling_score_for_agent", ["x"]),
-        ("calibration_curve_for_agent", ["x"]),
-    ])
-    def test_raises_when_disabled(self, monkeypatch: pytest.MonkeyPatch,
-                                   method: str, args: list) -> None:
+    @pytest.mark.parametrize(
+        "method,args",
+        [
+            ("agents", []),
+            ("rolling_score_for_agent", ["x"]),
+            ("calibration_curve_for_agent", ["x"]),
+        ],
+    )
+    def test_raises_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, method: str, args: list
+    ) -> None:
         monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)
         scorer = ManifoldBrierScorer()
         with pytest.raises(RuntimeError, match="disabled"):
@@ -53,6 +64,7 @@ class TestGate:
 # ---------------------------------------------------------------------------
 # agents()
 # ---------------------------------------------------------------------------
+
 
 class TestAgents:
     def test_empty_scorer(self) -> None:
@@ -67,10 +79,15 @@ class TestAgents:
 
     def test_blank_agent_id_excluded(self) -> None:
         scorer = ManifoldBrierScorer()
-        scorer.add(ManifoldPrediction(
-            question_id="anon", predicted_probability=0.5, outcome=1,
-            predicted_at=datetime.now(UTC), agent_id="",
-        ))
+        scorer.add(
+            ManifoldPrediction(
+                question_id="anon",
+                predicted_probability=0.5,
+                outcome=1,
+                predicted_at=datetime.now(UTC),
+                agent_id="",
+            )
+        )
         scorer.add(_pred(0.7, 1, agent_id="alpha"))
         assert scorer.agents() == ["alpha"]
 
@@ -78,6 +95,7 @@ class TestAgents:
 # ---------------------------------------------------------------------------
 # rolling_score_for_agent()
 # ---------------------------------------------------------------------------
+
 
 class TestRollingScoreForAgent:
     def test_empty_returns_none_stats(self) -> None:
@@ -97,16 +115,16 @@ class TestRollingScoreForAgent:
     def test_excludes_other_agents(self) -> None:
         s = ManifoldBrierScorer()
         s.add(_pred(1.0, 1, agent_id="alpha", question_id="a"))
-        s.add(_pred(0.0, 1, agent_id="beta",  question_id="b"))
+        s.add(_pred(0.0, 1, agent_id="beta", question_id="b"))
         assert s.rolling_score_for_agent("alpha").n_predictions == 1
         assert s.rolling_score_for_agent("beta").n_predictions == 1
 
     def test_two_agents_independent_scores(self) -> None:
         s = ManifoldBrierScorer()
         s.add(_pred(1.0, 1, agent_id="alpha", question_id="a"))  # BS=0.0
-        s.add(_pred(0.0, 1, agent_id="beta",  question_id="b"))  # BS=1.0
+        s.add(_pred(0.0, 1, agent_id="beta", question_id="b"))  # BS=1.0
         assert s.rolling_score_for_agent("alpha").mean_brier == pytest.approx(0.0)
-        assert s.rolling_score_for_agent("beta").mean_brier  == pytest.approx(1.0)
+        assert s.rolling_score_for_agent("beta").mean_brier == pytest.approx(1.0)
 
     def test_empty_agent_id_raises(self) -> None:
         with pytest.raises(ValueError, match="agent_id"):
@@ -125,6 +143,7 @@ class TestRollingScoreForAgent:
 # ---------------------------------------------------------------------------
 # calibration_curve_for_agent()
 # ---------------------------------------------------------------------------
+
 
 class TestCalibrationCurveForAgent:
     def test_returns_n_bins(self) -> None:


### PR DESCRIPTION
## Slice

Adds per-agent Brier scoring to the existing `ManifoldBrierScorer`: `agents()` returns sorted known agent IDs, `rolling_score_for_agent(agent_id, window_days=90)` returns a `BrierWindowSummary` scoped to one agent, and `calibration_curve_for_agent(agent_id, n_bins=10)` returns a per-agent reliability-diagram curve. Also converts `aragora/metrics/__init__.py` to PEP 562 lazy imports so `import aragora.metrics.manifold_brier` no longer drags in the heavy `aragora.swarm → pydantic` chain.

## Gating

- Default: **OFF** (flag: `ARAGORA_MANIFOLD_BRIER_ENABLED` — inherited from existing scorer; no new flag needed)
- Live queue effect: **none** — pure in-memory accumulator additions, no HTTP routes, no queue mutations
- Advances issue: #6064 (AGT-03, sub-deliverables 3 & 4: per-agent rolling Brier score + calibration curve reporting per agent)

## Tests

- `TestGate` (3 parametrized cases) — all three new methods raise `RuntimeError` when flag is off
- `TestAgents` (3 cases) — empty scorer, sorted/deduplicated output, blank `agent_id` excluded
- `TestRollingScoreForAgent` (7 cases) — empty window, 90-day default, cross-agent isolation, two-agent independence, empty/invalid-arg validation, unknown agent
- `TestCalibrationCurveForAgent` (7 cases) — bin count, empty scorer, cross-agent exclusion, fraction_yes correctness, p=1.0 clamping, empty/invalid-arg validation

## Validation

- `pytest tests/metrics/test_manifold_brier_per_agent.py tests/metrics/test_manifold_brier.py --noconftest -v` — **81 passed** (20 new + 61 existing)
- `ruff check aragora/metrics/manifold_brier.py aragora/metrics/__init__.py tests/metrics/test_manifold_brier_per_agent.py` — **clean**
- `mypy aragora/metrics/manifold_brier.py aragora/metrics/__init__.py --ignore-missing-imports` — **clean**
- Net diff: **~307 LOC** (82 impl + 62 init refactor + 163 tests)

## Out of scope

- Durable per-agent store backed by `aragora/storage/` — the scorer remains in-memory; persistence is deferred to a follow-on slice or AGT-05 wiring
- HTTP route exposing per-agent scores — deferred to the route layer
- Cross-scorer aggregation (multi-scorer fleet view) — deferred to AGT-05 reputation flow
- Metaculus per-agent scorer — a separate connector; this slice only extends `ManifoldBrierScorer`

Note: the proof-first Foreman gate in `docs/status/NEXT_STEPS_CANONICAL.md` is **not yet open** for the AGT-* tranche. This PR carries no `boss-ready` label and must remain DRAFT until the gate opens or is explicitly waived for this slice.


---
_Generated by [Claude Code](https://claude.ai/code/session_013K1x8M56UZbHk8TZjri94f)_