### PR TITLE
fix(heterogeneity): preserve H2 rules with OpenRouter fallback

### DIFF
--- a/scripts/compare_baseline_vs_panel.py
+++ b/scripts/compare_baseline_vs_panel.py
@@ -12,6 +12,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
 from aragora.heterogeneity.probe import ACCEPTANCE_GATES, SEEDED_CLASSES
 from aragora.heterogeneity.receipt import (
     HETEROGENEITY_RECEIPT_SCHEMA_VERSION,
@@ -25,6 +28,12 @@ ADDITIVE_MARGIN_VALUE = 0.10
 BASELINE_SATURATION_CI_UPPER = 0.999
 MIN_INDEPENDENT_FLAG_TRIALS = 18
 DIRECT_PROVIDER_OPERATORS = frozenset({"anthropic", "openai", "gemini", "xai", "mistral"})
+PROVIDER_ALIASES = {
+    "google": "gemini",
+    "google-ai": "gemini",
+    "google-vertex": "gemini",
+    "x-ai": "xai",
+}
 
 
 class ComparisonError(ValueError):
@@ -101,7 +110,9 @@ def _ci(receipt: Mapping[str, Any], key: str) -> tuple[float, float]:
 
 
 def _n_per_class(receipt: Mapping[str, Any]) -> dict[str, int]:
-    n_per_class = _metric(receipt, "n_per_class", default={})
+    n_per_class = _metric(receipt, "n_per_class", default=None)
+    if n_per_class is None:
+        n_per_class = receipt.get("n_per_class", {})
     if not isinstance(n_per_class, Mapping):
         return {}
     return {
@@ -162,6 +173,49 @@ def _provider_operator(agent: str) -> str:
     return value or "unknown"
 
 
+def _prompt_class(prompt: Mapping[str, Any]) -> str:
+    value = prompt.get("class", prompt.get("prompt_class", ""))
+    return value if isinstance(value, str) else ""
+
+
+def _string_field(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _normalize_provider(value: str) -> str:
+    normalized = value.lower()
+    base = normalized.split("/", 1)[0]
+    return PROVIDER_ALIASES.get(base, base)
+
+
+def _classification_transport_provider(classification: Mapping[str, Any]) -> str:
+    transport_provider = _string_field(classification.get("transport_provider"))
+    if transport_provider:
+        return _normalize_provider(transport_provider)
+    if classification.get("fallback_used") is True:
+        return "openrouter"
+    agent = _string_field(classification.get("agent")) or "unknown"
+    return _provider_operator(agent)
+
+
+def _classification_requested_provider(classification: Mapping[str, Any]) -> str:
+    requested_provider = _string_field(classification.get("requested_provider"))
+    if requested_provider:
+        return _normalize_provider(requested_provider)
+    requested_model = _string_field(classification.get("requested_model"))
+    if requested_model and "/" in requested_model:
+        return _normalize_provider(requested_model)
+    agent = _string_field(classification.get("agent")) or "unknown"
+    if agent.startswith("openrouter:") and "/" in agent:
+        model = agent.split(":", 1)[1]
+        return _normalize_provider(model)
+    return _provider_operator(agent)
+
+
+def _is_fallback_success(classification: Mapping[str, Any]) -> bool:
+    return classification.get("fallback_used") is True
+
+
 def _successful_panel_classifications(receipt: Mapping[str, Any]) -> list[dict[str, Any]]:
     breakdown = receipt.get("per_prompt_breakdown", [])
     if not isinstance(breakdown, list):
@@ -182,15 +236,63 @@ def _successful_panel_classifications(receipt: Mapping[str, Any]) -> list[dict[s
     return successful
 
 
+def _successful_seeded_trials(receipt: Mapping[str, Any]) -> int:
+    breakdown = receipt.get("per_prompt_breakdown", [])
+    if not isinstance(breakdown, list):
+        return 0
+    total = 0
+    for prompt in breakdown:
+        if not isinstance(prompt, Mapping) or _prompt_class(prompt) not in SEEDED_CLASSES:
+            continue
+        classifications = prompt.get("panelist_classifications", [])
+        if not isinstance(classifications, list):
+            continue
+        total += sum(
+            1
+            for classification in classifications
+            if isinstance(classification, Mapping)
+            and classification.get("verdict") != "dispatch_failed"
+        )
+    return total
+
+
+def provider_summary(panel_receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """Summarize direct, OpenRouter-mediated, and model-family successes."""
+    classifications = _successful_panel_classifications(panel_receipt)
+    transport_distribution: dict[str, int] = {}
+    model_family_distribution: dict[str, int] = {}
+    fallback_successes = 0
+    direct_successes = 0
+    for classification in classifications:
+        transport = _classification_transport_provider(classification)
+        model_family = _classification_requested_provider(classification)
+        transport_distribution[transport] = transport_distribution.get(transport, 0) + 1
+        model_family_distribution[model_family] = model_family_distribution.get(model_family, 0) + 1
+        if transport in DIRECT_PROVIDER_OPERATORS:
+            direct_successes += 1
+        if _is_fallback_success(classification):
+            fallback_successes += 1
+
+    total = len(classifications)
+    openrouter_mediated = transport_distribution.get("openrouter", 0)
+    return {
+        "successful_trials": total,
+        "direct_successes": direct_successes,
+        "openrouter_mediated_successes": openrouter_mediated,
+        "fallback_successes": fallback_successes,
+        "fallback_share": fallback_successes / total if total else 0.0,
+        "fallback_augmented": fallback_successes > 0,
+        "transport_provider_distribution": dict(sorted(transport_distribution.items())),
+        "model_family_distribution": dict(sorted(model_family_distribution.items())),
+    }
+
+
 def evaluate_provider_rule(panel_receipt: Mapping[str, Any]) -> dict[str, Any]:
     """Evaluate the Round 31 provider heterogeneity rule from successful trials."""
     classifications = _successful_panel_classifications(panel_receipt)
     distribution: dict[str, int] = {}
     for classification in classifications:
-        agent = classification.get("agent")
-        if not isinstance(agent, str) or not agent:
-            agent = "unknown"
-        provider = _provider_operator(agent)
+        provider = _classification_transport_provider(classification)
         distribution[provider] = distribution.get(provider, 0) + 1
 
     total = sum(distribution.values())
@@ -246,6 +348,7 @@ def _metrics_summary(receipt: Mapping[str, Any]) -> dict[str, Any]:
         "independent_flag_rate": _float_metric(receipt, "independent_flag_rate"),
         "independent_flag_rate_ci_95_wilson": [ci_low, ci_high],
         "false_positive_rates": _fp_summary(receipt),
+        "successful_seeded_trials": _successful_seeded_trials(receipt),
     }
 
 
@@ -291,13 +394,28 @@ def _verdict(
 
     baseline_trials = _int_metric(baseline_receipt, "independent_flag_trials")
     panel_trials = _int_metric(panel_receipt, "independent_flag_trials")
-    if baseline_trials < MIN_INDEPENDENT_FLAG_TRIALS or panel_trials < MIN_INDEPENDENT_FLAG_TRIALS:
+    baseline_successful_seeded = _successful_seeded_trials(baseline_receipt)
+    panel_successful_seeded = _successful_seeded_trials(panel_receipt)
+    if (
+        baseline_trials < MIN_INDEPENDENT_FLAG_TRIALS
+        or panel_trials < MIN_INDEPENDENT_FLAG_TRIALS
+        or baseline_successful_seeded < MIN_INDEPENDENT_FLAG_TRIALS
+        or panel_successful_seeded < MIN_INDEPENDENT_FLAG_TRIALS
+    ):
         return (
             "INSUFFICIENT",
             "insufficient_n:"
-            f"baseline={baseline_trials},panel={panel_trials},"
+            f"baseline_attempted={baseline_trials},panel_attempted={panel_trials},"
+            f"baseline_successful={baseline_successful_seeded},"
+            f"panel_successful={panel_successful_seeded},"
             f"minimum={MIN_INDEPENDENT_FLAG_TRIALS}",
         )
+
+    if not provider_rule.get("satisfied", False):
+        reasons = provider_rule.get("reasons", [])
+        if isinstance(reasons, list):
+            return ("INSUFFICIENT", "provider_rule_failed:" + ",".join(map(str, reasons)))
+        return ("INSUFFICIENT", "provider_rule_failed")
 
     baseline_ci_low, baseline_ci_high = _ci(baseline_receipt, "independent_flag_rate_ci_95_wilson")
     panel_ci_low, panel_ci_high = _ci(panel_receipt, "independent_flag_rate_ci_95_wilson")
@@ -307,11 +425,6 @@ def _verdict(
 
     required_gap = ADDITIVE_MARGIN_VALUE if verdict_rule == ADDITIVE_MARGIN else 0.0
     if panel_ci_low > baseline_ci_high + required_gap:
-        if not provider_rule.get("satisfied", False):
-            reasons = provider_rule.get("reasons", [])
-            if isinstance(reasons, list):
-                return ("INSUFFICIENT", "provider_rule_failed:" + ",".join(map(str, reasons)))
-            return ("INSUFFICIENT", "provider_rule_failed")
         return ("GO", verdict_rule)
 
     if panel_ci_high <= baseline_ci_high:
@@ -346,6 +459,7 @@ def build_comparison_receipt(
 
     composition_match, composition = _composition_match(baseline_receipt, panel_receipt)
     provider_rule = evaluate_provider_rule(panel_receipt)
+    fallback_summary = provider_summary(panel_receipt)
     verdict, verdict_reason = _verdict(
         baseline_receipt,
         panel_receipt,
@@ -364,6 +478,7 @@ def build_comparison_receipt(
         "panel_receipt_path": panel_receipt_path,
         "panel_receipt_id": _receipt_id(panel_receipt),
         "composition_match": composition_match,
+        "fallback_augmented": fallback_summary["fallback_augmented"],
         "verdict": verdict,
         "verdict_reason": verdict_reason,
         "verdict_rule_applied": verdict_rule,
@@ -372,6 +487,7 @@ def build_comparison_receipt(
         "comparison": {
             "composition": composition,
             "provider_rule": provider_rule,
+            "provider_summary": fallback_summary,
             "independent_flag_rate_ci_gap": {
                 "panel_ci_lower_minus_baseline_ci_upper": panel_ci_low - baseline_ci_high,
                 "panel_ci_upper_minus_baseline_ci_upper": panel_ci_high - baseline_ci_high,

--- a/scripts/preflight_h2_openrouter_failover.py
+++ b/scripts/preflight_h2_openrouter_failover.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Preflight H2 direct-provider slots and OpenRouter fallback targets.
+
+This script performs no paid model-completion calls. It exists to make H2
+fallback ordering explicit before a paid panel runner executes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+DIRECT_PROVIDERS = frozenset({"anthropic", "openai", "gemini", "xai", "mistral"})
+
+
+@dataclass(frozen=True)
+class H2ProviderAttempt:
+    requested_provider: str
+    requested_model: str
+    transport_provider: str
+    transport_model: str
+    secret_name: str
+    fallback_used: bool = False
+    fallback_for: str | None = None
+    fallback_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class H2PanelSlot:
+    slot_id: str
+    attempts: tuple[H2ProviderAttempt, ...]
+
+
+H2_PANEL_SLOTS: tuple[H2PanelSlot, ...] = (
+    H2PanelSlot(
+        "anthropic-direct",
+        (
+            H2ProviderAttempt(
+                "anthropic",
+                "claude-haiku-4-5",
+                "anthropic",
+                "claude-haiku-4-5",
+                "ANTHROPIC_API_KEY",
+            ),
+        ),
+    ),
+    H2PanelSlot(
+        "openai-frontier",
+        (
+            H2ProviderAttempt("openai", "gpt-5.5", "openai", "gpt-5.5", "OPENAI_API_KEY"),
+            H2ProviderAttempt(
+                "openai",
+                "gpt-5.5",
+                "openrouter",
+                "openai/gpt-5.5",
+                "OPENROUTER_API_KEY",
+                fallback_used=True,
+                fallback_for="openai:gpt-5.5",
+                fallback_reason="direct_openai_unavailable",
+            ),
+        ),
+    ),
+    H2PanelSlot(
+        "gemini-frontier",
+        (
+            H2ProviderAttempt(
+                "gemini",
+                "gemini-3-pro-preview",
+                "gemini",
+                "gemini-3-pro-preview",
+                "GEMINI_API_KEY",
+            ),
+            H2ProviderAttempt(
+                "gemini",
+                "gemini-3.1-pro-preview",
+                "openrouter",
+                "google/gemini-3.1-pro-preview",
+                "OPENROUTER_API_KEY",
+                fallback_used=True,
+                fallback_for="gemini:gemini-3-pro-preview",
+                fallback_reason="direct_gemini_unavailable",
+            ),
+            H2ProviderAttempt(
+                "gemini",
+                "gemini-pro-latest",
+                "openrouter",
+                "~google/gemini-pro-latest",
+                "OPENROUTER_API_KEY",
+                fallback_used=True,
+                fallback_for="gemini:gemini-3-pro-preview",
+                fallback_reason="direct_gemini_unavailable",
+            ),
+        ),
+    ),
+    H2PanelSlot(
+        "xai-direct",
+        (H2ProviderAttempt("xai", "grok-4-latest", "xai", "grok-4-latest", "XAI_API_KEY"),),
+    ),
+    H2PanelSlot(
+        "mistral-direct",
+        (
+            H2ProviderAttempt(
+                "mistral",
+                "mistral-large-2512",
+                "mistral",
+                "mistral-large-2512",
+                "MISTRAL_API_KEY",
+            ),
+        ),
+    ),
+    H2PanelSlot(
+        "openrouter-qwen",
+        (
+            H2ProviderAttempt(
+                "openrouter",
+                "qwen/qwen3-max",
+                "openrouter",
+                "qwen/qwen3-max",
+                "OPENROUTER_API_KEY",
+            ),
+        ),
+    ),
+)
+
+
+def _json_get(url: str, *, headers: dict[str, str] | None = None, timeout: int = 20) -> Any:
+    request = urllib.request.Request(url, headers=headers or {}, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _secret(name: str) -> str | None:
+    from aragora.config.secrets import SecretManager
+
+    value = SecretManager().get(name)
+    return value if value else None
+
+
+def _openrouter_model_ids() -> tuple[set[str], str | None]:
+    try:
+        payload = _json_get("https://openrouter.ai/api/v1/models")
+    except (OSError, urllib.error.HTTPError, json.JSONDecodeError) as exc:
+        return (set(), f"{type(exc).__name__}: {exc}")
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return (set(), "unexpected OpenRouter /models response")
+    ids = {item.get("id") for item in data if isinstance(item, dict)}
+    return ({item for item in ids if isinstance(item, str)}, None)
+
+
+def _gemini_model_ids() -> tuple[set[str], str | None]:
+    try:
+        api_key = _secret("GEMINI_API_KEY")
+    except Exception as exc:  # noqa: BLE001 - preflight reports credential setup failures.
+        return (set(), f"{type(exc).__name__}: {exc}")
+    if not api_key:
+        return (set(), "GEMINI_API_KEY missing")
+    try:
+        payload = _json_get(
+            f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}"
+        )
+    except (OSError, urllib.error.HTTPError, json.JSONDecodeError) as exc:
+        return (set(), f"{type(exc).__name__}: {exc}")
+    models = payload.get("models") if isinstance(payload, dict) else None
+    if not isinstance(models, list):
+        return (set(), "unexpected Gemini listModels response")
+    names = {item.get("name") for item in models if isinstance(item, dict)}
+    normalized = {name.removeprefix("models/") for name in names if isinstance(name, str)}
+    return (normalized, None)
+
+
+def _openai_model_ids() -> tuple[set[str], str | None]:
+    try:
+        api_key = _secret("OPENAI_API_KEY")
+    except Exception as exc:  # noqa: BLE001 - preflight reports credential setup failures.
+        return (set(), f"{type(exc).__name__}: {exc}")
+    if not api_key:
+        return (set(), "OPENAI_API_KEY missing")
+    try:
+        payload = _json_get(
+            "https://api.openai.com/v1/models",
+            headers={"authorization": f"Bearer {api_key}"},
+        )
+    except (OSError, urllib.error.HTTPError, json.JSONDecodeError) as exc:
+        return (set(), f"{type(exc).__name__}: {exc}")
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return (set(), "unexpected OpenAI models response")
+    ids = {item.get("id") for item in data if isinstance(item, dict)}
+    return ({item for item in ids if isinstance(item, str)}, None)
+
+
+def _attempt_status(
+    attempt: H2ProviderAttempt,
+    *,
+    model_ids_by_provider: dict[str, set[str]],
+    errors_by_provider: dict[str, str | None],
+    offline: bool,
+) -> dict[str, Any]:
+    payload = asdict(attempt)
+    if offline:
+        payload.update({"model_listed": None, "probe_error": None, "quota_verified": False})
+        return payload
+
+    provider = attempt.transport_provider
+    model_id = attempt.transport_model
+    if provider not in model_ids_by_provider and provider not in errors_by_provider:
+        payload["model_listed"] = None
+        payload["probe_error"] = "model listing probe not implemented for provider"
+        payload["quota_verified"] = False
+        return payload
+    ids = model_ids_by_provider.get(provider, set())
+    payload["model_listed"] = model_id in ids
+    payload["probe_error"] = errors_by_provider.get(provider)
+    payload["quota_verified"] = False
+    if provider == "openai":
+        payload["quota_note"] = (
+            "OpenAI quota is not verified by model listing; avoid paid probes here."
+        )
+    return payload
+
+
+def build_preflight_payload(*, offline: bool = False) -> dict[str, Any]:
+    model_ids_by_provider: dict[str, set[str]] = {}
+    errors_by_provider: dict[str, str | None] = {}
+    if not offline:
+        model_ids_by_provider["openrouter"], errors_by_provider["openrouter"] = (
+            _openrouter_model_ids()
+        )
+        model_ids_by_provider["gemini"], errors_by_provider["gemini"] = _gemini_model_ids()
+        model_ids_by_provider["openai"], errors_by_provider["openai"] = _openai_model_ids()
+
+    slots = []
+    for slot in H2_PANEL_SLOTS:
+        slots.append(
+            {
+                "slot_id": slot.slot_id,
+                "attempt_order": [
+                    _attempt_status(
+                        attempt,
+                        model_ids_by_provider=model_ids_by_provider,
+                        errors_by_provider=errors_by_provider,
+                        offline=offline,
+                    )
+                    for attempt in slot.attempts
+                ],
+            }
+        )
+
+    return {
+        "schema_version": "h2_provider_failover_preflight.v1",
+        "paid_calls": False,
+        "fallback_policy": (
+            "OpenRouter fallbacks are predeclared availability transports and must be "
+            "counted as transport_provider=openrouter for H2 provider-rule accounting."
+        ),
+        "direct_providers": sorted(DIRECT_PROVIDERS),
+        "slots": slots,
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print JSON output.")
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Print the fallback manifest without network or SecretManager probes.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_preflight_payload(offline=args.offline)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("H2 OpenRouter failover preflight")
+        print("paid_calls: false")
+        for slot in payload["slots"]:
+            print(f"- {slot['slot_id']}:")
+            for attempt in slot["attempt_order"]:
+                fallback = " fallback" if attempt["fallback_used"] else " direct"
+                print(
+                    "  "
+                    f"{attempt['transport_provider']}:{attempt['transport_model']}"
+                    f" ({fallback.strip()}, listed={attempt['model_listed']})"
+                )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_compare_baseline_vs_panel.py
+++ b/tests/scripts/test_compare_baseline_vs_panel.py
@@ -28,12 +28,30 @@ PANEL_AGENTS = (
 
 
 def _breakdown(agents: tuple[str, ...] = PANEL_AGENTS) -> list[dict[str, object]]:
+    return _breakdown_with_metadata(agents)
+
+
+def _breakdown_with_metadata(
+    agents: tuple[str, ...] = PANEL_AGENTS,
+    *,
+    metadata_by_agent: dict[str, dict[str, object]] | None = None,
+    dispatch_failed_agents: set[str] | None = None,
+) -> list[dict[str, object]]:
+    metadata_by_agent = metadata_by_agent or {}
+    dispatch_failed_agents = dispatch_failed_agents or set()
     return [
         {
             "prompt_class": prompt_class,
             "prompt_id": prompt_id,
             "panelist_classifications": [
-                {"agent": agent, "verdict": "flagged_correctly", "rationale": ""}
+                {
+                    "agent": agent,
+                    "verdict": "dispatch_failed"
+                    if agent in dispatch_failed_agents
+                    else "flagged_correctly",
+                    "rationale": "",
+                    **metadata_by_agent.get(agent, {}),
+                }
                 for agent in agents
             ],
         }
@@ -54,6 +72,9 @@ def _receipt(
     n_per_class: dict[str, int] | None = None,
     agents: tuple[str, ...] = PANEL_AGENTS,
     null_negative_fpr: float = 1 / 6,
+    metadata_by_agent: dict[str, dict[str, object]] | None = None,
+    dispatch_failed_agents: set[str] | None = None,
+    metrics_n_per_class: bool = True,
 ) -> dict[str, object]:
     counts = {
         "clean_neutral": 1,
@@ -72,8 +93,13 @@ def _receipt(
         "judge_model": "synthetic-judge",
         "n_panelists": len(agents),
         "n_prompts": sum(counts.values()),
+        "n_per_class": counts,
         "panel_models": list(agents),
-        "per_prompt_breakdown": _breakdown(agents),
+        "per_prompt_breakdown": _breakdown_with_metadata(
+            agents,
+            metadata_by_agent=metadata_by_agent,
+            dispatch_failed_agents=dispatch_failed_agents,
+        ),
         "pilot_token_spend_usd_estimate": {"actual_usd": 0.0, "estimate_usd": 0.0},
         "scope_caveats": ["synthetic test fixture"],
         "verdict": "synthetic",
@@ -81,7 +107,6 @@ def _receipt(
         "metrics": {
             "n_panelists": len(agents),
             "n_prompts": sum(counts.values()),
-            "n_per_class": counts,
             "independent_flag_successes": successes,
             "independent_flag_trials": trials,
             "independent_flag_rate": rate,
@@ -98,6 +123,10 @@ def _receipt(
             "false_positive_rate_on_null_negative": null_negative_fpr,
         },
     }
+    if metrics_n_per_class:
+        metrics = receipt["metrics"]
+        assert isinstance(metrics, dict)
+        metrics["n_per_class"] = counts
     receipt["receipt_id"] = compute_receipt_id(receipt)
     return receipt
 
@@ -194,6 +223,145 @@ def test_insufficient_n_is_insufficient() -> None:
 
     assert comparison["verdict"] == "INSUFFICIENT"
     assert str(comparison["verdict_reason"]).startswith("insufficient_n:")
+
+
+def test_successful_seeded_n_uses_dispatch_failures_not_attempted_only() -> None:
+    baseline = _receipt(ci=(0.0, 0.2), rate=0.0, successes=0, trials=18)
+    panel = _receipt(
+        ci=(0.31, 0.7),
+        rate=0.5,
+        successes=9,
+        trials=18,
+        dispatch_failed_agents={"gpt-4.1"},
+    )
+
+    comparison = build_comparison_receipt(
+        baseline,
+        panel,
+        baseline_receipt_path="baseline.json",
+        panel_receipt_path="panel.json",
+        produced_at="2026-05-04T00:00:00Z",
+    )
+
+    assert comparison["verdict"] == "INSUFFICIENT"
+    assert "panel_successful=15" in str(comparison["verdict_reason"])
+
+
+def test_top_level_n_per_class_is_used_when_metrics_omits_it() -> None:
+    baseline = _receipt(
+        ci=(0.0, 0.2),
+        rate=0.0,
+        successes=0,
+        metrics_n_per_class=False,
+    )
+    panel = _receipt(
+        ci=(0.31, 0.7),
+        rate=0.5,
+        successes=9,
+        metrics_n_per_class=False,
+    )
+
+    comparison = build_comparison_receipt(
+        baseline,
+        panel,
+        baseline_receipt_path="baseline.json",
+        panel_receipt_path="panel.json",
+        produced_at="2026-05-04T00:00:00Z",
+    )
+
+    assert comparison["composition_match"] is True
+    assert comparison["comparison"]["composition"]["baseline_seeded_class_counts"] == {
+        "multi_seeded_error": 1,
+        "red_team_paraphrase": 1,
+        "single_seeded_error": 1,
+    }
+    assert comparison["baseline_metrics"]["n_per_class"]["single_seeded_error"] == 1
+
+
+def test_openrouter_fallback_counts_as_openrouter_transport_not_direct_provider() -> None:
+    agents = (
+        "claude-haiku-4-5",
+        "openrouter:openai/gpt-5.5",
+        "gemini-3.1-pro",
+        "mistral-large",
+        "grok-4",
+        "openrouter/qwen",
+    )
+    baseline = _receipt(ci=(0.0, 0.2), rate=0.0, successes=0, agents=agents)
+    panel = _receipt(
+        ci=(0.31, 0.7),
+        rate=0.5,
+        successes=9,
+        agents=agents,
+        metadata_by_agent={
+            "openrouter:openai/gpt-5.5": {
+                "requested_provider": "openai",
+                "requested_model": "gpt-5.5",
+                "transport_provider": "openrouter",
+                "actual_model_id": "openai/gpt-5.5",
+                "fallback_used": True,
+                "fallback_reason": "direct_openai_insufficient_quota",
+            }
+        },
+    )
+
+    comparison = build_comparison_receipt(
+        baseline,
+        panel,
+        baseline_receipt_path="baseline.json",
+        panel_receipt_path="panel.json",
+        produced_at="2026-05-04T00:00:00Z",
+    )
+
+    provider_rule = comparison["comparison"]["provider_rule"]
+    summary = comparison["comparison"]["provider_summary"]
+    assert provider_rule["provider_distribution"]["openrouter"] == 6
+    assert "openai" not in provider_rule["provider_distribution"]
+    assert summary["fallback_augmented"] is True
+    assert comparison["fallback_augmented"] is True
+    assert summary["fallback_successes"] == 3
+    assert summary["model_family_distribution"]["openai"] == 3
+
+
+def test_openrouter_only_panel_is_insufficient() -> None:
+    agents = tuple(f"openrouter:model-{index}" for index in range(6))
+    baseline = _receipt(ci=(0.0, 0.2), rate=0.0, successes=0, agents=agents)
+    panel = _receipt(ci=(0.31, 0.7), rate=0.5, successes=9, agents=agents)
+
+    comparison = build_comparison_receipt(
+        baseline,
+        panel,
+        baseline_receipt_path="baseline.json",
+        panel_receipt_path="panel.json",
+        produced_at="2026-05-04T00:00:00Z",
+    )
+
+    assert comparison["verdict"] == "INSUFFICIENT"
+    assert "openrouter_only_panel" in str(comparison["verdict_reason"])
+
+
+def test_openrouter_dominance_above_half_is_insufficient() -> None:
+    agents = (
+        "openrouter:model-a",
+        "openrouter:model-b",
+        "openrouter:model-c",
+        "openrouter:model-d",
+        "claude-haiku-4-5",
+        "grok-4",
+    )
+    baseline = _receipt(ci=(0.0, 0.2), rate=0.0, successes=0, agents=agents)
+    panel = _receipt(ci=(0.31, 0.7), rate=0.5, successes=9, agents=agents)
+
+    comparison = build_comparison_receipt(
+        baseline,
+        panel,
+        baseline_receipt_path="baseline.json",
+        panel_receipt_path="panel.json",
+        produced_at="2026-05-04T00:00:00Z",
+    )
+
+    assert comparison["verdict"] == "INSUFFICIENT"
+    assert "provider_dominance:openrouter:0.667" in str(comparison["verdict_reason"])
 
 
 def test_baseline_saturation_is_insufficient_with_data() -> None:

--- a/tests/scripts/test_preflight_h2_openrouter_failover.py
+++ b/tests/scripts/test_preflight_h2_openrouter_failover.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+
+from scripts.preflight_h2_openrouter_failover import build_preflight_payload, main
+
+
+def test_offline_preflight_declares_openai_and_gemini_fallback_order() -> None:
+    payload = build_preflight_payload(offline=True)
+    slots = {slot["slot_id"]: slot for slot in payload["slots"]}
+
+    openai_attempts = slots["openai-frontier"]["attempt_order"]
+    assert openai_attempts[0]["transport_provider"] == "openai"
+    assert openai_attempts[0]["transport_model"] == "gpt-5.5"
+    assert openai_attempts[0]["fallback_used"] is False
+    assert openai_attempts[1]["transport_provider"] == "openrouter"
+    assert openai_attempts[1]["transport_model"] == "openai/gpt-5.5"
+    assert openai_attempts[1]["fallback_used"] is True
+
+    gemini_attempts = slots["gemini-frontier"]["attempt_order"]
+    assert gemini_attempts[0]["transport_provider"] == "gemini"
+    assert gemini_attempts[0]["transport_model"] == "gemini-3-pro-preview"
+    assert gemini_attempts[1]["transport_model"] == "google/gemini-3.1-pro-preview"
+    assert gemini_attempts[2]["transport_model"] == "~google/gemini-pro-latest"
+
+
+def test_offline_preflight_records_no_paid_calls_and_h2_policy() -> None:
+    payload = build_preflight_payload(offline=True)
+
+    assert payload["paid_calls"] is False
+    assert "transport_provider=openrouter" in payload["fallback_policy"]
+    assert "openai" in payload["direct_providers"]
+    assert "gemini" in payload["direct_providers"]
+
+
+def test_cli_offline_json_prints_manifest(capsys) -> None:
+    rc = main(["--offline", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "h2_provider_failover_preflight.v1"
+    assert payload["slots"][0]["slot_id"] == "anthropic-direct"


### PR DESCRIPTION
## Summary
- harden baseline-vs-panel comparison so composition reads top-level `n_per_class` and verdicts require successful seeded trials, not attempted trials only
- count OpenRouter fallback as `transport_provider=openrouter` for provider-rule accounting while separately recording model-family/fallback summaries
- add a no-paid-call H2 failover preflight manifest with direct-first OpenAI/Gemini slots and predeclared OpenRouter fallback targets

## Non-claims
- does not rerun the H2 panel
- does not claim OpenRouter fallbacks are direct OpenAI/Gemini evidence
- does not settle H2, #6375, or the 5% threshold

## Validation
- `python3 -m pytest tests/scripts/test_compare_baseline_vs_panel.py tests/scripts/test_preflight_h2_openrouter_failover.py -q -p no:randomly`
- `python3 -m pytest tests/heterogeneity/test_probe_metrics.py tests/heterogeneity/test_receipt.py tests/heterogeneity/test_judge.py tests/heterogeneity/test_prompts.py -q -p no:randomly`
- `python3 -m ruff check scripts/compare_baseline_vs_panel.py scripts/preflight_h2_openrouter_failover.py tests/scripts/test_compare_baseline_vs_panel.py tests/scripts/test_preflight_h2_openrouter_failover.py`
- `python3 -m ruff format --check scripts/compare_baseline_vs_panel.py scripts/preflight_h2_openrouter_failover.py tests/scripts/test_compare_baseline_vs_panel.py tests/scripts/test_preflight_h2_openrouter_failover.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `gitleaks detect --no-git --source /tmp/h2-openrouter-failover.diff`
- Rechecked prior H2 panel receipt: comparator now returns `INSUFFICIENT` with `panel_successful=12` and correct seeded class counts.
