### PR TITLE
docs(status): record proof-loop blockers

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,11 +1,25 @@
 # Aragora Project Status
 
-*Last updated: April 23, 2026*
+*Last updated: May 6, 2026*
 
 > Compatibility mirror for older links. The canonical current-status document is [status/STATUS.md](status/STATUS.md).
 > The thesis settlement ledger lives at [status/2026-04-21-thesis-settlement-session.md](status/2026-04-21-thesis-settlement-session.md).
 > Historical sections below are retained for continuity, but the active source of truth for current project status is `docs/status/STATUS.md`.
 > See [README](../README.md) for the five pillars framework. See [Documentation Index](INDEX.md) for the curated technical reference map.
+
+## May 6, 2026 — Proof Loop Operation Snapshot
+
+The older April note below is no longer the active operating picture.
+
+Current `main` has moved into operate-mode for the proof loop:
+
+- `docs/THESIS.md` is v4 canonical, not a draft awaiting another review.
+- Issue [#6375](https://github.com/synaptent/aragora/issues/6375) is closed.
+- `aragora/swarm/pr_review_protocol.py` now explicitly distinguishes `PROTOCOL_STATUS = "metadata_heuristic"` from `EXECUTED_PROTOCOL_STATUS = "heterogeneous_ensemble_v1"` and `FALLBACK_PROTOCOL_STATUS = "metadata_heuristic_fallback"`.
+- H1-01 rev-4 promotion is blocked by the canonical corpus freshness invariant: 16 staged issues have advisory dispatch evidence, but only 12 have metrics-backed `worker_outcome` evidence; 15 are required before promotion.
+- `docs/benchmarks/corpus.json` remains at the existing one-issue rev-4 corpus until the first rev-4 slice is metrics-backed promotion-ready.
+- Fresh B0 truth publication remains in `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`: 1 in-progress expected issue, 0 verified expected issues, and 0.0% current truth success.
+- `review-queue observe-outcomes` dry-run is currently blocked by missing settlement receipts under `.aragora/review-queue/receipts`; do not run `--write` until a real receipt slice exists and has been manually verified.
 
 ## April 21, 2026 — Canonical Reality Moved to Thesis + PDB Execution
 

--- a/docs/THESIS.md
+++ b/docs/THESIS.md
@@ -1,14 +1,14 @@
 # The Aragora Thesis
 
 > Canonical source of authority. Every other strategic doc links up to this.
-> Last updated: 2026-04-20. Status: v4 draft. v1 → v2 applied codex's
+> Last updated: 2026-05-06. Status: v4 canonical. v1 → v2 applied codex's
 > 5 required changes. v2 → v3 added premise 6 (Triage) and reframed
 > commitments around Pareto-efficient attention allocation after
 > founder arbitration. v3 → v4 applied codex round-3 findings with
 > founder's normative-vs-descriptive reframe: the thesis describes
 > the target shape of the product; category-B findings (where code
 > does not meet thesis) are named as Implementation gaps rather than
-> thesis errors. Awaiting fourth review before merge.
+> thesis errors.
 
 ---
 

--- a/docs/status/H1_01_REV4_PROMOTION_READINESS.md
+++ b/docs/status/H1_01_REV4_PROMOTION_READINESS.md
@@ -1,13 +1,13 @@
 # H1-01 Rev-4 Promotion Readiness
 
-Last updated: 2026-04-30T19:54:46Z
+Last updated: 2026-05-06T20:30:00Z
 
 This is the operator-facing readiness surface for promoting the staged rev-4 benchmark corpus into the canonical B0 truth loop.
 
 ## Verdict
 
-- Status: `promotion_ready`
-- Decision: Ready to promote the first canonical rev-4 slice.
+- Status: `needs_more_dispatch_evidence`
+- Decision: Not ready: needs 3 more metrics-backed dispatched issue(s) to reach the 15-issue promotion floor.
 - Staging corpus: `tests/benchmarks/corpus_rev4.json`
 - Metrics source: `.aragora/overnight/boss_metrics.jsonl`
 - Promotion target: `docs/benchmarks/corpus.json`
@@ -25,15 +25,16 @@ This is the operator-facing readiness surface for promoting the staged rev-4 ben
 | Metric | Value |
 | --- | --- |
 | Dispatch floor for first canonical slice | 15 |
-| Staged issues with dispatch evidence (any source) | 16 |
-| Staged issues still missing dispatch evidence | 17 |
-| Additional dispatches needed | 0 |
-| ...via metrics ledger only | 1 |
-| ...via merged/open boss-harvest PR only | 4 |
+| Metrics-backed staged issues eligible for canonical promotion | 12 |
+| Staged issues still missing metrics-backed evidence | 21 |
+| Additional metrics-backed dispatches needed | 3 |
+| Advisory dispatch evidence from any source | 16 |
+| ...via metrics ledger only | 2 |
+| ...via merged/open boss-harvest PR only (advisory) | 4 |
 
 ## Next Dispatch Targets
 
-`#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`
+`#5126`, `#5128`, `#5130`
 
 ## Execution-Class Coverage
 
@@ -41,19 +42,19 @@ This is the operator-facing readiness surface for promoting the staged rev-4 ben
 | --- | ---: | ---: | ---: |
 | `docs_reconciliation` | 1 | 2 | 1 |
 | `exception_narrowing` | 0 | 8 | 8 |
-| `missing_test_coverage` | 10 | 10 | 0 |
+| `missing_test_coverage` | 6 | 10 | 4 |
 | `silent_exception_replacement` | 0 | 8 | 8 |
 | `small_refactor` | 3 | 3 | 0 |
 | `validation_tightening` | 2 | 2 | 0 |
 
 ## Dispatched Issues
 
-`#5126`, `#5128`, `#5130`, `#5176`, `#5180`, `#5185`, `#5187`, `#5188`, `#5197`, `#5198`, `#5426`, `#5427`, `#5428`, `#5764`, `#5765`, `#5844`
+`#5176`, `#5180`, `#5185`, `#5187`, `#5197`, `#5198`, `#5426`, `#5427`, `#5428`, `#5764`, `#5765`, `#5844`
 
 ## Missing Evidence
 
-`#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`, `#5810`, `#5811`, `#5812`, `#5821`, `#5823`, `#5825`, `#5883`
+`#5126`, `#5128`, `#5130`, `#5188`, `#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`, `#5810`, `#5811`, `#5812`, `#5821`, `#5823`, `#5825`, `#5883`
 
 ## Promotion Rule
 
-Promote only a first canonical rev-4 slice after at least 15 staged entries have dispatch evidence. Dispatch evidence is satisfied by either (a) at least one row in `boss_metrics.jsonl` for the issue or (b) a merged or open pull request on the boss-loop's deterministic branch pattern `aragora/boss-harvest/issue-N-*`. Keep undispatched entries staged until they also accumulate evidence.
+Promote only a first canonical rev-4 slice after at least 15 staged entries have metrics-backed dispatch evidence: at least one `boss_metrics.jsonl` row for the issue with a recorded `worker_outcome`. Merged or open boss-harvest PRs are useful advisory evidence, but they are not sufficient for canonical corpus promotion because `tests/benchmarks/test_corpus_freshness.py` requires metrics-backed dispatch history for every `in_progress` entry.

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-04-18
+Last updated: 2026-05-06
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -10,7 +10,15 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The immediate gate is keeping recurring benchmark truth publication complete, fresh, and trustworthy on current `main`, then keeping `CS-01..03` narrower than measured proof before expanding the `B2` guard across the safest execution classes. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
+The immediate gate is operating the proof loop that already exists: keep recurring benchmark truth publication complete, fresh, and trustworthy on current `main`; keep `CS-01..03` narrower than measured proof; and do not expand the `B2` guard until repeated runs support it. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
+
+Current May 6 proof-loop state:
+
+- `docs/THESIS.md` is v4 canonical.
+- H1-01 rev-4 readiness is `needs_more_dispatch_evidence`: 16 staged issues have advisory dispatch evidence, but only 12 have metrics-backed `worker_outcome` evidence and 15 are required for canonical promotion.
+- The first canonical rev-4 B0 slice is not promoted yet; `docs/benchmarks/corpus.json` remains at the existing one-issue rev-4 corpus until the metrics-backed floor is met.
+- Fresh B0 publication remains complete for the existing canonical corpus and reports 0.0% current truth success.
+- `review-queue observe-outcomes` dry-run found no settlement receipts under `.aragora/review-queue/receipts`; the first `--write` remains blocked until a manually verifiable receipt slice exists.
 
 Operator commands only count as proof when they are run from a clean, current `origin/main` observer. A dirty or diverged founder checkout is planning context, not runtime truth.
 

--- a/scripts/measure_b0_scorecard.py
+++ b/scripts/measure_b0_scorecard.py
@@ -649,6 +649,7 @@ def main(argv: list[str] | None = None) -> int:
     corpus_issue_numbers: set[int] | None = None
     corpus_metadata_payload: dict[str, Any] | None = None
     corpus_metadata_source_path: Path | None = None
+    truth_payload: dict[str, Any] | None = None
     if corpus_path is not None:
         if not corpus_path.exists():
             raise SystemExit(f"corpus file not found: {corpus_path}")
@@ -687,7 +688,17 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
 
-    incomplete_corpus = (scorecard.get("coverage") or {}).get("is_complete") is False
+    truth_artifact_coverage = (
+        dict(truth_payload.get("coverage") or {})
+        if truth_artifact_path is not None and truth_payload is not None
+        else {}
+    )
+    if "is_complete" in truth_artifact_coverage:
+        incomplete_corpus = truth_artifact_coverage.get("is_complete") is False
+        incomplete_coverage = truth_artifact_coverage
+    else:
+        incomplete_corpus = (scorecard.get("coverage") or {}).get("is_complete") is False
+        incomplete_coverage = dict(scorecard.get("coverage") or {})
 
     published_scorecard: dict[str, Any] | None = None
     published_path: Path | None = None
@@ -738,7 +749,7 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(published_scorecard or scorecard, indent=2, sort_keys=True))
     elif args.ci:
         print(render_ci_summary(scorecard, threshold=args.threshold))
-        is_complete = bool((scorecard.get("coverage") or {}).get("is_complete", True))
+        is_complete = not incomplete_corpus
         return (
             0
             if scorecard.get("status") != "no_data"
@@ -750,9 +761,7 @@ def main(argv: list[str] | None = None) -> int:
         print_scorecard(scorecard)
 
     if args.fail_incomplete and incomplete_corpus:
-        missing_issue_numbers = list(
-            (scorecard.get("coverage") or {}).get("missing_issue_numbers") or []
-        )
+        missing_issue_numbers = list(incomplete_coverage.get("missing_issue_numbers") or [])
         missing_suffix = ", ".join(str(item) for item in missing_issue_numbers) or "unknown"
         print(
             f"incomplete corpus coverage: missing issue numbers {missing_suffix}",

--- a/scripts/render_rev4_promotion_readiness.py
+++ b/scripts/render_rev4_promotion_readiness.py
@@ -96,10 +96,13 @@ def build_readiness(
     issues.sort(key=_issue_id)
     issue_ids = {_issue_id(issue) for issue in issues}
     rows_by_issue: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    dispatch_rows_by_issue: dict[int, list[dict[str, Any]]] = defaultdict(list)
     for row in metrics_rows:
         issue_number = row.get("issue_number")
         if isinstance(issue_number, int) and issue_number in issue_ids:
             rows_by_issue[issue_number].append(row)
+            if str(row.get("worker_outcome") or "").strip():
+                dispatch_rows_by_issue[issue_number].append(row)
 
     # Cross-reference GitHub PR state. A merged or open PR on the
     # boss-loop's deterministic branch pattern is dispatch evidence
@@ -109,15 +112,17 @@ def build_readiness(
         issues_dispatched_via_pr(list(issue_ids), pr_records=pr_records or []) if pr_records else {}
     )
 
-    metrics_dispatched_set = set(rows_by_issue)
+    metrics_dispatched_set = set(dispatch_rows_by_issue)
     pr_dispatched_set = {n for n, verdict in pr_evidence.items() if bool(verdict.get("dispatched"))}
-    dispatched_ids = sorted(metrics_dispatched_set | pr_dispatched_set)
-    missing_ids = sorted(issue_ids - set(dispatched_ids))
+    advisory_dispatched_ids = sorted(metrics_dispatched_set | pr_dispatched_set)
+    dispatched_ids = sorted(metrics_dispatched_set)
+    missing_ids = sorted(issue_ids - metrics_dispatched_set)
+    advisory_missing_ids = sorted(issue_ids - set(advisory_dispatched_ids))
     needed_for_minimum = max(int(min_dispatched) - len(dispatched_ids), 0)
     recommended_ids = missing_ids[: needed_for_minimum or min(10, len(missing_ids))]
 
     dispatch_source_by_issue: dict[int, str] = {}
-    for issue_id in dispatched_ids:
+    for issue_id in advisory_dispatched_ids:
         in_metrics = issue_id in metrics_dispatched_set
         in_pr = issue_id in pr_dispatched_set
         if in_metrics and in_pr:
@@ -135,7 +140,7 @@ def build_readiness(
     for issue in issues:
         issue_number = _issue_id(issue)
         execution_class = str(issue.get("execution_class") or "unknown")
-        if issue_number in metrics_dispatched_set or issue_number in pr_dispatched_set:
+        if issue_number in metrics_dispatched_set:
             class_dispatched[execution_class] += 1
         rows = rows_by_issue.get(issue_number, [])
         latest_terminal = ""
@@ -175,6 +180,10 @@ def build_readiness(
             "dispatched_issue_ids": dispatched_ids,
             "missing_issue_ids": missing_ids,
             "recommended_next_issue_ids": recommended_ids,
+            "advisory_any_source_dispatched_issue_count": len(advisory_dispatched_ids),
+            "advisory_any_source_missing_issue_count": len(advisory_missing_ids),
+            "advisory_any_source_dispatched_issue_ids": advisory_dispatched_ids,
+            "advisory_any_source_missing_issue_ids": advisory_missing_ids,
             "latest_terminal_by_issue": latest_terminal_by_issue,
             "dispatch_source_by_issue": dispatch_source_by_issue,
             "pr_dispatched_only_ids": pr_dispatched_only_ids,
@@ -214,7 +223,7 @@ def render_markdown(
     verdict = (
         "Ready to promote the first canonical rev-4 slice."
         if status == "promotion_ready"
-        else f"Not ready: needs {needed} more dispatched issue(s) to reach the {min_dispatched}-issue promotion floor."
+        else f"Not ready: needs {needed} more metrics-backed dispatched issue(s) to reach the {min_dispatched}-issue promotion floor."
     )
 
     lines = [
@@ -245,11 +254,12 @@ def render_markdown(
         "| Metric | Value |",
         "| --- | --- |",
         f"| Dispatch floor for first canonical slice | {min_dispatched} |",
-        f"| Staged issues with dispatch evidence (any source) | {dispatch.get('dispatched_issue_count') or 0} |",
-        f"| Staged issues still missing dispatch evidence | {dispatch.get('missing_issue_count') or 0} |",
-        f"| Additional dispatches needed | {needed} |",
+        f"| Metrics-backed staged issues eligible for canonical promotion | {dispatch.get('dispatched_issue_count') or 0} |",
+        f"| Staged issues still missing metrics-backed evidence | {dispatch.get('missing_issue_count') or 0} |",
+        f"| Additional metrics-backed dispatches needed | {needed} |",
+        f"| Advisory dispatch evidence from any source | {dispatch.get('advisory_any_source_dispatched_issue_count') or 0} |",
         f"| ...via metrics ledger only | {len(list(dispatch.get('metrics_dispatched_only_ids') or []))} |",
-        f"| ...via merged/open boss-harvest PR only | {len(list(dispatch.get('pr_dispatched_only_ids') or []))} |",
+        f"| ...via merged/open boss-harvest PR only (advisory) | {len(list(dispatch.get('pr_dispatched_only_ids') or []))} |",
         "",
         "## Next Dispatch Targets",
         "",
@@ -280,7 +290,7 @@ def render_markdown(
             "",
             "## Promotion Rule",
             "",
-            "Promote only a first canonical rev-4 slice after at least 15 staged entries have dispatch evidence. Dispatch evidence is satisfied by either (a) at least one row in `boss_metrics.jsonl` for the issue or (b) a merged or open pull request on the boss-loop's deterministic branch pattern `aragora/boss-harvest/issue-N-*`. Keep undispatched entries staged until they also accumulate evidence.",
+            "Promote only a first canonical rev-4 slice after at least 15 staged entries have metrics-backed dispatch evidence: at least one `boss_metrics.jsonl` row for the issue with a recorded `worker_outcome`. Merged or open boss-harvest PRs are useful advisory evidence, but they are not sufficient for canonical corpus promotion because `tests/benchmarks/test_corpus_freshness.py` requires metrics-backed dispatch history for every `in_progress` entry.",
             "",
         ]
     )

--- a/tests/scripts/test_measure_b0_scorecard.py
+++ b/tests/scripts/test_measure_b0_scorecard.py
@@ -415,6 +415,58 @@ def test_main_json_with_corpus_filters_metrics_and_reports_coverage(tmp_path: Pa
     assert payload["coverage"]["status"] == "incomplete"
 
 
+def test_main_publish_fail_incomplete_honors_complete_truth_artifact(
+    tmp_path: Path, capsys
+) -> None:
+    metrics_path = _write_metrics(
+        tmp_path / "boss_metrics.jsonl",
+        [{"issue_number": 1001, "terminal_class": "deliverable_pr_created"}],
+    )
+    truth_artifact_path = _write_json(
+        tmp_path / "truth-artifact.json",
+        {
+            "generated_at": "2026-04-14T14:00:00Z",
+            "corpus": {
+                "path": "docs/benchmarks/corpus.json",
+                "corpus_id": "tw-01-bounded-execution-v1",
+                "revision": 4,
+                "recorded_on": "2026-04-14",
+                "success_contract": "mergeable_pr_or_merged_pr",
+                "manifest_sha256": "abc123",
+                "membership_sha256": "def456",
+                "membership_issue_numbers": [1001, 1002],
+                "issue_count": 2,
+            },
+            "issues": [{"issue_number": 1001}, {"issue_number": 1002}],
+            "primary_metrics": {"truth_success_rate": 0.5},
+            "coverage": {"is_complete": True, "missing_issue_numbers": [], "status": "complete"},
+            "failure_class_distribution": {},
+            "rescue_counts_by_type": {},
+        },
+    )
+
+    exit_code = mod.main(
+        [
+            "--metrics",
+            str(metrics_path),
+            "--publish-dir",
+            str(tmp_path / "published"),
+            "--truth-artifact",
+            str(truth_artifact_path),
+            "--json",
+            "--fail-incomplete",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["coverage"]["is_complete"] is True
+    assert payload["proxy_metrics"]["coverage"]["is_complete"] is False
+    assert payload["proxy_metrics"]["coverage"]["missing_issue_numbers"] == [1002]
+    assert (tmp_path / "published" / "tw-01-bounded-execution-v1" / "rev-4").exists()
+
+
 def test_main_publish_mode_uses_default_corpus_to_build_truth_artifact(
     tmp_path: Path,
     capsys,

--- a/tests/scripts/test_render_rev4_promotion_readiness.py
+++ b/tests/scripts/test_render_rev4_promotion_readiness.py
@@ -51,8 +51,16 @@ def test_build_readiness_reports_gap_to_promotion_floor() -> None:
     readiness = mod.build_readiness(
         corpus=_corpus(list(range(1001, 1031))),
         metrics_rows=[
-            {"issue_number": 1001, "terminal_class": "blocked_not_dispatch_bounded"},
-            {"issue_number": 1003, "terminal_class": "deliverable_pr_created"},
+            {
+                "issue_number": 1001,
+                "terminal_class": "blocked_not_dispatch_bounded",
+                "worker_outcome": "blocked",
+            },
+            {
+                "issue_number": 1003,
+                "terminal_class": "deliverable_pr_created",
+                "worker_outcome": "pr_adopted",
+            },
         ],
         min_dispatched=3,
     )
@@ -78,8 +86,16 @@ def test_build_readiness_reports_promotion_ready_at_floor() -> None:
     readiness = mod.build_readiness(
         corpus=_corpus(list(range(1001, 1031))),
         metrics_rows=[
-            {"issue_number": 1001, "terminal_class": "blocked_not_dispatch_bounded"},
-            {"issue_number": 1002, "terminal_class": "deliverable_pr_created"},
+            {
+                "issue_number": 1001,
+                "terminal_class": "blocked_not_dispatch_bounded",
+                "worker_outcome": "blocked",
+            },
+            {
+                "issue_number": 1002,
+                "terminal_class": "deliverable_pr_created",
+                "worker_outcome": "pr_adopted",
+            },
         ],
         min_dispatched=2,
     )
@@ -88,11 +104,45 @@ def test_build_readiness_reports_promotion_ready_at_floor() -> None:
     assert readiness["needed_for_minimum"] == 0
 
 
+def test_build_readiness_requires_worker_outcome_for_canonical_promotion() -> None:
+    readiness = mod.build_readiness(
+        corpus=_corpus(list(range(1001, 1031))),
+        metrics_rows=[
+            {"issue_number": 1001, "terminal_class": "deliverable_pr_created"},
+            {
+                "issue_number": 1002,
+                "terminal_class": "deliverable_pr_created",
+                "worker_outcome": "pr_adopted",
+            },
+        ],
+        pr_records=[
+            {
+                "number": 4242,
+                "state": "MERGED",
+                "headRefName": "aragora/boss-harvest/issue-1001-boss-abcd",
+            }
+        ],
+        min_dispatched=2,
+    )
+
+    assert readiness["status"] == "needs_more_dispatch_evidence"
+    assert readiness["needed_for_minimum"] == 1
+    assert readiness["dispatch"]["dispatched_issue_ids"] == [1002]
+    assert readiness["dispatch"]["advisory_any_source_dispatched_issue_ids"] == [1001, 1002]
+    assert readiness["dispatch"]["dispatch_source_by_issue"][1001] == "pr"
+
+
 def test_main_writes_markdown_readiness(tmp_path: Path) -> None:
     corpus_path = _write_json(tmp_path / "corpus.json", _corpus([1001, 1002, 1003, 1004]))
     metrics_path = _write_metrics(
         tmp_path / "boss_metrics.jsonl",
-        [{"issue_number": 1001, "terminal_class": "deliverable_pr_created"}],
+        [
+            {
+                "issue_number": 1001,
+                "terminal_class": "deliverable_pr_created",
+                "worker_outcome": "pr_adopted",
+            }
+        ],
     )
     output_path = tmp_path / "readiness.md"
 
@@ -116,7 +166,7 @@ def test_main_writes_markdown_readiness(tmp_path: Path) -> None:
     assert exit_code == 0
     assert "Last updated: 2026-04-25T00:00:00Z" in markdown
     assert "Status: `manifest_below_h1_floor`" in markdown
-    assert "| Staged issues with dispatch evidence (any source) | 1 |" in markdown
+    assert "| Metrics-backed staged issues eligible for canonical promotion | 1 |" in markdown
     assert "`#1002`" in markdown
 
 
@@ -124,7 +174,13 @@ def test_main_json_mode_emits_readiness(tmp_path: Path, capsys) -> None:
     corpus_path = _write_json(tmp_path / "corpus.json", _corpus(list(range(1001, 1031))))
     metrics_path = _write_metrics(
         tmp_path / "boss_metrics.jsonl",
-        [{"issue_number": 1001, "terminal_class": "deliverable_pr_created"}],
+        [
+            {
+                "issue_number": 1001,
+                "terminal_class": "deliverable_pr_created",
+                "worker_outcome": "pr_adopted",
+            }
+        ],
     )
 
     exit_code = mod.main(
@@ -187,7 +243,13 @@ def test_main_json_mode_auto_loads_gh_pr_evidence(tmp_path: Path, capsys, monkey
     corpus_path = _write_json(tmp_path / "corpus.json", _corpus(list(range(1001, 1031))))
     metrics_path = _write_metrics(
         tmp_path / "boss_metrics.jsonl",
-        [{"issue_number": 1001, "terminal_class": "deliverable_pr_created"}],
+        [
+            {
+                "issue_number": 1001,
+                "terminal_class": "deliverable_pr_created",
+                "worker_outcome": "pr_adopted",
+            }
+        ],
     )
 
     def fake_fetch(issue_ids, **kwargs):
@@ -216,6 +278,7 @@ def test_main_json_mode_auto_loads_gh_pr_evidence(tmp_path: Path, capsys, monkey
 
     payload = json.loads(capsys.readouterr().out)
     assert exit_code == 0
-    assert payload["status"] == "promotion_ready"
-    assert payload["dispatch"]["dispatched_issue_count"] == 2
+    assert payload["status"] == "needs_more_dispatch_evidence"
+    assert payload["dispatch"]["dispatched_issue_count"] == 1
+    assert payload["dispatch"]["advisory_any_source_dispatched_issue_count"] == 2
     assert payload["dispatch"]["dispatch_source_by_issue"]["1002"] == "pr"


### PR DESCRIPTION
## Summary
- make `docs/THESIS.md` v4 canonical by removing the stale awaiting-review caveat
- tighten H1 rev-4 readiness so canonical promotion requires metrics-backed `worker_outcome` evidence, while PR-only boss-harvest evidence remains advisory
- record the current proof-loop blockers in STATUS/NEXT_STEPS: rev-4 is not promotion-ready, canonical B0 remains one issue, and observe-outcomes has no 14-day settlement receipts to inspect
- let `measure_b0_scorecard --fail-incomplete` honor complete strict truth-artifact coverage while still exposing incomplete proxy-metrics coverage

## Proof-loop outcome
- #7030 was merged first at exact head `7c983705d0a05ec7b1614bea475cfb822bb4d869`
- H1 rev-4 now reports `needs_more_dispatch_evidence`: 12 metrics-backed staged issues, 16 advisory any-source staged issues, 3 more metrics-backed dispatches needed to reach the 15-issue floor
- `docs/benchmarks/corpus.json` was not promoted because `tests/benchmarks/test_corpus_freshness.py` correctly rejected the 16-issue attempted slice
- `review-queue observe-outcomes --window-days 14 --max-receipts 5 --json` found zero settlement receipts and did not write outcomes

## Validation
- `pytest tests/scripts/test_measure_b0_scorecard.py tests/scripts/test_render_rev4_promotion_readiness.py tests/benchmarks/test_corpus_freshness.py tests/benchmarks/test_corpus_rev4_manifest.py tests/scripts/test_build_benchmark_truth_artifact.py tests/scripts/test_render_benchmark_truth_status.py -q -p no:randomly`
- `ruff check scripts/measure_b0_scorecard.py scripts/render_rev4_promotion_readiness.py tests/scripts/test_measure_b0_scorecard.py tests/scripts/test_render_rev4_promotion_readiness.py`
- `ruff format --check scripts/measure_b0_scorecard.py scripts/render_rev4_promotion_readiness.py tests/scripts/test_measure_b0_scorecard.py tests/scripts/test_render_rev4_promotion_readiness.py`
- `git diff --check`
- `gitleaks protect --staged --redact --verbose`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Non-claims
- no paid calls
- no H2 panel/rerun
- no AWS work
- no `observe-outcomes --write`
- no canonical corpus promotion
- no AGT merge authorization
