### PR TITLE
codex/observe outcomes mutating cli

### DIFF
--- a/aragora/cli/commands/observe_outcomes_cmd.py
+++ b/aragora/cli/commands/observe_outcomes_cmd.py
@@ -1,0 +1,82 @@
+"""CLI dispatcher + rendering for ``aragora review-queue observe-outcomes``.
+
+The observation pipeline lives in
+:mod:`aragora.review.observe_outcomes_cli`. This module is the
+``aragora.cli.*`` surface that prints to stdout/stderr — kept here so
+the ``T201`` per-file-ignore covers ``print`` cleanly without leaking
+into non-CLI modules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.review.observe_outcomes_cli import run_observe_outcomes
+
+UTC = timezone.utc
+
+
+def cmd_observe_outcomes(args: argparse.Namespace) -> int:
+    if args.window_days <= 0:
+        print("error: --window-days must be positive", file=sys.stderr)
+        return 2
+    if args.max_receipts <= 0:
+        print("error: --max-receipts must be positive", file=sys.stderr)
+        return 2
+    if args.per_receipt_event_cap <= 0:
+        print("error: --per-receipt-event-cap must be positive", file=sys.stderr)
+        return 2
+
+    try:
+        summary = run_observe_outcomes(
+            store_root=args.review_queue_root,
+            repo_root=Path.cwd(),
+            window_end=datetime.now(UTC),
+            window_days=args.window_days,
+            max_receipts=args.max_receipts,
+            per_receipt_event_cap=args.per_receipt_event_cap,
+            write=bool(args.write),
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"error: observe-outcomes failed: {exc}", file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        _render_summary(summary)
+    return 0
+
+
+def _render_summary(summary: Mapping[str, Any]) -> None:
+    mode = summary["mode"]
+    print(f"observe-outcomes mode={mode}")
+    print(
+        f"  window_end={summary['window_end_utc']} "
+        f"window_days={summary['window_days']} "
+        f"max_receipts={summary['max_receipts']}"
+    )
+    print(
+        f"  receipts_examined={summary['receipts_examined']} "
+        f"with_signals={summary['receipts_with_signals_fired']} "
+        f"written={summary['receipts_written']} "
+        f"fetch_errors={summary['github_fetch_errors']}"
+    )
+    print(f"  v2_now_present_in_window={summary['v2_outcome_fields_now_present_in_window']}")
+    if summary["insufficiency_receipt_path"]:
+        print(f"  insufficiency_receipt={summary['insufficiency_receipt_path']}")
+    if mode == "dry-run" and summary["receipts_examined"] > 0:
+        print("  (dry-run; pass --write to mutate receipts in place)")
+    for r in summary["results"][:20]:
+        skipped = repr(r["skipped_reason"]) if r["skipped_reason"] else "None"
+        print(
+            f"  pr=#{r['pr_number']} fetched={r['fetched_event_count']} "
+            f"skipped={skipped} "
+            f"written={r['written']}"
+        )

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -193,7 +193,31 @@ class ReviewPacket:
 
 @dataclass(slots=True)
 class SettlementReceipt:
-    """Persisted human settlement receipt for one PR/head/packet tuple."""
+    """Persisted human settlement receipt for one PR/head/packet tuple.
+
+    The five ``outcome_*`` fields are optional post-settlement signals that
+    correspond exactly to the canonical invalidation labels in
+    :data:`aragora.review.invalidation.INVALIDATION_SIGNALS`. They default to
+    ``None`` (= "signal not yet observed") to preserve backward compatibility
+    with receipts written before #6375 phase 4. When ``observe_outcome`` (in
+    :mod:`aragora.review.settlement_outcome`) populates these, downstream
+    consumers like :mod:`aragora.review.invalidation_event_source` can finally
+    classify the human side of the baseline (closing the
+    ``schema_gap_human_numerator`` note that #6898 surfaces).
+
+    Semantics:
+      - All five ``None`` → receipt is denominator-only (counted in
+        ``total_human_settled`` but not in invalidation numerator).
+      - Any one ``True`` → receipt is invalidated, all firing signals
+        contribute to the numerator.
+      - All five ``False`` → receipt is a clean human-settled non-invalidation
+        (still denominator, explicitly not numerator).
+
+    ``outcome_observed_at`` is the ISO 8601 UTC timestamp at which the
+    observation was recorded (separate from ``reviewed_at`` which is the
+    settlement time). ``None`` iff none of the five outcome fields have been
+    observed yet.
+    """
 
     session_id: str
     reviewed_at: str
@@ -210,6 +234,13 @@ class SettlementReceipt:
     github_event: str
     elapsed_seconds: float | None = None
     receipt_path: str = ""
+    # Post-settlement outcome signals (#6375 phase 4). None == not yet observed.
+    outcome_revert_within_window: bool | None = None
+    outcome_post_merge_incident: bool | None = None
+    outcome_human_override_redo: bool | None = None
+    outcome_rollback: bool | None = None
+    outcome_reopened_pr: bool | None = None
+    outcome_observed_at: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -450,6 +450,10 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Output the BaselineMeasurement + ThresholdProposal as JSON.",
     )
 
+    from aragora.review.observe_outcomes_cli import add_observe_outcomes_subparser
+
+    add_observe_outcomes_subparser(sub)
+
     parser.set_defaults(func=cmd_review_queue)
 
 
@@ -468,8 +472,13 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
         return _cmd_merge_packet(args)
     if command == "baseline":
         return _cmd_baseline(args)
+    if command == "observe-outcomes":
+        from aragora.cli.commands.observe_outcomes_cmd import cmd_observe_outcomes
+
+        return cmd_observe_outcomes(args)
     print(
-        "Usage: aragora review-queue {build,packet,run,act,merge-packet,baseline} [...]\n"
+        "Usage: aragora review-queue "
+        "{build,packet,run,act,merge-packet,baseline,observe-outcomes} [...]\n"
         "Run 'aragora review-queue run --help' for the human settlement loop.",
         file=sys.stderr,
     )

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1732,6 +1732,60 @@ def _add_review_queue_parser(subparsers) -> None:
         func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue")
     )
 
+    # Round 30g phase A: observe-outcomes (dry-run-by-default; --write opt-in).
+    observe_parser = queue_subparsers.add_parser(
+        "observe-outcomes",
+        help=(
+            "Observe post-settlement invalidation signals from GitHub timeline "
+            "events and (optionally) write them back into receipt v2 outcome "
+            "fields. Dry-run by default."
+        ),
+        description=(
+            "Round 30g phase A. Iterates settled receipts in a bounded window, "
+            "fetches GitHub timeline events with bounded fanout, and computes "
+            "the canonical v2 outcome signals via "
+            "aragora.review.settlement_outcome.observe_outcome. Default mode is "
+            "read-only; --write opts in to in-place mutation of receipt JSON."
+        ),
+    )
+    observe_parser.add_argument(
+        "--window-days",
+        type=int,
+        default=14,
+        help="Observation window in days (default: 14).",
+    )
+    observe_parser.add_argument(
+        "--max-receipts",
+        type=int,
+        default=20,
+        help="Max receipts to inspect (default: 20). Bounds the GitHub fanout.",
+    )
+    observe_parser.add_argument(
+        "--per-receipt-event-cap",
+        type=int,
+        default=100,
+        help="Max timeline events per receipt (default: 100).",
+    )
+    observe_parser.add_argument(
+        "--review-queue-root",
+        default=None,
+        help="Override the review-queue store root for settlement receipts.",
+    )
+    observe_parser.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "OPT-IN: actually write v2 outcome fields back into receipt JSON. "
+            "Default is dry-run preview only."
+        ),
+    )
+    observe_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the run summary as JSON.",
+    )
+    observe_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
+
 
 def _add_codebase_audit_parser(subparsers) -> None:
     """Add the staged repository codebase audit parser."""

--- a/aragora/review/invalidation_event_source.py
+++ b/aragora/review/invalidation_event_source.py
@@ -282,6 +282,74 @@ def count_decisions_from_settlement_receipts(
     return total
 
 
+_V2_OUTCOME_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "outcome_revert_within_window",
+        "outcome_post_merge_incident",
+        "outcome_human_override_redo",
+        "outcome_rollback",
+        "outcome_reopened_pr",
+        "outcome_observed_at",
+    }
+)
+
+
+def _any_receipt_has_v2_outcome_fields(
+    *,
+    store_root: str | Path | None = None,
+    window_end: datetime,
+    window_days: int = DEFAULT_BASELINE_WINDOW_DAYS,
+    probe_cap: int = 50,
+) -> bool:
+    """Return True iff any receipt in the window carries a v2 outcome field
+    that is not ``None``.
+
+    A receipt is considered to "have v2 outcome fields" iff at least one of
+    the six v2 field names is present in the JSON payload AND its value is
+    not ``None``. Reading-only; bounded to ``probe_cap`` receipts to avoid
+    scanning very large stores.
+
+    This is the discriminator behind the two ``human_invalidations_source``
+    notes in :func:`measure_baseline_from_disk`.
+    """
+    if window_days <= 0:
+        raise ValueError("window_days must be positive")
+    window_end = _ensure_utc(window_end)
+    window_start = window_end - timedelta(days=window_days)
+
+    receipts_dir = resolve_review_queue_root(store_root) / RECEIPTS_SUBDIR
+    if not receipts_dir.exists():
+        return False
+
+    try:
+        candidates = [p for p in receipts_dir.iterdir() if p.is_file() and p.suffix == ".json"]
+    except OSError as exc:
+        logger.warning("review.invalidation_event_source: cannot list %s: %s", receipts_dir, exc)
+        return False
+
+    probed = 0
+    for path in candidates:
+        if probed >= probe_cap:
+            break
+        payload = _safe_read_json(path)
+        if payload is None:
+            continue
+        reviewed_raw = payload.get("reviewed_at")
+        if not reviewed_raw:
+            continue
+        try:
+            reviewed_at = _parse_iso(str(reviewed_raw))
+        except ValueError:
+            continue
+        if not (window_start <= reviewed_at <= window_end):
+            continue
+        probed += 1
+        for field_name in _V2_OUTCOME_FIELD_NAMES:
+            if field_name in payload and payload[field_name] is not None:
+                return True
+    return False
+
+
 def iter_invalidations_from_settlement_receipts(
     *,
     store_root: str | Path | None = None,
@@ -474,16 +542,46 @@ def measure_baseline_from_stores(
     )
 
     # Tag the gap explicitly so downstream consumers don't mistake a
-    # zero numerator for a measured zero rate.
+    # zero numerator for a measured zero rate. The note distinguishes the
+    # two failure modes:
+    #   - schema_gap_human_numerator: receipts in the window do not carry the
+    #     v2 outcome_* fields at all (i.e. observe_outcome has not yet run on
+    #     any of them); the schema can hold the signals but the data has not
+    #     been collected.
+    #   - schema_v1_only: receipts in the window have only legacy v1 fields
+    #     (reverted_at / post_merge_incident / redo_pr); kept for backwards
+    #     compatibility but no v2-shaped data is available.
     extra_notes = dict(measurement.notes)
     if not human_invalidations_in_window:
-        extra_notes.setdefault(
-            "human_invalidations_source",
-            "settlement-receipt schema does not yet record post-settlement "
-            "invalidation signals (revert/incident/redo); human-side numerator "
-            "is 0 by data availability, not by measurement. Tracked as a "
-            "follow-up to #6375 step A.",
+        # Probe a bounded set of receipts in the window to decide which
+        # data-collection note applies. Read-only and rate-limited by the
+        # ``count_decisions_from_settlement_receipts`` cap upstream.
+        v2_observed = _any_receipt_has_v2_outcome_fields(
+            store_root=review_queue_root,
+            window_end=window_end,
+            window_days=window_days,
         )
+        if v2_observed:
+            extra_notes.setdefault(
+                "human_invalidations_source",
+                "settlement-receipt schema-v2 outcome fields are present on at "
+                "least one receipt in the window, but no receipt in the window "
+                "fired any of the five canonical signals. Treat as measured "
+                "zero only if the observation timestamp is recent enough to "
+                "have caught any in-window signals.",
+            )
+        else:
+            extra_notes.setdefault(
+                "human_invalidations_source",
+                "schema_gap_human_numerator: settlement-receipt v2 outcome "
+                "fields (outcome_revert_within_window, "
+                "outcome_post_merge_incident, outcome_human_override_redo, "
+                "outcome_rollback, outcome_reopened_pr) are not yet populated "
+                "on any receipt in the window. Run "
+                "aragora.review.settlement_outcome.observe_outcome over the "
+                "window to close this gap. Until then, human-side numerator "
+                "is 0 by data availability, not by measurement.",
+            )
 
     # Re-pack to attach the additional note while keeping the
     # measurement immutable in spirit. BaselineMeasurement is frozen,
@@ -629,13 +727,44 @@ def _invalidation_from_settlement_receipt(
     signals: list[str] = []
     rationales: list[str] = []
 
-    # Future schema fields — defensive lookups so this function keeps
-    # working when receipt schemas grow without breaking.
+    # Schema v2 fields (#6375 phase 4) — explicit boolean signals populated by
+    # ``aragora.review.settlement_outcome.observe_outcome``. ``None`` means
+    # "not yet observed"; ``True`` means signal fired; ``False`` means signal
+    # was checked and did not fire.
+    v2_revert = payload.get("outcome_revert_within_window")
+    v2_incident = payload.get("outcome_post_merge_incident")
+    v2_redo = payload.get("outcome_human_override_redo")
+    v2_rollback = payload.get("outcome_rollback")
+    v2_reopened = payload.get("outcome_reopened_pr")
+
+    if v2_revert is True:
+        signals.append(INVALIDATION_REVERT_WITHIN_WINDOW)
+        rationales.append("settlement-receipt outcome_revert_within_window=True")
+    if v2_incident is True:
+        signals.append(INVALIDATION_POST_MERGE_INCIDENT)
+        rationales.append("settlement-receipt outcome_post_merge_incident=True")
+    if v2_redo is True:
+        signals.append(INVALIDATION_HUMAN_OVERRIDE_REDO)
+        rationales.append("settlement-receipt outcome_human_override_redo=True")
+    if v2_rollback is True:
+        from aragora.review.invalidation import INVALIDATION_ROLLBACK
+
+        signals.append(INVALIDATION_ROLLBACK)
+        rationales.append("settlement-receipt outcome_rollback=True")
+    if v2_reopened is True:
+        from aragora.review.invalidation import INVALIDATION_REOPENED_PR
+
+        signals.append(INVALIDATION_REOPENED_PR)
+        rationales.append("settlement-receipt outcome_reopened_pr=True")
+
+    # Schema v1 fields — kept for backwards compatibility with receipts that
+    # carry the older field names. Defensive lookups: continue working when
+    # receipt schemas grow without breaking.
     reverted_at_raw = payload.get("reverted_at")
     incident_attributed = bool(payload.get("post_merge_incident"))
     redo_pr = payload.get("redo_pr") or payload.get("human_override_redo_pr")
 
-    if reverted_at_raw:
+    if reverted_at_raw and INVALIDATION_REVERT_WITHIN_WINDOW not in signals:
         try:
             reverted_at = _parse_iso(str(reverted_at_raw))
         except ValueError:
@@ -649,11 +778,11 @@ def _invalidation_from_settlement_receipt(
                     f"(window={revert_window_days}d)"
                 )
 
-    if incident_attributed:
+    if incident_attributed and INVALIDATION_POST_MERGE_INCIDENT not in signals:
         signals.append(INVALIDATION_POST_MERGE_INCIDENT)
         rationales.append("settlement-receipt records post_merge_incident attributed to this PR")
 
-    if redo_pr:
+    if redo_pr and INVALIDATION_HUMAN_OVERRIDE_REDO not in signals:
         signals.append(INVALIDATION_HUMAN_OVERRIDE_REDO)
         rationales.append(f"settlement-receipt references follow-up redo PR {redo_pr!r}")
 

--- a/aragora/review/observe_outcomes_cli.py
+++ b/aragora/review/observe_outcomes_cli.py
@@ -278,7 +278,30 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_insufficiency_receipt_path(*, repo_root: Path, round_id: str) -> Path:
+def _resolve_insufficiency_receipt_path(
+    *,
+    repo_root: Path,
+    round_id: str,
+    dry_run: bool = False,
+    observed_at: datetime | None = None,
+) -> Path:
+    """Resolve the insufficiency-receipt destination.
+
+    Non-dry-run (write=True) routes to the round's canonical evolve
+    directory. Dry-run isolates the proposed artifact under an
+    observe-outcomes/<utc-iso> subtree so dry-run runs cannot pollute
+    a round's receipts and cannot ever land under docs/ or tests/.
+    """
+    if dry_run:
+        ts = (observed_at or datetime.now(UTC)).strftime("%Y%m%dT%H%M%SZ")
+        return (
+            repo_root
+            / ".aragora"
+            / "evolve-round"
+            / "observe-outcomes"
+            / ts
+            / "insufficiency-receipt.json"
+        )
     return (
         repo_root
         / ".aragora"
@@ -529,7 +552,10 @@ def run_observe_outcomes(
             v2_now_present=v2_now_present,
         )
         insufficiency_path = insufficiency_receipt_path or _resolve_insufficiency_receipt_path(
-            repo_root=repo_root, round_id=round_id
+            repo_root=repo_root,
+            round_id=round_id,
+            dry_run=not write,
+            observed_at=observed_at,
         )
         if write:
             try:

--- a/aragora/review/observe_outcomes_cli.py
+++ b/aragora/review/observe_outcomes_cli.py
@@ -1,0 +1,642 @@
+"""``aragora review-queue observe-outcomes`` — bounded receipt observation.
+
+Round 30g phase A (continues #6921 / δ #6375).
+
+Iterates settled receipts in a bounded window, fetches GitHub timeline
+events for each PR with bounded fanout, calls
+:func:`aragora.review.settlement_outcome.observe_outcome`, and either
+*previews* the proposed v2 outcome fields (the default; ``--dry-run``
+implied) or *writes* them back into the receipt JSON in place
+(``--write``).
+
+Safety contract
+---------------
+
+  - **Default mode is read-only.** No filesystem mutation, no GitHub
+    write, nothing committed. ``--write`` is the only flag that
+    permits in-place mutation.
+  - **Bounded fan-out.** ``--max-receipts`` (default 20) caps the
+    number of receipts examined; ``--per-receipt-event-cap`` (default
+    100) caps the number of timeline events fetched per PR. Both are
+    enforced before the GitHub fetch.
+  - **No network on dry-run when fixtures are provided.** Tests pass
+    ``timeline_provider`` to inject synthetic events so the CLI is
+    fully testable offline.
+  - **No commits.** This module never invokes ``git`` or ``gh pr``
+    write operations. Receipt files are JSON on disk and may be
+    rewritten by the operator's local tooling, but the *only* mutation
+    this CLI performs under ``--write`` is rewriting the receipt JSON
+    payload with the new ``outcome_*`` fields.
+  - **Sharper insufficiency receipt.** When the post-observation
+    baseline still lacks data, a structured insufficiency receipt is
+    written under ``.aragora/evolve-round/<round-id>/`` describing
+    *what* would unblock the next measurement (sample-size shortfall,
+    no v2-eligible receipts, GitHub-fetch errors, etc.). This is
+    additive to the dry-run preview output.
+
+Out of scope
+------------
+
+  - This CLI does **not** edit ``docs/THESIS.md``. Replacing the
+    placeholder 5% in Commitment 3 is gated on a measured baseline
+    *and* CI safety margin, neither of which this CLI produces on its
+    own.
+  - This CLI does **not** invent synthetic outcome data. If
+    ``observe_outcome`` returns "no signals fired" for every receipt
+    in the window, that is recorded honestly as
+    ``schema_v2_observed_no_signals``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.review.invalidation_event_source import (
+    RECEIPTS_SUBDIR,
+    _V2_OUTCOME_FIELD_NAMES,
+    _any_receipt_has_v2_outcome_fields,
+    resolve_review_queue_root,
+)
+from aragora.review.settlement_outcome import observe_outcome
+
+logger = logging.getLogger(__name__)
+
+UTC = timezone.utc
+
+DEFAULT_WINDOW_DAYS = 14
+DEFAULT_MAX_RECEIPTS = 20
+DEFAULT_PER_RECEIPT_EVENT_CAP = 100
+
+
+@dataclass(frozen=True, slots=True)
+class _ReceiptOnDisk:
+    path: Path
+    payload: dict[str, Any]
+
+
+@dataclass(slots=True)
+class _ObserveResult:
+    receipt_path: Path
+    pr_number: int
+    head_sha: str
+    fetched_event_count: int
+    fetch_error: str | None
+    signals_before: dict[str, Any]
+    signals_after: dict[str, Any]
+    written: bool
+    skipped_reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Receipt iteration (bounded, read-only)
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(raw: str) -> datetime:
+    cleaned = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+    parsed = datetime.fromisoformat(cleaned)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _iter_eligible_receipts(
+    *,
+    store_root: str | Path | None,
+    window_end: datetime,
+    window_days: int,
+    max_receipts: int,
+) -> list[_ReceiptOnDisk]:
+    receipts_dir = resolve_review_queue_root(store_root) / RECEIPTS_SUBDIR
+    if not receipts_dir.exists():
+        return []
+    window_start = window_end - timedelta(days=window_days)
+    out: list[_ReceiptOnDisk] = []
+    try:
+        candidates = sorted(
+            (p for p in receipts_dir.iterdir() if p.is_file() and p.suffix == ".json"),
+            key=lambda p: p.name,
+        )
+    except OSError as exc:
+        logger.warning("review.observe_outcomes_cli: cannot list %s: %s", receipts_dir, exc)
+        return []
+    for path in candidates:
+        if len(out) >= max_receipts:
+            break
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("could not read %s: %s", path, exc)
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("malformed JSON in %s: %s", path, exc)
+            continue
+        if not isinstance(payload, dict):
+            continue
+        reviewed_raw = payload.get("reviewed_at")
+        if not reviewed_raw:
+            continue
+        try:
+            reviewed_at = _parse_iso(str(reviewed_raw))
+        except (TypeError, ValueError):
+            continue
+        if not (window_start <= reviewed_at <= window_end):
+            continue
+        out.append(_ReceiptOnDisk(path=path, payload=payload))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# GitHub timeline fetch (bounded; pluggable for tests)
+# ---------------------------------------------------------------------------
+
+
+TimelineProvider = Callable[[int, str, int], tuple[list[Mapping[str, Any]], str | None]]
+"""Signature: (pr_number, head_sha, event_cap) -> (events, fetch_error_or_None)."""
+
+
+def _gh_timeline_provider(
+    pr_number: int, head_sha: str, event_cap: int
+) -> tuple[list[Mapping[str, Any]], str | None]:
+    """Default timeline provider using ``gh api``.
+
+    This is intentionally *minimal* — we fetch only the small set of
+    events that ``observe_outcome`` actually inspects, and we cap the
+    fetch with ``per_page`` plus a single page request to avoid
+    runaway pagination.
+
+    Returns (events, error). On any error returns ([], error_message).
+    """
+    if shutil.which("gh") is None:
+        return [], "gh CLI not found on PATH"
+    events: list[Mapping[str, Any]] = []
+    # Issue/PR timeline (covers reopen events and labeled issues that
+    # mention the merge sha). Bounded to one page of `event_cap` items.
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                f"/repos/:owner/:repo/issues/{pr_number}/timeline?per_page={min(event_cap, 100)}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        return [], f"gh timeline fetch raised {type(exc).__name__}: {exc}"
+    if proc.returncode != 0:
+        return [], f"gh timeline returned {proc.returncode}: {proc.stderr.strip()[:200]}"
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return [], f"timeline JSON parse error: {exc}"
+    for entry in data[:event_cap]:
+        if not isinstance(entry, dict):
+            continue
+        normalized = _normalize_timeline_entry(entry, pr_number=pr_number)
+        if normalized is not None:
+            events.append(normalized)
+    return events, None
+
+
+def _normalize_timeline_entry(
+    entry: Mapping[str, Any], *, pr_number: int
+) -> Mapping[str, Any] | None:
+    """Map a GitHub timeline entry into the shape ``observe_outcome`` expects."""
+    event_kind = entry.get("event")
+    created_at = entry.get("created_at") or entry.get("submitted_at")
+    if not isinstance(created_at, str):
+        return None
+    if event_kind == "reopened":
+        return {"type": "pr_reopened", "at": created_at, "pr_number": pr_number}
+    if event_kind == "committed":
+        message = ""
+        commit = entry.get("commit") if isinstance(entry.get("commit"), dict) else None
+        if commit:
+            message = str(commit.get("message", ""))
+        else:
+            message = str(entry.get("message", ""))
+        return {"type": "commit", "at": created_at, "message": message}
+    if event_kind == "labeled":
+        label_obj = entry.get("label") if isinstance(entry.get("label"), dict) else {}
+        labels = [str(label_obj.get("name", ""))] if label_obj else []
+        return {
+            "type": "issue_opened",
+            "at": created_at,
+            "labels": labels,
+            "title": str(entry.get("source", {}).get("issue", {}).get("title", ""))
+            if isinstance(entry.get("source"), dict)
+            else "",
+            "body": "",
+        }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON atomically via tempfile + rename, preserving permissions."""
+    target_dir = path.parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(target_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Insufficiency receipt
+# ---------------------------------------------------------------------------
+
+
+def _resolve_insufficiency_receipt_path(*, repo_root: Path, round_id: str) -> Path:
+    return (
+        repo_root
+        / ".aragora"
+        / "evolve-round"
+        / round_id
+        / "phase-a-observe-outcomes-insufficiency-receipt.json"
+    )
+
+
+def _build_insufficiency_receipt(
+    *,
+    window_end: datetime,
+    window_days: int,
+    max_receipts: int,
+    receipts_examined: int,
+    receipts_with_signals: int,
+    receipts_written: int,
+    fetch_errors: int,
+    v2_now_present: bool,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    if receipts_examined == 0:
+        reasons.append(
+            "no_receipts_in_window: 0 settlement receipts found inside the "
+            f"{window_days}d window ending {window_end.isoformat()}"
+        )
+    if receipts_examined > 0 and receipts_with_signals == 0:
+        reasons.append(
+            "no_signals_fired: every receipt observed produced 0 invalidation "
+            "signals; either the window is genuinely clean or the timeline "
+            "fetch did not surface revert/incident/redo events"
+        )
+    if fetch_errors > 0:
+        reasons.append(
+            f"github_fetch_errors: {fetch_errors} of {receipts_examined} "
+            "receipts had timeline fetch errors; rerun with network "
+            "connectivity verified"
+        )
+    if max_receipts <= receipts_examined:
+        reasons.append(
+            f"max_receipts_cap_hit: --max-receipts={max_receipts} reached, "
+            "increase the cap or narrow the window to inspect more"
+        )
+    return {
+        "kind": "phase-a-observe-outcomes-insufficiency-receipt",
+        "round": "2026-04-30g",
+        "window_end_utc": window_end.isoformat(),
+        "window_days": window_days,
+        "max_receipts": max_receipts,
+        "receipts_examined": receipts_examined,
+        "receipts_with_signals_fired": receipts_with_signals,
+        "receipts_written": receipts_written,
+        "github_fetch_errors": fetch_errors,
+        "v2_outcome_fields_now_present_in_window": v2_now_present,
+        "remaining_blockers": reasons,
+        "next_action_advice": (
+            "If v2_outcome_fields_now_present_in_window is True but no signals "
+            "fired, the empirical baseline can be measured but the human-side "
+            "numerator is genuinely zero in this window — do not invent a "
+            "threshold; rerun on a wider window or a later cohort."
+            if receipts_examined > 0 and receipts_with_signals == 0
+            else "Run with --window-days adjusted, ensure gh CLI is "
+            "authenticated, and re-attempt. Do NOT manually populate v2 "
+            "outcome fields without observing real timeline evidence."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core observation loop
+# ---------------------------------------------------------------------------
+
+
+def _materialize_receipt(payload: Mapping[str, Any]) -> Any:
+    """Reconstruct a ``SettlementReceipt`` from a JSON payload.
+
+    Imported here lazily so this module does not pull the full
+    review-queue CLI graph at top level.
+    """
+    from aragora.cli.commands.review_queue import SettlementReceipt
+
+    field_names = {f.name for f in SettlementReceipt.__dataclass_fields__.values()}
+    kwargs = {k: v for k, v in payload.items() if k in field_names}
+    return SettlementReceipt(**kwargs)
+
+
+def _signal_extract(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Project the v2 outcome-field subset for before/after comparison."""
+    return {name: payload.get(name) for name in sorted(_V2_OUTCOME_FIELD_NAMES)}
+
+
+def _observe_one(
+    receipt: _ReceiptOnDisk,
+    *,
+    window_days: int,
+    timeline_provider: TimelineProvider,
+    per_receipt_event_cap: int,
+    write: bool,
+    observed_at: datetime,
+) -> _ObserveResult:
+    payload = receipt.payload
+    pr_number = int(payload.get("pr_number", 0))
+    head_sha = str(payload.get("head_sha", ""))
+    if pr_number <= 0 or not head_sha:
+        return _ObserveResult(
+            receipt_path=receipt.path,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            fetched_event_count=0,
+            fetch_error="malformed receipt: missing pr_number or head_sha",
+            signals_before=_signal_extract(payload),
+            signals_after=_signal_extract(payload),
+            written=False,
+            skipped_reason="malformed receipt",
+        )
+    events, fetch_error = timeline_provider(pr_number, head_sha, per_receipt_event_cap)
+    if fetch_error is not None:
+        return _ObserveResult(
+            receipt_path=receipt.path,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            fetched_event_count=len(events),
+            fetch_error=fetch_error,
+            signals_before=_signal_extract(payload),
+            signals_after=_signal_extract(payload),
+            written=False,
+            skipped_reason="github fetch error",
+        )
+    receipt_obj = _materialize_receipt(payload)
+    observed = observe_outcome(
+        receipt_obj,
+        github_timeline=events,
+        window_days=window_days,
+        observed_at=observed_at,
+    )
+    new_payload = dict(payload)
+    for name in _V2_OUTCOME_FIELD_NAMES:
+        new_payload[name] = getattr(observed, name)
+    written = False
+    if write:
+        try:
+            _atomic_write_json(receipt.path, new_payload)
+            written = True
+        except OSError as exc:
+            return _ObserveResult(
+                receipt_path=receipt.path,
+                pr_number=pr_number,
+                head_sha=head_sha,
+                fetched_event_count=len(events),
+                fetch_error=None,
+                signals_before=_signal_extract(payload),
+                signals_after=_signal_extract(new_payload),
+                written=False,
+                skipped_reason=f"atomic write failed: {exc}",
+            )
+    return _ObserveResult(
+        receipt_path=receipt.path,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        fetched_event_count=len(events),
+        fetch_error=None,
+        signals_before=_signal_extract(payload),
+        signals_after=_signal_extract(new_payload),
+        written=written,
+    )
+
+
+def run_observe_outcomes(
+    *,
+    store_root: str | Path | None,
+    repo_root: Path,
+    window_end: datetime,
+    window_days: int,
+    max_receipts: int,
+    per_receipt_event_cap: int,
+    write: bool,
+    timeline_provider: TimelineProvider | None = None,
+    insufficiency_receipt_path: Path | None = None,
+    round_id: str = "2026-04-30g",
+) -> dict[str, Any]:
+    """Run the observation pipeline. Pure-function-shaped; testable.
+
+    Returns a structured summary dict that the CLI prints. The
+    summary includes a ``"results"`` list (one per receipt examined),
+    aggregate counters, the ``v2_outcome_fields_now_present`` boolean,
+    and (when applicable) the path to the insufficiency receipt that
+    was written.
+    """
+    if window_days <= 0:
+        raise ValueError("window_days must be positive")
+    if max_receipts <= 0:
+        raise ValueError("max_receipts must be positive")
+    if per_receipt_event_cap <= 0:
+        raise ValueError("per_receipt_event_cap must be positive")
+    provider = timeline_provider or _gh_timeline_provider
+    observed_at = datetime.now(UTC)
+
+    receipts = _iter_eligible_receipts(
+        store_root=store_root,
+        window_end=window_end,
+        window_days=window_days,
+        max_receipts=max_receipts,
+    )
+    results: list[_ObserveResult] = []
+    for receipt in receipts:
+        results.append(
+            _observe_one(
+                receipt,
+                window_days=window_days,
+                timeline_provider=provider,
+                per_receipt_event_cap=per_receipt_event_cap,
+                write=write,
+                observed_at=observed_at,
+            )
+        )
+
+    receipts_with_signals = sum(
+        1
+        for r in results
+        if any(v is True for v in r.signals_after.values() if isinstance(v, bool))
+    )
+    receipts_written = sum(1 for r in results if r.written)
+    fetch_errors = sum(1 for r in results if r.fetch_error is not None)
+
+    # If we wrote any v2 fields, the next baseline measurement should
+    # see them. Probe defensively.
+    try:
+        v2_now_present = _any_receipt_has_v2_outcome_fields(
+            store_root=store_root,
+            window_end=window_end,
+            window_days=window_days,
+        )
+    except (OSError, ValueError) as exc:
+        logger.warning("post-observation probe failed: %s", exc)
+        v2_now_present = False
+
+    insufficiency_path: Path | None = None
+    if len(results) == 0 or receipts_with_signals == 0 or fetch_errors > 0:
+        insufficiency_payload = _build_insufficiency_receipt(
+            window_end=window_end,
+            window_days=window_days,
+            max_receipts=max_receipts,
+            receipts_examined=len(results),
+            receipts_with_signals=receipts_with_signals,
+            receipts_written=receipts_written,
+            fetch_errors=fetch_errors,
+            v2_now_present=v2_now_present,
+        )
+        insufficiency_path = insufficiency_receipt_path or _resolve_insufficiency_receipt_path(
+            repo_root=repo_root, round_id=round_id
+        )
+        try:
+            _atomic_write_json(insufficiency_path, insufficiency_payload)
+        except OSError as exc:
+            logger.warning("could not write insufficiency receipt %s: %s", insufficiency_path, exc)
+
+    return {
+        "mode": "write" if write else "dry-run",
+        "window_end_utc": window_end.isoformat(),
+        "window_days": window_days,
+        "max_receipts": max_receipts,
+        "per_receipt_event_cap": per_receipt_event_cap,
+        "receipts_examined": len(results),
+        "receipts_with_signals_fired": receipts_with_signals,
+        "receipts_written": receipts_written,
+        "github_fetch_errors": fetch_errors,
+        "v2_outcome_fields_now_present_in_window": v2_now_present,
+        "insufficiency_receipt_path": (str(insufficiency_path) if insufficiency_path else None),
+        "results": [
+            {
+                "receipt_path": str(r.receipt_path),
+                "pr_number": r.pr_number,
+                "head_sha": r.head_sha,
+                "fetched_event_count": r.fetched_event_count,
+                "fetch_error": r.fetch_error,
+                "signals_before": r.signals_before,
+                "signals_after": r.signals_after,
+                "written": r.written,
+                "skipped_reason": r.skipped_reason,
+            }
+            for r in results
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# argparse subparser registration
+# ---------------------------------------------------------------------------
+
+
+def add_observe_outcomes_subparser(sub: argparse._SubParsersAction) -> None:
+    """Register ``observe-outcomes`` under the ``review-queue`` subparser."""
+    p = sub.add_parser(
+        "observe-outcomes",
+        help=(
+            "Observe post-settlement invalidation signals from GitHub "
+            "timeline events and (optionally) write them back into v2 "
+            "outcome fields on settlement receipts. Dry-run by default."
+        ),
+        description=(
+            "Round 30g phase A. Iterates settled receipts in a bounded\n"
+            "window, fetches GitHub timeline events for each PR with\n"
+            "bounded fanout, and computes the five canonical v2 outcome\n"
+            "signals via aragora.review.settlement_outcome.observe_outcome.\n\n"
+            "Default mode is read-only: nothing is written. Pass --write\n"
+            "to mutate receipt JSON files in place. The CLI never invokes\n"
+            "git or gh write operations and never edits docs/THESIS.md."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--window-days",
+        type=int,
+        default=DEFAULT_WINDOW_DAYS,
+        help=f"Observation window in days (default: {DEFAULT_WINDOW_DAYS}).",
+    )
+    p.add_argument(
+        "--max-receipts",
+        type=int,
+        default=DEFAULT_MAX_RECEIPTS,
+        help=(
+            "Maximum receipts to inspect in this run "
+            f"(default: {DEFAULT_MAX_RECEIPTS}). Bounds the GitHub fanout."
+        ),
+    )
+    p.add_argument(
+        "--per-receipt-event-cap",
+        type=int,
+        default=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        help=(
+            "Maximum timeline events fetched per receipt "
+            f"(default: {DEFAULT_PER_RECEIPT_EVENT_CAP})."
+        ),
+    )
+    p.add_argument(
+        "--review-queue-root",
+        default=None,
+        help=(
+            "Override the review-queue store root used for settlement "
+            "receipts. Defaults to <repo>/.aragora/review-queue."
+        ),
+    )
+    p.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "OPT-IN: actually write v2 outcome fields back into receipt "
+            "JSON files. Default is dry-run preview only."
+        ),
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the run summary as JSON.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatcher entry point lives in aragora.cli.commands.observe_outcomes_cmd
+# (T201 per-file-ignore covers print-rendering there). This module keeps the
+# pipeline pure-function-shaped.
+# ---------------------------------------------------------------------------

--- a/aragora/review/observe_outcomes_cli.py
+++ b/aragora/review/observe_outcomes_cli.py
@@ -29,10 +29,11 @@ Safety contract
     payload with the new ``outcome_*`` fields.
   - **Sharper insufficiency receipt.** When the post-observation
     baseline still lacks data, a structured insufficiency receipt is
-    written under ``.aragora/evolve-round/<round-id>/`` describing
-    *what* would unblock the next measurement (sample-size shortfall,
-    no v2-eligible receipts, GitHub-fetch errors, etc.). This is
-    additive to the dry-run preview output.
+    proposed in dry-run mode and written under
+    ``.aragora/evolve-round/<round-id>/`` only when ``--write`` is
+    passed. It describes *what* would unblock the next measurement
+    (sample-size shortfall, no v2-eligible receipts, GitHub-fetch
+    errors, etc.).
 
 Out of scope
 ------------
@@ -463,8 +464,8 @@ def run_observe_outcomes(
     Returns a structured summary dict that the CLI prints. The
     summary includes a ``"results"`` list (one per receipt examined),
     aggregate counters, the ``v2_outcome_fields_now_present`` boolean,
-    and (when applicable) the path to the insufficiency receipt that
-    was written.
+    and (when applicable) the proposed or written insufficiency
+    receipt payload and path.
     """
     if window_days <= 0:
         raise ValueError("window_days must be positive")
@@ -515,6 +516,7 @@ def run_observe_outcomes(
         v2_now_present = False
 
     insufficiency_path: Path | None = None
+    insufficiency_payload: dict[str, Any] | None = None
     if len(results) == 0 or receipts_with_signals == 0 or fetch_errors > 0:
         insufficiency_payload = _build_insufficiency_receipt(
             window_end=window_end,
@@ -529,10 +531,15 @@ def run_observe_outcomes(
         insufficiency_path = insufficiency_receipt_path or _resolve_insufficiency_receipt_path(
             repo_root=repo_root, round_id=round_id
         )
-        try:
-            _atomic_write_json(insufficiency_path, insufficiency_payload)
-        except OSError as exc:
-            logger.warning("could not write insufficiency receipt %s: %s", insufficiency_path, exc)
+        if write:
+            try:
+                _atomic_write_json(insufficiency_path, insufficiency_payload)
+            except OSError as exc:
+                logger.warning(
+                    "could not write insufficiency receipt %s: %s",
+                    insufficiency_path,
+                    exc,
+                )
 
     return {
         "mode": "write" if write else "dry-run",
@@ -546,6 +553,7 @@ def run_observe_outcomes(
         "github_fetch_errors": fetch_errors,
         "v2_outcome_fields_now_present_in_window": v2_now_present,
         "insufficiency_receipt_path": (str(insufficiency_path) if insufficiency_path else None),
+        "insufficiency_receipt": insufficiency_payload,
         "results": [
             {
                 "receipt_path": str(r.receipt_path),

--- a/aragora/review/settlement_outcome.py
+++ b/aragora/review/settlement_outcome.py
@@ -1,0 +1,262 @@
+"""Pure-function observation of post-settlement invalidation signals (#6375 phase 4).
+
+This module bridges the gap between :class:`aragora.cli.commands.review_queue.SettlementReceipt`
+(which captures *settlement* events) and the canonical invalidation signals in
+:mod:`aragora.review.invalidation` (which capture *post-settlement* invalidation
+events). The :func:`observe_outcome` function takes a settled receipt plus a
+windowed slice of GitHub timeline events and returns a *new* receipt with the
+five ``outcome_*`` signals populated.
+
+Scope
+-----
+
+Phase 1 (#6602): pure-function classification + baseline + threshold.
+Phase 2 (#6898): on-disk adapters reading existing stores.
+Phase 3 (#6898): recalibration scheduler + ``ThresholdUpdateReceipt``.
+Phase 4 (this module): observation function that closes the
+``schema_gap_human_numerator`` note in the existing invalidation event source.
+Phase 5 (separate PR, requires real data): replace the literal ``5%`` in
+``docs/THESIS.md`` Commitment 3.
+
+Design constraints
+------------------
+
+This is intentionally a **pure function**: no I/O, no SQL, no GitHub API
+fetch. Callers fan out the GitHub fetch separately (and rate-limit it) and
+then feed the timeline list here. This keeps the observation logic testable
+with synthetic fixtures and avoids coupling the schema-augmentation work to
+any specific live-fetch path.
+
+The five canonical signals are pinned by their string labels in
+:data:`aragora.review.invalidation.INVALIDATION_SIGNALS`. New signals require
+an additive change there (and an explicit acknowledgement); this module is
+forbidden from adding new signals on its own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Mapping
+
+from aragora.review.invalidation import (
+    DEFAULT_REVERT_WINDOW_DAYS,
+    INVALIDATION_HUMAN_OVERRIDE_REDO,
+    INVALIDATION_POST_MERGE_INCIDENT,
+    INVALIDATION_REOPENED_PR,
+    INVALIDATION_REVERT_WITHIN_WINDOW,
+    INVALIDATION_ROLLBACK,
+    INVALIDATION_SIGNALS,
+)
+
+UTC = timezone.utc
+
+__all__ = [
+    "INCIDENT_LABELS",
+    "ROLLBACK_LABELS",
+    "ObservationWindow",
+    "observe_outcome",
+]
+
+
+#: Issue labels that count as ``post_merge_incident`` when the issue body
+#: mentions the merge SHA, PR number, or named files. Pinned conservatively;
+#: new labels must be added here explicitly so the predicate vocabulary
+#: remains reviewable.
+INCIDENT_LABELS: frozenset[str] = frozenset(
+    {"incident", "regression", "revert-target", "boss-stuck"}
+)
+
+#: PR or commit-message markers that count as an explicit ``rollback``
+#: distinct from a clean revert (e.g., feature-flag rollback, infra rollback).
+ROLLBACK_LABELS: frozenset[str] = frozenset({"rollback", "feature-flag-rollback"})
+
+
+class ObservationWindow:
+    """Resolved time window for outcome observation.
+
+    Constructed from a settlement receipt's ``reviewed_at`` plus a
+    ``window_days`` parameter. Defaults to ``DEFAULT_REVERT_WINDOW_DAYS``
+    (= 14 days) so a slow rollback two weeks later still counts.
+    """
+
+    __slots__ = ("start", "end")
+
+    def __init__(self, settled_at: datetime, window_days: int) -> None:
+        if settled_at.tzinfo is None:
+            raise ValueError("settled_at must be timezone-aware")
+        if window_days <= 0:
+            raise ValueError(f"window_days must be positive; got {window_days}")
+        self.start: datetime = settled_at
+        self.end: datetime = settled_at + timedelta(days=window_days)
+
+
+def _parse_iso(ts: str) -> datetime:
+    """Parse ISO 8601 with ``Z`` suffix or offset; always returns UTC."""
+    cleaned = ts.replace("Z", "+00:00") if ts.endswith("Z") else ts
+    parsed = datetime.fromisoformat(cleaned)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _event_in_window(event_at: datetime, window: ObservationWindow) -> bool:
+    return window.start <= event_at <= window.end
+
+
+def _is_revert_commit(event: Mapping[str, Any], head_sha: str) -> bool:
+    """A commit-event is a revert when its message starts with ``Revert "``
+    AND mentions the merge SHA explicitly."""
+    if event.get("type") != "commit":
+        return False
+    message = str(event.get("message", ""))
+    if not message.startswith('Revert "'):
+        return False
+    return head_sha in message or head_sha[:7] in message
+
+
+def _is_rollback_pr(event: Mapping[str, Any]) -> bool:
+    """A PR event with title prefix ``Revert `` or label in ``ROLLBACK_LABELS``."""
+    if event.get("type") != "pr_opened":
+        return False
+    title = str(event.get("title", "")).lower()
+    if title.startswith("revert "):
+        return True
+    labels = {str(label).lower() for label in event.get("labels", [])}
+    return bool(labels & ROLLBACK_LABELS)
+
+
+def _is_post_merge_incident(event: Mapping[str, Any], head_sha: str, pr_number: int) -> bool:
+    """An issue event with an incident-class label that mentions the merge."""
+    if event.get("type") != "issue_opened":
+        return False
+    labels = {str(label).lower() for label in event.get("labels", [])}
+    if not (labels & INCIDENT_LABELS):
+        return False
+    body = str(event.get("body", ""))
+    title = str(event.get("title", ""))
+    haystack = f"{title}\n{body}"
+    return head_sha in haystack or head_sha[:7] in haystack or f"#{pr_number}" in haystack
+
+
+def _is_human_override_redo(event: Mapping[str, Any], pr_number: int) -> bool:
+    """A follow-up PR that closes/fixes/supersedes the original PR within the window."""
+    if event.get("type") != "pr_opened":
+        return False
+    body = str(event.get("body", "")).lower()
+    title = str(event.get("title", "")).lower()
+    haystack = f"{title}\n{body}"
+    refs = (
+        f"closes #{pr_number}",
+        f"fixes #{pr_number}",
+        f"resolves #{pr_number}",
+        f"supersedes #{pr_number}",
+        f"replaces #{pr_number}",
+    )
+    return any(ref in haystack for ref in refs)
+
+
+def _is_reopened_pr(event: Mapping[str, Any], pr_number: int) -> bool:
+    """A ``pr_reopened`` event for the same PR number."""
+    return event.get("type") == "pr_reopened" and event.get("pr_number") == pr_number
+
+
+def observe_outcome(
+    receipt: Any,
+    *,
+    github_timeline: Iterable[Mapping[str, Any]],
+    window_days: int = DEFAULT_REVERT_WINDOW_DAYS,
+    observed_at: datetime | None = None,
+) -> Any:
+    """Return a new receipt with the five ``outcome_*`` signals populated.
+
+    The original receipt is not mutated; ``dataclasses.replace`` is used to
+    construct a new frozen-equivalent instance.
+
+    :param receipt: a :class:`SettlementReceipt`. Imported from
+        :mod:`aragora.cli.commands.review_queue`; typed as ``Any`` here to
+        avoid an import cycle (the CLI module imports many things this
+        module's framework path does not need).
+    :param github_timeline: an iterable of timeline-event mappings. Each
+        event is ``{"type": str, "at": iso8601, ...}`` plus type-specific
+        fields. See module docstring for the canonical types.
+    :param window_days: observation window width in days. Defaults to
+        :data:`DEFAULT_REVERT_WINDOW_DAYS` (= 14). Must be positive.
+    :param observed_at: the time at which the observation is being recorded.
+        Defaults to ``datetime.now(UTC)``. Set explicitly in tests for
+        deterministic receipts.
+    :returns: a new ``SettlementReceipt`` with the five ``outcome_*`` fields
+        and ``outcome_observed_at`` populated. Fields that are ``False``
+        explicitly mean "checked, no signal"; ``None`` means "not yet
+        observed" and should never be returned by this function — every
+        field is set explicitly to ``True`` or ``False``.
+
+    All five signals are evaluated independently: a single PR can fire
+    multiple signals if e.g. it was reverted *and* triggered a post-merge
+    incident.
+    """
+    settled_at = _parse_iso(receipt.reviewed_at)
+    window = ObservationWindow(settled_at=settled_at, window_days=window_days)
+    head_sha = receipt.head_sha
+    pr_number = receipt.pr_number
+
+    revert_within_window = False
+    post_merge_incident = False
+    human_override_redo = False
+    rollback = False
+    reopened_pr = False
+
+    for event in github_timeline:
+        ts = event.get("at")
+        if not isinstance(ts, str):
+            continue
+        try:
+            event_at = _parse_iso(ts)
+        except (TypeError, ValueError):
+            continue
+        if not _event_in_window(event_at, window):
+            continue
+        if _is_revert_commit(event, head_sha):
+            revert_within_window = True
+        if _is_rollback_pr(event):
+            rollback = True
+        if _is_post_merge_incident(event, head_sha, pr_number):
+            post_merge_incident = True
+        if _is_human_override_redo(event, pr_number):
+            human_override_redo = True
+        if _is_reopened_pr(event, pr_number):
+            reopened_pr = True
+
+    if observed_at is None:
+        observed_at = datetime.now(UTC)
+    elif observed_at.tzinfo is None:
+        observed_at = observed_at.replace(tzinfo=UTC)
+
+    return replace(
+        receipt,
+        outcome_revert_within_window=revert_within_window,
+        outcome_post_merge_incident=post_merge_incident,
+        outcome_human_override_redo=human_override_redo,
+        outcome_rollback=rollback,
+        outcome_reopened_pr=reopened_pr,
+        outcome_observed_at=observed_at.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    )
+
+
+# Sanity check at import time: the five outcome signals here must correspond
+# exactly to the canonical invalidation set so the schema cannot silently
+# drift. Raises ``RuntimeError`` (rather than ``assert``) so the check is not
+# elided under ``python -O`` and survives ruff S101.
+_EXPECTED_SIGNALS = {
+    INVALIDATION_REVERT_WITHIN_WINDOW,
+    INVALIDATION_POST_MERGE_INCIDENT,
+    INVALIDATION_HUMAN_OVERRIDE_REDO,
+    INVALIDATION_ROLLBACK,
+    INVALIDATION_REOPENED_PR,
+}
+if _EXPECTED_SIGNALS != INVALIDATION_SIGNALS:
+    raise RuntimeError(
+        "settlement_outcome fields drifted from canonical INVALIDATION_SIGNALS; "
+        f"expected={sorted(INVALIDATION_SIGNALS)}, "
+        f"got={sorted(_EXPECTED_SIGNALS)}"
+    )

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -110,7 +110,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `merge-packet`, `packet`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `merge-packet`, `observe-outcomes`, `packet`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4101` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1928761` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4104` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1930041` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `136` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5141` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217274` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5145` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217345` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `662` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `61` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| CLI top-level command modules | `62` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3398` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `822` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `821` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -105,7 +105,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `merge-packet`, `packet`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `merge-packet`, `observe-outcomes`, `packet`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/tests/review/test_invalidation_event_source_v2.py
+++ b/tests/review/test_invalidation_event_source_v2.py
@@ -1,0 +1,219 @@
+"""Tests for v2 outcome-field handling in invalidation_event_source (#6375 phase 4)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from aragora.review.invalidation import (
+    INVALIDATION_HUMAN_OVERRIDE_REDO,
+    INVALIDATION_POST_MERGE_INCIDENT,
+    INVALIDATION_REOPENED_PR,
+    INVALIDATION_REVERT_WITHIN_WINDOW,
+    INVALIDATION_ROLLBACK,
+)
+from aragora.review.invalidation_event_source import (
+    _any_receipt_has_v2_outcome_fields,
+    _invalidation_from_settlement_receipt as _settlement_payload_to_invalidated_decision,
+)
+
+UTC = timezone.utc
+RECEIPTS_SUBDIR = "receipts"
+
+
+def _write_receipt(receipts_dir: Path, name: str, payload: dict) -> Path:
+    receipts_dir.mkdir(parents=True, exist_ok=True)
+    path = receipts_dir / f"{name}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _base_payload(
+    *,
+    pr_number: int = 100,
+    reviewed_at: str = "2026-04-15T12:00:00+00:00",
+) -> dict:
+    return {
+        "session_id": "sess-1",
+        "reviewed_at": reviewed_at,
+        "actor": "armand",
+        "action": "settle",
+        "reason": "test",
+        "pr_number": pr_number,
+        "pr_url": f"https://github.com/org/repo/pull/{pr_number}",
+        "head_sha": "abc1234",
+        "base_sha": "000",
+        "packet_sha": "p",
+        "queue_bucket": "ready",
+        "machine_recommendation": "fire_and_forget",
+        "github_event": "merged",
+    }
+
+
+class TestPayloadToInvalidatedDecisionV2Fields:
+    def test_v2_revert_signal_fires(self) -> None:
+        payload = _base_payload()
+        payload["outcome_revert_within_window"] = True
+        payload["outcome_observed_at"] = "2026-04-22T00:00:00Z"
+        decision = _settlement_payload_to_invalidated_decision(payload)
+        assert decision is not None
+        assert INVALIDATION_REVERT_WITHIN_WINDOW in decision.signals
+        assert decision.was_human_settled is True
+
+    def test_v2_incident_signal_fires(self) -> None:
+        payload = _base_payload()
+        payload["outcome_post_merge_incident"] = True
+        payload["outcome_observed_at"] = "2026-04-22T00:00:00Z"
+        decision = _settlement_payload_to_invalidated_decision(payload)
+        assert decision is not None
+        assert INVALIDATION_POST_MERGE_INCIDENT in decision.signals
+
+    def test_v2_redo_signal_fires(self) -> None:
+        payload = _base_payload()
+        payload["outcome_human_override_redo"] = True
+        decision = _settlement_payload_to_invalidated_decision(payload)
+        assert decision is not None
+        assert INVALIDATION_HUMAN_OVERRIDE_REDO in decision.signals
+
+    def test_v2_rollback_signal_fires(self) -> None:
+        payload = _base_payload()
+        payload["outcome_rollback"] = True
+        decision = _settlement_payload_to_invalidated_decision(payload)
+        assert decision is not None
+        assert INVALIDATION_ROLLBACK in decision.signals
+
+    def test_v2_reopened_signal_fires(self) -> None:
+        payload = _base_payload()
+        payload["outcome_reopened_pr"] = True
+        decision = _settlement_payload_to_invalidated_decision(payload)
+        assert decision is not None
+        assert INVALIDATION_REOPENED_PR in decision.signals
+
+    def test_v2_all_false_returns_none(self) -> None:
+        payload = _base_payload()
+        payload["outcome_revert_within_window"] = False
+        payload["outcome_post_merge_incident"] = False
+        payload["outcome_human_override_redo"] = False
+        payload["outcome_rollback"] = False
+        payload["outcome_reopened_pr"] = False
+        payload["outcome_observed_at"] = "2026-04-22T00:00:00Z"
+        decision = _settlement_payload_to_invalidated_decision(payload)
+        assert decision is None
+
+    def test_v2_all_none_returns_none(self) -> None:
+        # No outcome fields = no signals = None (denominator only)
+        payload = _base_payload()
+        decision = _settlement_payload_to_invalidated_decision(payload)
+        assert decision is None
+
+    def test_v2_multiple_signals_combine(self) -> None:
+        payload = _base_payload()
+        payload["outcome_revert_within_window"] = True
+        payload["outcome_post_merge_incident"] = True
+        decision = _settlement_payload_to_invalidated_decision(payload)
+        assert decision is not None
+        assert INVALIDATION_REVERT_WITHIN_WINDOW in decision.signals
+        assert INVALIDATION_POST_MERGE_INCIDENT in decision.signals
+        assert len(decision.signals) == 2
+
+    def test_v2_takes_precedence_over_v1(self) -> None:
+        # If both v1 and v2 fields are present, v2 wins (no double-counting).
+        payload = _base_payload()
+        payload["outcome_revert_within_window"] = True
+        payload["reverted_at"] = "2026-04-20T10:00:00Z"  # v1 legacy field
+        decision = _settlement_payload_to_invalidated_decision(payload)
+        assert decision is not None
+        revert_signals = [s for s in decision.signals if s == INVALIDATION_REVERT_WITHIN_WINDOW]
+        assert len(revert_signals) == 1
+
+
+class TestAnyReceiptHasV2OutcomeFields:
+    def test_returns_false_when_no_receipts(self, tmp_path: Path) -> None:
+        result = _any_receipt_has_v2_outcome_fields(
+            store_root=tmp_path,
+            window_end=datetime(2026, 4, 30, tzinfo=UTC),
+            window_days=30,
+        )
+        assert result is False
+
+    def test_returns_false_when_only_v1_receipts(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        _write_receipt(receipts_dir, "r2", _base_payload(pr_number=101))
+        result = _any_receipt_has_v2_outcome_fields(
+            store_root=tmp_path,
+            window_end=datetime(2026, 4, 30, tzinfo=UTC),
+            window_days=30,
+        )
+        assert result is False
+
+    def test_returns_true_when_v2_field_populated(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        v2_payload = _base_payload()
+        v2_payload["outcome_revert_within_window"] = False  # explicit False still counts
+        v2_payload["outcome_observed_at"] = "2026-04-22T00:00:00Z"
+        _write_receipt(receipts_dir, "r1", v2_payload)
+        result = _any_receipt_has_v2_outcome_fields(
+            store_root=tmp_path,
+            window_end=datetime(2026, 4, 30, tzinfo=UTC),
+            window_days=30,
+        )
+        assert result is True
+
+    def test_v2_field_present_but_none_does_not_count(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        v2_payload = _base_payload()
+        v2_payload["outcome_revert_within_window"] = None  # explicit None
+        v2_payload["outcome_observed_at"] = None
+        _write_receipt(receipts_dir, "r1", v2_payload)
+        result = _any_receipt_has_v2_outcome_fields(
+            store_root=tmp_path,
+            window_end=datetime(2026, 4, 30, tzinfo=UTC),
+            window_days=30,
+        )
+        assert result is False
+
+    def test_outside_window_does_not_count(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        old_payload = _base_payload(reviewed_at="2025-12-01T12:00:00+00:00")
+        old_payload["outcome_revert_within_window"] = True
+        _write_receipt(receipts_dir, "old", old_payload)
+        result = _any_receipt_has_v2_outcome_fields(
+            store_root=tmp_path,
+            window_end=datetime(2026, 4, 30, tzinfo=UTC),
+            window_days=30,
+        )
+        assert result is False
+
+    def test_probe_cap_bounds_scan(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        # 5 v1-only receipts, then 1 v2 receipt; with probe_cap=3 we should
+        # only see the first 3 receipts (alphabetic order under iterdir is not
+        # guaranteed, so we accept either result here — the cap ensures bounded
+        # work, not deterministic ordering).
+        for i in range(5):
+            _write_receipt(receipts_dir, f"v1_{i}", _base_payload(pr_number=i))
+        v2_payload = _base_payload(pr_number=99)
+        v2_payload["outcome_revert_within_window"] = True
+        _write_receipt(receipts_dir, "v2", v2_payload)
+        # The function returns True or False depending on iteration order;
+        # what we pin is that it terminates and respects the cap. Run with a
+        # small cap and ensure it returns a bool quickly.
+        result = _any_receipt_has_v2_outcome_fields(
+            store_root=tmp_path,
+            window_end=datetime(2026, 4, 30, tzinfo=UTC),
+            window_days=30,
+            probe_cap=3,
+        )
+        assert isinstance(result, bool)
+
+    def test_rejects_nonpositive_window_days(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            _any_receipt_has_v2_outcome_fields(
+                store_root=tmp_path,
+                window_end=datetime(2026, 4, 30, tzinfo=UTC),
+                window_days=0,
+            )

--- a/tests/review/test_observe_outcomes_cli.py
+++ b/tests/review/test_observe_outcomes_cli.py
@@ -86,7 +86,9 @@ def _failing_provider(
 
 
 class TestEmptyStore:
-    def test_no_receipts_emits_insufficiency_receipt(self, tmp_path: Path) -> None:
+    def test_dry_run_no_receipts_proposes_insufficiency_receipt_without_writing(
+        self, tmp_path: Path
+    ) -> None:
         repo_root = tmp_path
         summary = run_observe_outcomes(
             store_root=tmp_path,
@@ -102,8 +104,28 @@ class TestEmptyStore:
         assert summary["receipts_examined"] == 0
         assert summary["insufficiency_receipt_path"] is not None
         path = Path(summary["insufficiency_receipt_path"])
+        assert not path.exists()
+        body = summary["insufficiency_receipt"]
+        assert body["kind"] == "phase-a-observe-outcomes-insufficiency-receipt"
+        assert "no_receipts_in_window" in " ".join(body["remaining_blockers"])
+
+    def test_write_mode_no_receipts_writes_insufficiency_receipt(self, tmp_path: Path) -> None:
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["mode"] == "write"
+        assert summary["receipts_examined"] == 0
+        path = Path(summary["insufficiency_receipt_path"])
         assert path.exists()
         body = json.loads(path.read_text())
+        assert body == summary["insufficiency_receipt"]
         assert body["kind"] == "phase-a-observe-outcomes-insufficiency-receipt"
         assert "no_receipts_in_window" in " ".join(body["remaining_blockers"])
 
@@ -134,6 +156,30 @@ class TestDryRunDoesNotMutate:
         result = summary["results"][0]
         assert result["signals_after"]["outcome_revert_within_window"] is True
         assert result["written"] is False
+
+    def test_dry_run_no_signals_proposes_insufficiency_without_writing(
+        self, tmp_path: Path
+    ) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["mode"] == "dry-run"
+        assert summary["receipts_examined"] == 1
+        assert summary["receipts_written"] == 0
+        assert summary["insufficiency_receipt"] is not None
+        path = Path(summary["insufficiency_receipt_path"])
+        assert not path.exists()
+        joined = " ".join(summary["insufficiency_receipt"]["remaining_blockers"])
+        assert "no_signals_fired" in joined
 
 
 class TestWriteModeMutates:

--- a/tests/review/test_observe_outcomes_cli.py
+++ b/tests/review/test_observe_outcomes_cli.py
@@ -1,0 +1,353 @@
+"""Tests for ``aragora review-queue observe-outcomes`` (Round 30g phase A).
+
+Synthetic fixtures only — every test uses ``timeline_provider`` to inject
+timeline events. No network calls.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+from aragora.review.observe_outcomes_cli import (
+    DEFAULT_PER_RECEIPT_EVENT_CAP,
+    DEFAULT_WINDOW_DAYS,
+    run_observe_outcomes,
+)
+
+UTC = timezone.utc
+RECEIPTS_SUBDIR = "receipts"
+
+
+def _write_receipt(receipts_dir: Path, name: str, payload: dict) -> Path:
+    receipts_dir.mkdir(parents=True, exist_ok=True)
+    path = receipts_dir / f"{name}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _base_payload(
+    *,
+    pr_number: int = 1234,
+    reviewed_at: str = "2026-04-25T12:00:00+00:00",
+    head_sha: str = "abc1234567890",
+) -> dict:
+    return {
+        "session_id": "sess-1",
+        "reviewed_at": reviewed_at,
+        "actor": "armand",
+        "action": "settle",
+        "reason": "test",
+        "pr_number": pr_number,
+        "pr_url": f"https://github.com/org/repo/pull/{pr_number}",
+        "head_sha": head_sha,
+        "base_sha": "000",
+        "packet_sha": "p",
+        "queue_bucket": "ready",
+        "machine_recommendation": "fire_and_forget",
+        "github_event": "merged",
+    }
+
+
+def _silent_provider(
+    pr_number: int, head_sha: str, event_cap: int
+) -> tuple[list[Mapping[str, Any]], str | None]:
+    """A provider that returns no events (clean window)."""
+    return [], None
+
+
+def _revert_provider_for(head_sha: str):
+    def _p(pr_number: int, sha: str, cap: int) -> tuple[list[Mapping[str, Any]], str | None]:
+        return (
+            [
+                {
+                    "type": "commit",
+                    "at": "2026-04-30T08:00:00+00:00",
+                    "message": f'Revert "feat: thing" — refs {head_sha[:7]}',
+                }
+            ],
+            None,
+        )
+
+    return _p
+
+
+def _failing_provider(
+    pr_number: int, head_sha: str, cap: int
+) -> tuple[list[Mapping[str, Any]], str | None]:
+    return [], "gh: 503 Service Unavailable"
+
+
+# --- run_observe_outcomes ----------------------------------------------
+
+
+class TestEmptyStore:
+    def test_no_receipts_emits_insufficiency_receipt(self, tmp_path: Path) -> None:
+        repo_root = tmp_path
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=repo_root,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["mode"] == "dry-run"
+        assert summary["receipts_examined"] == 0
+        assert summary["insufficiency_receipt_path"] is not None
+        path = Path(summary["insufficiency_receipt_path"])
+        assert path.exists()
+        body = json.loads(path.read_text())
+        assert body["kind"] == "phase-a-observe-outcomes-insufficiency-receipt"
+        assert "no_receipts_in_window" in " ".join(body["remaining_blockers"])
+
+
+class TestDryRunDoesNotMutate:
+    def test_dry_run_does_not_change_receipt_files(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        path = _write_receipt(receipts_dir, "r1", _base_payload())
+        original_mtime = path.stat().st_mtime
+        original_text = path.read_text()
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_revert_provider_for(_base_payload()["head_sha"]),
+        )
+        assert summary["mode"] == "dry-run"
+        assert summary["receipts_examined"] == 1
+        assert summary["receipts_written"] == 0
+        # File on disk unchanged.
+        assert path.read_text() == original_text
+        assert path.stat().st_mtime == original_mtime
+        # Summary still records signals_after for preview.
+        result = summary["results"][0]
+        assert result["signals_after"]["outcome_revert_within_window"] is True
+        assert result["written"] is False
+
+
+class TestWriteModeMutates:
+    def test_write_mode_persists_v2_fields(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        path = _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_revert_provider_for(_base_payload()["head_sha"]),
+        )
+        assert summary["mode"] == "write"
+        assert summary["receipts_written"] == 1
+        body = json.loads(path.read_text())
+        assert body["outcome_revert_within_window"] is True
+        assert body["outcome_observed_at"] is not None
+        # Other v2 fields are explicit False, not None.
+        assert body["outcome_post_merge_incident"] is False
+        assert body["outcome_human_override_redo"] is False
+        assert body["outcome_rollback"] is False
+        assert body["outcome_reopened_pr"] is False
+
+    def test_write_mode_no_signals_emits_insufficiency(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["receipts_examined"] == 1
+        assert summary["receipts_with_signals_fired"] == 0
+        # v2 fields ARE now present (we wrote False values), but no
+        # signals fired -> insufficiency receipt with sharp note.
+        assert summary["insufficiency_receipt_path"] is not None
+        body = json.loads(Path(summary["insufficiency_receipt_path"]).read_text())
+        joined = " ".join(body["remaining_blockers"])
+        assert "no_signals_fired" in joined
+
+
+class TestFetchErrorsFlagged:
+    def test_fetch_errors_recorded_and_skipped(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        path = _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_failing_provider,
+        )
+        assert summary["github_fetch_errors"] == 1
+        assert summary["receipts_written"] == 0
+        # File on disk untouched even in write mode when fetch failed.
+        body = json.loads(path.read_text())
+        assert body.get("outcome_revert_within_window") is None
+        # Insufficiency receipt names the fetch errors.
+        body_ins = json.loads(Path(summary["insufficiency_receipt_path"]).read_text())
+        assert "github_fetch_errors" in " ".join(body_ins["remaining_blockers"])
+
+
+class TestBoundedFanout:
+    def test_max_receipts_cap_is_enforced(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        for i in range(5):
+            _write_receipt(receipts_dir, f"r{i}", _base_payload(pr_number=1000 + i))
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=3,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["receipts_examined"] == 3
+
+    def test_per_receipt_event_cap_passed_to_provider(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        observed_caps: list[int] = []
+
+        def _capturing(
+            pr_number: int, head_sha: str, cap: int
+        ) -> tuple[list[Mapping[str, Any]], str | None]:
+            observed_caps.append(cap)
+            return [], None
+
+        run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=42,
+            write=False,
+            timeline_provider=_capturing,
+        )
+        assert observed_caps == [42]
+
+
+class TestWindowFiltering:
+    def test_receipts_outside_window_skipped(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(
+            receipts_dir,
+            "old",
+            _base_payload(reviewed_at="2025-12-01T12:00:00+00:00"),
+        )
+        _write_receipt(receipts_dir, "in", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["receipts_examined"] == 1
+
+
+class TestValidationErrors:
+    def test_invalid_window_days(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="window_days must be positive"):
+            run_observe_outcomes(
+                store_root=tmp_path,
+                repo_root=tmp_path,
+                window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+                window_days=0,
+                max_receipts=20,
+                per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+                write=False,
+                timeline_provider=_silent_provider,
+            )
+
+    def test_invalid_max_receipts(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="max_receipts must be positive"):
+            run_observe_outcomes(
+                store_root=tmp_path,
+                repo_root=tmp_path,
+                window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+                window_days=14,
+                max_receipts=0,
+                per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+                write=False,
+                timeline_provider=_silent_provider,
+            )
+
+    def test_invalid_event_cap(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="per_receipt_event_cap must be positive"):
+            run_observe_outcomes(
+                store_root=tmp_path,
+                repo_root=tmp_path,
+                window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+                window_days=14,
+                max_receipts=20,
+                per_receipt_event_cap=0,
+                write=False,
+                timeline_provider=_silent_provider,
+            )
+
+
+class TestMalformedReceipts:
+    def test_missing_pr_number_skipped(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        bad = _base_payload()
+        bad["pr_number"] = 0
+        _write_receipt(receipts_dir, "bad", bad)
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_revert_provider_for(bad["head_sha"]),
+        )
+        assert summary["receipts_examined"] == 1
+        result = summary["results"][0]
+        assert result["skipped_reason"] == "malformed receipt"
+        assert result["written"] is False
+
+
+class TestInsufficiencyReceiptShape:
+    def test_v2_now_present_in_window_after_write(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_revert_provider_for(_base_payload()["head_sha"]),
+        )
+        assert summary["v2_outcome_fields_now_present_in_window"] is True
+        # Signals fired => no insufficiency receipt expected.
+        assert summary["insufficiency_receipt_path"] is None

--- a/tests/review/test_observe_outcomes_dry_run_isolation.py
+++ b/tests/review/test_observe_outcomes_dry_run_isolation.py
@@ -1,0 +1,172 @@
+"""Round 31a Phase 3: dry-run isolation contract.
+
+The insufficiency receipt produced by ``run_observe_outcomes`` in
+dry-run mode (write=False) must:
+
+1. Land under ``.aragora/evolve-round/observe-outcomes/<utc-iso>/`` and
+   never under a round-id directory.
+2. Never write under ``docs/`` or ``tests/`` even transiently.
+3. Not actually create the file when write=False (path is proposed
+   only; the payload is returned in the response so callers can inspect
+   it without filesystem side effects).
+
+These tests pin the contract so future refactors cannot quietly drift
+back to writing dry-run artifacts under round-receipt directories.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from aragora.review.observe_outcomes_cli import (
+    DEFAULT_PER_RECEIPT_EVENT_CAP,
+    DEFAULT_WINDOW_DAYS,
+    run_observe_outcomes,
+)
+
+UTC = timezone.utc
+
+
+def _silent_provider(pr_number, head_sha, event_cap):
+    return [], None
+
+
+def _list_files(root: Path, prefix: str) -> list[Path]:
+    target = root / prefix
+    if not target.exists():
+        return []
+    return sorted(p for p in target.rglob("*") if p.is_file())
+
+
+def test_dry_run_proposes_observe_outcomes_path(tmp_path: Path) -> None:
+    """Dry-run must propose a path under
+    .aragora/evolve-round/observe-outcomes/<utc-iso>/ — not under any
+    round-id directory.
+    """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    (store_root / "receipts").mkdir()
+
+    summary = run_observe_outcomes(
+        store_root=str(store_root),
+        repo_root=repo_root,
+        window_end=datetime(2026, 5, 1, tzinfo=UTC),
+        window_days=DEFAULT_WINDOW_DAYS,
+        max_receipts=10,
+        per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        write=False,
+        timeline_provider=_silent_provider,
+        round_id="2026-05-01a",
+    )
+
+    proposed = summary["insufficiency_receipt_path"]
+    assert proposed is not None, "dry-run with no receipts must still propose a path"
+    p = Path(proposed)
+    parts = p.parts
+    assert ".aragora" in parts
+    assert "evolve-round" in parts
+    assert "observe-outcomes" in parts, (
+        f"dry-run insufficiency-receipt path must be under "
+        f".aragora/evolve-round/observe-outcomes/, got: {p}"
+    )
+    assert p.name == "insufficiency-receipt.json"
+    # The <utc-iso> directory must look like ISO-compact (YYYYMMDDTHHMMSSZ)
+    iso_dir = p.parent.name
+    assert len(iso_dir) == 16
+    assert iso_dir.endswith("Z")
+    assert iso_dir[:8].isdigit()
+
+
+def test_dry_run_does_not_write_under_docs_or_tests(tmp_path: Path) -> None:
+    """No artifact may appear under docs/ or tests/ during dry-run."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "docs").mkdir()
+    (repo_root / "tests").mkdir()
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    (store_root / "receipts").mkdir()
+
+    run_observe_outcomes(
+        store_root=str(store_root),
+        repo_root=repo_root,
+        window_end=datetime(2026, 5, 1, tzinfo=UTC),
+        window_days=DEFAULT_WINDOW_DAYS,
+        max_receipts=10,
+        per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        write=False,
+        timeline_provider=_silent_provider,
+        round_id="2026-05-01a",
+    )
+
+    docs_files = _list_files(repo_root, "docs")
+    tests_files = _list_files(repo_root, "tests")
+    assert docs_files == [], f"dry-run wrote under docs/: {docs_files}"
+    assert tests_files == [], f"dry-run wrote under tests/: {tests_files}"
+
+
+def test_dry_run_does_not_actually_write_file(tmp_path: Path) -> None:
+    """write=False must NOT create the proposed file on disk."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    (store_root / "receipts").mkdir()
+
+    summary = run_observe_outcomes(
+        store_root=str(store_root),
+        repo_root=repo_root,
+        window_end=datetime(2026, 5, 1, tzinfo=UTC),
+        window_days=DEFAULT_WINDOW_DAYS,
+        max_receipts=10,
+        per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        write=False,
+        timeline_provider=_silent_provider,
+        round_id="2026-05-01a",
+    )
+
+    proposed = Path(summary["insufficiency_receipt_path"])
+    assert not proposed.exists(), f"dry-run actually wrote a file: {proposed}"
+    # Payload still returned in response for caller inspection.
+    assert summary["insufficiency_receipt"] is not None
+
+
+def test_write_mode_routes_to_round_id_directory(tmp_path: Path) -> None:
+    """write=True (non-dry-run) MUST route to the original
+    .aragora/evolve-round/<round_id>/ directory, not the
+    observe-outcomes/<utc-iso>/ dry-run isolation tree.
+    """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    (store_root / "receipts").mkdir()
+
+    summary = run_observe_outcomes(
+        store_root=str(store_root),
+        repo_root=repo_root,
+        window_end=datetime(2026, 5, 1, tzinfo=UTC),
+        window_days=DEFAULT_WINDOW_DAYS,
+        max_receipts=10,
+        per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        write=True,
+        timeline_provider=_silent_provider,
+        round_id="2026-05-01a",
+    )
+
+    proposed = Path(summary["insufficiency_receipt_path"])
+    parts = proposed.parts
+    assert "observe-outcomes" not in parts, (
+        f"write=True must NOT route through observe-outcomes/<utc-iso>/, got: {proposed}"
+    )
+    assert "2026-05-01a" in parts, (
+        f"write=True must route to the round_id directory, got: {proposed}"
+    )
+    assert proposed.name == "phase-a-observe-outcomes-insufficiency-receipt.json"
+    assert proposed.exists()
+    payload = json.loads(proposed.read_text(encoding="utf-8"))
+    assert payload.get("kind") == "phase-a-observe-outcomes-insufficiency-receipt"

--- a/tests/review/test_settlement_outcome.py
+++ b/tests/review/test_settlement_outcome.py
@@ -1,0 +1,372 @@
+"""Tests for settlement-receipt outcome observation (#6375 phase 4)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from aragora.cli.commands.review_queue import SettlementReceipt
+from aragora.review.invalidation import (
+    INVALIDATION_HUMAN_OVERRIDE_REDO,
+    INVALIDATION_POST_MERGE_INCIDENT,
+    INVALIDATION_REOPENED_PR,
+    INVALIDATION_REVERT_WITHIN_WINDOW,
+    INVALIDATION_ROLLBACK,
+    INVALIDATION_SIGNALS,
+)
+from aragora.review.settlement_outcome import (
+    INCIDENT_LABELS,
+    ROLLBACK_LABELS,
+    ObservationWindow,
+    observe_outcome,
+)
+
+UTC = timezone.utc
+
+
+def _base_receipt(*, reviewed_at: str = "2026-04-15T12:00:00+00:00") -> SettlementReceipt:
+    return SettlementReceipt(
+        session_id="sess-1",
+        reviewed_at=reviewed_at,
+        actor="armand",
+        action="settle",
+        reason="test",
+        pr_number=1234,
+        pr_url="https://github.com/org/repo/pull/1234",
+        head_sha="abc1234567890def1234567890abc1234567890d",
+        base_sha="000000000000000000000000000000000000",
+        packet_sha="packet-abc",
+        queue_bucket="ready",
+        machine_recommendation="fire_and_forget",
+        github_event="merged",
+    )
+
+
+# --- ObservationWindow ---------------------------------------------------
+
+
+class TestObservationWindow:
+    def test_constructs_with_positive_days(self) -> None:
+        settled = datetime(2026, 4, 15, 12, tzinfo=UTC)
+        window = ObservationWindow(settled, 14)
+        assert window.start == settled
+        assert window.end == settled + timedelta(days=14)
+
+    def test_rejects_naive_datetime(self) -> None:
+        with pytest.raises(ValueError, match="timezone-aware"):
+            ObservationWindow(datetime(2026, 4, 15, 12), 14)
+
+    def test_rejects_nonpositive_days(self) -> None:
+        settled = datetime(2026, 4, 15, 12, tzinfo=UTC)
+        with pytest.raises(ValueError, match="must be positive"):
+            ObservationWindow(settled, 0)
+        with pytest.raises(ValueError, match="must be positive"):
+            ObservationWindow(settled, -3)
+
+
+# --- observe_outcome ----------------------------------------------------
+
+
+class TestObserveOutcomeNoSignals:
+    def test_empty_timeline_yields_all_false(self) -> None:
+        receipt = _base_receipt()
+        observed = datetime(2026, 4, 30, 12, tzinfo=UTC)
+        out = observe_outcome(receipt, github_timeline=[], observed_at=observed)
+        assert out.outcome_revert_within_window is False
+        assert out.outcome_post_merge_incident is False
+        assert out.outcome_human_override_redo is False
+        assert out.outcome_rollback is False
+        assert out.outcome_reopened_pr is False
+        assert out.outcome_observed_at == "2026-04-30T12:00:00Z"
+
+    def test_does_not_mutate_input(self) -> None:
+        receipt = _base_receipt()
+        observe_outcome(receipt, github_timeline=[])
+        assert receipt.outcome_revert_within_window is None
+        assert receipt.outcome_observed_at is None
+
+
+class TestObserveOutcomeRevertSignal:
+    def test_revert_commit_in_window(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "commit",
+                "at": "2026-04-20T08:00:00+00:00",
+                "message": 'Revert "feat: thing" — refs abc1234',
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_revert_within_window is True
+
+    def test_revert_outside_window_does_not_fire(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "commit",
+                "at": "2026-05-15T08:00:00+00:00",
+                "message": 'Revert "feat: thing" — refs abc1234',
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline, window_days=14)
+        assert out.outcome_revert_within_window is False
+
+    def test_revert_without_sha_match_does_not_fire(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "commit",
+                "at": "2026-04-20T08:00:00+00:00",
+                "message": 'Revert "unrelated change" — refs deadbee',
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_revert_within_window is False
+
+
+class TestObserveOutcomeIncidentSignal:
+    def test_incident_label_with_pr_ref(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "issue_opened",
+                "at": "2026-04-22T10:00:00+00:00",
+                "labels": ["incident"],
+                "title": "API outage attributed to #1234",
+                "body": "rollback recommended",
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_post_merge_incident is True
+
+    def test_incident_label_without_ref_does_not_fire(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "issue_opened",
+                "at": "2026-04-22T10:00:00+00:00",
+                "labels": ["incident"],
+                "title": "Unrelated outage",
+                "body": "no merge ref",
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_post_merge_incident is False
+
+    def test_non_incident_label_does_not_fire(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "issue_opened",
+                "at": "2026-04-22T10:00:00+00:00",
+                "labels": ["question"],
+                "title": "ref to #1234",
+                "body": "",
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_post_merge_incident is False
+
+
+class TestObserveOutcomeRedoSignal:
+    def test_follow_up_pr_with_closes_keyword(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "pr_opened",
+                "at": "2026-04-20T15:00:00+00:00",
+                "title": "fix follow-up",
+                "body": "Closes #1234",
+                "labels": [],
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_human_override_redo is True
+
+    def test_follow_up_with_supersedes_keyword(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "pr_opened",
+                "at": "2026-04-21T09:00:00+00:00",
+                "title": "supersede prior PR",
+                "body": "supersedes #1234",
+                "labels": [],
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_human_override_redo is True
+
+
+class TestObserveOutcomeRollbackSignal:
+    def test_rollback_label(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "pr_opened",
+                "at": "2026-04-22T11:00:00+00:00",
+                "title": "feature flag off",
+                "body": "",
+                "labels": ["rollback"],
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_rollback is True
+
+    def test_revert_title_prefix(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "pr_opened",
+                "at": "2026-04-22T11:00:00+00:00",
+                "title": "Revert feature flag for safety",
+                "body": "",
+                "labels": [],
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_rollback is True
+
+    def test_feature_flag_rollback_label(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "pr_opened",
+                "at": "2026-04-22T11:00:00+00:00",
+                "title": "Disable launch",
+                "body": "",
+                "labels": ["feature-flag-rollback"],
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_rollback is True
+
+
+class TestObserveOutcomeReopenedSignal:
+    def test_reopened_event_for_pr(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "pr_reopened",
+                "at": "2026-04-20T10:00:00+00:00",
+                "pr_number": 1234,
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_reopened_pr is True
+
+    def test_reopened_for_other_pr_does_not_fire(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "pr_reopened",
+                "at": "2026-04-20T10:00:00+00:00",
+                "pr_number": 9999,
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_reopened_pr is False
+
+
+class TestObserveOutcomeMultipleSignals:
+    def test_pr_can_fire_multiple_signals(self) -> None:
+        receipt = _base_receipt()
+        timeline = [
+            {
+                "type": "commit",
+                "at": "2026-04-20T08:00:00+00:00",
+                "message": 'Revert "feat: thing" — refs abc1234',
+            },
+            {
+                "type": "issue_opened",
+                "at": "2026-04-22T10:00:00+00:00",
+                "labels": ["incident"],
+                "title": "regression in #1234",
+                "body": "",
+            },
+            {
+                "type": "pr_reopened",
+                "at": "2026-04-21T10:00:00+00:00",
+                "pr_number": 1234,
+            },
+        ]
+        out = observe_outcome(receipt, github_timeline=timeline)
+        assert out.outcome_revert_within_window is True
+        assert out.outcome_post_merge_incident is True
+        assert out.outcome_reopened_pr is True
+        assert out.outcome_rollback is False
+        assert out.outcome_human_override_redo is False
+
+
+class TestSchemaInvariants:
+    def test_module_canonical_signal_set_matches_invalidation(self) -> None:
+        from aragora.review import settlement_outcome
+
+        # The module-level assert at import time should pass; this test ensures
+        # the contract is checked even if pytest is run with -O.
+        expected = {
+            INVALIDATION_REVERT_WITHIN_WINDOW,
+            INVALIDATION_POST_MERGE_INCIDENT,
+            INVALIDATION_HUMAN_OVERRIDE_REDO,
+            INVALIDATION_ROLLBACK,
+            INVALIDATION_REOPENED_PR,
+        }
+        assert expected == INVALIDATION_SIGNALS
+        assert settlement_outcome._EXPECTED_SIGNALS == INVALIDATION_SIGNALS
+
+    def test_incident_labels_pinned(self) -> None:
+        # Pin INCIDENT_LABELS so adding a new label is an explicit acknowledgement.
+        assert INCIDENT_LABELS == frozenset(
+            {"incident", "regression", "revert-target", "boss-stuck"}
+        )
+
+    def test_rollback_labels_pinned(self) -> None:
+        assert ROLLBACK_LABELS == frozenset({"rollback", "feature-flag-rollback"})
+
+
+class TestSettlementReceiptSchemaV2:
+    def test_default_outcome_fields_are_none(self) -> None:
+        receipt = _base_receipt()
+        assert receipt.outcome_revert_within_window is None
+        assert receipt.outcome_post_merge_incident is None
+        assert receipt.outcome_human_override_redo is None
+        assert receipt.outcome_rollback is None
+        assert receipt.outcome_reopened_pr is None
+        assert receipt.outcome_observed_at is None
+
+    def test_to_dict_round_trip_preserves_outcome_fields(self) -> None:
+        receipt = _base_receipt()
+        out = observe_outcome(
+            receipt,
+            github_timeline=[],
+            observed_at=datetime(2026, 4, 30, 12, tzinfo=UTC),
+        )
+        d = out.to_dict()
+        assert d["outcome_revert_within_window"] is False
+        assert d["outcome_observed_at"] == "2026-04-30T12:00:00Z"
+
+    def test_legacy_receipt_without_outcome_fields_still_parses(self) -> None:
+        # SettlementReceipt has all-keyword defaults for the v2 fields; old
+        # callers that construct receipts positionally up through receipt_path
+        # must still work.
+        receipt = SettlementReceipt(
+            session_id="sess-1",
+            reviewed_at="2026-04-15T12:00:00+00:00",
+            actor="armand",
+            action="settle",
+            reason="test",
+            pr_number=1234,
+            pr_url="https://github.com/org/repo/pull/1234",
+            head_sha="abc",
+            base_sha="000",
+            packet_sha="p",
+            queue_bucket="ready",
+            machine_recommendation="fire_and_forget",
+            github_event="merged",
+            elapsed_seconds=1.5,
+            receipt_path="/tmp/x.json",
+        )
+        d = receipt.to_dict()
+        assert d["outcome_revert_within_window"] is None
+        assert d["outcome_observed_at"] is None


### PR DESCRIPTION
- **feat(review): augment SettlementReceipt with v2 outcome signals (#6375 phase 4)**
- **feat(review): add 'review-queue observe-outcomes' CLI (Round 30g phase A; #6921 continuation)**
- **fix(review): keep observe-outcomes dry-run read-only**
- **fix(review): isolate observe-outcomes dry-run insufficiency receipts**
