### PR TITLE
fix(automation): guard parallel audit PR lookup

### DIFF
--- a/scripts/audit_branch_backlog_parallel.py
+++ b/scripts/audit_branch_backlog_parallel.py
@@ -50,6 +50,7 @@ from audit_codex_branch_backlog import (  # noqa: E402
     unresolved_outbox_handoff_branches,
     worktree_map,
 )
+from github_cli_health import check_github_cli_health  # noqa: E402
 
 UTC = timezone.utc
 
@@ -201,6 +202,35 @@ def _load_resume_cache(path: Path) -> dict[str, dict[str, Any]]:
     return {r["branch"]: r for r in records if isinstance(r, dict) and "branch" in r}
 
 
+def _load_open_prs(
+    root: Path,
+    repo_name: str,
+    prefix: str,
+) -> tuple[dict[str, int], dict[str, Any], bool]:
+    """Fetch open PR heads only when the GitHub health probe is ready."""
+
+    try:
+        health = check_github_cli_health(root)
+    except Exception as exc:
+        return (
+            {},
+            {
+                "ready": False,
+                "auth_ok": False,
+                "api_ok": False,
+                "mode": "health_check_failed",
+                "error": str(exc),
+                "repo": str(root),
+            },
+            True,
+        )
+
+    health_payload = health.to_dict()
+    if not health.ready:
+        return {}, health_payload, True
+    return open_pr_heads(root, repo_name, prefix), health_payload, False
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -255,9 +285,16 @@ def main(argv: list[str] | None = None) -> int:
         f"  remotes={len(remotes)} merged={len(merged)} worktree-mapped-branches={len(worktrees)}"
     )
 
-    print("  fetching open PRs from GitHub (single bulk call)")
-    open_prs = open_pr_heads(root, args.repo_name, args.prefix)
-    print(f"  open_prs={len(open_prs)}")
+    print("  checking GitHub health for open PR lookup")
+    open_prs, github_health, open_pr_lookup_skipped = _load_open_prs(
+        root, args.repo_name, args.prefix
+    )
+    if open_pr_lookup_skipped:
+        mode = github_health.get("mode", "unknown")
+        error = " ".join(str(github_health.get("error", "")).split())
+        print(f"  open PR lookup skipped: GitHub unavailable [{mode}] {error}".rstrip())
+    else:
+        print(f"  open_prs={len(open_prs)}")
 
     print("  loading automation outbox + receipt protection")
     receipted = terminal_receipted_handoff_branches(root)
@@ -355,6 +392,8 @@ def main(argv: list[str] | None = None) -> int:
         "repo": str(root),
         "base": args.base,
         "prefix": args.prefix,
+        "github_health": github_health,
+        "open_pr_lookup_skipped": open_pr_lookup_skipped,
         "totals": {
             "branches_scanned": len(rows),
             "branches_with_open_pr": len(open_prs),

--- a/tests/scripts/test_audit_branch_backlog_parallel.py
+++ b/tests/scripts/test_audit_branch_backlog_parallel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import scripts.audit_branch_backlog_parallel as mod
@@ -65,6 +66,71 @@ def test_has_active_session_preserves_parallel_legacy_marker(tmp_path: Path) -> 
     (tmp_path / ".codex-session-active").write_text("active\n", encoding="utf-8")
 
     assert mod._has_active_session(tmp_path) is True
+
+
+def test_load_open_prs_skips_lookup_when_github_health_is_unavailable(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: SimpleNamespace(
+            ready=False,
+            to_dict=lambda: {
+                "ready": False,
+                "auth_ok": False,
+                "api_ok": False,
+                "mode": "connectivity_failed",
+                "error": "offline",
+                "repo": str(tmp_path),
+            },
+        ),
+    )
+
+    def fail_open_pr_lookup(*_args: Any, **_kwargs: Any) -> dict[str, int]:
+        raise AssertionError("open PR lookup should be skipped when GitHub is unavailable")
+
+    monkeypatch.setattr(mod, "open_pr_heads", fail_open_pr_lookup)
+
+    open_prs, health, skipped = mod._load_open_prs(tmp_path, "synaptent/aragora", "codex/")
+
+    assert open_prs == {}
+    assert skipped is True
+    assert health["mode"] == "connectivity_failed"
+
+
+def test_load_open_prs_uses_bulk_lookup_when_github_health_is_ready(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: SimpleNamespace(
+            ready=True,
+            to_dict=lambda: {
+                "ready": True,
+                "auth_ok": True,
+                "api_ok": True,
+                "mode": "ready",
+                "error": "",
+                "repo": str(tmp_path),
+            },
+        ),
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda root, repo, prefix: {"codex/has-pr": 6500}
+        if (root, repo, prefix) == (tmp_path, "synaptent/aragora", "codex/")
+        else {},
+    )
+
+    open_prs, health, skipped = mod._load_open_prs(tmp_path, "synaptent/aragora", "codex/")
+
+    assert open_prs == {"codex/has-pr": 6500}
+    assert skipped is False
+    assert health["mode"] == "ready"
 
 
 def test_classify_one_protects_status_failed_worktree(tmp_path: Path, monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary
- make the parallel backlog classifier run the GitHub health probe before open-PR lookup
- record github_health and open_pr_lookup_skipped in the classification payload
- add tests for degraded and ready GitHub lookup paths

## Validation
- python3 -m pytest -q tests/scripts/test_audit_branch_backlog_parallel.py -p no:rerunfailures -p no:cacheprovider
- python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py tests/scripts/test_audit_branch_backlog_parallel.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/audit_branch_backlog_parallel.py tests/scripts/test_audit_branch_backlog_parallel.py
- python3 -m ruff format --check scripts/audit_branch_backlog_parallel.py tests/scripts/test_audit_branch_backlog_parallel.py
- python3 scripts/audit_branch_backlog_parallel.py --repo . --base origin/main --prefix codex/ --workers 2 --max-branches 1 --out /tmp/parallel-audit-gh-health-smoke.json
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD