### PR TITLE
fix(debate): honor cruxset emission monkeypatch

### DIFF
--- a/aragora/debate/phases/winner_selector.py
+++ b/aragora/debate/phases/winner_selector.py
@@ -392,7 +392,7 @@ class WinnerSelector:
                 # is set; the emitter swallows its own errors so a CruxSet
                 # build failure cannot crash the debate.
                 try:
-                    from aragora.reasoning.cruxset_emission import maybe_emit_cruxset
+                    from aragora.reasoning import cruxset_emission
 
                     question_text = ""
                     debate_id = ""
@@ -402,7 +402,7 @@ class WinnerSelector:
                     debate_id = str(getattr(ctx, "debate_id", "") or "")
 
                     if question_text:
-                        cruxset = maybe_emit_cruxset(
+                        cruxset = cruxset_emission.maybe_emit_cruxset(
                             question=question_text,
                             analysis_payload=analysis.to_dict(),
                             decision=str(getattr(result, "winner", "") or "") or None,


### PR DESCRIPTION
## Summary
- route cruxset emission through the module object so test and dogfood monkeypatches reliably intercept maybe_emit_cruxset
- preserves production behavior while fixing the queue-blocking debate-phases CI failure seen on #7002

## Validation
- python3 -m pytest tests/debate/phases/test_winner_selector.py::TestCruxSetEmission::test_cruxset_emission_failure_swallowed tests/debate/phases/test_winner_selector.py::TestCruxSetEmission::test_cruxset_emitted_when_flag_on -q -p no:randomly
- python3 -m pytest tests/debate/phases/test_winner_selector.py -q -n 4 -p no:randomly
- python3 -m pytest tests/debate/phases -q -n 4 -p no:randomly
- python3 -m ruff check aragora/debate/phases/winner_selector.py tests/debate/phases/test_winner_selector.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD