### PR TITLE
fix(automation): report audit revision metadata

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -132,6 +132,13 @@ def repo_root(path: Path) -> Path:
     return Path(proc.stdout.strip()).resolve()
 
 
+def git_revision(root: Path, ref: str) -> str | None:
+    proc = run_git(["rev-parse", "--verify", ref], root)
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
 def parse_dt(value: str) -> datetime:
     return datetime.fromisoformat(value.strip())
 
@@ -1207,7 +1214,9 @@ def audit(
     )
     return {
         "repo": str(root),
+        "worktree_head_sha": git_revision(root, "HEAD"),
         "base": base,
+        "base_sha": git_revision(root, base),
         "prefix": prefix,
         "recent_hours": recent_hours,
         "publisher_backlog_limit": publisher_backlog_limit,
@@ -1281,7 +1290,9 @@ def print_markdown(payload: dict[str, Any], *, examples: int) -> None:
     summary = payload["summary"]
     print("# Codex Branch Backlog Audit\n")
     print(f"- Repo: `{payload['repo']}`")
+    print(f"- Worktree HEAD: `{payload.get('worktree_head_sha')}`")
     print(f"- Base: `{payload['base']}`")
+    print(f"- Base SHA: `{payload.get('base_sha')}`")
     print(f"- Branches audited: `{payload['branch_count']}`")
     print(f"- Safe cleanup candidates: `{summary['safe_cleanup_candidates']}`")
     print(f"- Salvage candidates: `{summary['salvage_candidates']}`")

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -287,6 +287,36 @@ def test_main_summary_only_json_honors_examples_flag(
     assert compact["record_examples_limit"] == 0
 
 
+def test_print_markdown_includes_revision_metadata(tmp_path: Path, capsys: Any) -> None:
+    payload = {
+        "repo": str(tmp_path),
+        "worktree_head_sha": "1111111111111111111111111111111111111111",
+        "base": "origin/main",
+        "base_sha": "2222222222222222222222222222222222222222",
+        "branch_count": 0,
+        "patch_equivalence_budget_exhausted": False,
+        "patch_equivalence_skipped_branches": 0,
+        "summary": {
+            "safe_cleanup_candidates": 0,
+            "salvage_candidates": 0,
+            "publishable_branch_backlog": 0,
+            "diverged_salvage_candidates": 0,
+            "handoff_receipted_branches": 0,
+            "handoff_outbox_branches": 0,
+            "writer_should_pause_for_branch_backlog": False,
+            "protected": 0,
+            "by_category": {},
+        },
+        "records": [],
+    }
+
+    mod.print_markdown(payload, examples=0)
+    out = capsys.readouterr().out
+
+    assert "- Worktree HEAD: `1111111111111111111111111111111111111111`" in out
+    assert "- Base SHA: `2222222222222222222222222222222222222222`" in out
+
+
 def test_audit_skips_open_pr_lookup_when_github_health_degraded(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
@@ -324,6 +354,44 @@ def test_audit_skips_open_pr_lookup_when_github_health_degraded(
     assert payload["open_pr_lookup_skipped"] is True
     assert payload["records"][0]["open_pr"] is None
     assert payload["records"][0]["category"] == "salvage_recent_unique"
+
+
+def test_audit_reports_worktree_and_base_revisions(tmp_path: Path, monkeypatch: Any) -> None:
+    _stub_git_inventory(monkeypatch, _branch_row())
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: GitHubCLIHealth(
+            ready=False,
+            auth_ok=False,
+            api_ok=False,
+            mode="connectivity_failed",
+            error="offline",
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "git_revision",
+        lambda _root, ref: {
+            "HEAD": "1111111111111111111111111111111111111111",
+            "origin/main": "2222222222222222222222222222222222222222",
+        }[ref],
+    )
+
+    payload = mod.audit(
+        root=tmp_path,
+        base="origin/main",
+        repo="synaptent/aragora",
+        prefix="codex/",
+        recent_hours=72,
+        max_branches=None,
+        include_patch_equivalence=False,
+        publisher_backlog_limit=12,
+    )
+
+    assert payload["worktree_head_sha"] == "1111111111111111111111111111111111111111"
+    assert payload["base_sha"] == "2222222222222222222222222222222222222222"
 
 
 def test_audit_uses_batched_divergence_before_fallback(tmp_path: Path, monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary

- Adds explicit `worktree_head_sha` / `base_sha` revision metadata to backlog audit summary output
- Keeps branch-audit reports easier to reconcile against stale handoff/cache state
- Adds regression coverage for the new metadata fields

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_audit_codex_branch_backlog.py -p no:rerunfailures -p no:cacheprovider` -> 50 passed
- `python3 -m ruff check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `python3 -m ruff format --check scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok
