### PR TITLE
fix(automation): classify gh auth timeouts as connectivity

### DIFF
--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -122,8 +122,10 @@ def check_github_cli_health(
     auth_proc = _run(["gh", "auth", "status"], cwd=repo_root, timeout_seconds=timeout_seconds)
     if auth_proc.returncode != 0:
         auth_error = _command_error(auth_proc, "gh auth status failed")
-        mode = "connectivity_failed" if is_github_connectivity_error(api_error) else "auth_failed"
-        error = api_error if mode == "connectivity_failed" else auth_error
+        api_connectivity = is_github_connectivity_error(api_error)
+        auth_connectivity = is_github_connectivity_error(auth_error)
+        mode = "connectivity_failed" if api_connectivity or auth_connectivity else "auth_failed"
+        error = api_error if api_connectivity else auth_error
         return GitHubCLIHealth(
             ready=False,
             auth_ok=False,

--- a/tests/scripts/test_github_cli_health.py
+++ b/tests/scripts/test_github_cli_health.py
@@ -181,6 +181,41 @@ def test_check_github_cli_health_prefers_connectivity_error_when_auth_status_is_
     assert health.error == "error connecting to api.github.com"
 
 
+def test_check_github_cli_health_classifies_auth_timeout_as_connectivity(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
+
+    def fake_run(
+        args: list[str], *, cwd: Path, timeout_seconds: int
+    ) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "api", "rate_limit"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="HTTP 401: Requires authentication",
+            )
+        if args[:3] == ["gh", "auth", "status"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=124,
+                stdout="",
+                stderr="command timed out after 20s: gh auth status",
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    health = mod.check_github_cli_health(Path("."))
+
+    assert health.ready is False
+    assert health.mode == "connectivity_failed"
+    assert health.auth_ok is False
+    assert health.api_ok is False
+    assert health.error == "command timed out after 20s: gh auth status"
+
+
 def test_check_github_cli_health_detects_auth_failure(monkeypatch) -> None:
     monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/gh")
 


### PR DESCRIPTION
## Summary

Classify bounded `gh auth status` timeouts as connectivity failures rather than auth failures in the GitHub CLI health probe.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_github_cli_health.py -p no:rerunfailures -p no:cacheprovider` -> 11 passed.
- `python3 -m ruff check scripts/github_cli_health.py tests/scripts/test_github_cli_health.py` -> All checks passed.
- `python3 -m ruff format --check scripts/github_cli_health.py tests/scripts/test_github_cli_health.py` -> 2 files already formatted.
- `git diff --check origin/main...HEAD` -> passed.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok.

## Non-claims

This does not change PR publication, branch cleanup, merge policy, or GitHub API auth semantics. It only keeps a timed-out local `gh auth status` probe in the connectivity-failed bucket so automation diagnostics do not mislabel DNS/network stalls as credential failures.

Outbox handoff: `.aragora/automation-outbox/open-pr-codex-github-health-auth-timeout-connectivity-65ab4337.json`.
