### PR TITLE
[AGT-03] Manifold Brier bridge — ResolutionEvent → ManifoldBrierScorer (SD-2)

### DIFF
--- a/aragora/metrics/manifold_brier_bridge.py
+++ b/aragora/metrics/manifold_brier_bridge.py
@@ -24,8 +24,7 @@ if TYPE_CHECKING:
     from aragora.connectors.prediction_markets.manifold import ManifoldResolution  # noqa: F401
 
 _DISABLED_MSG = (
-    "ManifoldBrierScorer bridge is disabled. "
-    "Set ARAGORA_MANIFOLD_BRIER_ENABLED=1 to enable."
+    "ManifoldBrierScorer bridge is disabled. Set ARAGORA_MANIFOLD_BRIER_ENABLED=1 to enable."
 )
 
 

--- a/aragora/metrics/manifold_brier_bridge.py
+++ b/aragora/metrics/manifold_brier_bridge.py
@@ -1,0 +1,130 @@
+"""AGT-03 sub-deliverable 2: bridge ResolutionEvent → ManifoldBrierScorer.
+
+Converts resolved market outcomes into ManifoldPrediction records for rolling
+Brier calibration.  Accepts any :class:`ResolutionEventProtocol`-compatible
+object so tests and Metaculus can use the same path without loading the full
+connectors package hierarchy.  Inconclusive outcomes are silently skipped.
+
+Flag: ARAGORA_MANIFOLD_BRIER_ENABLED.  Advances issue #6064 (AGT-03).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Protocol, Sequence, runtime_checkable
+
+from aragora.metrics.manifold_brier import (
+    ManifoldBrierScorer,
+    ManifoldPrediction,
+    manifold_brier_enabled,
+)
+
+if TYPE_CHECKING:
+    from aragora.connectors.prediction_markets.manifold import ManifoldResolution  # noqa: F401
+
+_DISABLED_MSG = (
+    "ManifoldBrierScorer bridge is disabled. "
+    "Set ARAGORA_MANIFOLD_BRIER_ENABLED=1 to enable."
+)
+
+
+@runtime_checkable
+class ResolutionEventProtocol(Protocol):
+    """Structural protocol satisfied by ManifoldResolution and compatible stubs."""
+
+    market_id: str
+    outcome: str  # "yes" | "no" | "inconclusive"
+    resolved_at_ms: int | None
+
+
+@dataclass(frozen=True)
+class PendingPrediction:
+    """An agent prediction waiting to be settled against a resolution."""
+
+    market_id: str
+    agent_id: str
+    predicted_probability: float
+    predicted_at: datetime
+    question_slug: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.market_id:
+            raise ValueError("market_id must be non-empty")
+        if not self.agent_id:
+            raise ValueError("agent_id must be non-empty")
+        if not (0.0 <= self.predicted_probability <= 1.0):
+            raise ValueError(
+                f"predicted_probability must be in [0, 1]; got {self.predicted_probability}"
+            )
+
+
+def resolution_to_binary_outcome(resolution: ResolutionEventProtocol) -> int | None:
+    """Map a resolution to 1 (YES), 0 (NO), or None (inconclusive). Pure, no flag check."""
+    if resolution.outcome == "yes":
+        return 1
+    if resolution.outcome == "no":
+        return 0
+    return None
+
+
+def _resolved_at_from_ms(resolved_at_ms: int | None) -> datetime | None:
+    if resolved_at_ms is None:
+        return None
+    return datetime.fromtimestamp(resolved_at_ms / 1000.0, tz=UTC)
+
+
+def record_resolution(
+    scorer: ManifoldBrierScorer,
+    resolution: ResolutionEventProtocol,
+    pending: PendingPrediction,
+) -> ManifoldPrediction | None:
+    """Add a scored ManifoldPrediction to scorer; returns None for inconclusive outcomes."""
+    if not manifold_brier_enabled():
+        raise RuntimeError(_DISABLED_MSG)
+    outcome = resolution_to_binary_outcome(resolution)
+    if outcome is None:
+        return None
+    prediction = ManifoldPrediction(
+        question_id=resolution.market_id,
+        predicted_probability=pending.predicted_probability,
+        outcome=outcome,
+        predicted_at=pending.predicted_at,
+        resolved_at=_resolved_at_from_ms(resolution.resolved_at_ms),
+        question_slug=pending.question_slug,
+        agent_id=pending.agent_id,
+    )
+    scorer.add(prediction)
+    return prediction
+
+
+def batch_record_resolutions(
+    scorer: ManifoldBrierScorer,
+    resolutions: dict[str, ResolutionEventProtocol],
+    pending_predictions: Sequence[PendingPrediction],
+) -> tuple[int, int]:
+    """Batch-settle predictions; returns (recorded, skipped) counts."""
+    if not manifold_brier_enabled():
+        raise RuntimeError(_DISABLED_MSG)
+    recorded = 0
+    skipped = 0
+    for pending in pending_predictions:
+        resolution = resolutions.get(pending.market_id)
+        if resolution is None:
+            skipped += 1
+            continue
+        result = record_resolution(scorer, resolution, pending)
+        if result is None:
+            skipped += 1
+        else:
+            recorded += 1
+    return recorded, skipped
+
+
+__all__ = [
+    "PendingPrediction",
+    "ResolutionEventProtocol",
+    "batch_record_resolutions",
+    "record_resolution",
+    "resolution_to_binary_outcome",
+]

--- a/tests/metrics/test_manifold_brier_bridge.py
+++ b/tests/metrics/test_manifold_brier_bridge.py
@@ -73,7 +73,9 @@ class TestPendingPrediction:
 
     def test_boundary_probabilities_ok(self) -> None:
         for prob in (0.0, 1.0):
-            p = PendingPrediction(market_id="m", agent_id="a", predicted_probability=prob, predicted_at=_NOW)
+            p = PendingPrediction(
+                market_id="m", agent_id="a", predicted_probability=prob, predicted_at=_NOW
+            )
             assert p.predicted_probability == prob
 
 
@@ -152,8 +154,12 @@ class TestBatchRecordResolutions:
         scorer = ManifoldBrierScorer()
         resolutions = {"m_a": _res("yes", "m_a"), "m_b": _res("no", "m_b")}
         pending = [
-            PendingPrediction(market_id="m_a", agent_id="ag", predicted_probability=1.0, predicted_at=_NOW),
-            PendingPrediction(market_id="m_b", agent_id="ag", predicted_probability=0.9, predicted_at=_NOW),
+            PendingPrediction(
+                market_id="m_a", agent_id="ag", predicted_probability=1.0, predicted_at=_NOW
+            ),
+            PendingPrediction(
+                market_id="m_b", agent_id="ag", predicted_probability=0.9, predicted_at=_NOW
+            ),
         ]
         batch_record_resolutions(scorer, resolutions, pending)
         summary = scorer.rolling_score_for_agent("ag", window_days=30, reference_time=_NOW)

--- a/tests/metrics/test_manifold_brier_bridge.py
+++ b/tests/metrics/test_manifold_brier_bridge.py
@@ -1,0 +1,161 @@
+"""Tests for aragora.metrics.manifold_brier_bridge — AGT-03 sub-deliverable 2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+
+from aragora.metrics.manifold_brier import ManifoldBrierScorer
+from aragora.metrics.manifold_brier_bridge import (
+    PendingPrediction,
+    ResolutionEventProtocol,
+    batch_record_resolutions,
+    record_resolution,
+    resolution_to_binary_outcome,
+)
+
+_NOW = datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC)
+_TS_MS = 1_747_224_000_000  # 2026-05-14T12:00:00Z
+
+
+@dataclass(frozen=True)
+class _Res:
+    """Minimal stub satisfying ResolutionEventProtocol."""
+
+    market_id: str
+    outcome: str
+    resolved_at_ms: int | None
+
+
+def _res(outcome: str, market_id: str = "mkt_abc") -> _Res:
+    return _Res(market_id=market_id, outcome=outcome, resolved_at_ms=_TS_MS)
+
+
+def _pend(market_id: str = "mkt_abc", agent: str = "ag", p: float = 0.7) -> PendingPrediction:
+    return PendingPrediction(
+        market_id=market_id, agent_id=agent, predicted_probability=p, predicted_at=_NOW
+    )
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionToBinaryOutcome:
+    @pytest.mark.parametrize("outcome,expected", [("yes", 1), ("no", 0), ("inconclusive", None)])
+    def test_mapping(self, outcome: str, expected: int | None) -> None:
+        assert resolution_to_binary_outcome(_res(outcome)) == expected
+
+    def test_stub_satisfies_protocol(self) -> None:
+        assert isinstance(_res("yes"), ResolutionEventProtocol)
+
+    def test_pure_no_flag_needed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)
+        assert resolution_to_binary_outcome(_res("yes")) == 1
+
+
+class TestPendingPrediction:
+    @pytest.mark.parametrize(
+        "kwargs,match",
+        [
+            ({"market_id": ""}, "market_id"),
+            ({"agent_id": ""}, "agent_id"),
+            ({"predicted_probability": 1.1}, "predicted_probability"),
+            ({"predicted_probability": -0.1}, "predicted_probability"),
+        ],
+    )
+    def test_validation(self, kwargs: dict, match: str) -> None:
+        base = dict(market_id="m", agent_id="a", predicted_probability=0.5, predicted_at=_NOW)
+        base.update(kwargs)
+        with pytest.raises(ValueError, match=match):
+            PendingPrediction(**base)  # type: ignore[arg-type]
+
+    def test_boundary_probabilities_ok(self) -> None:
+        for prob in (0.0, 1.0):
+            p = PendingPrediction(market_id="m", agent_id="a", predicted_probability=prob, predicted_at=_NOW)
+            assert p.predicted_probability == prob
+
+
+class TestRecordResolution:
+    def test_yes_records_outcome_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        scorer = ManifoldBrierScorer()
+        result = record_resolution(scorer, _res("yes"), _pend(p=0.8))
+        assert result is not None and result.outcome == 1 and result.predicted_probability == 0.8
+        assert len(scorer.all_predictions()) == 1
+
+    def test_no_records_outcome_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        scorer = ManifoldBrierScorer()
+        result = record_resolution(scorer, _res("no"), _pend(p=0.3))
+        assert result is not None and result.outcome == 0
+
+    def test_inconclusive_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        scorer = ManifoldBrierScorer()
+        assert record_resolution(scorer, _res("inconclusive"), _pend()) is None
+        assert len(scorer.all_predictions()) == 0
+
+    def test_fields_propagated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        scorer = ManifoldBrierScorer()
+        result = record_resolution(scorer, _res("yes", "mkt_xyz"), _pend(agent="codex"))
+        assert result is not None
+        assert result.question_id == "mkt_xyz"
+        assert result.agent_id == "codex"
+        assert result.resolved_at == datetime.fromtimestamp(_TS_MS / 1000.0, tz=UTC)
+
+    def test_none_resolved_at_ms(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        scorer = ManifoldBrierScorer()
+        r = _Res(market_id="m", outcome="yes", resolved_at_ms=None)
+        result = record_resolution(scorer, r, _pend())
+        assert result is not None and result.resolved_at is None
+
+    def test_disabled_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)
+        with pytest.raises(RuntimeError, match="ARAGORA_MANIFOLD_BRIER_ENABLED"):
+            record_resolution(ManifoldBrierScorer(), _res("yes"), _pend())
+
+
+class TestBatchRecordResolutions:
+    def test_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        assert batch_record_resolutions(ManifoldBrierScorer(), {}, []) == (0, 0)
+
+    def test_no_resolutions_all_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        r, s = batch_record_resolutions(ManifoldBrierScorer(), {}, [_pend("m1"), _pend("m2")])
+        assert r == 0 and s == 2
+
+    def test_mixed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        scorer = ManifoldBrierScorer()
+        resolutions = {
+            "m_yes": _res("yes", "m_yes"),
+            "m_no": _res("no", "m_no"),
+            "m_inc": _res("inconclusive", "m_inc"),
+        }
+        pending = [_pend("m_yes"), _pend("m_no"), _pend("m_inc"), _pend("m_missing")]
+        r, s = batch_record_resolutions(scorer, resolutions, pending)
+        assert r == 2 and s == 2
+        assert len(scorer.all_predictions()) == 2
+
+    def test_disabled_raises_before_iterating(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)
+        with pytest.raises(RuntimeError, match="ARAGORA_MANIFOLD_BRIER_ENABLED"):
+            batch_record_resolutions(ManifoldBrierScorer(), {"m": _res("yes")}, [_pend()])
+
+    def test_brier_arithmetic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        scorer = ManifoldBrierScorer()
+        resolutions = {"m_a": _res("yes", "m_a"), "m_b": _res("no", "m_b")}
+        pending = [
+            PendingPrediction(market_id="m_a", agent_id="ag", predicted_probability=1.0, predicted_at=_NOW),
+            PendingPrediction(market_id="m_b", agent_id="ag", predicted_probability=0.9, predicted_at=_NOW),
+        ]
+        batch_record_resolutions(scorer, resolutions, pending)
+        summary = scorer.rolling_score_for_agent("ag", window_days=30, reference_time=_NOW)
+        assert summary.n_predictions == 2
+        assert abs(summary.mean_brier - 0.405) < 1e-9  # (0.0 + 0.81) / 2


### PR DESCRIPTION
## Slice

Wires the existing Manifold connector resolution output into the `ManifoldBrierScorer`
accumulator. The SD-1 skeleton (already on `main`) explicitly deferred this connector
wiring as "AGT-03 sub-deliverable 2"; this PR closes that gap.

Two new files:
- `aragora/metrics/manifold_brier_bridge.py` — `ResolutionEventProtocol`, `PendingPrediction`, `resolution_to_binary_outcome`, `record_resolution`, `batch_record_resolutions`
- `tests/metrics/test_manifold_brier_bridge.py` — 21 tests across 4 classes

## Gating

- Default: **OFF** (flag: `ARAGORA_MANIFOLD_BRIER_ENABLED`, same as SD-1)
- Live queue effect: none
- Advances issue: #6064 (AGT-03)

## Tests

| Class | Cases |
|-------|-------|
| `TestResolutionToBinaryOutcome` | yes→1, no→0, inconclusive→None, pure (no flag needed) |
| `TestPendingPrediction` | empty market_id/agent_id, out-of-range probability, boundary values |
| `TestRecordResolution` | yes/no records, inconclusive skips, field propagation, None resolved_at_ms, disabled raises |
| `TestBatchRecordResolutions` | empty, no matches, mixed (yes+no+inconclusive+missing), disabled raises, Brier arithmetic |

## Validation

- `pytest tests/metrics/test_manifold_brier_bridge.py --noconftest` — 21 passed
- `ruff check aragora/metrics/manifold_brier_bridge.py tests/metrics/test_manifold_brier_bridge.py` — clean
- `mypy aragora/metrics/manifold_brier_bridge.py --ignore-missing-imports` — clean
- Net diff: **291 LOC** (130 impl + 161 tests)

## Design note

Uses `ResolutionEventProtocol` (a `@runtime_checkable` Protocol) instead of a direct import
of `ManifoldResolution` so tests can use a simple stub dataclass without loading the full
`aragora.connectors` package hierarchy (which pulls `defusedxml` and other optional deps).
The `TYPE_CHECKING` import preserves static-analysis compatibility with the concrete type.

## Out of scope

- Prediction *submission* to Manifold (AGT-03 Phase 2, write path, gated on `ARAGORA_MANIFOLD_WRITE_ENABLED`)
- Per-agent Brier wiring into the AGT-05 reputation flow (separate issue)
- Metaculus bridge (separate connector, same protocol can be reused when ready)
- Any live-queue, boss-loop, dispatch, or swarm-supervisor changes

Labels: `vision-layer` — do NOT add `boss-ready` or `autonomous`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159gne4bLMae9L8ySgDXUXc)_