### PR TITLE
docs: refresh metrics snapshot

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -15,8 +15,8 @@
 | Python files under aragora/ | `4107` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
 | Python lines of code under aragora/ | `1930982` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `136` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5151` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217440` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5152` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217451` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `662` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `63` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |


### PR DESCRIPTION
## Summary
- Refresh docs/METRICS.md after recent merged test-count drift.
- Keeps generated-doc gates green so Dependabot queue checks can be rerun against current main.

## Validation
- python3 scripts/regenerate_metrics.py --check
- PYTHONPATH=. python3 scripts/generate_cli_reference.py --check
- python3 scripts/check_version_alignment.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Queue context
This repairs the generated-doc drift seen in #6995/#6997 CI logs; the dependency PRs themselves are narrow aragora/live bumps.