### PR TITLE
fix(automation): ignore stale cleanup lock files

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -27,6 +27,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+from scripts import codex_worktree_autopilot as autopilot
 from scripts.github_cli_health import check_github_cli_health
 
 ACTIVE_SESSION_FILES = (
@@ -233,7 +234,9 @@ def dirty_worktree(path: Path) -> bool:
 
 
 def active_worktree(path: Path) -> bool:
-    return any((path / marker).exists() for marker in ACTIVE_SESSION_FILES)
+    if not path.is_dir():
+        return False
+    return autopilot._has_active_session(path)
 
 
 def _repo_relative(root: Path, path: Path) -> Path:

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -241,8 +241,6 @@ def inspect_worktree(
         blockers.append("missing_path")
     if active_session:
         blockers.append("active_session")
-    if lock_files:
-        blockers.append("session_lock_present")
     if dirty:
         blockers.append("dirty_worktree")
     if unique_commits_ahead > 0 and not patch_equivalent_to_main:

--- a/tests/scripts/test_audit_codex_branch_backlog.py
+++ b/tests/scripts/test_audit_codex_branch_backlog.py
@@ -556,6 +556,32 @@ def test_audit_ignores_missing_worktree_paths(tmp_path: Path, monkeypatch: Any) 
     assert payload["records"][0]["category"] == "salvage_recent_unique"
 
 
+def test_active_worktree_uses_live_session_detector(tmp_path: Path, monkeypatch: Any) -> None:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / ".claude-session-active").write_text("pid=12345\n", encoding="utf-8")
+
+    calls: list[Path] = []
+
+    def fake_has_active_session(path: Path) -> bool:
+        calls.append(path)
+        return False
+
+    monkeypatch.setattr(mod.autopilot, "_has_active_session", fake_has_active_session)
+
+    assert mod.active_worktree(worktree) is False
+    assert calls == [worktree]
+
+
+def test_active_worktree_preserves_live_session_blocker(tmp_path: Path, monkeypatch: Any) -> None:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: True)
+
+    assert mod.active_worktree(worktree) is True
+
+
 def test_audit_skips_patch_equivalence_for_dirty_worktrees(
     tmp_path: Path, monkeypatch: Any
 ) -> None:

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -387,7 +387,36 @@ def test_inspect_allows_patch_equivalent_branch_when_pr_lookup_fails(
     assert inspection.blockers == []
 
 
-def test_inspect_blocks_lock_files_and_history_lookup_failure(
+def test_inspect_reports_stale_lock_files_without_blocking_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".codex_session_active").write_text("pid=12345\n")
+
+    monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(
+        mod,
+        "_get_worktree_entries",
+        lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/test")],
+    )
+    monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(mod, "_worktree_is_dirty", lambda _path: False)
+    monkeypatch.setattr(mod, "_unique_commits_ahead_of_main", lambda _repo, _branch: (0, False))
+    monkeypatch.setattr(mod, "_lookup_open_prs", lambda _repo, _branch: ([], False))
+
+    inspection = mod.inspect_worktree(repo_root, worktree)
+
+    assert inspection.lock_files == [".codex_session_active"]
+    assert inspection.active_session is False
+    assert inspection.blockers == []
+
+
+def test_inspect_blocks_active_session_and_history_lookup_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import safe_worktree_cleanup as mod
@@ -404,7 +433,7 @@ def test_inspect_blocks_lock_files_and_history_lookup_failure(
         "_get_worktree_entries",
         lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/test")],
     )
-    monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: True)
     monkeypatch.setattr(mod, "_worktree_is_dirty", lambda _path: False)
     monkeypatch.setattr(mod, "_unique_commits_ahead_of_main", lambda _repo, _branch: (0, True))
     monkeypatch.setattr(mod, "_lookup_open_prs", lambda _repo, _branch: ([], False))
@@ -412,5 +441,6 @@ def test_inspect_blocks_lock_files_and_history_lookup_failure(
     inspection = mod.inspect_worktree(repo_root, worktree)
 
     assert inspection.lock_files == [".codex_session_active"]
+    assert inspection.active_session is True
     assert inspection.ahead_lookup_failed is True
-    assert inspection.blockers == ["session_lock_present", "ahead_lookup_failed"]
+    assert inspection.blockers == ["active_session", "ahead_lookup_failed"]


### PR DESCRIPTION
## Summary
- treat stale dead-PID cleanup lock files as reportable evidence but not blockers when active-session detection proves no live session
- align branch-backlog classification with safe cleanup so stale lock residue can be reclaimed safely
- add regression tests for stale lock classification and removal eligibility

## Validation
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python3 -m pytest -q tests/scripts/test_safe_worktree_cleanup.py tests/scripts/test_audit_codex_branch_backlog.py` -> 66 passed
- `python3 -m ruff check scripts/safe_worktree_cleanup.py tests/scripts/test_safe_worktree_cleanup.py scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py`
- `python3 -m ruff format --check scripts/safe_worktree_cleanup.py tests/scripts/test_safe_worktree_cleanup.py scripts/audit_codex_branch_backlog.py tests/scripts/test_audit_codex_branch_backlog.py`
- `git diff --check origin/main...HEAD`
- `gitleaks detect --no-git --source /tmp/safe-cleanup-stale-locks.patch`

Published from automation outbox item `open-pr-codex-safe-cleanup-stale-locks-20260515-f345ec3d`; rebased from original handoff head `f345ec3d` to `c0a26457` on current `origin/main`.