### PR TITLE
feat(review-queue): edge-triggered alerter for proof-loop health (stacks on #7150)

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -557,6 +557,52 @@ def add_review_queue_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Output the report as JSON.",
     )
 
+    alert_p = sub.add_parser(
+        "health-alert",
+        help="Edge-triggered alerter: writes an event when proof-loop health changes state",
+        description=(
+            "Runs the same checks as 'review-queue health', persists state under "
+            ".aragora/proof-loop-alerts/, and writes one JSON event per state "
+            "transition. Exits 1 if any surface is currently stale or missing."
+        ),
+    )
+    alert_p.add_argument(
+        "--repo-root",
+        default=None,
+        help="Override repo root used for status doc + overnight + state lookups.",
+    )
+    alert_p.add_argument(
+        "--review-queue-root",
+        default=None,
+        help="Override the review-queue store root.",
+    )
+    alert_p.add_argument(
+        "--overnight-root",
+        default=None,
+        help="Override the .aragora/overnight directory.",
+    )
+    alert_p.add_argument(
+        "--automation-receipts-root",
+        default=None,
+        help="Override the .aragora/automation-receipts directory.",
+    )
+    alert_p.add_argument(
+        "--state-dir",
+        default=None,
+        help="Override the alert state directory (default: <repo>/.aragora/proof-loop-alerts).",
+    )
+    alert_p.add_argument(
+        "--heartbeat",
+        action="store_true",
+        help="Emit a heartbeat event even when state is unchanged.",
+    )
+    alert_p.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output the result as JSON.",
+    )
+
     parser.set_defaults(func=cmd_review_queue)
 
 

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -583,9 +583,12 @@ def cmd_review_queue(args: argparse.Namespace) -> int:
         return cmd_observe_outcomes(args)
     if command == "health":
         return _cmd_health(args)
+    if command == "health-alert":
+        return _cmd_health_alert(args)
     print(
         "Usage: aragora review-queue "
-        "{build,packet,run,act,record-settlement,merge-packet,baseline,observe-outcomes,health} [...]\n"
+        "{build,packet,run,act,record-settlement,merge-packet,baseline,observe-outcomes,"
+        "health,health-alert} [...]\n"
         "Run 'aragora review-queue run --help' for the human settlement loop.",
         file=sys.stderr,
     )
@@ -913,6 +916,77 @@ def _cmd_health(args: argparse.Namespace) -> int:
         print(render_text(report))
 
     if report.overall_status in {"empty", "stale", "missing"}:
+        return 1
+    return 0
+
+
+def _cmd_health_alert(args: argparse.Namespace) -> int:
+    """Edge-triggered alerter for proof-loop write surfaces.
+
+    Runs the same checks as ``review-queue health``, persists state under
+    ``.aragora/proof-loop-alerts/``, and writes one JSON event whenever the
+    set of stale/missing surfaces changes (opens, set-change, recovers).
+    Designed for periodic launchd execution: repeated calls while a surface
+    is steady-state stale do NOT produce duplicate events.
+
+    Exits 1 if any surface is currently stale or missing (so launchd can
+    surface failures via its own log retention).
+    """
+    from aragora.review.alert import resolve_state_dir, run_alert
+    from aragora.review.health import _resolve_repo_root
+
+    repo_root_arg = getattr(args, "repo_root", None)
+    review_queue_root = getattr(args, "review_queue_root", None)
+    overnight_root = getattr(args, "overnight_root", None)
+    automation_root = getattr(args, "automation_receipts_root", None)
+    state_dir_arg = getattr(args, "state_dir", None)
+    emit_heartbeat = bool(getattr(args, "heartbeat", False))
+
+    repo_root_path = Path(repo_root_arg) if repo_root_arg else None
+    effective_repo = _resolve_repo_root(repo_root_path)
+    state_dir = Path(state_dir_arg) if state_dir_arg else resolve_state_dir(effective_repo)
+
+    result = run_alert(
+        state_dir=state_dir,
+        emit_heartbeat=emit_heartbeat,
+        repo_root=repo_root_path,
+        review_queue_root=Path(review_queue_root) if review_queue_root else None,
+        overnight_root=Path(overnight_root) if overnight_root else None,
+        automation_receipts_root=Path(automation_root) if automation_root else None,
+    )
+
+    json_output = bool(getattr(args, "json_output", False) or getattr(args, "json", False))
+    if json_output:
+        payload = {
+            "overall_status": result.report.overall_status,
+            "alerting_surfaces": result.state.alerting_surfaces,
+            "event_kind": result.event.kind if result.event is not None else None,
+            "event_path": str(result.event_path) if result.event_path is not None else None,
+            "state_path": str(result.state_path),
+            "last_run_at": (
+                result.state.last_run_at.isoformat()
+                if result.state.last_run_at is not None
+                else None
+            ),
+            "last_event_at": (
+                result.state.last_event_at.isoformat()
+                if result.state.last_event_at is not None
+                else None
+            ),
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        kind = result.event.kind if result.event is not None else "no-change"
+        print(f"proof-loop alert: kind={kind} overall={result.report.overall_status}")
+        if result.state.alerting_surfaces:
+            print(f"  alerting:  {', '.join(result.state.alerting_surfaces)}")
+        else:
+            print("  alerting:  (none)")
+        print(f"  state:     {result.state_path}")
+        if result.event_path is not None:
+            print(f"  event:     {result.event_path}")
+
+    if result.report.overall_status in {"stale", "missing"}:
         return 1
     return 0
 

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -112,6 +112,7 @@ TIER_4_PREFIXES: tuple[str, ...] = (
     # Elevate to Tier 4 (human preapproval) so the human chain-of-trust is
     # not delegated to the artifact under review.
     "aragora/cli/commands/review_queue.py",
+    "aragora/cli/parser.py",
 )
 PARKED_LABELS: tuple[str, ...] = ("stale", "do-not-merge", "wip", "blocked")
 

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -112,6 +112,14 @@ TIER_4_PREFIXES: tuple[str, ...] = (
     # Elevate to Tier 4 (human preapproval) so the human chain-of-trust is
     # not delegated to the artifact under review.
     "aragora/cli/commands/review_queue.py",
+    # ``aragora/cli/parser.py`` is the registration surface for every
+    # ``aragora`` subcommand the operator can invoke. Adding or modifying a
+    # registration changes which entrypoints exist on the merge-authority
+    # CLI — a new subcommand could expose tier-relevant behavior (signal
+    # collection, settlement recording, packet generation) that the gate
+    # would otherwise not see. Listing the parser here makes the
+    # registration surface follow the same human-chain-of-trust rule as
+    # ``review_queue.py`` itself.
     "aragora/cli/parser.py",
 )
 PARKED_LABELS: tuple[str, ...] = ("stale", "do-not-merge", "wip", "blocked")
@@ -1033,7 +1041,15 @@ def _cmd_health_alert(args: argparse.Namespace) -> int:
         if result.event_path is not None:
             print(f"  event:     {result.event_path}")
 
-    if result.report.overall_status in {"stale", "missing"}:
+    # Exit gate must be driven by the actual set of alerting surfaces, not by
+    # ``report.overall_status``. Surface statuses are ranked
+    # ``fresh < aging < stale < empty < missing`` (see ``health.py``), and only
+    # ``stale``/``missing`` are alerting (see ``alert.ALERTING_STATUSES``).
+    # ``overall_status`` is the *max severity rank* across surfaces, so a mix
+    # like ``[empty, stale]`` produces ``overall_status == "empty"`` even
+    # though a stale surface is firing. Gating on ``state.alerting_surfaces``
+    # captures the actual alert condition directly.
+    if result.state.alerting_surfaces:
         return 1
     return 0
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1871,6 +1871,59 @@ def _add_review_queue_parser(subparsers) -> None:
     )
     health_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
 
+    # Edge-triggered alerter that runs the health check, records state, and
+    # writes one JSON event whenever the set of stale/missing surfaces changes.
+    # Designed for periodic launchd execution.
+    alert_parser = queue_subparsers.add_parser(
+        "health-alert",
+        help="Edge-triggered alerter: writes an event when proof-loop health changes state",
+        description=(
+            "Runs the same checks as 'review-queue health', persists state under "
+            ".aragora/proof-loop-alerts/, and writes one JSON event per state "
+            "transition (opens, set-change, recovers). Designed to be invoked on "
+            "a schedule (e.g. launchd every 15 minutes) without producing repeat "
+            "alerts while a surface stays stale. Exits 1 if any surface is "
+            "currently stale or missing so launchd can surface failure."
+        ),
+    )
+    alert_parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Override repo root used for status doc + overnight + state lookups.",
+    )
+    alert_parser.add_argument(
+        "--review-queue-root",
+        default=None,
+        help="Override the review-queue store root.",
+    )
+    alert_parser.add_argument(
+        "--overnight-root",
+        default=None,
+        help="Override the .aragora/overnight directory.",
+    )
+    alert_parser.add_argument(
+        "--automation-receipts-root",
+        default=None,
+        help="Override the .aragora/automation-receipts directory.",
+    )
+    alert_parser.add_argument(
+        "--state-dir",
+        default=None,
+        help="Override the alert state directory (default: <repo>/.aragora/proof-loop-alerts).",
+    )
+    alert_parser.add_argument(
+        "--heartbeat",
+        action="store_true",
+        help="Emit a heartbeat event even when state is unchanged (useful for liveness checks).",
+    )
+    alert_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output the result as JSON (kind, paths, alerting surfaces).",
+    )
+    alert_parser.set_defaults(func=_lazy("aragora.cli.commands.review_queue", "cmd_review_queue"))
+
 
 def _add_codebase_audit_parser(subparsers) -> None:
     """Add the staged repository codebase audit parser."""

--- a/aragora/review/alert.py
+++ b/aragora/review/alert.py
@@ -228,7 +228,16 @@ def _safe_kind_slug(kind: str) -> str:
 
 
 def write_event(event: AlertEvent, events_dir: Path) -> Path:
-    """Write the event JSON. Returns the path that was written."""
+    """Atomically write the event JSON. Returns the path that was written.
+
+    Uses the same tempfile + ``os.replace`` pattern as :func:`save_state`:
+    the JSON is first written to a hidden temp file in the destination
+    directory, then renamed into place. If the process is interrupted
+    mid-write, the final file either does not exist or contains the
+    complete event — there is no observable partial state. A cleanup
+    on failure removes the temp file so the events directory does not
+    accumulate stray ``.event-*`` fragments.
+    """
     events_dir.mkdir(parents=True, exist_ok=True)
     ts = event.generated_at.strftime("%Y%m%dT%H%M%SZ")
     name = f"event-{ts}-{_safe_kind_slug(event.kind)}.json"
@@ -237,10 +246,19 @@ def write_event(event: AlertEvent, events_dir: Path) -> Path:
     while path.exists():
         path = events_dir / f"event-{ts}-{_safe_kind_slug(event.kind)}-{suffix}.json"
         suffix += 1
-    path.write_text(
-        json.dumps(event.to_dict(), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    payload = json.dumps(event.to_dict(), indent=2, sort_keys=True) + "\n"
+    fd, tmp_path_str = tempfile.mkstemp(prefix=".event-", suffix=".json", dir=events_dir)
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
     return path
 
 

--- a/aragora/review/alert.py
+++ b/aragora/review/alert.py
@@ -1,0 +1,319 @@
+"""Edge-triggered alerter for the proof-loop write-side daemons.
+
+Designed to be run periodically from launchd (or any scheduler) and produce
+one alert event when the set of stale/missing surfaces changes, instead of
+spamming events every tick.
+
+Algorithm:
+    1. Run :func:`aragora.review.health.gather_health` to get the current
+       observation.
+    2. Extract the set of "alerting" surfaces — those whose status is
+       ``stale`` or ``missing``. ``aging`` is intentionally not alerting
+       because it is recoverable and frequently transient.
+    3. Compare to the previously persisted state. If the set changed (new
+       stale surface, or full recovery), write an event JSON to disk.
+    4. Always persist the latest state and timestamps so an operator can
+       see the alerter itself is alive even when nothing fired.
+
+This is read-only with respect to the queue itself: it only writes under
+``.aragora/proof-loop-alerts/`` and never mutates queue receipts, briefs,
+or any other proof-loop artifact.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.review.health import (
+    STATUS_MISSING,
+    STATUS_STALE,
+    HealthReport,
+    SurfaceCheck,
+    gather_health,
+)
+
+UTC = timezone.utc
+
+DEFAULT_ALERTS_REL = Path(".aragora") / "proof-loop-alerts"
+STATE_FILENAME = "state.json"
+EVENTS_SUBDIR = "events"
+
+EVENT_KIND_OPENED = "alert_opened"
+EVENT_KIND_CHANGED = "alert_changed"
+EVENT_KIND_RECOVERED = "alert_recovered"
+EVENT_KIND_HEARTBEAT = "heartbeat"
+
+# Statuses that constitute an active alert. ``aging`` is deliberately
+# excluded — it is the warning band, not the alarm band.
+ALERTING_STATUSES: frozenset[str] = frozenset({STATUS_STALE, STATUS_MISSING})
+
+
+@dataclass(frozen=True)
+class AlertState:
+    """Persisted state between alerter runs."""
+
+    alerting_surfaces: list[str] = field(default_factory=list)
+    last_event_at: datetime | None = None
+    last_run_at: datetime | None = None
+    last_event_kind: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "alerting_surfaces": list(self.alerting_surfaces),
+            "last_event_at": (
+                self.last_event_at.isoformat() if self.last_event_at is not None else None
+            ),
+            "last_run_at": (self.last_run_at.isoformat() if self.last_run_at is not None else None),
+            "last_event_kind": self.last_event_kind,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AlertState:
+        surfaces_raw = data.get("alerting_surfaces") or []
+        if not isinstance(surfaces_raw, list):
+            surfaces_raw = []
+        surfaces = [str(s) for s in surfaces_raw if isinstance(s, str)]
+        return cls(
+            alerting_surfaces=surfaces,
+            last_event_at=_parse_dt(data.get("last_event_at")),
+            last_run_at=_parse_dt(data.get("last_run_at")),
+            last_event_kind=(
+                str(data["last_event_kind"]) if data.get("last_event_kind") is not None else None
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class AlertEvent:
+    """A single emitted alert event."""
+
+    kind: str
+    generated_at: datetime
+    previous_alerting: list[str]
+    current_alerting: list[str]
+    surfaces: list[dict[str, object]]
+    overall_status: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind,
+            "generated_at": self.generated_at.isoformat(),
+            "previous_alerting": list(self.previous_alerting),
+            "current_alerting": list(self.current_alerting),
+            "overall_status": self.overall_status,
+            "surfaces": list(self.surfaces),
+        }
+
+
+@dataclass(frozen=True)
+class AlertResult:
+    """Result of one alerter run."""
+
+    state: AlertState
+    event: AlertEvent | None
+    report: HealthReport
+    state_path: Path
+    event_path: Path | None
+
+
+def _parse_dt(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        text = value.rstrip("Z")
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def alerting_surface_names(report: HealthReport) -> list[str]:
+    """Return the sorted list of surface names whose status is stale/missing."""
+    return sorted(s.name for s in report.surfaces if s.status in ALERTING_STATUSES)
+
+
+def _surface_payload(surface: SurfaceCheck) -> dict[str, object]:
+    """Pare a SurfaceCheck down to the fields useful in an alert event."""
+    return {
+        "name": surface.name,
+        "status": surface.status,
+        "age_hours": (round(surface.age_hours, 2) if surface.age_hours is not None else None),
+        "count": surface.count,
+        "path": surface.path,
+        "detail": surface.detail,
+    }
+
+
+def determine_event_kind(
+    previous: list[str],
+    current: list[str],
+    *,
+    emit_heartbeat: bool = False,
+) -> str | None:
+    """Decide whether and what kind of event to emit.
+
+    Returns ``None`` when the state did not change (and a heartbeat was not
+    requested). The caller is responsible for persisting state regardless.
+    """
+    prev_set = set(previous)
+    cur_set = set(current)
+    if not prev_set and not cur_set:
+        return EVENT_KIND_HEARTBEAT if emit_heartbeat else None
+    if not prev_set and cur_set:
+        return EVENT_KIND_OPENED
+    if prev_set and not cur_set:
+        return EVENT_KIND_RECOVERED
+    if prev_set != cur_set:
+        return EVENT_KIND_CHANGED
+    return EVENT_KIND_HEARTBEAT if emit_heartbeat else None
+
+
+def load_state(path: Path) -> AlertState:
+    """Read persisted state. Missing/corrupt files yield a fresh state."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return AlertState()
+    except OSError:
+        return AlertState()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return AlertState()
+    if not isinstance(data, dict):
+        return AlertState()
+    return AlertState.from_dict(data)
+
+
+def save_state(state: AlertState, path: Path) -> None:
+    """Atomically write state.json so a partial write can never corrupt it."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = path.parent
+    fd, tmp_path = tempfile.mkstemp(prefix=".state-", suffix=".json", dir=tmp_dir)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(state.to_dict(), fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _safe_kind_slug(kind: str) -> str:
+    return "".join(ch if (ch.isalnum() or ch in {"-", "_"}) else "_" for ch in kind) or "event"
+
+
+def write_event(event: AlertEvent, events_dir: Path) -> Path:
+    """Write the event JSON. Returns the path that was written."""
+    events_dir.mkdir(parents=True, exist_ok=True)
+    ts = event.generated_at.strftime("%Y%m%dT%H%M%SZ")
+    name = f"event-{ts}-{_safe_kind_slug(event.kind)}.json"
+    path = events_dir / name
+    suffix = 1
+    while path.exists():
+        path = events_dir / f"event-{ts}-{_safe_kind_slug(event.kind)}-{suffix}.json"
+        suffix += 1
+    path.write_text(
+        json.dumps(event.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def evaluate(
+    report: HealthReport,
+    *,
+    state_dir: Path,
+    emit_heartbeat: bool = False,
+    now: datetime | None = None,
+) -> AlertResult:
+    """Pure decision step — no I/O. Run by the CLI handler after gathering health."""
+    now = now if now is not None else datetime.now(tz=UTC)
+    state_path = state_dir / STATE_FILENAME
+    events_dir = state_dir / EVENTS_SUBDIR
+    prev_state = load_state(state_path)
+    current_alerting = alerting_surface_names(report)
+    kind = determine_event_kind(
+        prev_state.alerting_surfaces,
+        current_alerting,
+        emit_heartbeat=emit_heartbeat,
+    )
+    event: AlertEvent | None = None
+    if kind is not None:
+        relevant = [
+            _surface_payload(s)
+            for s in report.surfaces
+            if (s.name in set(current_alerting) | set(prev_state.alerting_surfaces))
+        ]
+        if not relevant and emit_heartbeat:
+            relevant = [_surface_payload(s) for s in report.surfaces]
+        event = AlertEvent(
+            kind=kind,
+            generated_at=now,
+            previous_alerting=list(prev_state.alerting_surfaces),
+            current_alerting=list(current_alerting),
+            surfaces=relevant,
+            overall_status=report.overall_status,
+        )
+    new_state = AlertState(
+        alerting_surfaces=current_alerting,
+        last_event_at=(event.generated_at if event is not None else prev_state.last_event_at),
+        last_run_at=now,
+        last_event_kind=(event.kind if event is not None else prev_state.last_event_kind),
+    )
+    return AlertResult(
+        state=new_state,
+        event=event,
+        report=report,
+        state_path=state_path,
+        event_path=(events_dir / "" if event is None else None),
+    )
+
+
+def run_alert(
+    *,
+    state_dir: Path,
+    emit_heartbeat: bool = False,
+    repo_root: Path | None = None,
+    review_queue_root: Path | None = None,
+    overnight_root: Path | None = None,
+    automation_receipts_root: Path | None = None,
+) -> AlertResult:
+    """End-to-end run: gather health, evaluate, persist state and any event.
+
+    This is the function the CLI handler invokes. It performs I/O.
+    """
+    report = gather_health(
+        repo_root=repo_root,
+        review_queue_root=review_queue_root,
+        overnight_root=overnight_root,
+        automation_receipts_root=automation_receipts_root,
+    )
+    decision = evaluate(report, state_dir=state_dir, emit_heartbeat=emit_heartbeat)
+    save_state(decision.state, decision.state_path)
+    event_path: Path | None = None
+    if decision.event is not None:
+        event_path = write_event(decision.event, state_dir / EVENTS_SUBDIR)
+    return AlertResult(
+        state=decision.state,
+        event=decision.event,
+        report=decision.report,
+        state_path=decision.state_path,
+        event_path=event_path,
+    )
+
+
+def resolve_state_dir(repo_root: Path) -> Path:
+    return repo_root / DEFAULT_ALERTS_REL

--- a/aragora/review/alert.py
+++ b/aragora/review/alert.py
@@ -301,10 +301,10 @@ def run_alert(
         automation_receipts_root=automation_receipts_root,
     )
     decision = evaluate(report, state_dir=state_dir, emit_heartbeat=emit_heartbeat)
-    save_state(decision.state, decision.state_path)
     event_path: Path | None = None
     if decision.event is not None:
         event_path = write_event(decision.event, state_dir / EVENTS_SUBDIR)
+    save_state(decision.state, decision.state_path)
     return AlertResult(
         state=decision.state,
         event=decision.event,

--- a/aragora/review/alert.py
+++ b/aragora/review/alert.py
@@ -44,6 +44,18 @@ DEFAULT_ALERTS_REL = Path(".aragora") / "proof-loop-alerts"
 STATE_FILENAME = "state.json"
 EVENTS_SUBDIR = "events"
 
+EVENT_FILENAME_PREFIX = "event-"
+EVENT_FILENAME_SUFFIX = ".json"
+
+# Conservative default cap on the number of event files retained under
+# ``events/``. The alerter is designed for periodic launchd execution, so
+# without a cap a long-running heartbeat schedule would accumulate event
+# files indefinitely. 200 covers ~2 days of 15-minute heartbeats or
+# hundreds of real state-transition events; either way the operator-
+# relevant tail of recent events is preserved while bounding disk use.
+# A value <= 0 disables pruning (caller can opt out explicitly).
+DEFAULT_MAX_EVENTS = 200
+
 EVENT_KIND_OPENED = "alert_opened"
 EVENT_KIND_CHANGED = "alert_changed"
 EVENT_KIND_RECOVERED = "alert_recovered"
@@ -232,6 +244,55 @@ def write_event(event: AlertEvent, events_dir: Path) -> Path:
     return path
 
 
+def prune_event_files(
+    events_dir: Path,
+    *,
+    max_count: int = DEFAULT_MAX_EVENTS,
+) -> list[Path]:
+    """Remove oldest ``event-*.json`` files until at most ``max_count`` remain.
+
+    Conservative and local-only:
+
+    * Only files whose name starts with ``event-`` and ends with ``.json``
+      are considered; any unrelated file in ``events_dir`` (e.g. an
+      operator-placed ``README.md`` or backup) is never touched.
+    * Order is by file mtime (oldest first), which is robust against the
+      collision-suffix scheme in :func:`write_event` (where two events at
+      the same second produce names that do not sort chronologically).
+    * A non-existent ``events_dir`` is treated as empty (returns ``[]``).
+    * ``max_count`` <= 0 disables pruning (returns ``[]``); useful for
+      callers that want to opt out and retain everything.
+    * Individual unlink failures are tolerated — pruning is best-effort
+      housekeeping and must not break the alerter run.
+
+    Returns the list of paths actually removed (for testability).
+    """
+    if max_count <= 0:
+        return []
+    if not events_dir.exists() or not events_dir.is_dir():
+        return []
+    event_files: list[Path] = []
+    for entry in events_dir.iterdir():
+        if not entry.is_file():
+            continue
+        name = entry.name
+        if not name.startswith(EVENT_FILENAME_PREFIX) or not name.endswith(EVENT_FILENAME_SUFFIX):
+            continue
+        event_files.append(entry)
+    if len(event_files) <= max_count:
+        return []
+    event_files.sort(key=lambda p: p.stat().st_mtime)
+    excess = len(event_files) - max_count
+    removed: list[Path] = []
+    for path in event_files[:excess]:
+        try:
+            path.unlink()
+        except OSError:
+            continue
+        removed.append(path)
+    return removed
+
+
 def evaluate(
     report: HealthReport,
     *,
@@ -289,10 +350,15 @@ def run_alert(
     review_queue_root: Path | None = None,
     overnight_root: Path | None = None,
     automation_receipts_root: Path | None = None,
+    max_events: int = DEFAULT_MAX_EVENTS,
 ) -> AlertResult:
     """End-to-end run: gather health, evaluate, persist state and any event.
 
     This is the function the CLI handler invokes. It performs I/O.
+
+    ``max_events`` bounds the size of the events subdirectory; old files
+    beyond the cap are pruned after each write. Pass ``max_events <= 0``
+    to disable pruning entirely.
     """
     report = gather_health(
         repo_root=repo_root,
@@ -304,6 +370,7 @@ def run_alert(
     event_path: Path | None = None
     if decision.event is not None:
         event_path = write_event(decision.event, state_dir / EVENTS_SUBDIR)
+        prune_event_files(state_dir / EVENTS_SUBDIR, max_count=max_events)
     save_state(decision.state, decision.state_path)
     return AlertResult(
         state=decision.state,

--- a/aragora/review/alert.py
+++ b/aragora/review/alert.py
@@ -242,7 +242,6 @@ def evaluate(
     """Pure decision step — no I/O. Run by the CLI handler after gathering health."""
     now = now if now is not None else datetime.now(tz=UTC)
     state_path = state_dir / STATE_FILENAME
-    events_dir = state_dir / EVENTS_SUBDIR
     prev_state = load_state(state_path)
     current_alerting = alerting_surface_names(report)
     kind = determine_event_kind(
@@ -278,7 +277,7 @@ def evaluate(
         event=event,
         report=report,
         state_path=state_path,
-        event_path=(events_dir / "" if event is None else None),
+        event_path=None,
     )
 
 

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -110,7 +110,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `health`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `health`, `health-alert`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -105,7 +105,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `replay` | - | Replay stored debates | - |
 | `review` | - | Run AI code review on a diff or PR | - |
 | `review-pr` | - | Review a live GitHub PR head and optionally run a fixer loop | - |
-| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `health`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
+| `review-queue` | - | PR review queue + advisory packets + human settlement | `act`, `baseline`, `build`, `health`, `health-alert`, `merge-packet`, `observe-outcomes`, `packet`, `record-settlement`, `run` |
 | `rlm` | - | RLM (Recursive Language Models) operations | `clear-cache`, `compress`, `query`, `stats` |
 | `security` | - | Security operations (encryption, key rotation) | `health`, `list-tokens`, `migrate`, `rotate-key`, `rotate-token`, `status`, `verify-token` |
 | `self-improve` | - | Run self-improvement pipeline with worktree isolation and validation | - |

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -448,6 +448,7 @@ class TestModelReviewQuorum:
             (["deploy/k8s/app.yaml"], 4),
             # Merge-authority self-modification: see TIER_4_PREFIXES rationale.
             (["aragora/cli/commands/review_queue.py"], 4),
+            (["aragora/cli/parser.py"], 4),
         ],
     )
     def test_classifies_merge_tiers(self, files: list[str], expected_tier: int) -> None:

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -1323,6 +1323,11 @@ class TestCommandDispatch:
         ns_health = root.parse_args(["review-queue", "health", "--json"])
         assert ns_health.review_queue_command == "health"
         assert ns_health.json_output is True
+        # health-alert invocation parses through the standalone command parser
+        ns_alert = root.parse_args(["review-queue", "health-alert", "--heartbeat", "--json"])
+        assert ns_alert.review_queue_command == "health-alert"
+        assert ns_alert.heartbeat is True
+        assert ns_alert.json_output is True
         # act invocation parses
         ns_act = root.parse_args(
             ["review-queue", "act", "6280", "--request-changes", "--reason", "needs a test"]

--- a/tests/review/test_alert.py
+++ b/tests/review/test_alert.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from aragora.review import alert as alert_module
 from aragora.review.alert import (
     ALERTING_STATUSES,
     EVENT_KIND_CHANGED,
@@ -323,6 +324,35 @@ class TestWriteEvent:
         p2 = write_event(event, tmp_path)
         assert p1 != p2
         assert p1.exists() and p2.exists()
+
+
+class TestRunAlertPersistenceOrder:
+    def test_writes_event_before_saving_advanced_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        report = _report([_surf("briefs", STATUS_STALE)], overall=STATUS_STALE)
+        calls: list[str] = []
+        written_path = tmp_path / EVENTS_SUBDIR / "event.json"
+
+        def fake_write_event(event: AlertEvent, events_dir: Path) -> Path:
+            calls.append("write_event")
+            assert event.kind == EVENT_KIND_OPENED
+            assert events_dir == tmp_path / EVENTS_SUBDIR
+            return written_path
+
+        def fake_save_state(state: AlertState, path: Path) -> None:
+            calls.append("save_state")
+            assert state.alerting_surfaces == ["briefs"]
+            assert path == tmp_path / STATE_FILENAME
+
+        monkeypatch.setattr(alert_module, "gather_health", lambda **_: report)
+        monkeypatch.setattr(alert_module, "write_event", fake_write_event)
+        monkeypatch.setattr(alert_module, "save_state", fake_save_state)
+
+        result = alert_module.run_alert(state_dir=tmp_path)
+
+        assert calls == ["write_event", "save_state"]
+        assert result.event_path == written_path
 
 
 class TestEdgeTriggeredSemantics:

--- a/tests/review/test_alert.py
+++ b/tests/review/test_alert.py
@@ -161,6 +161,7 @@ class TestEvaluateTransitions:
         report = _report([_surf("briefs", STATUS_FRESH)])
         decision = evaluate(report, state_dir=tmp_path)
         assert decision.event is None
+        assert decision.event_path is None
         assert decision.state.alerting_surfaces == []
         assert decision.state.last_run_at is not None
 
@@ -176,6 +177,7 @@ class TestEvaluateTransitions:
         assert decision.event.kind == EVENT_KIND_OPENED
         assert decision.event.previous_alerting == []
         assert decision.event.current_alerting == ["settlement_receipts"]
+        assert decision.event_path is None
         assert decision.state.alerting_surfaces == ["settlement_receipts"]
         assert decision.state.last_event_kind == EVENT_KIND_OPENED
 

--- a/tests/review/test_alert.py
+++ b/tests/review/test_alert.py
@@ -174,6 +174,7 @@ class TestEvaluateTransitions:
         )
         decision = evaluate(report, state_dir=tmp_path)
         assert decision.event is not None
+        assert decision.event_path is None
         assert decision.event.kind == EVENT_KIND_OPENED
         assert decision.event.previous_alerting == []
         assert decision.event.current_alerting == ["settlement_receipts"]

--- a/tests/review/test_alert.py
+++ b/tests/review/test_alert.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -12,6 +13,9 @@ from aragora.review import alert as alert_module
 from aragora.review.alert import (
     ALERTING_STATUSES,
     EVENT_KIND_CHANGED,
+    DEFAULT_MAX_EVENTS,
+    EVENT_FILENAME_PREFIX,
+    EVENT_FILENAME_SUFFIX,
     EVENT_KIND_HEARTBEAT,
     EVENT_KIND_OPENED,
     EVENT_KIND_RECOVERED,
@@ -23,6 +27,7 @@ from aragora.review.alert import (
     determine_event_kind,
     evaluate,
     load_state,
+    prune_event_files,
     save_state,
     write_event,
 )
@@ -457,3 +462,279 @@ class TestStaleAndMissingTogether:
 def test_status_alerting_membership(status: str, expect_alerting: bool) -> None:
     is_alerting = status in ALERTING_STATUSES
     assert is_alerting == expect_alerting
+
+
+class TestPruneEventFiles:
+    """Bounded retention for the events subdirectory.
+
+    Pruning is conservative — only ``event-*.json`` files are eligible, and
+    pruning happens by mtime (oldest first) up to the ``max_count`` cap.
+    """
+
+    def _make_event_file(self, events_dir: Path, name: str, mtime: float) -> Path:
+        path = events_dir / name
+        path.write_text("{}\n", encoding="utf-8")
+        os.utime(path, (mtime, mtime))
+        return path
+
+    def test_below_cap_does_nothing(self, tmp_path: Path) -> None:
+        events_dir = tmp_path / EVENTS_SUBDIR
+        events_dir.mkdir()
+        for i in range(5):
+            self._make_event_file(
+                events_dir, f"event-2026051{i}T120000Z-alert_opened.json", 1000.0 + i
+            )
+        removed = prune_event_files(events_dir, max_count=10)
+        assert removed == []
+        # All files survive.
+        assert len(list(events_dir.iterdir())) == 5
+
+    def test_above_cap_prunes_oldest_first(self, tmp_path: Path) -> None:
+        events_dir = tmp_path / EVENTS_SUBDIR
+        events_dir.mkdir()
+        # 12 files with strictly increasing mtimes; only the newest 5 should survive.
+        created = []
+        for i in range(12):
+            created.append(
+                self._make_event_file(events_dir, f"event-{i:02d}-alert_opened.json", 1000.0 + i)
+            )
+        removed = prune_event_files(events_dir, max_count=5)
+        # 7 oldest files removed.
+        assert len(removed) == 7
+        # Surviving files are the 5 newest by mtime.
+        remaining = sorted(events_dir.iterdir(), key=lambda p: p.stat().st_mtime)
+        assert [p.name for p in remaining] == [
+            f"event-{i:02d}-alert_opened.json" for i in range(7, 12)
+        ]
+        # And removed files are exactly the 7 oldest.
+        assert {p.name for p in removed} == {f"event-{i:02d}-alert_opened.json" for i in range(7)}
+
+    def test_unrelated_files_are_not_touched(self, tmp_path: Path) -> None:
+        events_dir = tmp_path / EVENTS_SUBDIR
+        events_dir.mkdir()
+        # 10 real event files...
+        for i in range(10):
+            self._make_event_file(events_dir, f"event-{i:02d}-alert_opened.json", 1000.0 + i)
+        # ...plus assorted unrelated files an operator might place there.
+        unrelated_paths = {
+            events_dir / "README.md": "operator notes\n",
+            events_dir / "snapshot.tar.gz": "binary blob",
+            events_dir / "event-broken.txt": "wrong suffix",  # doesn't end in .json
+            events_dir / "log-20260514.json": "wrong prefix",  # doesn't start with event-
+            events_dir / ".hidden_event.json": "dotfile",  # also no event- prefix
+        }
+        for path, body in unrelated_paths.items():
+            path.write_text(body, encoding="utf-8")
+            os.utime(path, (500.0, 500.0))  # OLDER than all event files
+        removed = prune_event_files(events_dir, max_count=3)
+        # 7 of the 10 event files should be pruned.
+        assert len(removed) == 7
+        # All unrelated files must survive untouched.
+        for path, body in unrelated_paths.items():
+            assert path.exists(), f"unrelated file removed: {path.name}"
+            assert path.read_text(encoding="utf-8") == body, f"unrelated file modified: {path.name}"
+        # Verify only event-*.json files are affected.
+        for path in removed:
+            assert path.name.startswith(EVENT_FILENAME_PREFIX)
+            assert path.name.endswith(EVENT_FILENAME_SUFFIX)
+
+    def test_missing_directory_is_no_op(self, tmp_path: Path) -> None:
+        events_dir = tmp_path / "nonexistent_events"
+        assert not events_dir.exists()
+        removed = prune_event_files(events_dir, max_count=10)
+        assert removed == []
+        # Function must not create the directory.
+        assert not events_dir.exists()
+
+    def test_nondirectory_path_is_no_op(self, tmp_path: Path) -> None:
+        # If someone passes a file path by mistake, prune should bail safely.
+        not_a_dir = tmp_path / "not_a_dir"
+        not_a_dir.write_text("oops", encoding="utf-8")
+        removed = prune_event_files(not_a_dir, max_count=10)
+        assert removed == []
+        # File should still be there, untouched.
+        assert not_a_dir.read_text(encoding="utf-8") == "oops"
+
+    def test_zero_or_negative_max_disables_pruning(self, tmp_path: Path) -> None:
+        events_dir = tmp_path / EVENTS_SUBDIR
+        events_dir.mkdir()
+        for i in range(20):
+            self._make_event_file(events_dir, f"event-{i:02d}-alert_opened.json", 1000.0 + i)
+        # max_count = 0 → no pruning (caller opt-out).
+        assert prune_event_files(events_dir, max_count=0) == []
+        # max_count < 0 → no pruning (defensive).
+        assert prune_event_files(events_dir, max_count=-1) == []
+        # All 20 files survive.
+        assert len(list(events_dir.iterdir())) == 20
+
+    def test_default_max_events_constant(self) -> None:
+        # The default is documented in the module; this test pins the value
+        # so a casual edit cannot silently relax the retention policy.
+        assert DEFAULT_MAX_EVENTS == 200
+
+    def test_run_alert_invokes_prune_after_write(self, tmp_path: Path, monkeypatch) -> None:
+        """End-to-end: a run that writes an event should also prune below the cap."""
+        import aragora.review.alert as alert_module
+
+        events_dir = tmp_path / EVENTS_SUBDIR
+        events_dir.mkdir()
+        # Pre-populate with 50 stale event files (older than what run_alert will write).
+        for i in range(50):
+            path = events_dir / f"event-{i:02d}-alert_opened.json"
+            path.write_text("{}\n", encoding="utf-8")
+            os.utime(path, (1000.0 + i, 1000.0 + i))
+
+        # Stub gather_health to return a stale-fired report so an event is written.
+        from aragora.review.health import HealthReport, SurfaceCheck
+
+        def fake_gather_health(**_kwargs):
+            return HealthReport(
+                generated_at=_now(),
+                overall_status=STATUS_STALE,
+                surfaces=[SurfaceCheck(name="briefs", status=STATUS_STALE)],
+            )
+
+        monkeypatch.setattr(alert_module, "gather_health", fake_gather_health)
+
+        # Trigger one alert run with cap=10.
+        result = alert_module.run_alert(state_dir=tmp_path, max_events=10)
+
+        # Event should have been written.
+        assert result.event is not None
+        assert result.event_path is not None
+
+        # After prune, at most 10 event files should remain — pre-existing
+        # older ones got pruned to make room for the new one.
+        surviving = [
+            p
+            for p in events_dir.iterdir()
+            if p.name.startswith(EVENT_FILENAME_PREFIX) and p.name.endswith(EVENT_FILENAME_SUFFIX)
+        ]
+        assert len(surviving) <= 10
+        # The newly-written event must be among the survivors (it is the
+        # newest by mtime).
+        assert result.event_path in surviving
+
+
+class TestCmdHealthAlertExitCode:
+    """Regression for the mixed-state CLI exit-code bug.
+
+    ``aragora/review/health.py`` ranks statuses ``fresh < aging < stale < empty < missing``.
+    A surface set like ``[empty, stale]`` produces ``overall_status == "empty"``
+    even though a stale surface is firing. ``_cmd_health_alert`` must drive
+    its exit code from ``state.alerting_surfaces`` (the actual set of firing
+    surfaces), NOT from ``report.overall_status``.
+    """
+
+    def test_exit_1_when_stale_present_even_if_overall_is_empty(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        import argparse
+        import aragora.cli.commands.review_queue as rq
+
+        # Build a stub AlertResult representing the regression scenario:
+        # one empty surface (NOT alerting) + one stale surface (alerting).
+        # alert.alerting_surface_names() correctly returns only ['briefs'],
+        # so state.alerting_surfaces is non-empty even though
+        # report.overall_status is "empty" (3 > stale=2 in severity rank).
+        from aragora.review.alert import AlertResult, AlertState
+        from aragora.review.health import HealthReport, SurfaceCheck
+
+        report = HealthReport(
+            generated_at=_now(),
+            overall_status=STATUS_EMPTY,  # the regression: overall is NOT stale/missing
+            surfaces=[
+                SurfaceCheck(name="settlement_receipts", status=STATUS_EMPTY),
+                SurfaceCheck(name="briefs", status=STATUS_STALE),
+            ],
+        )
+        state = AlertState(
+            alerting_surfaces=["briefs"],  # actual firing surface
+            last_event_at=_now(),
+            last_run_at=_now(),
+            last_event_kind=EVENT_KIND_OPENED,
+        )
+        stub_result = AlertResult(
+            state=state,
+            event=None,
+            report=report,
+            state_path=tmp_path / STATE_FILENAME,
+            event_path=None,
+        )
+
+        # Patch run_alert to return our stub.
+        monkeypatch.setattr(rq, "_resolve_repo_root", lambda _x: tmp_path, raising=False)
+
+        def fake_run_alert(**_kwargs):
+            return stub_result
+
+        # _cmd_health_alert imports run_alert + _resolve_repo_root lazily inside
+        # the function body, so we patch their source modules directly.
+        import aragora.review.alert as alert_module
+        import aragora.review.health as health_module
+
+        monkeypatch.setattr(alert_module, "run_alert", fake_run_alert)
+        monkeypatch.setattr(health_module, "_resolve_repo_root", lambda _x: tmp_path, raising=False)
+
+        # Minimal namespace matching the CLI parser surface.
+        args = argparse.Namespace(
+            repo_root=str(tmp_path),
+            review_queue_root=None,
+            overnight_root=None,
+            automation_receipts_root=None,
+            state_dir=str(tmp_path),
+            heartbeat=False,
+            json_output=False,
+            json=False,
+        )
+
+        exit_code = rq._cmd_health_alert(args)
+        assert exit_code == 1, (
+            "exit code must be 1 because state.alerting_surfaces is non-empty, "
+            "even though report.overall_status is 'empty' (not in {stale, missing})"
+        )
+
+    def test_exit_0_when_no_alerting_surfaces(self, tmp_path: Path, monkeypatch) -> None:
+        """Symmetric check: no alerting surfaces → exit 0 regardless of overall status."""
+        import argparse
+        import aragora.cli.commands.review_queue as rq
+        from aragora.review.alert import AlertResult, AlertState
+        from aragora.review.health import HealthReport, SurfaceCheck
+        import aragora.review.alert as alert_module
+        import aragora.review.health as health_module
+
+        report = HealthReport(
+            generated_at=_now(),
+            overall_status=STATUS_AGING,  # aging is also not stale/missing
+            surfaces=[SurfaceCheck(name="briefs", status=STATUS_AGING)],
+        )
+        state = AlertState(
+            alerting_surfaces=[],  # nothing firing
+            last_event_at=None,
+            last_run_at=_now(),
+            last_event_kind=None,
+        )
+        stub_result = AlertResult(
+            state=state,
+            event=None,
+            report=report,
+            state_path=tmp_path / STATE_FILENAME,
+            event_path=None,
+        )
+
+        monkeypatch.setattr(alert_module, "run_alert", lambda **_kw: stub_result)
+        monkeypatch.setattr(health_module, "_resolve_repo_root", lambda _x: tmp_path, raising=False)
+
+        args = argparse.Namespace(
+            repo_root=str(tmp_path),
+            review_queue_root=None,
+            overnight_root=None,
+            automation_receipts_root=None,
+            state_dir=str(tmp_path),
+            heartbeat=False,
+            json_output=False,
+            json=False,
+        )
+
+        exit_code = rq._cmd_health_alert(args)
+        assert exit_code == 0

--- a/tests/review/test_alert.py
+++ b/tests/review/test_alert.py
@@ -1,0 +1,426 @@
+"""Tests for the proof-loop alerter (aragora.review.alert)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from aragora.review.alert import (
+    ALERTING_STATUSES,
+    EVENT_KIND_CHANGED,
+    EVENT_KIND_HEARTBEAT,
+    EVENT_KIND_OPENED,
+    EVENT_KIND_RECOVERED,
+    EVENTS_SUBDIR,
+    STATE_FILENAME,
+    AlertEvent,
+    AlertState,
+    alerting_surface_names,
+    determine_event_kind,
+    evaluate,
+    load_state,
+    save_state,
+    write_event,
+)
+from aragora.review.health import (
+    STATUS_AGING,
+    STATUS_EMPTY,
+    STATUS_FRESH,
+    STATUS_MISSING,
+    STATUS_STALE,
+    HealthReport,
+    SurfaceCheck,
+)
+
+UTC = timezone.utc
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 14, 17, 0, tzinfo=UTC)
+
+
+def _report(
+    surfaces: list[SurfaceCheck], *, overall: str = STATUS_FRESH, at: datetime | None = None
+) -> HealthReport:
+    return HealthReport(
+        generated_at=at if at is not None else _now(),
+        overall_status=overall,
+        surfaces=surfaces,
+    )
+
+
+def _surf(name: str, status: str = STATUS_FRESH, **kw: object) -> SurfaceCheck:
+    return SurfaceCheck(name=name, status=status, **kw)
+
+
+class TestAlertingStatuses:
+    def test_only_stale_and_missing_alert(self) -> None:
+        assert ALERTING_STATUSES == {STATUS_STALE, STATUS_MISSING}
+
+    def test_aging_is_not_alerting(self) -> None:
+        report = _report([_surf("briefs", STATUS_AGING)])
+        assert alerting_surface_names(report) == []
+
+    def test_empty_is_not_alerting(self) -> None:
+        report = _report([_surf("briefs", STATUS_EMPTY)])
+        assert alerting_surface_names(report) == []
+
+    def test_stale_alerts(self) -> None:
+        report = _report([_surf("briefs", STATUS_STALE)])
+        assert alerting_surface_names(report) == ["briefs"]
+
+    def test_missing_alerts(self) -> None:
+        report = _report([_surf("settlement_receipts", STATUS_MISSING)])
+        assert alerting_surface_names(report) == ["settlement_receipts"]
+
+    def test_alerting_names_sorted(self) -> None:
+        report = _report(
+            [
+                _surf("z", STATUS_STALE),
+                _surf("a", STATUS_MISSING),
+                _surf("m", STATUS_FRESH),
+            ]
+        )
+        assert alerting_surface_names(report) == ["a", "z"]
+
+
+class TestDetermineEventKind:
+    def test_idle_to_idle_no_event(self) -> None:
+        assert determine_event_kind([], []) is None
+
+    def test_idle_to_idle_heartbeat(self) -> None:
+        assert determine_event_kind([], [], emit_heartbeat=True) == EVENT_KIND_HEARTBEAT
+
+    def test_idle_to_alerting_opens(self) -> None:
+        assert determine_event_kind([], ["briefs"]) == EVENT_KIND_OPENED
+
+    def test_alerting_to_idle_recovers(self) -> None:
+        assert determine_event_kind(["briefs"], []) == EVENT_KIND_RECOVERED
+
+    def test_alerting_to_alerting_same_set_no_event(self) -> None:
+        assert determine_event_kind(["briefs"], ["briefs"]) is None
+
+    def test_alerting_to_alerting_same_set_heartbeat(self) -> None:
+        assert (
+            determine_event_kind(["briefs"], ["briefs"], emit_heartbeat=True)
+            == EVENT_KIND_HEARTBEAT
+        )
+
+    def test_alerting_to_alerting_changed(self) -> None:
+        assert determine_event_kind(["briefs"], ["briefs", "b0"]) == EVENT_KIND_CHANGED
+        assert determine_event_kind(["briefs", "b0"], ["briefs"]) == EVENT_KIND_CHANGED
+        assert determine_event_kind(["briefs"], ["b0"]) == EVENT_KIND_CHANGED
+
+
+class TestStatePersistence:
+    def test_load_state_missing_returns_empty(self, tmp_path: Path) -> None:
+        state = load_state(tmp_path / "nope.json")
+        assert state == AlertState()
+
+    def test_load_state_corrupt_returns_empty(self, tmp_path: Path) -> None:
+        p = tmp_path / "state.json"
+        p.write_text("{not valid json", encoding="utf-8")
+        state = load_state(p)
+        assert state == AlertState()
+
+    def test_load_state_non_dict_returns_empty(self, tmp_path: Path) -> None:
+        p = tmp_path / "state.json"
+        p.write_text("[]", encoding="utf-8")
+        state = load_state(p)
+        assert state == AlertState()
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        original = AlertState(
+            alerting_surfaces=["briefs", "b0_publication"],
+            last_event_at=datetime(2026, 5, 14, 12, 0, tzinfo=UTC),
+            last_run_at=datetime(2026, 5, 14, 17, 0, tzinfo=UTC),
+            last_event_kind=EVENT_KIND_OPENED,
+        )
+        path = tmp_path / STATE_FILENAME
+        save_state(original, path)
+        loaded = load_state(path)
+        assert loaded == original
+
+    def test_save_state_atomic_creates_parent(self, tmp_path: Path) -> None:
+        state = AlertState(alerting_surfaces=["briefs"])
+        path = tmp_path / "nested" / "dir" / STATE_FILENAME
+        save_state(state, path)
+        assert path.exists()
+
+    def test_save_state_no_tempfile_remnants(self, tmp_path: Path) -> None:
+        save_state(AlertState(), tmp_path / STATE_FILENAME)
+        leftover = [p for p in tmp_path.iterdir() if p.name.startswith(".state-")]
+        assert leftover == []
+
+
+class TestEvaluateTransitions:
+    def test_first_run_no_alerts_no_event(self, tmp_path: Path) -> None:
+        report = _report([_surf("briefs", STATUS_FRESH)])
+        decision = evaluate(report, state_dir=tmp_path)
+        assert decision.event is None
+        assert decision.state.alerting_surfaces == []
+        assert decision.state.last_run_at is not None
+
+    def test_first_run_with_alerts_opens(self, tmp_path: Path) -> None:
+        report = _report(
+            [
+                _surf("settlement_receipts", STATUS_MISSING),
+                _surf("briefs", STATUS_FRESH),
+            ]
+        )
+        decision = evaluate(report, state_dir=tmp_path)
+        assert decision.event is not None
+        assert decision.event.kind == EVENT_KIND_OPENED
+        assert decision.event.previous_alerting == []
+        assert decision.event.current_alerting == ["settlement_receipts"]
+        assert decision.state.alerting_surfaces == ["settlement_receipts"]
+        assert decision.state.last_event_kind == EVENT_KIND_OPENED
+
+    def test_alerting_to_alerting_same_set_no_event(self, tmp_path: Path) -> None:
+        save_state(
+            AlertState(alerting_surfaces=["briefs"], last_event_kind=EVENT_KIND_OPENED),
+            tmp_path / STATE_FILENAME,
+        )
+        report = _report([_surf("briefs", STATUS_STALE)])
+        decision = evaluate(report, state_dir=tmp_path)
+        assert decision.event is None
+        assert decision.state.alerting_surfaces == ["briefs"]
+        # Heartbeat fields update even when no event fires
+        assert decision.state.last_run_at is not None
+
+    def test_alerting_set_grows(self, tmp_path: Path) -> None:
+        save_state(
+            AlertState(alerting_surfaces=["briefs"], last_event_kind=EVENT_KIND_OPENED),
+            tmp_path / STATE_FILENAME,
+        )
+        report = _report(
+            [
+                _surf("briefs", STATUS_STALE),
+                _surf("b0_publication", STATUS_MISSING),
+            ]
+        )
+        decision = evaluate(report, state_dir=tmp_path)
+        assert decision.event is not None
+        assert decision.event.kind == EVENT_KIND_CHANGED
+        assert decision.event.previous_alerting == ["briefs"]
+        assert decision.event.current_alerting == ["b0_publication", "briefs"]
+
+    def test_alerting_set_shrinks_but_not_recovered(self, tmp_path: Path) -> None:
+        save_state(
+            AlertState(
+                alerting_surfaces=["briefs", "b0_publication"],
+                last_event_kind=EVENT_KIND_OPENED,
+            ),
+            tmp_path / STATE_FILENAME,
+        )
+        report = _report([_surf("briefs", STATUS_STALE)])
+        decision = evaluate(report, state_dir=tmp_path)
+        assert decision.event is not None
+        assert decision.event.kind == EVENT_KIND_CHANGED
+
+    def test_alerting_recovers(self, tmp_path: Path) -> None:
+        save_state(
+            AlertState(alerting_surfaces=["briefs"], last_event_kind=EVENT_KIND_OPENED),
+            tmp_path / STATE_FILENAME,
+        )
+        report = _report([_surf("briefs", STATUS_FRESH)])
+        decision = evaluate(report, state_dir=tmp_path)
+        assert decision.event is not None
+        assert decision.event.kind == EVENT_KIND_RECOVERED
+        assert decision.state.alerting_surfaces == []
+
+    def test_heartbeat_emitted_when_requested_and_no_change(self, tmp_path: Path) -> None:
+        save_state(AlertState(alerting_surfaces=["briefs"]), tmp_path / STATE_FILENAME)
+        report = _report([_surf("briefs", STATUS_STALE)])
+        decision = evaluate(report, state_dir=tmp_path, emit_heartbeat=True)
+        assert decision.event is not None
+        assert decision.event.kind == EVENT_KIND_HEARTBEAT
+
+
+class TestEventPayload:
+    def test_event_includes_overall_status(self, tmp_path: Path) -> None:
+        report = _report(
+            [_surf("briefs", STATUS_STALE)],
+            overall=STATUS_STALE,
+        )
+        decision = evaluate(report, state_dir=tmp_path)
+        assert decision.event is not None
+        assert decision.event.overall_status == STATUS_STALE
+
+    def test_event_surfaces_include_relevant_only(self, tmp_path: Path) -> None:
+        report = _report(
+            [
+                _surf("briefs", STATUS_STALE, path="/x"),
+                _surf("settlement_receipts", STATUS_FRESH, path="/y"),
+            ]
+        )
+        decision = evaluate(report, state_dir=tmp_path)
+        assert decision.event is not None
+        names = {s["name"] for s in decision.event.surfaces}
+        assert names == {"briefs"}
+
+    def test_event_to_dict_roundtrips(self, tmp_path: Path) -> None:
+        event = AlertEvent(
+            kind=EVENT_KIND_OPENED,
+            generated_at=_now(),
+            previous_alerting=[],
+            current_alerting=["briefs"],
+            surfaces=[{"name": "briefs", "status": STATUS_STALE}],
+            overall_status=STATUS_STALE,
+        )
+        data = event.to_dict()
+        assert data["kind"] == EVENT_KIND_OPENED
+        assert data["current_alerting"] == ["briefs"]
+        # serializable
+        json.dumps(data)
+
+
+class TestWriteEvent:
+    def test_creates_events_dir(self, tmp_path: Path) -> None:
+        event = AlertEvent(
+            kind=EVENT_KIND_OPENED,
+            generated_at=_now(),
+            previous_alerting=[],
+            current_alerting=["briefs"],
+            surfaces=[],
+            overall_status=STATUS_STALE,
+        )
+        events_dir = tmp_path / EVENTS_SUBDIR
+        path = write_event(event, events_dir)
+        assert path.exists()
+        assert path.parent == events_dir
+
+    def test_filename_encodes_kind_and_ts(self, tmp_path: Path) -> None:
+        event = AlertEvent(
+            kind=EVENT_KIND_RECOVERED,
+            generated_at=_now(),
+            previous_alerting=["briefs"],
+            current_alerting=[],
+            surfaces=[],
+            overall_status=STATUS_FRESH,
+        )
+        path = write_event(event, tmp_path)
+        assert path.name.startswith("event-")
+        assert EVENT_KIND_RECOVERED in path.name
+        assert path.name.endswith(".json")
+
+    def test_collision_suffixes(self, tmp_path: Path) -> None:
+        event = AlertEvent(
+            kind=EVENT_KIND_OPENED,
+            generated_at=_now(),
+            previous_alerting=[],
+            current_alerting=["briefs"],
+            surfaces=[],
+            overall_status=STATUS_STALE,
+        )
+        p1 = write_event(event, tmp_path)
+        p2 = write_event(event, tmp_path)
+        assert p1 != p2
+        assert p1.exists() and p2.exists()
+
+
+class TestEdgeTriggeredSemantics:
+    """End-to-end: simulate launchd ticks and verify only state transitions fire events."""
+
+    def test_steady_alerting_no_repeat_events(self, tmp_path: Path) -> None:
+        from aragora.review.alert import EVENTS_SUBDIR as ES
+
+        report = _report([_surf("briefs", STATUS_STALE)])
+        # tick 1: opens
+        decision1 = evaluate(report, state_dir=tmp_path)
+        assert decision1.event is not None and decision1.event.kind == EVENT_KIND_OPENED
+        save_state(decision1.state, tmp_path / STATE_FILENAME)
+        # tick 2: same state, no event
+        decision2 = evaluate(report, state_dir=tmp_path)
+        assert decision2.event is None
+        save_state(decision2.state, tmp_path / STATE_FILENAME)
+        # tick 3: still same state, still no event
+        decision3 = evaluate(report, state_dir=tmp_path)
+        assert decision3.event is None
+
+    def test_full_lifecycle(self, tmp_path: Path) -> None:
+        # tick 1: idle
+        d1 = evaluate(_report([_surf("briefs", STATUS_FRESH)]), state_dir=tmp_path)
+        save_state(d1.state, tmp_path / STATE_FILENAME)
+        assert d1.event is None
+        # tick 2: opens
+        d2 = evaluate(_report([_surf("briefs", STATUS_STALE)]), state_dir=tmp_path)
+        save_state(d2.state, tmp_path / STATE_FILENAME)
+        assert d2.event is not None and d2.event.kind == EVENT_KIND_OPENED
+        # tick 3: grows
+        d3 = evaluate(
+            _report(
+                [
+                    _surf("briefs", STATUS_STALE),
+                    _surf("b0_publication", STATUS_MISSING),
+                ]
+            ),
+            state_dir=tmp_path,
+        )
+        save_state(d3.state, tmp_path / STATE_FILENAME)
+        assert d3.event is not None and d3.event.kind == EVENT_KIND_CHANGED
+        # tick 4: shrinks (still alerting on one surface)
+        d4 = evaluate(_report([_surf("briefs", STATUS_STALE)]), state_dir=tmp_path)
+        save_state(d4.state, tmp_path / STATE_FILENAME)
+        assert d4.event is not None and d4.event.kind == EVENT_KIND_CHANGED
+        # tick 5: recovers
+        d5 = evaluate(_report([_surf("briefs", STATUS_FRESH)]), state_dir=tmp_path)
+        save_state(d5.state, tmp_path / STATE_FILENAME)
+        assert d5.event is not None and d5.event.kind == EVENT_KIND_RECOVERED
+
+
+class TestStateDictRoundTrip:
+    def test_state_to_dict_then_from_dict(self) -> None:
+        original = AlertState(
+            alerting_surfaces=["a", "b"],
+            last_event_at=_now(),
+            last_run_at=_now(),
+            last_event_kind=EVENT_KIND_OPENED,
+        )
+        restored = AlertState.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_from_dict_handles_bad_input(self) -> None:
+        bad: dict = {"alerting_surfaces": "not a list", "last_event_at": "garbage"}
+        state = AlertState.from_dict(bad)
+        assert state.alerting_surfaces == []
+        assert state.last_event_at is None
+
+    def test_from_dict_drops_non_string_surfaces(self) -> None:
+        bad: dict = {"alerting_surfaces": ["a", 1, None, "b"]}
+        state = AlertState.from_dict(bad)
+        assert state.alerting_surfaces == ["a", "b"]
+
+
+class TestStaleAndMissingTogether:
+    def test_mixed_stale_and_missing(self, tmp_path: Path) -> None:
+        report = _report(
+            [
+                _surf("settlement_receipts", STATUS_MISSING),
+                _surf("briefs", STATUS_STALE),
+                _surf("boss_metrics", STATUS_AGING),
+                _surf("automation_receipts", STATUS_FRESH),
+            ]
+        )
+        decision = evaluate(report, state_dir=tmp_path)
+        assert decision.event is not None
+        assert decision.event.kind == EVENT_KIND_OPENED
+        assert set(decision.event.current_alerting) == {"settlement_receipts", "briefs"}
+
+
+@pytest.mark.parametrize(
+    "status,expect_alerting",
+    [
+        (STATUS_FRESH, False),
+        (STATUS_EMPTY, False),
+        (STATUS_AGING, False),
+        (STATUS_STALE, True),
+        (STATUS_MISSING, True),
+    ],
+)
+def test_status_alerting_membership(status: str, expect_alerting: bool) -> None:
+    is_alerting = status in ALERTING_STATUSES
+    assert is_alerting == expect_alerting

--- a/tests/review/test_alert.py
+++ b/tests/review/test_alert.py
@@ -330,6 +330,88 @@ class TestWriteEvent:
         assert p1 != p2
         assert p1.exists() and p2.exists()
 
+    def test_complete_payload_written(self, tmp_path: Path) -> None:
+        """A successful write produces the complete, parseable event JSON
+        at the final path — never a partial file."""
+        event = AlertEvent(
+            kind=EVENT_KIND_OPENED,
+            generated_at=_now(),
+            previous_alerting=[],
+            current_alerting=["briefs", "settlement_receipts"],
+            surfaces=[
+                {"name": "briefs", "status": STATUS_STALE, "age_hours": 25.0},
+                {"name": "settlement_receipts", "status": STATUS_MISSING, "age_hours": None},
+            ],
+            overall_status=STATUS_MISSING,
+        )
+        path = write_event(event, tmp_path)
+        # File exists and parses to the exact expected payload.
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        assert loaded["kind"] == EVENT_KIND_OPENED
+        assert loaded["current_alerting"] == ["briefs", "settlement_receipts"]
+        assert loaded["overall_status"] == STATUS_MISSING
+        assert len(loaded["surfaces"]) == 2
+
+    def test_no_temp_remnants_on_success(self, tmp_path: Path) -> None:
+        """The atomic-write tempfile (``.event-*`` prefix) must be cleaned up
+        on success — leaving it behind would clutter the events directory."""
+        event = AlertEvent(
+            kind=EVENT_KIND_OPENED,
+            generated_at=_now(),
+            previous_alerting=[],
+            current_alerting=["briefs"],
+            surfaces=[],
+            overall_status=STATUS_STALE,
+        )
+        write_event(event, tmp_path)
+        leftover = [p for p in tmp_path.iterdir() if p.name.startswith(".event-")]
+        assert leftover == []
+
+    def test_failed_replace_cleans_temp_and_leaves_no_partial(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Simulate a failure between writing the tempfile and renaming
+        it into place. The final path must NOT exist (no partial file is
+        observable), AND the tempfile must be cleaned up so the events
+        directory does not accumulate .event-* fragments."""
+        event = AlertEvent(
+            kind=EVENT_KIND_OPENED,
+            generated_at=_now(),
+            previous_alerting=[],
+            current_alerting=["briefs"],
+            surfaces=[],
+            overall_status=STATUS_STALE,
+        )
+
+        # Inject a failure at the os.replace call site (atomic rename).
+        # write_event imports os at module scope, so patch
+        # alert_module.os.replace specifically.
+        def boom(*_args, **_kwargs):
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr(alert_module.os, "replace", boom)
+
+        with pytest.raises(OSError, match="simulated rename failure"):
+            write_event(event, tmp_path)
+
+        # The final ``event-*.json`` path must not exist — no partial file.
+        final_files = [
+            p
+            for p in tmp_path.iterdir()
+            if p.name.startswith("event-") and p.name.endswith(".json")
+        ]
+        assert final_files == [], (
+            f"partial event file should not be observable after failed rename, "
+            f"but found: {[p.name for p in final_files]}"
+        )
+
+        # And the temp file must be cleaned up.
+        temp_files = [p for p in tmp_path.iterdir() if p.name.startswith(".event-")]
+        assert temp_files == [], (
+            f"temp file should be cleaned up after failed rename, "
+            f"but found: {[p.name for p in temp_files]}"
+        )
+
 
 class TestRunAlertPersistenceOrder:
     def test_writes_event_before_saving_advanced_state(


### PR DESCRIPTION
## Slice

Adds `aragora review-queue health-alert` — an **edge-triggered alerter** that runs the same checks as `review-queue health` (PR #7150), persists state under `.aragora/proof-loop-alerts/`, and writes one JSON event whenever the set of stale/missing surfaces changes.

**Stack:** builds on PR #7150. Branch is based on `feat/review-queue-health`.

## Example

```
$ aragora review-queue health-alert
proof-loop alert: kind=alert_opened overall=stale
  alerting:  briefs, settlement_receipts
  state:     /repo/.aragora/proof-loop-alerts/state.json
  event:     /repo/.aragora/proof-loop-alerts/events/event-20260514T193000Z-alert_opened.json

$ aragora review-queue health-alert       # 15 minutes later, same state
proof-loop alert: kind=no-change overall=stale
  alerting:  briefs, settlement_receipts
  state:     /repo/.aragora/proof-loop-alerts/state.json

$ aragora review-queue health-alert       # operator fixes briefs writer
proof-loop alert: kind=alert_changed overall=stale
  alerting:  settlement_receipts
  ...

$ aragora review-queue health-alert       # writer back online
proof-loop alert: kind=alert_recovered overall=fresh
  alerting:  (none)
  ...
```

## Event kinds

| Kind | When |
|---|---|
| `alert_opened` | idle → alerting (first stale/missing surface) |
| `alert_changed` | alerting → alerting (set of stale surfaces changed) |
| `alert_recovered` | alerting → idle (all surfaces back to fresh/aging) |
| `heartbeat` | (optional, `--heartbeat`) liveness ping every run |

**Steady-state property:** repeated calls while a surface stays stale do NOT produce duplicate events. State is persisted atomically via tempfile + rename. Corrupt or missing state files are treated as a fresh start.

## Severity rule

`stale` and `missing` fire alerts; `aging` does **not**. Aging is the warning band — recoverable and frequently transient (founder briefs a few days late, a B0 publication overdue by 1 day). The alarm band is the May 6 class: surfaces a human would consider broken.

## Launchd integration

- `scripts/install_proof_loop_health_alert_launchd.sh` — installs a labelled job (`com.aragora.proof-loop-health-alert`) on a configurable interval (default 15 min)
- `scripts/uninstall_proof_loop_health_alert_launchd.sh` — removes it WITHOUT touching the state/event audit trail

Install: `./scripts/install_proof_loop_health_alert_launchd.sh`
Uninstall: `./scripts/uninstall_proof_loop_health_alert_launchd.sh`

## Tests

43 cases in `tests/review/test_alert.py`:

| Class | What it covers |
|---|---|
| `TestAlertingStatuses` | Only stale/missing alert; aging/empty/fresh do not |
| `TestDetermineEventKind` | All transition kinds (open, change, recover, heartbeat) |
| `TestStatePersistence` | Missing/corrupt/non-dict → fresh; atomic save; no tempfile leaks |
| `TestEvaluateTransitions` | First run, set-grows, set-shrinks, recovery, heartbeat |
| `TestEventPayload` | Event includes overall_status; only relevant surfaces; JSON-serializable |
| `TestWriteEvent` | Creates events dir; encodes kind/ts; collision suffixing |
| `TestEdgeTriggeredSemantics` | **Steady state never repeats events**; full 5-tick lifecycle |
| `TestStateDictRoundTrip` | to_dict/from_dict invariants; robust to bad input |
| `TestStaleAndMissingTogether` | Mixed stale+missing fire one combined alert |
| `test_status_alerting_membership` | Parametrized membership check across all statuses |

## Validation

- `pytest tests/review/test_alert.py tests/review/test_health.py --noconftest` → 58 passed
- `ruff check` — clean
- `ruff format --check` — clean
- `mypy` — no issues
- `gitleaks protect --staged` — clean
- Live smoke test on real repo: heartbeat works, no-change works, state persists, exit codes correct

## Scope discipline

- No new dependencies
- Writes only to `.aragora/proof-loop-alerts/` — never touches queue, briefs, receipts, or any other proof-loop artifact
- No network — pure local file I/O
- launchd install is opt-in (operator runs the install script); no install happens at PR merge time
- Closes the active-alerting gap left open by PR #7150 (which is observation-only)

## Out of scope (deliberate)

- Slack/email push delivery (events are local JSON; downstream consumers can wire delivery)
- Auto-remediation (alerter only reports — does not attempt to restart daemons)
- Aging-band alerts (filtered out by design; can be added behind a flag later if useful)

Labels: `vision-layer` | Draft | Stacked on #7150

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>