### PR TITLE
fix(automation): expose receipted outbox count

### DIFF
--- a/scripts/cache_codex_automation_github_status.py
+++ b/scripts/cache_codex_automation_github_status.py
@@ -150,6 +150,8 @@ def _local_queue_state(
     nonterminal_receipts = [
         item for item in receipt_states if item["status"] not in TERMINAL_RECEIPT_STATUSES
     ]
+    outbox_keys = [_queue_file_key(item) for item in outbox_files]
+    terminal_receipted_outbox_count = sum(1 for key in outbox_keys if key in terminal_receipt_keys)
     return {
         "outbox_dir": str(outbox),
         "receipt_dir": str(receipts),
@@ -158,9 +160,8 @@ def _local_queue_state(
         "terminal_receipt_count": len(terminal_receipt_keys),
         "nonterminal_receipt_count": len(nonterminal_receipts),
         "nonterminal_receipts": nonterminal_receipts,
-        "unreceipted_outbox_count": sum(
-            1 for item in outbox_files if _queue_file_key(item) not in terminal_receipt_keys
-        ),
+        "terminal_receipted_outbox_count": terminal_receipted_outbox_count,
+        "unreceipted_outbox_count": len(outbox_keys) - terminal_receipted_outbox_count,
     }
 
 

--- a/tests/scripts/test_cache_codex_automation_github_status.py
+++ b/tests/scripts/test_cache_codex_automation_github_status.py
@@ -47,6 +47,7 @@ def test_build_status_uses_local_queue_when_github_unavailable(
     assert payload["local_queue"]["terminal_receipt_count"] == 0
     assert payload["local_queue"]["nonterminal_receipt_count"] == 0
     assert payload["local_queue"]["nonterminal_receipts"] == []
+    assert payload["local_queue"]["terminal_receipted_outbox_count"] == 0
     assert payload["local_queue"]["unreceipted_outbox_count"] == 1
 
 
@@ -76,6 +77,7 @@ def test_local_queue_state_matches_receipts_by_idempotency_key(tmp_path: Path) -
     assert payload["terminal_receipt_count"] == 1
     assert payload["nonterminal_receipt_count"] == 0
     assert payload["nonterminal_receipts"] == []
+    assert payload["terminal_receipted_outbox_count"] == 1
     assert payload["unreceipted_outbox_count"] == 0
 
 
@@ -111,6 +113,7 @@ def test_local_queue_state_ignores_nonterminal_receipts(tmp_path: Path) -> None:
             "status": "failed",
         }
     ]
+    assert payload["terminal_receipted_outbox_count"] == 0
     assert payload["unreceipted_outbox_count"] == 1
 
 


### PR DESCRIPTION
## Summary
- expose terminal_receipted_outbox_count in the local automation queue cache
- compute unreceipted_outbox_count from cached outbox keys to clarify receipted residue
- add focused coverage for receipted and nonterminal receipt cases

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_cache_codex_automation_github_status.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py
- python3 -m ruff format --check scripts/cache_codex_automation_github_status.py tests/scripts/test_cache_codex_automation_github_status.py
- python3 scripts/cache_codex_automation_github_status.py --repo . --json --output /private/tmp/aragora-github-status-cache-receipted-postpatch.json
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD