### PR TITLE
feat(integrations): add local Flywheel tool probe

### DIFF
--- a/aragora/integrations/__init__.py
+++ b/aragora/integrations/__init__.py
@@ -51,6 +51,14 @@ from aragora.integrations.receipt_webhooks import (
     ReceiptWebhookPayload,
     get_receipt_notifier,
 )
+from aragora.integrations.flywheel import (
+    FlywheelToolError,
+    FlywheelToolSpec,
+    FlywheelToolStatus,
+    probe_flywheel_tools,
+    run_json_tool,
+    summarize_probe,
+)
 from aragora.integrations.whatsapp import (
     WhatsAppConfig,
     WhatsAppIntegration,
@@ -144,6 +152,13 @@ __all__ = [
     "ReceiptWebhookNotifier",
     "ReceiptWebhookPayload",
     "get_receipt_notifier",
+    # Agent Flywheel optional local tooling
+    "FlywheelToolError",
+    "FlywheelToolSpec",
+    "FlywheelToolStatus",
+    "probe_flywheel_tools",
+    "run_json_tool",
+    "summarize_probe",
     # Slack
     "SlackIntegration",
     "SlackConfig",

--- a/aragora/integrations/flywheel.py
+++ b/aragora/integrations/flywheel.py
@@ -1,0 +1,315 @@
+"""Optional adapters for local Agent Flywheel-style tooling.
+
+This module deliberately treats Flywheel repositories as external tools. It
+does not import, vendor, install, or require any of them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from collections.abc import Callable, Collection, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+Which = Callable[[str], str | None]
+
+
+class FlywheelToolError(RuntimeError):
+    """Raised when a guarded Flywheel tool invocation is unsafe or fails."""
+
+
+@dataclass(frozen=True)
+class FlywheelToolSpec:
+    """Static metadata used to detect an optional external tool."""
+
+    name: str
+    category: str
+    description: str
+    commands: tuple[str, ...]
+    repo_url: str
+    license_url: str
+    marker_paths: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class FlywheelToolStatus:
+    """Read-only local detection result for one optional external tool."""
+
+    name: str
+    category: str
+    description: str
+    available: bool
+    executable: str | None
+    matched_command: str | None
+    candidate_commands: tuple[str, ...]
+    marker_paths_found: tuple[str, ...]
+    version: str | None
+    help_excerpt: str | None
+    repo_url: str
+    license_url: str
+    detection_error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+DEFAULT_TOOL_SPECS: tuple[FlywheelToolSpec, ...] = (
+    FlywheelToolSpec(
+        name="agentic_coding_flywheel_setup",
+        category="bootstrap",
+        description="ACFS bootstrap repository and installer patterns",
+        commands=("acfs",),
+        repo_url="https://github.com/Dicklesworthstone/agentic_coding_flywheel_setup",
+        license_url=(
+            "https://github.com/Dicklesworthstone/agentic_coding_flywheel_setup/blob/main/LICENSE"
+        ),
+        marker_paths=(
+            "~/.aragora/flywheel-lab/agentic_coding_flywheel_setup",
+            "~/agentic_coding_flywheel_setup",
+        ),
+    ),
+    FlywheelToolSpec(
+        name="ntm",
+        category="session-orchestration",
+        description="tmux swarm/session management patterns",
+        commands=("ntm",),
+        repo_url="https://github.com/Dicklesworthstone/ntm",
+        license_url="https://github.com/Dicklesworthstone/ntm/blob/main/LICENSE",
+    ),
+    FlywheelToolSpec(
+        name="mcp_agent_mail",
+        category="coordination",
+        description="agent inbox/outbox and advisory file reservation patterns",
+        commands=("agent-mail", "agent_mail", "am"),
+        repo_url="https://github.com/Dicklesworthstone/mcp_agent_mail",
+        license_url="https://github.com/Dicklesworthstone/mcp_agent_mail/blob/main/LICENSE",
+    ),
+    FlywheelToolSpec(
+        name="coding_agent_session_search",
+        category="memory",
+        description="cross-agent transcript and session search patterns",
+        commands=("coding-agent-session-search", "coding_agent_session_search", "cass"),
+        repo_url="https://github.com/Dicklesworthstone/coding_agent_session_search",
+        license_url=(
+            "https://github.com/Dicklesworthstone/coding_agent_session_search/blob/main/LICENSE"
+        ),
+    ),
+    FlywheelToolSpec(
+        name="cass_memory_system",
+        category="memory",
+        description="procedural memory and command memory patterns",
+        commands=("cass-memory", "cass_memory", "cm"),
+        repo_url="https://github.com/Dicklesworthstone/cass_memory_system",
+        license_url="https://github.com/Dicklesworthstone/cass_memory_system/blob/main/LICENSE",
+    ),
+    FlywheelToolSpec(
+        name="beads",
+        category="task-graph",
+        description="task graph prioritization and dependency tracking patterns",
+        commands=("beads", "br", "bv"),
+        repo_url="https://github.com/Dicklesworthstone/beads_rust",
+        license_url="https://github.com/Dicklesworthstone/beads_rust/blob/main/LICENSE",
+    ),
+    FlywheelToolSpec(
+        name="destructive_command_guard",
+        category="safety",
+        description="guardrails for destructive shell commands",
+        commands=("destructive-command-guard", "dcg"),
+        repo_url="https://github.com/Dicklesworthstone/destructive_command_guard",
+        license_url="https://github.com/Dicklesworthstone/destructive_command_guard/blob/main/LICENSE",
+    ),
+    FlywheelToolSpec(
+        name="slb",
+        category="safety",
+        description="safety lockbox and two-person-rule command patterns",
+        commands=("slb",),
+        repo_url="https://github.com/Dicklesworthstone/slb",
+        license_url="https://github.com/Dicklesworthstone/slb/blob/main/LICENSE",
+    ),
+    FlywheelToolSpec(
+        name="ultimate_bug_scanner",
+        category="analysis",
+        description="multi-tool bug scanning workflow patterns",
+        commands=("ultimate-bug-scanner", "ubs"),
+        repo_url="https://github.com/Dicklesworthstone/ultimate_bug_scanner",
+        license_url="https://github.com/Dicklesworthstone/ultimate_bug_scanner/blob/main/LICENSE",
+    ),
+)
+
+DEFAULT_ALLOWED_BINARIES: frozenset[str] = frozenset(
+    command for spec in DEFAULT_TOOL_SPECS for command in spec.commands
+)
+
+
+def _excerpt(value: str, *, limit: int = 1200) -> str:
+    text = value.strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def _expand_marker_paths(paths: Sequence[str]) -> tuple[str, ...]:
+    found: list[str] = []
+    for raw_path in paths:
+        path = Path(os.path.expandvars(os.path.expanduser(raw_path)))
+        if path.exists():
+            found.append(str(path))
+    return tuple(found)
+
+
+def _run_probe_command(
+    executable: str,
+    args: Sequence[str],
+    *,
+    runner: Runner,
+    timeout_seconds: float,
+) -> str | None:
+    try:
+        completed = runner(
+            [executable, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    output = (completed.stdout or completed.stderr or "").strip()
+    if not output:
+        return None
+    return _excerpt(output)
+
+
+def probe_flywheel_tools(
+    specs: Sequence[FlywheelToolSpec] = DEFAULT_TOOL_SPECS,
+    *,
+    include_help: bool = True,
+    timeout_seconds: float = 2.0,
+    which: Which = shutil.which,
+    runner: Runner = subprocess.run,
+) -> list[FlywheelToolStatus]:
+    """Inspect optional local Flywheel-style tools without installing anything."""
+
+    statuses: list[FlywheelToolStatus] = []
+    for spec in specs:
+        executable: str | None = None
+        matched_command: str | None = None
+        detection_error: str | None = None
+
+        for command in spec.commands:
+            try:
+                executable = which(command)
+            except OSError as exc:
+                detection_error = f"which_failed:{type(exc).__name__}"
+                executable = None
+            if executable:
+                matched_command = command
+                break
+
+        marker_paths_found = _expand_marker_paths(spec.marker_paths)
+        version = None
+        help_excerpt = None
+        if executable:
+            version = _run_probe_command(
+                executable, ("--version",), runner=runner, timeout_seconds=timeout_seconds
+            )
+            if include_help:
+                help_excerpt = _run_probe_command(
+                    executable, ("--help",), runner=runner, timeout_seconds=timeout_seconds
+                )
+
+        statuses.append(
+            FlywheelToolStatus(
+                name=spec.name,
+                category=spec.category,
+                description=spec.description,
+                available=bool(executable or marker_paths_found),
+                executable=executable,
+                matched_command=matched_command,
+                candidate_commands=spec.commands,
+                marker_paths_found=marker_paths_found,
+                version=version,
+                help_excerpt=help_excerpt,
+                repo_url=spec.repo_url,
+                license_url=spec.license_url,
+                detection_error=detection_error,
+            )
+        )
+    return statuses
+
+
+def summarize_probe(statuses: Sequence[FlywheelToolStatus]) -> dict[str, Any]:
+    """Return a compact summary suitable for CLI JSON output."""
+
+    available = [status.name for status in statuses if status.available]
+    return {
+        "tool_count": len(statuses),
+        "available_count": len(available),
+        "available_tools": available,
+        "missing_tools": [status.name for status in statuses if not status.available],
+        "categories": sorted({status.category for status in statuses}),
+    }
+
+
+def run_json_tool(
+    command: Sequence[str],
+    *,
+    allowed_binaries: Collection[str] | None = None,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout_seconds: float = 10.0,
+    which: Which = shutil.which,
+    runner: Runner = subprocess.run,
+) -> Any:
+    """Run an allowlisted external tool command that is expected to emit JSON.
+
+    The guard intentionally rejects shell strings and path-qualified binaries.
+    This adapter is for narrow local integrations, not arbitrary command
+    execution.
+    """
+
+    if not command:
+        raise FlywheelToolError("command is required")
+
+    binary = command[0]
+    if Path(binary).name != binary:
+        raise FlywheelToolError("path-qualified binaries are not allowed")
+
+    allowed = set(allowed_binaries or DEFAULT_ALLOWED_BINARIES)
+    if binary not in allowed:
+        raise FlywheelToolError(f"binary is not allowlisted: {binary}")
+
+    executable = which(binary)
+    if not executable:
+        raise FlywheelToolError(f"binary not found on PATH: {binary}")
+
+    try:
+        completed = runner(
+            [executable, *command[1:]],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+            cwd=str(cwd) if cwd is not None else None,
+            env=dict(env) if env is not None else None,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise FlywheelToolError(f"command timed out: {binary}") from exc
+    except OSError as exc:
+        raise FlywheelToolError(f"command failed to start: {binary}") from exc
+
+    if completed.returncode != 0:
+        stderr = _excerpt(completed.stderr or completed.stdout or "")
+        raise FlywheelToolError(f"command exited {completed.returncode}: {stderr}")
+
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise FlywheelToolError(f"command did not emit valid JSON: {binary}") from exc

--- a/docs/integrations/AGENT_FLYWHEEL_ADOPTION_AUDIT_2026-05.md
+++ b/docs/integrations/AGENT_FLYWHEEL_ADOPTION_AUDIT_2026-05.md
@@ -1,0 +1,47 @@
+# Agent Flywheel Adoption Audit
+
+Aragora should treat Agent Flywheel repositories as optional external tooling
+and pattern sources, not vendored dependencies. Aragora's product boundary
+remains governance: vetted decisions, receipts, dissent, calibration, and
+settlement gates. Flywheel-style tools can improve local orchestration substrate.
+
+## Capability Map
+
+| Tool family | Useful pattern | Aragora adoption path |
+| --- | --- | --- |
+| Agent Mail | Agent inbox/outbox, file reservations, coordination messages | Compare with Aragora bridge lanes and shared outbox; consider an optional adapter after local validation |
+| NTM | tmux swarm lifecycle, session inventory, local API | Mine lifecycle and session-control patterns for `scripts/agent_bridge.py` and worktree sessions |
+| CASS / session search | Cross-agent transcript search and procedural memory | Compare against Aragora bridge snapshots, automation memory, and receipt search |
+| Beads | Task graph, dependency ranking, critical-path focus | Evaluate as optional task-DAG input for queue triage and review-lane prioritization |
+| Destructive command guard / SLB | Guardrails, confirmation policy, two-person rule patterns | Reimplement narrow safety gates for risky local commands; do not wrap all shell use blindly |
+| ACFS | Manifested bootstrap, checksums, idempotent setup | Reuse the manifest/checksum idea for Aragora local lab setup; do not run broad installers by default |
+
+## Licensing And Source Boundary
+
+The first Aragora spike must not vendor Flywheel source, add submodules, or copy
+substantial implementation code. The safe path is:
+
+- use repos privately as external local tools where license terms permit;
+- cite repository URLs in docs;
+- reimplement generic ideas and interfaces in Aragora-owned code;
+- require a separate legal/licensing gate before redistribution or vendoring.
+
+## Local-First Validation
+
+Local validation is required before AWS because local CLI auth state is part of
+the experiment. The first Aragora-owned deliverable is intentionally small:
+
+- `scripts/flywheel_tools_probe.py --json` for read-only local detection;
+- `aragora.integrations.flywheel` for optional, guarded subprocess adapters;
+- a runbook for scratch-directory lab work.
+
+This does not install Flywheel, run agents, call model APIs, mutate H2 receipts,
+or change GitHub runner behavior.
+
+## Candidate Follow-Ups
+
+- Add one optional adapter for a proven local tool, starting with read-only
+  session inventory or search.
+- Add a receipt around local tool probes if the output becomes part of Aragora
+  operator decisions.
+- Run an AWS portability pilot only after local value is demonstrated.

--- a/docs/runbooks/AGENT_FLYWHEEL_LOCAL_PILOT.md
+++ b/docs/runbooks/AGENT_FLYWHEEL_LOCAL_PILOT.md
@@ -1,0 +1,78 @@
+# Agent Flywheel Local Pilot Runbook
+
+This runbook validates Agent Flywheel-style tools on the local workstation first.
+Local validation comes before AWS because the active Claude, Codex, Gemini, and
+OpenRouter CLI credentials are part of the substrate being tested.
+
+## Rules
+
+- Do not run a broad workstation installer blindly.
+- Inspect install scripts, license files, shell-profile edits, daemon behavior,
+  network calls, and cleanup paths before executing anything.
+- Pin exact commits for any external repo cloned for inspection.
+- Keep external clones and logs outside this repository, preferably under
+  `~/.aragora/flywheel-lab/`.
+- Use a toy repository or disposable Aragora worktree for exercises.
+- Do not use Homebrew, global shell-profile mutation, launch agents, or daemon
+  installation without explicit operator approval.
+- Do not run paid model calls as part of this pilot.
+- Do not install the full stack on GitHub runners.
+
+## Local Lab Layout
+
+Recommended scratch layout:
+
+```text
+~/.aragora/flywheel-lab/
+  repos/
+  installs/
+  logs/
+  toy-repo/
+  manifest.json
+```
+
+Record each external repo as:
+
+```json
+{
+  "repo": "https://github.com/Dicklesworthstone/ntm",
+  "commit": "<pinned sha>",
+  "license_checked": true,
+  "install_surface": "user-space venv only",
+  "notes": "no shell profile mutation"
+}
+```
+
+## First Validation Pass
+
+1. Run the Aragora read-only probe:
+
+   ```bash
+   python3 scripts/flywheel_tools_probe.py --json --no-help
+   ```
+
+2. Pick at most one session-oriented tool for a manual lab exercise. Prefer
+   `ntm` or session search before Agent Mail, destructive-command wrappers, or
+   full ACFS bootstrap.
+
+3. Run the selected tool only inside the lab scratch directory or toy repo.
+
+4. Capture:
+
+   - exact repo URL and commit
+   - install command used
+   - changed files outside `~/.aragora/flywheel-lab/`, if any
+   - whether local Claude/Codex/Gemini auth was detected or required
+   - useful patterns Aragora should reimplement
+
+## AWS Deferral
+
+AWS is a later portability check. It should validate clean bootstrap and
+repeatability after local value is proven. AWS should not replace local testing
+because a fresh instance will not have the workstation's active agent CLI auth.
+
+## GitHub Runner Boundary
+
+GitHub runners may later use narrow, noninteractive adapters such as a JSON
+probe or task-graph export. They should not run full tmux swarm bootstrap or
+credential-dependent local-agent workflows by default.

--- a/scripts/flywheel_tools_probe.py
+++ b/scripts/flywheel_tools_probe.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Probe optional local Agent Flywheel-style tools.
+
+The probe is read-only: it never installs tools, mutates shell profiles, starts
+tmux sessions, launches agents, or calls model APIs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.integrations.flywheel import probe_flywheel_tools, summarize_probe
+
+
+def _json_payload(*, include_help: bool, timeout_seconds: float) -> dict[str, Any]:
+    statuses = probe_flywheel_tools(include_help=include_help, timeout_seconds=timeout_seconds)
+    return {
+        "schema_version": "flywheel_tools_probe.v1",
+        "mode": "read_only_local_probe",
+        "summary": summarize_probe(statuses),
+        "tools": [status.to_dict() for status in statuses],
+        "non_claims": [
+            "no tools were installed",
+            "no shell profiles were modified",
+            "no model calls were made",
+            "no GitHub runner or AWS environment was touched",
+        ],
+    }
+
+
+def _print_human(payload: dict[str, Any]) -> None:
+    summary = payload["summary"]
+    print("Flywheel local tool probe")
+    print(f"available: {summary['available_count']} / {summary['tool_count']}")
+    for tool in payload["tools"]:
+        marker = "available" if tool["available"] else "missing"
+        source = tool["matched_command"] or ", ".join(tool["marker_paths_found"]) or "-"
+        print(f"- {tool['name']}: {marker} ({source})")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument(
+        "--no-help",
+        action="store_true",
+        help="Skip --help probes and only run lightweight availability/version checks",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=2.0,
+        help="Per-command timeout for version/help probes",
+    )
+    args = parser.parse_args(argv)
+
+    payload = _json_payload(include_help=not args.no_help, timeout_seconds=args.timeout_seconds)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_human(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integrations/test_flywheel.py
+++ b/tests/integrations/test_flywheel.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from aragora.integrations.flywheel import (
+    FlywheelToolError,
+    FlywheelToolSpec,
+    probe_flywheel_tools,
+    run_json_tool,
+    summarize_probe,
+)
+
+
+def test_probe_reports_available_tool_with_version_and_help() -> None:
+    spec = FlywheelToolSpec(
+        name="ntm",
+        category="session-orchestration",
+        description="tmux manager",
+        commands=("ntm",),
+        repo_url="https://example.test/ntm",
+        license_url="https://example.test/license",
+    )
+
+    def fake_which(command: str) -> str | None:
+        return "/usr/local/bin/ntm" if command == "ntm" else None
+
+    def fake_runner(args, **_kwargs):
+        if args[-1] == "--version":
+            return subprocess.CompletedProcess(args, 0, stdout="ntm 1.2.3\n", stderr="")
+        if args[-1] == "--help":
+            return subprocess.CompletedProcess(args, 0, stdout="usage: ntm\n", stderr="")
+        raise AssertionError(args)
+
+    statuses = probe_flywheel_tools((spec,), which=fake_which, runner=fake_runner)
+
+    assert len(statuses) == 1
+    status = statuses[0]
+    assert status.available is True
+    assert status.executable == "/usr/local/bin/ntm"
+    assert status.matched_command == "ntm"
+    assert status.version == "ntm 1.2.3"
+    assert status.help_excerpt == "usage: ntm"
+    assert summarize_probe(statuses)["available_tools"] == ["ntm"]
+
+
+def test_probe_reports_missing_tool_without_running_commands() -> None:
+    spec = FlywheelToolSpec(
+        name="agent_mail",
+        category="coordination",
+        description="mail",
+        commands=("agent-mail", "am"),
+        repo_url="https://example.test/mail",
+        license_url="https://example.test/license",
+    )
+    runner_calls = []
+
+    def fake_runner(args, **_kwargs):
+        runner_calls.append(args)
+        raise AssertionError("runner should not be called when commands are missing")
+
+    statuses = probe_flywheel_tools((spec,), which=lambda _command: None, runner=fake_runner)
+
+    assert statuses[0].available is False
+    assert statuses[0].executable is None
+    assert statuses[0].candidate_commands == ("agent-mail", "am")
+    assert runner_calls == []
+
+
+def test_probe_can_detect_repository_marker_without_binary(tmp_path) -> None:
+    marker = tmp_path / "agentic_coding_flywheel_setup"
+    marker.mkdir()
+    spec = FlywheelToolSpec(
+        name="agentic_coding_flywheel_setup",
+        category="bootstrap",
+        description="bootstrap repo",
+        commands=("acfs",),
+        repo_url="https://example.test/acfs",
+        license_url="https://example.test/license",
+        marker_paths=(str(marker),),
+    )
+
+    statuses = probe_flywheel_tools((spec,), which=lambda _command: None)
+
+    assert statuses[0].available is True
+    assert statuses[0].matched_command is None
+    assert statuses[0].marker_paths_found == (str(marker),)
+
+
+def test_run_json_tool_executes_allowlisted_binary_and_parses_json() -> None:
+    def fake_runner(args, **kwargs):
+        assert args == ["/usr/local/bin/ntm", "sessions", "--json"]
+        assert kwargs["check"] is False
+        return subprocess.CompletedProcess(args, 0, stdout='{"sessions": []}', stderr="")
+
+    payload = run_json_tool(
+        ("ntm", "sessions", "--json"),
+        allowed_binaries={"ntm"},
+        which=lambda command: "/usr/local/bin/ntm" if command == "ntm" else None,
+        runner=fake_runner,
+    )
+
+    assert payload == {"sessions": []}
+
+
+def test_run_json_tool_rejects_unallowlisted_or_path_qualified_binary() -> None:
+    with pytest.raises(FlywheelToolError, match="not allowlisted"):
+        run_json_tool(("rm", "-rf", "/"), allowed_binaries={"ntm"})
+
+    with pytest.raises(FlywheelToolError, match="path-qualified"):
+        run_json_tool(("/usr/local/bin/ntm", "--json"), allowed_binaries={"ntm"})
+
+
+def test_run_json_tool_rejects_non_json_output() -> None:
+    def fake_runner(args, **_kwargs):
+        return subprocess.CompletedProcess(args, 0, stdout="not json", stderr="")
+
+    with pytest.raises(FlywheelToolError, match="valid JSON"):
+        run_json_tool(
+            ("ntm", "sessions"),
+            allowed_binaries={"ntm"},
+            which=lambda command: "/usr/local/bin/ntm" if command == "ntm" else None,
+            runner=fake_runner,
+        )

--- a/tests/scripts/test_flywheel_tools_probe.py
+++ b/tests/scripts/test_flywheel_tools_probe.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+def test_probe_cli_json_succeeds_when_tools_are_missing(monkeypatch, capsys) -> None:
+    import flywheel_tools_probe as mod
+
+    monkeypatch.setattr(mod, "probe_flywheel_tools", lambda **_kwargs: [])
+
+    assert mod.main(["--json", "--no-help"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["schema_version"] == "flywheel_tools_probe.v1"
+    assert payload["mode"] == "read_only_local_probe"
+    assert payload["summary"]["tool_count"] == 0
+    assert "no tools were installed" in payload["non_claims"]
+
+
+def test_probe_cli_human_output(monkeypatch, capsys) -> None:
+    import flywheel_tools_probe as mod
+
+    monkeypatch.setattr(mod, "probe_flywheel_tools", lambda **_kwargs: [])
+
+    assert mod.main(["--no-help"]) == 0
+    output = capsys.readouterr().out
+
+    assert "Flywheel local tool probe" in output
+    assert "available: 0 / 0" in output


### PR DESCRIPTION
## Summary

Adds a local-first Agent Flywheel validation spike for Aragora:

- read-only `scripts/flywheel_tools_probe.py --json` for detecting optional local Flywheel-style tools without installing or invoking model APIs
- optional `aragora.integrations.flywheel` adapter seam with typed tool-status records and guarded JSON subprocess invocation
- local pilot runbook that keeps Flywheel validation on the workstation first, with AWS deferred to a later portability check
- adoption audit mapping useful Flywheel patterns into Aragora without vendoring source

## Scope boundaries

- Does not vendor, submodule, or copy Flywheel source
- Does not install tools, edit shell profiles, start daemons, or launch tmux swarms
- Does not run paid model calls
- Does not launch AWS or alter GitHub runner behavior
- Does not touch H2 receipts, #7030, or heterogeneity artifacts

## Validation

- `python3 scripts/flywheel_tools_probe.py --json --no-help` -> `flywheel_tools_probe.v1 9 0`
- `pytest tests/integrations/test_flywheel.py tests/scripts/test_flywheel_tools_probe.py` -> 8 passed
- `ruff check aragora/integrations/__init__.py aragora/integrations/flywheel.py scripts/flywheel_tools_probe.py tests/integrations/test_flywheel.py tests/scripts/test_flywheel_tools_probe.py` -> passed
- `ruff format --check aragora/integrations/__init__.py aragora/integrations/flywheel.py scripts/flywheel_tools_probe.py tests/integrations/test_flywheel.py tests/scripts/test_flywheel_tools_probe.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok
- pre-push hook: whitespace/yaml/json/large-files/merge-conflicts/private-key/ruff/format/baseline-filtered mypy/gitleaks all passed
