### PR TITLE
fix(agent-bridge): isolate bridge state temp writes

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -26,6 +26,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import asdict, dataclass
 from datetime import UTC
@@ -98,6 +99,23 @@ def _bridge_file_for_write(default_path: Path) -> Path:
         fallback_dir = _state_root_bridge_dir()
         _assert_writable_dir(fallback_dir)
         return fallback_dir / default_path.name
+
+
+def _atomic_write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        tmp_path.replace(path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 @dataclass
@@ -227,9 +245,7 @@ def _write_session_snapshot(sessions: list[Session]) -> None:
     timestamp = datetime.now(UTC).isoformat()
     snapshot = [{"timestamp": timestamp, **s.to_dict()} for s in sessions]
     snapshot_file = _bridge_file_for_write(SESSION_SNAPSHOT_FILE)
-    tmp_path = snapshot_file.with_suffix(".json.tmp")
-    tmp_path.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
-    tmp_path.replace(snapshot_file)
+    _atomic_write_json(snapshot_file, snapshot)
 
 
 def _now_iso() -> str:
@@ -251,12 +267,7 @@ def _load_lane_registry() -> list[LaneRecord]:
 
 def _write_lane_registry(records: list[LaneRecord]) -> None:
     registry_file = _bridge_file_for_write(LANE_REGISTRY_FILE)
-    tmp_path = registry_file.with_suffix(".json.tmp")
-    tmp_path.write_text(
-        json.dumps([record.to_dict() for record in records], indent=2) + "\n",
-        encoding="utf-8",
-    )
-    tmp_path.replace(registry_file)
+    _atomic_write_json(registry_file, [record.to_dict() for record in records])
 
 
 def _find_lane_record(records: list[LaneRecord], lane_id: str) -> LaneRecord | None:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -464,6 +464,35 @@ def test_write_session_snapshot_falls_back_to_state_root(
     assert not (blocked_dir / "sessions.json").exists()
 
 
+def test_write_session_snapshot_uses_per_write_tempfile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    temp_paths: list[Path] = []
+    original_mkstemp = mod.tempfile.mkstemp
+
+    def _recording_mkstemp(*args, **kwargs):
+        fd, name = original_mkstemp(*args, **kwargs)
+        temp_paths.append(Path(name))
+        return fd, name
+
+    monkeypatch.setattr(mod.tempfile, "mkstemp", _recording_mkstemp)
+
+    mod._write_session_snapshot([mod.Session(name="codex-main", agent="codex")])
+
+    assert len(temp_paths) == 1
+    assert temp_paths[0].parent == tmp_path / "bridge"
+    assert temp_paths[0].name.startswith(".sessions.json.")
+    assert temp_paths[0].name.endswith(".tmp")
+    assert temp_paths[0].name != "sessions.json.tmp"
+    assert not temp_paths[0].exists()
+    payload = json.loads((tmp_path / "bridge" / "sessions.json").read_text())
+    assert payload[0]["name"] == "codex-main"
+
+
 def test_health_ignores_dead_root_checkout_session(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- replace shared bridge JSON temp filenames with per-write temp files
- use the atomic JSON helper for session snapshots and lane registry writes
- add regression coverage that guards against the old sessions.json.tmp collision path

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_agent_bridge.py -p no:rerunfailures -p no:cacheprovider
- python3 scripts/agent_bridge.py operator-snapshot --json --summary-only
- python3 scripts/agent_bridge.py operator-snapshot --json
- ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py
- ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD