### PR TITLE
docs(status): capture first proof-loop closure

### DIFF
--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -5,7 +5,7 @@ description: Next Steps (Canonical)
 
 # Next Steps (Canonical)
 
-Last updated: 2026-05-06
+Last updated: 2026-05-13
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
@@ -17,13 +17,14 @@ This is the single source of truth for short-horizon execution priorities.
 
 The immediate gate is operating the proof loop that already exists: keep recurring benchmark truth publication complete, fresh, and trustworthy on current `main`; keep `CS-01..03` narrower than measured proof; and do not expand the `B2` guard until repeated runs support it. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
 
-Current May 6 proof-loop state:
+Current May 13 proof-loop state:
 
 - `docs/THESIS.md` is v4 canonical.
-- H1-01 rev-4 readiness is `needs_more_dispatch_evidence`: 16 staged issues have advisory dispatch evidence, but only 12 have metrics-backed `worker_outcome` evidence and 15 are required for canonical promotion.
-- The first canonical rev-4 B0 slice is not promoted yet; `docs/benchmarks/corpus.json` remains at the existing one-issue rev-4 corpus until the metrics-backed floor is met.
+- H1-01 rev-4 readiness is `promotion_ready`: 15 staged issues have metrics-backed `worker_outcome` evidence, meeting the 15-issue floor for canonical promotion.
+- The first canonical rev-4 B0 slice is not promoted yet; `docs/benchmarks/corpus.json` remains at the existing one-issue rev-4 corpus until the promotion step is executed explicitly.
 - Fresh B0 publication remains complete for the existing canonical corpus and reports 0.0% current truth success.
-- `review-queue observe-outcomes` dry-run found no settlement receipts under `.aragora/review-queue/receipts`; the first `--write` remains blocked until a manually verifiable receipt slice exists.
+- The first settlement receipt exists for `#7060`, and `review-queue observe-outcomes --window-days 14 --max-receipts 5 --json` dry-runs over it successfully with all five v2 outcome signals false and no receipt JSON writes.
+- The first `observe-outcomes --write` remains a separate Tier-4 operator decision over a bounded manually verifiable receipt slice.
 
 Operator commands only count as proof when they are run from a clean, current `origin/main` observer. A dirty or diverged founder checkout is planning context, not runtime truth.
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,11 +12,11 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4107` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1930985` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4108` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1931960` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `136` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5153` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217462` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5155` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217542` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `662` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `63` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `822` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `827` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -16,7 +16,7 @@
 | Python lines of code under aragora/ | `1931960` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `136` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5155` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217542` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `217547` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `662` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `63` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2940` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/status/H1_01_REV4_PROMOTION_READINESS.md
+++ b/docs/status/H1_01_REV4_PROMOTION_READINESS.md
@@ -1,13 +1,13 @@
 # H1-01 Rev-4 Promotion Readiness
 
-Last updated: 2026-05-07T02:36:29Z
+Last updated: 2026-05-13T03:27:10Z
 
 This is the operator-facing readiness surface for promoting the staged rev-4 benchmark corpus into the canonical B0 truth loop.
 
 ## Verdict
 
-- Status: `needs_more_dispatch_evidence`
-- Decision: Not ready: needs 2 more metrics-backed dispatched issue(s) to reach the 15-issue promotion floor.
+- Status: `promotion_ready`
+- Decision: Ready to promote the first canonical rev-4 slice.
 - Staging corpus: `tests/benchmarks/corpus_rev4.json`
 - Metrics source: `.aragora/overnight/boss_metrics.jsonl`
 - Promotion target: `docs/benchmarks/corpus.json`
@@ -25,16 +25,16 @@ This is the operator-facing readiness surface for promoting the staged rev-4 ben
 | Metric | Value |
 | --- | --- |
 | Dispatch floor for first canonical slice | 15 |
-| Metrics-backed staged issues eligible for canonical promotion | 13 |
-| Staged issues still missing metrics-backed evidence | 20 |
-| Additional metrics-backed dispatches needed | 2 |
-| Advisory dispatch evidence from any source | 16 |
-| ...via metrics ledger only | 1 |
-| ...via merged/open boss-harvest PR only (advisory) | 3 |
+| Metrics-backed staged issues eligible for canonical promotion | 15 |
+| Staged issues still missing metrics-backed evidence | 18 |
+| Additional metrics-backed dispatches needed | 0 |
+| Advisory dispatch evidence from any source | 15 |
+| ...via metrics ledger only | 15 |
+| ...via merged/open boss-harvest PR only (advisory) | 0 |
 
 ## Next Metrics Evidence Gaps
 
-`#5128`, `#5130`
+`#5128`, `#5130`, `#5188`, `#5788`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`
 
 These are the earliest staged issues missing metrics-backed `worker_outcome` rows; verify live issue state before dispatching new work.
 
@@ -43,7 +43,7 @@ These are the earliest staged issues missing metrics-backed `worker_outcome` row
 | Execution class | Dispatched | Total | Missing |
 | --- | ---: | ---: | ---: |
 | `docs_reconciliation` | 1 | 2 | 1 |
-| `exception_narrowing` | 0 | 8 | 8 |
+| `exception_narrowing` | 2 | 8 | 6 |
 | `missing_test_coverage` | 7 | 10 | 3 |
 | `silent_exception_replacement` | 0 | 8 | 8 |
 | `small_refactor` | 3 | 3 | 0 |
@@ -51,11 +51,11 @@ These are the earliest staged issues missing metrics-backed `worker_outcome` row
 
 ## Dispatched Issues
 
-`#5176`, `#5180`, `#5185`, `#5187`, `#5197`, `#5198`, `#5200`, `#5426`, `#5427`, `#5428`, `#5764`, `#5765`, `#5844`
+`#5176`, `#5180`, `#5185`, `#5187`, `#5197`, `#5198`, `#5200`, `#5426`, `#5427`, `#5428`, `#5764`, `#5765`, `#5789`, `#5790`, `#5844`
 
 ## Missing Evidence
 
-`#5128`, `#5130`, `#5188`, `#5788`, `#5789`, `#5790`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`, `#5810`, `#5811`, `#5812`, `#5821`, `#5823`, `#5825`, `#5883`
+`#5128`, `#5130`, `#5188`, `#5788`, `#5791`, `#5792`, `#5793`, `#5794`, `#5801`, `#5808`, `#5809`, `#5810`, `#5811`, `#5812`, `#5821`, `#5823`, `#5825`, `#5883`
 
 ## Promotion Rule
 

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-05-06
+Last updated: 2026-05-13
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -12,13 +12,14 @@ This is the single source of truth for short-horizon execution priorities.
 
 The immediate gate is operating the proof loop that already exists: keep recurring benchmark truth publication complete, fresh, and trustworthy on current `main`; keep `CS-01..03` narrower than measured proof; and do not expand the `B2` guard until repeated runs support it. The execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806) are now closed; the current obligation is operationalizing the proof-first loop, not adding new roadmap scope.
 
-Current May 6 proof-loop state:
+Current May 13 proof-loop state:
 
 - `docs/THESIS.md` is v4 canonical.
-- H1-01 rev-4 readiness is `needs_more_dispatch_evidence`: 16 staged issues have advisory dispatch evidence, but only 12 have metrics-backed `worker_outcome` evidence and 15 are required for canonical promotion.
-- The first canonical rev-4 B0 slice is not promoted yet; `docs/benchmarks/corpus.json` remains at the existing one-issue rev-4 corpus until the metrics-backed floor is met.
+- H1-01 rev-4 readiness is `promotion_ready`: 15 staged issues have metrics-backed `worker_outcome` evidence, meeting the 15-issue floor for canonical promotion.
+- The first canonical rev-4 B0 slice is not promoted yet; `docs/benchmarks/corpus.json` remains at the existing one-issue rev-4 corpus until the promotion step is executed explicitly.
 - Fresh B0 publication remains complete for the existing canonical corpus and reports 0.0% current truth success.
-- `review-queue observe-outcomes` dry-run found no settlement receipts under `.aragora/review-queue/receipts`; the first `--write` remains blocked until a manually verifiable receipt slice exists.
+- The first settlement receipt exists for `#7060`, and `review-queue observe-outcomes --window-days 14 --max-receipts 5 --json` dry-runs over it successfully with all five v2 outcome signals false and no receipt JSON writes.
+- The first `observe-outcomes --write` remains a separate Tier-4 operator decision over a bounded manually verifiable receipt slice.
 
 Operator commands only count as proof when they are run from a clean, current `origin/main` observer. A dirty or diverged founder checkout is planning context, not runtime truth.
 

--- a/docs/status/PROOF_LOOP_FIRST_CLOSURE_2026-05-12.md
+++ b/docs/status/PROOF_LOOP_FIRST_CLOSURE_2026-05-12.md
@@ -1,0 +1,35 @@
+# Proof Loop First Closure - 2026-05-12
+
+This note captures the first end-to-end proof-loop observation before later queue
+and automation hygiene work obscures the milestone.
+
+## Observed State
+
+- H1-01 rev-4 promotion readiness now renders as `promotion_ready` from the live
+  metrics ledger: 15 staged issues have metrics-backed `worker_outcome` evidence,
+  meeting the 15-issue floor for promoting the first canonical rev-4 slice.
+- `.aragora/overnight/boss_metrics.jsonl` is live and fresh: 410 rows, modified
+  2026-05-12 20:47:43 -0500 during the boss-loop run that attempted issue
+  `#5790`.
+- The boss-loop dispatched `#5790` and produced a useful failure observation:
+  the worker changed `aragora/cli/commands/swarm_status.py`, but the acceptance
+  gate rejected it because the deliverable lacked a test file. Failure as
+  measured observation is valid proof-loop output.
+- The first settlement receipt exists:
+  `.aragora/review-queue/receipts/pr-7060-recorded-7060-a9beb87d86dc-admin_squash_merge-admin_squash_merge.json`.
+- `review-queue observe-outcomes --window-days 14 --max-receipts 5 --json`
+  dry-runs successfully over that receipt, fetches the GitHub timeline, computes
+  all five v2 outcome signals as false for `#7060`, and writes no receipt JSON.
+
+## Caveats
+
+- This does not empirically ground the thesis 5% invalidation threshold. The
+  dry-run examines one settlement receipt, with zero observed invalidation
+  signals, and the command correctly reports an insufficiency path rather than a
+  measured baseline.
+- This does not authorize unattended `observe-outcomes --write`. The first
+  write remains a separate Tier-4 operator decision over a bounded receipt set.
+- This does not unblock H2 panel execution. H2 remains gated on real baseline
+  comparison/manual-verdict tooling and a clean queue/automation posture.
+- The canonical corpus promotion itself is not performed here; this note records
+  that the promotion readiness gate is now satisfied by metrics-backed evidence.

--- a/tests/heterogeneity/probe_prompts/clean_neutral/05_h1_readiness_gate.md
+++ b/tests/heterogeneity/probe_prompts/clean_neutral/05_h1_readiness_gate.md
@@ -7,10 +7,10 @@ verification_refs:
   - "docs/status/H1_01_REV4_PROMOTION_READINESS.md"
 ---
 
-The H1-01 rev-4 promotion readiness surface specifies a 15-issue dispatch-evidence floor for promoting the staged corpus into the canonical B0 truth loop. As of 2026-04-30, the surface reports 16 staged issues with dispatch evidence and 17 still missing. The verdict is `promotion_ready`: 0 more dispatches are needed to reach the floor.
+The H1-01 rev-4 promotion readiness surface specifies a 15-issue metrics-backed dispatch-evidence floor for promoting the staged corpus into the canonical B0 truth loop. As of 2026-05-13, the surface reports 15 metrics-backed staged issues eligible for canonical promotion and 18 still missing. The verdict is `promotion_ready`: 0 more metrics-backed dispatches are needed to reach the floor.
 
-Dispatch evidence is satisfied by either (a) at least one row in `boss_metrics.jsonl` for the issue, or (b) a merged or open pull request on the boss-loop's deterministic branch pattern `aragora/boss-harvest/issue-N-*`. Undispatched entries stay staged until they accumulate evidence.
+Canonical promotion evidence is satisfied by at least one `boss_metrics.jsonl` row for the issue with a recorded `worker_outcome`. Merged or open boss-harvest PRs are useful advisory evidence, but they are not sufficient for canonical corpus promotion.
 
-The next dispatch targets are `#5788`, `#5789`, and `#5790`.
+The next metrics-evidence targets are `#5128`, `#5130`, and `#5188`.
 
 Review for accuracy. Flag errors if present.

--- a/tests/heterogeneity/test_prompts.py
+++ b/tests/heterogeneity/test_prompts.py
@@ -98,12 +98,12 @@ def test_clean_h1_readiness_prompt_matches_status_doc() -> None:
     assert status_match is not None
     status = status_match.group(1)
     dispatched = _read_status_metric(
-        status_doc, "Staged issues with dispatch evidence (any source)"
+        status_doc, "Metrics-backed staged issues eligible for canonical promotion"
     )
-    missing = _read_status_metric(status_doc, "Staged issues still missing dispatch evidence")
-    needed = _read_status_metric(status_doc, "Additional dispatches needed")
+    missing = _read_status_metric(status_doc, "Staged issues still missing metrics-backed evidence")
+    needed = _read_status_metric(status_doc, "Additional metrics-backed dispatches needed")
 
     assert f"verdict is `{status}`" in prompt.body
-    assert f"{dispatched} staged issues with dispatch evidence" in prompt.body
+    assert f"{dispatched} metrics-backed staged issues" in prompt.body
     assert f"{missing} still missing" in prompt.body
-    assert f"{needed} more dispatches" in prompt.body
+    assert f"{needed} more metrics-backed dispatches" in prompt.body


### PR DESCRIPTION
## Summary
- regenerate H1-01 rev-4 promotion readiness from the fresh 410-row boss metrics ledger
- add a proof-loop first-closure note for the May 12 boss/settlement/observe-outcomes milestone
- update the H1 readiness heterogeneity prompt/test contract so the clean-neutral prompt matches the new metrics-backed promotion language

## Validation
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 -m pytest tests/heterogeneity/test_prompts.py -q -p no:randomly
- python3 scripts/render_rev4_promotion_readiness.py --metrics /Users/armand/Development/aragora/.aragora/overnight/boss_metrics.jsonl --no-gh-pr-records --json

## Non-claims
- does not run observe-outcomes --write
- does not promote docs/benchmarks/corpus.json
- does not unblock H2 panel work
- does not empirically ground the thesis 5% invalidation threshold