### PR TITLE
fix(automation): accept publisher dry-run flag

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1338,6 +1338,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Disable loading JSON automation outbox handoffs.",
     )
     parser.add_argument("--apply", action="store_true", help="Create eligible GitHub issues")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview eligible handoffs without writing; this is the default mode",
+    )
     parser.add_argument("--json", action="store_true", help="Print machine-readable output")
     return parser
 
@@ -1345,6 +1350,8 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+    if args.apply and args.dry_run:
+        parser.error("--apply and --dry-run are mutually exclusive")
 
     repo_root = _repo_root(Path(args.repo))
     codex_home = _codex_home(args.codex_home)

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from scripts.github_cli_health import GitHubCLIHealth
 import scripts.publish_automation_handoffs as mod
 from scripts.publish_automation_handoffs import Handoff, PublishDecision
@@ -1578,6 +1580,76 @@ def test_main_preview_does_not_write_outbox_receipt(
     assert exit_code == 0
     assert not receipts.exists()
     assert '"reason": "existing_issue"' in capsys.readouterr().out
+
+
+def test_main_accepts_explicit_dry_run_alias(monkeypatch: Any, tmp_path: Path, capsys) -> None:
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    handoff = Handoff(
+        source_file=str(tmp_path / ".aragora" / "automation-outbox" / "example.json"),
+        task_title="Publish validated repair branch",
+        priority="MEDIUM",
+        body="body",
+        labels={},
+        expires_at=None,
+        idempotency_key="open-pr-codex-example-abc123",
+        source_kind="outbox",
+    )
+    monkeypatch.setattr(mod, "_repo_root", lambda path: tmp_path)
+    monkeypatch.setattr(mod, "load_handoffs", lambda codex_home, automation_ids=None: [])
+    monkeypatch.setattr(
+        mod,
+        "load_outbox_handoffs",
+        lambda repo_root, outbox_dir=None, receipt_dir=None: [handoff],
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda repo_root: GitHubCLIHealth(
+            ready=True,
+            auth_ok=True,
+            api_ok=True,
+            mode="ok",
+            error=None,
+            repo=str(tmp_path),
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "decide_handoffs",
+        lambda *args, **kwargs: [
+            PublishDecision(
+                task_title=handoff.task_title,
+                source_file=handoff.source_file,
+                eligible=False,
+                reason="existing_issue",
+                existing_issue_url="https://github.com/synaptent/aragora/issues/1",
+            )
+        ],
+    )
+
+    exit_code = mod.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "--codex-home",
+            str(tmp_path),
+            "--receipt-dir",
+            str(receipts),
+            "--json",
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    assert not receipts.exists()
+    assert '"reason": "existing_issue"' in capsys.readouterr().out
+
+
+def test_main_rejects_apply_with_dry_run(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        mod.main(["--repo", str(tmp_path), "--apply", "--dry-run"])
+
+    assert excinfo.value.code == 2
 
 
 def test_main_derives_outbox_dirs_from_explicit_aragora_state_root(


### PR DESCRIPTION
## Summary
- Accepts the existing publisher dry-run alias used by automation handoffs.
- Adds regression coverage for the alias path.

## Validation
- python3 -m pytest -q tests/scripts/test_publish_automation_handoffs.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- python3 -m ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Scope
- Tier 2 automation hygiene.
- No AGT, public API, publisher restart, or observe-outcomes write.

Current head: acdef63806146d559551042b6016beedfbd14aa5