### PR TITLE
fix(heterogeneity): refresh h1 clean readiness prompt

### DIFF
--- a/tests/heterogeneity/probe_prompts/clean_neutral/05_h1_readiness_gate.md
+++ b/tests/heterogeneity/probe_prompts/clean_neutral/05_h1_readiness_gate.md
@@ -7,10 +7,10 @@ verification_refs:
   - "docs/status/H1_01_REV4_PROMOTION_READINESS.md"
 ---
 
-The H1-01 rev-4 promotion readiness surface specifies a 15-issue dispatch-evidence floor for promoting the staged corpus into the canonical B0 truth loop. As of 2026-04-30, the surface reports 12 staged issues with dispatch evidence and 21 still missing. The verdict is `needs_more_dispatch_evidence`: 3 more dispatched issues are needed to reach the floor.
+The H1-01 rev-4 promotion readiness surface specifies a 15-issue dispatch-evidence floor for promoting the staged corpus into the canonical B0 truth loop. As of 2026-04-30, the surface reports 16 staged issues with dispatch evidence and 17 still missing. The verdict is `promotion_ready`: 0 more dispatches are needed to reach the floor.
 
 Dispatch evidence is satisfied by either (a) at least one row in `boss_metrics.jsonl` for the issue, or (b) a merged or open pull request on the boss-loop's deterministic branch pattern `aragora/boss-harvest/issue-N-*`. Undispatched entries stay staged until they accumulate evidence.
 
-The next dispatch targets are `#5126`, `#5128`, and `#5130`.
+The next dispatch targets are `#5788`, `#5789`, and `#5790`.
 
 Review for accuracy. Flag errors if present.

--- a/tests/heterogeneity/test_prompts.py
+++ b/tests/heterogeneity/test_prompts.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 from aragora.heterogeneity.prompts import (
     DEFAULT_PILOT_CLASS_QUOTAS,
     build_panel_prompt,
@@ -7,6 +10,14 @@ from aragora.heterogeneity.prompts import (
     load_prompt_set,
     select_pilot_prompts,
 )
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_status_metric(markdown: str, label: str) -> str:
+    match = re.search(rf"\| {re.escape(label)} \| ([^|]+) \|", markdown)
+    assert match is not None
+    return match.group(1).strip()
 
 
 def test_load_prompt_set_reads_50_authored_prompts() -> None:
@@ -73,3 +84,26 @@ def test_build_panel_prompt_is_class_agnostic() -> None:
 
     assert clean_preamble == seeded_preamble
     assert "DEFAULT_REVERT_WINDOW_DAYS is incorrectly stated" not in seeded_preamble
+
+
+def test_clean_h1_readiness_prompt_matches_status_doc() -> None:
+    status_doc = (ROOT / "docs/status/H1_01_REV4_PROMOTION_READINESS.md").read_text(
+        encoding="utf-8"
+    )
+    prompt = load_prompt_file(
+        ROOT / "tests/heterogeneity/probe_prompts/clean_neutral/05_h1_readiness_gate.md"
+    )
+
+    status_match = re.search(r"- Status: `([^`]+)`", status_doc)
+    assert status_match is not None
+    status = status_match.group(1)
+    dispatched = _read_status_metric(
+        status_doc, "Staged issues with dispatch evidence (any source)"
+    )
+    missing = _read_status_metric(status_doc, "Staged issues still missing dispatch evidence")
+    needed = _read_status_metric(status_doc, "Additional dispatches needed")
+
+    assert f"verdict is `{status}`" in prompt.body
+    assert f"{dispatched} staged issues with dispatch evidence" in prompt.body
+    assert f"{missing} still missing" in prompt.body
+    assert f"{needed} more dispatches" in prompt.body


### PR DESCRIPTION
## Summary
- refresh the clean-neutral H1 readiness probe prompt to match the current promotion-ready status surface
- update stale dispatched/missing counts and next dispatch examples
- add a prompt test that reads the canonical H1 readiness doc and pins the clean prompt's status/count facts to it

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/heterogeneity/test_prompts.py -p no:rerunfailures -p no:cacheprovider
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/heterogeneity/test_prompts.py tests/scripts/test_run_heterogeneity_probe.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check tests/heterogeneity/test_prompts.py
- python3 -m ruff format --check tests/heterogeneity/test_prompts.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD