### PR TITLE
[AGT-03] Manifold Brier bridge with market-match guard

### DIFF
--- a/aragora/metrics/manifold_brier_bridge.py
+++ b/aragora/metrics/manifold_brier_bridge.py
@@ -81,6 +81,11 @@ def record_resolution(
     """Add a scored ManifoldPrediction to scorer; returns None for inconclusive outcomes."""
     if not manifold_brier_enabled():
         raise RuntimeError(_DISABLED_MSG)
+    if resolution.market_id != pending.market_id:
+        raise ValueError(
+            f"resolution market_id {resolution.market_id!r} does not match "
+            f"pending market_id {pending.market_id!r}"
+        )
     outcome = resolution_to_binary_outcome(resolution)
     if outcome is None:
         return None

--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -58,7 +58,7 @@ modules:
   - name: connectors
     tier: core
     py_files: 266
-    importer_count: 141
+    importer_count: 142
     test_file_count: 256
   - name: core
     tier: core
@@ -187,8 +187,8 @@ modules:
   - name: blockchain
     tier: integrated
     py_files: 17
-    importer_count: 9
-    test_file_count: 20
+    importer_count: 10
+    test_file_count: 21
   - name: bots
     tier: integrated
     py_files: 7
@@ -377,9 +377,9 @@ modules:
     test_file_count: 10
   - name: markets
     tier: integrated
-    py_files: 5
+    py_files: 6
     importer_count: 6
-    test_file_count: 10
+    test_file_count: 11
   - name: mcp
     tier: integrated
     py_files: 27
@@ -387,9 +387,9 @@ modules:
     test_file_count: 35
   - name: metrics
     tier: integrated
-    py_files: 5
+    py_files: 6
     importer_count: 1
-    test_file_count: 6
+    test_file_count: 7
   - name: migrations
     tier: integrated
     py_files: 21

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4113` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1933019` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4115` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1933267` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `137` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5162` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217700` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `676` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5164` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217741` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `680` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `63` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `829` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `831` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/tests/metrics/test_manifold_brier_bridge.py
+++ b/tests/metrics/test_manifold_brier_bridge.py
@@ -102,7 +102,7 @@ class TestRecordResolution:
     def test_fields_propagated(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
         scorer = ManifoldBrierScorer()
-        result = record_resolution(scorer, _res("yes", "mkt_xyz"), _pend(agent="codex"))
+        result = record_resolution(scorer, _res("yes", "mkt_xyz"), _pend("mkt_xyz", agent="codex"))
         assert result is not None
         assert result.question_id == "mkt_xyz"
         assert result.agent_id == "codex"
@@ -112,8 +112,14 @@ class TestRecordResolution:
         monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
         scorer = ManifoldBrierScorer()
         r = _Res(market_id="m", outcome="yes", resolved_at_ms=None)
-        result = record_resolution(scorer, r, _pend())
+        result = record_resolution(scorer, r, _pend("m"))
         assert result is not None and result.resolved_at is None
+
+    def test_market_id_mismatch_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_MANIFOLD_BRIER_ENABLED", "1")
+        scorer = ManifoldBrierScorer()
+        with pytest.raises(ValueError, match="market_id"):
+            record_resolution(scorer, _res("yes", "m_other"), _pend("m_pending"))
 
     def test_disabled_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ARAGORA_MANIFOLD_BRIER_ENABLED", raising=False)


### PR DESCRIPTION
## Summary

Replacement for stale-head #7146. Wires Manifold resolution events into `ManifoldBrierScorer` and includes an additional Codex review fix: `record_resolution()` now rejects mismatched `resolution.market_id` / `pending.market_id` pairs instead of silently scoring the wrong market.

## Supersedes

Supersedes #7146. That PR's normal head branch disappeared; recreating `vision-incubator/agt-03-manifold-brier-bridge` did not reattach the PR (`refs/pull/7146/head` stayed at `9465c790f5fd6593ae529170bdc6f3075de264dc`). The fixed branch head is `45f7c01753391c9ebb7063e2aa99a254b9622afc`.

## Validation

```bash
python3 scripts/regenerate_module_tiers.py --check
# No tier drift.

python3 scripts/regenerate_metrics.py --check
# No drift beyond 0.5% threshold.

PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/metrics/test_manifold_brier_bridge.py --noconftest -q -p no:rerunfailures -p no:cacheprovider
# 22 passed

python3 -m ruff check aragora/metrics/manifold_brier_bridge.py tests/metrics/test_manifold_brier_bridge.py
# All checks passed!

python3 -m ruff format --check aragora/metrics/manifold_brier_bridge.py tests/metrics/test_manifold_brier_bridge.py
# 2 files already formatted

python3 -m mypy aragora/metrics/manifold_brier_bridge.py --ignore-missing-imports
# Success: no issues found in 1 source file

bash scripts/automation_pr_preflight.sh origin/main HEAD
# preflight: ok
```

## Non-Claims

- Feature remains flag-OFF by default behind `ARAGORA_MANIFOLD_BRIER_ENABLED`.
- No live Manifold write path.
- No boss-loop, queue, dispatcher, or reputation write behavior changes.
