### PR TITLE
[AGT-06] VIAH operator-truth status document generator (SD-5)

### DIFF
--- a/aragora/metrics/viah_status.py
+++ b/aragora/metrics/viah_status.py
@@ -1,0 +1,106 @@
+"""VIAH operator-truth status document generator (AGT-06 / #6067, SD-5).
+
+Generates a Markdown status report mirroring ``docs/status/B0_BENCHMARK_TRUTH_STATUS.md``.
+Gate: ``ARAGORA_VIAH_TREND_ENABLED``.
+
+Out of scope: writing to disk (caller decides), historical persistence (SD-4 / PR #7133),
+sidecar signals from AGT-05 (default 0 until wired).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Optional
+
+from aragora.metrics.viah import (
+    VIAH_TREND_FLAG,
+    compute_viah,
+    rolling_viah_trend,
+    viah_trend_enabled,
+)
+from aragora.swarm.shift_ledger import ShiftLedger
+
+__all__ = ["generate_viah_status_report"]
+
+
+def generate_viah_status_report(
+    ledger: ShiftLedger,
+    *,
+    weeks: int = 4,
+    now: Optional[datetime] = None,
+) -> str:
+    """Generate a Markdown VIAH status report.
+
+    Raises RuntimeError when ARAGORA_VIAH_TREND_ENABLED is not set.
+    """
+    if not viah_trend_enabled():
+        raise RuntimeError(
+            f"VIAH status surface is disabled; set {VIAH_TREND_FLAG}=1 to enable"
+        )
+    ref = (now or datetime.now(UTC)).astimezone(UTC)
+    trend = rolling_viah_trend(ledger=ledger, weeks=weeks, now=ref)
+    report = compute_viah(ledger=ledger, window_hours=168.0, now=ref)
+    ts = ref.strftime("%Y-%m-%dT%H:%M:%SZ")
+    viah_str = f"{report.viah:.4f}" if report.viah is not None else "N/A (no agent-hours)"
+    coef = report.coefficients
+
+    lines: list[str] = [
+        "# VIAH Status",
+        "",
+        f"Last updated: {ts}",
+        "",
+        "Operator-truth surface for Verifiable Improvements per Agent-Hour (VIAH). "
+        "See `docs/plans/AGENT_CIVILIZATION_SUBSTRATE.md` §4 and "
+        "issue [#6067](https://github.com/synaptent/aragora/issues/6067).",
+        "",
+        "## Summary",
+        "",
+        f"- **Current window VIAH (7 d):** {viah_str}",
+        f"- **Rolling trend ({trend.weeks_requested} w):** {trend.trend_direction}",
+        f"- **Agent-hours in window:** {report.agent_hours:.2f} h",
+        f"- **Merged autonomous PRs (7 d):** {report.merged_autonomous_prs}",
+        f"- **Rescues required (7 d):** {report.rescues_required}",
+        "",
+        "## Rolling Trend",
+        "",
+        "| Week | Window start | Window end | VIAH | PRs merged | Agent-hours |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for pt in trend.points:
+        vc = f"{pt.viah:.4f}" if pt.viah is not None else "—"
+        label = (
+            f"W{pt.week_index} (current)"
+            if pt.week_index == trend.weeks_requested - 1
+            else f"W{pt.week_index}"
+        )
+        lines.append(
+            f"| {label} | {pt.window_start[:10]} | {pt.window_end[:10]}"
+            f" | {vc} | {pt.merged_autonomous_prs} | {pt.agent_hours:.2f} h |"
+        )
+    lines += [
+        "",
+        "## Signal Breakdown (Most Recent 7-Day Window)",
+        "",
+        "| Signal | Count | Weight | Contribution |",
+        "| --- | --- | --- | --- |",
+        f"| Merged autonomous PRs | {report.merged_autonomous_prs} | +{coef.merged_pr_weight} | {coef.merged_pr_weight * report.merged_autonomous_prs:+.2f} |",
+        f"| Cruxes correctly detected \\* | {report.cruxes_correctly_detected} | +{coef.crux_weight} | {coef.crux_weight * report.cruxes_correctly_detected:+.2f} |",
+        f"| Predictions above Brier threshold \\* | {report.predictions_above_brier_threshold} | +{coef.prediction_weight} | {coef.prediction_weight * report.predictions_above_brier_threshold:+.2f} |",
+        f"| Rescues required | {report.rescues_required} | -{coef.rescue_weight} | {-coef.rescue_weight * report.rescues_required:+.2f} |",
+        f"| Failed claims promoted without repair | {report.failed_claims_promoted_without_repair} | -{coef.failed_claim_weight} | {-coef.failed_claim_weight * report.failed_claims_promoted_without_repair:+.2f} |",
+        "",
+        "_\\* Sidecar signal: defaults to 0 until AGT-05 settlement is live._",
+        "",
+        "## Caveats",
+        "",
+        "- VIAH **supplements** (does not replace) the TW-02 no-rescue success rate.",
+        "- Crux-correctness and prediction-Brier sidecar signals are wired by AGT-05 "
+        "and default to 0 until that path is live.",
+        "- Historical trend persistence requires AGT-06 SD-4 "
+        "(PR [#7133](https://github.com/synaptent/aragora/pull/7133)); "
+        "trend is computed on-the-fly from live ShiftLedger entries.",
+        f"- Gate: `{VIAH_TREND_FLAG}=1` required; default OFF.",
+        "- No live queue effect; report-only.",
+        "",
+    ]
+    return "\n".join(lines)

--- a/aragora/metrics/viah_status.py
+++ b/aragora/metrics/viah_status.py
@@ -34,9 +34,7 @@ def generate_viah_status_report(
     Raises RuntimeError when ARAGORA_VIAH_TREND_ENABLED is not set.
     """
     if not viah_trend_enabled():
-        raise RuntimeError(
-            f"VIAH status surface is disabled; set {VIAH_TREND_FLAG}=1 to enable"
-        )
+        raise RuntimeError(f"VIAH status surface is disabled; set {VIAH_TREND_FLAG}=1 to enable")
     ref = (now or datetime.now(UTC)).astimezone(UTC)
     trend = rolling_viah_trend(ledger=ledger, weeks=weeks, now=ref)
     report = compute_viah(ledger=ledger, window_hours=168.0, now=ref)

--- a/tests/metrics/test_viah_status.py
+++ b/tests/metrics/test_viah_status.py
@@ -41,21 +41,45 @@ def _ledger(tmp_path: Path, entries: list[dict]) -> ShiftLedger:
     return ShiftLedger(path=path)
 
 
-def _active_ledger(tmp_path: Path, *, now: datetime, shift_h: float = 4.0, prs: int = 2, rescues: int = 0) -> ShiftLedger:
+def _active_ledger(
+    tmp_path: Path, *, now: datetime, shift_h: float = 4.0, prs: int = 2, rescues: int = 0
+) -> ShiftLedger:
     sid = "s1"
     entries: list[dict] = [
-        {"entry_type": "shift_start", "timestamp": _ts(now - timedelta(hours=shift_h)), "payload": {"shift_id": sid}},
-        {"entry_type": "shift_stop", "timestamp": _ts(now - timedelta(minutes=5)), "payload": {"shift_id": sid}},
-        *[{"entry_type": "pr_merged", "timestamp": _ts(now - timedelta(hours=shift_h - 1 - i)), "payload": {"pr": i}} for i in range(prs)],
+        {
+            "entry_type": "shift_start",
+            "timestamp": _ts(now - timedelta(hours=shift_h)),
+            "payload": {"shift_id": sid},
+        },
+        {
+            "entry_type": "shift_stop",
+            "timestamp": _ts(now - timedelta(minutes=5)),
+            "payload": {"shift_id": sid},
+        },
+        *[
+            {
+                "entry_type": "pr_merged",
+                "timestamp": _ts(now - timedelta(hours=shift_h - 1 - i)),
+                "payload": {"pr": i},
+            }
+            for i in range(prs)
+        ],
     ]
     if rescues:
-        entries.append({"entry_type": "cycle_tick", "timestamp": _ts(now - timedelta(hours=1)), "payload": {"rescue_count": rescues}})
+        entries.append(
+            {
+                "entry_type": "cycle_tick",
+                "timestamp": _ts(now - timedelta(hours=1)),
+                "payload": {"rescue_count": rescues},
+            }
+        )
     return _ledger(tmp_path, entries)
 
 
 # ---------------------------------------------------------------------------
 # Feature gate
 # ---------------------------------------------------------------------------
+
 
 class TestFeatureGate:
     def test_raises_when_unset(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -64,13 +88,17 @@ class TestFeatureGate:
             generate_viah_status_report(_ledger(tmp_path, []))
 
     @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
-    def test_raises_for_falsy(self, val: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_raises_for_falsy(
+        self, val: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv(VIAH_TREND_FLAG, val)
         with pytest.raises(RuntimeError):
             generate_viah_status_report(_ledger(tmp_path, []))
 
     @pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE"])
-    def test_passes_for_truthy(self, val: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_passes_for_truthy(
+        self, val: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv(VIAH_TREND_FLAG, val)
         assert generate_viah_status_report(_ledger(tmp_path, []))
 
@@ -78,6 +106,7 @@ class TestFeatureGate:
 # ---------------------------------------------------------------------------
 # Structure
 # ---------------------------------------------------------------------------
+
 
 class TestReportStructure:
     @pytest.fixture(autouse=True)
@@ -107,13 +136,16 @@ class TestReportStructure:
         now = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
         for weeks in (2, 4):
             report = generate_viah_status_report(_ledger(tmp_path, []), weeks=weeks, now=now)
-            data_rows = [ln for ln in report.splitlines() if ln.startswith("| W") and ln[3:4].isdigit()]
+            data_rows = [
+                ln for ln in report.splitlines() if ln.startswith("| W") and ln[3:4].isdigit()
+            ]
             assert len(data_rows) == weeks
 
 
 # ---------------------------------------------------------------------------
 # Empty ledger
 # ---------------------------------------------------------------------------
+
 
 class TestEmptyLedger:
     @pytest.fixture(autouse=True)
@@ -124,7 +156,9 @@ class TestEmptyLedger:
         assert "N/A" in generate_viah_status_report(_ledger(tmp_path, []))
 
     def test_zero_prs(self, tmp_path: Path) -> None:
-        assert "Merged autonomous PRs (7 d):** 0" in generate_viah_status_report(_ledger(tmp_path, []))
+        assert "Merged autonomous PRs (7 d):** 0" in generate_viah_status_report(
+            _ledger(tmp_path, [])
+        )
 
     def test_insufficient_data_trend(self, tmp_path: Path) -> None:
         now = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
@@ -134,6 +168,7 @@ class TestEmptyLedger:
 # ---------------------------------------------------------------------------
 # Ledger with activity
 # ---------------------------------------------------------------------------
+
 
 class TestLedgerWithActivity:
     @pytest.fixture(autouse=True)
@@ -154,9 +189,13 @@ class TestLedgerWithActivity:
 
     def test_nonzero_viah_when_prs_and_hours(self, tmp_path: Path) -> None:
         now = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
-        summary = generate_viah_status_report(
-            _active_ledger(tmp_path, now=now, prs=2, shift_h=4.0), now=now
-        ).split("## Summary")[1].split("## ")[0]
+        summary = (
+            generate_viah_status_report(
+                _active_ledger(tmp_path, now=now, prs=2, shift_h=4.0), now=now
+            )
+            .split("## Summary")[1]
+            .split("## ")[0]
+        )
         assert "N/A" not in summary
 
     def test_now_controls_timestamp(self, tmp_path: Path) -> None:

--- a/tests/metrics/test_viah_status.py
+++ b/tests/metrics/test_viah_status.py
@@ -1,0 +1,173 @@
+"""Tests for aragora.metrics.viah_status — VIAH operator-truth report generator.
+
+Pre-registers an aragora.swarm package stub so Python never runs the heavy
+``aragora/swarm/__init__.py`` chain.  The real shift_ledger submodule
+(stdlib-only imports) loads normally and tests use the genuine ShiftLedger.
+"""
+
+from __future__ import annotations
+
+# ── Swarm package stub ───────────────────────────────────────────────────────
+# MUST precede any aragora import; prevents aragora/swarm/__init__.py from running.
+import pathlib as _pathlib
+import sys
+import types as _types
+
+if "aragora.swarm" not in sys.modules:
+    _swarm_mod = _types.ModuleType("aragora.swarm")
+    _swarm_mod.__path__ = [str(_pathlib.Path(__file__).parents[2] / "aragora" / "swarm")]
+    _swarm_mod.__package__ = "aragora.swarm"
+    sys.modules["aragora.swarm"] = _swarm_mod
+# ─────────────────────────────────────────────────────────────────────────────
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.metrics.viah import VIAH_TREND_FLAG
+from aragora.metrics.viah_status import generate_viah_status_report
+from aragora.swarm.shift_ledger import ShiftLedger
+
+
+def _ts(dt: datetime) -> str:
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ledger(tmp_path: Path, entries: list[dict]) -> ShiftLedger:
+    path = tmp_path / "sl.jsonl"
+    path.write_text("\n".join(json.dumps(e) for e in entries) + ("\n" if entries else ""))
+    return ShiftLedger(path=path)
+
+
+def _active_ledger(tmp_path: Path, *, now: datetime, shift_h: float = 4.0, prs: int = 2, rescues: int = 0) -> ShiftLedger:
+    sid = "s1"
+    entries: list[dict] = [
+        {"entry_type": "shift_start", "timestamp": _ts(now - timedelta(hours=shift_h)), "payload": {"shift_id": sid}},
+        {"entry_type": "shift_stop", "timestamp": _ts(now - timedelta(minutes=5)), "payload": {"shift_id": sid}},
+        *[{"entry_type": "pr_merged", "timestamp": _ts(now - timedelta(hours=shift_h - 1 - i)), "payload": {"pr": i}} for i in range(prs)],
+    ]
+    if rescues:
+        entries.append({"entry_type": "cycle_tick", "timestamp": _ts(now - timedelta(hours=1)), "payload": {"rescue_count": rescues}})
+    return _ledger(tmp_path, entries)
+
+
+# ---------------------------------------------------------------------------
+# Feature gate
+# ---------------------------------------------------------------------------
+
+class TestFeatureGate:
+    def test_raises_when_unset(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(VIAH_TREND_FLAG, raising=False)
+        with pytest.raises(RuntimeError, match=VIAH_TREND_FLAG):
+            generate_viah_status_report(_ledger(tmp_path, []))
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_raises_for_falsy(self, val: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(VIAH_TREND_FLAG, val)
+        with pytest.raises(RuntimeError):
+            generate_viah_status_report(_ledger(tmp_path, []))
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE"])
+    def test_passes_for_truthy(self, val: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(VIAH_TREND_FLAG, val)
+        assert generate_viah_status_report(_ledger(tmp_path, []))
+
+
+# ---------------------------------------------------------------------------
+# Structure
+# ---------------------------------------------------------------------------
+
+class TestReportStructure:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(VIAH_TREND_FLAG, "1")
+
+    def _report(self, tmp_path: Path) -> str:
+        return generate_viah_status_report(_ledger(tmp_path, []))
+
+    def test_heading(self, tmp_path: Path) -> None:
+        assert self._report(tmp_path).startswith("# VIAH Status")
+
+    def test_required_sections(self, tmp_path: Path) -> None:
+        r = self._report(tmp_path)
+        for section in ("## Summary", "## Rolling Trend", "## Signal Breakdown", "## Caveats"):
+            assert section in r
+
+    def test_issue_and_flag_referenced(self, tmp_path: Path) -> None:
+        r = self._report(tmp_path)
+        assert "#6067" in r and VIAH_TREND_FLAG in r
+
+    def test_agt05_and_pr7133_caveats(self, tmp_path: Path) -> None:
+        r = self._report(tmp_path)
+        assert "AGT-05" in r and "#7133" in r
+
+    def test_trend_table_row_count(self, tmp_path: Path) -> None:
+        now = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
+        for weeks in (2, 4):
+            report = generate_viah_status_report(_ledger(tmp_path, []), weeks=weeks, now=now)
+            data_rows = [ln for ln in report.splitlines() if ln.startswith("| W") and ln[3:4].isdigit()]
+            assert len(data_rows) == weeks
+
+
+# ---------------------------------------------------------------------------
+# Empty ledger
+# ---------------------------------------------------------------------------
+
+class TestEmptyLedger:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(VIAH_TREND_FLAG, "1")
+
+    def test_na_when_no_agent_hours(self, tmp_path: Path) -> None:
+        assert "N/A" in generate_viah_status_report(_ledger(tmp_path, []))
+
+    def test_zero_prs(self, tmp_path: Path) -> None:
+        assert "Merged autonomous PRs (7 d):** 0" in generate_viah_status_report(_ledger(tmp_path, []))
+
+    def test_insufficient_data_trend(self, tmp_path: Path) -> None:
+        now = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
+        assert "insufficient_data" in generate_viah_status_report(_ledger(tmp_path, []), now=now)
+
+
+# ---------------------------------------------------------------------------
+# Ledger with activity
+# ---------------------------------------------------------------------------
+
+class TestLedgerWithActivity:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(VIAH_TREND_FLAG, "1")
+
+    def test_pr_count_in_summary(self, tmp_path: Path) -> None:
+        now = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
+        assert "Merged autonomous PRs (7 d):** 3" in generate_viah_status_report(
+            _active_ledger(tmp_path, now=now, prs=3), now=now
+        )
+
+    def test_rescues_in_summary(self, tmp_path: Path) -> None:
+        now = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
+        assert "Rescues required (7 d):** 2" in generate_viah_status_report(
+            _active_ledger(tmp_path, now=now, prs=1, rescues=2), now=now
+        )
+
+    def test_nonzero_viah_when_prs_and_hours(self, tmp_path: Path) -> None:
+        now = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
+        summary = generate_viah_status_report(
+            _active_ledger(tmp_path, now=now, prs=2, shift_h=4.0), now=now
+        ).split("## Summary")[1].split("## ")[0]
+        assert "N/A" not in summary
+
+    def test_now_controls_timestamp(self, tmp_path: Path) -> None:
+        now_a = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
+        now_b = datetime(2026, 5, 28, 12, 0, tzinfo=UTC)
+        ledger = _active_ledger(tmp_path, now=now_a, prs=1, shift_h=2.0)
+        assert "2026-05-14" in generate_viah_status_report(ledger, now=now_a)
+        assert "2026-05-28" in generate_viah_status_report(ledger, now=now_b)
+
+    def test_out_of_window_shows_zero_prs(self, tmp_path: Path) -> None:
+        now = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
+        ledger = _active_ledger(tmp_path, now=now, prs=3, shift_h=2.0)
+        future = now + timedelta(weeks=4)
+        assert "Merged autonomous PRs (7 d):** 0" in generate_viah_status_report(ledger, now=future)


### PR DESCRIPTION
## Slice

Adds `aragora/metrics/viah_status.py` — a Markdown status report generator for the VIAH (Verifiable Improvements per Agent-Hour) productivity metric, following the pattern of `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`. `generate_viah_status_report(ledger, weeks=4, now=None)` produces a status doc with Summary, Rolling Trend table, Signal Breakdown, and Caveats sections.

## Gating

- Default: **OFF** (flag: `ARAGORA_VIAH_TREND_ENABLED` — reuses the existing AGT-06 flag from `aragora/metrics/viah.py`; no new flag needed)
- `generate_viah_status_report()` raises `RuntimeError` when the flag is unset; the function is the only entry point
- Live queue effect: **none** — pure string renderer, no HTTP routes, no queue mutations, no boss-loop changes
- Advances issue: #6067 (AGT-06, sub-deliverable 5: operator-truth surface for VIAH)

## Tests

- `TestFeatureGate` (11 cases) — flag off by default; 5 falsy env-var values raise `RuntimeError`; 5 truthy values succeed
- `TestReportStructure` (5 cases) — heading, required sections (`## Summary`, `## Rolling Trend`, `## Signal Breakdown`, `## Caveats`), issue `#6067` and flag name referenced, AGT-05 and `#7133` caveats present, trend table row count matches `weeks` param
- `TestEmptyLedger` (3 cases) — `N/A` when no agent-hours, zero PR count, `insufficient_data` trend direction
- `TestLedgerWithActivity` (5 cases) — PR count, rescue count, nonzero VIAH, `now` parameter controls timestamp, out-of-window data shows zero PRs

## Validation

- `pytest tests/metrics/test_viah_status.py --noconftest -v` — **24 passed**
- `ruff check aragora/metrics/viah_status.py tests/metrics/test_viah_status.py` — **clean**
- `mypy aragora/metrics/viah_status.py --ignore-missing-imports` — **clean**
- Net diff: **279 LOC** (106 impl + 173 tests)

## Out of scope

- Writing the report to `docs/status/VIAH_STATUS.md` — caller decides the destination; this module only produces the string
- Historical multi-snapshot trend from ShiftLedger persistence — requires AGT-06 SD-4 (PR #7133 unmerged); trend is computed on-the-fly from live ledger entries
- Sidecar signals (crux-correctness, prediction Brier from AGT-05): default to 0 until AGT-05 wires them; the report notes this explicitly
- CLI/script entry point in `scripts/` — deferred per worktree guardrails; callers invoke the module function directly

Note: the proof-first Foreman gate in `docs/status/NEXT_STEPS_CANONICAL.md` is **not yet open** for the AGT-* tranche. This PR carries no `boss-ready` label and must remain DRAFT until the gate opens or is explicitly waived for this slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XH8scHgCbYzdu5T9XxZh4i)_