### PR TITLE
fix(swarm): admit explicit rev4 corpus boss-ready issues

### DIFF
--- a/aragora/swarm/proof_first_queue.py
+++ b/aragora/swarm/proof_first_queue.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -59,6 +61,7 @@ _DRIFT_TERMS = (
     "outrun",
     "current gate",
 )
+_REV4_STAGING_CORPUS_PATH = Path("tests/benchmarks/corpus_rev4.json")
 
 
 @dataclass(frozen=True)
@@ -91,11 +94,54 @@ def _load_policy(
     return load_roadmap_priority_policy(Path(repo_root))
 
 
+@lru_cache(maxsize=8)
+def _staged_rev4_issue_numbers(repo_root: str) -> frozenset[int]:
+    path = Path(repo_root) / _REV4_STAGING_CORPUS_PATH
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return frozenset()
+    issues = payload.get("issues") if isinstance(payload, dict) else None
+    if not isinstance(issues, list):
+        return frozenset()
+    numbers: set[int] = set()
+    for issue in issues:
+        if not isinstance(issue, dict):
+            continue
+        try:
+            issue_number = int(issue.get("issue_id") or 0)
+        except (TypeError, ValueError):
+            continue
+        if issue_number > 0:
+            numbers.add(issue_number)
+    return frozenset(numbers)
+
+
+def _is_explicit_staged_rev4_issue(
+    *,
+    issue_number: int | None,
+    labels: list[str] | tuple[str, ...] | set[str],
+    repo_root: Path | str | None,
+) -> bool:
+    if "boss-ready" not in {str(label).strip() for label in labels}:
+        return False
+    if issue_number is None or repo_root is None:
+        return False
+    try:
+        normalized_issue_number = int(issue_number)
+    except (TypeError, ValueError):
+        return False
+    if normalized_issue_number <= 0:
+        return False
+    return normalized_issue_number in _staged_rev4_issue_numbers(str(Path(repo_root)))
+
+
 def classify_proof_first_queue_issue(
     title: str,
     body: str = "",
     *,
     labels: list[str] | tuple[str, ...] | set[str] = (),
+    issue_number: int | None = None,
     repo_root: Path | str | None = None,
     roadmap_policy: RoadmapPriorityPolicy | None = None,
 ) -> ProofFirstQueueDecision:
@@ -125,6 +171,20 @@ def classify_proof_first_queue_issue(
                 roadmap_codes=priority.codes,
                 blocked_codes=priority.blocked_codes,
             )
+
+    if _is_explicit_staged_rev4_issue(
+        issue_number=issue_number,
+        labels=labels,
+        repo_root=repo_root,
+    ):
+        return ProofFirstQueueDecision(
+            allowed=True,
+            lane="staged_rev4_corpus",
+            reason="explicit boss-ready issue is present in the staged rev-4 corpus",
+            matched_terms=("boss-ready", "corpus_rev4"),
+            roadmap_codes=roadmap_codes,
+            blocked_codes=(),
+        )
 
     benchmark_matches = _matched_terms(normalized_text, _BENCHMARK_TERMS)
     if "[tw-02]" in normalized_text or (
@@ -205,6 +265,7 @@ def filter_noncanonical_boss_ready_issues(
             issue.title,
             issue.body or "",
             labels=issue.labels,
+            issue_number=issue.number,
             repo_root=repo_root,
         )
         if decision.allowed:

--- a/scripts/reconcile_proof_first_queue.py
+++ b/scripts/reconcile_proof_first_queue.py
@@ -247,6 +247,7 @@ def reconcile_proof_first_queue(
             str(issue.get("title") or "").strip(),
             str(issue.get("body") or "").strip(),
             labels=labels,
+            issue_number=int(issue.get("number", 0) or 0),
             repo_root=repo_root,
         )
         record = {

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3281,6 +3281,12 @@ def test_filter_noncanonical_boss_ready_issues_strips_label_and_excludes_issue()
         body="Refresh benchmark corpus freshness after stale closed issues were detected.",
         labels=["boss-ready"],
     )
+    staged_rev4 = _make_issue(
+        5788,
+        "Narrow broad except Exception in performance_monitor.py",
+        body="Single-file exception hygiene task.",
+        labels=["boss-ready", "autonomous"],
+    )
     loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
     commands: list[list[str]] = []
     comments: list[str] = []
@@ -3295,11 +3301,18 @@ def test_filter_noncanonical_boss_ready_issues_strips_label_and_excludes_issue()
             comments.append(cmd[cmd.index("--body") + 1])
         return result
 
-    with patch("aragora.swarm.boss_loop.subprocess.run", side_effect=_run):
-        kept = loop._filter_noncanonical_boss_ready_issues([generic, canonical])
+    with (
+        patch("aragora.swarm.boss_loop.subprocess.run", side_effect=_run),
+        patch(
+            "aragora.swarm.proof_first_queue._staged_rev4_issue_numbers",
+            return_value=frozenset({5788}),
+        ),
+    ):
+        kept = loop._filter_noncanonical_boss_ready_issues([generic, canonical, staged_rev4])
 
-    assert kept == [canonical]
+    assert kept == [canonical, staged_rev4]
     assert "boss-ready" not in generic.labels
+    assert "boss-ready" in staged_rev4.labels
     assert comments
     assert "outside the canonical proof-first queue" in comments[-1]
     assert any(cmd[:3] == ["gh", "issue", "edit"] for cmd in commands)

--- a/tests/swarm/test_proof_first_queue_classification.py
+++ b/tests/swarm/test_proof_first_queue_classification.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from aragora.swarm.proof_first_queue import classify_proof_first_queue_issue
@@ -108,6 +110,58 @@ def test_classifies_benchmark_regression_lane(
     assert decision.allowed is True
     assert decision.lane == "benchmark_regression"
     assert set(expected_terms).issubset(decision.matched_terms)
+
+
+def test_classifies_explicit_staged_rev4_corpus_issue(tmp_path) -> None:
+    corpus_path = tmp_path / "tests" / "benchmarks" / "corpus_rev4.json"
+    corpus_path.parent.mkdir(parents=True)
+    corpus_path.write_text(json.dumps({"issues": [{"issue_id": 5788}]}))
+
+    decision = classify_proof_first_queue_issue(
+        "Narrow broad except Exception in performance_monitor.py",
+        "Single-file exception hygiene task.",
+        labels=("autonomous", "boss-ready"),
+        issue_number=5788,
+        repo_root=tmp_path,
+    )
+
+    assert decision.allowed is True
+    assert decision.lane == "staged_rev4_corpus"
+    assert "corpus_rev4" in decision.matched_terms
+
+
+def test_staged_rev4_corpus_issue_requires_explicit_boss_ready(tmp_path) -> None:
+    corpus_path = tmp_path / "tests" / "benchmarks" / "corpus_rev4.json"
+    corpus_path.parent.mkdir(parents=True)
+    corpus_path.write_text(json.dumps({"issues": [{"issue_id": 5788}]}))
+
+    decision = classify_proof_first_queue_issue(
+        "Narrow broad except Exception in performance_monitor.py",
+        "Single-file exception hygiene task.",
+        labels=("autonomous",),
+        issue_number=5788,
+        repo_root=tmp_path,
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "non_canonical"
+
+
+def test_staged_rev4_corpus_issue_requires_membership(tmp_path) -> None:
+    corpus_path = tmp_path / "tests" / "benchmarks" / "corpus_rev4.json"
+    corpus_path.parent.mkdir(parents=True)
+    corpus_path.write_text(json.dumps({"issues": [{"issue_id": 5788}]}))
+
+    decision = classify_proof_first_queue_issue(
+        "Narrow broad except Exception in unrelated.py",
+        "Single-file exception hygiene task.",
+        labels=("autonomous", "boss-ready"),
+        issue_number=9999,
+        repo_root=tmp_path,
+    )
+
+    assert decision.allowed is False
+    assert decision.lane == "non_canonical"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Allows explicitly labeled staged rev-4 corpus issues to remain in the proof-first `boss-ready` queue. This is a narrow operate-mode repair: issues like #5788/#5789/#5790 are members of `tests/benchmarks/corpus_rev4.json`, but the proof-first filter stripped `boss-ready` because their titles do not match benchmark/rescue/docs-proof terms.

## Scope

- Adds a `staged_rev4_corpus` classification lane only when an issue number is present in `tests/benchmarks/corpus_rev4.json` and the issue explicitly has `boss-ready`.
- Preserves roadmap block behavior for delayed/avoided lanes.
- Passes issue numbers through the live boss-loop filter and proof-first reconciler.
- Does not label issues, dispatch workers, run paid calls, mutate receipts, or run `observe-outcomes --write`.

## Validation

- `python3 -m pytest tests/swarm/test_proof_first_queue_classification.py tests/swarm/test_boss_loop.py::test_filter_noncanonical_boss_ready_issues_strips_label_and_excludes_issue -q` -> `17 passed`
- `python3 -m ruff check aragora/swarm/proof_first_queue.py scripts/reconcile_proof_first_queue.py tests/swarm/test_proof_first_queue_classification.py tests/swarm/test_boss_loop.py` -> pass
- `python3 -m ruff format --check aragora/swarm/proof_first_queue.py scripts/reconcile_proof_first_queue.py tests/swarm/test_proof_first_queue_classification.py tests/swarm/test_boss_loop.py` -> pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> pass
- Direct reproduction on #5788/#5789/#5790 with `boss-ready` added in classification inputs -> all classify as `staged_rev4_corpus`
