### PR TITLE
fix(review): throttle observe outcomes GitHub calls

### DIFF
--- a/aragora/review/observe_outcomes_cli.py
+++ b/aragora/review/observe_outcomes_cli.py
@@ -68,6 +68,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -89,6 +90,18 @@ UTC = timezone.utc
 DEFAULT_WINDOW_DAYS = 14
 DEFAULT_MAX_RECEIPTS = 20
 DEFAULT_PER_RECEIPT_EVENT_CAP = 100
+DEFAULT_GH_API_MAX_ATTEMPTS = 3
+DEFAULT_GH_API_THROTTLE_SECONDS = 0.15
+DEFAULT_GH_SEARCH_API_THROTTLE_SECONDS = 2.1
+DEFAULT_GH_API_BACKOFF_MAX_SECONDS = 30.0
+
+_GH_RATE_LIMIT_NEEDLES = (
+    "api rate limit exceeded",
+    "secondary rate limit",
+    "rate limit exceeded",
+    "rate limited",
+    "abuse detection",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -180,24 +193,66 @@ TimelineProvider = Callable[[int, str, int], tuple[list[Mapping[str, Any]], str 
 """Signature: (pr_number, head_sha, event_cap) -> (events, fetch_error_or_None)."""
 
 
-def _run_gh_json(args: list[str], *, timeout: int = 20) -> tuple[Any, str | None]:
-    """Run a bounded ``gh`` command and parse JSON, returning (payload, error)."""
-    try:
-        proc = subprocess.run(
-            args,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
+def _looks_like_github_rate_limit_error(message: str) -> bool:
+    lowered = message.lower()
+    return any(needle in lowered for needle in _GH_RATE_LIMIT_NEEDLES)
+
+
+def _gh_throttle_seconds_for(args: list[str]) -> float:
+    if "search/issues" in args or "search/commits" in args:
+        # GitHub search endpoints are more aggressively limited than
+        # ordinary API reads; 2.1s keeps sustained runs below 30/minute.
+        return DEFAULT_GH_SEARCH_API_THROTTLE_SECONDS
+    return DEFAULT_GH_API_THROTTLE_SECONDS
+
+
+def _run_gh_json(
+    args: list[str],
+    *,
+    timeout: int = 20,
+    attempts: int = DEFAULT_GH_API_MAX_ATTEMPTS,
+    throttle_seconds: float | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> tuple[Any, str | None]:
+    """Run a bounded ``gh`` command and parse JSON, returning (payload, error).
+
+    ``observe-outcomes`` can issue several read-only GitHub API requests per
+    receipt. Keep calls below GitHub's secondary-rate-limit burst envelope and
+    retry the transient rate-limit failures instead of marking clean receipts
+    as fetch errors.
+    """
+    max_attempts = max(1, attempts)
+    throttle = _gh_throttle_seconds_for(args) if throttle_seconds is None else throttle_seconds
+    sleeper = sleep or time.sleep
+    for attempt in range(1, max_attempts + 1):
+        try:
+            proc = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except (subprocess.SubprocessError, OSError) as exc:
+            return None, f"{args[:3]} raised {type(exc).__name__}: {exc}"
+        if throttle > 0:
+            sleeper(throttle)
+        if proc.returncode == 0:
+            try:
+                return json.loads(proc.stdout or "null"), None
+            except json.JSONDecodeError as exc:
+                return None, f"{args[:3]} JSON parse error: {exc}"
+
+        error_text = " ".join(
+            part.strip() for part in (proc.stderr, proc.stdout) if part and part.strip()
         )
-    except (subprocess.SubprocessError, OSError) as exc:
-        return None, f"{args[:3]} raised {type(exc).__name__}: {exc}"
-    if proc.returncode != 0:
-        return None, f"{args[:3]} returned {proc.returncode}: {proc.stderr.strip()[:200]}"
-    try:
-        return json.loads(proc.stdout or "null"), None
-    except json.JSONDecodeError as exc:
-        return None, f"{args[:3]} JSON parse error: {exc}"
+        error = f"{args[:3]} returned {proc.returncode}: {error_text[:300]}"
+        if attempt >= max_attempts or not _looks_like_github_rate_limit_error(error):
+            return None, error
+        backoff = min(throttle * (2**attempt), DEFAULT_GH_API_BACKOFF_MAX_SECONDS)
+        if backoff > 0:
+            sleeper(backoff)
+    return None, f"{args[:3]} failed after {max_attempts} attempts"
 
 
 def _gh_repo_slug() -> tuple[str | None, str | None]:

--- a/aragora/review/observe_outcomes_cli.py
+++ b/aragora/review/observe_outcomes_cli.py
@@ -235,13 +235,14 @@ def _run_gh_json(
             )
         except (subprocess.SubprocessError, OSError) as exc:
             return None, f"{args[:3]} raised {type(exc).__name__}: {exc}"
-        if throttle > 0:
-            sleeper(throttle)
         if proc.returncode == 0:
             try:
-                return json.loads(proc.stdout or "null"), None
+                payload = json.loads(proc.stdout or "null")
             except json.JSONDecodeError as exc:
                 return None, f"{args[:3]} JSON parse error: {exc}"
+            if throttle > 0:
+                sleeper(throttle)
+            return payload, None
 
         error_text = " ".join(
             part.strip() for part in (proc.stderr, proc.stdout) if part and part.strip()
@@ -249,7 +250,7 @@ def _run_gh_json(
         error = f"{args[:3]} returned {proc.returncode}: {error_text[:300]}"
         if attempt >= max_attempts or not _looks_like_github_rate_limit_error(error):
             return None, error
-        backoff = min(throttle * (2**attempt), DEFAULT_GH_API_BACKOFF_MAX_SECONDS)
+        backoff = min(throttle * (2 ** (attempt - 1)), DEFAULT_GH_API_BACKOFF_MAX_SECONDS)
         if backoff > 0:
             sleeper(backoff)
     return None, f"{args[:3]} failed after {max_attempts} attempts"

--- a/tests/review/test_observe_outcomes_cli.py
+++ b/tests/review/test_observe_outcomes_cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Mapping
 
 import pytest
@@ -611,6 +612,78 @@ class TestLiveProviderNormalization:
 
         assert events == []
         assert error == "search/issues returned 502"
+
+
+class TestGhJsonRateLimitHandling:
+    def test_search_api_uses_slower_default_throttle(self) -> None:
+        assert (
+            observe_module._gh_throttle_seconds_for(["gh", "api", "-X", "GET", "search/issues"])
+            == observe_module.DEFAULT_GH_SEARCH_API_THROTTLE_SECONDS
+        )
+        assert (
+            observe_module._gh_throttle_seconds_for(
+                [
+                    "gh",
+                    "api",
+                    "-H",
+                    "Accept: application/vnd.github+json",
+                    "/repos/:owner/:repo/issues/123/timeline",
+                ]
+            )
+            == observe_module.DEFAULT_GH_API_THROTTLE_SECONDS
+        )
+
+    def test_rate_limit_errors_retry_with_backoff(self, monkeypatch) -> None:
+        calls = []
+        sleeps: list[float] = []
+        responses = [
+            SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="API rate limit exceeded for user ID 33477136",
+            ),
+            SimpleNamespace(returncode=0, stdout='{"ok": true}', stderr=""),
+        ]
+
+        def fake_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            return responses.pop(0)
+
+        monkeypatch.setattr(observe_module.subprocess, "run", fake_run)
+
+        payload, error = observe_module._run_gh_json(
+            ["gh", "api", "search/issues"],
+            throttle_seconds=0.1,
+            sleep=sleeps.append,
+        )
+
+        assert error is None
+        assert payload == {"ok": True}
+        assert len(calls) == 2
+        assert sleeps == [0.1, 0.2, 0.1]
+
+    def test_non_rate_limit_errors_do_not_retry(self, monkeypatch) -> None:
+        calls = []
+        sleeps: list[float] = []
+
+        def fake_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            return SimpleNamespace(returncode=1, stdout="", stderr="Not Found")
+
+        monkeypatch.setattr(observe_module.subprocess, "run", fake_run)
+
+        payload, error = observe_module._run_gh_json(
+            ["gh", "api", "search/issues"],
+            attempts=3,
+            throttle_seconds=0.1,
+            sleep=sleeps.append,
+        )
+
+        assert payload is None
+        assert error is not None
+        assert "returned 1" in error
+        assert len(calls) == 1
+        assert sleeps == [0.1]
 
 
 class TestInsufficiencyReceiptShape:

--- a/tests/review/test_observe_outcomes_cli.py
+++ b/tests/review/test_observe_outcomes_cli.py
@@ -660,7 +660,7 @@ class TestGhJsonRateLimitHandling:
         assert error is None
         assert payload == {"ok": True}
         assert len(calls) == 2
-        assert sleeps == [0.1, 0.2, 0.1]
+        assert sleeps == [0.1, 0.1]
 
     def test_non_rate_limit_errors_do_not_retry(self, monkeypatch) -> None:
         calls = []
@@ -683,7 +683,7 @@ class TestGhJsonRateLimitHandling:
         assert error is not None
         assert "returned 1" in error
         assert len(calls) == 1
-        assert sleeps == [0.1]
+        assert sleeps == []
 
 
 class TestInsufficiencyReceiptShape:


### PR DESCRIPTION
## Summary
- Throttles observe-outcomes GitHub reads, with slower sustained pacing for search/issues and search/commits to stay below the search API burst bucket.
- Retries transient GitHub rate-limit/abuse-detection failures with bounded exponential backoff.
- Keeps non-rate-limit gh failures fail-closed so incomplete evidence never writes false outcome fields.

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/review/test_observe_outcomes_cli.py -p no:rerunfailures -p no:cacheprovider -> 27 passed
- python3 -m ruff check aragora/review/observe_outcomes_cli.py tests/review/test_observe_outcomes_cli.py -> passed
- python3 -m ruff format --check aragora/review/observe_outcomes_cli.py tests/review/test_observe_outcomes_cli.py -> passed
- git diff --check -> passed
- bash scripts/automation_pr_preflight.sh origin/main HEAD -> preflight: ok
- python3 -m aragora.cli.main review-queue observe-outcomes --window-days 14 --max-receipts 5 --json -> receipts_examined=5, receipts_written=0, github_fetch_errors=0, receipts_with_signals_fired=0

## Non-claims
- Does not run observe-outcomes --write.
- Does not resume mutating writers or publisher.
- Does not change settlement schema or outcome semantics.

## Operating note
- A prior all-receipt dry-run on the old 0.15s generic throttle still hit GitHub search rate limits after 10 receipts. This patch separates search endpoint pacing from ordinary timeline reads and validates the intended bounded --max-receipts 5 operator path.