### PR TITLE
fix(automation): report audit patch budget only on skips

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -1001,6 +1001,7 @@ def audit(
 
     records: list[BranchRecord] = []
     patch_equivalence_skipped_branches = 0
+    patch_equivalence_budget_exhausted = False
     for row in rows:
         branch = row["name"]
         committed_at = parse_dt(row["committed_at"])
@@ -1038,6 +1039,7 @@ def audit(
         patch_id = None
         if ahead_count > 0 and not merged_to_base and not protected_before_patch_check:
             if _patch_budget_exhausted(patch_deadline):
+                patch_equivalence_budget_exhausted = True
                 patch_equivalence_skipped_branches += 1
                 patch_equivalence_skipped = True
             else:
@@ -1122,6 +1124,7 @@ def audit(
             and category in SALVAGE_CATEGORIES
         ):
             if _patch_budget_exhausted(patch_deadline):
+                patch_equivalence_budget_exhausted = True
                 patch_equivalence_skipped_branches += 1
                 patch_equivalence_skipped = True
             else:
@@ -1210,7 +1213,7 @@ def audit(
         "publisher_backlog_limit": publisher_backlog_limit,
         "include_patch_equivalence": include_patch_equivalence,
         "patch_equivalence_time_budget_seconds": patch_equivalence_time_budget_seconds,
-        "patch_equivalence_budget_exhausted": _patch_budget_exhausted(patch_deadline),
+        "patch_equivalence_budget_exhausted": patch_equivalence_budget_exhausted,
         "patch_equivalence_skipped_branches": patch_equivalence_skipped_branches,
         "outbox_dir": str(resolved_outbox_dir),
         "receipt_dir": str(resolved_receipt_dir),

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -1972,6 +1972,7 @@ def test_audit_skips_patch_checks_for_exact_handoff_protected_branches(
         recent_hours=72,
         max_branches=None,
         include_patch_equivalence=True,
+        patch_equivalence_time_budget_seconds=0,
         publisher_backlog_limit=2,
     )
 
@@ -1982,6 +1983,7 @@ def test_audit_skips_patch_checks_for_exact_handoff_protected_branches(
         False,
         False,
     ]
+    assert payload["patch_equivalence_budget_exhausted"] is False
     assert payload["patch_equivalence_skipped_branches"] == 0
     assert payload["summary"]["patch_equivalence_skipped_by_category"] == {}
 


### PR DESCRIPTION
## Summary

- Makes `patch_equivalence_budget_exhausted` report true only when patch-equivalence work was actually skipped by the time budget
- Prevents completed slow backlog audits from looking budget-limited
- Adds regression coverage for the completed-within-budget case

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py -p no:rerunfailures -p no:cacheprovider` -> 48 passed
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok
