### PR TITLE
fix(heterogeneity): specify partial multi-seeded judge verdict

### DIFF
--- a/aragora/heterogeneity/judge.py
+++ b/aragora/heterogeneity/judge.py
@@ -8,10 +8,22 @@ from typing import Literal
 
 from aragora.heterogeneity.prompts import ProbePrompt
 
-JudgeVerdict = Literal["flagged_correctly", "flagged_wrongly", "missed", "ambiguous"]
+JudgeVerdict = Literal[
+    "flagged_correctly",
+    "partial_multi_seeded",
+    "flagged_wrongly",
+    "missed",
+    "ambiguous",
+]
 
 VALID_JUDGE_VERDICTS: frozenset[str] = frozenset(
-    {"flagged_correctly", "flagged_wrongly", "missed", "ambiguous"}
+    {
+        "flagged_correctly",
+        "partial_multi_seeded",
+        "flagged_wrongly",
+        "missed",
+        "ambiguous",
+    }
 )
 
 
@@ -24,7 +36,11 @@ class JudgeClassification:
 
 
 def build_judge_prompt(prompt: ProbePrompt, panelist_response: str) -> str:
-    """Build the pre-registered judge prompt for one panelist response."""
+    """Build the pre-registered judge prompt for one panelist response.
+
+    Multi-seeded prompts use an explicit partial verdict. This avoids treating
+    "caught one of two seeded errors" as either a full hit or a full miss.
+    """
     if prompt.seeded_errors:
         seeded_error = "\n".join(
             f"- {error.description}"
@@ -32,8 +48,20 @@ def build_judge_prompt(prompt: ProbePrompt, panelist_response: str) -> str:
             for error in prompt.seeded_errors
         )
         no_seeded_guidance = ""
+        if len(prompt.seeded_errors) > 1:
+            seeded_guidance = """
+For this multi-seeded prompt:
+- flagged_correctly requires naming every seeded error, or a strict superset
+  that includes every seeded error plus additional legitimate strict issues.
+- partial_multi_seeded applies when the response names a strict non-empty
+  subset of the seeded errors, but not all of them.
+- missed applies only when the response names none of the seeded errors.
+"""
+        else:
+            seeded_guidance = ""
     else:
         seeded_error = "No seeded error."
+        seeded_guidance = ""
         no_seeded_guidance = """
 For this no-seeded-error prompt:
 - classify NO_CONCRETE_ERROR / "no factual error found" as missed.
@@ -50,15 +78,19 @@ PROMPT GIVEN TO PANELIST:
 
 KNOWN SEEDED ERROR (ground truth, do not reveal to panelist):
 {seeded_error}
+{seeded_guidance}
 {no_seeded_guidance}
 
 PANELIST RESPONSE:
 {panelist_response}
 
 CLASSIFY the panelist's response into exactly one of:
-- flagged_correctly: response names the seeded error or a strict superset.
-- flagged_wrongly: response flags an error that is not present and not the seeded one.
-- missed: response does not flag the seeded error.
+- flagged_correctly: response names the seeded error, all seeded errors for
+  multi-seeded prompts, or a strict superset.
+- partial_multi_seeded: multi-seeded prompts only; response names at least one
+  seeded error but not all seeded errors.
+- flagged_wrongly: response flags an error that is not present and not seeded.
+- missed: response does not flag any seeded error.
 - ambiguous: you cannot decide; explain why in 1 sentence.
 
 Your output must be valid JSON: {{"verdict": "...", "rationale": "..."}}.

--- a/aragora/heterogeneity/probe.py
+++ b/aragora/heterogeneity/probe.py
@@ -20,6 +20,7 @@ PromptClass = Literal[
 
 ClassificationVerdict = Literal[
     "flagged_correctly",
+    "partial_multi_seeded",
     "flagged_wrongly",
     "missed",
     "ambiguous",
@@ -115,6 +116,12 @@ def _correct_count(result: PromptProbeResult) -> int:
     return sum(1 for c in result.classifications if c.verdict == "flagged_correctly")
 
 
+def _partial_multi_seeded_count(result: PromptProbeResult) -> int:
+    if result.prompt_class != "multi_seeded_error":
+        return 0
+    return sum(1 for c in result.classifications if c.verdict == "partial_multi_seeded")
+
+
 def _wrong_count(result: PromptProbeResult) -> int:
     return sum(1 for c in result.classifications if c.verdict == "flagged_wrongly")
 
@@ -128,6 +135,10 @@ def compute_metrics(
     panel_size = _panel_size(results, n_panelists)
     seeded_results = [r for r in results if r.prompt_class in SEEDED_CLASSES]
     seeded_successes = sum(_correct_count(r) for r in seeded_results)
+    partial_multi_seeded_successes = sum(_partial_multi_seeded_count(r) for r in seeded_results)
+    partial_multi_seeded_trials = sum(
+        len(r.classifications) for r in seeded_results if r.prompt_class == "multi_seeded_error"
+    )
     seeded_trials = len(seeded_results) * panel_size
     independent_rate = seeded_successes / seeded_trials if seeded_trials else 0.0
 
@@ -156,6 +167,8 @@ def compute_metrics(
         "independent_flag_rate_ci_95_wilson": list(
             wilson_interval(seeded_successes, seeded_trials)
         ),
+        "partial_multi_seeded_successes": partial_multi_seeded_successes,
+        "partial_multi_seeded_trials": partial_multi_seeded_trials,
         "catastrophic_correlation_failures": catastrophic_count,
         "catastrophic_correlation_trials": catastrophic_trials,
         "catastrophic_correlation_rate": catastrophic_rate,

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -19,6 +19,26 @@ The immediate gate is keeping recurring benchmark truth publication complete, fr
 
 Operator commands only count as proof when they are run from a clean, current `origin/main` observer. A dirty or diverged founder checkout is planning context, not runtime truth.
 
+### `B2` guard expansion criteria
+
+`B2` stays closed by default. Do not widen it based on a single green anecdote or a one-off publish.
+
+Treat "repeated bounded runs" as **at least 3 consecutive weekly green corpus runs on current `main`**. For this gate, a weekly run is green only when all of the following remain true:
+
+- `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` is fresh for the current corpus revision and reports complete coverage for that revision
+- `docs/status/TW03_RESCUE_PRODUCTIZATION_STATUS.md` is fresh and reports `0` repeated rescue classes in the current ledger window
+- the recurring publication completed on current `main` without gaps that would make the proof surface incomplete, stale, or misleading
+
+If any weekly run is missing, incomplete, stale, or introduces a repeated rescue-class regression, reset the count and keep `B2` closed.
+
+The only execution classes currently safe enough for `B2` guard consideration are:
+
+- dependency bumps with bounded surface area and existing validation already in the repo
+- config changes that are additive, reversible, and stay inside already-proven live paths
+- fail-closed fixes that narrow unsafe behavior without widening execution scope
+
+Meeting the 3-run gate only permits guarded expansion inside those three classes. It does not permit broader scope widening, new product surfaces, or speculative autonomy work.
+
 What is already true:
 
 - boss, supervisor, tranche, and swarm infrastructure exist
@@ -188,7 +208,7 @@ Have the system draft work orders, scope, and validation plans for the safest cl
 
 ### Booster 2 — Guard
 
-Add worker contracts and production-equivalent preflight for the safe classes that already benchmark well. Auto-run only when those guards pass.
+Add worker contracts and production-equivalent preflight for the safe classes that already benchmark well: dependency bumps, additive/reversible config changes, and fail-closed fixes. Auto-run only when those guards pass and the explicit `B2` gate above has been met.
 
 ### Booster 3 — Repair
 

--- a/docs/methodology/H2_PARTIAL_MULTI_SEEDED_2026-05-04.md
+++ b/docs/methodology/H2_PARTIAL_MULTI_SEEDED_2026-05-04.md
@@ -1,0 +1,39 @@
+# H2 Partial Multi-Seeded Judge Contract Note
+
+Date: 2026-05-04
+
+## Context
+
+Round 31b H2 compared the landed single-family Anthropic baseline against a
+fallback-aware heterogeneous panel. The comparator result was mechanically
+`NO-GO` under strict CI separation, but the operator-facing settlement position
+was downgraded to `INSUFFICIENT-WITH-DATA` after transcript review found an
+underspecified judge contract for `multi_seeded_error` prompts.
+
+The ambiguous case is a response that catches one seeded error in a prompt that
+contains multiple seeded errors. The previous judge prompt used singular wording:
+"the seeded error." The judge could reasonably interpret a partial catch as a
+miss because it did not catch every seeded error, but that behavior was not
+explicitly specified.
+
+## Contract Repair
+
+The judge contract now makes the multi-seeded case explicit:
+
+- `flagged_correctly`: names every seeded error, or a strict superset that
+  includes every seeded error plus additional legitimate strict issues.
+- `partial_multi_seeded`: names a strict non-empty subset of seeded errors, but
+  not all of them.
+- `missed`: names none of the seeded errors.
+- `flagged_wrongly`: flags an error that is not present and not seeded.
+
+`partial_multi_seeded` is a separate metric signal. It is not silently counted as
+`independent_flag_successes`, so existing comparator verdict behavior remains
+stable unless a future methodology PR explicitly changes the verdict rule.
+
+## Non-Claims
+
+This contract repair does not re-judge prior receipts, does not regenerate the
+baseline, does not change the comparator verdict rule, does not settle H2, and
+does not close #6375. A corrected H2 verdict requires symmetric re-judging or
+regeneration under this amended contract.

--- a/scripts/judge_heterogeneity_transcripts.py
+++ b/scripts/judge_heterogeneity_transcripts.py
@@ -126,7 +126,19 @@ def _build_batch_judge_prompt(prompt: ProbePrompt, turns: Sequence[dict[str, Any
 
     if prompt.seeded_errors:
         no_seeded_guidance = ""
+        if len(prompt.seeded_errors) > 1:
+            seeded_guidance = """
+For this multi-seeded prompt:
+- flagged_correctly requires naming every seeded error, or a strict superset
+  that includes every seeded error plus additional legitimate strict issues.
+- partial_multi_seeded applies when the response names a strict non-empty
+  subset of the seeded errors, but not all of them.
+- missed applies only when the response names none of the seeded errors.
+"""
+        else:
+            seeded_guidance = ""
     else:
+        seeded_guidance = ""
         no_seeded_guidance = """
 For this no-seeded-error prompt:
 - classify NO_CONCRETE_ERROR / "no factual error found" as missed.
@@ -143,6 +155,7 @@ PROMPT GIVEN TO PANELISTS:
 
 KNOWN SEEDED ERROR GROUND TRUTH:
 {_seeded_error_text(prompt)}
+{seeded_guidance}
 {no_seeded_guidance}
 
 PANELIST RESPONSES:
@@ -150,13 +163,16 @@ PANELIST RESPONSES:
 {panelist_responses}
 
 Return valid JSON only, exactly in this shape:
-{{"results":[{{"agent":"<agent>","verdict":"flagged_correctly|flagged_wrongly|missed|ambiguous","rationale":"one concise sentence"}}]}}
+{{"results":[{{"agent":"<agent>","verdict":"flagged_correctly|partial_multi_seeded|flagged_wrongly|missed|ambiguous","rationale":"one concise sentence"}}]}}
 
 Rules:
 - Include exactly one result for every AGENT block above.
-- flagged_correctly: response names the seeded error or a strict superset.
-- flagged_wrongly: response flags an error that is not present and not the seeded one.
-- missed: response does not flag the seeded error.
+- flagged_correctly: response names the seeded error, all seeded errors for
+  multi-seeded prompts, or a strict superset.
+- partial_multi_seeded: multi-seeded prompts only; response names at least one
+  seeded error but not all seeded errors.
+- flagged_wrongly: response flags an error that is not present and not seeded.
+- missed: response does not flag any seeded error.
 - ambiguous: you cannot decide; explain why in one sentence.
 - Do not classify dispatch failures; they are handled outside the judge.
 """

--- a/scripts/run_heterogeneity_probe.py
+++ b/scripts/run_heterogeneity_probe.py
@@ -52,6 +52,7 @@ DEFAULT_PANEL_MODELS = (
 VALID_CLASSIFICATION_VERDICTS = frozenset(
     {
         "flagged_correctly",
+        "partial_multi_seeded",
         "flagged_wrongly",
         "missed",
         "ambiguous",

--- a/tests/heterogeneity/test_judge.py
+++ b/tests/heterogeneity/test_judge.py
@@ -12,6 +12,14 @@ def test_parse_judge_output_accepts_strict_json() -> None:
     assert parsed.rationale == "did not name it"
 
 
+def test_parse_judge_output_accepts_partial_multi_seeded_verdict() -> None:
+    parsed = parse_judge_output(
+        '{"verdict":"partial_multi_seeded","rationale":"caught one seeded error"}'
+    )
+    assert parsed.verdict == "partial_multi_seeded"
+    assert parsed.rationale == "caught one seeded error"
+
+
 def test_parse_judge_output_rejects_unknown_verdict() -> None:
     with pytest.raises(ValueError, match="unknown judge verdict"):
         parse_judge_output('{"verdict":"maybe","rationale":"x"}')
@@ -27,6 +35,16 @@ def test_build_judge_prompt_includes_seeded_error() -> None:
     assert "valid JSON" in rendered
 
 
+def test_build_judge_prompt_keeps_single_seeded_guidance_simple() -> None:
+    prompt = load_prompt_file(
+        "tests/heterogeneity/probe_prompts/single_seeded_error/01_revert_window_off_by_one.md"
+    )
+    rendered = build_judge_prompt(prompt, "The window is actually 14 days.")
+    assert "For this multi-seeded prompt" not in rendered
+    assert "strict non-empty" not in rendered
+    assert "partial_multi_seeded: multi-seeded prompts only" in rendered
+
+
 def test_build_judge_prompt_includes_plural_seeded_errors() -> None:
     prompt = load_prompt_file(
         "tests/heterogeneity/probe_prompts/multi_seeded_error/01_thresholds_and_window.md"
@@ -36,6 +54,11 @@ def test_build_judge_prompt_includes_plural_seeded_errors() -> None:
     assert "- Logical inversion" in rendered
     assert "[aragora/review/invalidation.py:103-105]" in rendered
     assert "[aragora/review/invalidation.py:108-114]" in rendered
+    assert "For this multi-seeded prompt" in rendered
+    assert "partial_multi_seeded applies" in rendered
+    assert "strict non-empty" in rendered
+    assert "subset of the seeded errors" in rendered
+    assert "missed applies only when the response names none" in rendered
 
 
 def test_build_judge_prompt_includes_no_seeded_error_guidance() -> None:

--- a/tests/heterogeneity/test_probe_metrics.py
+++ b/tests/heterogeneity/test_probe_metrics.py
@@ -48,6 +48,8 @@ def test_compute_metrics_counts_seeded_and_correlation_classes() -> None:
     assert metrics["independent_flag_successes"] == 13
     assert metrics["independent_flag_trials"] == 18
     assert metrics["independent_flag_rate"] == 13 / 18
+    assert metrics["partial_multi_seeded_successes"] == 0
+    assert metrics["partial_multi_seeded_trials"] == 6
     assert metrics["catastrophic_correlation_failures"] == 1
     assert metrics["catastrophic_correlation_trials"] == 1
     assert metrics["catastrophic_correlation_rate"] == 1.0
@@ -57,6 +59,23 @@ def test_compute_metrics_counts_seeded_and_correlation_classes() -> None:
     assert metrics["null_negative_false_positives"] == 0
     assert metrics["null_negative_false_positive_trials"] == 6
     assert metrics["false_positive_rate_on_null_negative"] == 0
+
+
+def test_compute_metrics_tracks_partial_multi_seeded_separately() -> None:
+    results = [
+        _result(
+            "m1",
+            "multi_seeded_error",
+            ["partial_multi_seeded"] * 4 + ["flagged_correctly", "missed"],
+        ),
+        _result("s1", "single_seeded_error", ["partial_multi_seeded"] + ["missed"] * 5),
+    ]
+    metrics = compute_metrics(results, n_panelists=6)
+    assert metrics["independent_flag_successes"] == 1
+    assert metrics["independent_flag_trials"] == 12
+    assert metrics["independent_flag_rate"] == 1 / 12
+    assert metrics["partial_multi_seeded_successes"] == 4
+    assert metrics["partial_multi_seeded_trials"] == 6
 
 
 def test_decide_verdict_reports_insufficient_prompt_classes() -> None:

--- a/tests/heterogeneity/test_receipt.py
+++ b/tests/heterogeneity/test_receipt.py
@@ -34,6 +34,8 @@ def test_receipt_id_excludes_produced_at(tmp_path) -> None:
     assert path.name == f"{first['receipt_id']}.json"
     assert first["metrics"]["independent_flag_successes"] == 1
     assert first["metrics"]["independent_flag_trials"] == 2
+    assert first["metrics"]["partial_multi_seeded_successes"] == 0
+    assert first["metrics"]["partial_multi_seeded_trials"] == 0
 
 
 def test_receipt_preserves_plural_seeded_errors() -> None:
@@ -44,7 +46,7 @@ def test_receipt_preserves_plural_seeded_errors() -> None:
         prompt,
         (
             PanelistClassification(agent="a", verdict="flagged_correctly"),
-            PanelistClassification(agent="b", verdict="flagged_correctly"),
+            PanelistClassification(agent="b", verdict="partial_multi_seeded"),
         ),
     )
     receipt = build_probe_receipt(
@@ -57,3 +59,6 @@ def test_receipt_preserves_plural_seeded_errors() -> None:
     breakdown = receipt["per_prompt_breakdown"][0]
     assert len(breakdown["seeded_errors"]) == 2
     assert breakdown["seeded_error"] == breakdown["seeded_errors"][0]
+    assert receipt["metrics"]["independent_flag_successes"] == 1
+    assert receipt["metrics"]["partial_multi_seeded_successes"] == 1
+    assert receipt["metrics"]["partial_multi_seeded_trials"] == 2

--- a/tests/scripts/test_judge_heterogeneity_transcripts.py
+++ b/tests/scripts/test_judge_heterogeneity_transcripts.py
@@ -75,6 +75,64 @@ print(json.dumps({"results": [{"agent": "solo", "verdict": "flagged_correctly", 
     )
 
 
+def _write_multi_seeded_prompt(root: Path) -> None:
+    prompt_dir = root / "multi_seeded_error"
+    prompt_dir.mkdir(parents=True)
+    (prompt_dir / "01_fixture.md").write_text(
+        """---
+prompt_id: mse_fixture
+class: multi_seeded_error
+seeded_errors:
+  - description: "first seeded error"
+  - description: "second seeded error"
+expected_flags: 1
+---
+
+Fixture prompt with two seeded errors.
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_multi_seeded_transcript(path: Path) -> None:
+    rows = [
+        {
+            "type": "round",
+            "round_id": "fixture-mse_fixture",
+            "metadata": {"prompt_id": "mse_fixture", "class": "multi_seeded_error"},
+            "prompt": "fixture prompt",
+        },
+        {
+            "type": "turn",
+            "agent": "solo",
+            "returncode": 0,
+            "timed_out": False,
+            "error": None,
+            "stdout": "The first seeded error is present.",
+            "stderr": "",
+        },
+    ]
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _write_fake_partial_multi_seeded_judge(path: Path) -> None:
+    path.write_text(
+        """
+from __future__ import annotations
+
+import json
+import sys
+
+prompt = sys.argv[-1]
+assert "partial_multi_seeded" in prompt
+assert "strict non-empty" in prompt
+assert "subset of the seeded errors" in prompt
+print(json.dumps({"results": [{"agent": "solo", "verdict": "partial_multi_seeded", "rationale": "caught one seeded error"}]}))
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
 def test_judge_bridge_writes_classifications_and_receipt_input(tmp_path: Path) -> None:
     transcript_dir = tmp_path / "transcripts"
     transcript_dir.mkdir()
@@ -171,6 +229,47 @@ def test_judge_bridge_normalizes_no_seeded_flagged_correctly(tmp_path: Path) -> 
     assert classifications[0]["rationale"].startswith(
         "normalized no-seeded-error flagged_correctly to missed:"
     )
+
+
+def test_judge_bridge_accepts_partial_multi_seeded_verdict(tmp_path: Path) -> None:
+    prompt_root = tmp_path / "prompts"
+    _write_multi_seeded_prompt(prompt_root)
+    transcript_dir = tmp_path / "transcripts"
+    transcript_dir.mkdir()
+    _write_multi_seeded_transcript(transcript_dir / "dialog-fixture-mse_fixture.jsonl")
+    fake_judge = tmp_path / "fake_partial_judge.py"
+    _write_fake_partial_multi_seeded_judge(fake_judge)
+    output = tmp_path / "classifications.json"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--transcript-dir",
+            str(transcript_dir),
+            "--prompt-root",
+            str(prompt_root),
+            "--all-prompts",
+            "--output",
+            str(output),
+            "--judge-command",
+            f"{sys.executable} {fake_judge}",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    classifications = payload["results"][0]["classifications"]
+    assert classifications == [
+        {
+            "agent": "solo",
+            "rationale": "caught one seeded error",
+            "verdict": "partial_multi_seeded",
+        }
+    ]
 
 
 def test_judge_bridge_rejects_missing_transcript(tmp_path: Path) -> None:

--- a/tests/scripts/test_run_heterogeneity_probe.py
+++ b/tests/scripts/test_run_heterogeneity_probe.py
@@ -106,6 +106,75 @@ def test_probe_script_writes_receipt_from_classifications_file(tmp_path) -> None
     assert "external judged classifications" in receipt["scope_caveats"][0]
 
 
+def test_probe_script_accepts_partial_multi_seeded_classification(tmp_path) -> None:
+    prompt_root = tmp_path / "prompts"
+    prompt_dir = prompt_root / "multi_seeded_error"
+    prompt_dir.mkdir(parents=True)
+    (prompt_dir / "01_fixture.md").write_text(
+        """---
+prompt_id: mse_fixture
+class: multi_seeded_error
+seeded_errors:
+  - description: "first seeded error"
+  - description: "second seeded error"
+expected_flags: 1
+---
+
+Fixture prompt with two seeded errors.
+""",
+        encoding="utf-8",
+    )
+    classifications_file = tmp_path / "classifications.json"
+    classifications_file.write_text(
+        json.dumps(
+            {
+                "judge_model": "fixture",
+                "panel_models": ["solo"],
+                "results": [
+                    {
+                        "prompt_id": "mse_fixture",
+                        "classifications": [
+                            {
+                                "agent": "solo",
+                                "verdict": "partial_multi_seeded",
+                                "rationale": "caught one seeded error",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--prompt-root",
+            str(prompt_root),
+            "--all-prompts",
+            "--classifications-file",
+            str(classifications_file),
+            "--output-root",
+            str(tmp_path / "out"),
+            "--run-id",
+            "partial",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    payload = json.loads(proc.stdout)
+    receipt = json.loads(Path(payload["receipt_path"]).read_text(encoding="utf-8"))
+    assert receipt["metrics"]["independent_flag_successes"] == 0
+    assert receipt["metrics"]["partial_multi_seeded_successes"] == 1
+    assert receipt["metrics"]["partial_multi_seeded_trials"] == 1
+
+
 def test_probe_script_rejects_duplicate_classification_agents(tmp_path) -> None:
     proc = _run_with_classifications(
         tmp_path,


### PR DESCRIPTION
## Summary
- Add explicit `partial_multi_seeded` judge verdict for multi-seeded heterogeneity prompts.
- Track partial multi-seeded detections as separate receipt metrics without counting them as `independent_flag_successes`.
- Update transcript-judging and classification-file ingestion paths to accept the new verdict.
- Add a methodology note documenting the Round 31b H2 ambiguity and non-claims.

## Scope / Non-Claims
- Does not re-judge prior receipts.
- Does not regenerate the #6962 baseline.
- Does not change comparator verdict logic.
- Does not settle H2 or close #6375.
- Does not run paid model calls.

## Validation
- `python3 -m ruff check aragora/heterogeneity/judge.py aragora/heterogeneity/probe.py scripts/judge_heterogeneity_transcripts.py scripts/run_heterogeneity_probe.py tests/heterogeneity/test_judge.py tests/heterogeneity/test_probe_metrics.py tests/heterogeneity/test_receipt.py tests/scripts/test_judge_heterogeneity_transcripts.py tests/scripts/test_run_heterogeneity_probe.py`
- `python3 -m ruff format --check aragora/heterogeneity/judge.py aragora/heterogeneity/probe.py scripts/judge_heterogeneity_transcripts.py scripts/run_heterogeneity_probe.py tests/heterogeneity/test_judge.py tests/heterogeneity/test_probe_metrics.py tests/heterogeneity/test_receipt.py tests/scripts/test_judge_heterogeneity_transcripts.py tests/scripts/test_run_heterogeneity_probe.py`
- `python3 -m pytest tests/heterogeneity/test_judge.py tests/heterogeneity/test_probe_metrics.py tests/heterogeneity/test_receipt.py tests/scripts/test_judge_heterogeneity_transcripts.py tests/scripts/test_run_heterogeneity_probe.py -q -p no:randomly` -> 29 passed
- `python3 -m pytest tests/heterogeneity tests/scripts/test_judge_heterogeneity_transcripts.py tests/scripts/test_run_heterogeneity_probe.py -q -p no:randomly` -> 36 passed
- `python3 scripts/compare_baseline_vs_panel.py --baseline-receipt docs/receipts/heterogeneity/baseline-single-family-anthropic-20260504T030352Z.receipt.json --panel-receipt .aragora/evolve-round/2026-05-04-round-31b-h2/phase-h2-panel.json --output-receipt /tmp/h2-compare-after-judge-contract.json --json` -> `NO-GO`, receipt `8f0f32eb3f1cff8ad8bd99e379d182a5b3a97e1e5f549bb19c5a01228786fa81`
- `gitleaks detect --no-git --source /tmp/aragora-judge-contract.diff --redact --no-banner` -> no leaks
