### PR TITLE
[AGT-05] Metaculus → reputation bridge — flag-gated calibration scoring path

### DIFF
--- a/aragora/reputation/metaculus_bridge.py
+++ b/aragora/reputation/metaculus_bridge.py
@@ -1,0 +1,109 @@
+"""Metaculus → AGT-05 reputation bridge (AGT-05 / #6066).
+
+Flag: ARAGORA_REPUTATION_FLOW_ENABLED (default off).
+Outcome: resolution=1.0→"yes", 0.0→"no", else→"inconclusive".
+Companion to :mod:`aragora.reputation.bridge` (synthetic-GitHub path).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from aragora.reputation.types import (
+    DOMAIN_PREDICTION_MARKET,
+    ClaimOutcome,
+    ResolvedClaim,
+    StakeableClaim,
+    StakePolicy,
+)
+
+if TYPE_CHECKING:
+    from aragora.connectors.prediction_markets.metaculus import MetaculusQuestion
+
+_RESOLUTION_SOURCE = "metaculus"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def reputation_flow_enabled() -> bool:
+    """Return True when ``ARAGORA_REPUTATION_FLOW_ENABLED`` is truthy."""
+    return os.environ.get("ARAGORA_REPUTATION_FLOW_ENABLED", "").strip().lower() in _TRUTHY
+
+
+def _metaculus_outcome(resolution: float | None) -> ClaimOutcome:
+    if resolution == 1.0:
+        return "yes"
+    if resolution == 0.0:
+        return "no"
+    return "inconclusive"
+
+
+def bridge_from_metaculus_question(
+    question: "MetaculusQuestion",
+    agent_id: str,
+    predicted_probability: float,
+    *,
+    stake_units: int = 1,
+    stake_policy: StakePolicy = "forfeit_on_loss",
+    resolution_source: str = _RESOLUTION_SOURCE,
+    submitted_at: str | None = None,
+    require_enabled: bool = True,
+) -> tuple[StakeableClaim, ResolvedClaim]:
+    """Return (StakeableClaim, ResolvedClaim) ready for settlement.settle_claim."""
+    if require_enabled and not reputation_flow_enabled():
+        raise RuntimeError(
+            "ARAGORA_REPUTATION_FLOW_ENABLED is not set; "
+            "set it to '1' or 'true' to use the Metaculus reputation bridge"
+        )
+    if not question.is_resolved:
+        raise ValueError(
+            f"MetaculusQuestion {question.question_id!r} is not resolved "
+            f"(active_state={question.active_state!r})"
+        )
+    if not (0.0 <= predicted_probability <= 1.0):
+        raise ValueError(
+            f"predicted_probability must be in [0.0, 1.0]; got {predicted_probability!r}"
+        )
+    if stake_units < 1:
+        raise ValueError(f"stake_units must be >= 1; got {stake_units!r}")
+
+    _now = datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+    ts = submitted_at or _now
+    resolved_at = question.resolve_time or _now
+
+    claim = StakeableClaim.create(
+        agent_id=agent_id,
+        domain=DOMAIN_PREDICTION_MARKET,
+        statement=question.title,
+        position="yes" if predicted_probability >= 0.5 else "no",
+        predicted_probability=predicted_probability,
+        stake_units=stake_units,
+        stake_policy=stake_policy,
+        resolution_source=resolution_source,
+        resolution_id=str(question.question_id),
+        provenance={
+            "question_id": question.question_id,
+            "question_type": question.question_type,
+            "close_time": question.close_time,
+            "resolve_time": question.resolve_time,
+            "submitted_at": ts,
+        },
+        created_at=ts,
+    )
+    resolved = ResolvedClaim(
+        claim_id=claim.claim_id,
+        outcome=_metaculus_outcome(question.resolution),
+        resolved_at=resolved_at,
+        resolution_source=resolution_source,
+        evidence={
+            "question_id": question.question_id,
+            "resolution": question.resolution,
+            "community_q2": question.community_q2,
+            "active_state": question.active_state,
+        },
+    )
+    return claim, resolved
+
+
+__all__ = ["bridge_from_metaculus_question", "reputation_flow_enabled"]

--- a/tests/reputation/test_metaculus_bridge.py
+++ b/tests/reputation/test_metaculus_bridge.py
@@ -1,0 +1,199 @@
+"""Tests for aragora.reputation.metaculus_bridge (AGT-05 / #6066)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from aragora.reputation.metaculus_bridge import (
+    bridge_from_metaculus_question,
+    reputation_flow_enabled,
+)
+from aragora.reputation.types import DOMAIN_PREDICTION_MARKET
+
+
+@dataclass(frozen=True)
+class _FQ:
+    """Structural stand-in for MetaculusQuestion — no network import needed."""
+
+    question_id: int
+    title: str
+    question_type: str
+    created_time: str | None
+    close_time: str | None
+    resolve_time: str | None
+    active_state: str
+    resolution: float | None
+    community_q2: float | None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_resolved(self) -> bool:
+        return self.active_state == "resolved"
+
+
+def _q(
+    question_id: int = 123,
+    title: str = "Will Aragora ship?",
+    resolution: float | None = 1.0,
+    resolve_time: str | None = "2026-05-01T00:00:00Z",
+    active_state: str = "resolved",
+) -> _FQ:
+    return _FQ(
+        question_id=question_id, title=title, question_type="binary",
+        created_time="2026-04-01T00:00:00Z", close_time="2026-04-30T00:00:00Z",
+        resolve_time=resolve_time, active_state=active_state,
+        resolution=resolution, community_q2=0.7,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Feature gate
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureGate:
+    def test_off_by_default_and_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+        assert reputation_flow_enabled() is False
+        with pytest.raises(RuntimeError, match="ARAGORA_REPUTATION_FLOW_ENABLED"):
+            bridge_from_metaculus_question(_q(), "a", 0.8)
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE"])
+    def test_truthy_values(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", val)
+        assert reputation_flow_enabled() is True
+        claim, _ = bridge_from_metaculus_question(_q(), "a", 0.8)
+        assert claim.agent_id == "a"
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_falsy_values_block(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", val)
+        with pytest.raises(RuntimeError):
+            bridge_from_metaculus_question(_q(), "a", 0.8)
+
+    def test_require_enabled_false_bypasses_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+        claim, resolved = bridge_from_metaculus_question(_q(), "a", 0.8, require_enabled=False)
+        assert claim.agent_id == "a"
+        assert resolved.outcome == "yes"
+
+
+# ---------------------------------------------------------------------------
+# Outcome mapping
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeMapping:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+
+    def test_resolution_1_0_yes(self) -> None:
+        assert bridge_from_metaculus_question(_q(resolution=1.0), "a", 0.8)[1].outcome == "yes"
+
+    def test_resolution_0_0_no(self) -> None:
+        assert bridge_from_metaculus_question(_q(resolution=0.0), "a", 0.2)[1].outcome == "no"
+
+    @pytest.mark.parametrize("res", [None, 0.5, 0.73])
+    def test_other_resolution_inconclusive(self, res: float | None) -> None:
+        assert bridge_from_metaculus_question(_q(resolution=res), "a", 0.6)[1].outcome == "inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# Claim shape
+# ---------------------------------------------------------------------------
+
+
+class TestClaimShape:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+
+    def test_domain_title_and_probability(self) -> None:
+        claim, _ = bridge_from_metaculus_question(_q(title="Will crux ship?"), "a", 0.73)
+        assert claim.domain == DOMAIN_PREDICTION_MARKET
+        assert claim.statement == "Will crux ship?"
+        assert claim.predicted_probability == pytest.approx(0.73)
+
+    def test_position_from_probability(self) -> None:
+        assert bridge_from_metaculus_question(_q(), "a", 0.5)[0].position == "yes"
+        assert bridge_from_metaculus_question(_q(), "a", 0.49)[0].position == "no"
+
+    def test_resolution_source_default_and_override(self) -> None:
+        c1, r1 = bridge_from_metaculus_question(_q(), "a", 0.8)
+        assert c1.resolution_source == r1.resolution_source == "metaculus"
+        c2, r2 = bridge_from_metaculus_question(_q(), "a", 0.8, resolution_source="custom")
+        assert c2.resolution_source == r2.resolution_source == "custom"
+
+    def test_resolution_id_and_provenance(self) -> None:
+        claim, _ = bridge_from_metaculus_question(_q(question_id=42), "a", 0.8)
+        assert claim.resolution_id == "42"
+        assert claim.provenance["question_id"] == 42
+        for key in ("question_type", "close_time", "resolve_time", "submitted_at"):
+            assert key in claim.provenance
+
+    def test_evidence_shape(self) -> None:
+        _, resolved = bridge_from_metaculus_question(_q(resolution=1.0), "a", 0.8)
+        assert resolved.evidence["question_id"] == 123
+        assert resolved.evidence["resolution"] == 1.0
+        assert resolved.evidence["active_state"] == "resolved"
+
+    def test_claim_id_content_addressed(self) -> None:
+        q = _q()
+        c1, _ = bridge_from_metaculus_question(q, "a", 0.8, require_enabled=False)
+        c2, _ = bridge_from_metaculus_question(q, "a", 0.8, require_enabled=False)
+        assert c1.claim_id == c2.claim_id
+
+    def test_claim_id_stable_and_unique(self) -> None:
+        q = _q()
+        c1, _ = bridge_from_metaculus_question(q, "a", 0.8, require_enabled=False)
+        c2, _ = bridge_from_metaculus_question(q, "a", 0.8, require_enabled=False)
+        cb, _ = bridge_from_metaculus_question(q, "b", 0.8, require_enabled=False)
+        assert c1.claim_id == c2.claim_id  # deterministic
+        assert c1.claim_id != cb.claim_id  # differs by agent
+
+    def test_resolved_at_and_stake_params(self) -> None:
+        _, r = bridge_from_metaculus_question(
+            _q(resolve_time="2026-03-01T00:00:00Z"), "a", 0.8, require_enabled=False
+        )
+        assert r.resolved_at == "2026-03-01T00:00:00Z"
+        c, r2 = bridge_from_metaculus_question(
+            _q(), "a", 0.8, stake_units=3, stake_policy="scaled", require_enabled=False
+        )
+        assert c.claim_id == r2.claim_id and c.stake_units == 3 and c.stake_policy == "scaled"
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCases:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+
+    def test_unresolved_question_raises(self) -> None:
+        with pytest.raises(ValueError, match="not resolved"):
+            bridge_from_metaculus_question(
+                _q(active_state="open", resolution=None, resolve_time=None), "a", 0.8
+            )
+
+    @pytest.mark.parametrize("prob", [1.001, -0.001])
+    def test_out_of_range_probability_raises(self, prob: float) -> None:
+        with pytest.raises(ValueError, match="predicted_probability"):
+            bridge_from_metaculus_question(_q(), "a", prob)
+
+    @pytest.mark.parametrize("units", [0, -1])
+    def test_invalid_stake_units_raises(self, units: int) -> None:
+        with pytest.raises(ValueError, match="stake_units"):
+            bridge_from_metaculus_question(_q(), "a", 0.8, stake_units=units)
+
+    def test_boundary_probabilities_valid(self) -> None:
+        c0, _ = bridge_from_metaculus_question(_q(), "a", 0.0, require_enabled=False)
+        c1, _ = bridge_from_metaculus_question(_q(), "a", 1.0, require_enabled=False)
+        assert c0.predicted_probability == 0.0
+        assert c1.predicted_probability == 1.0

--- a/tests/reputation/test_metaculus_bridge.py
+++ b/tests/reputation/test_metaculus_bridge.py
@@ -42,10 +42,15 @@ def _q(
     active_state: str = "resolved",
 ) -> _FQ:
     return _FQ(
-        question_id=question_id, title=title, question_type="binary",
-        created_time="2026-04-01T00:00:00Z", close_time="2026-04-30T00:00:00Z",
-        resolve_time=resolve_time, active_state=active_state,
-        resolution=resolution, community_q2=0.7,
+        question_id=question_id,
+        title=title,
+        question_type="binary",
+        created_time="2026-04-01T00:00:00Z",
+        close_time="2026-04-30T00:00:00Z",
+        resolve_time=resolve_time,
+        active_state=active_state,
+        resolution=resolution,
+        community_q2=0.7,
     )
 
 
@@ -99,7 +104,10 @@ class TestOutcomeMapping:
 
     @pytest.mark.parametrize("res", [None, 0.5, 0.73])
     def test_other_resolution_inconclusive(self, res: float | None) -> None:
-        assert bridge_from_metaculus_question(_q(resolution=res), "a", 0.6)[1].outcome == "inconclusive"
+        assert (
+            bridge_from_metaculus_question(_q(resolution=res), "a", 0.6)[1].outcome
+            == "inconclusive"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Slice

Adds `aragora/reputation/metaculus_bridge.py` — the Metaculus calibration scoring path for AGT-05. `bridge_from_metaculus_question()` converts a resolved `MetaculusQuestion` + an agent's predicted probability into a `(StakeableClaim, ResolvedClaim)` pair ready for `settlement.settle_claim()`. The existing `metaculus.py` connector explicitly deferred this ("Out of scope: per-agent Brier (AGT-05)"); this slice closes that gap.

## Gating

- Default: **OFF** (flag: `ARAGORA_REPUTATION_FLOW_ENABLED` — reuses the existing AGT-05 flag; no new flag needed)
- Dataclasses are always importable; only `bridge_from_metaculus_question()` raises `RuntimeError` when the flag is unset
- Live queue effect: **none** — pure in-memory bridge, no HTTP routes, no queue mutations, no boss-loop changes
- Advances issue: #6066 (AGT-05, Metaculus calibration scoring path)

## Tests

- `TestFeatureGate` (11 cases) — flag off by default; truthy env-var values (5); falsy values block (5); `require_enabled=False` bypasses flag
- `TestOutcomeMapping` (5 cases) — `resolution=1.0`→`"yes"`, `0.0`→`"no"`, `None`/fractional→`"inconclusive"` (parametrized over `[None, 0.5, 0.73]`)
- `TestClaimShape` (9 cases) — domain, statement from title, position from probability, resolution ID, source default/override, provenance keys, evidence shape, content-addressed claim IDs, resolved_at + stake params
- `TestErrorCases` (6 cases) — unresolved question, out-of-range probability (parametrized), invalid stake_units (parametrized), boundary values valid

## Validation

- `pytest tests/reputation/test_metaculus_bridge.py --noconftest -v` — **31 passed**
- `ruff check aragora/reputation/metaculus_bridge.py tests/reputation/test_metaculus_bridge.py` — **clean**
- `mypy aragora/reputation/metaculus_bridge.py --ignore-missing-imports` — **clean**
- Net diff: **~308 LOC** (109 impl + 199 tests; comparable to AGT-03 at 307 LOC)

## Out of scope

- Batch Metaculus prediction submission — the connector is read-only; prediction ingestion is a follow-on
- Per-agent Brier score aggregation from Metaculus resolutions — deferred to a follow-on slice that reads from `ReputationStore`
- HTTP route exposing Metaculus-backed per-agent scores — deferred to the route layer
- Metaculus continuous-question probabilistic Brier scoring — `resolution ∉ {0.0, 1.0}` maps to `"inconclusive"` for now; a weighted Brier extension is a follow-on

Note: the proof-first Foreman gate in `docs/status/NEXT_STEPS_CANONICAL.md` is **not yet open** for the AGT-* tranche. This PR carries no `boss-ready` label and must remain DRAFT until the gate opens or is explicitly waived for this slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaAbE1WzYtuWjZ1fhzcJnD)_