### PR TITLE
feat(review-queue): add observe-outcomes operator CLI

### DIFF
--- a/aragora/cli/commands/observe_outcomes_cmd.py
+++ b/aragora/cli/commands/observe_outcomes_cmd.py
@@ -1,0 +1,82 @@
+"""CLI dispatcher + rendering for ``aragora review-queue observe-outcomes``.
+
+The observation pipeline lives in
+:mod:`aragora.review.observe_outcomes_cli`. This module is the
+``aragora.cli.*`` surface that prints to stdout/stderr — kept here so
+the ``T201`` per-file-ignore covers ``print`` cleanly without leaking
+into non-CLI modules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.review.observe_outcomes_cli import run_observe_outcomes
+
+UTC = timezone.utc
+
+
+def cmd_observe_outcomes(args: argparse.Namespace) -> int:
+    if args.window_days <= 0:
+        print("error: --window-days must be positive", file=sys.stderr)
+        return 2
+    if args.max_receipts <= 0:
+        print("error: --max-receipts must be positive", file=sys.stderr)
+        return 2
+    if args.per_receipt_event_cap <= 0:
+        print("error: --per-receipt-event-cap must be positive", file=sys.stderr)
+        return 2
+
+    try:
+        summary = run_observe_outcomes(
+            store_root=args.review_queue_root,
+            repo_root=Path.cwd(),
+            window_end=datetime.now(UTC),
+            window_days=args.window_days,
+            max_receipts=args.max_receipts,
+            per_receipt_event_cap=args.per_receipt_event_cap,
+            write=bool(args.write),
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"error: observe-outcomes failed: {exc}", file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        _render_summary(summary)
+    return 0
+
+
+def _render_summary(summary: Mapping[str, Any]) -> None:
+    mode = summary["mode"]
+    print(f"observe-outcomes mode={mode}")
+    print(
+        f"  window_end={summary['window_end_utc']} "
+        f"window_days={summary['window_days']} "
+        f"max_receipts={summary['max_receipts']}"
+    )
+    print(
+        f"  receipts_examined={summary['receipts_examined']} "
+        f"with_signals={summary['receipts_with_signals_fired']} "
+        f"written={summary['receipts_written']} "
+        f"fetch_errors={summary['github_fetch_errors']}"
+    )
+    print(f"  v2_now_present_in_window={summary['v2_outcome_fields_now_present_in_window']}")
+    if summary["insufficiency_receipt_path"]:
+        print(f"  insufficiency_receipt={summary['insufficiency_receipt_path']}")
+    if mode == "dry-run" and summary["receipts_examined"] > 0:
+        print("  (dry-run; pass --write to mutate receipts in place)")
+    for r in summary["results"][:20]:
+        skipped = repr(r["skipped_reason"]) if r["skipped_reason"] else "None"
+        print(
+            f"  pr=#{r['pr_number']} fetched={r['fetched_event_count']} "
+            f"skipped={skipped} "
+            f"written={r['written']}"
+        )

--- a/aragora/cli/commands/observe_outcomes_cmd.py
+++ b/aragora/cli/commands/observe_outcomes_cmd.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from aragora.review.observe_outcomes_cli import run_observe_outcomes
+from aragora.worktree.fleet import resolve_repo_root
 
 UTC = timezone.utc
 
@@ -36,7 +37,7 @@ def cmd_observe_outcomes(args: argparse.Namespace) -> int:
     try:
         summary = run_observe_outcomes(
             store_root=args.review_queue_root,
-            repo_root=Path.cwd(),
+            repo_root=resolve_repo_root(Path.cwd()),
             window_end=datetime.now(UTC),
             window_days=args.window_days,
             max_receipts=args.max_receipts,

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -450,6 +450,10 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Output the BaselineMeasurement + ThresholdProposal as JSON.",
     )
 
+    from aragora.review.observe_outcomes_cli import add_observe_outcomes_subparser
+
+    add_observe_outcomes_subparser(sub)
+
     parser.set_defaults(func=cmd_review_queue)
 
 
@@ -468,8 +472,13 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
         return _cmd_merge_packet(args)
     if command == "baseline":
         return _cmd_baseline(args)
+    if command == "observe-outcomes":
+        from aragora.cli.commands.observe_outcomes_cmd import cmd_observe_outcomes
+
+        return cmd_observe_outcomes(args)
     print(
-        "Usage: aragora review-queue {build,packet,run,act,merge-packet,baseline} [...]\n"
+        "Usage: aragora review-queue "
+        "{build,packet,run,act,merge-packet,baseline,observe-outcomes} [...]\n"
         "Run 'aragora review-queue run --help' for the human settlement loop.",
         file=sys.stderr,
     )

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1732,6 +1732,60 @@ def _add_review_queue_parser(subparsers) -> None:
         func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue")
     )
 
+    # Round 30g phase A: observe-outcomes (dry-run-by-default; --write opt-in).
+    observe_parser = queue_subparsers.add_parser(
+        "observe-outcomes",
+        help=(
+            "Observe post-settlement invalidation signals from GitHub timeline "
+            "events and (optionally) write them back into receipt v2 outcome "
+            "fields. Dry-run by default."
+        ),
+        description=(
+            "Round 30g phase A. Iterates settled receipts in a bounded window, "
+            "fetches GitHub timeline events with bounded fanout, and computes "
+            "the canonical v2 outcome signals via "
+            "aragora.review.settlement_outcome.observe_outcome. Default mode is "
+            "read-only; --write opts in to in-place mutation of receipt JSON."
+        ),
+    )
+    observe_parser.add_argument(
+        "--window-days",
+        type=int,
+        default=14,
+        help="Observation window in days (default: 14).",
+    )
+    observe_parser.add_argument(
+        "--max-receipts",
+        type=int,
+        default=20,
+        help="Max receipts to inspect (default: 20). Bounds the GitHub fanout.",
+    )
+    observe_parser.add_argument(
+        "--per-receipt-event-cap",
+        type=int,
+        default=100,
+        help="Max timeline events per receipt (default: 100).",
+    )
+    observe_parser.add_argument(
+        "--review-queue-root",
+        default=None,
+        help="Override the review-queue store root for settlement receipts.",
+    )
+    observe_parser.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "OPT-IN: actually write v2 outcome fields back into receipt JSON. "
+            "Default is dry-run preview only."
+        ),
+    )
+    observe_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the run summary as JSON.",
+    )
+    observe_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
+
 
 def _add_codebase_audit_parser(subparsers) -> None:
     """Add the staged repository codebase audit parser."""

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1745,7 +1745,11 @@ def _add_review_queue_parser(subparsers) -> None:
             "fetches GitHub timeline events with bounded fanout, and computes "
             "the canonical v2 outcome signals via "
             "aragora.review.settlement_outcome.observe_outcome. Default mode is "
-            "read-only; --write opts in to in-place mutation of receipt JSON."
+            "read-only; --write opts in to in-place mutation of receipt JSON. "
+            "Scope: this command observes outcomes; it does NOT close #6375, "
+            "does NOT replace the placeholder 5% threshold, and does NOT "
+            "unblock H2. Operator caution: --write mutates audit-record receipt "
+            "JSON in place; do not run this in unattended CI loops."
         ),
     )
     observe_parser.add_argument(
@@ -1775,8 +1779,10 @@ def _add_review_queue_parser(subparsers) -> None:
         "--write",
         action="store_true",
         help=(
-            "OPT-IN: actually write v2 outcome fields back into receipt JSON. "
-            "Default is dry-run preview only."
+            "OPT-IN: actually write v2 outcome fields back into audit-record "
+            "receipt JSON in place. Default is dry-run preview only. Do not "
+            "run this in unattended CI loops; treat each --write invocation as "
+            "a discrete operator decision."
         ),
     )
     observe_parser.add_argument(

--- a/aragora/review/observe_outcomes_cli.py
+++ b/aragora/review/observe_outcomes_cli.py
@@ -169,15 +169,43 @@ TimelineProvider = Callable[[int, str, int], tuple[list[Mapping[str, Any]], str 
 """Signature: (pr_number, head_sha, event_cap) -> (events, fetch_error_or_None)."""
 
 
+def _run_gh_json(args: list[str], *, timeout: int = 20) -> tuple[Any, str | None]:
+    """Run a bounded ``gh`` command and parse JSON, returning (payload, error)."""
+    try:
+        proc = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        return None, f"{args[:3]} raised {type(exc).__name__}: {exc}"
+    if proc.returncode != 0:
+        return None, f"{args[:3]} returned {proc.returncode}: {proc.stderr.strip()[:200]}"
+    try:
+        return json.loads(proc.stdout or "null"), None
+    except json.JSONDecodeError as exc:
+        return None, f"{args[:3]} JSON parse error: {exc}"
+
+
+def _gh_repo_slug() -> tuple[str | None, str | None]:
+    payload, error = _run_gh_json(["gh", "repo", "view", "--json", "nameWithOwner"])
+    if error is not None:
+        return None, error
+    if not isinstance(payload, dict) or not isinstance(payload.get("nameWithOwner"), str):
+        return None, "gh repo view did not return nameWithOwner"
+    return payload["nameWithOwner"], None
+
+
 def _gh_timeline_provider(
     pr_number: int, head_sha: str, event_cap: int
 ) -> tuple[list[Mapping[str, Any]], str | None]:
     """Default timeline provider using ``gh api``.
 
-    This is intentionally *minimal* — we fetch only the small set of
-    events that ``observe_outcome`` actually inspects, and we cap the
-    fetch with ``per_page`` plus a single page request to avoid
-    runaway pagination.
+    This intentionally fails closed. If any bounded GitHub fetch fails,
+    we return an error and the caller must not write explicit ``False``
+    outcome fields from an incomplete evidence source.
 
     Returns (events, error). On any error returns ([], error_message).
     """
@@ -186,35 +214,156 @@ def _gh_timeline_provider(
     events: list[Mapping[str, Any]] = []
     # Issue/PR timeline (covers reopen events and labeled issues that
     # mention the merge sha). Bounded to one page of `event_cap` items.
-    try:
-        proc = subprocess.run(
-            [
-                "gh",
-                "api",
-                "-H",
-                "Accept: application/vnd.github+json",
-                f"/repos/:owner/:repo/issues/{pr_number}/timeline?per_page={min(event_cap, 100)}",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=20,
-            check=False,
-        )
-    except (subprocess.SubprocessError, OSError) as exc:
-        return [], f"gh timeline fetch raised {type(exc).__name__}: {exc}"
-    if proc.returncode != 0:
-        return [], f"gh timeline returned {proc.returncode}: {proc.stderr.strip()[:200]}"
-    try:
-        data = json.loads(proc.stdout or "[]")
-    except json.JSONDecodeError as exc:
-        return [], f"timeline JSON parse error: {exc}"
+    data, error = _run_gh_json(
+        [
+            "gh",
+            "api",
+            "-H",
+            "Accept: application/vnd.github+json",
+            f"/repos/:owner/:repo/issues/{pr_number}/timeline?per_page={min(event_cap, 100)}",
+        ]
+    )
+    if error is not None:
+        return [], error
+    if not isinstance(data, list):
+        return [], "timeline JSON was not a list"
     for entry in data[:event_cap]:
         if not isinstance(entry, dict):
             continue
         normalized = _normalize_timeline_entry(entry, pr_number=pr_number)
         if normalized is not None:
             events.append(normalized)
-    return events, None
+
+    repo_slug, error = _gh_repo_slug()
+    if error is not None:
+        return [], error
+    if repo_slug is None:
+        return [], "gh repo view did not return a repository slug"
+
+    # Search issues/PRs that reference the original PR or head sha so the
+    # operator CLI can observe the non-timeline signals that observe_outcome
+    # understands: post-merge incidents, human redo PRs, and rollback PRs.
+    # Each query is bounded to a single page and the combined result is capped
+    # again before returning.
+    queries = [
+        f"repo:{repo_slug} {head_sha}",
+        f"repo:{repo_slug} {head_sha[:7]}",
+        f"repo:{repo_slug} #{pr_number}",
+    ]
+    seen: set[str] = set()
+    per_page = min(event_cap, 100)
+    for query in queries:
+        payload, error = _run_gh_json(
+            [
+                "gh",
+                "api",
+                "-X",
+                "GET",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "search/issues",
+                "-f",
+                f"q={query}",
+                "-f",
+                f"per_page={per_page}",
+            ]
+        )
+        if error is not None:
+            return [], error
+        items = payload.get("items", []) if isinstance(payload, dict) else []
+        if not isinstance(items, list):
+            return [], "search/issues JSON did not contain an items list"
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            key = str(item.get("node_id") or item.get("html_url") or item.get("url") or id(item))
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized = _normalize_issue_search_item(item)
+            if normalized is not None:
+                events.append(normalized)
+
+    for query in (f"repo:{repo_slug} {head_sha}", f"repo:{repo_slug} {head_sha[:7]}"):
+        payload, error = _run_gh_json(
+            [
+                "gh",
+                "api",
+                "-X",
+                "GET",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "search/commits",
+                "-f",
+                f"q={query}",
+                "-f",
+                f"per_page={per_page}",
+            ]
+        )
+        if error is not None:
+            return [], error
+        items = payload.get("items", []) if isinstance(payload, dict) else []
+        if not isinstance(items, list):
+            return [], "search/commits JSON did not contain an items list"
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            key = str(item.get("node_id") or item.get("sha") or item.get("url") or id(item))
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized = _normalize_commit_search_item(item)
+            if normalized is not None:
+                events.append(normalized)
+
+    return events[:event_cap], None
+
+
+def _str_or_empty(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _labels_from_issue(item: Mapping[str, Any]) -> list[str]:
+    labels = item.get("labels")
+    if not isinstance(labels, list):
+        return []
+    out: list[str] = []
+    for label in labels:
+        if isinstance(label, Mapping) and isinstance(label.get("name"), str):
+            out.append(label["name"])
+    return out
+
+
+def _normalize_issue_search_item(item: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    created_at = item.get("created_at")
+    if not isinstance(created_at, str):
+        return None
+    common = {
+        "at": created_at,
+        "labels": _labels_from_issue(item),
+        "title": _str_or_empty(item.get("title")),
+        "body": _str_or_empty(item.get("body")),
+        "number": item.get("number"),
+    }
+    if isinstance(item.get("pull_request"), Mapping):
+        return {"type": "pr_opened", **common}
+    return {"type": "issue_opened", **common}
+
+
+def _normalize_commit_search_item(item: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    commit_raw = item.get("commit")
+    commit: Mapping[str, Any] = commit_raw if isinstance(commit_raw, Mapping) else {}
+    author_raw = commit.get("author")
+    author: Mapping[str, Any] = author_raw if isinstance(author_raw, Mapping) else {}
+    created_at = author.get("date") or item.get("committer_date") or item.get("author_date")
+    if not isinstance(created_at, str):
+        return None
+    return {
+        "type": "commit",
+        "at": created_at,
+        "message": _str_or_empty(commit.get("message")),
+        "sha": _str_or_empty(item.get("sha")),
+    }
 
 
 def _normalize_timeline_entry(
@@ -238,14 +387,16 @@ def _normalize_timeline_entry(
     if event_kind == "labeled":
         label_obj = entry.get("label") if isinstance(entry.get("label"), dict) else {}
         labels = [str(label_obj.get("name", ""))] if label_obj else []
+        source_raw = entry.get("source")
+        source: Mapping[str, Any] = source_raw if isinstance(source_raw, Mapping) else {}
+        issue_raw = source.get("issue")
+        issue: Mapping[str, Any] = issue_raw if isinstance(issue_raw, Mapping) else {}
         return {
             "type": "issue_opened",
             "at": created_at,
             "labels": labels,
-            "title": str(entry.get("source", {}).get("issue", {}).get("title", ""))
-            if isinstance(entry.get("source"), dict)
-            else "",
-            "body": "",
+            "title": _str_or_empty(issue.get("title")),
+            "body": _str_or_empty(issue.get("body")),
         }
     return None
 
@@ -259,11 +410,17 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     """Write JSON atomically via tempfile + rename, preserving permissions."""
     target_dir = path.parent
     target_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        existing_mode = path.stat().st_mode & 0o777
+    except FileNotFoundError:
+        existing_mode = None
     fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(target_dir))
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump(payload, fh, indent=2, sort_keys=True)
             fh.write("\n")
+        if existing_mode is not None:
+            os.chmod(tmp_name, existing_mode)
         os.replace(tmp_name, path)
     except Exception:
         try:
@@ -417,6 +574,20 @@ def _observe_one(
             written=False,
             skipped_reason="malformed receipt",
         )
+    try:
+        receipt_obj = _materialize_receipt(payload)
+    except (TypeError, ValueError) as exc:
+        return _ObserveResult(
+            receipt_path=receipt.path,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            fetched_event_count=0,
+            fetch_error=f"malformed receipt: {exc}",
+            signals_before=_signal_extract(payload),
+            signals_after=_signal_extract(payload),
+            written=False,
+            skipped_reason="malformed receipt",
+        )
     events, fetch_error = timeline_provider(pr_number, head_sha, per_receipt_event_cap)
     if fetch_error is not None:
         return _ObserveResult(
@@ -430,7 +601,6 @@ def _observe_one(
             written=False,
             skipped_reason="github fetch error",
         )
-    receipt_obj = _materialize_receipt(payload)
     observed = observe_outcome(
         receipt_obj,
         github_timeline=events,

--- a/aragora/review/observe_outcomes_cli.py
+++ b/aragora/review/observe_outcomes_cli.py
@@ -1,0 +1,676 @@
+"""``aragora review-queue observe-outcomes`` — bounded receipt observation.
+
+Round 30g phase A (continues #6921 / δ #6375).
+
+Iterates settled receipts in a bounded window, fetches GitHub timeline
+events for each PR with bounded fanout, calls
+:func:`aragora.review.settlement_outcome.observe_outcome`, and either
+*previews* the proposed v2 outcome fields (the default; ``--dry-run``
+implied) or *writes* them back into the receipt JSON in place
+(``--write``).
+
+Safety contract
+---------------
+
+  - **Default mode is read-only.** No filesystem mutation, no GitHub
+    write, nothing committed. ``--write`` is the only flag that
+    permits in-place mutation.
+  - **Bounded fan-out.** ``--max-receipts`` (default 20) caps the
+    number of receipts examined; ``--per-receipt-event-cap`` (default
+    100) caps the number of timeline events fetched per PR. Both are
+    enforced before the GitHub fetch.
+  - **No network on dry-run when fixtures are provided.** Tests pass
+    ``timeline_provider`` to inject synthetic events so the CLI is
+    fully testable offline.
+  - **No commits.** This module never invokes ``git`` or ``gh pr``
+    write operations. Receipt files are JSON on disk and may be
+    rewritten by the operator's local tooling, but the *only* mutation
+    this CLI performs under ``--write`` is rewriting the receipt JSON
+    payload with the new ``outcome_*`` fields.
+  - **Sharper insufficiency receipt.** When the post-observation
+    baseline still lacks data, a structured insufficiency receipt is
+    proposed in dry-run mode and written under
+    ``.aragora/evolve-round/<round-id>/`` only when ``--write`` is
+    passed. It describes *what* would unblock the next measurement
+    (sample-size shortfall, no v2-eligible receipts, GitHub-fetch
+    errors, etc.).
+
+Out of scope
+------------
+
+  - This CLI does **not** edit ``docs/THESIS.md``. Replacing the
+    placeholder 5% in Commitment 3 is gated on a measured baseline
+    *and* CI safety margin, neither of which this CLI produces on its
+    own.
+  - This CLI does **not** invent synthetic outcome data. If
+    ``observe_outcome`` returns "no signals fired" for every receipt
+    in the window, that is recorded honestly as
+    ``schema_v2_observed_no_signals``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.review.invalidation_event_source import (
+    RECEIPTS_SUBDIR,
+    _V2_OUTCOME_FIELD_NAMES,
+    _any_receipt_has_v2_outcome_fields,
+    resolve_review_queue_root,
+)
+from aragora.review.settlement_outcome import observe_outcome
+
+logger = logging.getLogger(__name__)
+
+UTC = timezone.utc
+
+DEFAULT_WINDOW_DAYS = 14
+DEFAULT_MAX_RECEIPTS = 20
+DEFAULT_PER_RECEIPT_EVENT_CAP = 100
+
+
+@dataclass(frozen=True, slots=True)
+class _ReceiptOnDisk:
+    path: Path
+    payload: dict[str, Any]
+
+
+@dataclass(slots=True)
+class _ObserveResult:
+    receipt_path: Path
+    pr_number: int
+    head_sha: str
+    fetched_event_count: int
+    fetch_error: str | None
+    signals_before: dict[str, Any]
+    signals_after: dict[str, Any]
+    written: bool
+    skipped_reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Receipt iteration (bounded, read-only)
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(raw: str) -> datetime:
+    cleaned = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+    parsed = datetime.fromisoformat(cleaned)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _iter_eligible_receipts(
+    *,
+    store_root: str | Path | None,
+    window_end: datetime,
+    window_days: int,
+    max_receipts: int,
+) -> list[_ReceiptOnDisk]:
+    receipts_dir = resolve_review_queue_root(store_root) / RECEIPTS_SUBDIR
+    if not receipts_dir.exists():
+        return []
+    window_start = window_end - timedelta(days=window_days)
+    out: list[_ReceiptOnDisk] = []
+    try:
+        candidates = sorted(
+            (p for p in receipts_dir.iterdir() if p.is_file() and p.suffix == ".json"),
+            key=lambda p: p.name,
+        )
+    except OSError as exc:
+        logger.warning("review.observe_outcomes_cli: cannot list %s: %s", receipts_dir, exc)
+        return []
+    for path in candidates:
+        if len(out) >= max_receipts:
+            break
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("could not read %s: %s", path, exc)
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("malformed JSON in %s: %s", path, exc)
+            continue
+        if not isinstance(payload, dict):
+            continue
+        reviewed_raw = payload.get("reviewed_at")
+        if not reviewed_raw:
+            continue
+        try:
+            reviewed_at = _parse_iso(str(reviewed_raw))
+        except (TypeError, ValueError):
+            continue
+        if not (window_start <= reviewed_at <= window_end):
+            continue
+        out.append(_ReceiptOnDisk(path=path, payload=payload))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# GitHub timeline fetch (bounded; pluggable for tests)
+# ---------------------------------------------------------------------------
+
+
+TimelineProvider = Callable[[int, str, int], tuple[list[Mapping[str, Any]], str | None]]
+"""Signature: (pr_number, head_sha, event_cap) -> (events, fetch_error_or_None)."""
+
+
+def _gh_timeline_provider(
+    pr_number: int, head_sha: str, event_cap: int
+) -> tuple[list[Mapping[str, Any]], str | None]:
+    """Default timeline provider using ``gh api``.
+
+    This is intentionally *minimal* — we fetch only the small set of
+    events that ``observe_outcome`` actually inspects, and we cap the
+    fetch with ``per_page`` plus a single page request to avoid
+    runaway pagination.
+
+    Returns (events, error). On any error returns ([], error_message).
+    """
+    if shutil.which("gh") is None:
+        return [], "gh CLI not found on PATH"
+    events: list[Mapping[str, Any]] = []
+    # Issue/PR timeline (covers reopen events and labeled issues that
+    # mention the merge sha). Bounded to one page of `event_cap` items.
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                f"/repos/:owner/:repo/issues/{pr_number}/timeline?per_page={min(event_cap, 100)}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        return [], f"gh timeline fetch raised {type(exc).__name__}: {exc}"
+    if proc.returncode != 0:
+        return [], f"gh timeline returned {proc.returncode}: {proc.stderr.strip()[:200]}"
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return [], f"timeline JSON parse error: {exc}"
+    for entry in data[:event_cap]:
+        if not isinstance(entry, dict):
+            continue
+        normalized = _normalize_timeline_entry(entry, pr_number=pr_number)
+        if normalized is not None:
+            events.append(normalized)
+    return events, None
+
+
+def _normalize_timeline_entry(
+    entry: Mapping[str, Any], *, pr_number: int
+) -> Mapping[str, Any] | None:
+    """Map a GitHub timeline entry into the shape ``observe_outcome`` expects."""
+    event_kind = entry.get("event")
+    created_at = entry.get("created_at") or entry.get("submitted_at")
+    if not isinstance(created_at, str):
+        return None
+    if event_kind == "reopened":
+        return {"type": "pr_reopened", "at": created_at, "pr_number": pr_number}
+    if event_kind == "committed":
+        message = ""
+        commit = entry.get("commit") if isinstance(entry.get("commit"), dict) else None
+        if commit:
+            message = str(commit.get("message", ""))
+        else:
+            message = str(entry.get("message", ""))
+        return {"type": "commit", "at": created_at, "message": message}
+    if event_kind == "labeled":
+        label_obj = entry.get("label") if isinstance(entry.get("label"), dict) else {}
+        labels = [str(label_obj.get("name", ""))] if label_obj else []
+        return {
+            "type": "issue_opened",
+            "at": created_at,
+            "labels": labels,
+            "title": str(entry.get("source", {}).get("issue", {}).get("title", ""))
+            if isinstance(entry.get("source"), dict)
+            else "",
+            "body": "",
+        }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON atomically via tempfile + rename, preserving permissions."""
+    target_dir = path.parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(target_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Insufficiency receipt
+# ---------------------------------------------------------------------------
+
+
+def _resolve_insufficiency_receipt_path(
+    *,
+    repo_root: Path,
+    round_id: str,
+    dry_run: bool = False,
+    observed_at: datetime | None = None,
+) -> Path:
+    """Resolve the insufficiency-receipt destination.
+
+    Non-dry-run (write=True) routes to the round's canonical evolve
+    directory. Dry-run isolates the proposed artifact under an
+    observe-outcomes/<utc-iso> subtree so dry-run runs cannot pollute
+    a round's receipts and cannot ever land under docs/ or tests/.
+    """
+    if dry_run:
+        ts = (observed_at or datetime.now(UTC)).strftime("%Y%m%dT%H%M%SZ")
+        return (
+            repo_root
+            / ".aragora"
+            / "evolve-round"
+            / "observe-outcomes"
+            / ts
+            / "insufficiency-receipt.json"
+        )
+    return (
+        repo_root
+        / ".aragora"
+        / "evolve-round"
+        / round_id
+        / "phase-a-observe-outcomes-insufficiency-receipt.json"
+    )
+
+
+def _build_insufficiency_receipt(
+    *,
+    window_end: datetime,
+    window_days: int,
+    max_receipts: int,
+    receipts_examined: int,
+    receipts_with_signals: int,
+    receipts_written: int,
+    fetch_errors: int,
+    v2_now_present: bool,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    if receipts_examined == 0:
+        reasons.append(
+            "no_receipts_in_window: 0 settlement receipts found inside the "
+            f"{window_days}d window ending {window_end.isoformat()}"
+        )
+    if receipts_examined > 0 and receipts_with_signals == 0:
+        reasons.append(
+            "no_signals_fired: every receipt observed produced 0 invalidation "
+            "signals; either the window is genuinely clean or the timeline "
+            "fetch did not surface revert/incident/redo events"
+        )
+    if fetch_errors > 0:
+        reasons.append(
+            f"github_fetch_errors: {fetch_errors} of {receipts_examined} "
+            "receipts had timeline fetch errors; rerun with network "
+            "connectivity verified"
+        )
+    if max_receipts <= receipts_examined:
+        reasons.append(
+            f"max_receipts_cap_hit: --max-receipts={max_receipts} reached, "
+            "increase the cap or narrow the window to inspect more"
+        )
+    return {
+        "kind": "phase-a-observe-outcomes-insufficiency-receipt",
+        "round": "2026-04-30g",
+        "window_end_utc": window_end.isoformat(),
+        "window_days": window_days,
+        "max_receipts": max_receipts,
+        "receipts_examined": receipts_examined,
+        "receipts_with_signals_fired": receipts_with_signals,
+        "receipts_written": receipts_written,
+        "github_fetch_errors": fetch_errors,
+        "v2_outcome_fields_now_present_in_window": v2_now_present,
+        "remaining_blockers": reasons,
+        "next_action_advice": (
+            "If v2_outcome_fields_now_present_in_window is True but no signals "
+            "fired, the empirical baseline can be measured but the human-side "
+            "numerator is genuinely zero in this window — do not invent a "
+            "threshold; rerun on a wider window or a later cohort."
+            if receipts_examined > 0 and receipts_with_signals == 0
+            else "Run with --window-days adjusted, ensure gh CLI is "
+            "authenticated, and re-attempt. Do NOT manually populate v2 "
+            "outcome fields without observing real timeline evidence."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core observation loop
+# ---------------------------------------------------------------------------
+
+
+def _materialize_receipt(payload: Mapping[str, Any]) -> Any:
+    """Reconstruct a ``SettlementReceipt`` from a JSON payload.
+
+    Imported here lazily so this module does not pull the full
+    review-queue CLI graph at top level.
+    """
+    from aragora.cli.commands.review_queue import SettlementReceipt
+
+    field_names = {f.name for f in SettlementReceipt.__dataclass_fields__.values()}
+    kwargs = {k: v for k, v in payload.items() if k in field_names}
+    return SettlementReceipt(**kwargs)
+
+
+def _signal_extract(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Project the v2 outcome-field subset for before/after comparison."""
+    return {name: payload.get(name) for name in sorted(_V2_OUTCOME_FIELD_NAMES)}
+
+
+def _observe_one(
+    receipt: _ReceiptOnDisk,
+    *,
+    window_days: int,
+    timeline_provider: TimelineProvider,
+    per_receipt_event_cap: int,
+    write: bool,
+    observed_at: datetime,
+) -> _ObserveResult:
+    payload = receipt.payload
+    pr_number = int(payload.get("pr_number", 0))
+    head_sha = str(payload.get("head_sha", ""))
+    if pr_number <= 0 or not head_sha:
+        return _ObserveResult(
+            receipt_path=receipt.path,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            fetched_event_count=0,
+            fetch_error="malformed receipt: missing pr_number or head_sha",
+            signals_before=_signal_extract(payload),
+            signals_after=_signal_extract(payload),
+            written=False,
+            skipped_reason="malformed receipt",
+        )
+    events, fetch_error = timeline_provider(pr_number, head_sha, per_receipt_event_cap)
+    if fetch_error is not None:
+        return _ObserveResult(
+            receipt_path=receipt.path,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            fetched_event_count=len(events),
+            fetch_error=fetch_error,
+            signals_before=_signal_extract(payload),
+            signals_after=_signal_extract(payload),
+            written=False,
+            skipped_reason="github fetch error",
+        )
+    receipt_obj = _materialize_receipt(payload)
+    observed = observe_outcome(
+        receipt_obj,
+        github_timeline=events,
+        window_days=window_days,
+        observed_at=observed_at,
+    )
+    new_payload = dict(payload)
+    for name in _V2_OUTCOME_FIELD_NAMES:
+        new_payload[name] = getattr(observed, name)
+    written = False
+    if write:
+        try:
+            _atomic_write_json(receipt.path, new_payload)
+            written = True
+        except OSError as exc:
+            return _ObserveResult(
+                receipt_path=receipt.path,
+                pr_number=pr_number,
+                head_sha=head_sha,
+                fetched_event_count=len(events),
+                fetch_error=None,
+                signals_before=_signal_extract(payload),
+                signals_after=_signal_extract(new_payload),
+                written=False,
+                skipped_reason=f"atomic write failed: {exc}",
+            )
+    return _ObserveResult(
+        receipt_path=receipt.path,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        fetched_event_count=len(events),
+        fetch_error=None,
+        signals_before=_signal_extract(payload),
+        signals_after=_signal_extract(new_payload),
+        written=written,
+    )
+
+
+def run_observe_outcomes(
+    *,
+    store_root: str | Path | None,
+    repo_root: Path,
+    window_end: datetime,
+    window_days: int,
+    max_receipts: int,
+    per_receipt_event_cap: int,
+    write: bool,
+    timeline_provider: TimelineProvider | None = None,
+    insufficiency_receipt_path: Path | None = None,
+    round_id: str = "2026-04-30g",
+) -> dict[str, Any]:
+    """Run the observation pipeline. Pure-function-shaped; testable.
+
+    Returns a structured summary dict that the CLI prints. The
+    summary includes a ``"results"`` list (one per receipt examined),
+    aggregate counters, the ``v2_outcome_fields_now_present`` boolean,
+    and (when applicable) the proposed or written insufficiency
+    receipt payload and path.
+    """
+    if window_days <= 0:
+        raise ValueError("window_days must be positive")
+    if max_receipts <= 0:
+        raise ValueError("max_receipts must be positive")
+    if per_receipt_event_cap <= 0:
+        raise ValueError("per_receipt_event_cap must be positive")
+    provider = timeline_provider or _gh_timeline_provider
+    observed_at = datetime.now(UTC)
+
+    receipts = _iter_eligible_receipts(
+        store_root=store_root,
+        window_end=window_end,
+        window_days=window_days,
+        max_receipts=max_receipts,
+    )
+    results: list[_ObserveResult] = []
+    for receipt in receipts:
+        results.append(
+            _observe_one(
+                receipt,
+                window_days=window_days,
+                timeline_provider=provider,
+                per_receipt_event_cap=per_receipt_event_cap,
+                write=write,
+                observed_at=observed_at,
+            )
+        )
+
+    receipts_with_signals = sum(
+        1
+        for r in results
+        if any(v is True for v in r.signals_after.values() if isinstance(v, bool))
+    )
+    receipts_written = sum(1 for r in results if r.written)
+    fetch_errors = sum(1 for r in results if r.fetch_error is not None)
+
+    # If we wrote any v2 fields, the next baseline measurement should
+    # see them. Probe defensively.
+    try:
+        v2_now_present = _any_receipt_has_v2_outcome_fields(
+            store_root=store_root,
+            window_end=window_end,
+            window_days=window_days,
+        )
+    except (OSError, ValueError) as exc:
+        logger.warning("post-observation probe failed: %s", exc)
+        v2_now_present = False
+
+    insufficiency_path: Path | None = None
+    insufficiency_payload: dict[str, Any] | None = None
+    if len(results) == 0 or receipts_with_signals == 0 or fetch_errors > 0:
+        insufficiency_payload = _build_insufficiency_receipt(
+            window_end=window_end,
+            window_days=window_days,
+            max_receipts=max_receipts,
+            receipts_examined=len(results),
+            receipts_with_signals=receipts_with_signals,
+            receipts_written=receipts_written,
+            fetch_errors=fetch_errors,
+            v2_now_present=v2_now_present,
+        )
+        insufficiency_path = insufficiency_receipt_path or _resolve_insufficiency_receipt_path(
+            repo_root=repo_root,
+            round_id=round_id,
+            dry_run=not write,
+            observed_at=observed_at,
+        )
+        if write:
+            try:
+                _atomic_write_json(insufficiency_path, insufficiency_payload)
+            except OSError as exc:
+                logger.warning(
+                    "could not write insufficiency receipt %s: %s",
+                    insufficiency_path,
+                    exc,
+                )
+
+    return {
+        "mode": "write" if write else "dry-run",
+        "window_end_utc": window_end.isoformat(),
+        "window_days": window_days,
+        "max_receipts": max_receipts,
+        "per_receipt_event_cap": per_receipt_event_cap,
+        "receipts_examined": len(results),
+        "receipts_with_signals_fired": receipts_with_signals,
+        "receipts_written": receipts_written,
+        "github_fetch_errors": fetch_errors,
+        "v2_outcome_fields_now_present_in_window": v2_now_present,
+        "insufficiency_receipt_path": (str(insufficiency_path) if insufficiency_path else None),
+        "insufficiency_receipt": insufficiency_payload,
+        "results": [
+            {
+                "receipt_path": str(r.receipt_path),
+                "pr_number": r.pr_number,
+                "head_sha": r.head_sha,
+                "fetched_event_count": r.fetched_event_count,
+                "fetch_error": r.fetch_error,
+                "signals_before": r.signals_before,
+                "signals_after": r.signals_after,
+                "written": r.written,
+                "skipped_reason": r.skipped_reason,
+            }
+            for r in results
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# argparse subparser registration
+# ---------------------------------------------------------------------------
+
+
+def add_observe_outcomes_subparser(sub: argparse._SubParsersAction) -> None:
+    """Register ``observe-outcomes`` under the ``review-queue`` subparser."""
+    p = sub.add_parser(
+        "observe-outcomes",
+        help=(
+            "Observe post-settlement invalidation signals from GitHub "
+            "timeline events and (optionally) write them back into v2 "
+            "outcome fields on settlement receipts. Dry-run by default."
+        ),
+        description=(
+            "Round 30g phase A. Iterates settled receipts in a bounded\n"
+            "window, fetches GitHub timeline events for each PR with\n"
+            "bounded fanout, and computes the five canonical v2 outcome\n"
+            "signals via aragora.review.settlement_outcome.observe_outcome.\n\n"
+            "Default mode is read-only: nothing is written. Pass --write\n"
+            "to mutate receipt JSON files in place. The CLI never invokes\n"
+            "git or gh write operations and never edits docs/THESIS.md."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--window-days",
+        type=int,
+        default=DEFAULT_WINDOW_DAYS,
+        help=f"Observation window in days (default: {DEFAULT_WINDOW_DAYS}).",
+    )
+    p.add_argument(
+        "--max-receipts",
+        type=int,
+        default=DEFAULT_MAX_RECEIPTS,
+        help=(
+            "Maximum receipts to inspect in this run "
+            f"(default: {DEFAULT_MAX_RECEIPTS}). Bounds the GitHub fanout."
+        ),
+    )
+    p.add_argument(
+        "--per-receipt-event-cap",
+        type=int,
+        default=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        help=(
+            "Maximum timeline events fetched per receipt "
+            f"(default: {DEFAULT_PER_RECEIPT_EVENT_CAP})."
+        ),
+    )
+    p.add_argument(
+        "--review-queue-root",
+        default=None,
+        help=(
+            "Override the review-queue store root used for settlement "
+            "receipts. Defaults to <repo>/.aragora/review-queue."
+        ),
+    )
+    p.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "OPT-IN: actually write v2 outcome fields back into receipt "
+            "JSON files. Default is dry-run preview only."
+        ),
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the run summary as JSON.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatcher entry point lives in aragora.cli.commands.observe_outcomes_cmd
+# (T201 per-file-ignore covers print-rendering there). This module keeps the
+# pipeline pure-function-shaped.
+# ---------------------------------------------------------------------------

--- a/aragora/review/observe_outcomes_cli.py
+++ b/aragora/review/observe_outcomes_cli.py
@@ -1,6 +1,6 @@
 """``aragora review-queue observe-outcomes`` — bounded receipt observation.
 
-Round 30g phase A (continues #6921 / δ #6375).
+Round 30g phase A (operator tool that follows on from #6921; this CLI does NOT close #6375).
 
 Iterates settled receipts in a bounded window, fetches GitHub timeline
 events for each PR with bounded fanout, calls
@@ -42,6 +42,17 @@ Out of scope
     placeholder 5% in Commitment 3 is gated on a measured baseline
     *and* CI safety margin, neither of which this CLI produces on its
     own.
+  - This CLI does **not** close #6375. It is an operator tool that
+    observes outcome signals into receipts; the empirical question
+    behind #6375 (human-side invalidation rate) is a separate
+    downstream interpretation step.
+  - This CLI does **not** replace the placeholder 5% threshold.
+    Threshold replacement requires a measured baseline plus an
+    explicit thesis-level decision, neither of which this tool
+    produces.
+  - This CLI does **not** unblock H2. H2's no-go status is determined
+    by separate evidence questions and is not advanced by running
+    this tool.
   - This CLI does **not** invent synthetic outcome data. If
     ``observe_outcome`` returns "no signals fired" for every receipt
     in the window, that is recorded honestly as

--- a/tests/review/test_observe_outcomes_cli.py
+++ b/tests/review/test_observe_outcomes_cli.py
@@ -1,0 +1,421 @@
+"""Tests for ``aragora review-queue observe-outcomes`` (Round 30g phase A).
+
+Synthetic fixtures only — every test uses ``timeline_provider`` to inject
+timeline events. No network calls.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+from aragora.cli.parser import build_parser
+from aragora.cli.commands.review_queue import cmd_review_queue
+from aragora.review.observe_outcomes_cli import (
+    DEFAULT_PER_RECEIPT_EVENT_CAP,
+    DEFAULT_WINDOW_DAYS,
+    run_observe_outcomes,
+)
+
+UTC = timezone.utc
+RECEIPTS_SUBDIR = "receipts"
+
+
+class TestCliParser:
+    def test_review_queue_observe_outcomes_json_routes_to_command(self, monkeypatch) -> None:
+        import aragora.cli.commands.observe_outcomes_cmd as command_module
+
+        called = {}
+
+        def fake_cmd_observe_outcomes(args) -> int:
+            called["args"] = args
+            return 0
+
+        monkeypatch.setattr(command_module, "cmd_observe_outcomes", fake_cmd_observe_outcomes)
+        args = build_parser().parse_args(["review-queue", "observe-outcomes", "--json"])
+
+        assert args.review_queue_command == "observe-outcomes"
+        assert args.json is True
+        assert args.write is False
+        assert cmd_review_queue(args) == 0
+        assert called["args"] is args
+
+
+def _write_receipt(receipts_dir: Path, name: str, payload: dict) -> Path:
+    receipts_dir.mkdir(parents=True, exist_ok=True)
+    path = receipts_dir / f"{name}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _base_payload(
+    *,
+    pr_number: int = 1234,
+    reviewed_at: str = "2026-04-25T12:00:00+00:00",
+    head_sha: str = "abc1234567890",
+) -> dict:
+    return {
+        "session_id": "sess-1",
+        "reviewed_at": reviewed_at,
+        "actor": "armand",
+        "action": "settle",
+        "reason": "test",
+        "pr_number": pr_number,
+        "pr_url": f"https://github.com/org/repo/pull/{pr_number}",
+        "head_sha": head_sha,
+        "base_sha": "000",
+        "packet_sha": "p",
+        "queue_bucket": "ready",
+        "machine_recommendation": "fire_and_forget",
+        "github_event": "merged",
+    }
+
+
+def _silent_provider(
+    pr_number: int, head_sha: str, event_cap: int
+) -> tuple[list[Mapping[str, Any]], str | None]:
+    """A provider that returns no events (clean window)."""
+    return [], None
+
+
+def _revert_provider_for(head_sha: str):
+    def _p(pr_number: int, sha: str, cap: int) -> tuple[list[Mapping[str, Any]], str | None]:
+        return (
+            [
+                {
+                    "type": "commit",
+                    "at": "2026-04-30T08:00:00+00:00",
+                    "message": f'Revert "feat: thing" — refs {head_sha[:7]}',
+                }
+            ],
+            None,
+        )
+
+    return _p
+
+
+def _failing_provider(
+    pr_number: int, head_sha: str, cap: int
+) -> tuple[list[Mapping[str, Any]], str | None]:
+    return [], "gh: 503 Service Unavailable"
+
+
+# --- run_observe_outcomes ----------------------------------------------
+
+
+class TestEmptyStore:
+    def test_dry_run_no_receipts_proposes_insufficiency_receipt_without_writing(
+        self, tmp_path: Path
+    ) -> None:
+        repo_root = tmp_path
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=repo_root,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["mode"] == "dry-run"
+        assert summary["receipts_examined"] == 0
+        assert summary["insufficiency_receipt_path"] is not None
+        path = Path(summary["insufficiency_receipt_path"])
+        assert not path.exists()
+        body = summary["insufficiency_receipt"]
+        assert body["kind"] == "phase-a-observe-outcomes-insufficiency-receipt"
+        assert "no_receipts_in_window" in " ".join(body["remaining_blockers"])
+
+    def test_write_mode_no_receipts_writes_insufficiency_receipt(self, tmp_path: Path) -> None:
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["mode"] == "write"
+        assert summary["receipts_examined"] == 0
+        path = Path(summary["insufficiency_receipt_path"])
+        assert path.exists()
+        body = json.loads(path.read_text())
+        assert body == summary["insufficiency_receipt"]
+        assert body["kind"] == "phase-a-observe-outcomes-insufficiency-receipt"
+        assert "no_receipts_in_window" in " ".join(body["remaining_blockers"])
+
+
+class TestDryRunDoesNotMutate:
+    def test_dry_run_does_not_change_receipt_files(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        path = _write_receipt(receipts_dir, "r1", _base_payload())
+        original_mtime = path.stat().st_mtime
+        original_text = path.read_text()
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_revert_provider_for(_base_payload()["head_sha"]),
+        )
+        assert summary["mode"] == "dry-run"
+        assert summary["receipts_examined"] == 1
+        assert summary["receipts_written"] == 0
+        # File on disk unchanged.
+        assert path.read_text() == original_text
+        assert path.stat().st_mtime == original_mtime
+        # Summary still records signals_after for preview.
+        result = summary["results"][0]
+        assert result["signals_after"]["outcome_revert_within_window"] is True
+        assert result["written"] is False
+
+    def test_dry_run_no_signals_proposes_insufficiency_without_writing(
+        self, tmp_path: Path
+    ) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["mode"] == "dry-run"
+        assert summary["receipts_examined"] == 1
+        assert summary["receipts_written"] == 0
+        assert summary["insufficiency_receipt"] is not None
+        path = Path(summary["insufficiency_receipt_path"])
+        assert not path.exists()
+        joined = " ".join(summary["insufficiency_receipt"]["remaining_blockers"])
+        assert "no_signals_fired" in joined
+
+
+class TestWriteModeMutates:
+    def test_write_mode_persists_v2_fields(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        path = _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_revert_provider_for(_base_payload()["head_sha"]),
+        )
+        assert summary["mode"] == "write"
+        assert summary["receipts_written"] == 1
+        body = json.loads(path.read_text())
+        assert body["outcome_revert_within_window"] is True
+        assert body["outcome_observed_at"] is not None
+        # Other v2 fields are explicit False, not None.
+        assert body["outcome_post_merge_incident"] is False
+        assert body["outcome_human_override_redo"] is False
+        assert body["outcome_rollback"] is False
+        assert body["outcome_reopened_pr"] is False
+
+    def test_write_mode_no_signals_emits_insufficiency(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["receipts_examined"] == 1
+        assert summary["receipts_with_signals_fired"] == 0
+        # v2 fields ARE now present (we wrote False values), but no
+        # signals fired -> insufficiency receipt with sharp note.
+        assert summary["insufficiency_receipt_path"] is not None
+        body = json.loads(Path(summary["insufficiency_receipt_path"]).read_text())
+        joined = " ".join(body["remaining_blockers"])
+        assert "no_signals_fired" in joined
+
+
+class TestFetchErrorsFlagged:
+    def test_fetch_errors_recorded_and_skipped(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        path = _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_failing_provider,
+        )
+        assert summary["github_fetch_errors"] == 1
+        assert summary["receipts_written"] == 0
+        # File on disk untouched even in write mode when fetch failed.
+        body = json.loads(path.read_text())
+        assert body.get("outcome_revert_within_window") is None
+        # Insufficiency receipt names the fetch errors.
+        body_ins = json.loads(Path(summary["insufficiency_receipt_path"]).read_text())
+        assert "github_fetch_errors" in " ".join(body_ins["remaining_blockers"])
+
+
+class TestBoundedFanout:
+    def test_max_receipts_cap_is_enforced(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        for i in range(5):
+            _write_receipt(receipts_dir, f"r{i}", _base_payload(pr_number=1000 + i))
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=3,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["receipts_examined"] == 3
+
+    def test_per_receipt_event_cap_passed_to_provider(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        observed_caps: list[int] = []
+
+        def _capturing(
+            pr_number: int, head_sha: str, cap: int
+        ) -> tuple[list[Mapping[str, Any]], str | None]:
+            observed_caps.append(cap)
+            return [], None
+
+        run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=42,
+            write=False,
+            timeline_provider=_capturing,
+        )
+        assert observed_caps == [42]
+
+
+class TestWindowFiltering:
+    def test_receipts_outside_window_skipped(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(
+            receipts_dir,
+            "old",
+            _base_payload(reviewed_at="2025-12-01T12:00:00+00:00"),
+        )
+        _write_receipt(receipts_dir, "in", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=False,
+            timeline_provider=_silent_provider,
+        )
+        assert summary["receipts_examined"] == 1
+
+
+class TestValidationErrors:
+    def test_invalid_window_days(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="window_days must be positive"):
+            run_observe_outcomes(
+                store_root=tmp_path,
+                repo_root=tmp_path,
+                window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+                window_days=0,
+                max_receipts=20,
+                per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+                write=False,
+                timeline_provider=_silent_provider,
+            )
+
+    def test_invalid_max_receipts(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="max_receipts must be positive"):
+            run_observe_outcomes(
+                store_root=tmp_path,
+                repo_root=tmp_path,
+                window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+                window_days=14,
+                max_receipts=0,
+                per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+                write=False,
+                timeline_provider=_silent_provider,
+            )
+
+    def test_invalid_event_cap(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="per_receipt_event_cap must be positive"):
+            run_observe_outcomes(
+                store_root=tmp_path,
+                repo_root=tmp_path,
+                window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+                window_days=14,
+                max_receipts=20,
+                per_receipt_event_cap=0,
+                write=False,
+                timeline_provider=_silent_provider,
+            )
+
+
+class TestMalformedReceipts:
+    def test_missing_pr_number_skipped(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        bad = _base_payload()
+        bad["pr_number"] = 0
+        _write_receipt(receipts_dir, "bad", bad)
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_revert_provider_for(bad["head_sha"]),
+        )
+        assert summary["receipts_examined"] == 1
+        result = summary["results"][0]
+        assert result["skipped_reason"] == "malformed receipt"
+        assert result["written"] is False
+
+
+class TestInsufficiencyReceiptShape:
+    def test_v2_now_present_in_window_after_write(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_revert_provider_for(_base_payload()["head_sha"]),
+        )
+        assert summary["v2_outcome_fields_now_present_in_window"] is True
+        # Signals fired => no insufficiency receipt expected.
+        assert summary["insufficiency_receipt_path"] is None

--- a/tests/review/test_observe_outcomes_cli.py
+++ b/tests/review/test_observe_outcomes_cli.py
@@ -15,6 +15,7 @@ import pytest
 
 from aragora.cli.parser import build_parser
 from aragora.cli.commands.review_queue import cmd_review_queue
+from aragora.review import observe_outcomes_cli as observe_module
 from aragora.review.observe_outcomes_cli import (
     DEFAULT_PER_RECEIPT_EVENT_CAP,
     DEFAULT_WINDOW_DAYS,
@@ -43,6 +44,30 @@ class TestCliParser:
         assert args.write is False
         assert cmd_review_queue(args) == 0
         assert called["args"] is args
+
+    def test_command_resolves_repo_root_instead_of_nested_cwd(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        import aragora.cli.commands.observe_outcomes_cmd as command_module
+
+        repo = tmp_path / "repo"
+        nested = repo / "tools" / "subdir"
+        (repo / ".git").mkdir(parents=True)
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        called: dict[str, Any] = {}
+
+        def fake_run_observe_outcomes(**kwargs):
+            called.update(kwargs)
+            return {"mode": "dry-run"}
+
+        monkeypatch.setattr(command_module, "resolve_repo_root", lambda path: repo)
+        monkeypatch.setattr(command_module, "run_observe_outcomes", fake_run_observe_outcomes)
+        args = build_parser().parse_args(["review-queue", "observe-outcomes", "--json"])
+
+        assert command_module.cmd_observe_outcomes(args) == 0
+        assert called["repo_root"] == repo
 
 
 def _write_receipt(receipts_dir: Path, name: str, payload: dict) -> Path:
@@ -229,6 +254,24 @@ class TestWriteModeMutates:
         assert body["outcome_rollback"] is False
         assert body["outcome_reopened_pr"] is False
 
+    def test_atomic_write_preserves_existing_receipt_permissions(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        path = _write_receipt(receipts_dir, "r1", _base_payload())
+        path.chmod(0o644)
+
+        run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_revert_provider_for(_base_payload()["head_sha"]),
+        )
+
+        assert path.stat().st_mode & 0o777 == 0o644
+
     def test_write_mode_no_signals_emits_insufficiency(self, tmp_path: Path) -> None:
         receipts_dir = tmp_path / RECEIPTS_SUBDIR
         _write_receipt(receipts_dir, "r1", _base_payload())
@@ -400,6 +443,174 @@ class TestMalformedReceipts:
         result = summary["results"][0]
         assert result["skipped_reason"] == "malformed receipt"
         assert result["written"] is False
+
+    def test_partial_receipt_skipped_before_network_fetch(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(
+            receipts_dir,
+            "partial",
+            {
+                "reviewed_at": "2026-04-25T12:00:00+00:00",
+                "pr_number": 1234,
+                "head_sha": "abc1234567890",
+            },
+        )
+
+        def _provider_should_not_run(pr_number: int, head_sha: str, cap: int):
+            raise AssertionError("network provider should not run for malformed receipts")
+
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_provider_should_not_run,
+        )
+
+        assert summary["receipts_examined"] == 1
+        assert summary["results"][0]["skipped_reason"] == "malformed receipt"
+        assert "missing" in str(summary["results"][0]["fetch_error"])
+
+
+class TestLiveProviderNormalization:
+    def test_issue_search_items_emit_pr_opened_for_follow_up_prs(self) -> None:
+        event = observe_module._normalize_issue_search_item(
+            {
+                "created_at": "2026-04-30T08:00:00Z",
+                "number": 9999,
+                "title": "Revert feature",
+                "body": "Supersedes #1234",
+                "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/9999"},
+                "labels": [{"name": "rollback"}],
+            }
+        )
+
+        assert event == {
+            "type": "pr_opened",
+            "at": "2026-04-30T08:00:00Z",
+            "labels": ["rollback"],
+            "title": "Revert feature",
+            "body": "Supersedes #1234",
+            "number": 9999,
+        }
+
+    def test_issue_search_items_preserve_incident_body(self) -> None:
+        event = observe_module._normalize_issue_search_item(
+            {
+                "created_at": "2026-04-30T08:00:00Z",
+                "number": 42,
+                "title": "Incident after #1234",
+                "body": "The regression references abc1234.",
+                "labels": [{"name": "incident"}],
+            }
+        )
+
+        assert event == {
+            "type": "issue_opened",
+            "at": "2026-04-30T08:00:00Z",
+            "labels": ["incident"],
+            "title": "Incident after #1234",
+            "body": "The regression references abc1234.",
+            "number": 42,
+        }
+
+    def test_timeline_labeled_entry_preserves_source_issue_body(self) -> None:
+        event = observe_module._normalize_timeline_entry(
+            {
+                "event": "labeled",
+                "created_at": "2026-04-30T08:00:00Z",
+                "label": {"name": "incident"},
+                "source": {"issue": {"title": "Incident #1234", "body": "mentions abc1234"}},
+            },
+            pr_number=1234,
+        )
+
+        assert event == {
+            "type": "issue_opened",
+            "at": "2026-04-30T08:00:00Z",
+            "labels": ["incident"],
+            "title": "Incident #1234",
+            "body": "mentions abc1234",
+        }
+
+    def test_gh_provider_combines_timeline_issue_pr_and_commit_search(self, monkeypatch) -> None:
+        monkeypatch.setattr(observe_module.shutil, "which", lambda name: "/usr/bin/gh")
+
+        def fake_run_gh_json(args, *, timeout=20):
+            if args[:4] == ["gh", "repo", "view", "--json"]:
+                return {"nameWithOwner": "owner/repo"}, None
+            if any("timeline" in str(part) for part in args):
+                return [{"event": "reopened", "created_at": "2026-04-30T08:00:00Z"}], None
+            if "search/issues" in args:
+                return {
+                    "items": [
+                        {
+                            "node_id": "PR_1",
+                            "created_at": "2026-04-30T09:00:00Z",
+                            "number": 9999,
+                            "title": "Revert feature",
+                            "body": "Supersedes #1234",
+                            "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/9999"},
+                            "labels": [{"name": "rollback"}],
+                        },
+                        {
+                            "node_id": "I_1",
+                            "created_at": "2026-04-30T10:00:00Z",
+                            "number": 77,
+                            "title": "Incident #1234",
+                            "body": "mentions abc1234",
+                            "labels": [{"name": "incident"}],
+                        },
+                    ]
+                }, None
+            if "search/commits" in args:
+                return {
+                    "items": [
+                        {
+                            "node_id": "C_1",
+                            "sha": "def456",
+                            "commit": {
+                                "message": 'Revert "feature" refs abc1234',
+                                "author": {"date": "2026-04-30T11:00:00Z"},
+                            },
+                        }
+                    ]
+                }, None
+            raise AssertionError(f"unexpected gh args: {args}")
+
+        monkeypatch.setattr(observe_module, "_run_gh_json", fake_run_gh_json)
+
+        events, error = observe_module._gh_timeline_provider(1234, "abc1234567890", 100)
+
+        assert error is None
+        assert {event["type"] for event in events} == {
+            "pr_reopened",
+            "pr_opened",
+            "issue_opened",
+            "commit",
+        }
+
+    def test_gh_provider_fails_closed_when_search_fetch_fails(self, monkeypatch) -> None:
+        monkeypatch.setattr(observe_module.shutil, "which", lambda name: "/usr/bin/gh")
+
+        def fake_run_gh_json(args, *, timeout=20):
+            if args[:4] == ["gh", "repo", "view", "--json"]:
+                return {"nameWithOwner": "owner/repo"}, None
+            if any("timeline" in str(part) for part in args):
+                return [], None
+            if "search/issues" in args:
+                return None, "search/issues returned 502"
+            raise AssertionError(f"unexpected gh args: {args}")
+
+        monkeypatch.setattr(observe_module, "_run_gh_json", fake_run_gh_json)
+
+        events, error = observe_module._gh_timeline_provider(1234, "abc1234567890", 100)
+
+        assert events == []
+        assert error == "search/issues returned 502"
 
 
 class TestInsufficiencyReceiptShape:

--- a/tests/review/test_observe_outcomes_dry_run_isolation.py
+++ b/tests/review/test_observe_outcomes_dry_run_isolation.py
@@ -1,0 +1,172 @@
+"""Round 31a Phase 3: dry-run isolation contract.
+
+The insufficiency receipt produced by ``run_observe_outcomes`` in
+dry-run mode (write=False) must:
+
+1. Land under ``.aragora/evolve-round/observe-outcomes/<utc-iso>/`` and
+   never under a round-id directory.
+2. Never write under ``docs/`` or ``tests/`` even transiently.
+3. Not actually create the file when write=False (path is proposed
+   only; the payload is returned in the response so callers can inspect
+   it without filesystem side effects).
+
+These tests pin the contract so future refactors cannot quietly drift
+back to writing dry-run artifacts under round-receipt directories.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from aragora.review.observe_outcomes_cli import (
+    DEFAULT_PER_RECEIPT_EVENT_CAP,
+    DEFAULT_WINDOW_DAYS,
+    run_observe_outcomes,
+)
+
+UTC = timezone.utc
+
+
+def _silent_provider(pr_number, head_sha, event_cap):
+    return [], None
+
+
+def _list_files(root: Path, prefix: str) -> list[Path]:
+    target = root / prefix
+    if not target.exists():
+        return []
+    return sorted(p for p in target.rglob("*") if p.is_file())
+
+
+def test_dry_run_proposes_observe_outcomes_path(tmp_path: Path) -> None:
+    """Dry-run must propose a path under
+    .aragora/evolve-round/observe-outcomes/<utc-iso>/ — not under any
+    round-id directory.
+    """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    (store_root / "receipts").mkdir()
+
+    summary = run_observe_outcomes(
+        store_root=str(store_root),
+        repo_root=repo_root,
+        window_end=datetime(2026, 5, 1, tzinfo=UTC),
+        window_days=DEFAULT_WINDOW_DAYS,
+        max_receipts=10,
+        per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        write=False,
+        timeline_provider=_silent_provider,
+        round_id="2026-05-01a",
+    )
+
+    proposed = summary["insufficiency_receipt_path"]
+    assert proposed is not None, "dry-run with no receipts must still propose a path"
+    p = Path(proposed)
+    parts = p.parts
+    assert ".aragora" in parts
+    assert "evolve-round" in parts
+    assert "observe-outcomes" in parts, (
+        f"dry-run insufficiency-receipt path must be under "
+        f".aragora/evolve-round/observe-outcomes/, got: {p}"
+    )
+    assert p.name == "insufficiency-receipt.json"
+    # The <utc-iso> directory must look like ISO-compact (YYYYMMDDTHHMMSSZ)
+    iso_dir = p.parent.name
+    assert len(iso_dir) == 16
+    assert iso_dir.endswith("Z")
+    assert iso_dir[:8].isdigit()
+
+
+def test_dry_run_does_not_write_under_docs_or_tests(tmp_path: Path) -> None:
+    """No artifact may appear under docs/ or tests/ during dry-run."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "docs").mkdir()
+    (repo_root / "tests").mkdir()
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    (store_root / "receipts").mkdir()
+
+    run_observe_outcomes(
+        store_root=str(store_root),
+        repo_root=repo_root,
+        window_end=datetime(2026, 5, 1, tzinfo=UTC),
+        window_days=DEFAULT_WINDOW_DAYS,
+        max_receipts=10,
+        per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        write=False,
+        timeline_provider=_silent_provider,
+        round_id="2026-05-01a",
+    )
+
+    docs_files = _list_files(repo_root, "docs")
+    tests_files = _list_files(repo_root, "tests")
+    assert docs_files == [], f"dry-run wrote under docs/: {docs_files}"
+    assert tests_files == [], f"dry-run wrote under tests/: {tests_files}"
+
+
+def test_dry_run_does_not_actually_write_file(tmp_path: Path) -> None:
+    """write=False must NOT create the proposed file on disk."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    (store_root / "receipts").mkdir()
+
+    summary = run_observe_outcomes(
+        store_root=str(store_root),
+        repo_root=repo_root,
+        window_end=datetime(2026, 5, 1, tzinfo=UTC),
+        window_days=DEFAULT_WINDOW_DAYS,
+        max_receipts=10,
+        per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        write=False,
+        timeline_provider=_silent_provider,
+        round_id="2026-05-01a",
+    )
+
+    proposed = Path(summary["insufficiency_receipt_path"])
+    assert not proposed.exists(), f"dry-run actually wrote a file: {proposed}"
+    # Payload still returned in response for caller inspection.
+    assert summary["insufficiency_receipt"] is not None
+
+
+def test_write_mode_routes_to_round_id_directory(tmp_path: Path) -> None:
+    """write=True (non-dry-run) MUST route to the original
+    .aragora/evolve-round/<round_id>/ directory, not the
+    observe-outcomes/<utc-iso>/ dry-run isolation tree.
+    """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    (store_root / "receipts").mkdir()
+
+    summary = run_observe_outcomes(
+        store_root=str(store_root),
+        repo_root=repo_root,
+        window_end=datetime(2026, 5, 1, tzinfo=UTC),
+        window_days=DEFAULT_WINDOW_DAYS,
+        max_receipts=10,
+        per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+        write=True,
+        timeline_provider=_silent_provider,
+        round_id="2026-05-01a",
+    )
+
+    proposed = Path(summary["insufficiency_receipt_path"])
+    parts = proposed.parts
+    assert "observe-outcomes" not in parts, (
+        f"write=True must NOT route through observe-outcomes/<utc-iso>/, got: {proposed}"
+    )
+    assert "2026-05-01a" in parts, (
+        f"write=True must route to the round_id directory, got: {proposed}"
+    )
+    assert proposed.name == "phase-a-observe-outcomes-insufficiency-receipt.json"
+    assert proposed.exists()
+    payload = json.loads(proposed.read_text(encoding="utf-8"))
+    assert payload.get("kind") == "phase-a-observe-outcomes-insufficiency-receipt"


### PR DESCRIPTION
## Summary

Follow-up to #6921. This PR contains the **mutating operator CLI** that was intentionally split out so #6921 can stay a narrower read-only infrastructure PR.

This PR adds `aragora review-queue observe-outcomes`, including:
- bounded receipt iteration
- bounded GitHub timeline fetch
- dry-run preview mode
- `--write` opt-in mutation of receipt JSON
- insufficiency-receipt generation
- CLI JSON/text rendering

## Why this is separate

`#6921` now contains only:
- `SettlementReceipt` v2 outcome fields
- pure `observe_outcome(...)` logic
- read-only event-source precedence / schema-gap discrimination
- tests for those read-only behaviors

This PR is the **operator tool** that applies those observation results to local receipt JSON. That write-capable surface is materially more operationally sensitive, so it remains isolated here.

## Scope

Included here:
- `aragora/review/observe_outcomes_cli.py`
- `aragora/cli/commands/observe_outcomes_cmd.py`
- `review-queue observe-outcomes` parser/dispatcher wiring
- tests for CLI behavior and dry-run/write isolation

Explicitly not included:
- any claim that `#6375` is empirically solved
- any change to the 5% placeholder threshold
- any thesis text claiming measured baseline sufficiency

## Validation

- `python3 -m pytest tests/review/test_observe_outcomes_cli.py tests/review/test_observe_outcomes_dry_run_isolation.py tests/review/test_settlement_outcome.py tests/review/test_invalidation_event_source_v2.py -q -p no:randomly`
- `python3 -m ruff check aragora/cli/commands/observe_outcomes_cmd.py aragora/cli/commands/review_queue.py aragora/cli/parser.py aragora/review/observe_outcomes_cli.py tests/review/test_observe_outcomes_cli.py tests/review/test_observe_outcomes_dry_run_isolation.py`
- `python3 -m ruff format --check aragora/cli/commands/observe_outcomes_cmd.py aragora/cli/commands/review_queue.py aragora/cli/parser.py aragora/review/observe_outcomes_cli.py tests/review/test_observe_outcomes_cli.py tests/review/test_observe_outcomes_dry_run_isolation.py`

## Settlement posture

This PR should be reviewed as a local-state mutating operator surface. It is intentionally separated from the schema/library correctness question handled by #6921.
