### PR TITLE
fix(server): keep critical v1 warning marked deprecated

### DIFF
--- a/aragora/server/middleware/deprecation.py
+++ b/aragora/server/middleware/deprecation.py
@@ -135,7 +135,8 @@ def get_v1_deprecation_headers(path: str | None = None) -> dict[str, str]:
     # Add urgency indicator when close to sunset
     if level == "critical":
         headers["X-API-Version-Warning"] = (
-            f"URGENT: API v1 will be removed in {days_left} days ({V1_SUNSET_ISO}). "
+            f"URGENT: API v1 is deprecated and will be removed in {days_left} days "
+            f"({V1_SUNSET_ISO}). "
             f"Migrate to API {CURRENT_API_VERSION} immediately. "
             f"See {MIGRATION_DOCS_URL}"
         )


### PR DESCRIPTION
## Summary
- keep the critical V1 sunset warning explicitly marked as deprecated
- fixes the current date-rollover failure in tests/server/middleware/test_deprecation.py::TestGetV1DeprecationHeaders::test_returns_x_api_version_warning
- unblocks dependency PR CI that is failing on this main-level test

## Validation
- python3 -m pytest tests/server/middleware/test_deprecation.py::TestGetV1DeprecationHeaders::test_returns_x_api_version_warning tests/server/middleware/test_deprecation.py::TestGetV1DeprecationHeadersExtended::test_critical_level_urgent_warning tests/server/middleware/test_deprecation.py::TestGetV1DeprecationHeadersExtended::test_warning_level_standard_message -q -p no:randomly --timeout=60
- python3 -m pytest tests/server/middleware/test_deprecation.py -q -p no:randomly --timeout=60
- python3 -m ruff check aragora/server/middleware/deprecation.py tests/server/middleware/test_deprecation.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
