### PR TITLE
fix(cli): narrow swarm status terminal fallback

### DIFF
--- a/aragora/cli/commands/swarm_status.py
+++ b/aragora/cli/commands/swarm_status.py
@@ -106,7 +106,7 @@ def _resolve_terminal_class(row: dict[str, Any]) -> str:
         return existing
     try:
         return classify_from_metrics(row).value
-    except Exception:
+    except (AttributeError, KeyError, TypeError, ValueError):
         return TerminalClass.RESCUE_NO_DELIVERABLE.value
 
 

--- a/tests/cli/test_swarm_status_command.py
+++ b/tests/cli/test_swarm_status_command.py
@@ -10,6 +10,7 @@ from aragora.cli.commands.swarm import cmd_swarm
 from aragora.cli.commands.swarm_status import (
     _optional_float,
     _optional_int,
+    _resolve_terminal_class,
     load_operator_status,
     render_operator_status,
 )
@@ -98,6 +99,23 @@ def test_numeric_coercion_helpers_accept_common_object_inputs() -> None:
     assert _optional_float(7) == 7.0
     assert _optional_float("9.5") == 9.5
     assert _optional_float(object()) is None
+
+
+def test_resolve_terminal_class_falls_back_for_malformed_metrics() -> None:
+    assert _resolve_terminal_class({"files_changed": object()}) == "rescue_no_deliverable"
+
+
+def test_resolve_terminal_class_does_not_swallow_unexpected_errors() -> None:
+    with patch(
+        "aragora.cli.commands.swarm_status.classify_from_metrics",
+        side_effect=RuntimeError("unexpected classifier failure"),
+    ):
+        try:
+            _resolve_terminal_class({"worker_status": "needs_human"})
+        except RuntimeError as exc:
+            assert str(exc) == "unexpected classifier failure"
+        else:  # pragma: no cover - keeps the assertion readable without pytest.raises
+            raise AssertionError("unexpected classifier errors should propagate")
 
 
 def test_load_operator_status_reports_unknown_queue_depth_when_probe_unavailable(


### PR DESCRIPTION
## Summary
- Replaces the broad `except Exception:` in `swarm_status._resolve_terminal_class` with the specific exception types expected from malformed metrics rows.
- Adds regression coverage proving malformed rows still fall back to `rescue_no_deliverable` while unexpected classifier failures propagate.

## Context
- Recovered from boss-loop issue #5790 after the initial worker deliverable failed the acceptance gate because it changed `aragora/cli/commands/swarm_status.py` without adding tests.
- This PR republishes the repair on a clean branch from current `origin/main`; the original worker branch is preserved as evidence.

## Validation
- `python3 -m pytest tests/cli/test_swarm_status_command.py -q` -> 11 passed
- `python3 -m ruff check aragora/cli/commands/swarm_status.py tests/cli/test_swarm_status_command.py`
- `python3 -m ruff format --check aragora/cli/commands/swarm_status.py tests/cli/test_swarm_status_command.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Refs #5790.
