### PR TITLE
fix(automation): accept direct aragora state roots

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -234,6 +234,8 @@ def _automation_state_root(root: Path) -> Path:
             resolved = candidate.resolve()
         except OSError:
             resolved = candidate
+        if resolved.name == ".aragora" and resolved.is_dir():
+            return resolved
         if not (resolved / ".aragora").is_dir():
             continue
         if explicit or _same_git_origin(root, resolved):
@@ -244,7 +246,7 @@ def _automation_state_root(root: Path) -> Path:
 def _automation_state_path(root: Path, path: Path | None, default_relative: Path) -> Path:
     if path is not None:
         return _repo_relative(root, path)
-    return _automation_state_root(root) / default_relative
+    return _automation_state_default_path(_automation_state_root(root), default_relative)
 
 
 def _automation_state_default_path(state_root: Path, default_relative: Path) -> Path:

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -1179,6 +1179,26 @@ def test_audit_uses_automation_state_root_for_default_handoff_dirs(
     assert payload["records"][0]["category"] == "protected_handoff_receipt"
 
 
+def test_automation_state_root_env_accepts_aragora_directory(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo_root = tmp_path / "worktree"
+    state_root = tmp_path / "shared" / ".aragora"
+    repo_root.mkdir()
+    state_root.mkdir(parents=True)
+
+    monkeypatch.setenv("ARAGORA_AUTOMATION_STATE_ROOT", str(state_root))
+
+    assert (
+        mod._automation_state_path(repo_root, None, mod.DEFAULT_OUTBOX_DIR)
+        == state_root / "automation-outbox"
+    )
+    assert (
+        mod._automation_state_path(repo_root, None, mod.DEFAULT_RECEIPT_DIR)
+        == state_root / "automation-receipts"
+    )
+
+
 def test_parser_checks_patch_equivalence_by_default() -> None:
     args = mod.build_parser().parse_args([])
 


### PR DESCRIPTION
## Summary
- honor ARAGORA_AUTOMATION_STATE_ROOT when it points directly at a shared .aragora directory
- add regression coverage for direct shared outbox resolution in the branch backlog audit

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py
- python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py
- ARAGORA_AUTOMATION_STATE_ROOT=/Users/armand/Development/aragora/.aragora python3 scripts/audit_codex_branch_backlog.py --max-branches 20 --json --summary-only --skip-patch-equivalence
- bash scripts/automation_pr_preflight.sh origin/main HEAD