### PR TITLE
fix(blockchain): honor cached web3 unavailable state

### DIFF
--- a/aragora/blockchain/provider.py
+++ b/aragora/blockchain/provider.py
@@ -27,6 +27,8 @@ Web3: Any | None = None
 def _check_web3() -> bool:
     """Check if web3 is available."""
     global _web3_available
+    if _web3_available is False:
+        return False
     if Web3 is not None:
         _web3_available = True
         return True


### PR DESCRIPTION
## Summary
- Honor an explicit cached `_web3_available is False` state before treating an already-imported `Web3` global as available.
- Keeps `require_web3()` fail-closed when tests or runtime probes intentionally mark web3 unavailable.
- Unblocks the #6998 web3>=7.16.0 validation failure.

## Validation
- `uv run --extra blockchain --extra test --with numpy python -m pytest tests/blockchain/test_provider.py::TestWeb3Check::test_require_web3_raises_when_unavailable -q -p no:randomly` -> `1 passed, 1 warning in 0.41s`
- `uv run --extra blockchain --extra test --with numpy python -m pytest tests/blockchain/test_config.py tests/blockchain/test_models.py tests/blockchain/test_provider.py -q -p no:randomly` -> `158 passed, 1 warning in 4.27s`
- `python3 -m ruff check aragora/blockchain/provider.py tests/blockchain/test_provider.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`

## Notes
- No new tests were added because the existing regression test already describes the intended contract and failed against the previous implementation.
- This PR is intentionally separate from #6998 so the dependency bump can be validated after the runtime availability contract is repaired.