### PR TITLE
fix(heterogeneity): bind receipts to transcript sidecars

### DIFF
--- a/aragora/heterogeneity/__init__.py
+++ b/aragora/heterogeneity/__init__.py
@@ -18,7 +18,14 @@ from aragora.heterogeneity.prompts import (
 )
 from aragora.heterogeneity.receipt import (
     HETEROGENEITY_RECEIPT_SCHEMA_VERSION,
+    SOURCE_ARTIFACT_HASH_SPEC,
+    TRANSCRIPT_SIDECAR_ROLE,
+    MissingProvenanceError,
+    build_source_artifact,
     compute_receipt_id,
+    require_source_artifacts,
+    sha256_file,
+    source_artifact_status,
     write_receipt,
 )
 
@@ -26,16 +33,23 @@ __all__ = [
     "ACCEPTANCE_GATES",
     "DEFAULT_PILOT_CLASS_QUOTAS",
     "HETEROGENEITY_RECEIPT_SCHEMA_VERSION",
+    "SOURCE_ARTIFACT_HASH_SPEC",
+    "TRANSCRIPT_SIDECAR_ROLE",
+    "MissingProvenanceError",
     "PanelistClassification",
     "ProbePrompt",
     "PromptProbeResult",
     "SeededError",
+    "build_source_artifact",
     "build_probe_receipt",
     "compute_metrics",
     "compute_receipt_id",
     "decide_verdict",
     "load_prompt_file",
     "load_prompt_set",
+    "require_source_artifacts",
     "select_pilot_prompts",
+    "sha256_file",
+    "source_artifact_status",
     "write_receipt",
 ]

--- a/aragora/heterogeneity/probe.py
+++ b/aragora/heterogeneity/probe.py
@@ -266,6 +266,7 @@ def build_probe_receipt(
     judge_model: str,
     pilot_token_spend_usd_estimate: float = 0.0,
     scope_caveats: Sequence[str] = (),
+    source_artifacts: Sequence[Mapping[str, Any]] = (),
     produced_at: str | None = None,
 ) -> dict[str, Any]:
     """Build a deterministic HeterogeneityProbeReceipt.v1 payload."""
@@ -303,5 +304,7 @@ def build_probe_receipt(
         "pilot_token_spend_usd_estimate": pilot_token_spend_usd_estimate,
         "scope_caveats": list(scope_caveats),
     }
+    if source_artifacts:
+        receipt["source_artifacts"] = [dict(artifact) for artifact in source_artifacts]
     receipt["receipt_id"] = compute_receipt_id(receipt)
     return receipt

--- a/aragora/heterogeneity/receipt.py
+++ b/aragora/heterogeneity/receipt.py
@@ -9,6 +9,12 @@ from pathlib import Path
 from typing import Any, Mapping
 
 HETEROGENEITY_RECEIPT_SCHEMA_VERSION = "heterogeneity_probe_receipt.v1"
+SOURCE_ARTIFACT_HASH_SPEC = "sha256(raw file bytes)"
+TRANSCRIPT_SIDECAR_ROLE = "transcript_sidecar"
+
+
+class MissingProvenanceError(ValueError):
+    """Raised when a settlement-grade receipt lacks required source artifacts."""
 
 
 def canonical_json(payload: Mapping[str, Any]) -> str:
@@ -24,11 +30,163 @@ def compute_receipt_id(receipt: Mapping[str, Any]) -> str:
     return hashlib.sha256(canonical_json(body).encode("utf-8")).hexdigest()
 
 
-def write_receipt(receipt: Mapping[str, Any], output_dir: str | Path) -> Path:
+def sha256_file(path: str | Path) -> str:
+    """Return the SHA-256 digest for the exact bytes at ``path``."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _portable_path(path: Path, *, root: str | Path | None) -> str:
+    if root is None:
+        return str(path)
+    try:
+        return str(path.resolve().relative_to(Path(root).resolve()))
+    except ValueError:
+        return str(path)
+
+
+def build_source_artifact(
+    path: str | Path,
+    *,
+    role: str = TRANSCRIPT_SIDECAR_ROLE,
+    format: str,
+    root: str | Path | None = None,
+    required_for_rejudge: bool = True,
+    text_capture: str = "full",
+    created_before_receipt_id: bool = True,
+) -> dict[str, Any]:
+    """Build a source-artifact binding for a receipt."""
+    artifact_path = Path(path)
+    return {
+        "role": role,
+        "path": _portable_path(artifact_path, root=root),
+        "sha256": sha256_file(artifact_path),
+        "bytes": artifact_path.stat().st_size,
+        "format": format,
+        "hash_spec": SOURCE_ARTIFACT_HASH_SPEC,
+        "required_for_rejudge": required_for_rejudge,
+        "text_capture": text_capture,
+        "created_before_receipt_id": created_before_receipt_id,
+    }
+
+
+def _artifact_path(artifact: Mapping[str, Any], *, base_dir: str | Path | None) -> Path | None:
+    raw_path = artifact.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    path = Path(raw_path)
+    if path.is_absolute() or base_dir is None:
+        return path
+    return Path(base_dir) / path
+
+
+def source_artifact_status(
+    receipt: Mapping[str, Any],
+    *,
+    base_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Return source-artifact binding status without rejecting legacy receipts."""
+    artifacts = receipt.get("source_artifacts")
+    if artifacts is None:
+        return {
+            "canonical": False,
+            "status": "legacy_unbound",
+            "source_artifact_count": 0,
+            "problems": ["missing_source_artifacts"],
+        }
+    if not isinstance(artifacts, list):
+        return {
+            "canonical": False,
+            "status": "malformed_source_artifacts",
+            "source_artifact_count": 0,
+            "problems": ["source_artifacts_not_list"],
+        }
+
+    problems: list[str] = []
+    checked = 0
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, Mapping):
+            problems.append(f"artifact_{index}:not_object")
+            continue
+        path = _artifact_path(artifact, base_dir=base_dir)
+        if path is None:
+            problems.append(f"artifact_{index}:missing_path")
+            continue
+        expected_sha = artifact.get("sha256")
+        expected_bytes = artifact.get("bytes")
+        if not isinstance(expected_sha, str) or len(expected_sha) != 64:
+            problems.append(f"artifact_{index}:missing_sha256")
+            continue
+        if not path.exists():
+            problems.append(f"artifact_{index}:transcript_missing")
+            continue
+        if isinstance(expected_bytes, int) and path.stat().st_size != expected_bytes:
+            problems.append(f"artifact_{index}:bytes_mismatch")
+            continue
+        if sha256_file(path) != expected_sha:
+            problems.append(f"artifact_{index}:hash_mismatch")
+            continue
+        checked += 1
+
+    if not artifacts:
+        problems.append("empty_source_artifacts")
+    if problems:
+        if any(problem.endswith(":transcript_missing") for problem in problems):
+            status = "transcript_missing"
+        elif any(
+            problem.endswith(":hash_mismatch") or problem.endswith(":bytes_mismatch")
+            for problem in problems
+        ):
+            status = "hash_mismatch"
+        else:
+            status = "malformed_source_artifacts"
+        return {
+            "canonical": False,
+            "status": status,
+            "source_artifact_count": len(artifacts),
+            "checked_source_artifact_count": checked,
+            "problems": problems,
+        }
+
+    return {
+        "canonical": True,
+        "status": "bound",
+        "source_artifact_count": len(artifacts),
+        "checked_source_artifact_count": checked,
+        "problems": [],
+    }
+
+
+def require_source_artifacts(
+    receipt: Mapping[str, Any],
+    *,
+    base_dir: str | Path | None = None,
+) -> None:
+    """Fail closed unless ``receipt`` is bound to existing source artifacts."""
+    status = source_artifact_status(receipt, base_dir=base_dir)
+    if status.get("canonical") is not True:
+        raise MissingProvenanceError(
+            "receipt source artifacts are not bound: "
+            f"{status.get('status')} ({', '.join(map(str, status.get('problems', [])))})"
+        )
+
+
+def write_receipt(
+    receipt: Mapping[str, Any],
+    output_dir: str | Path,
+    *,
+    require_bound_source_artifacts: bool = False,
+    artifact_base_dir: str | Path | None = None,
+) -> Path:
     """Write a receipt under ``output_dir`` using its receipt ID."""
     receipt_id = receipt.get("receipt_id")
     if not isinstance(receipt_id, str) or not receipt_id:
         raise ValueError("receipt must include a non-empty receipt_id")
+    if require_bound_source_artifacts:
+        require_source_artifacts(receipt, base_dir=artifact_base_dir)
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"{receipt_id}.json"

--- a/docs/methodology/H2_TRANSCRIPT_PROVENANCE_2026-05-05.md
+++ b/docs/methodology/H2_TRANSCRIPT_PROVENANCE_2026-05-05.md
@@ -1,0 +1,60 @@
+# H2 Transcript Provenance Guard
+
+Date: 2026-05-05
+
+## Problem
+
+Round 31b H2 exposed a receipt-to-transcript preservation gap. The final
+single-family baseline receipt survived at
+`docs/receipts/heterogeneity/baseline-single-family-anthropic-20260504T030352Z.receipt.json`,
+but the matching transcript sidecar
+`.aragora/evolve-round/2026-05-01b/transcripts/baseline-single-family-anthropic-20260504T030352Z.transcripts.json`
+was not present on disk. That made a symmetric raw-text re-judge under the
+post-#7014 judge contract impossible without re-running baseline panel calls.
+
+## Guard
+
+New heterogeneity probe receipts can carry a top-level `source_artifacts` array.
+For transcript evidence, each artifact records:
+
+- `role: transcript_sidecar`
+- `path`
+- `sha256`
+- `bytes`
+- `format`
+- `hash_spec: sha256(raw file bytes)`
+- `required_for_rejudge`
+- `text_capture`
+- `created_before_receipt_id`
+
+The artifact metadata is included in `receipt_id` hashing. If transcript bytes
+change after receipt production, the binding no longer validates.
+
+## Policy
+
+New settlement-grade receipts should fail closed when source artifacts are
+missing or hash-mismatched. Legacy `heterogeneity_probe_receipt.v1` receipts
+without `source_artifacts` are still readable, but comparison receipts label
+them `legacy_unbound` and set `comparison_canonical: false`.
+
+This PR does not retroactively hash old receipts. Retroactive hashing would turn
+an honest "artifact not bound at production time" into a false provenance claim.
+
+## Legacy Receipts
+
+The following known receipts remain valid historical receipts but are
+provenance-unbound unless a future operator explicitly reruns the producer:
+
+- `docs/receipts/heterogeneity/baseline-single-family-anthropic-20260504T030352Z.receipt.json`
+- `.aragora/evolve-round/2026-05-04-round-31b-h2/phase-h2-panel.json`
+- `.aragora/evolve-round/2026-05-04-round-31b-h2/phase-h2-comparison.json`
+- `.aragora/evolve-round/2026-05-04-round-31b-h2/round-receipt-final.json`
+
+## Non-Claims
+
+This guard does not re-judge any receipt, rerun the H2 panel, mutate historical
+H2 artifacts, settle H2, close #6375, or modify the strict CI-separation
+verdict rule. It only binds future receipt evidence to transcript sidecars.
+
+Ledger-to-receipt hash binding is a separate follow-up. This guard binds probe
+receipts to transcript evidence, not round ledgers to every downstream receipt.

--- a/scripts/compare_baseline_vs_panel.py
+++ b/scripts/compare_baseline_vs_panel.py
@@ -19,6 +19,7 @@ from aragora.heterogeneity.probe import ACCEPTANCE_GATES, SEEDED_CLASSES
 from aragora.heterogeneity.receipt import (
     HETEROGENEITY_RECEIPT_SCHEMA_VERSION,
     canonical_json,
+    source_artifact_status,
 )
 
 COMPARISON_RECEIPT_SCHEMA_VERSION = "heterogeneity_comparison_receipt.v1"
@@ -352,6 +353,18 @@ def _metrics_summary(receipt: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _receipt_provenance(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    status = source_artifact_status(receipt, base_dir=ROOT)
+    artifacts = receipt.get("source_artifacts", [])
+    return {
+        "canonical": status["canonical"],
+        "status": status["status"],
+        "problems": list(status.get("problems", [])),
+        "source_artifact_count": status.get("source_artifact_count", 0),
+        "source_artifacts": artifacts if isinstance(artifacts, list) else [],
+    }
+
+
 def _fp_flags(
     baseline_receipt: Mapping[str, Any], panel_receipt: Mapping[str, Any]
 ) -> dict[str, Any]:
@@ -460,6 +473,17 @@ def build_comparison_receipt(
     composition_match, composition = _composition_match(baseline_receipt, panel_receipt)
     provider_rule = evaluate_provider_rule(panel_receipt)
     fallback_summary = provider_summary(panel_receipt)
+    baseline_provenance = _receipt_provenance(baseline_receipt)
+    panel_provenance = _receipt_provenance(panel_receipt)
+    comparison_canonical = bool(baseline_provenance["canonical"] and panel_provenance["canonical"])
+    non_canonical_inputs = [
+        name
+        for name, provenance in (
+            ("baseline_receipt", baseline_provenance),
+            ("panel_receipt", panel_provenance),
+        )
+        if provenance["canonical"] is not True
+    ]
     verdict, verdict_reason = _verdict(
         baseline_receipt,
         panel_receipt,
@@ -477,6 +501,8 @@ def build_comparison_receipt(
         "baseline_receipt_id": _receipt_id(baseline_receipt),
         "panel_receipt_path": panel_receipt_path,
         "panel_receipt_id": _receipt_id(panel_receipt),
+        "comparison_canonical": comparison_canonical,
+        "non_canonical_inputs": non_canonical_inputs,
         "composition_match": composition_match,
         "fallback_augmented": fallback_summary["fallback_augmented"],
         "verdict": verdict,
@@ -486,6 +512,10 @@ def build_comparison_receipt(
         "panel_metrics": _metrics_summary(panel_receipt),
         "comparison": {
             "composition": composition,
+            "input_provenance": {
+                "baseline_receipt": baseline_provenance,
+                "panel_receipt": panel_provenance,
+            },
             "provider_rule": provider_rule,
             "provider_summary": fallback_summary,
             "independent_flag_rate_ci_gap": {
@@ -518,6 +548,7 @@ def _summary(receipt: Mapping[str, Any]) -> dict[str, Any]:
         "verdict": receipt.get("verdict"),
         "verdict_reason": receipt.get("verdict_reason"),
         "composition_match": receipt.get("composition_match"),
+        "comparison_canonical": receipt.get("comparison_canonical"),
         "provider_rule_satisfied": provider_rule.get("satisfied"),
         "provider_distribution": provider_rule.get("provider_distribution", {}),
     }
@@ -535,6 +566,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         choices=(STRICT_CI_SEPARATION, ADDITIVE_MARGIN),
         default=STRICT_CI_SEPARATION,
     )
+    parser.add_argument(
+        "--require-canonical-inputs",
+        action="store_true",
+        help="Fail closed unless both input receipts are bound to source artifacts.",
+    )
     parser.add_argument("--json", action="store_true", help="Print a JSON summary to stdout.")
     return parser.parse_args(argv)
 
@@ -551,6 +587,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             panel_receipt_path=str(args.panel_receipt),
             verdict_rule=args.verdict_rule,
         )
+        if (
+            args.require_canonical_inputs
+            and comparison_receipt.get("comparison_canonical") is not True
+        ):
+            raise ComparisonError(
+                "comparison inputs are not canonical: "
+                + ", ".join(map(str, comparison_receipt.get("non_canonical_inputs", [])))
+            )
         _write_output_receipt(comparison_receipt, args.output_receipt)
     except ComparisonError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/scripts/judge_heterogeneity_transcripts.py
+++ b/scripts/judge_heterogeneity_transcripts.py
@@ -26,6 +26,7 @@ from aragora.heterogeneity.prompts import (  # noqa: E402
     load_prompt_set,
     select_pilot_prompts,
 )
+from aragora.heterogeneity.receipt import build_source_artifact  # noqa: E402
 
 DEFAULT_PROMPT_ROOT = Path("tests/heterogeneity/probe_prompts")
 DEFAULT_JUDGE_COMMAND = "claude -p {prompt}"
@@ -315,15 +316,26 @@ def build_classifications(args: argparse.Namespace) -> dict[str, Any]:
     prompts = _select_prompts(args)
     raw_output_dir = args.raw_output_dir or args.transcript_dir.parent / "judge-raw"
     results: list[dict[str, Any]] = []
+    source_artifacts: list[dict[str, Any]] = []
     panel_models: list[str] | None = None
     for prompt in prompts:
+        transcript_path = _transcript_for_prompt(args.transcript_dir, prompt.prompt_id)
         classifications, prompt_panel = classify_prompt(
             prompt=prompt,
-            transcript_path=_transcript_for_prompt(args.transcript_dir, prompt.prompt_id),
+            transcript_path=transcript_path,
             raw_output_dir=raw_output_dir,
             judge_command=args.judge_command,
             timeout_seconds=args.timeout_seconds,
             reuse_raw=args.reuse_raw,
+        )
+        source_artifacts.append(
+            build_source_artifact(
+                transcript_path,
+                format="dialog_jsonl_transcript.v1",
+                root=ROOT,
+                required_for_rejudge=True,
+                text_capture="full",
+            )
         )
         if panel_models is None:
             panel_models = prompt_panel
@@ -335,6 +347,7 @@ def build_classifications(args: argparse.Namespace) -> dict[str, Any]:
     return {
         "judge_model": args.judge_model,
         "panel_models": panel_models or [],
+        "source_artifacts": source_artifacts,
         "results": results,
     }
 
@@ -349,6 +362,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "output": str(output),
         "judge_model": payload["judge_model"],
         "panel_models": payload["panel_models"],
+        "source_artifact_count": len(payload.get("source_artifacts", [])),
         "prompt_count": len(payload["results"]),
         "classification_count": sum(len(item["classifications"]) for item in payload["results"]),
     }

--- a/scripts/run_baseline_panel.py
+++ b/scripts/run_baseline_panel.py
@@ -52,6 +52,7 @@ from aragora.heterogeneity.prompts import (
     build_panel_prompt,
     load_prompt_file,
 )
+from aragora.heterogeneity.receipt import build_source_artifact
 
 
 PROMPTS_ROOT = REPO_ROOT / "tests" / "heterogeneity" / "probe_prompts"
@@ -463,7 +464,7 @@ def main() -> int:
                         "phase": "judge",
                         "ok": False,
                         "error": judge_resp["error"],
-                        "panel_text_preview": panel_resp["text"][:200],
+                        "panel_text": panel_resp["text"],
                     }
                 )
                 continue
@@ -507,8 +508,8 @@ def main() -> int:
                     "judge_input_tokens": judge_resp["input_tokens"],
                     "judge_output_tokens": judge_resp["output_tokens"],
                     "judge_latency_ms": judge_resp["latency_ms"],
-                    "panel_text": panel_resp["text"][:1500],
-                    "judge_text": judge_resp["text"][:600],
+                    "panel_text": panel_resp["text"],
+                    "judge_text": judge_resp["text"],
                     "cumulative_estimate_usd_after": round(cumulative_estimate_usd, 5),
                     "cumulative_actual_usd_after": round(cumulative_actual_usd, 5),
                 }
@@ -527,6 +528,33 @@ def main() -> int:
 
         if cumulative_actual_usd > BUDGET_HARD_CAP_USD:
             break
+
+    transcripts_path = (
+        REPO_ROOT
+        / ".aragora"
+        / "evolve-round"
+        / "2026-05-01b"
+        / "transcripts"
+        / f"{run_id}.transcripts.json"
+    )
+    transcripts_payload = {
+        "run_id": run_id,
+        "started_at": started_at,
+        "ended_at": datetime.now(timezone.utc).isoformat(),
+        "panel_models": panel_models,
+        "judge_model": JUDGE_MODEL,
+        "transcripts": transcripts,
+        "cumulative_estimate_usd": round(cumulative_estimate_usd, 5),
+        "cumulative_actual_usd": round(cumulative_actual_usd, 5),
+    }
+    _atomic_write_json(transcripts_path, transcripts_payload)
+    transcript_artifact = build_source_artifact(
+        transcripts_path,
+        format="baseline_panel_transcripts.v1",
+        root=REPO_ROOT,
+        required_for_rejudge=True,
+        text_capture="full",
+    )
 
     receipt = build_probe_receipt(
         run_id=run_id,
@@ -555,33 +583,12 @@ def main() -> int:
             f"Hard cap: ${BUDGET_HARD_CAP_USD}. Estimator trip: ${BUDGET_ESTIMATOR_TRIP_USD}.",
             f"Actual spend: ~${cumulative_actual_usd:.4f}.",
         ],
+        source_artifacts=[transcript_artifact],
         produced_at=started_at,
     )
 
     receipt_path = RECEIPTS_DIR / f"{run_id}.receipt.json"
     _atomic_write_json(receipt_path, receipt)
-
-    transcripts_path = (
-        REPO_ROOT
-        / ".aragora"
-        / "evolve-round"
-        / "2026-05-01b"
-        / "transcripts"
-        / f"{run_id}.transcripts.json"
-    )
-    _atomic_write_json(
-        transcripts_path,
-        {
-            "run_id": run_id,
-            "started_at": started_at,
-            "ended_at": datetime.now(timezone.utc).isoformat(),
-            "panel_models": panel_models,
-            "judge_model": JUDGE_MODEL,
-            "transcripts": transcripts,
-            "cumulative_estimate_usd": round(cumulative_estimate_usd, 5),
-            "cumulative_actual_usd": round(cumulative_actual_usd, 5),
-        },
-    )
 
     print()
     print("=== Round 31b Phase 1 baseline complete ===")

--- a/scripts/run_heterogeneity_probe.py
+++ b/scripts/run_heterogeneity_probe.py
@@ -86,6 +86,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--require-source-artifacts",
+        action="store_true",
+        help="Fail closed unless the classifications file carries bound transcript artifacts.",
+    )
+    parser.add_argument(
         "--dispatch-live-transcripts",
         action="store_true",
         help=(
@@ -145,13 +150,14 @@ def _synthetic_results(prompts: Sequence[ProbePrompt]) -> list[PromptProbeResult
 def _results_from_classifications_file(
     prompts: Sequence[ProbePrompt],
     path: Path,
-) -> tuple[list[PromptProbeResult], list[str], str]:
+) -> tuple[list[PromptProbeResult], list[str], str, list[dict[str, object]]]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError("classifications file must contain a JSON object")
     panel_models = payload.get("panel_models", DEFAULT_PANEL_MODELS)
     judge_model = payload.get("judge_model", "external-judge")
     raw_results = payload.get("results")
+    raw_source_artifacts = payload.get("source_artifacts", [])
     if not isinstance(panel_models, list) or not all(
         isinstance(item, str) for item in panel_models
     ):
@@ -160,6 +166,10 @@ def _results_from_classifications_file(
         raise ValueError("classifications file judge_model must be a non-empty string")
     if not isinstance(raw_results, list):
         raise ValueError("classifications file results must be a list")
+    if not isinstance(raw_source_artifacts, list) or not all(
+        isinstance(item, dict) for item in raw_source_artifacts
+    ):
+        raise ValueError("classifications file source_artifacts must be a list of objects")
 
     prompts_by_id = {prompt.prompt_id: prompt for prompt in prompts}
     results: list[PromptProbeResult] = []
@@ -219,7 +229,7 @@ def _results_from_classifications_file(
         raise ValueError(
             "classifications file missing results for prompt_ids: " + ", ".join(missing_prompt_ids)
         )
-    return results, panel_models, judge_model
+    return results, panel_models, judge_model, [dict(artifact) for artifact in raw_source_artifacts]
 
 
 async def _dispatch_live_transcripts(
@@ -285,14 +295,15 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.synthetic_fixture or args.classifications_file is not None:
         if args.classifications_file is not None:
-            results, panel_models, judge_model = _results_from_classifications_file(
-                prompts, args.classifications_file
+            results, panel_models, judge_model, source_artifacts = (
+                _results_from_classifications_file(prompts, args.classifications_file)
             )
             caveats = ["receipt computed from external judged classifications file"]
         else:
             results = _synthetic_results(prompts)
             panel_models = list(DEFAULT_PANEL_MODELS)
             judge_model = "synthetic-fixture"
+            source_artifacts = []
             caveats = [
                 "synthetic fixture only; not a live model or judge result",
                 "used for receipt plumbing and deterministic metric tests",
@@ -303,11 +314,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             panel_models=panel_models,
             judge_model=judge_model,
             scope_caveats=caveats,
+            source_artifacts=source_artifacts,
         )
-        receipt_path = write_receipt(receipt, args.output_root / run_id)
+        receipt_path = write_receipt(
+            receipt,
+            args.output_root / run_id,
+            require_bound_source_artifacts=args.require_source_artifacts,
+            artifact_base_dir=ROOT,
+        )
         payload["receipt_path"] = str(receipt_path)
         payload["receipt_verdict"] = receipt["verdict"]
         payload["receipt_id"] = receipt["receipt_id"]
+        payload["source_artifact_count"] = len(source_artifacts)
 
     if args.dispatch_live_transcripts:
         transcripts = asyncio.run(

--- a/tests/heterogeneity/test_receipt.py
+++ b/tests/heterogeneity/test_receipt.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
+import hashlib
+
+import pytest
+
 from aragora.heterogeneity.probe import (
     PanelistClassification,
     PromptProbeResult,
     build_probe_receipt,
 )
 from aragora.heterogeneity.prompts import load_prompt_file
-from aragora.heterogeneity.receipt import compute_receipt_id, write_receipt
+from aragora.heterogeneity.receipt import (
+    MissingProvenanceError,
+    build_source_artifact,
+    compute_receipt_id,
+    require_source_artifacts,
+    sha256_file,
+    source_artifact_status,
+    write_receipt,
+)
 
 
 def test_receipt_id_excludes_produced_at(tmp_path) -> None:
@@ -62,3 +74,94 @@ def test_receipt_preserves_plural_seeded_errors() -> None:
     assert receipt["metrics"]["independent_flag_successes"] == 1
     assert receipt["metrics"]["partial_multi_seeded_successes"] == 1
     assert receipt["metrics"]["partial_multi_seeded_trials"] == 2
+
+
+def test_source_artifact_hashes_exact_file_bytes(tmp_path) -> None:
+    transcript = tmp_path / "transcript.json"
+    transcript.write_bytes(b'{"transcript": "one"}\n')
+
+    artifact = build_source_artifact(
+        transcript,
+        format="test_transcript.v1",
+        root=tmp_path,
+        required_for_rejudge=True,
+        text_capture="full",
+    )
+
+    assert artifact["path"] == "transcript.json"
+    assert artifact["bytes"] == transcript.stat().st_size
+    assert artifact["sha256"] == hashlib.sha256(transcript.read_bytes()).hexdigest()
+    assert sha256_file(transcript) == artifact["sha256"]
+
+
+def test_source_artifacts_are_part_of_receipt_id(tmp_path) -> None:
+    transcript = tmp_path / "transcript.json"
+    transcript.write_text('{"transcript": "one"}\n', encoding="utf-8")
+    artifact = build_source_artifact(
+        transcript,
+        format="test_transcript.v1",
+        root=tmp_path,
+    )
+    result = PromptProbeResult(
+        prompt_id="p1",
+        prompt_class="single_seeded_error",
+        seeded_error="seed",
+        classifications=(PanelistClassification(agent="a", verdict="missed"),),
+    )
+
+    bound = build_probe_receipt(
+        run_id="run",
+        results=[result],
+        panel_models=["a"],
+        judge_model="fixture",
+        source_artifacts=[artifact],
+        produced_at="2026-04-30T00:00:00+00:00",
+    )
+    unbound = build_probe_receipt(
+        run_id="run",
+        results=[result],
+        panel_models=["a"],
+        judge_model="fixture",
+        produced_at="2026-04-30T00:00:00+00:00",
+    )
+
+    assert bound["receipt_id"] != unbound["receipt_id"]
+    assert bound["source_artifacts"] == [artifact]
+
+
+def test_source_artifact_status_distinguishes_legacy_bound_and_mutated(tmp_path) -> None:
+    transcript = tmp_path / "transcript.json"
+    transcript.write_text('{"transcript": "one"}\n', encoding="utf-8")
+    artifact = build_source_artifact(
+        transcript,
+        format="test_transcript.v1",
+        root=tmp_path,
+    )
+    receipt = {"source_artifacts": [artifact]}
+
+    legacy = source_artifact_status({})
+    assert legacy["canonical"] is False
+    assert legacy["status"] == "legacy_unbound"
+
+    bound = source_artifact_status(receipt, base_dir=tmp_path)
+    assert bound["canonical"] is True
+    assert bound["status"] == "bound"
+
+    transcript.write_text('{"transcript": "mutated"}\n', encoding="utf-8")
+    mutated = source_artifact_status(receipt, base_dir=tmp_path)
+    assert mutated["canonical"] is False
+    assert mutated["status"] == "hash_mismatch"
+
+
+def test_write_receipt_can_fail_closed_on_missing_source_artifacts(tmp_path) -> None:
+    receipt = {
+        "schema_version": "heterogeneity_probe_receipt.v1",
+        "receipt_id": "abc123",
+        "metrics": {},
+    }
+
+    with pytest.raises(MissingProvenanceError, match="legacy_unbound"):
+        write_receipt(receipt, tmp_path, require_bound_source_artifacts=True)
+
+    with pytest.raises(MissingProvenanceError, match="legacy_unbound"):
+        require_source_artifacts(receipt)

--- a/tests/scripts/test_compare_baseline_vs_panel.py
+++ b/tests/scripts/test_compare_baseline_vs_panel.py
@@ -7,6 +7,7 @@ import pytest
 
 from aragora.heterogeneity.receipt import (
     HETEROGENEITY_RECEIPT_SCHEMA_VERSION,
+    build_source_artifact,
     compute_receipt_id,
 )
 from scripts.compare_baseline_vs_panel import (
@@ -75,6 +76,7 @@ def _receipt(
     metadata_by_agent: dict[str, dict[str, object]] | None = None,
     dispatch_failed_agents: set[str] | None = None,
     metrics_n_per_class: bool = True,
+    source_artifacts: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     counts = {
         "clean_neutral": 1,
@@ -123,6 +125,8 @@ def _receipt(
             "false_positive_rate_on_null_negative": null_negative_fpr,
         },
     }
+    if source_artifacts is not None:
+        receipt["source_artifacts"] = source_artifacts
     if metrics_n_per_class:
         metrics = receipt["metrics"]
         assert isinstance(metrics, dict)
@@ -437,6 +441,69 @@ def test_schema_validation_rejects_non_v1_receipt(tmp_path: Path) -> None:
         load_probe_receipt(path)
 
 
+def test_comparison_marks_legacy_unbound_inputs_non_canonical() -> None:
+    baseline = _receipt(ci=(0.0, 0.2), rate=0.0, successes=0)
+    panel = _receipt(ci=(0.31, 0.7), rate=0.5, successes=9)
+
+    comparison = build_comparison_receipt(
+        baseline,
+        panel,
+        baseline_receipt_path="baseline.json",
+        panel_receipt_path="panel.json",
+        produced_at="2026-05-04T00:00:00Z",
+    )
+
+    assert comparison["comparison_canonical"] is False
+    assert comparison["non_canonical_inputs"] == ["baseline_receipt", "panel_receipt"]
+    provenance = comparison["comparison"]["input_provenance"]
+    assert provenance["baseline_receipt"]["status"] == "legacy_unbound"
+    assert provenance["panel_receipt"]["status"] == "legacy_unbound"
+    assert comparison["verdict"] == "GO"
+
+
+def test_comparison_marks_bound_source_artifacts_canonical(tmp_path: Path) -> None:
+    baseline_transcript = tmp_path / "baseline.transcripts.json"
+    panel_transcript = tmp_path / "panel.transcripts.json"
+    baseline_transcript.write_text('{"run_id":"baseline"}\n', encoding="utf-8")
+    panel_transcript.write_text('{"run_id":"panel"}\n', encoding="utf-8")
+    baseline = _receipt(
+        ci=(0.0, 0.2),
+        rate=0.0,
+        successes=0,
+        source_artifacts=[
+            build_source_artifact(
+                baseline_transcript,
+                format="baseline_panel_transcripts.v1",
+            )
+        ],
+    )
+    panel = _receipt(
+        ci=(0.31, 0.7),
+        rate=0.5,
+        successes=9,
+        source_artifacts=[
+            build_source_artifact(
+                panel_transcript,
+                format="h2_panel_transcripts.v1",
+            )
+        ],
+    )
+
+    comparison = build_comparison_receipt(
+        baseline,
+        panel,
+        baseline_receipt_path="baseline.json",
+        panel_receipt_path="panel.json",
+        produced_at="2026-05-04T00:00:00Z",
+    )
+
+    assert comparison["comparison_canonical"] is True
+    assert comparison["non_canonical_inputs"] == []
+    provenance = comparison["comparison"]["input_provenance"]
+    assert provenance["baseline_receipt"]["status"] == "bound"
+    assert provenance["panel_receipt"]["status"] == "bound"
+
+
 def test_output_receipt_id_is_deterministic() -> None:
     baseline = _receipt(ci=(0.0, 0.2), rate=0.0, successes=0)
     panel = _receipt(ci=(0.31, 0.7), rate=0.5, successes=9)
@@ -487,3 +554,29 @@ def test_cli_writes_receipt_and_prints_json_summary(
     assert output_path.exists()
     written = json.loads(output_path.read_text(encoding="utf-8"))
     assert written["schema_version"] == "heterogeneity_comparison_receipt.v1"
+
+
+def test_cli_can_fail_closed_on_non_canonical_inputs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    baseline_path = _write(
+        tmp_path / "baseline.json", _receipt(ci=(0.0, 0.2), rate=0.0, successes=0)
+    )
+    panel_path = _write(tmp_path / "panel.json", _receipt(ci=(0.31, 0.7), rate=0.5, successes=9))
+    output_path = tmp_path / "comparison.json"
+
+    rc = main(
+        [
+            "--baseline-receipt",
+            str(baseline_path),
+            "--panel-receipt",
+            str(panel_path),
+            "--output-receipt",
+            str(output_path),
+            "--require-canonical-inputs",
+        ]
+    )
+
+    assert rc == 2
+    assert not output_path.exists()
+    assert "comparison inputs are not canonical" in capsys.readouterr().err

--- a/tests/scripts/test_judge_heterogeneity_transcripts.py
+++ b/tests/scripts/test_judge_heterogeneity_transcripts.py
@@ -163,9 +163,13 @@ def test_judge_bridge_writes_classifications_and_receipt_input(tmp_path: Path) -
     summary = json.loads(proc.stdout)
     assert summary["prompt_count"] == 1
     assert summary["classification_count"] == 2
+    assert summary["source_artifact_count"] == 1
 
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["panel_models"] == ["solo", "failed"]
+    assert payload["source_artifacts"][0]["role"] == "transcript_sidecar"
+    assert payload["source_artifacts"][0]["format"] == "dialog_jsonl_transcript.v1"
+    assert payload["source_artifacts"][0]["text_capture"] == "full"
     classifications = payload["results"][0]["classifications"]
     assert classifications == [
         {"agent": "solo", "rationale": "fixture judged", "verdict": "missed"},
@@ -193,6 +197,8 @@ def test_judge_bridge_writes_classifications_and_receipt_input(tmp_path: Path) -
     )
     receipt_summary = json.loads(receipt_proc.stdout)
     assert receipt_summary["receipt_verdict"] == "insufficient_pilot"
+    receipt = json.loads(Path(receipt_summary["receipt_path"]).read_text(encoding="utf-8"))
+    assert receipt["source_artifacts"] == payload["source_artifacts"]
 
 
 def test_judge_bridge_normalizes_no_seeded_flagged_correctly(tmp_path: Path) -> None:

--- a/tests/scripts/test_run_heterogeneity_probe.py
+++ b/tests/scripts/test_run_heterogeneity_probe.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -15,6 +16,7 @@ def _run_with_classifications(
     payload: dict[str, object],
     *,
     limit: int | None = None,
+    extra_args: list[str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     classifications_file = tmp_path / "classifications.json"
     classifications_file.write_text(json.dumps(payload), encoding="utf-8")
@@ -31,6 +33,8 @@ def _run_with_classifications(
     ]
     if limit is not None:
         cmd[2:2] = ["--limit", str(limit)]
+    if extra_args:
+        cmd.extend(extra_args)
     return subprocess.run(
         cmd,
         cwd=ROOT,
@@ -104,6 +108,69 @@ def test_probe_script_writes_receipt_from_classifications_file(tmp_path) -> None
     assert receipt["judge_model"] == "external-judge-fixture"
     assert receipt["verdict"] == "insufficient_pilot"
     assert "external judged classifications" in receipt["scope_caveats"][0]
+    assert payload["source_artifact_count"] == 0
+
+
+def test_probe_script_propagates_classification_source_artifacts(tmp_path) -> None:
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"round"}\n', encoding="utf-8")
+    source_artifact = {
+        "role": "transcript_sidecar",
+        "path": str(transcript),
+        "sha256": hashlib.sha256(transcript.read_bytes()).hexdigest(),
+        "bytes": transcript.stat().st_size,
+        "format": "dialog_jsonl_transcript.v1",
+        "hash_spec": "sha256(raw file bytes)",
+        "required_for_rejudge": True,
+        "text_capture": "full",
+        "created_before_receipt_id": True,
+    }
+    proc = _run_with_classifications(
+        tmp_path,
+        {
+            "judge_model": "artifact-repro",
+            "panel_models": ["solo"],
+            "source_artifacts": [source_artifact],
+            "results": [
+                {
+                    "prompt_id": "cn_01_invalidation_signals",
+                    "classifications": [
+                        {"agent": "solo", "verdict": "missed", "rationale": "no issue"}
+                    ],
+                }
+            ],
+        },
+        limit=1,
+    )
+
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    receipt = json.loads(Path(payload["receipt_path"]).read_text(encoding="utf-8"))
+    assert payload["source_artifact_count"] == 1
+    assert receipt["source_artifacts"] == [source_artifact]
+
+
+def test_probe_script_can_fail_closed_when_source_artifacts_are_required(tmp_path) -> None:
+    proc = _run_with_classifications(
+        tmp_path,
+        {
+            "judge_model": "missing-artifact-repro",
+            "panel_models": ["solo"],
+            "results": [
+                {
+                    "prompt_id": "cn_01_invalidation_signals",
+                    "classifications": [
+                        {"agent": "solo", "verdict": "missed", "rationale": "no issue"}
+                    ],
+                }
+            ],
+        },
+        limit=1,
+        extra_args=["--require-source-artifacts"],
+    )
+
+    assert proc.returncode == 1
+    assert "receipt source artifacts are not bound: legacy_unbound" in proc.stderr
 
 
 def test_probe_script_accepts_partial_multi_seeded_classification(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Adds source-artifact provenance helpers for heterogeneity receipts, including transcript sidecar path, sha256, bytes, hash spec, and fail-closed validation.
- Propagates transcript artifacts through the judge bridge and receipt builder; future baseline receipts write the transcript sidecar before receipt construction with full panel/judge text capture.
- Marks comparator outputs with comparison_canonical=false when legacy receipts lack bound transcript artifacts, without changing verdict mechanics.

## Validation
- python3 -m ruff format --check aragora/heterogeneity/receipt.py aragora/heterogeneity/probe.py scripts/run_baseline_panel.py scripts/run_heterogeneity_probe.py scripts/judge_heterogeneity_transcripts.py scripts/compare_baseline_vs_panel.py tests/heterogeneity/test_receipt.py tests/scripts/test_run_heterogeneity_probe.py tests/scripts/test_judge_heterogeneity_transcripts.py tests/scripts/test_compare_baseline_vs_panel.py
- python3 -m ruff check aragora/heterogeneity/receipt.py aragora/heterogeneity/probe.py scripts/run_baseline_panel.py scripts/run_heterogeneity_probe.py scripts/judge_heterogeneity_transcripts.py scripts/compare_baseline_vs_panel.py tests/heterogeneity/test_receipt.py tests/scripts/test_run_heterogeneity_probe.py tests/scripts/test_judge_heterogeneity_transcripts.py tests/scripts/test_compare_baseline_vs_panel.py
- pytest tests/heterogeneity/test_receipt.py tests/scripts/test_run_heterogeneity_probe.py tests/scripts/test_judge_heterogeneity_transcripts.py tests/scripts/test_compare_baseline_vs_panel.py -q -p no:randomly
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- gitleaks protect --staged --no-banner --redact --log-level error
- Round 31b comparator smoke: verdict remains NO-GO / panel_ci_within_or_below_baseline_ci; comparison_canonical=false; both inputs legacy_unbound.

## Non-Claims
- No paid calls were run.
- Does not re-judge existing receipts.
- Does not rerun the H2 panel or regenerate the #6962 baseline.
- Does not mutate historical H2 artifacts or settle H2.
- Does not close #6375 or change the strict CI-separation verdict rule.