### PR TITLE
feat(automation): add goal conductor wrapper

### DIFF
--- a/aragora/cli/commands/spec.py
+++ b/aragora/cli/commands/spec.py
@@ -316,6 +316,54 @@ def _save_spec_result(result: dict[str, Any], output_path: str, output_format: s
     return path
 
 
+def _spec_result_task_text(prompt: str, result: dict[str, Any]) -> str:
+    """Build deterministic decomposition input from a spec command result."""
+    spec = result.get("specification") or {}
+    sections: list[str] = []
+    if isinstance(spec, dict):
+        for key in ("title", "problem_statement", "proposed_solution", "raw"):
+            value = str(spec.get(key) or "").strip()
+            if value:
+                sections.append(value)
+        criteria = spec.get("success_criteria") or []
+        if isinstance(criteria, list) and criteria:
+            rendered: list[str] = []
+            for item in criteria:
+                if isinstance(item, dict):
+                    text = str(item.get("description") or "").strip()
+                else:
+                    text = str(item or "").strip()
+                if text:
+                    rendered.append(f"- {text}")
+            if rendered:
+                sections.append("Success criteria:\n" + "\n".join(rendered))
+    if sections:
+        return "\n\n".join(sections)
+    return prompt
+
+
+def _write_mission_from_spec_result(
+    *,
+    prompt: str,
+    result: dict[str, Any],
+    output_path: str,
+) -> Path:
+    """Convert the spec output into a conductor mission YAML file."""
+    from aragora.nomic.mission_bridge import decomposition_to_mission, write_mission_yaml
+    from aragora.nomic.task_decomposer import TaskDecomposer
+
+    task_text = _spec_result_task_text(prompt, result)
+    decomp = TaskDecomposer().analyze(task_text)
+    mission = decomposition_to_mission(
+        decomp,
+        objective=prompt,
+        stop_condition=(
+            "Stop when every lane reaches a draft PR, a precise blocker report, or a handoff."
+        ),
+    )
+    return write_mission_yaml(mission, output_path)
+
+
 def cmd_spec(args: argparse.Namespace) -> None:
     """Handle the 'spec' command."""
     prompt = getattr(args, "prompt", None)
@@ -330,6 +378,7 @@ def cmd_spec(args: argparse.Namespace) -> None:
     output_format = getattr(args, "format", "text")
     dry_run = getattr(args, "dry_run", False)
     use_orchestrator = getattr(args, "orchestrator", False)
+    to_mission = getattr(args, "to_mission", None)
 
     print("\n" + "=" * 60)
     print("  ARAGORA SPEC")
@@ -378,6 +427,15 @@ def cmd_spec(args: argparse.Namespace) -> None:
     if output_path:
         path = _save_spec_result(result, output_path, output_format)
         print(f"\nSpec saved to: {path}")
+
+    if to_mission:
+        mission_path = _write_mission_from_spec_result(
+            prompt=prompt,
+            result=result,
+            output_path=to_mission,
+        )
+        print(f"\nConductor mission saved to: {mission_path}")
+        print(f"Run: python3 scripts/goal_conductor.py run-once --mission {mission_path} --json")
 
     print("\nNext steps:")
     print("  aragora decide 'task' --spec <file>  # Execute from spec")

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -3631,6 +3631,7 @@ Examples:
   aragora spec "Make our onboarding flow better"
   aragora spec "Add dark mode" --depth thorough --profile cto
   aragora spec "Improve test coverage" --format json --output spec.json
+  aragora spec "Publish H1-01 rev-4 benchmark result" --to-mission /tmp/mission.yaml
   aragora spec "Design a rate limiter" --dry-run
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -3668,6 +3669,10 @@ Examples:
         "--output",
         "-o",
         help="Save spec to file",
+    )
+    spec_parser.add_argument(
+        "--to-mission",
+        help="Write a goal-conductor mission YAML file from the generated spec, without dispatching agents.",
     )
     spec_parser.add_argument(
         "--dry-run",

--- a/aragora/nomic/mission_bridge.py
+++ b/aragora/nomic/mission_bridge.py
@@ -1,0 +1,190 @@
+"""Bridge Nomic task decompositions into goal-conductor mission YAML."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_GOAL_CONDUCTOR_OUTPUT_DIR = ".aragora/goal-conductor"
+DEFAULT_AGENTS = ["codex", "claude"]
+DEFAULT_STOP_CONDITION = (
+    "Stop when every lane reaches a draft PR, a precise blocker report, or a handoff."
+)
+
+
+def _slug(value: str, *, fallback: str = "goal") -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-").lower()
+    return slug[:80] or fallback
+
+
+def _text(value: Any, *, fallback: str = "") -> str:
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def _subtasks_from_decomposition(decomp: Any) -> list[Any]:
+    subtasks = getattr(decomp, "subtasks", None)
+    if isinstance(subtasks, list):
+        return subtasks
+    return []
+
+
+def _subtask_title(subtask: Any, *, index: int) -> str:
+    return _text(getattr(subtask, "title", ""), fallback=f"Subtask {index}")
+
+
+def _subtask_description(subtask: Any, *, title: str) -> str:
+    return _text(getattr(subtask, "description", ""), fallback=title)
+
+
+def _subtask_prompt(subtask: Any, *, title: str, description: str) -> str:
+    parts = [
+        "You are an Aragora implementation worker.",
+        "",
+        f"Goal: {title}",
+        "",
+        description,
+        "",
+        "Rules:",
+        "- Rebuild live repo and queue truth before editing.",
+        "- Keep the change bounded to this lane.",
+        "- Do not merge PRs.",
+        "- Do not run observe-outcomes --write.",
+        "- Do not install launchd jobs, close issues, or clean worktrees.",
+        "- Stop after one draft PR or one precise blocker report with validation evidence.",
+    ]
+    file_scope = getattr(subtask, "file_scope", None) or []
+    if file_scope:
+        parts.extend(["", "Suggested file scope:"])
+        parts.extend(f"- {path}" for path in file_scope)
+    success_criteria = getattr(subtask, "success_criteria", None) or {}
+    if success_criteria:
+        parts.extend(["", "Success criteria:"])
+        if isinstance(success_criteria, dict):
+            parts.extend(f"- {key}: {value}" for key, value in success_criteria.items())
+        else:
+            parts.append(f"- {success_criteria}")
+    return "\n".join(parts)
+
+
+def decomposition_to_mission(
+    decomp: Any,
+    *,
+    objective: str,
+    stop_condition: str = "",
+    agents: list[str] | None = None,
+    include_panel_review: bool = True,
+    queue_cap: int = 6,
+) -> dict[str, Any]:
+    """Convert a TaskDecomposition-like object into a conductor mission dict.
+
+    The returned mapping intentionally matches ``scripts/goal_conductor.py``
+    ``Mission.from_dict()`` so the user can feed it directly to the conductor
+    after writing YAML.
+    """
+    objective_text = _text(objective, fallback=getattr(decomp, "original_task", ""))
+    if not objective_text:
+        objective_text = "Aragora goal-mode mission"
+    selected_agents = [agent.strip().lower() for agent in (agents or DEFAULT_AGENTS) if agent]
+    if not selected_agents:
+        selected_agents = list(DEFAULT_AGENTS)
+
+    subtasks = _subtasks_from_decomposition(decomp)
+    if not subtasks:
+        subtasks = [
+            type(
+                "_MissionBridgeSubtask",
+                (),
+                {
+                    "title": objective_text[:80],
+                    "description": objective_text,
+                    "file_scope": [],
+                    "success_criteria": {},
+                },
+            )()
+        ]
+
+    lanes: list[dict[str, Any]] = []
+    for index, subtask in enumerate(subtasks[:2], start=1):
+        title = _subtask_title(subtask, index=index)
+        description = _subtask_description(subtask, title=title)
+        agent = selected_agents[(index - 1) % len(selected_agents)]
+        lanes.append(
+            {
+                "id": f"implementation-{index}",
+                "agent": agent,
+                "mode": "implementation",
+                "goal": title,
+                "cwd": ".",
+                "autonomous": True,
+                "source": "mission-bridge",
+                "status": "active",
+                "next_action": "Open one draft PR or report one blocker, then stop.",
+                "prompt": _subtask_prompt(subtask, title=title, description=description),
+            }
+        )
+
+    if include_panel_review:
+        lanes.append(
+            {
+                "id": "adversarial-review",
+                "mode": "panel",
+                "agents_spec": "heterogeneous",
+                "goal": f"Review mission plan: {objective_text[:120]}",
+                "round_id": f"{_slug(objective_text)}-mission-review",
+                "prompt": (
+                    "Review this Aragora conductor mission before execution.\n\n"
+                    f"Objective: {objective_text}\n\n"
+                    "Focus on hidden safety, settlement, evidence, queue-cap, "
+                    "validation, and wedge-alignment risks. Output concise findings "
+                    "and a proceed/hold/narrow recommendation."
+                ),
+            }
+        )
+
+    return {
+        "name": _slug(objective_text),
+        "objective": objective_text,
+        "stop_condition": stop_condition or DEFAULT_STOP_CONDITION,
+        "checkpoints": [
+            "Snapshot root, open PRs, publisher, proof-loop health, and agent lanes.",
+            "Run at most two implementation lanes and one review lane.",
+            "Stop at hard gates and write a handoff.",
+        ],
+        "base_branch": "main",
+        "output_dir": DEFAULT_GOAL_CONDUCTOR_OUTPUT_DIR,
+        "limits": {
+            "queue_cap": int(queue_cap),
+            "max_implementation_lanes": 2,
+            "max_review_lanes": 1,
+        },
+        "allowed_mutations": [
+            "draft_pr",
+            "bounded_repo_patch",
+            "status_artifact",
+        ],
+        "stop_conditions": [
+            "root_dirty",
+            "queue_at_cap",
+            "tier4_gate",
+            "destructive_or_live_spend_request",
+        ],
+        "collect_merge_packets": True,
+        "max_merge_packets": 5,
+        "lanes": lanes,
+    }
+
+
+def write_mission_yaml(mission: dict[str, Any], path: str | Path) -> Path:
+    """Write a conductor mission dict to YAML and return the path."""
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - repo dependency missing
+        raise RuntimeError("PyYAML is required to write mission YAML") from exc
+
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(yaml.safe_dump(mission, sort_keys=False), encoding="utf-8")
+    return output_path

--- a/aragora/swarm/agent_bridge/harnesses/droid.py
+++ b/aragora/swarm/agent_bridge/harnesses/droid.py
@@ -38,7 +38,7 @@ class DroidTransport(Transport):
         self.home = home or Path.home()
 
     def _build_launch_command(self, prompt: str) -> tuple[list[str], str | None]:
-        auto_mode = str(self.harness_options.get("auto", "low"))
+        auto_mode = str(self.harness_options.get("auto", "high"))
         command = [self.harness, "exec", "--auto", auto_mode, "--output-format", "json"]
         if self.model:
             command.extend(["--model", self.model])
@@ -48,7 +48,7 @@ class DroidTransport(Transport):
         return command, None
 
     def _build_resume_command(self, session_id: str, prompt: str) -> list[str]:
-        auto_mode = str(self.harness_options.get("auto", "low"))
+        auto_mode = str(self.harness_options.get("auto", "high"))
         command = [
             self.harness,
             "exec",

--- a/aragora/swarm/multi_agent_dialog.py
+++ b/aragora/swarm/multi_agent_dialog.py
@@ -204,13 +204,15 @@ DROID_REVIEW_SYSTEM_PROMPT: str = (
 
 DROID_FLAGS: tuple[str, ...] = (
     "exec",
+    "--auto",
+    "high",
     "--disabled-tools",
     "Execute",
     "--append-system-prompt",
     DROID_REVIEW_SYSTEM_PROMPT,
 )
-"""``droid exec`` defaults to read-only mode; disabling ``Execute``
-keeps dialog turns on file/read/search tools only.
+"""``droid exec --auto high`` avoids non-interactive permission prompts
+while disabling ``Execute`` keeps dialog turns on file/read/search tools only.
 
 Round 30f dogfood showed that repo-review prompts under the previous
 ``--auto low`` setting could fail with a permission/autonomy error

--- a/docs/examples/goal_conductor_mission.yaml
+++ b/docs/examples/goal_conductor_mission.yaml
@@ -1,0 +1,90 @@
+# Example mission for scripts/goal_conductor.py.
+#
+# Prefer generating this shape from the existing spec pipeline:
+#   aragora spec "publish H1-01 rev-4 benchmark result" --to-mission /tmp/h1-mission.yaml
+#
+# Dry-run first:
+#   python3 scripts/goal_conductor.py run-once --mission docs/examples/goal_conductor_mission.yaml --json
+#
+# Execute only after the dry-run handoff is correct:
+#   python3 scripts/goal_conductor.py loop --mission docs/examples/goal_conductor_mission.yaml --execute --max-cycles 3 --interval-seconds 300 --json
+name: publish-h1-01-rev-4-benchmark-result
+objective: >
+  Publish the H1-01 rev-4 benchmark result as a public truth-surface artifact.
+stop_condition: >
+  Stop when the open PR queue reaches cap, root becomes dirty, a Tier-4 or
+  human/non-author settlement gate is encountered, or every lane reaches PR,
+  blocker, or handoff.
+checkpoints:
+  - Snapshot root, open PRs, publisher, proof-loop health, and agent lanes.
+  - Assign no more than two implementation lanes and one review lane.
+  - Validate claimed benchmark outputs from live repo/GitHub truth before settlement.
+  - Emit JSONL transcript and markdown handoff each cycle.
+external_references:
+  - https://developers.openai.com/codex/use-cases/follow-goals
+  - https://github.com/Dicklesworthstone/agentic_coding_flywheel_setup
+  - https://github.com/Dicklesworthstone/mcp_agent_mail
+base_branch: main
+output_dir: .aragora/goal-conductor
+limits:
+  queue_cap: 6
+  max_implementation_lanes: 2
+  max_review_lanes: 1
+allowed_mutations:
+  - draft_pr
+  - bounded_repo_patch
+  - status_artifact
+collect_merge_packets: true
+max_merge_packets: 5
+stop_conditions:
+  - root_dirty
+  - queue_at_cap
+  - tier4_gate
+  - destructive_or_live_spend_request
+lanes:
+  - id: implementation-1
+    agent: codex
+    mode: implementation
+    goal: Run the existing H1-01 benchmark publication path.
+    cwd: .
+    autonomous: true
+    source: goal-conductor
+    status: active
+    next_action: Open one draft PR or report one blocker, then stop.
+    prompt: |
+      You are an Aragora implementation worker.
+
+      Rebuild live repo and queue truth first. Identify the current H1-01
+      rev-4 benchmark status, run only existing benchmark/truth publication
+      commands needed for a dry-run or draft artifact, and stop after one draft
+      PR or one precise blocker report. Do not merge PRs. Do not run
+      observe-outcomes --write. Do not install launchd jobs. Do not close issues.
+
+  - id: implementation-2
+    agent: claude
+    mode: implementation
+    goal: Draft the public benchmark result artifact.
+    cwd: .
+    autonomous: true
+    source: goal-conductor
+    status: active
+    next_action: Open one draft PR or report one blocker, then stop.
+    prompt: |
+      You are an Aragora implementation worker in a separate lane.
+
+      Coordinate by lane ownership. Draft the public-facing H1-01 benchmark
+      result/status artifact from measured truth only. Do not touch files
+      assigned to another active lane. Keep the work additive and reversible.
+      Stop after one draft PR or one blocker.
+
+  - id: adversarial-review
+    mode: panel
+    agents_spec: heterogeneous
+    goal: Bounded cross-model review of the H1-01 benchmark publication gate.
+    round_id: h1-01-benchmark-publication-review
+    prompt: |
+      Review the H1-01 rev-4 benchmark publication gate.
+
+      Focus on hidden safety, settlement, evidence, queue-cap, and validation
+      risks. Do not propose broad new work. Output concise findings, required
+      evidence, and whether the gate should proceed, hold, or narrow.

--- a/docs/guides/CONDUCTOR_WORKFLOW.md
+++ b/docs/guides/CONDUCTOR_WORKFLOW.md
@@ -78,6 +78,33 @@ python3 scripts/codex_worktree_autopilot.py reconcile --all --base main
 python3 scripts/codex_worktree_autopilot.py cleanup --base main --ttl-hours 24
 ```
 
+## 3.1 Goal Conductor Wrapper
+
+For longer-running `/goal` style work, generate a conductor mission from the
+existing prompt-to-spec surface instead of manually copy-pasting across Codex,
+Claude, Factory, and panel sessions:
+
+```bash
+aragora spec "publish H1-01 rev-4 benchmark result" --to-mission /tmp/h1-mission.yaml
+python3 scripts/goal_conductor.py validate --mission /tmp/h1-mission.yaml --json
+python3 scripts/goal_conductor.py run-once --mission /tmp/h1-mission.yaml --json
+python3 scripts/goal_conductor.py loop --mission /tmp/h1-mission.yaml --max-cycles 3 --interval-seconds 300 --json
+```
+
+The wrapper is dry-run by default. Add `--execute` only after the dry-run
+handoff shows the expected lane commands. Each cycle snapshots live repo/PR
+truth, current non-draft merge packets, publisher health, proof-loop health,
+agent-bridge state, and local boss/Ralph/nomic loop surfaces; then it enforces
+queue cap and lane-count gates before launching or sending through
+`scripts/agent_bridge.py` or dispatching a bounded `scripts/multi_agent_dialog.py`
+panel.
+
+Mission files should include the goal objective, stop condition, checkpoints,
+lane ownership, and allowed mutation class. The conductor emits a JSONL
+transcript and markdown handoff under `.aragora/goal-conductor/`; it does not
+merge PRs, bypass Tier gates, install launchd jobs, run `observe-outcomes
+--write`, close issues, or clean worktrees.
+
 ## 4. Decision Rule
 
 Only do one of these per conductor cycle:

--- a/scripts/agent_bridge_broker.py
+++ b/scripts/agent_bridge_broker.py
@@ -141,7 +141,7 @@ def _parse_actors(items: list[str]) -> SessionRegistry:
     sessions: dict[str, BridgeSession] = {}
     for item in items:
         role, harness, model = _parse_actor(item)
-        harness_options = {"auto": "low"} if harness == "droid" else {}
+        harness_options = {"auto": "high"} if harness == "droid" else {}
         sessions[role] = BridgeSession(
             role=role,
             harness=harness,

--- a/scripts/goal_conductor.py
+++ b/scripts/goal_conductor.py
@@ -371,12 +371,18 @@ class GoalConductor:
         if not isinstance(prs, list):
             prs = []
         merge_packets: Any = []
+        merge_packet_status: dict[str, Any] = {
+            "targets": [],
+            "returncode": None,
+            "parse_ok": True,
+        }
         if self.mission.collect_merge_packets:
             packet_targets = [
                 int(pr["number"])
                 for pr in prs
                 if isinstance(pr, dict) and pr.get("number") and not bool(pr.get("isDraft"))
             ][: self.mission.max_merge_packets]
+            merge_packet_status["targets"] = packet_targets
             if packet_targets:
                 packet_args = [
                     "python3",
@@ -388,7 +394,11 @@ class GoalConductor:
                 ]
                 for number in packet_targets:
                     packet_args.extend(["--pr", str(number)])
-                merge_packets, _ = self._run_json(packet_args, timeout=120)
+                merge_packets, packet_result = self._run_json(packet_args, timeout=120)
+                merge_packet_status["returncode"] = packet_result.returncode
+                merge_packet_status["parse_ok"] = isinstance(merge_packets, (dict, list))
+                if merge_packets is None:
+                    merge_packets = []
         publisher, _ = self._run_json(["python3", "scripts/publisher_freshness_check.py", "--json"])
         bridge, _ = self._run_json(
             [
@@ -425,6 +435,7 @@ class GoalConductor:
             "open_pr_count": len(prs),
             "open_non_draft_count": sum(1 for pr in prs if not bool(pr.get("isDraft"))),
             "merge_packets": merge_packets,
+            "merge_packet_status": merge_packet_status,
             "publisher": publisher,
             "agent_bridge": bridge,
             "loop_surfaces": discover_loop_surfaces(self.repo_root),
@@ -436,6 +447,17 @@ class GoalConductor:
 
     def hard_gates(self, snapshot: dict[str, Any]) -> list[str]:
         gates: list[str] = []
+        if int(snapshot.get("pr_query_returncode") or 0) != 0:
+            gates.append(f"open PR query failed: rc={snapshot.get('pr_query_returncode')}")
+        packet_status = snapshot.get("merge_packet_status")
+        if isinstance(packet_status, dict) and packet_status.get("targets"):
+            if int(packet_status.get("returncode") or 0) != 0 or not bool(
+                packet_status.get("parse_ok", True)
+            ):
+                gates.append(
+                    "merge-packet query failed for "
+                    f"{','.join(str(item) for item in packet_status.get('targets') or [])}"
+                )
         if snapshot["root"]["dirty_file_count"]:
             gates.append("root checkout is dirty")
         if snapshot["open_pr_count"] >= self.mission.limits.queue_cap:

--- a/scripts/goal_conductor.py
+++ b/scripts/goal_conductor.py
@@ -1,0 +1,792 @@
+#!/usr/bin/env python3
+"""Goal-mode conductor for Aragora agent lanes.
+
+This is a thin orchestration wrapper around existing repo surfaces:
+
+* ``scripts/agent_bridge.py`` for long-running tmux agent lanes.
+* ``scripts/multi_agent_dialog.py`` for bounded heterogeneous review panels.
+* ``aragora review-queue merge-packet`` and GitHub state for gates.
+
+The conductor is intentionally conservative. It is read-only by default; pass
+``--execute`` before it will launch/send agents or run panel prompts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_OUTPUT_DIR = Path(".aragora/goal-conductor")
+DEFAULT_QUEUE_CAP = 6
+DEFAULT_MAX_IMPLEMENTATION_LANES = 2
+DEFAULT_MAX_REVIEW_LANES = 1
+ALLOWED_AGENTS = {"codex", "claude", "droid", "factory"}
+PANEL_MODE = "panel"
+IMPLEMENTATION_MODES = {"implementation", "implement", "write"}
+REVIEW_MODES = {"review", "watch", "validator", PANEL_MODE}
+MUTATING_LANE_MODES = IMPLEMENTATION_MODES
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-")
+    return slug[:80] or "goal"
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _as_str_list(value: Any) -> list[str]:
+    return [str(item) for item in _as_list(value)]
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML mission file.
+
+    PyYAML is already a repo dependency. Import it lazily so ``--help`` remains
+    usable even in partially bootstrapped environments.
+    """
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - environment failure
+        raise SystemExit("PyYAML is required to load mission YAML files") from exc
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"mission file must contain a mapping: {path}")
+    return data
+
+
+@dataclass(frozen=True)
+class LaneSpec:
+    lane_id: str
+    agent: str
+    goal: str
+    prompt: str = ""
+    prompt_file: str = ""
+    source: str = ""
+    mode: str = "implementation"
+    cwd: str = "."
+    autonomous: bool = True
+    status: str = "active"
+    next_action: str = ""
+    agents_spec: str = "heterogeneous"
+    context_file: str = ""
+    round_id: str = ""
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any], *, index: int) -> "LaneSpec":
+        lane_id = str(payload.get("id") or payload.get("lane_id") or f"lane-{index}").strip()
+        agent = str(payload.get("agent") or "codex").strip().lower()
+        mode = str(payload.get("mode") or "implementation").strip().lower()
+        goal = str(payload.get("goal") or payload.get("title") or "").strip()
+        if not goal:
+            raise ValueError(f"lane {lane_id!r} must define goal")
+        if mode == PANEL_MODE:
+            agent = PANEL_MODE
+        elif agent not in ALLOWED_AGENTS:
+            raise ValueError(f"lane {lane_id!r} has unsupported agent {agent!r}")
+        prompt = str(payload.get("prompt") or "").strip()
+        prompt_file = str(payload.get("prompt_file") or payload.get("file") or "").strip()
+        if not prompt and not prompt_file:
+            raise ValueError(f"lane {lane_id!r} must define prompt or prompt_file")
+        return cls(
+            lane_id=lane_id,
+            agent=agent,
+            goal=goal,
+            prompt=prompt,
+            prompt_file=prompt_file,
+            source=str(payload.get("source") or "").strip(),
+            mode=mode,
+            cwd=str(payload.get("cwd") or ".").strip(),
+            autonomous=bool(payload.get("autonomous", True)),
+            status=str(payload.get("status") or "active").strip(),
+            next_action=str(payload.get("next_action") or "").strip(),
+            agents_spec=str(payload.get("agents_spec") or "heterogeneous").strip(),
+            context_file=str(payload.get("context_file") or "").strip(),
+            round_id=str(payload.get("round_id") or "").strip(),
+        )
+
+    @property
+    def mutates(self) -> bool:
+        return self.mode in MUTATING_LANE_MODES
+
+    @property
+    def is_review(self) -> bool:
+        return self.mode in REVIEW_MODES
+
+
+@dataclass(frozen=True)
+class MissionLimits:
+    queue_cap: int = DEFAULT_QUEUE_CAP
+    max_implementation_lanes: int = DEFAULT_MAX_IMPLEMENTATION_LANES
+    max_review_lanes: int = DEFAULT_MAX_REVIEW_LANES
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "MissionLimits":
+        return cls(
+            queue_cap=int(payload.get("queue_cap", DEFAULT_QUEUE_CAP)),
+            max_implementation_lanes=int(
+                payload.get("max_implementation_lanes", DEFAULT_MAX_IMPLEMENTATION_LANES)
+            ),
+            max_review_lanes=int(payload.get("max_review_lanes", DEFAULT_MAX_REVIEW_LANES)),
+        )
+
+
+@dataclass(frozen=True)
+class Mission:
+    name: str
+    lanes: list[LaneSpec]
+    objective: str = ""
+    stop_condition: str = ""
+    base_branch: str = "main"
+    output_dir: Path = DEFAULT_OUTPUT_DIR
+    limits: MissionLimits = field(default_factory=MissionLimits)
+    checkpoints: list[str] = field(default_factory=list)
+    external_references: list[str] = field(default_factory=list)
+    stop_conditions: list[str] = field(default_factory=list)
+    allowed_mutations: list[str] = field(default_factory=list)
+    collect_merge_packets: bool = True
+    max_merge_packets: int = 5
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "Mission":
+        lanes_payload = payload.get("lanes")
+        if not isinstance(lanes_payload, list) or not lanes_payload:
+            raise ValueError("mission must define at least one lane")
+        raw_limits = payload.get("limits") or {}
+        if not isinstance(raw_limits, dict):
+            raise ValueError("mission limits must be a mapping")
+        name = str(payload.get("name") or "goal-mode").strip()
+        return cls(
+            name=name,
+            objective=str(payload.get("objective") or "").strip(),
+            stop_condition=str(payload.get("stop_condition") or "").strip(),
+            lanes=[
+                LaneSpec.from_dict(lane, index=i + 1)
+                for i, lane in enumerate(lanes_payload)
+                if isinstance(lane, dict)
+            ],
+            base_branch=str(payload.get("base_branch") or "main").strip(),
+            output_dir=Path(str(payload.get("output_dir") or DEFAULT_OUTPUT_DIR)),
+            limits=MissionLimits.from_dict(raw_limits),
+            checkpoints=_as_str_list(payload.get("checkpoints")),
+            external_references=_as_str_list(payload.get("external_references")),
+            stop_conditions=_as_str_list(payload.get("stop_conditions")),
+            allowed_mutations=_as_str_list(payload.get("allowed_mutations")),
+            collect_merge_packets=bool(payload.get("collect_merge_packets", True)),
+            max_merge_packets=int(payload.get("max_merge_packets", 5)),
+        )
+
+
+@dataclass
+class CommandResult:
+    args: list[str]
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+    timed_out: bool = False
+
+    def json(self) -> Any:
+        return json.loads(self.stdout or "null")
+
+
+class CommandRunner:
+    def __init__(self, repo_root: Path):
+        self.repo_root = repo_root
+
+    def run(self, args: list[str], *, timeout: int = 60) -> CommandResult:
+        try:
+            proc = subprocess.run(
+                args,
+                cwd=self.repo_root,
+                text=True,
+                capture_output=True,
+                timeout=timeout,
+                check=False,
+            )
+            return CommandResult(
+                args=args,
+                returncode=proc.returncode,
+                stdout=proc.stdout,
+                stderr=proc.stderr,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return CommandResult(
+                args=args,
+                returncode=124,
+                stdout=exc.stdout if isinstance(exc.stdout, str) else "",
+                stderr=exc.stderr if isinstance(exc.stderr, str) else "",
+                timed_out=True,
+            )
+
+
+def _path_summary(path: Path) -> dict[str, Any]:
+    """Return stable local state for a file/directory without opening it."""
+    if not path.exists():
+        return {"exists": False}
+    stat = path.stat()
+    return {
+        "exists": True,
+        "path": str(path),
+        "is_dir": path.is_dir(),
+        "size_bytes": stat.st_size,
+        "mtime": datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
+    }
+
+
+def discover_loop_surfaces(repo_root: Path) -> dict[str, Any]:
+    """Detect repo-native long-running loop surfaces used by goal mode.
+
+    This deliberately avoids starting, stopping, or querying privileged launchd
+    state. The conductor only needs enough local truth to route work: boss loop
+    for queued implementation, Ralph for campaign-style incident repair, nomic
+    loop for experimental self-improvement, and bridge/dialog scripts for
+    explicit full-agent coordination.
+    """
+    paths = {
+        "agent_bridge": repo_root / "scripts/agent_bridge.py",
+        "tmux_launcher": repo_root / "scripts/tmux_session_launcher.sh",
+        "multi_agent_dialog": repo_root / "scripts/multi_agent_dialog.py",
+        "boss_loop": repo_root / "aragora/swarm/boss_loop.py",
+        "boss_metrics": repo_root / ".aragora/overnight/boss_metrics.jsonl",
+        "boss_launchd_log": repo_root / ".aragora/overnight/boss-loop-launchd.log",
+        "ralph_supervisor": repo_root / "aragora/ralph/supervisor.py",
+        "ralph_cli": repo_root / "aragora/cli/commands/ralph.py",
+        "nomic_loop": repo_root / "scripts/nomic_loop.py",
+        "nomic_orchestrator": repo_root / "aragora/nomic/autonomous_orchestrator.py",
+        "review_merge_packet": repo_root / "aragora/cli/commands/review_queue.py",
+    }
+    return {name: _path_summary(path) for name, path in paths.items()}
+
+
+@dataclass
+class ConductorEvent:
+    timestamp: str
+    phase: str
+    message: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+
+@dataclass
+class LaneDecision:
+    lane_id: str
+    action: str
+    reason: str
+    commands: list[list[str]] = field(default_factory=list)
+
+
+@dataclass
+class ConductorResult:
+    mission_name: str
+    execute: bool
+    snapshot: dict[str, Any]
+    decisions: list[LaneDecision]
+    hard_gates: list[str]
+    jsonl_path: Path
+    markdown_path: Path
+
+
+class GoalConductor:
+    def __init__(
+        self,
+        *,
+        mission: Mission,
+        repo_root: Path,
+        execute: bool = False,
+        runner: CommandRunner | None = None,
+    ):
+        self.mission = mission
+        self.repo_root = repo_root.resolve()
+        self.execute = execute
+        self.runner = runner or CommandRunner(self.repo_root)
+        self.events: list[ConductorEvent] = []
+
+    def emit(self, phase: str, message: str, **data: Any) -> None:
+        self.events.append(
+            ConductorEvent(timestamp=_utc_now(), phase=phase, message=message, data=data)
+        )
+
+    def _run_json(self, args: list[str], *, timeout: int = 60) -> tuple[Any, CommandResult]:
+        result = self.runner.run(args, timeout=timeout)
+        if result.returncode != 0:
+            return None, result
+        try:
+            return result.json(), result
+        except json.JSONDecodeError:
+            return None, result
+
+    def snapshot(self) -> dict[str, Any]:
+        root_status = self.runner.run(["git", "status", "--short", "--branch"]).stdout.strip()
+        head = self.runner.run(["git", "rev-parse", "--short", "HEAD"]).stdout.strip()
+        origin_main = self.runner.run(
+            ["git", "rev-parse", "--short", f"refs/remotes/origin/{self.mission.base_branch}"]
+        ).stdout.strip()
+        prs, pr_result = self._run_json(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--limit",
+                "100",
+                "--json",
+                "number,title,isDraft,headRefName,mergeStateStatus,reviewDecision,url",
+            ],
+            timeout=60,
+        )
+        if not isinstance(prs, list):
+            prs = []
+        merge_packets: Any = []
+        if self.mission.collect_merge_packets:
+            packet_targets = [
+                int(pr["number"])
+                for pr in prs
+                if isinstance(pr, dict) and pr.get("number") and not bool(pr.get("isDraft"))
+            ][: self.mission.max_merge_packets]
+            if packet_targets:
+                packet_args = [
+                    "python3",
+                    "-m",
+                    "aragora.cli.main",
+                    "review-queue",
+                    "merge-packet",
+                    "--json",
+                ]
+                for number in packet_targets:
+                    packet_args.extend(["--pr", str(number)])
+                merge_packets, _ = self._run_json(packet_args, timeout=120)
+        publisher, _ = self._run_json(["python3", "scripts/publisher_freshness_check.py", "--json"])
+        bridge, _ = self._run_json(
+            [
+                "python3",
+                "scripts/agent_bridge.py",
+                "--json",
+                "operator-snapshot",
+                "--summary-only",
+            ],
+            timeout=30,
+        )
+        proof_health, _ = self._run_json(
+            [
+                "python3",
+                "-m",
+                "aragora.cli.main",
+                "review-queue",
+                "health",
+                "--json",
+            ],
+            timeout=60,
+        )
+        dirty_lines = [line for line in root_status.splitlines()[1:] if line.strip()]
+        snapshot = {
+            "generated_at": _utc_now(),
+            "repo_root": str(self.repo_root),
+            "root": {
+                "status": root_status,
+                "head": head,
+                "origin_base": origin_main,
+                "dirty_file_count": len(dirty_lines),
+            },
+            "open_prs": prs,
+            "open_pr_count": len(prs),
+            "open_non_draft_count": sum(1 for pr in prs if not bool(pr.get("isDraft"))),
+            "merge_packets": merge_packets,
+            "publisher": publisher,
+            "agent_bridge": bridge,
+            "loop_surfaces": discover_loop_surfaces(self.repo_root),
+            "proof_loop_health": proof_health,
+            "pr_query_returncode": pr_result.returncode,
+        }
+        self.emit("snapshot", "captured live state", open_pr_count=len(prs), dirty=len(dirty_lines))
+        return snapshot
+
+    def hard_gates(self, snapshot: dict[str, Any]) -> list[str]:
+        gates: list[str] = []
+        if snapshot["root"]["dirty_file_count"]:
+            gates.append("root checkout is dirty")
+        if snapshot["open_pr_count"] >= self.mission.limits.queue_cap:
+            gates.append(
+                f"open PR queue at/above cap ({snapshot['open_pr_count']}/{self.mission.limits.queue_cap})"
+            )
+        if snapshot.get("publisher") and snapshot["publisher"].get("verdict") not in {
+            None,
+            "ready",
+        }:
+            gates.append(f"publisher not ready: {snapshot['publisher'].get('summary', 'unknown')}")
+        return gates
+
+    def _prompt_file_for(self, lane: LaneSpec, run_dir: Path) -> Path:
+        if lane.prompt_file:
+            path = Path(lane.prompt_file)
+            return path if path.is_absolute() else self.repo_root / path
+        prompt_dir = run_dir / "prompts"
+        prompt_dir.mkdir(parents=True, exist_ok=True)
+        path = prompt_dir / f"{_slug(lane.lane_id)}.md"
+        path.write_text(lane.prompt + "\n", encoding="utf-8")
+        return path
+
+    def _known_sessions(self) -> set[str]:
+        data, _ = self._run_json(["python3", "scripts/agent_bridge.py", "--json", "sessions"])
+        if not isinstance(data, list):
+            return set()
+        return {str(item.get("name", "")) for item in data if isinstance(item, dict)}
+
+    def _agent_commands(self, lane: LaneSpec, run_dir: Path, sessions: set[str]) -> list[list[str]]:
+        prompt_file = self._prompt_file_for(lane, run_dir)
+        cwd_path = Path(lane.cwd)
+        cwd = str(cwd_path if cwd_path.is_absolute() else self.repo_root / cwd_path)
+        commands: list[list[str]] = []
+        if lane.lane_id not in sessions:
+            launch = [
+                "python3",
+                "scripts/agent_bridge.py",
+                "launch",
+                "--name",
+                lane.lane_id,
+                "--agent",
+                lane.agent,
+                "--cwd",
+                cwd,
+            ]
+            if lane.autonomous:
+                launch.append("--autonomous")
+            commands.append(launch)
+        commands.append(
+            [
+                "python3",
+                "scripts/agent_bridge.py",
+                "send",
+                lane.lane_id,
+                "--file",
+                str(prompt_file),
+                "--lane",
+                lane.lane_id,
+                "--goal",
+                lane.goal,
+                "--source",
+                lane.source,
+                "--status",
+                lane.status,
+                "--next-action",
+                lane.next_action,
+            ]
+        )
+        return commands
+
+    def _panel_commands(self, lane: LaneSpec, run_dir: Path) -> list[list[str]]:
+        prompt_file = self._prompt_file_for(lane, run_dir)
+        round_id = lane.round_id or _slug(lane.lane_id)
+        output_dir = run_dir / "panels" / _slug(lane.lane_id)
+        command = [
+            "python3",
+            "scripts/multi_agent_dialog.py",
+            "--round-id",
+            round_id,
+            "--prompt-file",
+            str(prompt_file),
+            "--agents-spec",
+            lane.agents_spec,
+            "--output-dir",
+            str(output_dir),
+        ]
+        if lane.context_file:
+            command.extend(["--context-file", lane.context_file])
+        return [command]
+
+    def plan_lanes(self, snapshot: dict[str, Any], run_dir: Path) -> list[LaneDecision]:
+        sessions = self._known_sessions()
+        implementation_used = 0
+        review_used = 0
+        at_cap = snapshot["open_pr_count"] >= self.mission.limits.queue_cap
+        decisions: list[LaneDecision] = []
+        for lane in self.mission.lanes:
+            if lane.mutates and at_cap:
+                decisions.append(
+                    LaneDecision(
+                        lane_id=lane.lane_id,
+                        action="blocked",
+                        reason="queue cap reached; mutating implementation lanes are disabled",
+                    )
+                )
+                continue
+            if lane.mutates:
+                if implementation_used >= self.mission.limits.max_implementation_lanes:
+                    decisions.append(
+                        LaneDecision(
+                            lane_id=lane.lane_id,
+                            action="blocked",
+                            reason="max implementation lanes already assigned",
+                        )
+                    )
+                    continue
+                implementation_used += 1
+            elif lane.is_review:
+                if review_used >= self.mission.limits.max_review_lanes:
+                    decisions.append(
+                        LaneDecision(
+                            lane_id=lane.lane_id,
+                            action="blocked",
+                            reason="max review lanes already assigned",
+                        )
+                    )
+                    continue
+                review_used += 1
+            commands = (
+                self._panel_commands(lane, run_dir)
+                if lane.mode == PANEL_MODE
+                else self._agent_commands(lane, run_dir, sessions)
+            )
+            decisions.append(
+                LaneDecision(
+                    lane_id=lane.lane_id,
+                    action="execute" if self.execute else "dry_run",
+                    reason="lane accepted by queue and concurrency gates",
+                    commands=commands,
+                )
+            )
+        return decisions
+
+    def apply_decisions(self, decisions: list[LaneDecision]) -> None:
+        for decision in decisions:
+            self.emit(
+                "decision",
+                f"{decision.lane_id}: {decision.action}",
+                reason=decision.reason,
+                commands=decision.commands,
+            )
+            if decision.action != "execute":
+                continue
+            for command in decision.commands:
+                result = self.runner.run(command, timeout=180)
+                self.emit(
+                    "command",
+                    "executed command",
+                    args=command,
+                    returncode=result.returncode,
+                    timed_out=result.timed_out,
+                    stdout_tail=result.stdout[-2000:],
+                    stderr_tail=result.stderr[-2000:],
+                )
+                if result.returncode != 0:
+                    break
+
+    def run_once(self) -> ConductorResult:
+        run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        run_dir = self.repo_root / self.mission.output_dir / _slug(self.mission.name) / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        self.emit(
+            "start", "goal conductor run started", mission=self.mission.name, execute=self.execute
+        )
+        snapshot = self.snapshot()
+        gates = self.hard_gates(snapshot)
+        for gate in gates:
+            self.emit("hard_gate", gate)
+        if self.execute and "root checkout is dirty" in gates:
+            decisions = [
+                LaneDecision(
+                    lane_id=lane.lane_id,
+                    action="blocked",
+                    reason="fatal hard gate: root checkout is dirty",
+                )
+                for lane in self.mission.lanes
+            ]
+        else:
+            decisions = self.plan_lanes(snapshot, run_dir)
+        self.apply_decisions(decisions)
+        jsonl_path = run_dir / "conductor.jsonl"
+        markdown_path = run_dir / "handoff.md"
+        result = ConductorResult(
+            mission_name=self.mission.name,
+            execute=self.execute,
+            snapshot=snapshot,
+            decisions=decisions,
+            hard_gates=gates,
+            jsonl_path=jsonl_path,
+            markdown_path=markdown_path,
+        )
+        self._write_outputs(result)
+        return result
+
+    def run_loop(
+        self,
+        *,
+        max_cycles: int,
+        interval_seconds: float,
+        stop_on_hard_gate: bool = True,
+    ) -> list[ConductorResult]:
+        """Run repeated goal cycles with explicit finite bounds."""
+        results: list[ConductorResult] = []
+        for cycle in range(1, max_cycles + 1):
+            self.emit("loop", "starting cycle", cycle=cycle, max_cycles=max_cycles)
+            result = self.run_once()
+            results.append(result)
+            if result.hard_gates and stop_on_hard_gate:
+                self.emit(
+                    "loop", "stopping on hard gate", cycle=cycle, hard_gates=result.hard_gates
+                )
+                break
+            if cycle < max_cycles and interval_seconds > 0:
+                time.sleep(interval_seconds)
+        return results
+
+    def _write_outputs(self, result: ConductorResult) -> None:
+        result.jsonl_path.write_text(
+            "\n".join(event.to_json() for event in self.events) + "\n",
+            encoding="utf-8",
+        )
+        lines = [
+            f"# Goal conductor handoff — {result.mission_name}",
+            "",
+            f"- Generated: {_utc_now()}",
+            f"- Mode: {'execute' if result.execute else 'dry-run'}",
+            f"- Open PRs: {result.snapshot['open_pr_count']}/{self.mission.limits.queue_cap}",
+            f"- Root dirty files: {result.snapshot['root']['dirty_file_count']}",
+        ]
+        if self.mission.objective:
+            lines.append(f"- Objective: {self.mission.objective}")
+        if self.mission.stop_condition:
+            lines.append(f"- Stop condition: {self.mission.stop_condition}")
+        if self.mission.checkpoints:
+            lines.extend(["", "## Checkpoints", ""])
+            lines.extend(f"- {checkpoint}" for checkpoint in self.mission.checkpoints)
+        if self.mission.external_references:
+            lines.extend(["", "## External References", ""])
+            lines.extend(f"- {reference}" for reference in self.mission.external_references)
+        lines.extend(["", "## Hard gates", ""])
+        if result.hard_gates:
+            lines.extend(f"- {gate}" for gate in result.hard_gates)
+        else:
+            lines.append("- None")
+        lines.extend(["", "## Lane decisions", ""])
+        for decision in result.decisions:
+            lines.append(f"- `{decision.lane_id}`: {decision.action} — {decision.reason}")
+            for command in decision.commands:
+                lines.append(f"  - `{' '.join(command)}`")
+        lines.extend(["", "## Open PRs", ""])
+        for pr in result.snapshot.get("open_prs", []):
+            title = str(pr.get("title", ""))
+            lines.append(
+                f"- #{pr.get('number')} draft={pr.get('isDraft')} "
+                f"state={pr.get('mergeStateStatus')} — {title}"
+            )
+        result.markdown_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def load_mission(path: Path) -> Mission:
+    return Mission.from_dict(load_yaml(path))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "snapshot", "run-once", "loop"))
+    parser.add_argument("--mission", type=Path, required=True, help="Mission YAML file")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually launch/send agents. Default is dry-run.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable output")
+    parser.add_argument(
+        "--max-cycles",
+        type=int,
+        default=3,
+        help="Maximum cycles for loop mode.",
+    )
+    parser.add_argument(
+        "--interval-seconds",
+        type=float,
+        default=300.0,
+        help="Sleep between loop cycles.",
+    )
+    parser.add_argument(
+        "--continue-on-hard-gate",
+        action="store_true",
+        help="Do not stop loop mode when a hard gate is detected.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    mission = load_mission(args.mission)
+    conductor = GoalConductor(mission=mission, repo_root=args.repo_root, execute=args.execute)
+    if args.command == "validate":
+        payload = {
+            "ok": True,
+            "mission": mission.name,
+            "objective": mission.objective,
+            "stop_condition": mission.stop_condition,
+            "checkpoints": mission.checkpoints,
+            "external_references": mission.external_references,
+            "lanes": [asdict(lane) for lane in mission.lanes],
+            "limits": asdict(mission.limits),
+            "collect_merge_packets": mission.collect_merge_packets,
+            "max_merge_packets": mission.max_merge_packets,
+        }
+        print(json.dumps(payload, indent=2) if args.json else f"mission ok: {mission.name}")
+        return 0
+    if args.command == "snapshot":
+        snapshot = conductor.snapshot()
+        print(json.dumps(snapshot, indent=2) if args.json else json.dumps(snapshot, indent=2))
+        return 0
+    if args.command == "loop":
+        results = conductor.run_loop(
+            max_cycles=args.max_cycles,
+            interval_seconds=args.interval_seconds,
+            stop_on_hard_gate=not args.continue_on_hard_gate,
+        )
+        payload = {
+            "mission": mission.name,
+            "execute": args.execute,
+            "cycles": len(results),
+            "results": [
+                {
+                    "open_pr_count": result.snapshot["open_pr_count"],
+                    "hard_gates": result.hard_gates,
+                    "decisions": [asdict(decision) for decision in result.decisions],
+                    "jsonl_path": str(result.jsonl_path),
+                    "markdown_path": str(result.markdown_path),
+                }
+                for result in results
+            ],
+        }
+        print(json.dumps(payload, indent=2) if args.json else f"cycles: {len(results)}")
+        return 0
+    result = conductor.run_once()
+    payload = {
+        "mission": result.mission_name,
+        "execute": result.execute,
+        "open_pr_count": result.snapshot["open_pr_count"],
+        "hard_gates": result.hard_gates,
+        "decisions": [asdict(decision) for decision in result.decisions],
+        "jsonl_path": str(result.jsonl_path),
+        "markdown_path": str(result.markdown_path),
+    }
+    print(json.dumps(payload, indent=2) if args.json else f"handoff: {result.markdown_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/goal_conductor.py
+++ b/scripts/goal_conductor.py
@@ -306,6 +306,19 @@ class ConductorResult:
     markdown_path: Path
 
 
+def _merge_packet_entries(packet: Any) -> list[dict[str, Any]]:
+    if isinstance(packet, dict):
+        entries = packet.get("entries")
+        if isinstance(entries, list):
+            return [entry for entry in entries if isinstance(entry, dict)]
+        packets = packet.get("packets")
+        if isinstance(packets, list):
+            return [entry for entry in packets if isinstance(entry, dict)]
+    if isinstance(packet, list):
+        return [entry for entry in packet if isinstance(entry, dict)]
+    return []
+
+
 class GoalConductor:
     def __init__(
         self,
@@ -434,6 +447,12 @@ class GoalConductor:
             "ready",
         }:
             gates.append(f"publisher not ready: {snapshot['publisher'].get('summary', 'unknown')}")
+        for entry in _merge_packet_entries(snapshot.get("merge_packets")):
+            tier = int(entry.get("tier") or 0)
+            if tier >= 4 or bool(entry.get("requires_human_risk_settlement")):
+                pr_number = entry.get("pr_number", "?")
+                tier_name = entry.get("tier_name") or f"tier_{tier}"
+                gates.append(f"human/non-author settlement gate present: #{pr_number} {tier_name}")
         return gates
 
     def _prompt_file_for(self, lane: LaneSpec, run_dir: Path) -> Path:
@@ -602,12 +621,12 @@ class GoalConductor:
         gates = self.hard_gates(snapshot)
         for gate in gates:
             self.emit("hard_gate", gate)
-        if self.execute and "root checkout is dirty" in gates:
+        if self.execute and gates:
             decisions = [
                 LaneDecision(
                     lane_id=lane.lane_id,
                     action="blocked",
-                    reason="fatal hard gate: root checkout is dirty",
+                    reason=f"fatal hard gate: {'; '.join(gates)}",
                 )
                 for lane in self.mission.lanes
             ]

--- a/scripts/self_develop.py
+++ b/scripts/self_develop.py
@@ -247,6 +247,25 @@ def run_heuristic_decomposition(goal: str) -> TaskDecomposition:
     return decomposer.analyze(goal)
 
 
+def write_conductor_mission_from_decomposition(
+    *,
+    goal: str,
+    decomposition: TaskDecomposition,
+    output_path: str,
+) -> Path:
+    """Write a goal-conductor mission YAML from a self-develop decomposition."""
+    from aragora.nomic.mission_bridge import decomposition_to_mission, write_mission_yaml
+
+    mission = decomposition_to_mission(
+        decomposition,
+        objective=goal,
+        stop_condition=(
+            "Stop when every lane reaches a draft PR, a precise blocker report, or a handoff."
+        ),
+    )
+    return write_mission_yaml(mission, output_path)
+
+
 async def run_pipeline_execution(
     goal: str,
     use_debate: bool = False,
@@ -609,6 +628,9 @@ Examples:
   # Preview with debate decomposition (slower, abstract goals)
   %(prog)s --goal "Maximize utility for SME businesses" --dry-run --debate
 
+  # Convert a goal decomposition into a conductor mission without executing
+  %(prog)s --goal "Publish H1-01 rev-4 benchmark result" --to-mission /tmp/mission.yaml
+
   # Run with human approval at each checkpoint
   %(prog)s --goal "Improve test coverage" --require-approval
 
@@ -671,6 +693,10 @@ Examples:
         "--dry-run",
         action="store_true",
         help="Show goal decomposition without executing",
+    )
+    parser.add_argument(
+        "--to-mission",
+        help="Write a goal-conductor mission YAML file from the decomposition, without executing.",
     )
     parser.add_argument(
         "--debate",
@@ -955,6 +981,31 @@ Examples:
         except (ImportError, RuntimeError, ValueError) as e:
             print(f"\nDaemon failed: {e}")
             return 1
+
+    if args.to_mission:
+        if args.goal is None:
+            parser.error("--goal is required when --to-mission is used")
+        use_debate = args.debate
+        if use_debate:
+            try:
+                decomposition = asyncio.run(run_debate_decomposition(args.goal))
+            except RuntimeError as e:
+                if "No API agents available" in str(e):
+                    print(f"[!] Debate mode requires API keys: {e}")
+                    print("[!] Falling back to heuristic decomposition...\n")
+                    decomposition = run_heuristic_decomposition(args.goal)
+                else:
+                    raise
+        else:
+            decomposition = run_heuristic_decomposition(args.goal)
+        path = write_conductor_mission_from_decomposition(
+            goal=args.goal,
+            decomposition=decomposition,
+            output_path=args.to_mission,
+        )
+        print(f"Conductor mission saved to: {path}")
+        print(f"Run: python3 scripts/goal_conductor.py run-once --mission {path} --json")
+        return 0
 
     # Dry run: just show decomposition (unless --self-improve handles its own dry-run)
     if args.dry_run and not args.self_improve:

--- a/tests/cli/test_spec_command.py
+++ b/tests/cli/test_spec_command.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import yaml
 
 from aragora.agents.errors import AgentCircuitOpenError
 from aragora.cli.commands.spec import _run_spec_pipeline, cmd_spec
@@ -126,6 +127,8 @@ class TestSpecParser:
                 "json",
                 "--output",
                 "spec.json",
+                "--to-mission",
+                "mission.yaml",
                 "--dry-run",
             ]
         )
@@ -138,6 +141,7 @@ class TestSpecParser:
         assert args.skip_interrogation is True
         assert args.format == "json"
         assert args.output == "spec.json"
+        assert args.to_mission == "mission.yaml"
         assert args.dry_run is True
         assert args.func.__name__ == "cmd_spec"
 
@@ -279,6 +283,52 @@ class TestCmdSpec:
             use_orchestrator=False,
         )
         assert json.loads(output_path.read_text()) == result
+
+    def test_cmd_spec_writes_conductor_mission_without_dispatch(self, tmp_path, capsys):
+        mission_path = tmp_path / "mission.yaml"
+        result = {
+            "intent": {"intent_type": "benchmark", "scope_estimate": "medium"},
+            "specification": {
+                "title": "Publish H1-01 rev-4 benchmark result",
+                "problem_statement": "The benchmark result needs to become a public artifact.",
+                "proposed_solution": (
+                    "Run the existing benchmark publication path and write the result."
+                ),
+                "success_criteria": [{"description": "Mission dry-run handoff exists."}],
+                "confidence": 0.8,
+            },
+            "research": None,
+            "timing": {},
+        }
+        args = argparse.Namespace(
+            prompt="publish H1-01 rev-4 benchmark result",
+            depth="quick",
+            profile="founder",
+            skip_research=False,
+            skip_interrogation=False,
+            format="text",
+            dry_run=False,
+            output=None,
+            orchestrator=False,
+            to_mission=str(mission_path),
+        )
+
+        with patch(
+            "aragora.cli.commands.spec._run_spec_pipeline",
+            new_callable=AsyncMock,
+            return_value=result,
+        ):
+            cmd_spec(args)
+
+        out = capsys.readouterr().out
+        mission = yaml.safe_load(mission_path.read_text())
+
+        assert "Conductor mission saved to:" in out
+        assert "goal_conductor.py run-once" in out
+        assert mission["objective"] == "publish H1-01 rev-4 benchmark result"
+        impl_lanes = [lane for lane in mission["lanes"] if lane["mode"] == "implementation"]
+        assert len(impl_lanes) <= 2
+        assert mission["lanes"][-1]["mode"] == "panel"
 
     def test_cmd_spec_writes_text_output_when_requested(self, tmp_path, capsys):
         output_path = tmp_path / "spec.txt"

--- a/tests/nomic/test_mission_bridge.py
+++ b/tests/nomic/test_mission_bridge.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+from aragora.nomic.mission_bridge import decomposition_to_mission, write_mission_yaml
+from aragora.nomic.task_decomposer import SubTask, TaskDecomposition
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+def _load_goal_conductor_module():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        import goal_conductor
+
+        return goal_conductor
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+def _decomposition() -> TaskDecomposition:
+    return TaskDecomposition(
+        original_task="publish H1-01 rev-4 benchmark result",
+        complexity_score=6,
+        complexity_level="medium",
+        should_decompose=True,
+        subtasks=[
+            SubTask(
+                id="bench",
+                title="Run the benchmark harness",
+                description="Run the existing benchmark publication scripts.",
+                file_scope=["scripts/build_benchmark_truth_artifact.py"],
+                success_criteria={"artifact": "generated"},
+            ),
+            SubTask(
+                id="docs",
+                title="Write the public result",
+                description="Publish the benchmark result as a status artifact.",
+                file_scope=["docs/status/B0_BENCHMARK_TRUTH_STATUS.md"],
+            ),
+            SubTask(
+                id="extra",
+                title="Extra lane should be capped",
+                description="This should not become an implementation lane.",
+            ),
+        ],
+    )
+
+
+def test_decomposition_to_mission_is_goal_conductor_compatible() -> None:
+    mod = _load_goal_conductor_module()
+
+    mission = decomposition_to_mission(
+        _decomposition(),
+        objective="publish H1-01 rev-4 benchmark result",
+    )
+
+    parsed = mod.Mission.from_dict(mission)
+    assert parsed.name == "publish-h1-01-rev-4-benchmark-result"
+    assert parsed.limits.queue_cap == 6
+    assert [lane.mode for lane in parsed.lanes] == ["implementation", "implementation", "panel"]
+    assert [lane.agent for lane in parsed.lanes[:2]] == ["codex", "claude"]
+    assert parsed.lanes[2].agents_spec == "heterogeneous"
+
+
+def test_decomposition_to_mission_can_omit_panel_review() -> None:
+    mission = decomposition_to_mission(
+        _decomposition(),
+        objective="publish H1-01 rev-4 benchmark result",
+        include_panel_review=False,
+    )
+
+    assert len(mission["lanes"]) == 2
+    assert all(lane["mode"] == "implementation" for lane in mission["lanes"])
+
+
+def test_write_mission_yaml_round_trips(tmp_path: Path) -> None:
+    mod = _load_goal_conductor_module()
+    mission = decomposition_to_mission(
+        _decomposition(),
+        objective="publish H1-01 rev-4 benchmark result",
+    )
+    path = write_mission_yaml(mission, tmp_path / "mission.yaml")
+
+    loaded = yaml.safe_load(path.read_text())
+    parsed = mod.Mission.from_dict(loaded)
+    assert parsed.objective == "publish H1-01 rev-4 benchmark result"

--- a/tests/scripts/test_goal_conductor.py
+++ b/tests/scripts/test_goal_conductor.py
@@ -1,0 +1,280 @@
+"""Tests for scripts/goal_conductor.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+class FakeRunner:
+    def __init__(self, mod, *, open_prs: list[dict] | None = None, dirty: bool = False):
+        self.mod = mod
+        self.open_prs = open_prs or []
+        self.dirty = dirty
+        self.calls: list[list[str]] = []
+        self.executed: list[list[str]] = []
+
+    def run(self, args: list[str], *, timeout: int = 60):
+        self.calls.append(args)
+        command = " ".join(args)
+        if args[:3] == ["git", "status", "--short"]:
+            status = "## main...origin/main\n"
+            if self.dirty:
+                status += " M scripts/example.py\n"
+            return self.mod.CommandResult(args=args, returncode=0, stdout=status)
+        if args[:3] == ["git", "rev-parse", "--short"]:
+            return self.mod.CommandResult(args=args, returncode=0, stdout="abcdef1\n")
+        if args[:3] == ["gh", "pr", "list"]:
+            return self.mod.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(self.open_prs),
+            )
+        if "review-queue merge-packet --json" in command:
+            return self.mod.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=json.dumps({"packets": []}),
+            )
+        if "publisher_freshness_check.py" in command:
+            return self.mod.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=json.dumps({"verdict": "ready", "summary": "ready"}),
+            )
+        if "agent_bridge.py --json operator-snapshot" in command:
+            return self.mod.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=json.dumps({"sessions": 0, "lanes": 0}),
+            )
+        if "agent_bridge.py --json sessions" in command:
+            return self.mod.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=json.dumps([{"name": "existing-lane"}]),
+            )
+        if "review-queue health --json" in command:
+            return self.mod.CommandResult(
+                args=args,
+                returncode=0,
+                stdout=json.dumps({"overall_status": "fresh"}),
+            )
+        self.executed.append(args)
+        return self.mod.CommandResult(args=args, returncode=0, stdout="")
+
+
+def _mission_dict(tmp_path: Path) -> dict:
+    return {
+        "name": "proof-loop-goal",
+        "objective": "Advance the proof-loop operating baseline.",
+        "stop_condition": "Stop at queue cap or Tier 4 settlement.",
+        "checkpoints": ["snapshot", "assign bounded lanes", "write handoff"],
+        "external_references": [
+            "https://developers.openai.com/codex/use-cases/follow-goals",
+            "https://github.com/Dicklesworthstone/mcp_agent_mail",
+        ],
+        "output_dir": str(tmp_path / "goal-output"),
+        "limits": {
+            "queue_cap": 2,
+            "max_implementation_lanes": 1,
+            "max_review_lanes": 1,
+        },
+        "collect_merge_packets": True,
+        "max_merge_packets": 5,
+        "lanes": [
+            {
+                "id": "impl",
+                "agent": "codex",
+                "mode": "implementation",
+                "goal": "Make one bounded code change.",
+                "prompt": "Implement only the assigned file.",
+            },
+            {
+                "id": "panel",
+                "mode": "panel",
+                "goal": "Review the current gate.",
+                "prompt": "Adversarially review the merge gate.",
+                "agents_spec": "heterogeneous",
+            },
+        ],
+    }
+
+
+def test_load_mission_preserves_follow_goal_fields(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    mission_path = tmp_path / "mission.yaml"
+    mission_path.write_text(
+        """
+name: proof-loop-goal
+objective: Advance proof-loop reliability.
+stop_condition: Stop at hard gates.
+checkpoints:
+  - Snapshot live truth
+  - Assign lanes
+external_references:
+  - https://developers.openai.com/codex/use-cases/follow-goals
+limits:
+  queue_cap: 3
+lanes:
+  - id: impl
+    agent: codex
+    goal: Patch one bounded file.
+    prompt: Patch it.
+""",
+        encoding="utf-8",
+    )
+
+    mission = mod.load_mission(mission_path)
+
+    assert mission.name == "proof-loop-goal"
+    assert mission.objective == "Advance proof-loop reliability."
+    assert mission.stop_condition == "Stop at hard gates."
+    assert mission.checkpoints == ["Snapshot live truth", "Assign lanes"]
+    assert mission.external_references == [
+        "https://developers.openai.com/codex/use-cases/follow-goals"
+    ]
+    assert mission.limits.queue_cap == 3
+    assert mission.lanes[0].lane_id == "impl"
+
+
+def test_run_once_blocks_mutating_lane_at_queue_cap_but_allows_panel(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    mission = mod.Mission.from_dict(_mission_dict(tmp_path))
+    open_prs = [
+        {"number": 1, "title": "ready", "isDraft": False, "mergeStateStatus": "CLEAN"},
+        {"number": 2, "title": "draft", "isDraft": True, "mergeStateStatus": "BLOCKED"},
+    ]
+    runner = FakeRunner(mod, open_prs=open_prs)
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=False,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    assert result.hard_gates == ["open PR queue at/above cap (2/2)"]
+    assert result.snapshot["merge_packets"] == {"packets": []}
+    assert any("merge-packet" in " ".join(call) for call in runner.calls)
+    assert [decision.action for decision in result.decisions] == ["blocked", "dry_run"]
+    assert "queue cap reached" in result.decisions[0].reason
+    assert result.decisions[1].commands[0][:2] == ["python3", "scripts/multi_agent_dialog.py"]
+    assert result.jsonl_path.exists()
+    assert result.markdown_path.exists()
+    assert "Initial" not in result.markdown_path.read_text(encoding="utf-8")
+    assert (
+        "Objective: Advance the proof-loop operating baseline."
+        in result.markdown_path.read_text(encoding="utf-8")
+    )
+    assert "https://developers.openai.com/codex/use-cases/follow-goals" in (
+        result.markdown_path.read_text(encoding="utf-8")
+    )
+
+
+def test_execute_reuses_existing_agent_lane_and_sends_prompt(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    payload = _mission_dict(tmp_path)
+    payload["limits"]["queue_cap"] = 5
+    payload["lanes"] = [
+        {
+            "id": "existing-lane",
+            "agent": "claude",
+            "mode": "implementation",
+            "goal": "Continue an existing lane.",
+            "prompt": "Continue safely.",
+            "source": "#123",
+            "next_action": "open draft PR",
+        }
+    ]
+    mission = mod.Mission.from_dict(payload)
+    runner = FakeRunner(mod, open_prs=[])
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=True,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    assert result.decisions[0].action == "execute"
+    assert not any("launch" in call for command in runner.executed for call in command)
+    send_commands = [command for command in runner.executed if "send" in command]
+    assert len(send_commands) == 1
+    assert send_commands[0][:3] == ["python3", "scripts/agent_bridge.py", "send"]
+    assert "--lane" in send_commands[0]
+    assert "existing-lane" in send_commands[0]
+
+
+def test_loop_stops_after_first_hard_gate(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    mission = mod.Mission.from_dict(_mission_dict(tmp_path))
+    open_prs = [
+        {"number": 1, "title": "one", "isDraft": False},
+        {"number": 2, "title": "two", "isDraft": True},
+    ]
+    runner = FakeRunner(mod, open_prs=open_prs)
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=False,
+        runner=runner,
+    )
+
+    results = conductor.run_loop(max_cycles=3, interval_seconds=0)
+
+    assert len(results) == 1
+    assert results[0].hard_gates == ["open PR queue at/above cap (2/2)"]
+
+
+def test_execute_blocks_all_lanes_when_root_is_dirty(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    payload = _mission_dict(tmp_path)
+    payload["limits"]["queue_cap"] = 5
+    mission = mod.Mission.from_dict(payload)
+    runner = FakeRunner(mod, open_prs=[], dirty=True)
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=True,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    assert result.hard_gates == ["root checkout is dirty"]
+    assert [decision.action for decision in result.decisions] == ["blocked", "blocked"]
+    assert all("fatal hard gate" in decision.reason for decision in result.decisions)
+    assert runner.executed == []
+
+
+def test_discover_loop_surfaces_reports_existing_tools(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    tool = tmp_path / "scripts/agent_bridge.py"
+    tool.parent.mkdir(parents=True)
+    tool.write_text("# bridge\n", encoding="utf-8")
+
+    surfaces = mod.discover_loop_surfaces(tmp_path)
+
+    assert surfaces["agent_bridge"]["exists"] is True
+    assert surfaces["boss_loop"]["exists"] is False

--- a/tests/scripts/test_goal_conductor.py
+++ b/tests/scripts/test_goal_conductor.py
@@ -26,11 +26,15 @@ class FakeRunner:
         open_prs: list[dict] | None = None,
         dirty: bool = False,
         merge_packet: dict | None = None,
+        pr_query_returncode: int = 0,
+        merge_packet_returncode: int = 0,
     ):
         self.mod = mod
         self.open_prs = open_prs or []
         self.dirty = dirty
         self.merge_packet = merge_packet or {"packets": []}
+        self.pr_query_returncode = pr_query_returncode
+        self.merge_packet_returncode = merge_packet_returncode
         self.calls: list[list[str]] = []
         self.executed: list[list[str]] = []
 
@@ -47,13 +51,13 @@ class FakeRunner:
         if args[:3] == ["gh", "pr", "list"]:
             return self.mod.CommandResult(
                 args=args,
-                returncode=0,
+                returncode=self.pr_query_returncode,
                 stdout=json.dumps(self.open_prs),
             )
         if "review-queue merge-packet --json" in command:
             return self.mod.CommandResult(
                 args=args,
-                returncode=0,
+                returncode=self.merge_packet_returncode,
                 stdout=json.dumps(self.merge_packet),
             )
         if "publisher_freshness_check.py" in command:
@@ -307,6 +311,49 @@ def test_execute_blocks_all_lanes_when_human_settlement_gate_present(tmp_path: P
     ]
     assert [decision.action for decision in result.decisions] == ["blocked", "blocked"]
     assert all("fatal hard gate" in decision.reason for decision in result.decisions)
+    assert runner.executed == []
+
+
+def test_execute_blocks_all_lanes_when_pr_query_fails(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    payload = _mission_dict(tmp_path)
+    payload["limits"]["queue_cap"] = 5
+    mission = mod.Mission.from_dict(payload)
+    runner = FakeRunner(mod, pr_query_returncode=1)
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=True,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    assert "open PR query failed: rc=1" in result.hard_gates
+    assert [decision.action for decision in result.decisions] == ["blocked", "blocked"]
+    assert runner.executed == []
+
+
+def test_execute_blocks_all_lanes_when_merge_packet_fails(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    payload = _mission_dict(tmp_path)
+    payload["limits"]["queue_cap"] = 5
+    mission = mod.Mission.from_dict(payload)
+    open_prs = [{"number": 7156, "title": "needs packet", "isDraft": False}]
+    runner = FakeRunner(mod, open_prs=open_prs, merge_packet_returncode=1)
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=True,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    assert "merge-packet query failed for 7156" in result.hard_gates
+    assert [decision.action for decision in result.decisions] == ["blocked", "blocked"]
     assert runner.executed == []
 
 

--- a/tests/scripts/test_goal_conductor.py
+++ b/tests/scripts/test_goal_conductor.py
@@ -19,10 +19,18 @@ def _setup_path():
 
 
 class FakeRunner:
-    def __init__(self, mod, *, open_prs: list[dict] | None = None, dirty: bool = False):
+    def __init__(
+        self,
+        mod,
+        *,
+        open_prs: list[dict] | None = None,
+        dirty: bool = False,
+        merge_packet: dict | None = None,
+    ):
         self.mod = mod
         self.open_prs = open_prs or []
         self.dirty = dirty
+        self.merge_packet = merge_packet or {"packets": []}
         self.calls: list[list[str]] = []
         self.executed: list[list[str]] = []
 
@@ -46,7 +54,7 @@ class FakeRunner:
             return self.mod.CommandResult(
                 args=args,
                 returncode=0,
-                stdout=json.dumps({"packets": []}),
+                stdout=json.dumps(self.merge_packet),
             )
         if "publisher_freshness_check.py" in command:
             return self.mod.CommandResult(
@@ -262,6 +270,41 @@ def test_execute_blocks_all_lanes_when_root_is_dirty(tmp_path: Path) -> None:
     result = conductor.run_once()
 
     assert result.hard_gates == ["root checkout is dirty"]
+    assert [decision.action for decision in result.decisions] == ["blocked", "blocked"]
+    assert all("fatal hard gate" in decision.reason for decision in result.decisions)
+    assert runner.executed == []
+
+
+def test_execute_blocks_all_lanes_when_human_settlement_gate_present(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    payload = _mission_dict(tmp_path)
+    payload["limits"]["queue_cap"] = 5
+    mission = mod.Mission.from_dict(payload)
+    open_prs = [{"number": 7156, "title": "tier 4 gate", "isDraft": False}]
+    merge_packet = {
+        "entries": [
+            {
+                "pr_number": 7156,
+                "tier": 4,
+                "tier_name": "tier_4_preapproval_required",
+                "requires_human_risk_settlement": True,
+            }
+        ]
+    }
+    runner = FakeRunner(mod, open_prs=open_prs, merge_packet=merge_packet)
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=True,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    assert result.hard_gates == [
+        "human/non-author settlement gate present: #7156 tier_4_preapproval_required"
+    ]
     assert [decision.action for decision in result.decisions] == ["blocked", "blocked"]
     assert all("fatal hard gate" in decision.reason for decision in result.decisions)
     assert runner.executed == []

--- a/tests/scripts/test_self_develop_to_mission.py
+++ b/tests/scripts/test_self_develop_to_mission.py
@@ -1,0 +1,82 @@
+"""Tests for ``scripts/self_develop.py --to-mission``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from aragora.nomic.task_decomposer import SubTask, TaskDecomposition
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+def _decomposition(goal: str) -> TaskDecomposition:
+    return TaskDecomposition(
+        original_task=goal,
+        complexity_score=5,
+        complexity_level="medium",
+        should_decompose=True,
+        subtasks=[
+            SubTask(
+                id="bench",
+                title="Publish benchmark result",
+                description="Run the benchmark publication path.",
+            ),
+            SubTask(
+                id="docs",
+                title="Write public artifact",
+                description="Document the benchmark result.",
+            ),
+        ],
+    )
+
+
+def test_self_develop_to_mission_writes_yaml_without_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import self_develop as mod
+
+    mission_path = tmp_path / "mission.yaml"
+
+    monkeypatch.setattr(mod, "run_heuristic_decomposition", lambda goal: _decomposition(goal))
+
+    async def _fail_run_orchestration(**_kwargs):
+        raise AssertionError("self_develop --to-mission must not execute orchestration")
+
+    monkeypatch.setattr(mod, "run_orchestration", _fail_run_orchestration)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "self_develop.py",
+            "--goal",
+            "publish H1-01 rev-4 benchmark result",
+            "--to-mission",
+            str(mission_path),
+        ],
+    )
+
+    rc = mod.main()
+
+    out = capsys.readouterr().out
+    mission = yaml.safe_load(mission_path.read_text())
+    assert rc == 0
+    assert "Conductor mission saved to:" in out
+    assert mission["objective"] == "publish H1-01 rev-4 benchmark result"
+    assert [lane["mode"] for lane in mission["lanes"]] == [
+        "implementation",
+        "implementation",
+        "panel",
+    ]

--- a/tests/swarm/agent_bridge/test_harnesses_droid.py
+++ b/tests/swarm/agent_bridge/test_harnesses_droid.py
@@ -22,7 +22,7 @@ class FakeRunner:
         return subprocess.CompletedProcess(command, 0, stdout=self.stdout, stderr="")
 
 
-def test_droid_launch_parses_session_id_usage_and_default_auto_low(tmp_path: Path) -> None:
+def test_droid_launch_parses_session_id_usage_and_default_auto_high(tmp_path: Path) -> None:
     fake_runner = FakeRunner(_fixture_text("droid_start.json"))
     transport = DroidTransport(
         cwd=tmp_path,
@@ -40,7 +40,7 @@ def test_droid_launch_parses_session_id_usage_and_default_auto_low(tmp_path: Pat
         "droid",
         "exec",
         "--auto",
-        "low",
+        "high",
         "--output-format",
         "json",
         "--model",
@@ -95,7 +95,7 @@ def test_droid_resume_uses_session_flag(tmp_path: Path) -> None:
         "droid",
         "exec",
         "--auto",
-        "low",
+        "high",
         "--output-format",
         "json",
         "-s",

--- a/tests/swarm/test_multi_agent_dialog.py
+++ b/tests/swarm/test_multi_agent_dialog.py
@@ -57,7 +57,8 @@ def test_agent_spec_codex_flags_include_minimal_reasoning() -> None:
 def test_agent_spec_droid_flags_are_read_search_only() -> None:
     spec = AgentSpec.droid()
     assert "exec" in spec.base_flags
-    assert "--auto" not in spec.base_flags
+    assert "--auto" in spec.base_flags
+    assert spec.base_flags[spec.base_flags.index("--auto") + 1] == "high"
     assert "--disabled-tools" in spec.base_flags
     assert "Execute" in spec.base_flags
     assert DROID_REVIEW_SYSTEM_PROMPT in spec.base_flags
@@ -317,6 +318,8 @@ def test_constants_match_round_30d_verification() -> None:
     assert "--skip-git-repo-check" in CODEX_FLAGS
     assert DROID_FLAGS == (
         "exec",
+        "--auto",
+        "high",
         "--disabled-tools",
         "Execute",
         "--append-system-prompt",


### PR DESCRIPTION
## Summary

Rescopes the goal-mode conductor work to reuse Aragora's existing goal-entry surfaces instead of adding a new `aragora goal` command or `.aragora/goals` bundle tree.

The v1 flow is now:

```bash
aragora spec "publish H1-01 rev-4 benchmark result" --to-mission /tmp/mission.yaml
python3 scripts/goal_conductor.py run-once --mission /tmp/mission.yaml --json
```

## Changes

- Adds `aragora/nomic/mission_bridge.py` with `decomposition_to_mission(...) -> dict`, producing mission dictionaries accepted by `scripts/goal_conductor.py`'s `Mission.from_dict()`.
- Adds `write_mission_yaml(...)` for deterministic mission YAML output.
- Adds `--to-mission PATH` to `aragora spec`, routing the generated spec through `TaskDecomposer` and writing conductor mission YAML without dispatching agents.
- Adds `--to-mission PATH` to `scripts/self_develop.py`, converting its existing decomposition output into the same mission YAML without executing orchestration.
- Keeps `scripts/goal_conductor.py` as the execution/conductor surface: `validate`, `snapshot`, `run-once`, and finite `loop` cycles.
- Updates docs/example mission to dogfood the H1-01 rev-4 benchmark publication goal.

## Guardrails

- No new `aragora goal` CLI verb.
- No `.aragora/goals` persistence tree.
- No Agent Mail, web UI, nomic-loop-primary mode, issue closure, launchd install, or `observe-outcomes --write`.
- `--to-mission` writes YAML only; it does not launch agents.

## Validation

- `ruff check aragora/nomic/mission_bridge.py aragora/cli/commands/spec.py aragora/cli/parser.py scripts/self_develop.py tests/nomic/test_mission_bridge.py tests/cli/test_spec_command.py tests/scripts/test_self_develop_to_mission.py tests/scripts/test_goal_conductor.py`
- `ruff format --check aragora/nomic/mission_bridge.py aragora/cli/commands/spec.py aragora/cli/parser.py scripts/self_develop.py tests/nomic/test_mission_bridge.py tests/cli/test_spec_command.py tests/scripts/test_self_develop_to_mission.py tests/scripts/test_goal_conductor.py`
- `mypy aragora/nomic/mission_bridge.py aragora/cli/commands/spec.py`
- `pytest tests/nomic/test_mission_bridge.py tests/cli/test_spec_command.py tests/scripts/test_self_develop_to_mission.py tests/scripts/test_goal_conductor.py -q --noconftest` — 18 passed
- `python3 scripts/self_develop.py --goal "publish H1-01 rev-4 benchmark result" --to-mission /tmp/h1-mission.yaml`
- `python3 scripts/goal_conductor.py validate --mission /tmp/h1-mission.yaml --json`
- `python3 -m aragora.cli.main spec "publish H1-01 rev-4 benchmark result" --dry-run --to-mission /tmp/spec-dryrun-mission.yaml`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
