### PR TITLE
fix(agent-bridge): lighten summary snapshots

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -171,7 +171,7 @@ class LaneRecord:
         )
 
 
-def discover() -> list[Session]:
+def discover(*, include_summaries: bool = True) -> list[Session]:
     """Discover all sessions via agent_bridge_sessions.
 
     Falls back to minimal tmux-only discovery if agent_bridge_sessions
@@ -182,6 +182,7 @@ def discover() -> list[Session]:
             repo_root=REPO_ROOT,
             tmux_dir=TMUX_SESSIONS_DIR,
             claude_projects_root=Path.home() / ".claude" / "projects",
+            include_summaries=include_summaries,
         )
         sessions: list[Session] = []
         for r in records:
@@ -847,10 +848,10 @@ def cmd_health(args: argparse.Namespace) -> int:
 def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     """Output a unified operator snapshot combining sessions, lanes, and health."""
     summary_only = bool(getattr(args, "summary_only", False))
-    sessions = discover()
+    sessions = discover(include_summaries=not summary_only)
     if not summary_only:
         _enrich_prs(sessions)
-    _write_session_snapshot(sessions)
+        _write_session_snapshot(sessions)
     records = _sync_lane_records(_load_lane_registry(), sessions)
 
     issues = _collect_health_issues(sessions, records)

--- a/scripts/agent_bridge_sessions.py
+++ b/scripts/agent_bridge_sessions.py
@@ -241,6 +241,69 @@ def _extract_text(content: Any) -> str:
     return _collapse("\n".join(parts))
 
 
+def _content_has_text(content: Any) -> bool:
+    if isinstance(content, str):
+        return bool(content.strip())
+    if not isinstance(content, list):
+        return False
+    for item in content:
+        if isinstance(item, str) and item.strip():
+            return True
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text" and str(item.get("text", "")).strip():
+            return True
+    return False
+
+
+def _extract_recent_claude_metadata(path: Path) -> dict[str, Any] | None:
+    updated_at: str | None = None
+    cwd: str | None = None
+    branch: str | None = None
+    has_text_turn = False
+    session_id = path.stem
+
+    for raw in reversed(_tail_lines(path)):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if cwd is None:
+            raw_cwd = payload.get("cwd")
+            if isinstance(raw_cwd, str) and raw_cwd.strip():
+                cwd = raw_cwd
+        if branch is None:
+            raw_branch = payload.get("gitBranch")
+            if isinstance(raw_branch, str) and raw_branch.strip():
+                branch = raw_branch
+        if updated_at is None:
+            raw_ts = payload.get("timestamp")
+            if isinstance(raw_ts, str) and raw_ts.strip():
+                updated_at = raw_ts
+
+        if not has_text_turn and payload.get("type") in {"user", "assistant"}:
+            message = payload.get("message")
+            if isinstance(message, dict) and _content_has_text(message.get("content")):
+                has_text_turn = True
+
+        if has_text_turn and updated_at and (cwd or branch):
+            break
+
+    if not has_text_turn:
+        return None
+
+    return {
+        "session_id": session_id,
+        "updated_at": updated_at or datetime.fromtimestamp(path.stat().st_mtime, UTC).isoformat(),
+        "cwd": cwd,
+        "branch": branch,
+    }
+
+
 def _extract_recent_claude_turns(path: Path) -> dict[str, Any] | None:
     last_user_text: str | None = None
     last_assistant_text: str | None = None
@@ -347,7 +410,9 @@ def _latest_log_line(log_file: Path) -> str:
     return _select_summary(_tail_lines(log_file, max_bytes=64 * 1024))
 
 
-def load_tmux_sessions(*, repo_root: Path, tmux_dir: Path) -> list[SessionRecord]:
+def load_tmux_sessions(
+    *, repo_root: Path, tmux_dir: Path, include_summaries: bool = True
+) -> list[SessionRecord]:
     records: list[SessionRecord] = []
     if not tmux_dir.exists():
         return records
@@ -385,9 +450,11 @@ def load_tmux_sessions(*, repo_root: Path, tmux_dir: Path) -> list[SessionRecord
                 updated_at = started
 
         status = _tmux_alive(name)
-        summary = _capture_tmux_summary(name) if status == "alive" else ""
-        if not summary and log_file.exists():
-            summary = _latest_log_line(log_file)
+        summary = ""
+        if include_summaries:
+            summary = _capture_tmux_summary(name) if status == "alive" else ""
+            if not summary and log_file.exists():
+                summary = _latest_log_line(log_file)
 
         records.append(
             SessionRecord(
@@ -407,14 +474,20 @@ def load_tmux_sessions(*, repo_root: Path, tmux_dir: Path) -> list[SessionRecord
     return records
 
 
-def _candidate_claude_logs(*, repo_root: Path, projects_root: Path) -> list[Path]:
+def _candidate_claude_logs(
+    *, repo_root: Path, projects_root: Path, include_summaries: bool = True
+) -> list[Path]:
     preferred = projects_root / _claude_project_slug(repo_root)
     if preferred.exists():
         return sorted(preferred.glob("*.jsonl"))
 
     candidates: list[Path] = []
     for path in projects_root.glob("*/*.jsonl"):
-        transcript = _extract_recent_claude_turns(path)
+        transcript = (
+            _extract_recent_claude_turns(path)
+            if include_summaries
+            else _extract_recent_claude_metadata(path)
+        )
         if transcript is None:
             continue
         cwd = transcript.get("cwd")
@@ -423,10 +496,20 @@ def _candidate_claude_logs(*, repo_root: Path, projects_root: Path) -> list[Path
     return sorted(candidates)
 
 
-def load_claude_sessions(*, repo_root: Path, projects_root: Path) -> list[SessionRecord]:
+def load_claude_sessions(
+    *, repo_root: Path, projects_root: Path, include_summaries: bool = True
+) -> list[SessionRecord]:
     records: list[SessionRecord] = []
-    for jsonl_path in _candidate_claude_logs(repo_root=repo_root, projects_root=projects_root):
-        transcript = _extract_recent_claude_turns(jsonl_path)
+    for jsonl_path in _candidate_claude_logs(
+        repo_root=repo_root,
+        projects_root=projects_root,
+        include_summaries=include_summaries,
+    ):
+        transcript = (
+            _extract_recent_claude_turns(jsonl_path)
+            if include_summaries
+            else _extract_recent_claude_metadata(jsonl_path)
+        )
         if transcript is None:
             continue
         cwd = transcript.get("cwd")
@@ -446,7 +529,7 @@ def load_claude_sessions(*, repo_root: Path, projects_root: Path) -> list[Sessio
                 branch=str(branch) if branch else None,
                 cwd=str(cwd) if cwd else None,
                 prompt_file=None,
-                summary=str(transcript["last_text"]),
+                summary=str(transcript.get("last_text") or ""),
                 transcript_file=str(jsonl_path),
                 last_role=str(transcript.get("last_role") or ""),
                 last_user_text=(
@@ -470,16 +553,27 @@ def collect_sessions(
     source: str = "all",
     limit: int = 100,
     resolve_repo: bool = True,
+    include_summaries: bool = True,
 ) -> list[SessionRecord]:
     normalized_repo = (
         resolve_canonical_repo_root(repo_root) if resolve_repo else repo_root.resolve()
     )
     records: list[SessionRecord] = []
     if source in {"all", "tmux"}:
-        records.extend(load_tmux_sessions(repo_root=normalized_repo, tmux_dir=tmux_dir))
+        records.extend(
+            load_tmux_sessions(
+                repo_root=normalized_repo,
+                tmux_dir=tmux_dir,
+                include_summaries=include_summaries,
+            )
+        )
     if source in {"all", "claude"}:
         records.extend(
-            load_claude_sessions(repo_root=normalized_repo, projects_root=claude_projects_root)
+            load_claude_sessions(
+                repo_root=normalized_repo,
+                projects_root=claude_projects_root,
+                include_summaries=include_summaries,
+            )
         )
     records.sort(key=lambda item: item.updated_at or "", reverse=True)
     return records[:limit]

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -335,10 +335,11 @@ def test_operator_snapshot_summary_only_json_omits_records(
     import agent_bridge as mod
 
     _patch_bridge_paths(mod, tmp_path, monkeypatch)
-    monkeypatch.setattr(
-        mod,
-        "discover",
-        lambda: [
+    discover_include_summaries: list[bool] = []
+
+    def fake_discover(*, include_summaries: bool = True):
+        discover_include_summaries.append(include_summaries)
+        return [
             mod.Session(
                 name="codex-main",
                 agent="codex",
@@ -346,13 +347,21 @@ def test_operator_snapshot_summary_only_json_omits_records(
                 branch="codex/example",
                 worktree=str(tmp_path),
             )
-        ],
-    )
+        ]
+
+    monkeypatch.setattr(mod, "discover", fake_discover)
     monkeypatch.setattr(
         mod,
         "_enrich_prs",
         lambda _sessions: (_ for _ in ()).throw(
             AssertionError("summary-only should not call GitHub PR enrichment")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_write_session_snapshot",
+        lambda _sessions: (_ for _ in ()).throw(
+            AssertionError("summary-only should not overwrite detailed session snapshots")
         ),
     )
 
@@ -366,6 +375,7 @@ def test_operator_snapshot_summary_only_json_omits_records(
     assert payload["summary"]["total_sessions"] == 1
     assert payload["summary"]["alive_sessions"] == 1
     assert payload["health"] == {"ok": True, "issues": []}
+    assert discover_include_summaries == [False]
 
 
 def test_cmd_launch_invokes_tmux_launcher_for_droid(

--- a/tests/scripts/test_agent_bridge_sessions.py
+++ b/tests/scripts/test_agent_bridge_sessions.py
@@ -134,6 +134,91 @@ def test_collect_sessions_merges_tmux_and_claude_sources(
     assert claude_session.summary == "I’m watching #5294 and #5295; #5295 is closest to merge."
 
 
+def test_collect_sessions_can_skip_expensive_summaries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_bridge_sessions as mod
+
+    repo_root = tmp_path / "aragora"
+    repo_root.mkdir()
+    tmux_dir = tmp_path / "tmux"
+    tmux_dir.mkdir()
+    claude_projects_root = tmp_path / "claude-projects"
+    project_dir = claude_projects_root / "-tmp-aragora"
+    project_dir.mkdir(parents=True)
+
+    log_file = tmux_dir / "codex-strategic.log"
+    log_file.write_text("PR #5297 opened\n", encoding="utf-8")
+    (tmux_dir / "codex-strategic.meta.json").write_text(
+        json.dumps(
+            {
+                "name": "codex-strategic",
+                "agent": "codex",
+                "started": "2026-04-13T18:00:00Z",
+                "log_file": str(log_file),
+                "repo_root": str(repo_root),
+                "cwd": str(repo_root),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    claude_log = project_dir / "1431bd39-6ab6-41e0-9ead-05f91680e1df.jsonl"
+    claude_log.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-13T18:02:00Z",
+                "cwd": str(repo_root),
+                "gitBranch": "codex/example",
+                "message": {
+                    "content": [{"type": "text", "text": "Detailed summary should not be parsed."}]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(mod, "_tmux_alive", lambda _name: "alive")
+    monkeypatch.setattr(
+        mod,
+        "_capture_tmux_summary",
+        lambda _name: (_ for _ in ()).throw(AssertionError("summary capture should be skipped")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_latest_log_line",
+        lambda _path: (_ for _ in ()).throw(AssertionError("log summary should be skipped")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_extract_text",
+        lambda _content: (_ for _ in ()).throw(
+            AssertionError("transcript text extraction should be skipped")
+        ),
+    )
+    monkeypatch.setattr(mod, "_claude_project_slug", lambda _repo_root: "-tmp-aragora")
+
+    sessions = mod.collect_sessions(
+        repo_root=repo_root,
+        tmux_dir=tmux_dir,
+        claude_projects_root=claude_projects_root,
+        resolve_repo=False,
+        include_summaries=False,
+    )
+
+    assert len(sessions) == 2
+    assert {item.source for item in sessions} == {"tmux", "claude_jsonl"}
+    assert {item.summary for item in sessions} == {""}
+
+    claude_session = next(item for item in sessions if item.source == "claude_jsonl")
+    assert claude_session.cwd == str(repo_root)
+    assert claude_session.branch == "codex/example"
+    assert claude_session.last_role == ""
+    assert claude_session.last_user_text is None
+    assert claude_session.last_assistant_text is None
+
+
 def test_collect_sessions_filters_tmux_sessions_to_matching_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Add a lightweight summary-only path for agent-bridge session discovery.
- Let `operator-snapshot --summary-only` avoid tmux log capture and Claude transcript detail collection while preserving counts and health signals.
- Extend focused agent-bridge tests for summary-only behavior.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_sessions.py -p no:randomly` -> `28 passed`
- `python3 -m ruff check scripts/agent_bridge.py scripts/agent_bridge_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_sessions.py` -> `All checks passed!`
- `python3 -m ruff format --check scripts/agent_bridge.py scripts/agent_bridge_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_sessions.py` -> `4 files already formatted`
- `/usr/bin/time -p python3 scripts/agent_bridge.py operator-snapshot --json --summary-only` -> completed; `real 10.33`
- `git diff --check origin/main...HEAD` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`

## Notes
Rebased from outbox handoff `open-pr-codex-operator-snapshot-summary-skip-details-f27921cf` onto current `origin/main`; new head is `5644b8df77604fc7150ffe226d2e6cf171b6d095`.
