### PR TITLE
feat(agt-05): smoke ledger persistence via existing ReputationStore (flag-OFF)

### DIFF
--- a/scripts/agt_05_reputation_flow_smoke.py
+++ b/scripts/agt_05_reputation_flow_smoke.py
@@ -24,9 +24,9 @@ Optional persistence (AGT-05 SD-1 substrate continuation)::
             --persist /tmp/agt_05_ledger.jsonl
 
 When ``--persist`` is given, computed deltas are recorded via the
-existing :class:`aragora.reputation.store.ReputationStore`, appended
-atomically to the JSONL path, and the post-persist per-agent score is
-read back from the store to demonstrate the round-trip.
+existing :class:`aragora.reputation.store.ReputationStore`, appended to
+the JSONL path, and the post-persist per-agent score is read back from
+the store to demonstrate the round-trip.
 
 The script prints a per-agent per-question table of reputation deltas
 and a per-agent total. No live API calls. No public-API mutation.
@@ -207,14 +207,14 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
 
 
 def _smoke(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
     if not reputation_flow_enabled():
         print(
             "ARAGORA_REPUTATION_FLOW_ENABLED is not set; nothing to demonstrate.",
             file=sys.stderr,
         )
         return 2
-
-    args = _parse_args(argv)
 
     deltas, rows = compute_deltas()
 

--- a/scripts/agt_05_reputation_flow_smoke.py
+++ b/scripts/agt_05_reputation_flow_smoke.py
@@ -4,10 +4,10 @@
 Exercises the full path:
 
     MetaculusQuestion (resolved) + agent prediction
-        → bridge_from_metaculus_question
-        → StakeableClaim + ResolvedClaim
-        → settle_claim (Brier-proper scoring rule)
-        → ReputationDelta
+        -> bridge_from_metaculus_question
+        -> StakeableClaim + ResolvedClaim
+        -> settle_claim (Brier-proper scoring rule)
+        -> ReputationDelta
 
 with the ``ARAGORA_REPUTATION_FLOW_ENABLED`` flag set to ``1``. Uses
 synthetic-but-realistic data so the run is hermetic and deterministic.
@@ -17,28 +17,39 @@ Run::
     ARAGORA_REPUTATION_FLOW_ENABLED=1 \\
         python3 scripts/agt_05_reputation_flow_smoke.py
 
+Optional persistence (AGT-05 SD-1 substrate continuation)::
+
+    ARAGORA_REPUTATION_FLOW_ENABLED=1 \\
+        python3 scripts/agt_05_reputation_flow_smoke.py \\
+            --persist /tmp/agt_05_ledger.jsonl
+
+When ``--persist`` is given, computed deltas are recorded via the
+existing :class:`aragora.reputation.store.ReputationStore`, appended
+atomically to the JSONL path, and the post-persist per-agent score is
+read back from the store to demonstrate the round-trip.
+
 The script prints a per-agent per-question table of reputation deltas
-and a per-agent total. No live API calls. No mutation of any ledger.
+and a per-agent total. No live API calls. No public-API mutation.
 This is purely a calibration exercise to prove the signal flow runs
 end-to-end on the same code path a live Arena debate would use once
 the predictor/resolver hooks are wired.
 
 Out of scope (deliberate):
 
-- Calling :func:`aragora.reputation.ledger.apply_delta` or any
-  on-chain registry — this script only computes deltas.
-- Wiring into ``Arena`` — that is the production integration step
+- Wiring into ``Arena`` -- that is the production integration step
   ``AGT-05`` sub-deliverable that follows this calibration.
-- Choosing between ``brier_proper`` and ``binary`` for live use —
-  this script demonstrates both for comparison.
+- On-chain anchoring via :class:`ReputationRegistry`.
+- ``team_selector`` consumption of store scores (separate flag).
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 # Ensure repo root is importable when run from anywhere.
@@ -52,6 +63,26 @@ from aragora.reputation.metaculus_bridge import (
     reputation_flow_enabled,
 )
 from aragora.reputation.settlement import settle_claim
+from aragora.reputation.store import ReputationStore
+from aragora.reputation.types import ReputationDelta
+
+
+# ---------------------------------------------------------------------------
+# Pure data construction (testable without env or I/O)
+# ---------------------------------------------------------------------------
+
+
+SMOKE_QUESTIONS: list[tuple[str, str, float]] = [
+    ("manifold-1001", "Will the H1-01 rev-4 corpus be promoted by 2026-05-15?", 1.0),
+    ("manifold-1002", "Will the proof-loop alerter PR (#7156) land by 2026-05-20?", 1.0),
+    ("manifold-1003", "Will boss_metrics.jsonl reach 10k rows by 2026-06-01?", 0.0),
+]
+
+SMOKE_AGENT_PREDICTIONS: dict[str, list[float]] = {
+    "claude-opus-4-7": [0.90, 0.85, 0.10],
+    "gpt-4.1": [0.60, 0.55, 0.45],
+    "demo-anti": [0.10, 0.05, 0.90],
+}
 
 
 def _resolved_question(qid: int, title: str, resolution: float) -> MetaculusQuestion:
@@ -70,52 +101,39 @@ def _resolved_question(qid: int, title: str, resolution: float) -> MetaculusQues
     )
 
 
-def _smoke() -> int:
-    if not reputation_flow_enabled():
-        print(
-            "ARAGORA_REPUTATION_FLOW_ENABLED is not set; nothing to demonstrate.",
-            file=sys.stderr,
-        )
-        return 2
+def compute_deltas(
+    questions: list[tuple[str, str, float]] | None = None,
+    agent_predictions: dict[str, list[float]] | None = None,
+    *,
+    stake_units: int = 10,
+) -> tuple[list[ReputationDelta], list[dict[str, Any]]]:
+    """Compute reputation deltas for the smoke scenario.
 
-    questions = [
-        ("manifold-1001", "Will the H1-01 rev-4 corpus be promoted by 2026-05-15?", 1.0),
-        ("manifold-1002", "Will the proof-loop alerter PR (#7156) land by 2026-05-20?", 1.0),
-        ("manifold-1003", "Will boss_metrics.jsonl reach 10k rows by 2026-06-01?", 0.0),
-    ]
-    # Agents and their predicted probabilities per question.
-    # Calibrated (=outcome): high score; opposite: low/negative score.
-    agents = {
-        "claude-opus-4-7": [0.90, 0.85, 0.10],  # well-calibrated
-        "gpt-4.1": [0.60, 0.55, 0.45],  # roughly indifferent
-        "demo-anti": [0.10, 0.05, 0.90],  # systematically wrong
-    }
+    Returns ``(deltas, rows)`` where ``rows`` is a list of dicts with
+    one entry per (question, agent) pair for pretty-printing.
+    """
+    qs = questions if questions is not None else SMOKE_QUESTIONS
+    preds = agent_predictions if agent_predictions is not None else SMOKE_AGENT_PREDICTIONS
 
-    print()
-    print("AGT-05 Reputation Flow Smoke Test")
-    print("=" * 78)
-    print(f"  ARAGORA_REPUTATION_FLOW_ENABLED={os.environ.get('ARAGORA_REPUTATION_FLOW_ENABLED')}")
-    print("  scoring_rule=brier_proper")
-    print(f"  agents={list(agents.keys())}")
-    print(f"  questions={[q[0] for q in questions]}")
-    print()
-
-    per_agent_total: dict[str, float] = dict.fromkeys(agents, 0.0)
+    deltas: list[ReputationDelta] = []
     rows: list[dict[str, Any]] = []
 
-    for q_id, q_title, resolution in questions:
-        q = _resolved_question(qid=int(q_id.split("-")[1]), title=q_title, resolution=resolution)
-        for agent_id, predictions in agents.items():
-            idx = [q[0] for q in questions].index(q_id)
-            p = predictions[idx]
+    for q_idx, (q_id, q_title, resolution) in enumerate(qs):
+        q = _resolved_question(
+            qid=int(q_id.split("-")[1]),
+            title=q_title,
+            resolution=resolution,
+        )
+        for agent_id, predictions in preds.items():
+            p = predictions[q_idx]
             claim, resolved = bridge_from_metaculus_question(
                 q,
                 agent_id=agent_id,
                 predicted_probability=p,
-                stake_units=10,
+                stake_units=stake_units,
             )
             delta = settle_claim(claim, resolved)
-            per_agent_total[agent_id] += delta.delta
+            deltas.append(delta)
             rows.append(
                 {
                     "question_id": q_id,
@@ -128,7 +146,51 @@ def _smoke() -> int:
                 }
             )
 
-    # Pretty print
+    return deltas, rows
+
+
+def persist_to_store(
+    deltas: list[ReputationDelta],
+    path: Path,
+) -> tuple[ReputationStore, dict[str, float]]:
+    """Persist *deltas* via :class:`ReputationStore` and read back per-agent scores.
+
+    Returns ``(store, scores)`` where ``scores`` maps agent_id to the
+    decayed running score from the store after all deltas are recorded.
+    """
+    store = ReputationStore(path=path)
+    for d in deltas:
+        store.record_delta(d)
+    scores = {aid: store.get_score(aid) for aid in store.agent_ids()}
+    return store, scores
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="AGT-05 reputation flow smoke")
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Also emit a JSON summary to stdout",
+    )
+    p.add_argument(
+        "--persist",
+        type=Path,
+        default=None,
+        help=(
+            "Path to a JSONL ledger; when given, computed deltas are recorded "
+            "via aragora.reputation.store.ReputationStore and per-agent scores "
+            "are read back from the store after persistence."
+        ),
+    )
+    return p.parse_args(argv)
+
+
+def _print_table(rows: list[dict[str, Any]]) -> None:
     print(
         f"{'question':<14} {'agent':<24} {'pred_p':>7} {'outcome':<6} "
         f"{'brier':>7} {'payout':>8} {'delta':>7}"
@@ -142,20 +204,63 @@ def _smoke() -> int:
             f"{r['delta']:>7.2f}"
         )
     print("-" * 78)
+
+
+def _smoke(argv: list[str] | None = None) -> int:
+    if not reputation_flow_enabled():
+        print(
+            "ARAGORA_REPUTATION_FLOW_ENABLED is not set; nothing to demonstrate.",
+            file=sys.stderr,
+        )
+        return 2
+
+    args = _parse_args(argv)
+
+    deltas, rows = compute_deltas()
+
+    print()
+    print("AGT-05 Reputation Flow Smoke Test")
+    print("=" * 78)
+    print(f"  ARAGORA_REPUTATION_FLOW_ENABLED={os.environ.get('ARAGORA_REPUTATION_FLOW_ENABLED')}")
+    print("  scoring_rule=brier_proper")
+    print(f"  agents={list(SMOKE_AGENT_PREDICTIONS.keys())}")
+    print(f"  questions={[q[0] for q in SMOKE_QUESTIONS]}")
+    if args.persist is not None:
+        print(f"  persist_to={args.persist}")
+    print()
+
+    _print_table(rows)
+
+    per_agent_total: dict[str, float] = dict.fromkeys(SMOKE_AGENT_PREDICTIONS, 0.0)
+    for r in rows:
+        per_agent_total[r["agent"]] += r["delta"]
+
     print()
     print("Per-agent total reputation delta (Brier-proper, stake_units=10 per Q):")
     for a in sorted(per_agent_total):
         print(f"  {a:<24} {per_agent_total[a]:>+8.3f}")
     print()
+
+    store_scores: dict[str, float] = {}
+    if args.persist is not None:
+        _, store_scores = persist_to_store(deltas, args.persist)
+        print(f"Persisted {len(deltas)} deltas to {args.persist}")
+        print("Per-agent decayed score read back from ReputationStore:")
+        for a in sorted(store_scores):
+            print(f"  {a:<24} {store_scores[a]:>+8.3f}")
+        print()
+        print("Round-trip verified: the ledger file is replayable via")
+        print("ReputationStore.load_from_file() to reconstruct the same state.")
+        print()
+
     print("Interpretation:")
-    print("  delta > 0  → agent gained reputation (calibrated towards outcome)")
-    print("  delta < 0  → agent lost reputation (systematically miscalibrated)")
-    print("  delta ≈ 0  → agent indifferent (predicted near 0.5)")
+    print("  delta > 0  -> agent gained reputation (calibrated towards outcome)")
+    print("  delta < 0  -> agent lost reputation (systematically miscalibrated)")
+    print("  delta ~= 0 -> agent indifferent (predicted near 0.5)")
     print()
     print("This proves the end-to-end signal flow runs cleanly with the flag enabled.")
-    print("Production wiring: have an Arena post-debate hook call this same path")
-    print("with debate-derived predictions on a real resolved Manifold/Metaculus")
-    print("question — that is the next AGT-05 production integration step.")
+    print("With --persist, deltas are also durable in a JSONL ledger the")
+    print("ReputationCalibrationBridge (selection_bridge.py) can consume.")
     print()
 
     summary = {
@@ -163,9 +268,11 @@ def _smoke() -> int:
         "flag": os.environ.get("ARAGORA_REPUTATION_FLOW_ENABLED"),
         "rows": rows,
         "per_agent_total": per_agent_total,
+        "persist_path": str(args.persist) if args.persist else None,
+        "store_scores": store_scores,
         "ran_at": datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
     }
-    if "--json" in sys.argv[1:]:
+    if args.json:
         print(json.dumps(summary, indent=2))
 
     return 0

--- a/tests/scripts/test_agt_05_reputation_flow_smoke.py
+++ b/tests/scripts/test_agt_05_reputation_flow_smoke.py
@@ -122,7 +122,7 @@ class TestPersistToStore:
             reloaded_score = reloaded.get_score(agent_id, apply_decay=False)
             assert abs(reloaded_score - original_score) < 1e-6
 
-    def test_persist_atomic_append_when_called_twice(self, tmp_path: Path) -> None:
+    def test_persist_append_only_when_called_twice(self, tmp_path: Path) -> None:
         deltas, _ = smoke.compute_deltas()
         ledger = tmp_path / "ledger.jsonl"
         smoke.persist_to_store(deltas, ledger)
@@ -152,6 +152,12 @@ class TestCli:
         monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
         rc = smoke._smoke([])
         assert rc == 2
+
+    def test_help_works_when_flag_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+        with pytest.raises(SystemExit) as excinfo:
+            smoke._smoke(["--help"])
+        assert excinfo.value.code == 0
 
     def test_smoke_returns_0_when_flag_on(self, capsys: pytest.CaptureFixture[str]) -> None:
         rc = smoke._smoke([])

--- a/tests/scripts/test_agt_05_reputation_flow_smoke.py
+++ b/tests/scripts/test_agt_05_reputation_flow_smoke.py
@@ -1,0 +1,217 @@
+"""Tests for ``scripts/agt_05_reputation_flow_smoke.py``.
+
+Covers the substrate-continuation slice added on top of the original
+demo PR (#7161): the smoke now accepts a ``--persist <path>`` argument
+and round-trips computed deltas through
+:class:`aragora.reputation.store.ReputationStore`.
+
+These tests do not run the smoke as a subprocess; they import its
+helpers directly to keep the test surface narrow and to avoid coupling
+to argv parsing for the pure-computation paths. The store/file
+round-trip is verified end-to-end against an actual JSONL on disk.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import agt_05_reputation_flow_smoke as smoke  # noqa: E402
+
+from aragora.reputation.store import ReputationStore  # noqa: E402
+from aragora.reputation.types import ReputationDelta  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _enable_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARAGORA_REPUTATION_FLOW_ENABLED", "1")
+
+
+class TestComputeDeltas:
+    def test_returns_one_delta_per_agent_per_question(self) -> None:
+        deltas, rows = smoke.compute_deltas()
+        n_q = len(smoke.SMOKE_QUESTIONS)
+        n_a = len(smoke.SMOKE_AGENT_PREDICTIONS)
+        assert len(deltas) == n_q * n_a
+        assert len(rows) == n_q * n_a
+
+    def test_each_delta_has_brier_proper_reason(self) -> None:
+        deltas, _ = smoke.compute_deltas()
+        for d in deltas:
+            assert d.scoring_rule == "brier_proper"
+            assert "brier" in d.reason
+            assert "payout_fraction" in d.reason
+
+    def test_well_calibrated_agent_has_positive_total(self) -> None:
+        deltas, _ = smoke.compute_deltas()
+        total = sum(d.delta for d in deltas if d.agent_id == "claude-opus-4-7")
+        assert total > 0.0
+        # Calibrated at p in {0.90, 0.85, 0.10} against outcomes {yes, yes, no}.
+        # Each Brier <= 0.04 -> payout >= 0.92 -> delta >= 9.2; sum >= 27.
+        assert total > 25.0
+
+    def test_anti_calibrated_agent_has_negative_total(self) -> None:
+        deltas, _ = smoke.compute_deltas()
+        total = sum(d.delta for d in deltas if d.agent_id == "demo-anti")
+        assert total < 0.0
+
+    def test_indifferent_agent_total_is_modest(self) -> None:
+        deltas, _ = smoke.compute_deltas()
+        total = sum(d.delta for d in deltas if d.agent_id == "gpt-4.1")
+        # gpt-4.1 predictions hover near 0.5 -> small-positive aggregate.
+        assert 0.0 < abs(total) < 25.0
+
+    def test_rows_align_with_deltas(self) -> None:
+        deltas, rows = smoke.compute_deltas()
+        for d, r in zip(deltas, rows, strict=True):
+            assert r["agent"] == d.agent_id
+            assert abs(r["delta"] - round(d.delta, 3)) < 1e-9
+
+    def test_custom_predictions_yield_custom_deltas(self) -> None:
+        custom_questions = [("manifold-9001", "Custom Q?", 1.0)]
+        custom_predictions = {"agent-X": [0.99]}
+        deltas, rows = smoke.compute_deltas(
+            questions=custom_questions,
+            agent_predictions=custom_predictions,
+        )
+        assert len(deltas) == 1
+        assert deltas[0].agent_id == "agent-X"
+        # p=0.99 against outcome yes -> Brier=0.0001 -> payout ~= 0.9998
+        assert deltas[0].delta > 9.99
+
+
+class TestPersistToStore:
+    def test_persist_writes_jsonl_file(self, tmp_path: Path) -> None:
+        deltas, _ = smoke.compute_deltas()
+        ledger = tmp_path / "ledger.jsonl"
+        store, scores = smoke.persist_to_store(deltas, ledger)
+        assert ledger.exists()
+        # one JSON line per delta
+        line_count = sum(1 for _ in ledger.read_text(encoding="utf-8").splitlines() if _.strip())
+        assert line_count == len(deltas)
+        assert len(store) == len(deltas)
+
+    def test_store_scores_match_per_agent_totals(self, tmp_path: Path) -> None:
+        deltas, _ = smoke.compute_deltas()
+        ledger = tmp_path / "ledger.jsonl"
+        _, scores = smoke.persist_to_store(deltas, ledger)
+        # Decay over <1s should be effectively 1.0; compare to undecayed sum.
+        for agent_id in smoke.SMOKE_AGENT_PREDICTIONS:
+            raw_total = sum(d.delta for d in deltas if d.agent_id == agent_id)
+            assert agent_id in scores
+            assert abs(scores[agent_id] - raw_total) < 0.01
+
+    def test_persist_then_load_roundtrip(self, tmp_path: Path) -> None:
+        deltas, _ = smoke.compute_deltas()
+        ledger = tmp_path / "ledger.jsonl"
+        smoke.persist_to_store(deltas, ledger)
+        reloaded = ReputationStore.load_from_file(ledger)
+        assert len(reloaded) == len(deltas)
+        # Same set of agent ids.
+        assert set(reloaded.agent_ids()) == set(smoke.SMOKE_AGENT_PREDICTIONS.keys())
+        # Same per-agent score (within decay tolerance).
+        for agent_id in smoke.SMOKE_AGENT_PREDICTIONS:
+            original_score = sum(d.delta for d in deltas if d.agent_id == agent_id)
+            reloaded_score = reloaded.get_score(agent_id, apply_decay=False)
+            assert abs(reloaded_score - original_score) < 1e-6
+
+    def test_persist_atomic_append_when_called_twice(self, tmp_path: Path) -> None:
+        deltas, _ = smoke.compute_deltas()
+        ledger = tmp_path / "ledger.jsonl"
+        smoke.persist_to_store(deltas, ledger)
+        line_count_a = sum(1 for _ in ledger.read_text(encoding="utf-8").splitlines() if _.strip())
+        # Second invocation should append (not overwrite). The store class
+        # appends to file via _append_to_file; recording the same deltas a
+        # second time will write them again because they have new applied_at
+        # timestamps via the new ReputationDelta instances.
+        deltas2, _ = smoke.compute_deltas()
+        smoke.persist_to_store(deltas2, ledger)
+        line_count_b = sum(1 for _ in ledger.read_text(encoding="utf-8").splitlines() if _.strip())
+        assert line_count_b == line_count_a + len(deltas2)
+
+
+class TestCli:
+    def test_parse_args_persist_optional(self) -> None:
+        ns = smoke._parse_args([])
+        assert ns.persist is None
+        assert ns.json is False
+
+    def test_parse_args_persist_path(self, tmp_path: Path) -> None:
+        target = tmp_path / "ledger.jsonl"
+        ns = smoke._parse_args(["--persist", str(target)])
+        assert ns.persist == target
+
+    def test_smoke_returns_2_when_flag_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ARAGORA_REPUTATION_FLOW_ENABLED", raising=False)
+        rc = smoke._smoke([])
+        assert rc == 2
+
+    def test_smoke_returns_0_when_flag_on(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = smoke._smoke([])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "AGT-05 Reputation Flow Smoke Test" in captured.out
+
+    def test_smoke_with_persist_writes_ledger(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ledger = tmp_path / "ledger.jsonl"
+        rc = smoke._smoke(["--persist", str(ledger)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert ledger.exists()
+        assert "Persisted" in captured.out
+        assert str(ledger) in captured.out
+
+
+def test_module_uses_existing_store_no_duplicate_module() -> None:
+    """Guard: the smoke must reuse ReputationStore; it must not define its own ledger."""
+    src = (SCRIPTS / "agt_05_reputation_flow_smoke.py").read_text(encoding="utf-8")
+    assert "from aragora.reputation.store import ReputationStore" in src
+    # No private ledger class re-defined in this script.
+    assert "class ReputationLedger" not in src
+    assert "class ReputationStore" not in src
+
+
+def test_delta_id_stable_for_smoke_scenario() -> None:
+    """Deltas should be deterministic given the smoke inputs (modulo timestamps)."""
+    a, _ = smoke.compute_deltas()
+    b, _ = smoke.compute_deltas()
+    assert len(a) == len(b)
+    # delta values are deterministic functions of (p, outcome, stake), so
+    # numerical fields must match exactly even though delta_ids differ.
+    for d1, d2 in zip(a, b, strict=True):
+        assert d1.agent_id == d2.agent_id
+        assert d1.domain == d2.domain
+        assert d1.delta == pytest.approx(d2.delta)
+        assert d1.reason.get("brier") == pytest.approx(d2.reason.get("brier"))
+
+
+def test_store_scores_match_smoke_table_in_e2e_run(tmp_path: Path) -> None:
+    """End-to-end check: smoke produces N deltas, store reads back same N agents."""
+    ledger = tmp_path / "ledger.jsonl"
+    rc = smoke._smoke(["--persist", str(ledger)])
+    assert rc == 0
+    reloaded = ReputationStore.load_from_file(ledger)
+    # Should have the canonical 3 agents.
+    assert set(reloaded.agent_ids()) == {"claude-opus-4-7", "gpt-4.1", "demo-anti"}
+    # claude-opus-4-7 has been well-calibrated -> positive score even after decay.
+    claude_score = reloaded.get_score("claude-opus-4-7")
+    assert claude_score > 0.0
+    # demo-anti has been systematically wrong -> negative score.
+    anti_score = reloaded.get_score("demo-anti")
+    assert anti_score < 0.0
+    # Type assertions hold for delta objects.
+    for agent_id in reloaded.agent_ids():
+        for d in reloaded.deltas_for(agent_id):
+            assert isinstance(d, ReputationDelta)
+            assert d.scoring_rule == "brier_proper"


### PR DESCRIPTION
## Summary

Substrate continuation of AGT-05: the reputation-flow smoke now optionally persists computed deltas through the existing `ReputationStore` JSONL ledger and reads scores back from that store. This keeps the slice bounded: no new module, no public API expansion, no Arena wiring, no on-chain anchoring.

## Scope

Changed files:

- `scripts/agt_05_reputation_flow_smoke.py`
- `tests/scripts/test_agt_05_reputation_flow_smoke.py`

Behavioral posture:

- Default smoke behavior is unchanged when `--persist` is not provided.
- Persistence is opt-in via `--persist <path>` and still gated by `ARAGORA_REPUTATION_FLOW_ENABLED=1`.
- The persistence path uses the existing `aragora.reputation.store.ReputationStore`.

## Fresh validation after rebase onto current main

Head: `e863b4c0a4bffab82ce8c09d892afe58e4201115`

- `pytest tests/scripts/test_agt_05_reputation_flow_smoke.py tests/reputation/test_store.py tests/reputation/test_metaculus_bridge.py -q` -> `90 passed`
- `ruff check scripts/agt_05_reputation_flow_smoke.py tests/scripts/test_agt_05_reputation_flow_smoke.py` -> clean
- `ruff format --check scripts/agt_05_reputation_flow_smoke.py tests/scripts/test_agt_05_reputation_flow_smoke.py` -> clean
- `mypy scripts/agt_05_reputation_flow_smoke.py tests/scripts/test_agt_05_reputation_flow_smoke.py` -> clean
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`
- Manual smoke: `ARAGORA_REPUTATION_FLOW_ENABLED=1 python scripts/agt_05_reputation_flow_smoke.py --persist /tmp/agt05-7168-ledger.jsonl` wrote 9 JSONL lines and replayed the same per-agent totals from `ReputationStore.load_from_file()`.
- `python scripts/agt_05_reputation_flow_smoke.py --help` works with the feature flag unset.

## Out of scope

- No production Arena hook.
- No CLI command under `aragora/cli/`.
- No new reputation store abstraction.
- No team-selection consumer.
