### PR TITLE
codex/agent bridge session control summary refresh 20260506

### DIFF
--- a/scripts/agent_bridge_sessions.py
+++ b/scripts/agent_bridge_sessions.py
@@ -41,7 +41,10 @@ MODEL_STATUS_RE = re.compile(
 UI_CHROME_RE = re.compile(
     r"\bnavigate\s+enter\s+select\s+esc\s+cancel\b"
     r"|\bshift\+tab\s+to\s+cycle\b"
-    r"|\?\s+for\s+help\b.*\bide\b",
+    r"|\?\s+for\s+help\b.*\bide\b"
+    r"|\balways\s+allow\s+(?:low|medium|high)\s+impact\s+commands\b"
+    r"|\bauto\s+\((?:low|medium|high)\)\s+-\s+edits\b"
+    r"|\bpermissions\s*dialog\s*dismissed\b",
     re.I,
 )
 

--- a/scripts/agent_bridge_sessions.py
+++ b/scripts/agent_bridge_sessions.py
@@ -42,6 +42,7 @@ UI_CHROME_RE = re.compile(
     r"\bnavigate\s+enter\s+select\s+esc\s+cancel\b"
     r"|\bshift\+tab\s+to\s+cycle\b"
     r"|\?\s+for\s+help\b.*\bide\b"
+    r"|^\W*no,\s+cancel(?:\s|$)"
     r"|\balways\s+allow\s+(?:low|medium|high)\s+impact\s+commands\b"
     r"|\bauto\s+\((?:low|medium|high)\)\s+-\s+edits\b"
     r"|\bpermissions\s*dialog\s*dismissed\b",

--- a/tests/scripts/test_agent_bridge_sessions.py
+++ b/tests/scripts/test_agent_bridge_sessions.py
@@ -257,6 +257,21 @@ def test_select_summary_skips_terminal_ui_chrome() -> None:
     assert summary == "PR #5297 opened"
 
 
+def test_select_summary_skips_permission_mode_chrome() -> None:
+    import agent_bridge_sessions as mod
+
+    summary = mod._select_summary(
+        [
+            "PR #5297 opened",
+            "│ Yes, and always allow low impact commands (file edits and read-only commands) │",
+            "Auto (Low) - edits and read-only commands Opus 4.7 (High)",
+            "⏿Permissionsdialogdismissed",
+        ]
+    )
+
+    assert summary == "PR #5297 opened"
+
+
 def test_select_summary_skips_terminal_border_residue() -> None:
     import agent_bridge_sessions as mod
 

--- a/tests/scripts/test_agent_bridge_sessions.py
+++ b/tests/scripts/test_agent_bridge_sessions.py
@@ -264,6 +264,7 @@ def test_select_summary_skips_permission_mode_chrome() -> None:
         [
             "PR #5297 opened",
             "│ Yes, and always allow low impact commands (file edits and read-only commands) │",
+            "│ No, cancel 38;2;135;1",
             "Auto (Low) - edits and read-only commands Opus 4.7 (High)",
             "⏿Permissionsdialogdismissed",
         ]


### PR DESCRIPTION
- **fix(agent-bridge): skip permission mode summaries**
- **fix(agent-bridge): skip session cancel summaries**
