### PR TITLE
fix(automation): count only terminal queue receipts

### DIFF
--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -39,6 +39,7 @@ DEFAULT_MAX_OPEN_PRS = 12
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_OUTPUT = Path(".aragora/automation-github-status/latest.json")
+TERMINAL_RECEIPT_STATUSES = {"published", "already_satisfied", "completed", "skipped"}
 
 
 def _repo_root(path: Path) -> Path:
@@ -92,6 +93,20 @@ def _queue_file_key(path: Path) -> str:
     return path.stem
 
 
+def _terminal_receipt_key(path: Path) -> str | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    status = str(payload.get("status") or "").strip().lower()
+    if status not in TERMINAL_RECEIPT_STATUSES:
+        return None
+    key = str(payload.get("idempotency_key") or "").strip()
+    return key or path.stem
+
+
 def _local_queue_state(
     *,
     repo_root: Path,
@@ -102,14 +117,17 @@ def _local_queue_state(
     receipts = _resolve_state_path(repo_root, receipt_dir, DEFAULT_RECEIPT_DIR)
     outbox_files = _json_files(outbox)
     receipt_files = _json_files(receipts)
-    receipt_keys = {_queue_file_key(item) for item in receipt_files}
+    terminal_receipt_keys = {
+        key for item in receipt_files if (key := _terminal_receipt_key(item)) is not None
+    }
     return {
         "outbox_dir": str(outbox),
         "receipt_dir": str(receipts),
         "outbox_count": len(outbox_files),
         "receipt_count": len(receipt_files),
+        "terminal_receipt_count": len(terminal_receipt_keys),
         "unreceipted_outbox_count": sum(
-            1 for item in outbox_files if _queue_file_key(item) not in receipt_keys
+            1 for item in outbox_files if _queue_file_key(item) not in terminal_receipt_keys
         ),
     }
 

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -44,6 +44,7 @@ def test_build_status_uses_local_queue_when_github_unavailable(
     }
     assert payload["local_queue"]["outbox_count"] == 1
     assert payload["local_queue"]["receipt_count"] == 0
+    assert payload["local_queue"]["terminal_receipt_count"] == 0
     assert payload["local_queue"]["unreceipted_outbox_count"] == 1
 
 
@@ -70,7 +71,35 @@ def test_local_queue_state_matches_receipts_by_idempotency_key(tmp_path: Path) -
 
     assert payload["outbox_count"] == 1
     assert payload["receipt_count"] == 1
+    assert payload["terminal_receipt_count"] == 1
     assert payload["unreceipted_outbox_count"] == 0
+
+
+def test_local_queue_state_ignores_nonterminal_receipts(tmp_path: Path) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-example-abc123"
+    (outbox / "handoff.json").write_text(
+        f'{{"idempotency_key": "{key}"}}',
+        encoding="utf-8",
+    )
+    (receipts / "failed-receipt.json").write_text(
+        f'{{"idempotency_key": "{key}", "status": "failed"}}',
+        encoding="utf-8",
+    )
+
+    payload = mod._local_queue_state(
+        repo_root=tmp_path,
+        outbox_dir=None,
+        receipt_dir=None,
+    )
+
+    assert payload["outbox_count"] == 1
+    assert payload["receipt_count"] == 1
+    assert payload["terminal_receipt_count"] == 0
+    assert payload["unreceipted_outbox_count"] == 1
 
 
 def test_build_status_records_remote_pressure_when_github_available(


### PR DESCRIPTION
## Summary
- count only terminal automation receipts when calculating local queue receipt coverage
- preserve non-terminal published issue receipts without masking unresolved outbox work
- add regression coverage for failed/non-terminal receipt handling

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_cache_codex_automation_github_status.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py
- python3 -m ruff format --check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Refs #6941