### PR TITLE
fix(automation): bound disk recovery cleanup probes

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -15,8 +15,8 @@
 | Python files under aragora/ | `4113` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
 | Python lines of code under aragora/ | `1933019` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `137` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5161` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217692` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5162` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217700` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `676` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `63` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/scripts/disk_recovery_coordinator.py
+++ b/scripts/disk_recovery_coordinator.py
@@ -285,6 +285,8 @@ def _external_cleanup(repo: Path, args: argparse.Namespace) -> dict[str, Any]:
     for candidate in paths:
         if len(removed) + len(would_remove) >= args.max_cleanup_per_cycle:
             break
+        if inspected >= args.max_inspect_per_cycle:
+            break
         inspected += 1
         inspect_payload, inspect_result = _run_json(
             [
@@ -355,6 +357,7 @@ def _external_cleanup(repo: Path, args: argparse.Namespace) -> dict[str, Any]:
         "quarantined_skipped": len(quarantined),
         "inactive_candidates_seen": len(paths),
         "inspected": inspected,
+        "max_inspect_per_cycle": args.max_inspect_per_cycle,
         "removed": removed,
         "would_remove": would_remove,
         "blocked": blocked[:10],
@@ -426,6 +429,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--hours", type=float, default=6.0)
     parser.add_argument("--cycle-seconds", type=float, default=900.0)
     parser.add_argument("--max-cleanup-per-cycle", type=int, default=5)
+    parser.add_argument(
+        "--max-inspect-per-cycle",
+        type=int,
+        default=25,
+        help="Maximum external worktree candidates to inspect per cycle.",
+    )
     parser.add_argument("--max-salvage-per-cycle", type=int, default=2)
     parser.add_argument("--inspect-timeout", type=float, default=30.0)
     parser.add_argument("--remove-timeout", type=float, default=60.0)

--- a/scripts/disk_recovery_coordinator.py
+++ b/scripts/disk_recovery_coordinator.py
@@ -52,11 +52,13 @@ def _run(
         except ProcessLookupError:
             pass
         stdout, stderr = proc.communicate()
+        timeout_stdout = _as_text(stdout) or _as_text(exc.stdout)
+        timeout_stderr = _as_text(stderr) or _as_text(exc.stderr)
         return {
             "argv": argv,
             "returncode": 124,
-            "stdout": stdout or exc.stdout or "",
-            "stderr": (stderr or exc.stderr or "") + f"\ntimed out after {exc.timeout}s",
+            "stdout": timeout_stdout,
+            "stderr": timeout_stderr + f"\ntimed out after {exc.timeout}s",
             "timed_out": True,
             "elapsed": round(time.monotonic() - started, 3),
         }
@@ -68,6 +70,14 @@ def _run(
         "timed_out": timed_out,
         "elapsed": round(time.monotonic() - started, 3),
     }
+
+
+def _as_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value
 
 
 def _run_json(

--- a/scripts/disk_recovery_coordinator.py
+++ b/scripts/disk_recovery_coordinator.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
+import signal
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -33,30 +35,36 @@ def _run(
     timeout: float,
 ) -> dict[str, Any]:
     started = time.monotonic()
+    proc = subprocess.Popen(
+        argv,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
     try:
-        proc = subprocess.run(
-            argv,
-            cwd=cwd,
-            text=True,
-            capture_output=True,
-            check=False,
-            timeout=timeout,
-        )
+        stdout, stderr = proc.communicate(timeout=timeout)
         timed_out = False
     except subprocess.TimeoutExpired as exc:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        stdout, stderr = proc.communicate()
         return {
             "argv": argv,
             "returncode": 124,
-            "stdout": exc.stdout or "",
-            "stderr": (exc.stderr or "") + f"\ntimed out after {exc.timeout}s",
+            "stdout": stdout or exc.stdout or "",
+            "stderr": (stderr or exc.stderr or "") + f"\ntimed out after {exc.timeout}s",
             "timed_out": True,
             "elapsed": round(time.monotonic() - started, 3),
         }
     return {
         "argv": argv,
         "returncode": proc.returncode,
-        "stdout": proc.stdout,
-        "stderr": proc.stderr,
+        "stdout": stdout,
+        "stderr": stderr,
         "timed_out": timed_out,
         "elapsed": round(time.monotonic() - started, 3),
     }

--- a/scripts/disk_recovery_coordinator.py
+++ b/scripts/disk_recovery_coordinator.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Bounded Aragora disk recovery coordinator.
+
+This script is intentionally conservative: it only removes worktrees through
+scripts/safe_worktree_cleanup.py and treats every timeout as a preservation
+blocker recorded in a local quarantine file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+UTC = timezone.utc
+DEFAULT_QUARANTINE = Path(".aragora/cleanup-state/worktree-quarantine.jsonl")
+DEFAULT_LOG = Path(".aragora/cleanup-state/disk-recovery-coordinator.jsonl")
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    timeout: float,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+        timed_out = False
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "argv": argv,
+            "returncode": 124,
+            "stdout": exc.stdout or "",
+            "stderr": (exc.stderr or "") + f"\ntimed out after {exc.timeout}s",
+            "timed_out": True,
+            "elapsed": round(time.monotonic() - started, 3),
+        }
+    return {
+        "argv": argv,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "timed_out": timed_out,
+        "elapsed": round(time.monotonic() - started, 3),
+    }
+
+
+def _run_json(
+    argv: list[str], *, cwd: Path, timeout: float
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    result = _run(argv, cwd=cwd, timeout=timeout)
+    try:
+        payload = json.loads(result["stdout"] or "{}")
+    except json.JSONDecodeError:
+        payload = None
+    return payload, result
+
+
+def _free_gib(path: Path) -> float:
+    usage = shutil.disk_usage(path)
+    return usage.free / (1024**3)
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _load_quarantine(path: Path) -> set[str]:
+    quarantined: set[str] = set()
+    if not path.exists():
+        return quarantined
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        candidate = str(payload.get("path") or "").strip()
+        if candidate:
+            quarantined.add(candidate)
+    return quarantined
+
+
+def _quarantine(path: Path, candidate: str, reason: str, detail: dict[str, Any]) -> None:
+    _append_jsonl(
+        path,
+        {
+            "recorded_at": _utc_now(),
+            "path": candidate,
+            "reason": reason,
+            "detail": detail,
+        },
+    )
+
+
+def _git_worktree_paths(repo: Path, timeout: float) -> list[str]:
+    result = _run(["git", "worktree", "list", "--porcelain"], cwd=repo, timeout=timeout)
+    if result["returncode"] != 0:
+        return []
+    return [
+        line.split(" ", 1)[1]
+        for line in str(result["stdout"]).splitlines()
+        if line.startswith("worktree ")
+    ]
+
+
+def _active_external_worktrees(prefix: str) -> set[str]:
+    proc = subprocess.run(
+        ["lsof", "-a", "-d", "cwd", "-Fpcn"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    active: set[str] = set()
+    current: dict[str, Any] = {}
+    records: list[dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        if not line:
+            continue
+        key, value = line[0], line[1:]
+        if key == "p":
+            if current:
+                records.append(current)
+            current = {"pid": value}
+        elif key == "n":
+            current.setdefault("cwds", []).append(value)
+    if current:
+        records.append(current)
+
+    for record in records:
+        for cwd in record.get("cwds", []):
+            if not isinstance(cwd, str) or not cwd.startswith(prefix):
+                continue
+            parts = cwd[len(prefix) :].split("/")
+            if len(parts) >= 2 and parts[1] == "aragora":
+                active.add(prefix + parts[0] + "/aragora")
+    return active
+
+
+def _root_clean_current(repo: Path, timeout: float) -> tuple[bool, dict[str, Any]]:
+    status = _run(["git", "status", "--short"], cwd=repo, timeout=timeout)
+    head = _run(["git", "rev-parse", "HEAD"], cwd=repo, timeout=timeout)
+    origin = _run(["git", "rev-parse", "origin/main"], cwd=repo, timeout=timeout)
+    ok = (
+        status["returncode"] == 0
+        and not str(status["stdout"]).strip()
+        and head["returncode"] == 0
+        and origin["returncode"] == 0
+        and str(head["stdout"]).strip() == str(origin["stdout"]).strip()
+    )
+    return ok, {
+        "status": status,
+        "head": str(head["stdout"]).strip(),
+        "origin_main": str(origin["stdout"]).strip(),
+    }
+
+
+def _runtime_cleanup(repo: Path, args: argparse.Namespace) -> dict[str, Any]:
+    argv = ["python3", "scripts/cleanup_runtime_artifacts.py", "--purge-caches"]
+    if args.apply:
+        argv.append("--apply")
+    return _run(argv, cwd=repo, timeout=args.command_timeout)
+
+
+def _reconcile_outbox(repo: Path, args: argparse.Namespace) -> dict[str, Any]:
+    dry_payload, dry = _run_json(
+        [
+            "python3",
+            "scripts/reconcile_automation_outbox.py",
+            "--repo",
+            str(repo),
+            "--base",
+            "origin/main",
+            "--dry-run",
+            "--json",
+        ],
+        cwd=repo,
+        timeout=args.command_timeout,
+    )
+    apply_result: dict[str, Any] | None = None
+    counts = dry_payload.get("counts", {}) if isinstance(dry_payload, dict) else {}
+    satisfied = sum(
+        int(counts.get(key, 0) or 0)
+        for key in (
+            "satisfied_by_existing_receipt",
+            "satisfied_by_landed_on_main",
+            "satisfied_by_open_pr_merged",
+            "satisfied_by_superseded_handoff",
+        )
+    )
+    if args.apply and satisfied > 0:
+        _, apply_result = _run_json(
+            [
+                "python3",
+                "scripts/reconcile_automation_outbox.py",
+                "--repo",
+                str(repo),
+                "--base",
+                "origin/main",
+                "--apply",
+                "--json",
+            ],
+            cwd=repo,
+            timeout=args.command_timeout,
+        )
+    return {"dry_run": dry, "dry_payload": dry_payload, "apply": apply_result}
+
+
+def _autopilot_cleanup(repo: Path, args: argparse.Namespace) -> dict[str, Any]:
+    if not args.apply:
+        return {"skipped": True, "reason": "dry_run"}
+    payload, result = _run_json(
+        [
+            "python3",
+            "scripts/codex_worktree_autopilot.py",
+            "cleanup",
+            "--base",
+            "main",
+            "--ttl-hours",
+            "24",
+            "--no-delete-branches",
+            "--json",
+        ],
+        cwd=repo,
+        timeout=args.command_timeout,
+    )
+    return {"result": result, "payload": payload}
+
+
+def _external_cleanup(repo: Path, args: argparse.Namespace) -> dict[str, Any]:
+    prefix = "/Users/armand/.codex/worktrees/"
+    active = _active_external_worktrees(prefix)
+    quarantined = _load_quarantine(args.quarantine_file)
+    paths = [
+        path
+        for path in _git_worktree_paths(repo, args.command_timeout)
+        if path.startswith(prefix)
+        and path not in active
+        and path not in quarantined
+        and not path.startswith(prefix + "b968/")
+    ]
+
+    inspected = 0
+    removed: list[str] = []
+    would_remove: list[str] = []
+    blocked: list[dict[str, Any]] = []
+
+    for candidate in paths:
+        if len(removed) + len(would_remove) >= args.max_cleanup_per_cycle:
+            break
+        inspected += 1
+        inspect_payload, inspect_result = _run_json(
+            [
+                "python3",
+                "scripts/safe_worktree_cleanup.py",
+                "--repo",
+                str(repo),
+                "inspect",
+                candidate,
+                "--json",
+            ],
+            cwd=repo,
+            timeout=args.inspect_timeout,
+        )
+        if inspect_result["timed_out"]:
+            _quarantine(args.quarantine_file, candidate, "inspect_timeout", inspect_result)
+            blocked.append({"path": candidate, "reason": "inspect_timeout"})
+            continue
+        if not isinstance(inspect_payload, dict):
+            _quarantine(args.quarantine_file, candidate, "inspect_parse_failed", inspect_result)
+            blocked.append({"path": candidate, "reason": "inspect_parse_failed"})
+            continue
+        if not inspect_payload.get("removable"):
+            blocked.append(
+                {
+                    "path": candidate,
+                    "reason": "not_removable",
+                    "blockers": inspect_payload.get("blockers", []),
+                }
+            )
+            continue
+
+        if not args.apply:
+            would_remove.append(candidate)
+            continue
+
+        remove_payload, remove_result = _run_json(
+            [
+                "python3",
+                "scripts/safe_worktree_cleanup.py",
+                "--repo",
+                str(repo),
+                "remove",
+                candidate,
+                "--json",
+            ],
+            cwd=repo,
+            timeout=args.remove_timeout,
+        )
+        if remove_result["timed_out"]:
+            _quarantine(args.quarantine_file, candidate, "remove_timeout", remove_result)
+            blocked.append({"path": candidate, "reason": "remove_timeout"})
+            continue
+        if remove_result["returncode"] == 0 and not Path(candidate).exists():
+            removed.append(candidate)
+        else:
+            blocked.append(
+                {
+                    "path": candidate,
+                    "reason": "remove_failed",
+                    "payload": remove_payload,
+                    "returncode": remove_result["returncode"],
+                }
+            )
+
+    return {
+        "active_external_skipped": len(active),
+        "quarantined_skipped": len(quarantined),
+        "inactive_candidates_seen": len(paths),
+        "inspected": inspected,
+        "removed": removed,
+        "would_remove": would_remove,
+        "blocked": blocked[:10],
+    }
+
+
+def _salvage_snapshot(repo: Path, args: argparse.Namespace) -> dict[str, Any]:
+    if args.max_salvage_per_cycle <= 0:
+        return {"skipped": True, "reason": "disabled"}
+    payload, result = _run_json(
+        [
+            "python3",
+            "scripts/audit_codex_branch_backlog.py",
+            "--repo",
+            str(repo),
+            "--base",
+            "origin/main",
+            "--prefix",
+            "codex/",
+            "--summary-only",
+            "--json",
+            "--include-patch-equivalence",
+            "--patch-equivalence-time-budget-seconds",
+            "30",
+            "--examples",
+            str(args.max_salvage_per_cycle),
+        ],
+        cwd=repo,
+        timeout=args.command_timeout,
+    )
+    return {"payload": payload, "result": result}
+
+
+def _run_cycle(repo: Path, args: argparse.Namespace, cycle: int) -> dict[str, Any]:
+    before = _free_gib(repo)
+    clean_current, root = _root_clean_current(repo, args.command_timeout)
+    if not clean_current:
+        return {
+            "cycle": cycle,
+            "started_at": _utc_now(),
+            "ok": False,
+            "stop_reason": "root_not_clean_current",
+            "root": root,
+            "free_gib_before": round(before, 2),
+        }
+
+    result = {
+        "cycle": cycle,
+        "started_at": _utc_now(),
+        "ok": True,
+        "free_gib_before": round(before, 2),
+        "runtime_cleanup": _runtime_cleanup(repo, args),
+        "outbox": _reconcile_outbox(repo, args),
+        "autopilot_cleanup": _autopilot_cleanup(repo, args),
+        "external_cleanup": _external_cleanup(repo, args),
+        "salvage_snapshot": _salvage_snapshot(repo, args),
+    }
+    result["free_gib_after"] = round(_free_gib(repo), 2)
+    result["completed_at"] = _utc_now()
+    return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run bounded Aragora disk recovery cycles.")
+    parser.add_argument("--repo", default=".", help="Repository path.")
+    parser.add_argument("--target-free-gib", type=float, default=100.0)
+    parser.add_argument("--hours", type=float, default=6.0)
+    parser.add_argument("--cycle-seconds", type=float, default=900.0)
+    parser.add_argument("--max-cleanup-per-cycle", type=int, default=5)
+    parser.add_argument("--max-salvage-per-cycle", type=int, default=2)
+    parser.add_argument("--inspect-timeout", type=float, default=30.0)
+    parser.add_argument("--remove-timeout", type=float, default=60.0)
+    parser.add_argument("--command-timeout", type=float, default=180.0)
+    parser.add_argument("--quarantine-file", type=Path, default=DEFAULT_QUARANTINE)
+    parser.add_argument("--jsonl-log", type=Path, default=DEFAULT_LOG)
+    parser.add_argument("--apply", action="store_true", help="Apply safe cleanup actions.")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run one cycle even when --apply is set.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    repo = Path(args.repo).resolve()
+    args.quarantine_file = (repo / args.quarantine_file).resolve()
+    args.jsonl_log = (repo / args.jsonl_log).resolve()
+
+    deadline = time.monotonic() + args.hours * 3600
+    cycle = 0
+    last_result: dict[str, Any] | None = None
+    while True:
+        cycle += 1
+        last_result = _run_cycle(repo, args, cycle)
+        _append_jsonl(args.jsonl_log, last_result)
+        print(json.dumps(last_result, indent=2, sort_keys=True))
+        if not last_result.get("ok"):
+            return 2
+        if float(last_result.get("free_gib_after", 0.0)) >= args.target_free_gib:
+            return 0
+        if args.once or not args.apply:
+            return 0
+        if time.monotonic() >= deadline:
+            return 1
+        time.sleep(args.cycle_seconds)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/disk_recovery_coordinator.py
+++ b/scripts/disk_recovery_coordinator.py
@@ -157,21 +157,30 @@ def _active_external_worktrees(prefix: str) -> set[str]:
     return active
 
 
-def _root_clean_current(repo: Path, timeout: float) -> tuple[bool, dict[str, Any]]:
+def _root_clean_current(
+    repo: Path, timeout: float, *, allow_branch_ahead: bool
+) -> tuple[bool, dict[str, Any]]:
     status = _run(["git", "status", "--short"], cwd=repo, timeout=timeout)
     head = _run(["git", "rev-parse", "HEAD"], cwd=repo, timeout=timeout)
     origin = _run(["git", "rev-parse", "origin/main"], cwd=repo, timeout=timeout)
+    ancestor = _run(
+        ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"], cwd=repo, timeout=timeout
+    )
+    same_head = str(head["stdout"]).strip() == str(origin["stdout"]).strip()
+    branch_ahead_allowed = allow_branch_ahead and ancestor["returncode"] == 0
     ok = (
         status["returncode"] == 0
         and not str(status["stdout"]).strip()
         and head["returncode"] == 0
         and origin["returncode"] == 0
-        and str(head["stdout"]).strip() == str(origin["stdout"]).strip()
+        and (same_head or branch_ahead_allowed)
     )
     return ok, {
         "status": status,
         "head": str(head["stdout"]).strip(),
         "origin_main": str(origin["stdout"]).strip(),
+        "same_head": same_head,
+        "branch_ahead_allowed": branch_ahead_allowed,
     }
 
 
@@ -373,7 +382,9 @@ def _salvage_snapshot(repo: Path, args: argparse.Namespace) -> dict[str, Any]:
 
 def _run_cycle(repo: Path, args: argparse.Namespace, cycle: int) -> dict[str, Any]:
     before = _free_gib(repo)
-    clean_current, root = _root_clean_current(repo, args.command_timeout)
+    clean_current, root = _root_clean_current(
+        repo, args.command_timeout, allow_branch_ahead=args.allow_branch_ahead
+    )
     if not clean_current:
         return {
             "cycle": cycle,
@@ -414,6 +425,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--quarantine-file", type=Path, default=DEFAULT_QUARANTINE)
     parser.add_argument("--jsonl-log", type=Path, default=DEFAULT_LOG)
     parser.add_argument("--apply", action="store_true", help="Apply safe cleanup actions.")
+    parser.add_argument(
+        "--allow-branch-ahead",
+        action="store_true",
+        help="Allow a clean branch whose HEAD is ahead of origin/main for PR dogfood runs.",
+    )
     parser.add_argument(
         "--once",
         action="store_true",

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 from dataclasses import asdict, dataclass
@@ -12,6 +13,13 @@ from pathlib import Path
 from typing import Any
 
 import codex_worktree_autopilot as autopilot
+
+BRANCH_LOOKUP_FAILED = "__branch_lookup_failed__"
+DEFAULT_GIT_TIMEOUT_SECONDS = float(os.environ.get("SAFE_WORKTREE_CLEANUP_GIT_TIMEOUT", "20"))
+DEFAULT_GH_TIMEOUT_SECONDS = float(os.environ.get("SAFE_WORKTREE_CLEANUP_GH_TIMEOUT", "20"))
+DEFAULT_PATCH_EQUIV_TIMEOUT_SECONDS = int(
+    float(os.environ.get("SAFE_WORKTREE_CLEANUP_PATCH_EQUIV_TIMEOUT", "45"))
+)
 
 
 @dataclass
@@ -55,13 +63,17 @@ def _branch_for_path(path: Path, entry: autopilot.WorktreeEntry | None) -> str |
         return None
     if not (path / ".git").exists():
         return None
-    proc = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        cwd=path,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=path,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=DEFAULT_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return BRANCH_LOOKUP_FAILED
     if proc.returncode != 0:
         return None
     branch = proc.stdout.strip()
@@ -88,8 +100,9 @@ def _lookup_open_prs(repo_root: Path, branch: str | None) -> tuple[list[dict[str
             text=True,
             capture_output=True,
             check=False,
+            timeout=DEFAULT_GH_TIMEOUT_SECONDS,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return [], True
     if proc.returncode != 0:
         return [], True
@@ -105,13 +118,18 @@ def _lookup_open_prs(repo_root: Path, branch: str | None) -> tuple[list[dict[str
 def _worktree_is_dirty(path: Path) -> bool:
     if not path.exists():
         return False
-    proc = subprocess.run(
-        ["git", "status", "--short"],
-        cwd=path,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--short"],
+            cwd=path,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=DEFAULT_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        # Conservatively treat status timeouts as dirty so cleanup is blocked.
+        return True
     if proc.returncode != 0:
         return False
     return bool(proc.stdout.strip())
@@ -123,7 +141,19 @@ def _unique_commits_ahead_of_main(
 ) -> tuple[int, bool]:
     if not branch:
         return 0, False
-    proc = autopilot._run_git(repo_root, "rev-list", "--count", f"origin/main..{branch}")
+    if branch == BRANCH_LOOKUP_FAILED:
+        return 0, True
+    try:
+        proc = subprocess.run(
+            ["git", "rev-list", "--count", f"origin/main..{branch}"],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=DEFAULT_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return 0, True
     if proc.returncode != 0:
         return 0, True
     try:
@@ -139,7 +169,18 @@ def _patch_equivalent_to_main(repo_root: Path, branch: str | None) -> tuple[bool
         from audit_codex_branch_backlog import is_patch_equivalent
     except Exception:
         return False, True
-    return is_patch_equivalent(repo_root, "origin/main", branch, timeout=60), False
+    try:
+        return (
+            is_patch_equivalent(
+                repo_root,
+                "origin/main",
+                branch,
+                timeout=DEFAULT_PATCH_EQUIV_TIMEOUT_SECONDS,
+            ),
+            False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, True
 
 
 def _pr_lookup_failure_blocks(
@@ -191,6 +232,8 @@ def inspect_worktree(
         blockers.append("branch_ahead_of_origin_main")
     if patch_equivalence_lookup_failed:
         blockers.append("patch_equivalence_lookup_failed")
+    if branch == BRANCH_LOOKUP_FAILED:
+        blockers.append("branch_lookup_failed")
     if open_prs:
         blockers.append("open_pr")
     if branch and ahead_lookup_failed:
@@ -255,7 +298,17 @@ def _print_inspection(inspection: WorktreeInspection, *, as_json: bool) -> None:
 def _delete_branch(repo_root: Path, branch: str) -> bool:
     if not autopilot._branch_exists(repo_root, branch):
         return True
-    proc = autopilot._run_git(repo_root, "branch", "-D", branch)
+    try:
+        proc = subprocess.run(
+            ["git", "branch", "-D", branch],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=DEFAULT_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return False
     return proc.returncode == 0
 
 
@@ -281,7 +334,19 @@ def remove_worktree(
         return result
 
     if inspection.tracked_worktree:
-        proc = autopilot._run_git(repo_root, "worktree", "remove", "--force", inspection.path)
+        try:
+            proc = subprocess.run(
+                ["git", "worktree", "remove", "--force", inspection.path],
+                cwd=repo_root,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=DEFAULT_GIT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            result["status"] = "remove_failed"
+            result["stderr"] = f"git worktree remove timed out after {exc.timeout}s"
+            return result
         if proc.returncode != 0:
             result["status"] = "remove_failed"
             result["stderr"] = proc.stderr.strip()

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -50,10 +50,27 @@ def _active_lock_files(path: Path) -> list[str]:
 
 def _get_worktree_entry(repo_root: Path, path: Path) -> autopilot.WorktreeEntry | None:
     target = path.resolve()
-    for entry in autopilot._get_worktree_entries(repo_root):
+    for entry in _get_worktree_entries(repo_root):
         if entry.path.resolve() == target:
             return entry
     return None
+
+
+def _get_worktree_entries(repo_root: Path) -> list[autopilot.WorktreeEntry]:
+    try:
+        proc = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=DEFAULT_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return []
+    if proc.returncode != 0:
+        return []
+    return autopilot._parse_worktree_porcelain(proc.stdout)
 
 
 def _branch_for_path(path: Path, entry: autopilot.WorktreeEntry | None) -> str | None:

--- a/tests/scripts/test_disk_recovery_coordinator.py
+++ b/tests/scripts/test_disk_recovery_coordinator.py
@@ -26,6 +26,7 @@ def _args(tmp_path: Path, *, apply: bool) -> argparse.Namespace:
         inspect_timeout=5.0,
         remove_timeout=5.0,
         max_cleanup_per_cycle=5,
+        max_inspect_per_cycle=25,
         quarantine_file=tmp_path / "quarantine.jsonl",
     )
 
@@ -93,6 +94,34 @@ def test_external_cleanup_skips_quarantined_paths(
     assert result["quarantined_skipped"] == 1
     assert result["inspected"] == 0
     assert result["removed"] == []
+
+
+def test_external_cleanup_honors_inspect_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import disk_recovery_coordinator as mod
+
+    candidates = [
+        "/Users/armand/.codex/worktrees/aaaa/aragora",
+        "/Users/armand/.codex/worktrees/bbbb/aragora",
+    ]
+    args = _args(tmp_path, apply=False)
+    args.max_inspect_per_cycle = 1
+    monkeypatch.setattr(mod, "_git_worktree_paths", lambda _repo, _timeout: candidates)
+    monkeypatch.setattr(mod, "_active_external_worktrees", lambda _prefix: set())
+    monkeypatch.setattr(
+        mod,
+        "_run_json",
+        lambda *_args, **_kwargs: (
+            {"removable": False, "blockers": ["open_pr"]},
+            {"timed_out": False},
+        ),
+    )
+
+    result = mod._external_cleanup(tmp_path, args)
+
+    assert result["inspected"] == 1
+    assert result["max_inspect_per_cycle"] == 1
 
 
 def test_root_clean_current_allows_branch_ahead_when_requested(

--- a/tests/scripts/test_disk_recovery_coordinator.py
+++ b/tests/scripts/test_disk_recovery_coordinator.py
@@ -93,3 +93,35 @@ def test_external_cleanup_skips_quarantined_paths(
     assert result["quarantined_skipped"] == 1
     assert result["inspected"] == 0
     assert result["removed"] == []
+
+
+def test_root_clean_current_allows_branch_ahead_when_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import disk_recovery_coordinator as mod
+
+    def fake_run(argv, **_kwargs):
+        stdout = ""
+        returncode = 0
+        if argv == ["git", "rev-parse", "HEAD"]:
+            stdout = "feature-head\n"
+        elif argv == ["git", "rev-parse", "origin/main"]:
+            stdout = "main-head\n"
+        elif argv == ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"]:
+            returncode = 0
+        return {
+            "argv": argv,
+            "returncode": returncode,
+            "stdout": stdout,
+            "stderr": "",
+            "timed_out": False,
+            "elapsed": 0,
+        }
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    ok, payload = mod._root_clean_current(tmp_path, 5.0, allow_branch_ahead=True)
+
+    assert ok is True
+    assert payload["same_head"] is False
+    assert payload["branch_ahead_allowed"] is True

--- a/tests/scripts/test_disk_recovery_coordinator.py
+++ b/tests/scripts/test_disk_recovery_coordinator.py
@@ -1,0 +1,95 @@
+"""Unit tests for scripts/disk_recovery_coordinator.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+def _args(tmp_path: Path, *, apply: bool) -> argparse.Namespace:
+    return argparse.Namespace(
+        apply=apply,
+        command_timeout=5.0,
+        inspect_timeout=5.0,
+        remove_timeout=5.0,
+        max_cleanup_per_cycle=5,
+        quarantine_file=tmp_path / "quarantine.jsonl",
+    )
+
+
+def test_external_cleanup_quarantines_inspect_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import disk_recovery_coordinator as mod
+
+    candidate = "/Users/armand/.codex/worktrees/abcd/aragora"
+    monkeypatch.setattr(mod, "_git_worktree_paths", lambda _repo, _timeout: [candidate])
+    monkeypatch.setattr(mod, "_active_external_worktrees", lambda _prefix: set())
+
+    def fake_run_json(*_args, **_kwargs):
+        return None, {"returncode": 124, "timed_out": True, "stderr": "timeout"}
+
+    monkeypatch.setattr(mod, "_run_json", fake_run_json)
+
+    result = mod._external_cleanup(tmp_path, _args(tmp_path, apply=True))
+
+    assert result["removed"] == []
+    assert result["blocked"] == [{"path": candidate, "reason": "inspect_timeout"}]
+    records = [
+        json.loads(line) for line in (tmp_path / "quarantine.jsonl").read_text().splitlines()
+    ]
+    assert records[0]["path"] == candidate
+    assert records[0]["reason"] == "inspect_timeout"
+
+
+def test_external_cleanup_dry_run_reports_would_remove(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import disk_recovery_coordinator as mod
+
+    candidate = "/Users/armand/.codex/worktrees/abcd/aragora"
+    monkeypatch.setattr(mod, "_git_worktree_paths", lambda _repo, _timeout: [candidate])
+    monkeypatch.setattr(mod, "_active_external_worktrees", lambda _prefix: set())
+    monkeypatch.setattr(
+        mod,
+        "_run_json",
+        lambda *_args, **_kwargs: ({"removable": True}, {"returncode": 0, "timed_out": False}),
+    )
+
+    result = mod._external_cleanup(tmp_path, _args(tmp_path, apply=False))
+
+    assert result["would_remove"] == [candidate]
+    assert result["removed"] == []
+
+
+def test_external_cleanup_skips_quarantined_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import disk_recovery_coordinator as mod
+
+    candidate = "/Users/armand/.codex/worktrees/abcd/aragora"
+    (tmp_path / "quarantine.jsonl").write_text(
+        json.dumps({"path": candidate, "reason": "inspect_timeout"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_git_worktree_paths", lambda _repo, _timeout: [candidate])
+    monkeypatch.setattr(mod, "_active_external_worktrees", lambda _prefix: set())
+
+    result = mod._external_cleanup(tmp_path, _args(tmp_path, apply=True))
+
+    assert result["quarantined_skipped"] == 1
+    assert result["inspected"] == 0
+    assert result["removed"] == []

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -148,6 +148,55 @@ def test_branch_detection_requires_local_git_metadata(tmp_path: Path) -> None:
     assert mod._branch_for_path(orphan_path, None) is None
 
 
+def test_branch_detection_timeout_returns_preservation_sentinel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    orphan_path = tmp_path / "orphan"
+    orphan_path.mkdir()
+    (orphan_path / ".git").mkdir()
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    assert mod._branch_for_path(orphan_path, None) == mod.BRANCH_LOOKUP_FAILED
+
+
+def test_open_pr_lookup_timeout_is_lookup_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    open_prs, failed = mod._lookup_open_prs(tmp_path, "codex/test")
+
+    assert open_prs == []
+    assert failed is True
+
+
+def test_status_timeout_blocks_cleanup_as_dirty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    assert mod._worktree_is_dirty(worktree) is True
+
+
 def test_remove_purges_residual_path_after_failed_git_remove(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -229,16 +278,16 @@ def test_remove_deletes_branch_when_requested(
         blockers=[],
     )
     monkeypatch.setattr(mod.autopilot, "_branch_exists", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(
-        mod.autopilot,
-        "_run_git",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
-            args=["git", "branch", "-D", "codex/test"],
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
             returncode=0,
             stdout="Deleted branch codex/test\n",
             stderr="",
-        ),
-    )
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
 
     result = mod.remove_worktree(
         repo_root,

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -30,7 +30,7 @@ def test_inspect_reports_open_pr_blocker(tmp_path: Path, monkeypatch: pytest.Mon
 
     monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
     monkeypatch.setattr(
-        mod.autopilot,
+        mod,
         "_get_worktree_entries",
         lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/test")],
     )
@@ -115,7 +115,7 @@ def test_inspect_accepts_branch_override_for_orphaned_path(
     orphan_path = tmp_path / "manual-orphan"
     orphan_path.mkdir()
 
-    monkeypatch.setattr(mod.autopilot, "_get_worktree_entries", lambda _repo: [])
+    monkeypatch.setattr(mod, "_get_worktree_entries", lambda _repo: [])
     monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
     monkeypatch.setattr(mod, "_worktree_is_dirty", lambda _path: False)
     monkeypatch.setattr(mod, "_unique_commits_ahead_of_main", lambda _repo, _branch: (0, False))
@@ -313,7 +313,7 @@ def test_inspect_blocks_dirty_and_ahead_worktrees(
 
     monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
     monkeypatch.setattr(
-        mod.autopilot,
+        mod,
         "_get_worktree_entries",
         lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/test")],
     )
@@ -341,7 +341,7 @@ def test_inspect_allows_pr_lookup_failure_for_branch_with_no_unique_commits(
 
     monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
     monkeypatch.setattr(
-        mod.autopilot,
+        mod,
         "_get_worktree_entries",
         lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/merged")],
     )
@@ -369,7 +369,7 @@ def test_inspect_allows_patch_equivalent_branch_when_pr_lookup_fails(
 
     monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
     monkeypatch.setattr(
-        mod.autopilot,
+        mod,
         "_get_worktree_entries",
         lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/replayed")],
     )
@@ -400,7 +400,7 @@ def test_inspect_blocks_lock_files_and_history_lookup_failure(
 
     monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
     monkeypatch.setattr(
-        mod.autopilot,
+        mod,
         "_get_worktree_entries",
         lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/test")],
     )


### PR DESCRIPTION
## Summary
- Add timeouts to `safe_worktree_cleanup.py` proof subprocesses so `gh`, `git status`, history lookup, patch-equivalence, branch deletion, and worktree removal cannot hang indefinitely.
- Add `scripts/disk_recovery_coordinator.py`, a bounded recovery coordinator that reconciles satisfied outbox entries, runs repo-declared cache cleanup, invokes autopilot cleanup, and removes external Codex worktrees only through `safe_worktree_cleanup.py`.
- Add quarantine/log state for timeout blockers and hard per-cycle caps (`--max-cleanup-per-cycle`, `--max-inspect-per-cycle`) so multi-hour recovery loops stay bounded and preserve ambiguous work.

## Codex focused dogfood
Current head: `e86245d54cc741259b670df3e62730318d77704d`

Local dogfood run, dry-run:
```bash
SAFE_WORKTREE_CLEANUP_GH_TIMEOUT=3 SAFE_WORKTREE_CLEANUP_GIT_TIMEOUT=3 SAFE_WORKTREE_CLEANUP_PATCH_EQUIV_TIMEOUT=3 \
python3 scripts/disk_recovery_coordinator.py --repo . --once --allow-branch-ahead \
  --target-free-gib 100 --max-cleanup-per-cycle 1 --max-inspect-per-cycle 2 \
  --max-salvage-per-cycle 0 --inspect-timeout 8 --command-timeout 30 \
  --quarantine-file /tmp/aragora-disk-recovery-quarantine.jsonl \
  --jsonl-log /tmp/aragora-disk-recovery-test.jsonl
```
Result: `ok=true`; inspected 2 external candidates; both blocked by dirty/ahead safety blockers; no worktrees removed.

Local bounded apply cycle:
```bash
SAFE_WORKTREE_CLEANUP_GH_TIMEOUT=5 SAFE_WORKTREE_CLEANUP_GIT_TIMEOUT=5 SAFE_WORKTREE_CLEANUP_PATCH_EQUIV_TIMEOUT=5 \
python3 scripts/disk_recovery_coordinator.py --repo . --apply --once --allow-branch-ahead \
  --target-free-gib 100 --max-cleanup-per-cycle 5 --max-inspect-per-cycle 8 \
  --max-salvage-per-cycle 0 --inspect-timeout 12 --remove-timeout 30 --command-timeout 90
```
Result: `ok=true`; archived 1 receipt-backed outbox handoff; repo-declared cache cleanup ran; autopilot removed 0 and preserved 8 unmerged + 3 dirty repo-local worktrees; external cleanup inspected 8 and removed 0 because all were dirty or ahead of `origin/main`.

## Validation
```bash
python3 -m pytest tests/scripts/test_safe_worktree_cleanup.py tests/scripts/test_disk_recovery_coordinator.py -q
# 18 passed

python3 -m ruff check scripts/safe_worktree_cleanup.py scripts/disk_recovery_coordinator.py tests/scripts/test_safe_worktree_cleanup.py tests/scripts/test_disk_recovery_coordinator.py
# All checks passed

python3 -m ruff format --check scripts/safe_worktree_cleanup.py scripts/disk_recovery_coordinator.py tests/scripts/test_safe_worktree_cleanup.py tests/scripts/test_disk_recovery_coordinator.py
# 4 files already formatted

bash scripts/automation_pr_preflight.sh origin/main HEAD
# preflight: ok

git push -u origin codex/disk-recovery-coordinator-20260514
# pre-push hooks passed, including mypy-baseline and gitleaks
```

## Non-claims
- Does not delete remote branches.
- Does not touch AGT PRs.
- Does not run `observe-outcomes --write`.
- Does not restart mutating writers or publisher.
- Does not implement automatic Tier-2 merge publication; salvage snapshots are informational until a packet-gated publication lane consumes them.
