### PR TITLE
fix(automation): support shared outbox reconciliation state

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -42,6 +42,9 @@ from audit_codex_branch_backlog import (  # noqa: E402
 from github_cli_health import check_github_cli_health  # noqa: E402
 
 UTC = timezone.utc
+DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
+DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
+DEFAULT_ARCHIVE_DIR = Path(".aragora/automation-outbox-archive")
 
 
 def _load_json(path: Path) -> dict[str, Any] | None:
@@ -55,6 +58,22 @@ def _list_json(path: Path) -> list[Path]:
     if not path.exists():
         return []
     return sorted(p for p in path.iterdir() if p.is_file() and p.suffix == ".json")
+
+
+def _state_default_path(state_root: Path, default_relative: Path) -> Path:
+    expanded = state_root.expanduser()
+    if default_relative.parts[:1] == (".aragora",) and expanded.name == ".aragora":
+        return expanded.joinpath(*default_relative.parts[1:])
+    return expanded / default_relative
+
+
+def _resolve_path(repo_root: Path, value: Path | None, default: Path) -> Path:
+    if value is None:
+        return default.resolve()
+    expanded = value.expanduser()
+    if expanded.is_absolute():
+        return expanded.resolve()
+    return (repo_root / expanded).resolve()
 
 
 def _branch_has_landed_on_main(root: Path, base: str, branch: str) -> bool:
@@ -328,12 +347,42 @@ def main(argv: list[str] | None = None) -> int:
         "--repo",
         required=True,
         help=(
-            "Main repository root (NOT a worktree). Outbox/receipt state "
-            "is read from this path's .aragora/ subdirectory."
+            "Repository root or disposable worktree used for git checks. "
+            "Outbox/receipt state defaults to this path's .aragora/ subdirectory."
         ),
     )
     parser.add_argument("--base", default="origin/main")
     parser.add_argument("--repo-name", default="synaptent/aragora")
+    parser.add_argument(
+        "--state-root",
+        type=Path,
+        default=None,
+        help=(
+            "Checkout or .aragora directory that owns shared automation state. "
+            "Explicit --outbox-dir/--receipt-dir/--archive-dir override it."
+        ),
+    )
+    parser.add_argument(
+        "--outbox-dir",
+        type=Path,
+        default=None,
+        help="Directory containing JSON automation outbox handoffs.",
+    )
+    parser.add_argument(
+        "--receipt-dir",
+        type=Path,
+        default=None,
+        help="Directory containing JSON automation publisher receipts.",
+    )
+    parser.add_argument(
+        "--archive-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory for archived satisfied outbox handoffs. Defaults beside "
+            "the selected automation outbox."
+        ),
+    )
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
         "--apply",
@@ -372,14 +421,23 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     root = Path(args.repo).resolve()
-    outbox_dir = root / ".aragora" / "automation-outbox"
-    receipt_dir = root / ".aragora" / "automation-receipts"
-    archive_dir = root / ".aragora" / "automation-outbox-archive"
+    state_root = Path(args.state_root).expanduser().resolve() if args.state_root else root
+    outbox_default = _state_default_path(state_root, DEFAULT_OUTBOX_DIR)
+    receipt_default = _state_default_path(state_root, DEFAULT_RECEIPT_DIR)
+    outbox_dir = _resolve_path(root, args.outbox_dir, outbox_default)
+    receipt_dir = _resolve_path(root, args.receipt_dir, receipt_default)
+    archive_default = (
+        outbox_dir.with_name("automation-outbox-archive")
+        if args.outbox_dir is not None
+        else _state_default_path(state_root, DEFAULT_ARCHIVE_DIR)
+    )
+    archive_dir = _resolve_path(root, args.archive_dir, archive_default)
 
     def emit(message: str = "") -> None:
         if not args.json:
             print(message)
 
+    emit(f"state_root: {state_root}")
     emit(f"outbox_dir: {outbox_dir}")
     emit(f"receipt_dir: {receipt_dir}")
     emit(f"archive_dir: {archive_dir} {'(will create)' if not archive_dir.exists() else ''}")
@@ -653,6 +711,7 @@ def main(argv: list[str] | None = None) -> int:
                     "repo": str(root),
                     "repo_name": args.repo_name,
                     "report": str(report_path) if report_path is not None else None,
+                    "state_root": str(state_root),
                     "terminal_receipt_count": len(receipt_keys),
                 },
                 indent=2,

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -116,6 +116,111 @@ def test_json_output_reports_reconciliation_without_human_preamble(
     assert payload["actions"][0]["branch"] == "codex/json-output"
 
 
+def test_state_root_can_point_at_direct_dot_aragora(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    repo = tmp_path / "disposable-worktree"
+    repo.mkdir()
+    state_root = tmp_path / "shared-checkout" / ".aragora"
+    outbox_dir = state_root / "automation-outbox"
+    receipt_dir = state_root / "automation-receipts"
+    key = "open-pr-codex-shared-state-abc123"
+    _write_outbox_handoff(outbox_dir, branch="codex/shared-state", key=key)
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps({"idempotency_key": key, "status": "published"}),
+        encoding="utf-8",
+    )
+
+    rc = mod.main(["--repo", str(repo), "--state-root", str(state_root), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["state_root"] == str(state_root.resolve())
+    assert payload["outbox_dir"] == str(outbox_dir.resolve())
+    assert payload["receipt_dir"] == str(receipt_dir.resolve())
+    assert payload["archive_dir"] == str((state_root / "automation-outbox-archive").resolve())
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 1
+
+
+def test_apply_uses_explicit_shared_state_dirs(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    repo = tmp_path / "disposable-worktree"
+    repo.mkdir()
+    shared_state = tmp_path / "shared-state"
+    outbox_dir = shared_state / "outbox"
+    receipt_dir = shared_state / "receipts"
+    archive_dir = shared_state / "archive"
+    key = "open-pr-codex-explicit-state-abc123"
+    handoff = _write_outbox_handoff(outbox_dir, branch="codex/explicit-state", key=key)
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps({"idempotency_key": key, "status": "published"}),
+        encoding="utf-8",
+    )
+
+    rc = mod.main(
+        [
+            "--repo",
+            str(repo),
+            "--outbox-dir",
+            str(outbox_dir),
+            "--receipt-dir",
+            str(receipt_dir),
+            "--archive-dir",
+            str(archive_dir),
+            "--apply",
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["outbox_dir"] == str(outbox_dir.resolve())
+    assert payload["receipt_dir"] == str(receipt_dir.resolve())
+    assert payload["archive_dir"] == str(archive_dir.resolve())
+    assert payload["archived"] == 1
+    assert handoff.exists() is False
+    assert (archive_dir / handoff.name).exists()
+
+
+def test_explicit_outbox_dir_defaults_archive_beside_outbox(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    repo = tmp_path / "disposable-worktree"
+    repo.mkdir()
+    shared_state = tmp_path / "shared-state"
+    outbox_dir = shared_state / "automation-outbox"
+    receipt_dir = shared_state / "automation-receipts"
+    key = "open-pr-codex-explicit-outbox-abc123"
+    _write_outbox_handoff(outbox_dir, branch="codex/explicit-outbox", key=key)
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps({"idempotency_key": key, "status": "published"}),
+        encoding="utf-8",
+    )
+
+    rc = mod.main(
+        [
+            "--repo",
+            str(repo),
+            "--outbox-dir",
+            str(outbox_dir),
+            "--receipt-dir",
+            str(receipt_dir),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["archive_dir"] == str((shared_state / "automation-outbox-archive").resolve())
+
+
 def test_apply_archives_outbox_handoff_superseded_by_active_handoff(
     tmp_path: Path,
     monkeypatch: Any,


### PR DESCRIPTION
## Summary
- Teaches outbox reconciliation about shared automation state.
- Adds regression coverage for the shared-state reconciliation path.

## Validation
- python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py
- python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Scope
- Tier 2 automation hygiene.
- No AGT, public API, publisher restart, or observe-outcomes write.

Current head: d543a8c4d788f32cc8e251dcab5960076412e32b