### PR TITLE
fix(automation): share state dirs in parallel backlog audit

### DIFF
--- a/scripts/audit_branch_backlog_parallel.py
+++ b/scripts/audit_branch_backlog_parallel.py
@@ -37,6 +37,10 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 
 from audit_codex_branch_backlog import (  # noqa: E402
     ACTIVE_SESSION_FILES,
+    DEFAULT_OUTBOX_DIR,
+    DEFAULT_RECEIPT_DIR,
+    _automation_state_default_path,
+    _automation_state_path,
     branch_patch_id,
     count_ahead,
     is_patch_equivalent,
@@ -263,9 +267,45 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--max-branches", type=int, default=None, help="Cap branches scanned (testing)"
     )
+    parser.add_argument(
+        "--state-root",
+        type=Path,
+        default=None,
+        help=(
+            "Shared automation state root used to derive default handoff dirs. "
+            "Accepts either a repo root containing .aragora or the .aragora "
+            "directory itself. Explicit --outbox-dir/--receipt-dir override it."
+        ),
+    )
+    parser.add_argument(
+        "--outbox-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Automation outbox directory to use for terminal handoff receipt matching. "
+            "Relative paths are resolved from the repo root."
+        ),
+    )
+    parser.add_argument(
+        "--receipt-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Automation receipt directory to use for terminal handoff receipt matching. "
+            "Relative paths are resolved from the repo root."
+        ),
+    )
     args = parser.parse_args(argv)
 
     root = Path(args.repo).resolve()
+    state_root = args.state_root.expanduser() if args.state_root else None
+    outbox_dir = args.outbox_dir
+    receipt_dir = args.receipt_dir
+    if state_root is not None:
+        if outbox_dir is None:
+            outbox_dir = _automation_state_default_path(state_root, DEFAULT_OUTBOX_DIR)
+        if receipt_dir is None:
+            receipt_dir = _automation_state_default_path(state_root, DEFAULT_RECEIPT_DIR)
     out_path = root / args.out
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -297,9 +337,19 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  open_prs={len(open_prs)}")
 
     print("  loading automation outbox + receipt protection")
-    receipted = terminal_receipted_handoff_branches(root)
-    outbox = unresolved_outbox_handoff_branches(root)
-    handoff_keys = terminal_handoff_keys(root / ".aragora" / "automation-receipts")
+    resolved_outbox_dir = _automation_state_path(root, outbox_dir, DEFAULT_OUTBOX_DIR)
+    resolved_receipt_dir = _automation_state_path(root, receipt_dir, DEFAULT_RECEIPT_DIR)
+    receipted = terminal_receipted_handoff_branches(
+        root,
+        outbox_dir=resolved_outbox_dir,
+        receipt_dir=resolved_receipt_dir,
+    )
+    outbox = unresolved_outbox_handoff_branches(
+        root,
+        outbox_dir=resolved_outbox_dir,
+        receipt_dir=resolved_receipt_dir,
+    )
+    handoff_keys = terminal_handoff_keys(resolved_receipt_dir)
     print(
         f"  receipted_branches={len(receipted)} unresolved_outbox_branches={len(outbox)} "
         f"terminal_handoff_keys={len(handoff_keys)}"
@@ -394,6 +444,8 @@ def main(argv: list[str] | None = None) -> int:
         "prefix": args.prefix,
         "github_health": github_health,
         "open_pr_lookup_skipped": open_pr_lookup_skipped,
+        "outbox_dir": str(resolved_outbox_dir),
+        "receipt_dir": str(resolved_receipt_dir),
         "totals": {
             "branches_scanned": len(rows),
             "branches_with_open_pr": len(open_prs),

--- a/tests/scripts/test_audit_branch_backlog_parallel.py
+++ b/tests/scripts/test_audit_branch_backlog_parallel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -182,3 +183,128 @@ def test_classify_one_protects_canonical_active_session_marker(tmp_path: Path) -
     assert record["category"] == mod.CATEGORY_PROTECTED_ACTIVE_WT
     assert record["active_session"] is True
     assert record["worktree_paths"] == [str(worktree)]
+
+
+def _stub_inventory(monkeypatch: Any, branch: str = "codex/example") -> None:
+    monkeypatch.setattr(mod, "local_branches", lambda _root, _prefix, _base: [_branch_row(branch)])
+    monkeypatch.setattr(mod, "remote_branch_names", lambda _root, _prefix: set())
+    monkeypatch.setattr(mod, "merged_branch_names", lambda _root, _base, _prefix: set())
+    monkeypatch.setattr(mod, "worktree_map", lambda _root: {})
+    monkeypatch.setattr(
+        mod,
+        "_load_open_prs",
+        lambda _root, _repo_name, _prefix: (
+            {},
+            {"ready": False, "mode": "connectivity_failed"},
+            True,
+        ),
+    )
+    monkeypatch.setattr(mod, "is_patch_equivalent", lambda _root, _base, _branch: False)
+    monkeypatch.setattr(mod, "branch_patch_id", lambda _root, _base, _branch: "pid-example")
+
+
+def test_main_accepts_explicit_shared_handoff_dirs(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "disposable-worktree"
+    repo.mkdir()
+    outbox = tmp_path / "shared" / ".aragora" / "automation-outbox"
+    receipts = tmp_path / "shared" / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    output = tmp_path / "parallel-audit.json"
+    captured: dict[str, tuple[Path | None, Path | None] | Path] = {}
+    _stub_inventory(monkeypatch)
+
+    def fake_receipted(
+        _root: Path, *, outbox_dir: Path | None = None, receipt_dir: Path | None = None
+    ) -> set[str]:
+        captured["receipted_dirs"] = (outbox_dir, receipt_dir)
+        return {"codex/example"}
+
+    def fake_outbox(
+        _root: Path, *, outbox_dir: Path | None = None, receipt_dir: Path | None = None
+    ) -> set[str]:
+        captured["outbox_dirs"] = (outbox_dir, receipt_dir)
+        return set()
+
+    def fake_terminal_keys(receipt_dir: Path) -> set[str]:
+        captured["terminal_keys_dir"] = receipt_dir
+        return set()
+
+    monkeypatch.setattr(mod, "terminal_receipted_handoff_branches", fake_receipted)
+    monkeypatch.setattr(mod, "unresolved_outbox_handoff_branches", fake_outbox)
+    monkeypatch.setattr(mod, "terminal_handoff_keys", fake_terminal_keys)
+
+    rc = mod.main(
+        [
+            "--repo",
+            str(repo),
+            "--out",
+            str(output),
+            "--max-branches",
+            "1",
+            "--outbox-dir",
+            str(outbox),
+            "--receipt-dir",
+            str(receipts),
+        ]
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert captured["receipted_dirs"] == (outbox, receipts)
+    assert captured["outbox_dirs"] == (outbox, receipts)
+    assert captured["terminal_keys_dir"] == receipts
+    assert payload["outbox_dir"] == str(outbox)
+    assert payload["receipt_dir"] == str(receipts)
+    assert payload["records"][0]["category"] == mod.CATEGORY_PROTECTED_HANDOFF_RECEIPT
+
+
+def test_main_state_root_accepts_direct_dot_aragora(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "disposable-worktree"
+    repo.mkdir()
+    state_root = tmp_path / "shared" / ".aragora"
+    outbox = state_root / "automation-outbox"
+    receipts = state_root / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    output = tmp_path / "parallel-audit.json"
+    _stub_inventory(monkeypatch)
+
+    monkeypatch.setattr(
+        mod,
+        "terminal_receipted_handoff_branches",
+        lambda _root, *, outbox_dir=None, receipt_dir=None: {"codex/example"}
+        if (outbox_dir, receipt_dir) == (outbox, receipts)
+        else set(),
+    )
+    monkeypatch.setattr(
+        mod,
+        "unresolved_outbox_handoff_branches",
+        lambda _root, *, outbox_dir=None, receipt_dir=None: set(),
+    )
+    monkeypatch.setattr(mod, "terminal_handoff_keys", lambda _receipt_dir: set())
+
+    rc = mod.main(
+        [
+            "--repo",
+            str(repo),
+            "--out",
+            str(output),
+            "--max-branches",
+            "1",
+            "--state-root",
+            str(state_root),
+        ]
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert payload["outbox_dir"] == str(outbox)
+    assert payload["receipt_dir"] == str(receipts)
+    assert payload["totals"]["receipted_handoff_branches"] == 1


### PR DESCRIPTION
## Summary
- Share state-dir flag handling through parallel backlog audit worker execution.
- Preserve worker compatibility while allowing backlog audit state/output roots to be routed consistently.

## Validation
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok
- `git push -u origin codex/parallel-audit-shared-state-flags-20260512` -> pre-push hooks passed and branch pushed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_audit_branch_backlog_parallel.py tests/scripts/test_audit_codex_branch_backlog.py -p no:rerunfail` -> 56 passed

Outbox source: `.aragora/automation-outbox/open-pr-codex-parallel-audit-shared-state-flags-20260512-fa75c068.json`
