### PR TITLE
fix(automation): honor list evidence supersession

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -314,7 +314,7 @@ def _add_branch_reference(branches: set[str], value: Any) -> None:
 def _superseded_branches_from_payload(payload: dict[str, Any]) -> set[str]:
     branches: set[str] = set()
 
-    def collect(container: dict[str, Any]) -> None:
+    def collect(container: Mapping[str, Any]) -> None:
         _add_branch_reference(branches, container.get("supersedes_branch"))
         supersedes_branches = container.get("supersedes_branches")
         if isinstance(supersedes_branches, list):
@@ -329,8 +329,12 @@ def _superseded_branches_from_payload(payload: dict[str, Any]) -> set[str]:
 
     collect(payload)
     local_evidence = payload.get("local_evidence")
-    if isinstance(local_evidence, dict):
+    if isinstance(local_evidence, Mapping):
         collect(local_evidence)
+    elif isinstance(local_evidence, list):
+        for item in local_evidence:
+            if isinstance(item, Mapping):
+                collect(item)
     return branches
 
 

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -160,6 +160,34 @@ def test_outbox_superseded_branches_reads_local_supersession_metadata(
     }
 
 
+def test_outbox_superseded_branches_reads_list_local_evidence(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "repair.json").write_text(
+        json.dumps(
+            {
+                "task": "Open PR for stronger repair branch",
+                "local_evidence": [
+                    "older handoffs sometimes stored local evidence as bullet text",
+                    {
+                        "branch": "codex/stronger",
+                        "supersedes_branch": "codex/stale-local",
+                        "supersedes": ["codex/stale-sibling"],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert mod.outbox_superseded_branches(tmp_path, outbox_dir=outbox) == {
+        "codex/stale-local",
+        "codex/stale-sibling",
+    }
+
+
 def test_outbox_superseded_branches_uses_automation_state_root_default(
     tmp_path: Path, monkeypatch: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- teach the automation branch publisher to read supersession metadata from mapping entries inside list-shaped local_evidence
- add regression coverage for historical list evidence handoff payloads

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- python3 -m ruff format --check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD