### PR TITLE
fix(automation): bound backlog divergence queries

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -64,6 +64,7 @@ COMPACT_RECORD_EXAMPLE_FIELDS = (
     "handoff_outbox_exists",
 )
 DEFAULT_SUMMARY_EXAMPLES_PER_CATEGORY = 3
+DIVERGENCE_REF_BATCH_SIZE = 200
 
 
 @dataclass(frozen=True)
@@ -586,33 +587,35 @@ def branch_divergence_map(
 ) -> dict[str, tuple[int, int]]:
     """Resolve ahead/behind counts for many branches in one Git call."""
 
-    wanted = {branch for branch in branches if branch}
+    wanted = {branch for branch in branches if branch and branch.startswith(prefix)}
     if not wanted:
         return {}
 
-    proc = run_git(
-        [
-            "for-each-ref",
-            f"--format=%(refname:short)|%(ahead-behind:{base})",
-            f"refs/heads/{prefix}",
-        ],
-        root,
-    )
-    if proc.returncode != 0:
-        return {}
-
     counts: dict[str, tuple[int, int]] = {}
-    for line in proc.stdout.splitlines():
-        if not line.strip():
-            continue
-        name, _, divergence = line.partition("|")
-        if name not in wanted:
-            continue
-        try:
-            ahead_text, behind_text = divergence.split()
-            counts[name] = (int(ahead_text), int(behind_text))
-        except ValueError:
-            continue
+    refs = [f"refs/heads/{branch}" for branch in sorted(wanted)]
+    for index in range(0, len(refs), DIVERGENCE_REF_BATCH_SIZE):
+        proc = run_git(
+            [
+                "for-each-ref",
+                f"--format=%(refname:short)|%(ahead-behind:{base})",
+                *refs[index : index + DIVERGENCE_REF_BATCH_SIZE],
+            ],
+            root,
+        )
+        if proc.returncode != 0:
+            return {}
+
+        for line in proc.stdout.splitlines():
+            if not line.strip():
+                continue
+            name, _, divergence = line.partition("|")
+            if name not in wanted:
+                continue
+            try:
+                ahead_text, behind_text = divergence.split()
+                counts[name] = (int(ahead_text), int(behind_text))
+            except ValueError:
+                continue
     return counts
 
 

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -86,7 +86,8 @@ def test_branch_divergence_map_parses_batch_ahead_behind_output(
         assert args == [
             "for-each-ref",
             "--format=%(refname:short)|%(ahead-behind:origin/main)",
-            "refs/heads/codex/",
+            "refs/heads/codex/example",
+            "refs/heads/codex/missing",
         ]
         return subprocess.CompletedProcess(
             args=args,
@@ -109,7 +110,7 @@ def test_branch_divergence_map_honors_custom_prefix(tmp_path: Path, monkeypatch:
         assert args == [
             "for-each-ref",
             "--format=%(refname:short)|%(ahead-behind:origin/main)",
-            "refs/heads/automation/",
+            "refs/heads/automation/example",
         ]
         return subprocess.CompletedProcess(
             args=args,


### PR DESCRIPTION
## Summary
- Bound `audit_codex_branch_backlog.py` divergence lookups to the selected branches instead of scanning the full branch prefix after `--max-branches` trimming.
- Batch selected refs with `DIVERGENCE_REF_BATCH_SIZE` to keep large local branch sets from dominating the audit path.
- Update focused tests for the narrower `for-each-ref` invocation.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py -p no:randomly` -> `43 passed`
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> `All checks passed!`
- `python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> `2 files already formatted`
- `git diff --check origin/main...HEAD` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`

## Notes
Rebased from outbox handoff `open-pr-codex-audit-divergence-bounds-selected-branches-9a52f150` onto current `origin/main`; new head is `0169a74fae7b7b4d597d860113a0c79f03a5a408`.
