### PR TITLE
fix(review-queue): classify observe-outcomes fetch errors by cause

### DIFF
--- a/aragora/review/observe_outcomes_cli.py
+++ b/aragora/review/observe_outcomes_cli.py
@@ -122,6 +122,7 @@ class _ObserveResult:
     signals_after: dict[str, Any]
     written: bool
     skipped_reason: str | None = None
+    fetch_error_class: str | None = None  # "rate_limit" | "other" | None when fetch_error is None
 
 
 # ---------------------------------------------------------------------------
@@ -576,6 +577,8 @@ def _build_insufficiency_receipt(
     receipts_with_signals: int,
     receipts_written: int,
     fetch_errors: int,
+    rate_limit_fetch_errors: int = 0,
+    other_fetch_errors: int = 0,
     v2_now_present: bool,
 ) -> dict[str, Any]:
     reasons: list[str] = []
@@ -590,11 +593,18 @@ def _build_insufficiency_receipt(
             "signals; either the window is genuinely clean or the timeline "
             "fetch did not surface revert/incident/redo events"
         )
-    if fetch_errors > 0:
+    if rate_limit_fetch_errors > 0:
         reasons.append(
-            f"github_fetch_errors: {fetch_errors} of {receipts_examined} "
-            "receipts had timeline fetch errors; rerun with network "
-            "connectivity verified"
+            f"github_rate_limit_fetch_errors: {rate_limit_fetch_errors} of "
+            f"{receipts_examined} receipts hit GitHub API rate limits during "
+            "timeline fetch; wait for the rate limit window to reset "
+            "(check 'gh api rate_limit') and rerun"
+        )
+    if other_fetch_errors > 0:
+        reasons.append(
+            f"github_fetch_errors: {other_fetch_errors} of {receipts_examined} "
+            "receipts had non-rate-limit timeline fetch errors; rerun with "
+            "network connectivity verified"
         )
     if max_receipts <= receipts_examined:
         reasons.append(
@@ -611,6 +621,8 @@ def _build_insufficiency_receipt(
         "receipts_with_signals_fired": receipts_with_signals,
         "receipts_written": receipts_written,
         "github_fetch_errors": fetch_errors,
+        "github_rate_limit_fetch_errors": rate_limit_fetch_errors,
+        "github_other_fetch_errors": other_fetch_errors,
         "v2_outcome_fields_now_present_in_window": v2_now_present,
         "remaining_blockers": reasons,
         "next_action_advice": (
@@ -689,6 +701,9 @@ def _observe_one(
         )
     events, fetch_error = timeline_provider(pr_number, head_sha, per_receipt_event_cap)
     if fetch_error is not None:
+        fetch_error_class = (
+            "rate_limit" if _looks_like_github_rate_limit_error(fetch_error) else "other"
+        )
         return _ObserveResult(
             receipt_path=receipt.path,
             pr_number=pr_number,
@@ -699,6 +714,7 @@ def _observe_one(
             signals_after=_signal_extract(payload),
             written=False,
             skipped_reason="github fetch error",
+            fetch_error_class=fetch_error_class,
         )
     observed = observe_outcome(
         receipt_obj,
@@ -794,6 +810,10 @@ def run_observe_outcomes(
     )
     receipts_written = sum(1 for r in results if r.written)
     fetch_errors = sum(1 for r in results if r.fetch_error is not None)
+    rate_limit_fetch_errors = sum(1 for r in results if r.fetch_error_class == "rate_limit")
+    other_fetch_errors = sum(
+        1 for r in results if r.fetch_error is not None and r.fetch_error_class != "rate_limit"
+    )
 
     # If we wrote any v2 fields, the next baseline measurement should
     # see them. Probe defensively.
@@ -818,6 +838,8 @@ def run_observe_outcomes(
             receipts_with_signals=receipts_with_signals,
             receipts_written=receipts_written,
             fetch_errors=fetch_errors,
+            rate_limit_fetch_errors=rate_limit_fetch_errors,
+            other_fetch_errors=other_fetch_errors,
             v2_now_present=v2_now_present,
         )
         insufficiency_path = insufficiency_receipt_path or _resolve_insufficiency_receipt_path(
@@ -846,6 +868,8 @@ def run_observe_outcomes(
         "receipts_with_signals_fired": receipts_with_signals,
         "receipts_written": receipts_written,
         "github_fetch_errors": fetch_errors,
+        "github_rate_limit_fetch_errors": rate_limit_fetch_errors,
+        "github_other_fetch_errors": other_fetch_errors,
         "v2_outcome_fields_now_present_in_window": v2_now_present,
         "insufficiency_receipt_path": (str(insufficiency_path) if insufficiency_path else None),
         "insufficiency_receipt": insufficiency_payload,
@@ -856,6 +880,7 @@ def run_observe_outcomes(
                 "head_sha": r.head_sha,
                 "fetched_event_count": r.fetched_event_count,
                 "fetch_error": r.fetch_error,
+                "fetch_error_class": r.fetch_error_class,
                 "signals_before": r.signals_before,
                 "signals_after": r.signals_after,
                 "written": r.written,

--- a/tests/review/test_observe_outcomes_cli.py
+++ b/tests/review/test_observe_outcomes_cli.py
@@ -296,6 +296,15 @@ class TestWriteModeMutates:
         assert "no_signals_fired" in joined
 
 
+def _rate_limit_provider(
+    pr_number: int, head_sha: str, cap: int
+) -> tuple[list[Mapping[str, Any]], str | None]:
+    return (
+        [],
+        "['gh', 'api', '-X'] returned 1: gh: API rate limit exceeded for user ID 33477136",
+    )
+
+
 class TestFetchErrorsFlagged:
     def test_fetch_errors_recorded_and_skipped(self, tmp_path: Path) -> None:
         receipts_dir = tmp_path / RECEIPTS_SUBDIR
@@ -311,13 +320,83 @@ class TestFetchErrorsFlagged:
             timeline_provider=_failing_provider,
         )
         assert summary["github_fetch_errors"] == 1
+        assert summary["github_other_fetch_errors"] == 1
+        assert summary["github_rate_limit_fetch_errors"] == 0
         assert summary["receipts_written"] == 0
         # File on disk untouched even in write mode when fetch failed.
         body = json.loads(path.read_text())
         assert body.get("outcome_revert_within_window") is None
-        # Insufficiency receipt names the fetch errors.
+        # Insufficiency receipt names the fetch errors (non-rate-limit).
         body_ins = json.loads(Path(summary["insufficiency_receipt_path"]).read_text())
-        assert "github_fetch_errors" in " ".join(body_ins["remaining_blockers"])
+        joined = " ".join(body_ins["remaining_blockers"])
+        assert "github_fetch_errors" in joined
+        assert "github_rate_limit_fetch_errors" not in joined
+        # Per-result entry carries the classification.
+        assert summary["results"][0]["fetch_error_class"] == "other"
+
+    def test_rate_limit_fetch_errors_classified_separately(self, tmp_path: Path) -> None:
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload())
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_rate_limit_provider,
+        )
+        # Totals: 1 fetch error, classified as rate_limit.
+        assert summary["github_fetch_errors"] == 1
+        assert summary["github_rate_limit_fetch_errors"] == 1
+        assert summary["github_other_fetch_errors"] == 0
+        assert summary["results"][0]["fetch_error_class"] == "rate_limit"
+        # Insufficiency receipt advises waiting for rate limit, not debugging
+        # network connectivity.
+        body_ins = json.loads(Path(summary["insufficiency_receipt_path"]).read_text())
+        joined = " ".join(body_ins["remaining_blockers"])
+        assert "github_rate_limit_fetch_errors" in joined
+        assert "rate limit window to reset" in joined
+        assert "github_fetch_errors:" not in joined  # the generic blocker (not rate-limit)
+        # Insufficiency body also exposes the classified counts as fields.
+        assert body_ins["github_rate_limit_fetch_errors"] == 1
+        assert body_ins["github_other_fetch_errors"] == 0
+
+    def test_mixed_fetch_errors_classified_per_receipt(self, tmp_path: Path) -> None:
+        """A batch with both rate-limit and non-rate-limit failures should
+        produce both blocker reasons and split per-class counts."""
+        receipts_dir = tmp_path / RECEIPTS_SUBDIR
+        _write_receipt(receipts_dir, "r1", _base_payload(pr_number=4001))
+        _write_receipt(receipts_dir, "r2", _base_payload(pr_number=4002))
+
+        def _mixed_provider(
+            pr_number: int, head_sha: str, cap: int
+        ) -> tuple[list[Mapping[str, Any]], str | None]:
+            if pr_number == 4001:
+                return [], "gh: 503 Service Unavailable"
+            return (
+                [],
+                "['gh', 'api'] returned 1: gh: secondary rate limit exceeded",
+            )
+
+        summary = run_observe_outcomes(
+            store_root=tmp_path,
+            repo_root=tmp_path,
+            window_end=datetime(2026, 4, 30, 12, tzinfo=UTC),
+            window_days=DEFAULT_WINDOW_DAYS,
+            max_receipts=20,
+            per_receipt_event_cap=DEFAULT_PER_RECEIPT_EVENT_CAP,
+            write=True,
+            timeline_provider=_mixed_provider,
+        )
+        assert summary["github_fetch_errors"] == 2
+        assert summary["github_rate_limit_fetch_errors"] == 1
+        assert summary["github_other_fetch_errors"] == 1
+        body_ins = json.loads(Path(summary["insufficiency_receipt_path"]).read_text())
+        joined = " ".join(body_ins["remaining_blockers"])
+        assert "github_rate_limit_fetch_errors" in joined
+        assert "github_fetch_errors:" in joined
 
 
 class TestBoundedFanout:


### PR DESCRIPTION
## Summary

- Classify `observe-outcomes` timeline fetch errors as `rate_limit` vs `other` in the report, using the existing `_looks_like_github_rate_limit_error` detector
- Replaces a single generic "github_fetch_errors: ... rerun with network connectivity verified" blocker with two specific blockers that direct the operator to the right remediation
- Adds `github_rate_limit_fetch_errors` and `github_other_fetch_errors` counts to both the top-level summary and the insufficiency receipt
- Adds `fetch_error_class` to each per-result entry so per-receipt diagnostics are classified consistently
- Preserves the existing `github_fetch_errors` total for backward compatibility

## Background

A dry-run over 13 receipts on 2026-05-13 hit GitHub secondary rate-limit on the last 3 paginated timeline fetches. The existing report only said:

`github_fetch_errors: 3 of 13 receipts had timeline fetch errors; rerun with network connectivity verified`

…which misled toward debugging a network problem when the actual issue was a rate-limit window that resolves on its own. After this change the operator sees a specific rate-limit blocker that directs them to `gh api rate_limit`.

## Non-Claims

- Does not change the existing retry/throttle/backoff logic in `_run_gh_json`
- Does not silence rate-limit errors; they still appear in the per-receipt `fetch_error` string and total `github_fetch_errors` count
- Does not modify the `observe-outcomes` mutation contract; `--write` still fails closed on any fetch error
- Does not change the schema of settlement receipts
- Does not authorize unattended `observe-outcomes --write` automation

## Validation

- `python3 -m pytest tests/review/test_observe_outcomes_cli.py tests/review/test_observe_outcomes_dry_run_isolation.py tests/cli/commands/test_review_queue.py -q` → **150 passed**
- `python3 -m ruff check aragora/review/observe_outcomes_cli.py tests/review/test_observe_outcomes_cli.py` → clean
- `python3 -m ruff format --check` → clean
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → preflight: ok
- `gitleaks protect --staged --redact` → no leaks found
- Three new tests cover: (1) all-rate-limit case classified correctly; (2) mixed rate-limit + other case classified correctly per receipt; (3) existing non-rate-limit case unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)