### PR TITLE
feat(triage): calibration-only multi-model GitHub issue triage with guided founder review

### DIFF
--- a/aragora/triage/__init__.py
+++ b/aragora/triage/__init__.py
@@ -1,30 +1,46 @@
-"""Triage observability package — rolling-window metric computation.
+"""Triage observability and issue-triage utilities.
 
-Implements the measurement substrate for Commitment 5 of the Aragora
-thesis (docs/THESIS.md), which requires the triage layer to emit per
-rolling window:
+This package historically holds the measurement substrate for
+Commitment 5 of the Aragora thesis (rolling-window triage metrics and
+auto-handle calibration). It now also hosts a calibration-only
+multi-model GitHub issue triage library used by
+``scripts/triage_issues_via_debate.py`` to evaluate the repository's
+own issue backlog with a heterogeneous frontier panel.
 
-  - escalation rate
-  - auto-handle override rate
-  - human-override-outcome correlation
-  - time-per-settlement
+Two distinct subsystems live here; both are intentionally independent
+modules so neither imports the other implicitly.
 
-The package is split into two layers:
-
-``metrics`` — pure-function aggregation over ``TriageDecisionEvent``
+Observability submodules
+------------------------
+``metrics`` -- pure-function aggregation over ``TriageDecisionEvent``
 sequences. No I/O, no database, no filesystem. Testable with synthetic
 event lists.
 
-``event_source`` — adapter that reads existing brief receipts,
+``event_source`` -- adapter that reads existing brief receipts,
 settlement receipts, and PDB brief index events from disk and yields
 ``TriageDecisionEvent`` instances. Does NOT modify receipt schemas.
 
-The HTTP surface for these metrics lives in
-:mod:`aragora.server.handlers.triage_metrics` (gap #6373).
+``auto_handle_calibration`` -- per-class auto-handle gate decisions
+and drift detection.
+
+Issue-triage submodules (calibration v1)
+----------------------------------------
+``evidence`` -- gather GitHub + repo evidence before any model call.
+
+``receipts`` -- persist per-model and aggregate audit artifacts.
+
+``issue_evaluator`` -- panel construction, prompt assembly, aggregation,
+the main ``evaluate_issue`` entry point.
+
+The HTTP surface for observability metrics lives in
+:mod:`aragora.server.handlers.triage_metrics` (gap #6373). The CLI
+surface for the issue-triage library lives in
+``scripts/triage_issues_via_debate.py``.
 """
 
 from __future__ import annotations
 
+# Observability surface (unchanged, mirrors prior contract).
 from aragora.triage.auto_handle_calibration import (
     AUTO_HANDLE_PATH_ADMIN_MERGE_ALLOWED,
     AUTO_HANDLE_PATH_FIRE_AND_FORGET,
@@ -49,7 +65,39 @@ from aragora.triage.metrics import (
     detect_drift,
 )
 
+# Issue-triage calibration surface (new).
+from aragora.triage.evidence import (
+    IssueEvidence,
+    IssueRecord,
+    gather_evidence,
+    is_automation_generated,
+)
+from aragora.triage.issue_evaluator import (
+    AUTOMATION_VALUE_VALUES,
+    CONFIDENCE_CLASSES,
+    DEFAULT_PANEL,
+    PANEL_PROMPT_RUBRIC,
+    VERDICT_CATEGORIES,
+    AggregateVerdict,
+    FounderRecommendation,
+    PanelMember,
+    PerModelVerdict,
+    aggregate_verdicts,
+    build_panel,
+    build_panel_prompt,
+    estimate_cost_usd,
+    evaluate_issue,
+    parse_model_response,
+)
+from aragora.triage.receipts import (
+    RECEIPT_SCHEMA_VERSION,
+    IssueDebateReceipt,
+    write_jsonl_receipt,
+    write_markdown_report,
+)
+
 __all__ = [
+    # Observability (preserved)
     "AUTO_HANDLE_PATH_ADMIN_MERGE_ALLOWED",
     "AUTO_HANDLE_PATH_FIRE_AND_FORGET",
     "MIN_EVENTS_FOR_METRICS",
@@ -69,4 +117,28 @@ __all__ = [
     "detect_drift",
     "fingerprint_admin_merge_class",
     "fingerprint_low_risk_class",
+    # Issue-triage calibration (new)
+    "AUTOMATION_VALUE_VALUES",
+    "AggregateVerdict",
+    "CONFIDENCE_CLASSES",
+    "DEFAULT_PANEL",
+    "FounderRecommendation",
+    "IssueDebateReceipt",
+    "IssueEvidence",
+    "IssueRecord",
+    "PANEL_PROMPT_RUBRIC",
+    "PanelMember",
+    "PerModelVerdict",
+    "RECEIPT_SCHEMA_VERSION",
+    "VERDICT_CATEGORIES",
+    "aggregate_verdicts",
+    "build_panel",
+    "build_panel_prompt",
+    "estimate_cost_usd",
+    "evaluate_issue",
+    "gather_evidence",
+    "is_automation_generated",
+    "parse_model_response",
+    "write_jsonl_receipt",
+    "write_markdown_report",
 ]

--- a/aragora/triage/evidence.py
+++ b/aragora/triage/evidence.py
@@ -1,0 +1,339 @@
+"""Evidence gathering for issue triage.
+
+Per the calibration-only v1 contract, evidence is collected from GitHub +
+repo state BEFORE any model is invoked. The panel judges against this
+evidence, not just the title.
+
+Evidence includes:
+- Raw issue body, labels, author, created/updated timestamps
+- Referenced file paths and whether they exist in HEAD
+- Related PR/issue numbers found in the body, with their state
+- Duplicate-candidate suggestions (title similarity over open issues)
+
+This module is intentionally side-effect free: it reads from the local
+repo and from the GitHub CLI / a callable injected at test time.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+ISSUE_REF_PATTERN = re.compile(r"#(\d{2,6})\b")
+FILE_PATH_PATTERN = re.compile(
+    r"(?:^|[\s`(])([a-zA-Z0-9_./\\-]+\.(?:py|md|yml|yaml|toml|cfg|sh|ts|tsx|js|jsx|json))(?=[\s`):,.]|$)"
+)
+AUTOMATION_AUTHOR_HINTS = (
+    "[bot]",
+    "an0mium",
+    "boss-loop",
+    "stage-gate",
+    "swarm-",
+    "factory-droid",
+    "codex-automation",
+    "github-actions",
+)
+
+
+@dataclass(frozen=True)
+class IssueRecord:
+    """Minimal projection of a GitHub issue for triage."""
+
+    number: int
+    title: str
+    body: str
+    author: str
+    labels: tuple[str, ...]
+    state: str
+    url: str
+    created_at: str
+    updated_at: str
+    comments_count: int = 0
+    assignees: tuple[str, ...] = ()
+
+
+@dataclass
+class IssueEvidence:
+    """Pre-model evidence assembled for an issue."""
+
+    issue: IssueRecord
+    is_automation_generated: bool
+    referenced_files: list[dict[str, Any]] = field(default_factory=list)
+    referenced_issues: list[dict[str, Any]] = field(default_factory=list)
+    duplicate_candidates: list[dict[str, Any]] = field(default_factory=list)
+    repo_head_sha: str | None = None
+    gathered_at: str = ""
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "issue": {
+                "number": self.issue.number,
+                "title": self.issue.title,
+                "body": self.issue.body,
+                "author": self.issue.author,
+                "labels": list(self.issue.labels),
+                "state": self.issue.state,
+                "url": self.issue.url,
+                "created_at": self.issue.created_at,
+                "updated_at": self.issue.updated_at,
+                "comments_count": self.issue.comments_count,
+                "assignees": list(self.issue.assignees),
+            },
+            "is_automation_generated": self.is_automation_generated,
+            "referenced_files": list(self.referenced_files),
+            "referenced_issues": list(self.referenced_issues),
+            "duplicate_candidates": list(self.duplicate_candidates),
+            "repo_head_sha": self.repo_head_sha,
+            "gathered_at": self.gathered_at,
+            "notes": list(self.notes),
+        }
+
+
+def is_automation_generated(
+    *,
+    author: str,
+    labels: Sequence[str] = (),
+    body: str = "",
+) -> bool:
+    """Heuristic detector for automation-origin issues.
+
+    Authorship is one signal, not the verdict. The triage rubric must still
+    judge substantive value regardless of this flag.
+    """
+    author_lower = author.lower()
+    if any(hint in author_lower for hint in AUTOMATION_AUTHOR_HINTS):
+        return True
+    automation_labels = {"automation", "automated", "stage-gate-drift", "boss-stuck"}
+    if any(label.lower() in automation_labels for label in labels):
+        return True
+    body_lower = body.lower()
+    machine_markers = (
+        "this issue was opened by",
+        "auto-generated",
+        "automation report",
+        "boss-loop dispatched",
+    )
+    return any(marker in body_lower for marker in machine_markers)
+
+
+def extract_file_references(body: str) -> list[str]:
+    """Return file-path-like substrings mentioned in the issue body."""
+    if not body:
+        return []
+    matches = FILE_PATH_PATTERN.findall(body)
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for match in matches:
+        cleaned = match.strip().rstrip(".,)`")
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            ordered.append(cleaned)
+    return ordered
+
+
+def extract_issue_references(body: str, *, exclude: int | None = None) -> list[int]:
+    """Return #NNN issue/PR references in the body, excluding ``exclude``."""
+    if not body:
+        return []
+    refs: list[int] = []
+    seen: set[int] = set()
+    for match in ISSUE_REF_PATTERN.findall(body):
+        try:
+            num = int(match)
+        except ValueError:
+            continue
+        if num == exclude or num in seen:
+            continue
+        seen.add(num)
+        refs.append(num)
+    return refs
+
+
+def _run_gh_json(args: Sequence[str]) -> Any:
+    """Run a `gh` command expecting JSON output. Returns ``None`` on failure."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _check_file_exists(repo_root: Path, path: str) -> bool:
+    """Return True iff a path resolves to an existing file inside ``repo_root``."""
+    try:
+        candidate = (repo_root / path).resolve()
+        repo_resolved = repo_root.resolve()
+        if not str(candidate).startswith(str(repo_resolved)):
+            return False
+        return candidate.is_file()
+    except (OSError, ValueError):
+        return False
+
+
+def gather_evidence(
+    issue: IssueRecord,
+    *,
+    repo: str = "synaptent/aragora",
+    repo_root: Path | None = None,
+    open_issue_index: Sequence[IssueRecord] | None = None,
+    gh_runner: Callable[[Sequence[str]], Any] | None = None,
+    now_iso: str = "",
+) -> IssueEvidence:
+    """Collect pre-model evidence for ``issue``.
+
+    Args:
+        issue: The issue to evaluate.
+        repo: Owner/name slug for ``gh`` lookups.
+        repo_root: Local checkout path. Used to verify file references.
+        open_issue_index: Optional in-memory list of other open issues used
+            to suggest duplicate candidates without hitting the network.
+        gh_runner: Injection seam for tests; defaults to subprocess gh.
+        now_iso: Timestamp for the receipt; tests pass a fixed value.
+
+    Returns:
+        ``IssueEvidence`` populated with everything we know prior to any
+        model invocation. Failures degrade to empty fields plus a note so
+        the audit trail is honest about what was actually checked.
+    """
+    runner = gh_runner or _run_gh_json
+    repo_root = repo_root or Path.cwd()
+    evidence = IssueEvidence(
+        issue=issue,
+        is_automation_generated=is_automation_generated(
+            author=issue.author,
+            labels=issue.labels,
+            body=issue.body,
+        ),
+        gathered_at=now_iso,
+    )
+
+    file_refs = extract_file_references(issue.body)
+    for path in file_refs[:20]:
+        exists = _check_file_exists(repo_root, path)
+        evidence.referenced_files.append({"path": path, "exists_in_head": exists})
+
+    issue_refs = extract_issue_references(issue.body, exclude=issue.number)
+    for ref in issue_refs[:10]:
+        data = runner(
+            [
+                "issue",
+                "view",
+                str(ref),
+                "--repo",
+                repo,
+                "--json",
+                "number,title,state,url,closedAt",
+            ]
+        )
+        if data is None:
+            data = runner(
+                [
+                    "pr",
+                    "view",
+                    str(ref),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,title,state,url,closedAt",
+                ]
+            )
+        if data is None:
+            evidence.referenced_issues.append(
+                {"number": ref, "state": "unknown", "lookup": "failed"}
+            )
+            continue
+        evidence.referenced_issues.append(
+            {
+                "number": data.get("number", ref),
+                "title": data.get("title", ""),
+                "state": data.get("state", "unknown"),
+                "url": data.get("url", ""),
+                "closed_at": data.get("closedAt"),
+            }
+        )
+
+    if open_issue_index:
+        evidence.duplicate_candidates = _shortlist_duplicates(issue, open_issue_index, limit=5)
+
+    head = _read_repo_head(repo_root)
+    if head:
+        evidence.repo_head_sha = head
+
+    if not evidence.referenced_issues and issue_refs:
+        evidence.notes.append("issue references present but gh lookups returned nothing")
+    return evidence
+
+
+def _read_repo_head(repo_root: Path) -> str | None:
+    try:
+        head_file = repo_root / ".git" / "HEAD"
+        if not head_file.exists():
+            return None
+        head_text = head_file.read_text().strip()
+        if head_text.startswith("ref: "):
+            ref_path = repo_root / ".git" / head_text.split(" ", 1)[1].strip()
+            if ref_path.exists():
+                return ref_path.read_text().strip()[:12]
+            return None
+        return head_text[:12]
+    except OSError:
+        return None
+
+
+def _shortlist_duplicates(
+    issue: IssueRecord,
+    candidates: Sequence[IssueRecord],
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Return likely-duplicate issues using title-shingle Jaccard similarity."""
+    target_shingles = _title_shingles(issue.title)
+    if not target_shingles:
+        return []
+    scored: list[tuple[float, IssueRecord]] = []
+    for candidate in candidates:
+        if candidate.number == issue.number:
+            continue
+        candidate_shingles = _title_shingles(candidate.title)
+        if not candidate_shingles:
+            continue
+        intersect = len(target_shingles & candidate_shingles)
+        union = len(target_shingles | candidate_shingles)
+        if union == 0:
+            continue
+        similarity = intersect / union
+        if similarity >= 0.4:
+            scored.append((similarity, candidate))
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [
+        {
+            "number": rec.number,
+            "title": rec.title,
+            "url": rec.url,
+            "similarity": round(score, 3),
+        }
+        for score, rec in scored[:limit]
+    ]
+
+
+def _title_shingles(title: str, *, size: int = 3) -> set[str]:
+    tokens = [token.lower() for token in re.split(r"[^a-zA-Z0-9]+", title) if len(token) >= 2]
+    if len(tokens) < size:
+        return set(tokens)
+    return {" ".join(tokens[i : i + size]) for i in range(len(tokens) - size + 1)}

--- a/aragora/triage/evidence.py
+++ b/aragora/triage/evidence.py
@@ -177,9 +177,12 @@ def _run_gh_json(args: Sequence[str]) -> Any:
 def _check_file_exists(repo_root: Path, path: str) -> bool:
     """Return True iff a path resolves to an existing file inside ``repo_root``."""
     try:
-        candidate = (repo_root / path).resolve()
+        normalized_path = path.replace("\\", "/")
+        candidate = (repo_root / normalized_path).resolve()
         repo_resolved = repo_root.resolve()
-        if not str(candidate).startswith(str(repo_resolved)):
+        try:
+            candidate.relative_to(repo_resolved)
+        except ValueError:
             return False
         return candidate.is_file()
     except (OSError, ValueError):

--- a/aragora/triage/issue_evaluator.py
+++ b/aragora/triage/issue_evaluator.py
@@ -1,0 +1,805 @@
+"""Heterogeneous panel evaluation for an individual issue.
+
+This module is the core of the triage calibration system. It assembles a
+locked prompt rubric, runs the prompt against a panel of frontier agents
+in parallel, parses each model's structured response, aggregates verdicts,
+and returns an audit-ready receipt.
+
+The panel and rubric are intentionally decoupled from the CLI so the
+library can be reused from notebooks or future Arena integrations.
+
+Receipt-equivalence (per Codex's review)
+----------------------------------------
+Even though this bypasses ``aragora.debate.Arena`` for speed, every model
+invocation persists:
+    prompt, model id, raw response, parsed verdict, confidence, cost,
+    latency, dissent.
+That preserves the auditable-heterogeneous-deliberation differentiator
+without paying the full Arena boot cost per issue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Sequence
+
+from aragora.triage.evidence import IssueEvidence
+from aragora.triage.receipts import IssueDebateReceipt
+
+logger = logging.getLogger(__name__)
+
+VERDICT_CATEGORIES: tuple[str, ...] = (
+    "keep",
+    "refine",
+    "consolidate",
+    "close-obsolete",
+    "close-duplicate",
+    "close-malformed",
+    "flag-for-human",
+)
+
+AUTOMATION_VALUE_VALUES: tuple[str, ...] = (
+    "valuable",
+    "neutral",
+    "noise",
+    "n/a",
+)
+
+CONFIDENCE_CLASSES: tuple[str, ...] = (
+    "easy-call",
+    "needs-spot-check",
+    "do-not-act-without-human",
+)
+
+PANEL_PROMPT_RUBRIC = """You are one of three independent frontier models evaluating a single
+GitHub issue for the Aragora repository as part of a calibration audit.
+
+The standard is SUBSTANTIVE VALUE, not authorship. Automation-generated
+issues can be excellent. Human-generated issues can be noise. Judge what
+is actually in front of you.
+
+The founder reading your verdict may NOT already know whether this
+issue is good. Your job is not just to label it -- it is to TEACH the
+founder how you reached the verdict, with concrete evidence anchors and
+clear inspection guidance. A non-expert reviewer should be able to
+trust or challenge your recommendation by reading what you wrote.
+
+Output a strict JSON object with this exact shape (no prose outside the
+JSON, no markdown fences):
+
+{
+  "verdict": "<one of: keep | refine | consolidate | close-obsolete | close-duplicate | close-malformed | flag-for-human>",
+  "confidence": <float 0.0-1.0>,
+  "confidence_class": "<one of: easy-call | needs-spot-check | do-not-act-without-human>",
+  "automation_value": "<one of: valuable | neutral | noise | n/a>",
+  "rationale": "<3-6 sentences citing concrete evidence>",
+  "suggested_action": "<one actionable sentence the founder can do>",
+  "evidence_used": ["<list of specific evidence anchors you relied on: e.g. 'body para 2', 'broken file ref aragora/foo.py', 'dup candidate #6371'>"],
+  "what_to_inspect": "<2-3 sentences naming what the founder should look at to trust or challenge this verdict; cite file paths, issue numbers, or sections of the body>",
+  "safety_note": "<one sentence: why is acting on this verdict SAFE, or what could go wrong if you act on it>",
+  "refined_title": "<optional, only when verdict=refine: a tighter title you would rewrite the issue to>",
+  "refined_body_outline": "<optional, only when verdict=refine: a short bullet outline (3-5 lines) of what the rewritten issue body should cover>",
+  "consolidate_with": <optional, only when verdict in (consolidate, close-duplicate): integer issue number this should merge into>
+}
+
+Verdicts:
+- keep: substantively valuable, leave open as-is.
+- refine: valuable but needs scope tightening, repro steps, or an owner.
+- consolidate: should be merged with a referenced/related issue.
+- close-obsolete: referenced code/feature/file no longer exists in HEAD.
+- close-duplicate: exact duplicate of an existing issue.
+- close-malformed: empty body, template only, no actionable content.
+- flag-for-human: you are uncertain or the panel may legitimately
+  disagree; defer to a human reviewer.
+
+Confidence classes (your self-assessment of how risky it is to act on
+your verdict without further human review):
+- easy-call: evidence is unambiguous; safe to act on without spot-check.
+- needs-spot-check: evidence is mostly clear but a quick human glance
+  is wise before acting.
+- do-not-act-without-human: ambiguity, missing context, or potential
+  for false-positive close; require explicit human review.
+
+Automation value (orthogonal to verdict):
+- valuable: automation produced something worth keeping or refining.
+  This is an EXPLICIT POSITIVE outcome -- automation authorship is not
+  a strike against the issue.
+- neutral: automation contribution neither strengthens nor weakens.
+- noise: automation produced low-signal output that wastes attention.
+- n/a: issue is not automation-generated.
+
+You MUST ground your verdict in the evidence block below:
+- If referenced files are broken in HEAD, weight `close-obsolete` more.
+- If duplicate candidates exist above similarity 0.55, weight
+  `close-duplicate` or `consolidate`; cite the candidate number in
+  `consolidate_with`.
+- If the body is empty or template-only, weight `close-malformed`.
+- If the issue describes a real-but-undefined problem, lean `refine`
+  and provide a `refined_title` + `refined_body_outline`.
+- If you cannot decide between two verdicts without more information,
+  use `flag-for-human` with `do-not-act-without-human`.
+
+Return ONLY the JSON object. No prose, no fences, no preamble."""
+
+
+@dataclass(frozen=True)
+class PanelMember:
+    """One participant in the triage panel."""
+
+    agent_type: str
+    model_id: str
+    estimated_input_cost_per_1k: float
+    estimated_output_cost_per_1k: float
+    role: str = "critic"
+    nickname: str | None = None
+
+
+DEFAULT_PANEL: tuple[PanelMember, ...] = (
+    PanelMember(
+        agent_type="anthropic-api",
+        model_id="claude-opus-4-7",
+        estimated_input_cost_per_1k=0.015,
+        estimated_output_cost_per_1k=0.075,
+        nickname="opus",
+    ),
+    PanelMember(
+        agent_type="openai-api",
+        model_id="gpt-4.1",
+        estimated_input_cost_per_1k=0.005,
+        estimated_output_cost_per_1k=0.020,
+        nickname="gpt",
+    ),
+    PanelMember(
+        agent_type="gemini",
+        model_id="gemini-3.1-pro-preview",
+        estimated_input_cost_per_1k=0.003,
+        estimated_output_cost_per_1k=0.012,
+        nickname="gemini",
+    ),
+)
+
+
+@dataclass
+class PerModelVerdict:
+    """Parsed verdict for a single model invocation."""
+
+    panel_member: PanelMember
+    verdict: str
+    confidence: float
+    automation_value: str
+    rationale: str
+    suggested_action: str
+    evidence_used: list[str]
+    raw_response: str
+    prompt_chars: int
+    response_chars: int
+    cost_usd: float
+    latency_seconds: float
+    confidence_class: str = "needs-spot-check"
+    what_to_inspect: str = ""
+    safety_note: str = ""
+    refined_title: str = ""
+    refined_body_outline: str = ""
+    consolidate_with: int | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_id": self.panel_member.model_id,
+            "agent_type": self.panel_member.agent_type,
+            "verdict": self.verdict,
+            "confidence": self.confidence,
+            "confidence_class": self.confidence_class,
+            "automation_value": self.automation_value,
+            "rationale": self.rationale,
+            "suggested_action": self.suggested_action,
+            "evidence_used": list(self.evidence_used),
+            "what_to_inspect": self.what_to_inspect,
+            "safety_note": self.safety_note,
+            "refined_title": self.refined_title,
+            "refined_body_outline": self.refined_body_outline,
+            "consolidate_with": self.consolidate_with,
+            "raw_response": self.raw_response,
+            "prompt_chars": self.prompt_chars,
+            "response_chars": self.response_chars,
+            "cost_usd": round(self.cost_usd, 6),
+            "latency_seconds": round(self.latency_seconds, 3),
+            "error": self.error,
+        }
+
+
+@dataclass
+class FounderRecommendation:
+    """Founder-facing recommendation distilled from the panel."""
+
+    action: str
+    safety: str
+    inspect: str
+    refined_title: str = ""
+    refined_body_outline: str = ""
+    consolidate_with: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "safety": self.safety,
+            "inspect": self.inspect,
+            "refined_title": self.refined_title,
+            "refined_body_outline": self.refined_body_outline,
+            "consolidate_with": self.consolidate_with,
+        }
+
+
+@dataclass
+class AggregateVerdict:
+    """Aggregated panel verdict + dissent metadata."""
+
+    verdict: str
+    confidence: float
+    consensus: str
+    rationale: str
+    automation_value: str
+    suggested_action: str
+    confidence_class: str = "needs-spot-check"
+    recommendation: FounderRecommendation | None = None
+    notes: list[str] = field(default_factory=list)
+
+
+def build_panel(
+    agent_types: Sequence[str] | None = None,
+    *,
+    base: Sequence[PanelMember] = DEFAULT_PANEL,
+) -> list[PanelMember]:
+    """Return a panel filtered to the requested agent types (default = all)."""
+    if not agent_types:
+        return list(base)
+    requested = {at.strip() for at in agent_types if at.strip()}
+    panel = [member for member in base if member.agent_type in requested]
+    missing = requested - {m.agent_type for m in panel}
+    if missing:
+        raise ValueError(
+            f"Unknown agent types for triage panel: {sorted(missing)}. "
+            f"Allowed: {sorted({m.agent_type for m in base})}"
+        )
+    if len(panel) < 2:
+        raise ValueError(
+            f"Triage panel requires at least 2 heterogeneous models; got {len(panel)}."
+        )
+    return panel
+
+
+def build_panel_prompt(evidence: IssueEvidence) -> str:
+    """Assemble the locked rubric + evidence block prompt sent to each model."""
+    issue = evidence.issue
+    file_lines = (
+        "\n".join(
+            f"  - {ref['path']} (exists_in_head={ref['exists_in_head']})"
+            for ref in evidence.referenced_files
+        )
+        or "  - (none detected)"
+    )
+    related_lines = (
+        "\n".join(
+            f"  - #{ref['number']} state={ref.get('state', '?')} title={ref.get('title', '')[:80]}"
+            for ref in evidence.referenced_issues
+        )
+        or "  - (none resolved)"
+    )
+    dup_lines = (
+        "\n".join(
+            f"  - #{cand['number']} similarity={cand['similarity']} "
+            f"title={cand.get('title', '')[:80]}"
+            for cand in evidence.duplicate_candidates
+        )
+        or "  - (none above threshold)"
+    )
+    body_excerpt = (issue.body or "").strip()
+    if len(body_excerpt) > 4000:
+        body_excerpt = body_excerpt[:4000] + "\n[... truncated ...]"
+
+    labels_joined = ", ".join(issue.labels) or "(none)"
+    head_label = evidence.repo_head_sha or "?"
+    if evidence.notes:
+        newline = "\n- "
+        notes_block = "- " + newline.join(evidence.notes)
+    else:
+        notes_block = "(none)"
+
+    evidence_block = f"""ISSUE
+- number: #{issue.number}
+- title: {issue.title}
+- author: {issue.author} (automation_origin={evidence.is_automation_generated})
+- labels: {labels_joined}
+- state: {issue.state}
+- created_at: {issue.created_at}
+- updated_at: {issue.updated_at}
+- url: {issue.url}
+
+BODY
+{body_excerpt or "(empty)"}
+
+REFERENCED FILES (resolved against HEAD {head_label})
+{file_lines}
+
+REFERENCED ISSUES / PRS
+{related_lines}
+
+DUPLICATE CANDIDATES (title-shingle Jaccard, threshold 0.40)
+{dup_lines}
+
+NOTES
+{notes_block}"""
+
+    return f"{PANEL_PROMPT_RUBRIC}\n\nEVIDENCE BLOCK:\n{evidence_block}\n"
+
+
+_JSON_FENCE_PATTERN = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+def parse_model_response(raw: str) -> dict[str, Any]:
+    """Best-effort parse of a model's JSON triage response.
+
+    Returns a normalized dict with the rubric fields. Raises ValueError
+    if the response cannot be coerced into the expected shape.
+    """
+    if not raw or not raw.strip():
+        raise ValueError("empty response")
+    candidate = raw.strip()
+    fence_match = _JSON_FENCE_PATTERN.search(candidate)
+    if fence_match:
+        candidate = fence_match.group(1)
+    else:
+        start = candidate.find("{")
+        end = candidate.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            candidate = candidate[start : end + 1]
+
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"unparseable JSON response: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("response is not a JSON object")
+
+    verdict = str(parsed.get("verdict", "")).strip()
+    if verdict not in VERDICT_CATEGORIES:
+        raise ValueError(f"verdict '{verdict}' not in {VERDICT_CATEGORIES}")
+    try:
+        confidence = float(parsed.get("confidence", 0.0))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"non-numeric confidence: {parsed.get('confidence')!r}") from exc
+    confidence = max(0.0, min(1.0, confidence))
+
+    automation_value = str(parsed.get("automation_value", "n/a")).strip()
+    if automation_value not in AUTOMATION_VALUE_VALUES:
+        automation_value = "n/a"
+
+    rationale = str(parsed.get("rationale", "")).strip()
+    suggested = str(parsed.get("suggested_action", "")).strip()
+    evidence_used_raw = parsed.get("evidence_used", []) or []
+    if isinstance(evidence_used_raw, str):
+        evidence_used = [evidence_used_raw]
+    else:
+        evidence_used = [str(item) for item in evidence_used_raw][:20]
+
+    confidence_class = str(parsed.get("confidence_class", "")).strip()
+    if confidence_class not in CONFIDENCE_CLASSES:
+        confidence_class = _infer_confidence_class(confidence)
+
+    what_to_inspect = str(parsed.get("what_to_inspect", "")).strip()
+    safety_note = str(parsed.get("safety_note", "")).strip()
+    refined_title = str(parsed.get("refined_title", "")).strip()
+    refined_body_outline = str(parsed.get("refined_body_outline", "")).strip()
+    consolidate_with_raw = parsed.get("consolidate_with")
+    consolidate_with: int | None = None
+    if consolidate_with_raw is not None:
+        try:
+            consolidate_with = int(consolidate_with_raw)
+        except (TypeError, ValueError):
+            consolidate_with = None
+
+    return {
+        "verdict": verdict,
+        "confidence": confidence,
+        "confidence_class": confidence_class,
+        "automation_value": automation_value,
+        "rationale": rationale,
+        "suggested_action": suggested,
+        "evidence_used": evidence_used,
+        "what_to_inspect": what_to_inspect,
+        "safety_note": safety_note,
+        "refined_title": refined_title,
+        "refined_body_outline": refined_body_outline,
+        "consolidate_with": consolidate_with,
+    }
+
+
+def _infer_confidence_class(confidence: float) -> str:
+    """Fallback confidence_class derivation when a model omits the field."""
+    if confidence >= 0.8:
+        return "easy-call"
+    if confidence >= 0.6:
+        return "needs-spot-check"
+    return "do-not-act-without-human"
+
+
+def aggregate_verdicts(
+    per_model: Sequence[PerModelVerdict],
+) -> AggregateVerdict:
+    """Combine per-model verdicts into a single panel verdict with dissent.
+
+    Aggregation rules:
+    - Drop verdicts that errored.
+    - If all valid verdicts agree on the category -> consensus = unanimous.
+    - If a strict majority agrees -> consensus = majority.
+    - Otherwise consensus = split; pick the highest-confidence verdict
+      and surface dissent in the rationale; flag for human if all
+      verdicts disagree and average confidence < 0.55.
+    - Automation value is taken from the majority; ties default to
+      ``neutral`` when at least one valid verdict, ``n/a`` otherwise.
+    """
+    valid = [pm for pm in per_model if pm.error is None]
+    if not valid:
+        errors = "; ".join(f"{pm.panel_member.model_id}:{pm.error}" for pm in per_model)
+        return AggregateVerdict(
+            verdict="flag-for-human",
+            confidence=0.0,
+            consensus="unclear",
+            rationale=f"All panel members failed: {errors}",
+            automation_value="n/a",
+            suggested_action="Re-run triage when models are reachable.",
+            confidence_class="do-not-act-without-human",
+            recommendation=FounderRecommendation(
+                action="Do not act. Re-run after restoring panel reachability.",
+                safety="UNSAFE to act: no model returned a parseable verdict.",
+                inspect="Inspect run logs and provider auth state before re-running.",
+            ),
+        )
+
+    verdict_counts = Counter(pm.verdict for pm in valid)
+    top_verdict, top_count = verdict_counts.most_common(1)[0]
+    distinct = len(verdict_counts)
+    total = len(valid)
+
+    if distinct == 1:
+        consensus = "unanimous"
+    elif top_count > total / 2:
+        consensus = "majority"
+    else:
+        consensus = "split"
+
+    if consensus == "split":
+        valid_sorted = sorted(valid, key=lambda pm: pm.confidence, reverse=True)
+        chosen = valid_sorted[0]
+        avg_conf = sum(pm.confidence for pm in valid) / total
+        if avg_conf < 0.55:
+            verdict = "flag-for-human"
+            rationale = (
+                f"Panel split ({dict(verdict_counts)}) with low average confidence "
+                f"({avg_conf:.2f}); deferring to human reviewer."
+            )
+        else:
+            verdict = chosen.verdict
+            rationale = (
+                f"Panel split ({dict(verdict_counts)}); highest-confidence verdict "
+                f"({chosen.panel_member.model_id} at {chosen.confidence:.2f}) selected: "
+                f"{chosen.rationale}"
+            )
+        suggested = chosen.suggested_action
+    else:
+        winners = [pm for pm in valid if pm.verdict == top_verdict]
+        verdict = top_verdict
+        avg_conf = sum(pm.confidence for pm in winners) / len(winners)
+        rationale_segments = [
+            f"{pm.panel_member.model_id} ({pm.confidence:.2f}): {pm.rationale}" for pm in winners
+        ]
+        rationale = " | ".join(rationale_segments)
+        suggested = winners[0].suggested_action
+
+    automation_counts = Counter(pm.automation_value for pm in valid)
+    automation_top, _automation_count = automation_counts.most_common(1)[0]
+    if (
+        len(automation_counts) > 1
+        and automation_counts.most_common(2)[0][1] == automation_counts.most_common(2)[1][1]
+    ):
+        automation_top = "neutral" if any(pm.automation_value != "n/a" for pm in valid) else "n/a"
+
+    confidence = sum(pm.confidence for pm in valid) / total
+    confidence_class = _aggregate_confidence_class(consensus, confidence, valid)
+    recommendation = _build_recommendation(
+        verdict=verdict,
+        confidence_class=confidence_class,
+        consensus=consensus,
+        valid=valid,
+        verdict_counts=verdict_counts,
+        suggested=suggested,
+    )
+
+    return AggregateVerdict(
+        verdict=verdict,
+        confidence=round(confidence, 3),
+        consensus=consensus,
+        rationale=rationale,
+        automation_value=automation_top,
+        suggested_action=suggested,
+        confidence_class=confidence_class,
+        recommendation=recommendation,
+        notes=[f"verdict_counts={dict(verdict_counts)}"],
+    )
+
+
+def _aggregate_confidence_class(
+    consensus: str,
+    avg_confidence: float,
+    valid: Sequence[PerModelVerdict],
+) -> str:
+    """Derive a single confidence class from per-model classes + consensus.
+
+    Rules (deliberately conservative -- when in doubt, escalate):
+    - any model said `do-not-act-without-human` -> do-not-act-without-human
+    - consensus split -> do-not-act-without-human (panel disagrees)
+    - unanimous + avg conf >= 0.8 + every model said easy-call -> easy-call
+    - majority + avg conf >= 0.7 + no dissenter said do-not-act -> needs-spot-check
+    - otherwise -> needs-spot-check
+    """
+    per_model_classes = [pm.confidence_class for pm in valid]
+    if "do-not-act-without-human" in per_model_classes:
+        return "do-not-act-without-human"
+    if consensus == "split":
+        return "do-not-act-without-human"
+    if (
+        consensus == "unanimous"
+        and avg_confidence >= 0.8
+        and all(cls == "easy-call" for cls in per_model_classes)
+    ):
+        return "easy-call"
+    return "needs-spot-check"
+
+
+def _build_recommendation(
+    *,
+    verdict: str,
+    confidence_class: str,
+    consensus: str,
+    valid: Sequence[PerModelVerdict],
+    verdict_counts: Counter[str],
+    suggested: str,
+) -> FounderRecommendation:
+    """Distill a single founder-facing recommendation from the panel."""
+    inspect_pieces: list[str] = []
+    safety_pieces: list[str] = []
+    refined_title = ""
+    refined_body_outline = ""
+    consolidate_with: int | None = None
+
+    for pm in valid:
+        if pm.verdict != verdict:
+            continue
+        if pm.what_to_inspect:
+            inspect_pieces.append(f"[{pm.panel_member.model_id}] {pm.what_to_inspect}")
+        if pm.safety_note:
+            safety_pieces.append(f"[{pm.panel_member.model_id}] {pm.safety_note}")
+        if not refined_title and pm.refined_title:
+            refined_title = pm.refined_title
+        if not refined_body_outline and pm.refined_body_outline:
+            refined_body_outline = pm.refined_body_outline
+        if consolidate_with is None and pm.consolidate_with is not None:
+            consolidate_with = pm.consolidate_with
+
+    if not inspect_pieces:
+        inspect_pieces.append(
+            "Read the issue body, then check whether the referenced code still exists."
+        )
+    if not safety_pieces:
+        if confidence_class == "easy-call":
+            safety_pieces.append("Panel unanimous and high-confidence; action is reversible.")
+        elif confidence_class == "needs-spot-check":
+            safety_pieces.append("Panel mostly aligned but a quick human glance is wise.")
+        else:
+            safety_pieces.append(
+                "Panel disagrees or confidence is low; DO NOT act without human review."
+            )
+
+    action_descriptions = {
+        "keep": "Leave the issue open as-is.",
+        "refine": "Rewrite the issue with the suggested title and outline; keep it open.",
+        "consolidate": "Merge into the suggested target issue and close this one.",
+        "close-obsolete": "Close: referenced code/feature no longer exists in HEAD.",
+        "close-duplicate": "Close: duplicate of the cited target issue.",
+        "close-malformed": "Close: no actionable content.",
+        "flag-for-human": "Do not act automatically. Triage manually.",
+    }
+    action = action_descriptions.get(verdict, suggested or "Manual review.")
+
+    if confidence_class == "do-not-act-without-human":
+        action = f"DO NOT ACT WITHOUT HUMAN REVIEW. Tentative verdict: {verdict}. {action}"
+
+    return FounderRecommendation(
+        action=action,
+        safety=" ".join(safety_pieces),
+        inspect=" ".join(inspect_pieces),
+        refined_title=refined_title,
+        refined_body_outline=refined_body_outline,
+        consolidate_with=consolidate_with,
+    )
+
+
+def estimate_cost_usd(
+    *,
+    panel: Sequence[PanelMember],
+    issue_count: int,
+    avg_prompt_chars: int = 4500,
+    avg_response_chars: int = 1500,
+) -> dict[str, Any]:
+    """Project total cost for a triage run before any model is called.
+
+    Token estimate uses the 4-chars-per-token heuristic. Returns a dict
+    with per-model and total projections suitable for printing as a
+    pre-run summary.
+    """
+    prompt_tokens = max(1, avg_prompt_chars // 4)
+    response_tokens = max(1, avg_response_chars // 4)
+    per_call: dict[str, dict[str, float]] = {}
+    total_cost = 0.0
+    for member in panel:
+        input_cost = prompt_tokens / 1000 * member.estimated_input_cost_per_1k
+        output_cost = response_tokens / 1000 * member.estimated_output_cost_per_1k
+        per_call_cost = input_cost + output_cost
+        total_for_member = per_call_cost * issue_count
+        per_call[member.model_id] = {
+            "per_issue_usd": round(per_call_cost, 5),
+            "issues": issue_count,
+            "subtotal_usd": round(total_for_member, 4),
+        }
+        total_cost += total_for_member
+    return {
+        "panel": [m.model_id for m in panel],
+        "issues": issue_count,
+        "avg_prompt_chars": avg_prompt_chars,
+        "avg_response_chars": avg_response_chars,
+        "per_model": per_call,
+        "total_usd": round(total_cost, 4),
+    }
+
+
+def _estimate_per_call_cost(
+    member: PanelMember,
+    *,
+    prompt_chars: int,
+    response_chars: int,
+) -> float:
+    prompt_tokens = max(1, prompt_chars // 4)
+    response_tokens = max(1, response_chars // 4)
+    return (
+        prompt_tokens / 1000 * member.estimated_input_cost_per_1k
+        + response_tokens / 1000 * member.estimated_output_cost_per_1k
+    )
+
+
+AgentGenerator = Callable[[PanelMember, str], Awaitable[str]]
+
+
+async def evaluate_issue(
+    evidence: IssueEvidence,
+    *,
+    panel: Sequence[PanelMember] = DEFAULT_PANEL,
+    generator: AgentGenerator,
+    timeout_seconds: float = 60.0,
+    now_iso: str | None = None,
+) -> IssueDebateReceipt:
+    """Run the panel against a single issue and return an audit receipt.
+
+    Args:
+        evidence: Pre-model evidence assembled by
+            :func:`aragora.triage.evidence.gather_evidence`.
+        panel: Heterogeneous panel members.
+        generator: Async callable ``(member, prompt) -> raw_response``.
+            Production wires this to ``aragora.agents.create_agent(...).generate``.
+            Tests inject a deterministic stub.
+        timeout_seconds: Per-model deadline.
+        now_iso: Timestamp override for deterministic receipts in tests.
+
+    Returns:
+        ``IssueDebateReceipt`` with per-model rows and the aggregated verdict.
+    """
+    started = now_iso or datetime.now(timezone.utc).isoformat()
+    started_monotonic = time.monotonic()
+    prompt = build_panel_prompt(evidence)
+
+    async def _call_member(member: PanelMember) -> PerModelVerdict:
+        member_start = time.monotonic()
+        raw = ""
+        error: str | None = None
+        try:
+            raw = await asyncio.wait_for(generator(member, prompt), timeout=timeout_seconds)
+        except asyncio.TimeoutError:
+            error = "timeout"
+        except (RuntimeError, ValueError, ConnectionError, OSError) as exc:
+            error = f"{type(exc).__name__}: {exc}"
+        latency = time.monotonic() - member_start
+        parsed: dict[str, Any] = {
+            "verdict": "flag-for-human",
+            "confidence": 0.0,
+            "confidence_class": "do-not-act-without-human",
+            "automation_value": "n/a",
+            "rationale": "",
+            "suggested_action": "",
+            "evidence_used": [],
+            "what_to_inspect": "",
+            "safety_note": "",
+            "refined_title": "",
+            "refined_body_outline": "",
+            "consolidate_with": None,
+        }
+        if error is None:
+            try:
+                parsed = parse_model_response(raw)
+            except ValueError as exc:
+                error = f"parse_error: {exc}"
+        cost = _estimate_per_call_cost(
+            member,
+            prompt_chars=len(prompt),
+            response_chars=len(raw),
+        )
+        return PerModelVerdict(
+            panel_member=member,
+            verdict=parsed["verdict"],
+            confidence=parsed["confidence"],
+            confidence_class=parsed.get("confidence_class", "needs-spot-check"),
+            automation_value=parsed["automation_value"],
+            rationale=parsed["rationale"],
+            suggested_action=parsed["suggested_action"],
+            evidence_used=parsed["evidence_used"],
+            what_to_inspect=parsed.get("what_to_inspect", ""),
+            safety_note=parsed.get("safety_note", ""),
+            refined_title=parsed.get("refined_title", ""),
+            refined_body_outline=parsed.get("refined_body_outline", ""),
+            consolidate_with=parsed.get("consolidate_with"),
+            raw_response=raw,
+            prompt_chars=len(prompt),
+            response_chars=len(raw),
+            cost_usd=cost,
+            latency_seconds=latency,
+            error=error,
+        )
+
+    tasks = [_call_member(member) for member in panel]
+    per_model = await asyncio.gather(*tasks)
+    aggregate = aggregate_verdicts(per_model)
+    finished = datetime.now(timezone.utc).isoformat() if now_iso is None else now_iso
+    total_cost = sum(pm.cost_usd for pm in per_model)
+    recommendation_payload = (
+        aggregate.recommendation.to_dict() if aggregate.recommendation else None
+    )
+    receipt = IssueDebateReceipt(
+        issue_number=evidence.issue.number,
+        issue_title=evidence.issue.title,
+        issue_url=evidence.issue.url,
+        issue_author=evidence.issue.author,
+        is_automation_generated=evidence.is_automation_generated,
+        panel=[member.model_id for member in panel],
+        prompt=prompt,
+        per_model=[pm.to_dict() for pm in per_model],
+        aggregate_verdict=aggregate.verdict,
+        aggregate_confidence=aggregate.confidence,
+        aggregate_consensus=aggregate.consensus,
+        aggregation_rationale=aggregate.rationale,
+        confidence_class=aggregate.confidence_class,
+        recommendation=recommendation_payload,
+        automation_value=aggregate.automation_value,
+        suggested_action=aggregate.suggested_action,
+        evidence=evidence.to_dict(),
+        started_at=started,
+        finished_at=finished,
+        cost_usd=round(total_cost, 6),
+        latency_seconds=round(time.monotonic() - started_monotonic, 3),
+        notes=list(aggregate.notes),
+    )
+    return receipt

--- a/aragora/triage/issue_evaluator.py
+++ b/aragora/triage/issue_evaluator.py
@@ -723,6 +723,8 @@ async def evaluate_issue(
             error = "timeout"
         except (RuntimeError, ValueError, ConnectionError, OSError) as exc:
             error = f"{type(exc).__name__}: {exc}"
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
         latency = time.monotonic() - member_start
         parsed: dict[str, Any] = {
             "verdict": "flag-for-human",

--- a/aragora/triage/receipts.py
+++ b/aragora/triage/receipts.py
@@ -1,0 +1,320 @@
+"""Receipt persistence and founder-facing rendering for issue triage.
+
+Per the calibration contract, every model call writes an auditable receipt
+containing prompt, model id, raw response, parsed verdict, confidence,
+cost, latency, and aggregation rationale. This is the receipt-equivalent
+artifact Codex required when bypassing Arena for speed.
+
+Three outputs per run:
+- ``receipts.jsonl``: one ``IssueDebateReceipt`` per line (audit log).
+- ``report.md``: human-readable cards designed to TEACH the founder how
+  the panel reached each verdict (not just label it).
+- ``summary.json``: run-level summary with verdict + confidence-class
+  distributions.
+
+The markdown renderer is deliberately founder-friendly: each card carries
+an evidence summary, per-model verdicts with rationale and evidence
+anchors, dissent display, and a structured founder-facing recommendation
+(action / safety / what-to-inspect / refined-title-body / consolidate-with).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+RECEIPT_SCHEMA_VERSION = "triage-receipt/1.1"
+
+
+@dataclass
+class IssueDebateReceipt:
+    """Audit artifact for a single multi-model issue evaluation.
+
+    Schema 1.1 adds founder-facing fields (confidence_class +
+    recommendation) and per-model rationale enrichment without breaking
+    1.0 readers: every new field has a default.
+    """
+
+    issue_number: int
+    issue_title: str
+    issue_url: str
+    issue_author: str
+    is_automation_generated: bool
+
+    panel: list[str]
+    prompt: str
+
+    per_model: list[dict[str, Any]]
+    aggregate_verdict: str
+    aggregate_confidence: float
+    aggregate_consensus: str
+    aggregation_rationale: str
+    automation_value: str
+    suggested_action: str
+
+    evidence: dict[str, Any]
+
+    started_at: str
+    finished_at: str
+    cost_usd: float
+    latency_seconds: float
+    confidence_class: str = "needs-spot-check"
+    recommendation: dict[str, Any] | None = None
+    schema_version: str = RECEIPT_SCHEMA_VERSION
+
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_jsonl_line(self) -> str:
+        return json.dumps(self.to_dict(), separators=(",", ":"), sort_keys=True)
+
+
+def write_jsonl_receipt(path: Path, receipt: IssueDebateReceipt) -> Path:
+    """Append a single receipt to ``path`` (atomic per-line append)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(receipt.to_jsonl_line())
+        fh.write("\n")
+    return path
+
+
+HOW_TO_REVIEW_GUIDE = """## How to review this report
+
+Each card below describes one GitHub issue evaluated by a heterogeneous
+panel of frontier models. The goal of this report is to TEACH you how
+the panel reached its verdict so you can trust or challenge it -- not
+to replace your judgement.
+
+Read each card top-to-bottom:
+
+1. **Evidence summary** -- what the panel actually saw (body, labels,
+   referenced files in HEAD, related PRs, duplicate candidates). This
+   is the ground truth the panel was given.
+2. **Per-model verdicts** -- each frontier model's verdict, confidence,
+   and rationale, with the specific evidence anchors it cited. If
+   models disagree, the dissent block explains why.
+3. **Founder-facing recommendation** -- a single structured action
+   distilled from the panel: action, why it is safe (or not), what to
+   inspect to double-check, and any refined title / body / merge
+   target.
+4. **Confidence class** -- the panel's own assessment of how risky it
+   is to act on the verdict without human review:
+   - `easy-call` -- evidence unambiguous, safe to act.
+   - `needs-spot-check` -- act after a quick human glance.
+   - `do-not-act-without-human` -- ambiguity, dissent, or low
+     confidence; require explicit human review.
+
+V1 calibration outputs ARTIFACTS ONLY: no comments, no labels, no
+closures, no automation pauses. Closing remains a founder action.
+
+If a verdict is wrong: open the JSONL receipt for that issue, read the
+raw model responses, and adjust ``PANEL_PROMPT_RUBRIC`` or the evidence
+gathering accordingly. Then re-run that specific issue with
+``--issues <N>``.
+"""
+
+
+def write_markdown_report(
+    path: Path,
+    receipts: Iterable[IssueDebateReceipt],
+    *,
+    summary_header: str | None = None,
+) -> Path:
+    """Render a founder-friendly markdown report.
+
+    Layout:
+    - Optional summary header (e.g. repo + panel + budget line).
+    - Title.
+    - Top-of-report ``how to review`` guide.
+    - Verdict distribution, confidence-class distribution, automation
+      cross-tab.
+    - Per-issue cards grouped by verdict, then ordered so easy-call
+      cases appear before do-not-act-without-human ones inside each
+      group.
+    """
+    receipts_list = list(receipts)
+    grouped: dict[str, list[IssueDebateReceipt]] = {}
+    confidence_breakdown: dict[str, int] = {}
+    automation_breakdown: dict[str, int] = {}
+    for receipt in receipts_list:
+        grouped.setdefault(receipt.aggregate_verdict, []).append(receipt)
+        confidence_breakdown[receipt.confidence_class] = (
+            confidence_breakdown.get(receipt.confidence_class, 0) + 1
+        )
+        automation_breakdown[receipt.automation_value] = (
+            automation_breakdown.get(receipt.automation_value, 0) + 1
+        )
+
+    lines: list[str] = []
+    if summary_header:
+        lines.append(summary_header)
+        lines.append("")
+    lines.append("# Issue Triage Calibration Report")
+    lines.append("")
+    lines.append(f"Total issues evaluated: **{len(receipts_list)}**")
+    lines.append("")
+    lines.append(HOW_TO_REVIEW_GUIDE)
+    lines.append("")
+    lines.append("## Verdict distribution")
+    for verdict in sorted(grouped):
+        lines.append(f"- `{verdict}`: {len(grouped[verdict])}")
+    lines.append("")
+    lines.append("## Confidence-class distribution")
+    for cls in ("easy-call", "needs-spot-check", "do-not-act-without-human"):
+        if cls in confidence_breakdown:
+            lines.append(f"- `{cls}`: {confidence_breakdown[cls]}")
+    lines.append("")
+    lines.append("## Automation-value cross-tab")
+    for value in sorted(automation_breakdown):
+        lines.append(f"- `{value}`: {automation_breakdown[value]}")
+    lines.append("")
+    lines.append(
+        "> `automation_value=valuable` is an EXPLICIT POSITIVE outcome. "
+        "Automation-origin is not a strike against an issue."
+    )
+    lines.append("")
+
+    confidence_rank = {
+        "easy-call": 0,
+        "needs-spot-check": 1,
+        "do-not-act-without-human": 2,
+    }
+    for verdict in sorted(grouped):
+        lines.append(f"## Verdict: `{verdict}`")
+        lines.append("")
+        ordered = sorted(
+            grouped[verdict],
+            key=lambda r: (confidence_rank.get(r.confidence_class, 99), r.issue_number),
+        )
+        for receipt in ordered:
+            lines.append(_render_card(receipt))
+            lines.append("")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _render_card(receipt: IssueDebateReceipt) -> str:
+    """Render a single founder-facing card for an evaluated issue."""
+    auto_tag = (
+        f" [automation-{receipt.automation_value}]" if receipt.is_automation_generated else ""
+    )
+    rec = receipt.recommendation or {}
+
+    body_excerpt = ""
+    issue_section = (receipt.evidence or {}).get("issue") or {}
+    body = (issue_section.get("body") or "").strip()
+    if body:
+        snippet = body.splitlines()
+        joined = " ".join(line.strip() for line in snippet if line.strip())
+        if len(joined) > 320:
+            joined = joined[:320] + "..."
+        body_excerpt = joined
+
+    refs = receipt.evidence.get("referenced_files") or []
+    broken_refs = [r for r in refs if not r.get("exists_in_head")]
+    related = receipt.evidence.get("referenced_issues") or []
+    dups = receipt.evidence.get("duplicate_candidates") or []
+
+    lines: list[str] = [
+        f"### #{receipt.issue_number}: {receipt.issue_title}{auto_tag}",
+        "",
+        f"- URL: {receipt.issue_url}",
+        f"- Author: `{receipt.issue_author}`"
+        + (" (automation-origin)" if receipt.is_automation_generated else ""),
+        f"- Labels: {', '.join((issue_section.get('labels') or [])) or '(none)'}",
+        f"- Confidence class: **`{receipt.confidence_class}`** "
+        f"(panel confidence {receipt.aggregate_confidence:.2f}, "
+        f"consensus `{receipt.aggregate_consensus}`)",
+        "",
+        "**Evidence summary**",
+    ]
+    if body_excerpt:
+        lines.append(f"- Body excerpt: {body_excerpt}")
+    else:
+        lines.append("- Body: (empty)")
+    if refs:
+        lines.append(
+            f"- File references: {len(refs)} mentioned, {len(broken_refs)} missing in HEAD"
+        )
+        for ref in broken_refs[:5]:
+            lines.append(f"  - MISSING in HEAD: `{ref.get('path')}`")
+    if related:
+        lines.append(f"- Related issues/PRs: {len(related)}")
+        for rel in related[:5]:
+            lines.append(
+                f"  - #{rel.get('number')} state=`{rel.get('state', '?')}` "
+                f"title: {(rel.get('title') or '')[:80]}"
+            )
+    if dups:
+        lines.append(f"- Duplicate candidates (Jaccard >= 0.40): {len(dups)}")
+        for dup in dups[:5]:
+            lines.append(
+                f"  - #{dup.get('number')} similarity={dup.get('similarity')} "
+                f"title: {(dup.get('title') or '')[:80]}"
+            )
+
+    lines.append("")
+    lines.append("**Per-model verdicts**")
+    for pm in receipt.per_model:
+        model_id = pm.get("model_id", "?")
+        if pm.get("error"):
+            lines.append(f"- `{model_id}`: ERROR: {pm.get('error')}")
+            continue
+        lines.append(
+            f"- `{model_id}` -> **{pm.get('verdict')}** "
+            f"(conf {pm.get('confidence', 0.0):.2f}, "
+            f"class `{pm.get('confidence_class', '?')}`)"
+        )
+        if pm.get("rationale"):
+            lines.append(f"  - Rationale: {pm['rationale']}")
+        evidence_used = pm.get("evidence_used") or []
+        if evidence_used:
+            lines.append(f"  - Evidence anchors: {', '.join(evidence_used)}")
+        if pm.get("what_to_inspect"):
+            lines.append(f"  - What to inspect: {pm['what_to_inspect']}")
+        if pm.get("safety_note"):
+            lines.append(f"  - Safety: {pm['safety_note']}")
+        if pm.get("refined_title"):
+            lines.append(f"  - Refined title: {pm['refined_title']}")
+        if pm.get("refined_body_outline"):
+            lines.append(f"  - Refined body outline: {pm['refined_body_outline']}")
+        if pm.get("consolidate_with"):
+            lines.append(f"  - Consolidate with: #{pm['consolidate_with']}")
+
+    if receipt.aggregate_consensus in ("split", "unclear"):
+        lines.append("")
+        lines.append("**Dissent**")
+        lines.append(f"- {receipt.aggregation_rationale}")
+
+    lines.append("")
+    lines.append("**Founder-facing recommendation**")
+    action = rec.get("action") or receipt.suggested_action or "(no action provided)"
+    safety = rec.get("safety") or ""
+    inspect = rec.get("inspect") or ""
+    lines.append(f"- **Action:** {action}")
+    if safety:
+        lines.append(f"- **Why safe / not safe:** {safety}")
+    if inspect:
+        lines.append(f"- **What to inspect:** {inspect}")
+    if rec.get("refined_title"):
+        lines.append(f"- **Suggested refined title:** {rec['refined_title']}")
+    if rec.get("refined_body_outline"):
+        lines.append("- **Suggested refined body outline:**")
+        for body_line in str(rec["refined_body_outline"]).splitlines():
+            if body_line.strip():
+                lines.append(f"  - {body_line.strip().lstrip('-').strip()}")
+    if rec.get("consolidate_with"):
+        lines.append(f"- **Consolidate into:** #{rec['consolidate_with']}")
+
+    if receipt.notes:
+        lines.append("")
+        lines.append("**Notes**")
+        for note in receipt.notes:
+            lines.append(f"- {note}")
+    return "\n".join(lines)

--- a/docs/guides/ISSUE_TRIAGE.md
+++ b/docs/guides/ISSUE_TRIAGE.md
@@ -87,7 +87,7 @@ Every panel invocation persists:
   and a rationale that explicitly cites dissenting members in split
   cases.
 
-Schema version: `triage-receipt/1.0`. The receipt schema mirrors
+Schema version: `triage-receipt/1.1`. The receipt schema mirrors
 Aragora debate-receipt surface area so future upgrades to a full
 `Arena.run()` integration are a schema-compatible swap, not a rewrite.
 

--- a/docs/guides/ISSUE_TRIAGE.md
+++ b/docs/guides/ISSUE_TRIAGE.md
@@ -1,0 +1,273 @@
+# Multi-Model Issue Triage (Calibration v1)
+
+This guide covers `scripts/triage_issues_via_debate.py`, the
+calibration-only multi-model triage tool that dogfoods Aragora's
+heterogeneous-panel differentiator on its own GitHub issue backlog.
+
+The report is designed to TEACH the founder how each verdict was
+reached, not to assume the founder already knows whether an issue is
+good. Each card carries: evidence summary, per-model verdicts with
+rationale and evidence anchors, dissent block (when applicable),
+founder-facing recommendation (action / safety / what-to-inspect /
+refined-title-body / consolidate-with), and a confidence class
+(`easy-call` / `needs-spot-check` / `do-not-act-without-human`).
+
+## What this does
+
+1. Fetches open issues from `synaptent/aragora` via `gh`.
+2. Picks a stratified sample (default 30 issues) across label and author
+   buckets so the calibration set isn't dominated by a single source.
+3. Gathers **evidence first**, before any model invocation:
+   - Issue body, labels, author, timestamps
+   - File references in the body, checked against the repo HEAD
+   - Referenced issue / PR numbers with their state
+   - Duplicate candidates by title-shingle Jaccard similarity
+4. Runs a heterogeneous frontier panel (Claude Opus 4.7 + GPT-4.1 +
+   Gemini 3.1 Pro) against the same locked rubric, in parallel.
+5. Aggregates verdicts with explicit dissent reporting.
+6. Writes two artifacts per run:
+   - `receipts.jsonl` – one full audit receipt per issue (prompt, model
+     id, raw response, parsed verdict, confidence, cost, latency).
+   - `report.md` – human-readable recommendations grouped by verdict
+     with the automation-value cross-tab.
+
+## What this does NOT do (v1)
+
+- **Never closes issues.** Closing remains a founder action.
+- **Never posts comments.**
+- **Never applies labels.**
+- **Does not pause Stage-Gate Conductor or any other automation.**
+- Does not scale beyond the 30-issue calibration sample without a
+  separate founder approval.
+
+These constraints exist because v1 is a calibration audit: founder
+reviews the rubric's precision on a stratified sample before any
+mutation surface is enabled.
+
+## Rubric
+
+Each model independently emits a strict JSON object with seven verdict
+categories plus orthogonal `automation_value`. The standard is
+**substantive value, not authorship**: automation-generated issues are
+not penalized by origin.
+
+| Verdict             | Meaning                                                                   |
+| ------------------- | ------------------------------------------------------------------------- |
+| `keep`              | substantively valuable, leave open as-is.                                 |
+| `refine`            | valuable but needs scope tightening, repro steps, or an owner.            |
+| `consolidate`       | should be merged with a referenced or duplicate issue.                    |
+| `close-obsolete`    | referenced code/feature/file no longer exists in HEAD.                    |
+| `close-duplicate`   | exact duplicate of an existing open issue.                                |
+| `close-malformed`   | empty body, template only, no actionable content.                         |
+| `flag-for-human`    | panel uncertain or dissent is real; defer to a human reviewer.            |
+
+| `automation_value`  | Meaning                                                                   |
+| ------------------- | ------------------------------------------------------------------------- |
+| `valuable`          | automation produced something worth keeping or refining (positive!).      |
+| `neutral`           | automation neither strengthened nor weakened the issue.                   |
+| `noise`             | automation produced low-signal output that wastes attention.              |
+| `n/a`               | issue is not automation-generated.                                        |
+
+`valuable` is an explicit positive outcome of the rubric. It exists to
+acknowledge that the boss loop, stage-gate conductor, and other
+automation can produce excellent issues; the calibration aims to find
+them, not delete them by association.
+
+## Receipt-equivalent artifacts
+
+Every panel invocation persists:
+
+- The full prompt sent to the model.
+- The model id and panel-member metadata (`agent_type`, `nickname`).
+- The raw response (verbatim, before parsing).
+- Parsed verdict, confidence, automation value, rationale, suggested
+  action, evidence anchors cited.
+- Cost (tokens × per-model rate) and per-call latency.
+- Aggregate verdict, consensus kind (unanimous/majority/split/unclear),
+  and a rationale that explicitly cites dissenting members in split
+  cases.
+
+Schema version: `triage-receipt/1.0`. The receipt schema mirrors
+Aragora debate-receipt surface area so future upgrades to a full
+`Arena.run()` integration are a schema-compatible swap, not a rewrite.
+
+## Aggregation
+
+- **Unanimous**: all models agreed on the verdict.
+- **Majority**: strict majority chose one verdict; the verdict is
+  reported with averaged confidence over winners.
+- **Split with high confidence (avg ≥ 0.55)**: the highest-confidence
+  model wins; dissent is surfaced in the rationale.
+- **Split with low confidence (avg < 0.55)**: verdict flips to
+  `flag-for-human`.
+- **All errors**: `flag-for-human` with the error trail in the
+  rationale.
+
+## Recommended founder review sequence
+
+1. Print a synthetic sample card to learn the report shape (no model
+   calls, no GitHub calls, no cost):
+
+   ```bash
+   python scripts/triage_issues_via_debate.py --sample-card
+   ```
+
+   Read the rendered card to confirm the evidence-summary / per-model /
+   founder-facing-recommendation layout matches what you want to act on.
+
+2. Estimate cost on a real stratified sample:
+
+   ```bash
+   python scripts/triage_issues_via_debate.py \
+     --repo synaptent/aragora --sample 30 --limit-pool 200 --estimate
+   ```
+
+3. Print the first issue's full prompt (still no model calls) to verify
+   the evidence block looks correct:
+
+   ```bash
+   python scripts/triage_issues_via_debate.py \
+     --repo synaptent/aragora --sample 30 --limit-pool 200 --dry-run-prompt
+   ```
+
+4. Only after the shape is acceptable, run the real calibration:
+
+   ```bash
+   python scripts/triage_issues_via_debate.py \
+     --repo synaptent/aragora --sample 30 --limit-pool 200 \
+     --budget-usd 5 \
+     --output-dir .aragora/triage/calibration/$(date -u +%Y%m%dT%H%M%SZ)
+   ```
+
+5. Review `report.md`. For each issue:
+   - Check the evidence summary matches the real issue.
+   - Check the per-model rationale uses concrete evidence anchors.
+   - For `easy-call` cards: confirm the action is reversible.
+   - For `needs-spot-check` cards: quickly verify the inspect block.
+   - For `do-not-act-without-human` cards: read the dissent and decide.
+6. If the rubric is good, scale (separate spec). If not, adjust
+   `PANEL_PROMPT_RUBRIC` in `aragora/triage/issue_evaluator.py` and
+   re-run targeted issues via `--issues N1,N2,...`.
+
+## Usage
+
+### Estimate cost without invoking models
+
+```bash
+python scripts/triage_issues_via_debate.py \
+  --repo synaptent/aragora \
+  --sample 30 \
+  --estimate
+```
+
+Prints the projected cost broken down by panel member. No model is
+invoked, no artifacts are written.
+
+### Run the 30-issue calibration sample
+
+```bash
+mkdir -p .aragora/triage/runs/$(date +%Y%m%dT%H%M%S)
+python scripts/triage_issues_via_debate.py \
+  --repo synaptent/aragora \
+  --sample 30 \
+  --output-dir .aragora/triage/runs/$(date +%Y%m%dT%H%M%S) \
+  --budget-usd 10
+```
+
+Writes `receipts.jsonl`, `report.md`, and `summary.json` into the
+output directory. Reruns into the same directory skip already-evaluated
+issues (resume safety).
+
+### Re-evaluate specific issues
+
+```bash
+python scripts/triage_issues_via_debate.py \
+  --issues 7172,7171,7169 \
+  --output-dir .aragora/triage/calibration/focused
+```
+
+Useful for re-running the panel after a rubric tweak on a known set of
+issues.
+
+### Print the first issue's prompt (no model invocation)
+
+```bash
+python scripts/triage_issues_via_debate.py \
+  --repo synaptent/aragora \
+  --sample 5 \
+  --dry-run-prompt
+```
+
+Use this to inspect what evidence the panel will actually see for a
+given issue before paying for the call.
+
+## Flags
+
+| Flag                  | Default                                  | Notes                                            |
+| --------------------- | ---------------------------------------- | ------------------------------------------------ |
+| `--repo`              | `synaptent/aragora`                      | GitHub owner/name slug.                          |
+| `--sample`            | `30`                                     | Stratified sample size (ignored if `--issues`).  |
+| `--issues`            | `""`                                     | Comma-separated issue numbers; overrides sample. |
+| `--seed`              | `1337`                                   | Sampling RNG seed for reproducibility.           |
+| `--panel`             | `""`  (= default 3-member panel)         | Comma-separated agent types.                     |
+| `--output-dir`        | `.aragora/triage/runs/<timestamp>`       | All artifacts land here.                         |
+| `--budget-usd`        | `10.0`                                   | Hard cap; run aborts if projection exceeds.      |
+| `--max-concurrent`    | `3`                                      | Parallel panel evaluations.                      |
+| `--estimate`          | off                                      | Print projection and exit.                       |
+| `--dry-run-prompt`    | off                                      | Print first-issue prompt and exit.               |
+| `--sample-card`       | off                                      | Render a synthetic founder-facing card, no costs.|
+| `--limit-pool`        | `1000`                                   | Max issues fetched before sampling.              |
+| `--log-level`         | `INFO`                                   | Standard logging level.                          |
+
+Environment overrides: `ARAGORA_TRIAGE_SEED`, `ARAGORA_TRIAGE_LOG_LEVEL`.
+
+## Calibration loop (intended)
+
+1. Run `--sample 30 --estimate` to confirm cost projection.
+2. Run the same with model invocations under `--budget-usd 10`.
+3. Founder reviews `report.md`. For each issue, decide whether the
+   panel verdict matches your judgement.
+4. If precision is acceptable, propose scale (more issues, additional
+   verdict actions) in a separate spec.
+5. If precision is not acceptable, adjust the rubric in
+   `aragora/triage/issue_evaluator.py::PANEL_PROMPT_RUBRIC` and re-run
+   the same issues via `--issues N1,N2,...` to compare.
+
+## Tests
+
+```bash
+PYTHONPATH=. .venv/bin/python -m pytest tests/scripts/test_triage_issues_via_debate.py -v
+```
+
+The suite stubs every external surface (`gh`, agent generators) so
+nothing hits GitHub or model providers.
+
+## Library entry points
+
+```python
+from aragora.triage import (
+    DEFAULT_PANEL,
+    PANEL_PROMPT_RUBRIC,
+    VERDICT_CATEGORIES,
+    AUTOMATION_VALUE_VALUES,
+    build_panel,
+    build_panel_prompt,
+    estimate_cost_usd,
+    evaluate_issue,
+    gather_evidence,
+    is_automation_generated,
+    parse_model_response,
+    aggregate_verdicts,
+    IssueRecord,
+    IssueEvidence,
+    IssueDebateReceipt,
+    PanelMember,
+    PerModelVerdict,
+    write_jsonl_receipt,
+    write_markdown_report,
+)
+```
+
+The library is also useful from notebooks or from a future Arena-backed
+integration: feed in your own panel + generator and you get the same
+receipt shape.

--- a/scripts/triage_issues_via_debate.py
+++ b/scripts/triage_issues_via_debate.py
@@ -730,7 +730,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.issues:
         numbers = [int(part) for part in args.issues.split(",") if part.strip()]
         target_issues = fetch_specific_issues(args.repo, numbers)
-        open_index = target_issues
+        open_index = fetch_open_issues(args.repo, limit=args.limit_pool)
     else:
         open_index = fetch_open_issues(args.repo, limit=args.limit_pool)
         target_issues = stratified_sample(open_index, sample_size=args.sample, seed=args.seed)

--- a/scripts/triage_issues_via_debate.py
+++ b/scripts/triage_issues_via_debate.py
@@ -1,0 +1,808 @@
+#!/usr/bin/env python3
+"""Calibration-only multi-model issue triage CLI.
+
+V1 contract (per #7170 review by Codex):
+    - Estimate cost.
+    - Pick a stratified sample of issues (default 30).
+    - Gather evidence from GitHub + repo state BEFORE invoking models.
+    - Run heterogeneous panel; persist receipt-equivalent artifacts.
+    - Write JSONL + markdown.
+    - No comments. No labels. No closures. No automation pause.
+
+Examples
+--------
+
+Show the cost projection without invoking any model::
+
+    python scripts/triage_issues_via_debate.py \\
+        --repo synaptent/aragora \\
+        --sample 30 \\
+        --estimate
+
+Run the 30-issue calibration sample (writes artifacts only)::
+
+    python scripts/triage_issues_via_debate.py \\
+        --repo synaptent/aragora \\
+        --sample 30 \\
+        --output-dir .aragora/triage/runs/$(date +%Y%m%dT%H%M%S) \\
+        --budget-usd 10
+
+Re-evaluate specific issues (calibration follow-up)::
+
+    python scripts/triage_issues_via_debate.py \\
+        --issues 7172,7171,7169 \\
+        --output-dir .aragora/triage/calibration
+
+Closing remains a founder action. Founder reviews artifacts and acts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import random
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.triage import (  # noqa: E402
+    DEFAULT_PANEL,
+    IssueDebateReceipt,
+    IssueEvidence,
+    IssueRecord,
+    PanelMember,
+    build_panel,
+    estimate_cost_usd,
+    evaluate_issue,
+    gather_evidence,
+    write_jsonl_receipt,
+    write_markdown_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StratumKey:
+    label_bucket: str
+    author_bucket: str
+    is_automation: bool
+
+    def key(self) -> str:
+        return f"{self.author_bucket}::{self.label_bucket}::auto={self.is_automation}"
+
+
+def _classify(issue: IssueRecord) -> StratumKey:
+    labels_lower = {label.lower() for label in issue.labels}
+    if "boss-stuck" in labels_lower:
+        label_bucket = "boss-stuck"
+    elif "stage-gate-drift" in labels_lower:
+        label_bucket = "stage-gate-drift"
+    elif "boss-ready" in labels_lower:
+        label_bucket = "boss-ready"
+    elif "automation" in labels_lower:
+        label_bucket = "automation-label"
+    elif not issue.labels:
+        label_bucket = "no-label"
+    else:
+        label_bucket = "other"
+    author_bucket = (
+        "automation-author"
+        if "[bot]" in issue.author or issue.author in {"an0mium"}
+        else "human-author"
+    )
+    from aragora.triage.evidence import is_automation_generated
+
+    return StratumKey(
+        label_bucket=label_bucket,
+        author_bucket=author_bucket,
+        is_automation=is_automation_generated(
+            author=issue.author, labels=issue.labels, body=issue.body
+        ),
+    )
+
+
+def stratified_sample(
+    issues: Sequence[IssueRecord],
+    *,
+    sample_size: int,
+    seed: int = 0,
+) -> list[IssueRecord]:
+    """Return a stratified sample across (label_bucket, author_bucket, automation).
+
+    Aims for proportional coverage so the calibration set isn't dominated
+    by the single largest bucket (currently boss-stuck).
+    """
+    if sample_size <= 0:
+        return []
+    rng = random.Random(seed)
+    buckets: dict[str, list[IssueRecord]] = defaultdict(list)
+    for issue in issues:
+        buckets[_classify(issue).key()].append(issue)
+
+    if not buckets:
+        return []
+
+    total = len(issues)
+    quotas: dict[str, int] = {}
+    for key, bucket in buckets.items():
+        proportional = max(1, round(sample_size * len(bucket) / total))
+        quotas[key] = min(proportional, len(bucket))
+
+    while sum(quotas.values()) > sample_size:
+        largest = max(quotas, key=lambda k: quotas[k])
+        if quotas[largest] <= 1:
+            break
+        quotas[largest] -= 1
+    while sum(quotas.values()) < sample_size:
+        candidates = [k for k, v in quotas.items() if v < len(buckets[k])]
+        if not candidates:
+            break
+        pick = rng.choice(candidates)
+        quotas[pick] += 1
+
+    selected: list[IssueRecord] = []
+    for key, count in quotas.items():
+        rng.shuffle(buckets[key])
+        selected.extend(buckets[key][:count])
+    rng.shuffle(selected)
+    return selected[:sample_size]
+
+
+def _gh_json(args: Sequence[str]) -> Any:
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"gh invocation failed: {exc}") from exc
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh exited {proc.returncode}: {proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh did not return JSON: {exc}") from exc
+
+
+def fetch_open_issues(
+    repo: str,
+    *,
+    limit: int = 1000,
+    fetcher: Any = None,
+) -> list[IssueRecord]:
+    """Fetch open issues via gh. Returns ``IssueRecord`` objects."""
+    runner = fetcher or _gh_json
+    raw = runner(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,body,author,labels,state,url,createdAt,updatedAt,comments",
+        ]
+    )
+    records: list[IssueRecord] = []
+    for item in raw:
+        author_obj = item.get("author") or {}
+        author = author_obj.get("login") or author_obj.get("name") or "unknown"
+        labels = tuple(label.get("name", "") for label in item.get("labels") or [])
+        comments = item.get("comments") or []
+        records.append(
+            IssueRecord(
+                number=int(item["number"]),
+                title=item.get("title") or "",
+                body=item.get("body") or "",
+                author=author,
+                labels=labels,
+                state=item.get("state") or "open",
+                url=item.get("url") or "",
+                created_at=item.get("createdAt") or "",
+                updated_at=item.get("updatedAt") or "",
+                comments_count=len(comments) if isinstance(comments, list) else int(comments or 0),
+            )
+        )
+    return records
+
+
+def fetch_specific_issues(
+    repo: str,
+    numbers: Sequence[int],
+    *,
+    fetcher: Any = None,
+) -> list[IssueRecord]:
+    """Fetch a specific subset of issues by number."""
+    runner = fetcher or _gh_json
+    records: list[IssueRecord] = []
+    for num in numbers:
+        item = runner(
+            [
+                "issue",
+                "view",
+                str(num),
+                "--repo",
+                repo,
+                "--json",
+                "number,title,body,author,labels,state,url,createdAt,updatedAt,comments",
+            ]
+        )
+        if not item:
+            continue
+        author_obj = item.get("author") or {}
+        author = author_obj.get("login") or author_obj.get("name") or "unknown"
+        labels = tuple(label.get("name", "") for label in item.get("labels") or [])
+        comments = item.get("comments") or []
+        records.append(
+            IssueRecord(
+                number=int(item["number"]),
+                title=item.get("title") or "",
+                body=item.get("body") or "",
+                author=author,
+                labels=labels,
+                state=item.get("state") or "open",
+                url=item.get("url") or "",
+                created_at=item.get("createdAt") or "",
+                updated_at=item.get("updatedAt") or "",
+                comments_count=len(comments) if isinstance(comments, list) else int(comments or 0),
+            )
+        )
+    return records
+
+
+async def _agent_generator_factory(
+    panel: Sequence[PanelMember],
+) -> Any:
+    """Return an async callable wrapping ``aragora.agents.create_agent``.
+
+    Creates and caches one agent per panel member. Each call invokes
+    ``agent.generate(prompt)``.
+    """
+    from aragora.agents import create_agent
+
+    cache: dict[str, Any] = {}
+    for member in panel:
+        cache[member.agent_type] = create_agent(
+            member.agent_type,
+            name=f"triage-panel-{member.nickname or member.agent_type}",
+            role=member.role,
+            model=member.model_id,
+        )
+
+    async def generator(member: PanelMember, prompt: str) -> str:
+        agent = cache[member.agent_type]
+        return await agent.generate(prompt)
+
+    return generator
+
+
+async def _run_triage(
+    *,
+    issues: Sequence[IssueRecord],
+    open_index: Sequence[IssueRecord],
+    panel: Sequence[PanelMember],
+    output_dir: Path,
+    repo: str,
+    budget_usd: float,
+    max_concurrent: int,
+    generator: Any,
+) -> tuple[list[IssueDebateReceipt], dict[str, Any]]:
+    jsonl_path = output_dir / "receipts.jsonl"
+    md_path = output_dir / "report.md"
+    summary_path = output_dir / "summary.json"
+
+    already_done: set[int] = set()
+    if jsonl_path.exists():
+        for line in jsonl_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                already_done.add(int(json.loads(line).get("issue_number", -1)))
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+    receipts: list[IssueDebateReceipt] = []
+    spent_usd = 0.0
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def evaluate_one(issue: IssueRecord) -> IssueDebateReceipt | None:
+        nonlocal spent_usd
+        async with semaphore:
+            if spent_usd >= budget_usd:
+                logger.warning(
+                    "budget_cap_reached spent=%.4f cap=%.4f issue=#%s",
+                    spent_usd,
+                    budget_usd,
+                    issue.number,
+                )
+                return None
+            evidence = gather_evidence(
+                issue,
+                repo=repo,
+                repo_root=REPO_ROOT,
+                open_issue_index=open_index,
+                now_iso=datetime.now(timezone.utc).isoformat(),
+            )
+            receipt = await evaluate_issue(
+                evidence,
+                panel=panel,
+                generator=generator,
+            )
+            spent_usd += receipt.cost_usd
+            write_jsonl_receipt(jsonl_path, receipt)
+            print(
+                f"#{receipt.issue_number} -> {receipt.aggregate_verdict} "
+                f"({receipt.aggregate_consensus}, conf {receipt.aggregate_confidence:.2f}, "
+                f"${receipt.cost_usd:.4f})",
+                flush=True,
+            )
+            return receipt
+
+    pending = [iss for iss in issues if iss.number not in already_done]
+    if not pending:
+        print("All issues already triaged in this run directory (resume noop).", flush=True)
+    results = await asyncio.gather(*(evaluate_one(iss) for iss in pending))
+    receipts = [r for r in results if r is not None]
+
+    summary = {
+        "repo": repo,
+        "panel": [m.model_id for m in panel],
+        "issues_targeted": len(issues),
+        "issues_evaluated_this_run": len(receipts),
+        "issues_skipped_resume": len(already_done),
+        "spent_usd": round(spent_usd, 4),
+        "budget_usd": budget_usd,
+        "verdict_counts": _verdict_counts(receipts),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "jsonl": str(jsonl_path),
+        "markdown": str(md_path),
+    }
+    all_receipts = _load_all_receipts(jsonl_path)
+    write_markdown_report(
+        md_path,
+        all_receipts,
+        summary_header=(
+            f"Repo: {repo} | Panel: {', '.join(m.model_id for m in panel)} | "
+            f"Budget used: ${spent_usd:.4f}/${budget_usd:.2f}"
+        ),
+    )
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return receipts, summary
+
+
+def _verdict_counts(receipts: Sequence[IssueDebateReceipt]) -> dict[str, int]:
+    counter: dict[str, int] = {}
+    for receipt in receipts:
+        counter[receipt.aggregate_verdict] = counter.get(receipt.aggregate_verdict, 0) + 1
+    return counter
+
+
+def _load_all_receipts(path: Path) -> list[IssueDebateReceipt]:
+    if not path.exists():
+        return []
+    loaded: list[IssueDebateReceipt] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        loaded.append(
+            IssueDebateReceipt(
+                issue_number=int(data.get("issue_number", 0)),
+                issue_title=data.get("issue_title", ""),
+                issue_url=data.get("issue_url", ""),
+                issue_author=data.get("issue_author", ""),
+                is_automation_generated=bool(data.get("is_automation_generated", False)),
+                panel=list(data.get("panel", []) or []),
+                prompt=data.get("prompt", ""),
+                per_model=list(data.get("per_model", []) or []),
+                aggregate_verdict=data.get("aggregate_verdict", "flag-for-human"),
+                aggregate_confidence=float(data.get("aggregate_confidence", 0.0)),
+                aggregate_consensus=data.get("aggregate_consensus", "unclear"),
+                aggregation_rationale=data.get("aggregation_rationale", ""),
+                confidence_class=data.get("confidence_class", "needs-spot-check"),
+                recommendation=data.get("recommendation"),
+                automation_value=data.get("automation_value", "n/a"),
+                suggested_action=data.get("suggested_action", ""),
+                evidence=dict(data.get("evidence", {}) or {}),
+                started_at=data.get("started_at", ""),
+                finished_at=data.get("finished_at", ""),
+                cost_usd=float(data.get("cost_usd", 0.0)),
+                latency_seconds=float(data.get("latency_seconds", 0.0)),
+                notes=list(data.get("notes", []) or []),
+                schema_version=data.get("schema_version", "triage-receipt/1.1"),
+            )
+        )
+    return loaded
+
+
+def _render_sample_card() -> str:
+    """Build a synthetic receipt with mock per-model verdicts and render it.
+
+    Used by ``--sample-card`` so the founder can see exactly what a single
+    triage card looks like BEFORE paying for model calls. No network, no
+    gh, no model API.
+    """
+    from aragora.triage.issue_evaluator import (
+        PerModelVerdict,
+        aggregate_verdicts,
+    )
+    from aragora.triage.receipts import write_markdown_report
+
+    sample_issue = IssueRecord(
+        number=9999,
+        title="Narrow broad except Exception in aragora/billing/cost_tracker.py",
+        body=(
+            "Auto-generated by stage-gate-conductor. The handler in "
+            "`aragora/billing/cost_tracker.py` catches `Exception:` at line 142 "
+            "which masks real failures.\n\nProposed: replace with a narrower "
+            "exception or re-raise after logging. See similar #6371."
+        ),
+        author="an0mium",
+        labels=("boss-stuck", "automation", "narrow-except"),
+        state="open",
+        url="https://github.com/synaptent/aragora/issues/9999",
+        created_at="2026-05-10T03:00:00Z",
+        updated_at="2026-05-10T03:00:00Z",
+        comments_count=0,
+    )
+    sample_evidence = IssueEvidence(
+        issue=sample_issue,
+        is_automation_generated=True,
+        referenced_files=[
+            {"path": "aragora/billing/cost_tracker.py", "exists_in_head": True},
+        ],
+        referenced_issues=[
+            {
+                "number": 6371,
+                "title": "Narrow broad except Exception in fabric/runtime.py",
+                "state": "OPEN",
+                "url": "https://github.com/synaptent/aragora/issues/6371",
+            },
+        ],
+        duplicate_candidates=[
+            {
+                "number": 6371,
+                "title": "Narrow broad except Exception in fabric/runtime.py",
+                "similarity": 0.62,
+                "url": "https://github.com/synaptent/aragora/issues/6371",
+            },
+        ],
+        repo_head_sha="dbd25030c",
+        gathered_at="2026-05-15T04:00:00Z",
+        notes=[],
+    )
+
+    mock_responses = {
+        DEFAULT_PANEL[0]: PerModelVerdict(
+            panel_member=DEFAULT_PANEL[0],
+            verdict="refine",
+            confidence=0.82,
+            confidence_class="needs-spot-check",
+            automation_value="valuable",
+            rationale=(
+                "Real bug in a live file; automation correctly identified an actionable "
+                "narrow-except site. Title and body lack repro steps and don't propose a "
+                "specific catch target, so refining the issue would unblock a human owner."
+            ),
+            suggested_action=(
+                "Rewrite the title with the file/line and add a 3-line repro / proposed catch list."
+            ),
+            evidence_used=[
+                "body para 1 cites aragora/billing/cost_tracker.py line 142",
+                "referenced file exists in HEAD",
+                "duplicate candidate #6371 similarity 0.62 (related but different file)",
+            ],
+            what_to_inspect=(
+                "Open aragora/billing/cost_tracker.py around line 142 and confirm the "
+                "broad except is still there. Compare to #6371 to see how the same kind of "
+                "fix was scoped previously."
+            ),
+            safety_note=(
+                "Safe to refine because the file exists and the issue describes a real "
+                "anti-pattern."
+            ),
+            refined_title=(
+                "billing/cost_tracker: narrow `except Exception` at line ~142 to specific errors"
+            ),
+            refined_body_outline=(
+                "- Current code (link to line)\n"
+                "- Why it masks real failures (one example)\n"
+                "- Proposed narrower catch list (ConnectionError, ValueError, ...)\n"
+                "- How to test (unit test pattern)"
+            ),
+            consolidate_with=None,
+            raw_response="(mock)",
+            prompt_chars=4500,
+            response_chars=900,
+            cost_usd=0.045,
+            latency_seconds=4.2,
+            error=None,
+        ),
+        DEFAULT_PANEL[1]: PerModelVerdict(
+            panel_member=DEFAULT_PANEL[1],
+            verdict="refine",
+            confidence=0.74,
+            confidence_class="needs-spot-check",
+            automation_value="valuable",
+            rationale=(
+                "Concrete file reference resolves to HEAD; the broad-except anti-pattern is "
+                "real and consistent with house style enforcement. The issue would benefit "
+                "from cleaner scope and an explicit owner."
+            ),
+            suggested_action="Refine with repro and proposed catch list before acting.",
+            evidence_used=[
+                "file ref exists",
+                "label `narrow-except` consistent with body",
+            ],
+            what_to_inspect="Inspect cost_tracker.py line range 130-160 and the test for it.",
+            safety_note="Refining a real-bug ticket is reversible.",
+            refined_title="narrow except in cost_tracker.py line 142",
+            refined_body_outline=("- Reproducer\n- Proposed exception list\n- Test plan"),
+            consolidate_with=None,
+            raw_response="(mock)",
+            prompt_chars=4500,
+            response_chars=600,
+            cost_usd=0.013,
+            latency_seconds=3.4,
+            error=None,
+        ),
+        DEFAULT_PANEL[2]: PerModelVerdict(
+            panel_member=DEFAULT_PANEL[2],
+            verdict="consolidate",
+            confidence=0.58,
+            confidence_class="do-not-act-without-human",
+            automation_value="neutral",
+            rationale=(
+                "Title is nearly identical to #6371; duplicate similarity at 0.62 suggests "
+                "this should merge into the broader narrow-except track rather than stand "
+                "alone. Not fully certain because the files are different."
+            ),
+            suggested_action="Consolidate into #6371 as a sub-bullet for cost_tracker.py.",
+            evidence_used=[
+                "duplicate candidate #6371",
+                "title pattern identical to several other broad-except issues",
+            ],
+            what_to_inspect=(
+                "Open #6371 and decide whether it should be one tracker issue covering all "
+                "narrow-except sites or per-file tickets."
+            ),
+            safety_note=(
+                "Risk: consolidating prematurely loses the per-file specificity if the "
+                "tracker doesn't enumerate sub-sites."
+            ),
+            refined_title="",
+            refined_body_outline="",
+            consolidate_with=6371,
+            raw_response="(mock)",
+            prompt_chars=4500,
+            response_chars=550,
+            cost_usd=0.008,
+            latency_seconds=2.8,
+            error=None,
+        ),
+    }
+    per_model_objs = list(mock_responses.values())
+    aggregate = aggregate_verdicts(per_model_objs)
+    recommendation_payload = (
+        aggregate.recommendation.to_dict() if aggregate.recommendation else None
+    )
+    receipt = IssueDebateReceipt(
+        issue_number=sample_issue.number,
+        issue_title=sample_issue.title,
+        issue_url=sample_issue.url,
+        issue_author=sample_issue.author,
+        is_automation_generated=True,
+        panel=[m.model_id for m in DEFAULT_PANEL],
+        prompt="(mock prompt)",
+        per_model=[pm.to_dict() for pm in per_model_objs],
+        aggregate_verdict=aggregate.verdict,
+        aggregate_confidence=aggregate.confidence,
+        aggregate_consensus=aggregate.consensus,
+        aggregation_rationale=aggregate.rationale,
+        confidence_class=aggregate.confidence_class,
+        recommendation=recommendation_payload,
+        automation_value=aggregate.automation_value,
+        suggested_action=aggregate.suggested_action,
+        evidence=sample_evidence.to_dict(),
+        started_at="2026-05-15T04:00:00Z",
+        finished_at="2026-05-15T04:00:05Z",
+        cost_usd=round(sum(pm.cost_usd for pm in per_model_objs), 6),
+        latency_seconds=4.5,
+        notes=list(aggregate.notes),
+    )
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(
+        prefix="aragora-sample-card-", suffix=".md", delete=False
+    ) as fh:
+        out_path = Path(fh.name)
+    write_markdown_report(
+        out_path,
+        [receipt],
+        summary_header=("Repo: synaptent/aragora (SAMPLE CARD ONLY -- no real models invoked)"),
+    )
+    return out_path.read_text(encoding="utf-8")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Calibration-only multi-model GitHub issue triage.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "V1 is calibration-only: no comments, no labels, no closures.\n"
+            "Founder reviews the JSONL + markdown artifacts and decides next steps."
+        ),
+    )
+    parser.add_argument("--repo", default="synaptent/aragora")
+    parser.add_argument("--sample", type=int, default=30, help="Stratified sample size.")
+    parser.add_argument(
+        "--issues",
+        default="",
+        help="Comma-separated issue numbers (overrides --sample).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=int(os.environ.get("ARAGORA_TRIAGE_SEED", "1337")),
+    )
+    parser.add_argument(
+        "--panel",
+        default="",
+        help="Comma-separated agent_types to use; default = anthropic-api,openai-api,gemini.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=f".aragora/triage/runs/{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}",
+    )
+    parser.add_argument("--budget-usd", type=float, default=10.0)
+    parser.add_argument("--max-concurrent", type=int, default=3)
+    parser.add_argument(
+        "--estimate",
+        action="store_true",
+        help="Print cost projection and exit without invoking any model.",
+    )
+    parser.add_argument(
+        "--dry-run-prompt",
+        action="store_true",
+        help="Print the first issue's full prompt and exit without invoking any model.",
+    )
+    parser.add_argument(
+        "--sample-card",
+        action="store_true",
+        help=(
+            "Generate a synthetic receipt with mock per-model verdicts and "
+            "render the founder-facing card to stdout. No model calls, no gh "
+            "calls. Use to inspect report shape before running real calibration."
+        ),
+    )
+    parser.add_argument(
+        "--limit-pool",
+        type=int,
+        default=1000,
+        help="Max issues to fetch from gh before sampling.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=os.environ.get("ARAGORA_TRIAGE_LOG_LEVEL", "INFO"),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    if getattr(args, "sample_card", False):
+        print(_render_sample_card())
+        return 0
+
+    panel = build_panel([item.strip() for item in args.panel.split(",")] if args.panel else None)
+
+    if args.issues:
+        numbers = [int(part) for part in args.issues.split(",") if part.strip()]
+        target_issues = fetch_specific_issues(args.repo, numbers)
+        open_index = target_issues
+    else:
+        open_index = fetch_open_issues(args.repo, limit=args.limit_pool)
+        target_issues = stratified_sample(open_index, sample_size=args.sample, seed=args.seed)
+
+    if not target_issues:
+        print("No target issues resolved; nothing to do.", file=sys.stderr)
+        return 1
+
+    projection = estimate_cost_usd(panel=panel, issue_count=len(target_issues))
+    print("Cost projection (4-chars-per-token heuristic):")
+    print(json.dumps(projection, indent=2))
+    print()
+    print(f"Target issues: {[iss.number for iss in target_issues]}")
+    print(f"Output dir: {args.output_dir}")
+
+    if args.estimate:
+        return 0
+
+    if projection["total_usd"] > args.budget_usd:
+        print(
+            f"Projected cost ${projection['total_usd']:.2f} exceeds budget "
+            f"${args.budget_usd:.2f}; aborting (rerun with higher --budget-usd or smaller --sample).",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.dry_run_prompt:
+        evidence = gather_evidence(
+            target_issues[0],
+            repo=args.repo,
+            repo_root=REPO_ROOT,
+            open_issue_index=open_index,
+            now_iso=datetime.now(timezone.utc).isoformat(),
+        )
+        from aragora.triage.issue_evaluator import build_panel_prompt
+
+        prompt = build_panel_prompt(evidence)
+        print("---- DRY RUN PROMPT (first issue) ----")
+        print(prompt)
+        return 0
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    generator = asyncio.run(_agent_generator_factory(panel))
+    receipts, summary = asyncio.run(
+        _run_triage(
+            issues=target_issues,
+            open_index=open_index,
+            panel=panel,
+            output_dir=output_dir,
+            repo=args.repo,
+            budget_usd=args.budget_usd,
+            max_concurrent=args.max_concurrent,
+            generator=generator,
+        )
+    )
+
+    print()
+    print("Run summary:")
+    print(json.dumps(summary, indent=2))
+    print()
+    print(f"Receipts: {output_dir / 'receipts.jsonl'}")
+    print(f"Report:   {output_dir / 'report.md'}")
+    print(f"Summary:  {output_dir / 'summary.json'}")
+    print()
+    print(
+        "Calibration v1 wrote artifacts only. Closing remains a founder action; "
+        "review precision against the rubric before scaling."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_triage_issues_via_debate.py
+++ b/tests/scripts/test_triage_issues_via_debate.py
@@ -1,0 +1,851 @@
+"""Tests for the calibration-only multi-model issue triage tool.
+
+Coverage targets:
+- Evidence gathering does not penalize automation authorship by default.
+- Stratified sampler covers heterogeneous buckets.
+- Prompt rubric is locked (regression guard).
+- Per-model JSON parser is robust to fences, prose, malformed payloads.
+- Aggregator handles unanimous / majority / split / all-error cases.
+- Receipts persist all receipt-equivalent fields.
+- CLI ``--estimate`` produces a cost projection without invoking models.
+- Budget cap halts evaluation mid-run.
+
+No tests hit external services. All GitHub + agent calls are stubbed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.triage import (  # noqa: E402
+    IssueDebateReceipt,
+    IssueEvidence,
+    IssueRecord,
+    PanelMember,
+    PerModelVerdict,
+    aggregate_verdicts,
+    build_panel,
+    build_panel_prompt,
+    estimate_cost_usd,
+    evaluate_issue,
+    gather_evidence,
+    is_automation_generated,
+    parse_model_response,
+    write_jsonl_receipt,
+    write_markdown_report,
+)
+from aragora.triage.evidence import extract_file_references, extract_issue_references
+from aragora.triage.issue_evaluator import (
+    AUTOMATION_VALUE_VALUES,
+    CONFIDENCE_CLASSES,
+    DEFAULT_PANEL,
+    PANEL_PROMPT_RUBRIC,
+    VERDICT_CATEGORIES,
+    FounderRecommendation,
+    _aggregate_confidence_class,
+    _build_recommendation,
+)
+from collections import Counter
+
+
+def _make_issue(
+    number: int = 1,
+    *,
+    title: str = "Open PR for typo fix",
+    body: str = "Auto-generated. See `aragora/foo.py`.",
+    author: str = "an0mium",
+    labels: tuple[str, ...] = ("boss-stuck",),
+    state: str = "open",
+) -> IssueRecord:
+    return IssueRecord(
+        number=number,
+        title=title,
+        body=body,
+        author=author,
+        labels=labels,
+        state=state,
+        url=f"https://github.com/synaptent/aragora/issues/{number}",
+        created_at="2026-05-10T00:00:00Z",
+        updated_at="2026-05-10T01:00:00Z",
+        comments_count=0,
+    )
+
+
+def _stub_panel(*, members: Sequence[PanelMember] | None = None) -> list[PanelMember]:
+    return list(members or DEFAULT_PANEL)
+
+
+def _verdict(
+    *,
+    member: PanelMember,
+    verdict: str = "keep",
+    confidence: float = 0.8,
+    automation_value: str = "valuable",
+    confidence_class: str = "needs-spot-check",
+    what_to_inspect: str = "inspect body",
+    safety_note: str = "low risk",
+    refined_title: str = "",
+    refined_body_outline: str = "",
+    consolidate_with: int | None = None,
+    error: str | None = None,
+) -> PerModelVerdict:
+    return PerModelVerdict(
+        panel_member=member,
+        verdict=verdict,
+        confidence=confidence,
+        confidence_class=confidence_class,
+        automation_value=automation_value,
+        rationale="rationale",
+        suggested_action="do thing",
+        evidence_used=["body"],
+        what_to_inspect=what_to_inspect,
+        safety_note=safety_note,
+        refined_title=refined_title,
+        refined_body_outline=refined_body_outline,
+        consolidate_with=consolidate_with,
+        raw_response="{}",
+        prompt_chars=100,
+        response_chars=50,
+        cost_usd=0.01,
+        latency_seconds=0.5,
+        error=error,
+    )
+
+
+def test_verdict_categories_are_stable():
+    assert "keep" in VERDICT_CATEGORIES
+    assert "flag-for-human" in VERDICT_CATEGORIES
+    assert "close-duplicate" in VERDICT_CATEGORIES
+    assert len(VERDICT_CATEGORIES) == 7
+
+
+def test_automation_value_includes_positive_outcome():
+    assert "valuable" in AUTOMATION_VALUE_VALUES
+    assert "noise" in AUTOMATION_VALUE_VALUES
+    assert "n/a" in AUTOMATION_VALUE_VALUES
+
+
+def test_panel_prompt_rubric_explicit_about_automation_not_being_bad():
+    assert "SUBSTANTIVE VALUE" in PANEL_PROMPT_RUBRIC
+    assert "Automation-generated" in PANEL_PROMPT_RUBRIC
+    assert "valuable" in PANEL_PROMPT_RUBRIC
+
+
+def test_is_automation_generated_handles_bots_and_labels():
+    assert is_automation_generated(author="github-actions[bot]")
+    assert is_automation_generated(author="an0mium")
+    assert is_automation_generated(author="alice", labels=("stage-gate-drift",))
+    assert is_automation_generated(
+        author="alice", labels=(), body="This issue was opened by the swarm boss loop."
+    )
+    assert not is_automation_generated(author="founder", labels=("bug",), body="repro: ...")
+
+
+def test_extract_file_references_finds_python_paths():
+    refs = extract_file_references(
+        "See aragora/foo.py and scripts/bar.sh and docs/x.md. Also `aragora/baz.py`."
+    )
+    assert "aragora/foo.py" in refs
+    assert "scripts/bar.sh" in refs
+    assert "docs/x.md" in refs
+    assert "aragora/baz.py" in refs
+
+
+def test_extract_issue_references_excludes_self():
+    refs = extract_issue_references("Related #123 fixes #456 closes #7172.", exclude=123)
+    assert 123 not in refs
+    assert 456 in refs
+    assert 7172 in refs
+
+
+def test_gather_evidence_marks_broken_file_refs(tmp_path: Path):
+    (tmp_path / "aragora").mkdir()
+    (tmp_path / "aragora" / "existing.py").write_text("# real")
+    issue = _make_issue(
+        body="Refers to aragora/existing.py and aragora/ghost.py for fixes.",
+    )
+    evidence = gather_evidence(
+        issue,
+        repo="synaptent/aragora",
+        repo_root=tmp_path,
+        open_issue_index=[],
+        gh_runner=lambda args: None,
+        now_iso="2026-05-14T12:00:00Z",
+    )
+    paths = {ref["path"]: ref["exists_in_head"] for ref in evidence.referenced_files}
+    assert paths["aragora/existing.py"] is True
+    assert paths["aragora/ghost.py"] is False
+    assert evidence.is_automation_generated is True
+
+
+def test_gather_evidence_suggests_duplicates(tmp_path: Path):
+    target = _make_issue(number=1, title="Narrow broad except Exception in foo")
+    others = [
+        _make_issue(number=2, title="Narrow broad except Exception in bar"),
+        _make_issue(number=3, title="Add unit tests for foo"),
+    ]
+    evidence = gather_evidence(
+        target,
+        repo="x/y",
+        repo_root=tmp_path,
+        open_issue_index=others,
+        gh_runner=lambda args: None,
+        now_iso="2026-05-14T12:00:00Z",
+    )
+    dup_numbers = [c["number"] for c in evidence.duplicate_candidates]
+    assert 2 in dup_numbers
+    assert 3 not in dup_numbers
+
+
+def test_build_panel_default_and_filter():
+    full = build_panel()
+    assert len(full) == 3
+    filtered = build_panel(["anthropic-api", "openai-api"])
+    assert {m.agent_type for m in filtered} == {"anthropic-api", "openai-api"}
+
+
+def test_build_panel_rejects_solo_panel():
+    with pytest.raises(ValueError):
+        build_panel(["anthropic-api"])
+
+
+def test_build_panel_rejects_unknown_agent():
+    with pytest.raises(ValueError):
+        build_panel(["anthropic-api", "fictional-agent"])
+
+
+def test_build_panel_prompt_contains_evidence_block(tmp_path: Path):
+    issue = _make_issue(body="See aragora/x.py")
+    evidence = gather_evidence(
+        issue,
+        repo="x/y",
+        repo_root=tmp_path,
+        open_issue_index=[],
+        gh_runner=lambda args: None,
+        now_iso="2026-05-14T12:00:00Z",
+    )
+    prompt = build_panel_prompt(evidence)
+    assert "ISSUE" in prompt
+    assert "BODY" in prompt
+    assert "REFERENCED FILES" in prompt
+    assert "DUPLICATE CANDIDATES" in prompt
+    assert "EVIDENCE BLOCK" in prompt
+    assert "aragora/x.py" in prompt
+
+
+def test_parse_model_response_strict_object():
+    raw = (
+        '{"verdict":"keep","confidence":0.9,"automation_value":"valuable",'
+        '"rationale":"r","suggested_action":"do","evidence_used":["body"]}'
+    )
+    parsed = parse_model_response(raw)
+    assert parsed["verdict"] == "keep"
+    assert parsed["confidence"] == pytest.approx(0.9)
+    assert parsed["automation_value"] == "valuable"
+
+
+def test_parse_model_response_handles_fence_and_prose():
+    raw = (
+        "Here is my analysis.\n"
+        "```json\n"
+        '{"verdict":"refine","confidence":0.6,"automation_value":"neutral",'
+        '"rationale":"needs scope","suggested_action":"tighten","evidence_used":[]}\n'
+        "```\nThanks."
+    )
+    parsed = parse_model_response(raw)
+    assert parsed["verdict"] == "refine"
+
+
+def test_parse_model_response_rejects_invalid_verdict():
+    raw = '{"verdict":"explode","confidence":0.5,"automation_value":"n/a","rationale":"r"}'
+    with pytest.raises(ValueError):
+        parse_model_response(raw)
+
+
+def test_parse_model_response_clamps_confidence():
+    raw = '{"verdict":"keep","confidence":1.5,"automation_value":"valuable","rationale":"r","suggested_action":"x","evidence_used":[]}'
+    parsed = parse_model_response(raw)
+    assert parsed["confidence"] == pytest.approx(1.0)
+
+
+def test_parse_model_response_empty_string():
+    with pytest.raises(ValueError):
+        parse_model_response("")
+
+
+def test_aggregate_verdicts_unanimous():
+    panel = _stub_panel()
+    per_model = [_verdict(member=m, verdict="keep", confidence=0.9) for m in panel]
+    agg = aggregate_verdicts(per_model)
+    assert agg.verdict == "keep"
+    assert agg.consensus == "unanimous"
+    assert agg.confidence == pytest.approx(0.9)
+
+
+def test_aggregate_verdicts_majority_wins():
+    panel = _stub_panel()
+    per_model = [
+        _verdict(member=panel[0], verdict="keep", confidence=0.8),
+        _verdict(member=panel[1], verdict="keep", confidence=0.75),
+        _verdict(member=panel[2], verdict="refine", confidence=0.6),
+    ]
+    agg = aggregate_verdicts(per_model)
+    assert agg.verdict == "keep"
+    assert agg.consensus == "majority"
+
+
+def test_aggregate_verdicts_split_low_confidence_flags_human():
+    panel = _stub_panel()
+    per_model = [
+        _verdict(member=panel[0], verdict="keep", confidence=0.4),
+        _verdict(member=panel[1], verdict="refine", confidence=0.5),
+        _verdict(member=panel[2], verdict="close-duplicate", confidence=0.4),
+    ]
+    agg = aggregate_verdicts(per_model)
+    assert agg.verdict == "flag-for-human"
+    assert agg.consensus == "split"
+
+
+def test_aggregate_verdicts_split_high_confidence_picks_highest():
+    panel = _stub_panel()
+    per_model = [
+        _verdict(member=panel[0], verdict="keep", confidence=0.9),
+        _verdict(member=panel[1], verdict="refine", confidence=0.7),
+        _verdict(member=panel[2], verdict="close-duplicate", confidence=0.6),
+    ]
+    agg = aggregate_verdicts(per_model)
+    assert agg.verdict == "keep"
+    assert agg.consensus == "split"
+
+
+def test_aggregate_verdicts_all_errors_flags_human():
+    panel = _stub_panel()
+    per_model = [_verdict(member=m, verdict="keep", confidence=0.0, error="timeout") for m in panel]
+    agg = aggregate_verdicts(per_model)
+    assert agg.verdict == "flag-for-human"
+    assert agg.consensus == "unclear"
+
+
+def test_estimate_cost_usd_scales_with_issue_count():
+    panel = _stub_panel()
+    one = estimate_cost_usd(panel=panel, issue_count=1)
+    thirty = estimate_cost_usd(panel=panel, issue_count=30)
+    assert thirty["total_usd"] > one["total_usd"]
+    assert thirty["issues"] == 30
+    assert set(one["per_model"].keys()) == {m.model_id for m in panel}
+
+
+def test_evaluate_issue_uses_injected_generator(tmp_path: Path):
+    issue = _make_issue()
+    evidence = gather_evidence(
+        issue,
+        repo="x/y",
+        repo_root=tmp_path,
+        open_issue_index=[],
+        gh_runner=lambda args: None,
+        now_iso="2026-05-14T12:00:00Z",
+    )
+
+    responses = {
+        "claude-opus-4-7": '{"verdict":"keep","confidence":0.9,"automation_value":"valuable","rationale":"r","suggested_action":"a","evidence_used":[]}',
+        "gpt-4.1": '{"verdict":"keep","confidence":0.8,"automation_value":"valuable","rationale":"r","suggested_action":"a","evidence_used":[]}',
+        "gemini-3.1-pro-preview": '{"verdict":"refine","confidence":0.6,"automation_value":"neutral","rationale":"r","suggested_action":"a","evidence_used":[]}',
+    }
+
+    async def generator(member: PanelMember, prompt: str) -> str:
+        return responses[member.model_id]
+
+    receipt = asyncio.run(evaluate_issue(evidence, generator=generator))
+    assert receipt.aggregate_verdict == "keep"
+    assert receipt.aggregate_consensus == "majority"
+    assert len(receipt.per_model) == 3
+    assert all(entry.get("raw_response") for entry in receipt.per_model)
+    assert receipt.automation_value in AUTOMATION_VALUE_VALUES
+
+
+def test_evaluate_issue_handles_model_error(tmp_path: Path):
+    issue = _make_issue()
+    evidence = gather_evidence(
+        issue,
+        repo="x/y",
+        repo_root=tmp_path,
+        open_issue_index=[],
+        gh_runner=lambda args: None,
+        now_iso="2026-05-14T12:00:00Z",
+    )
+
+    async def generator(member: PanelMember, prompt: str) -> str:
+        if member.model_id == "gpt-4.1":
+            raise RuntimeError("api down")
+        return '{"verdict":"keep","confidence":0.9,"automation_value":"valuable","rationale":"r","suggested_action":"a","evidence_used":[]}'
+
+    receipt = asyncio.run(evaluate_issue(evidence, generator=generator))
+    errored = [pm for pm in receipt.per_model if pm.get("error")]
+    assert len(errored) == 1
+    assert receipt.aggregate_verdict == "keep"
+
+
+def test_evaluate_issue_handles_parse_error(tmp_path: Path):
+    issue = _make_issue()
+    evidence = gather_evidence(
+        issue,
+        repo="x/y",
+        repo_root=tmp_path,
+        open_issue_index=[],
+        gh_runner=lambda args: None,
+        now_iso="2026-05-14T12:00:00Z",
+    )
+
+    async def generator(member: PanelMember, prompt: str) -> str:
+        if member.model_id == "gemini-3.1-pro-preview":
+            return "this is not json"
+        return '{"verdict":"keep","confidence":0.85,"automation_value":"valuable","rationale":"r","suggested_action":"a","evidence_used":[]}'
+
+    receipt = asyncio.run(evaluate_issue(evidence, generator=generator))
+    parse_errors = [
+        pm for pm in receipt.per_model if (pm.get("error") or "").startswith("parse_error")
+    ]
+    assert len(parse_errors) == 1
+    assert receipt.aggregate_verdict == "keep"
+
+
+def test_write_jsonl_and_markdown_roundtrip(tmp_path: Path):
+    panel = _stub_panel()
+    per_model = [_verdict(member=panel[0])]
+    receipt = IssueDebateReceipt(
+        issue_number=42,
+        issue_title="Test",
+        issue_url="https://example/issues/42",
+        issue_author="alice",
+        is_automation_generated=False,
+        panel=[panel[0].model_id],
+        prompt="prompt",
+        per_model=[pm.to_dict() for pm in per_model],
+        aggregate_verdict="keep",
+        aggregate_confidence=0.9,
+        aggregate_consensus="unanimous",
+        aggregation_rationale="r",
+        automation_value="n/a",
+        suggested_action="action",
+        evidence={"referenced_files": []},
+        started_at="2026-05-14T00:00:00Z",
+        finished_at="2026-05-14T00:01:00Z",
+        cost_usd=0.01,
+        latency_seconds=1.0,
+    )
+    jsonl_path = tmp_path / "receipts.jsonl"
+    write_jsonl_receipt(jsonl_path, receipt)
+    assert jsonl_path.exists()
+    line = jsonl_path.read_text().strip().splitlines()[0]
+    loaded = json.loads(line)
+    assert loaded["issue_number"] == 42
+    md_path = tmp_path / "report.md"
+    write_markdown_report(md_path, [receipt])
+    text = md_path.read_text()
+    assert "Verdict distribution" in text
+    assert "Automation-value cross-tab" in text
+    assert "automation_value=valuable" in text
+
+
+def test_stratified_sample_covers_buckets():
+    from scripts.triage_issues_via_debate import stratified_sample
+
+    issues: list[IssueRecord] = []
+    for i in range(50):
+        issues.append(_make_issue(number=i, author="an0mium", labels=("boss-stuck",)))
+    for i in range(50, 60):
+        issues.append(_make_issue(number=i, author="founder", labels=("bug",)))
+    for i in range(60, 70):
+        issues.append(
+            _make_issue(number=i, author="github-actions[bot]", labels=("stage-gate-drift",))
+        )
+
+    sample = stratified_sample(issues, sample_size=15, seed=42)
+    assert len(sample) == 15
+    authors = {iss.author for iss in sample}
+    assert authors >= {"an0mium", "founder", "github-actions[bot]"}
+
+
+def test_stratified_sample_zero_returns_empty():
+    from scripts.triage_issues_via_debate import stratified_sample
+
+    assert stratified_sample([_make_issue()], sample_size=0) == []
+
+
+def test_cli_estimate_prints_projection_without_calling_models(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    from scripts import triage_issues_via_debate as cli
+
+    issues = [_make_issue(number=i) for i in range(40)]
+    monkeypatch.setattr(cli, "fetch_open_issues", lambda repo, **_: issues)
+
+    def boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("estimate must not invoke agents")
+
+    monkeypatch.setattr(cli, "_agent_generator_factory", boom)
+
+    rc = cli.main(
+        [
+            "--repo",
+            "x/y",
+            "--sample",
+            "10",
+            "--estimate",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Cost projection" in out
+    assert "total_usd" in out
+
+
+def test_cli_budget_cap_aborts_when_projected_exceeds(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    from scripts import triage_issues_via_debate as cli
+
+    issues = [_make_issue(number=i) for i in range(100)]
+    monkeypatch.setattr(cli, "fetch_open_issues", lambda repo, **_: issues)
+
+    rc = cli.main(
+        [
+            "--repo",
+            "x/y",
+            "--sample",
+            "30",
+            "--budget-usd",
+            "0.01",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "exceeds budget" in captured.out + captured.err
+
+
+def test_jsonl_resume_skips_completed_issues(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from scripts import triage_issues_via_debate as cli
+
+    issues = [_make_issue(number=i) for i in range(3)]
+    monkeypatch.setattr(cli, "fetch_specific_issues", lambda repo, numbers, **_: issues)
+
+    output_dir = tmp_path / "run"
+    output_dir.mkdir()
+    (output_dir / "receipts.jsonl").write_text(
+        json.dumps(
+            {
+                "issue_number": 0,
+                "issue_title": "x",
+                "aggregate_verdict": "keep",
+                "aggregate_confidence": 0.9,
+                "aggregate_consensus": "unanimous",
+            }
+        )
+        + "\n"
+    )
+
+    async def stub_generator(*_args: Any, **_kwargs: Any) -> Any:
+        async def gen(_member: PanelMember, _prompt: str) -> str:
+            return '{"verdict":"keep","confidence":0.9,"automation_value":"valuable","rationale":"r","suggested_action":"a","evidence_used":[]}'
+
+        return gen
+
+    monkeypatch.setattr(cli, "_agent_generator_factory", stub_generator)
+    monkeypatch.setattr(
+        cli,
+        "gather_evidence",
+        lambda issue, **kwargs: IssueEvidence(
+            issue=issue,
+            is_automation_generated=True,
+            gathered_at="2026-05-14T00:00:00Z",
+        ),
+    )
+
+    rc = cli.main(
+        [
+            "--repo",
+            "x/y",
+            "--issues",
+            "0,1,2",
+            "--budget-usd",
+            "100",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+    assert rc == 0
+    written = (output_dir / "receipts.jsonl").read_text().splitlines()
+    issue_numbers = {json.loads(line)["issue_number"] for line in written}
+    assert {0, 1, 2}.issubset(issue_numbers)
+
+
+def test_confidence_classes_are_stable():
+    assert "easy-call" in CONFIDENCE_CLASSES
+    assert "needs-spot-check" in CONFIDENCE_CLASSES
+    assert "do-not-act-without-human" in CONFIDENCE_CLASSES
+
+
+def test_rubric_teaches_founder_to_inspect_evidence():
+    assert "TEACH" in PANEL_PROMPT_RUBRIC
+    assert "non-expert" in PANEL_PROMPT_RUBRIC
+    assert "what_to_inspect" in PANEL_PROMPT_RUBRIC
+    assert "safety_note" in PANEL_PROMPT_RUBRIC
+    assert "refined_title" in PANEL_PROMPT_RUBRIC
+    assert "consolidate_with" in PANEL_PROMPT_RUBRIC
+    assert "confidence_class" in PANEL_PROMPT_RUBRIC
+
+
+def test_parse_model_response_accepts_new_fields():
+    raw = json.dumps(
+        {
+            "verdict": "refine",
+            "confidence": 0.78,
+            "confidence_class": "needs-spot-check",
+            "automation_value": "valuable",
+            "rationale": "real bug",
+            "suggested_action": "refine",
+            "evidence_used": ["body para 1"],
+            "what_to_inspect": "inspect line 142",
+            "safety_note": "reversible",
+            "refined_title": "narrow except in cost_tracker.py",
+            "refined_body_outline": "- repro\n- proposed catch list\n- test plan",
+            "consolidate_with": 6371,
+        }
+    )
+    parsed = parse_model_response(raw)
+    assert parsed["confidence_class"] == "needs-spot-check"
+    assert parsed["what_to_inspect"] == "inspect line 142"
+    assert parsed["safety_note"] == "reversible"
+    assert parsed["refined_title"].startswith("narrow except")
+    assert "- repro" in parsed["refined_body_outline"]
+    assert parsed["consolidate_with"] == 6371
+
+
+def test_parse_model_response_falls_back_to_inferred_confidence_class():
+    raw = json.dumps(
+        {
+            "verdict": "keep",
+            "confidence": 0.91,
+            "automation_value": "valuable",
+            "rationale": "ok",
+            "suggested_action": "keep",
+            "evidence_used": [],
+        }
+    )
+    parsed = parse_model_response(raw)
+    assert parsed["confidence_class"] == "easy-call"
+
+
+def test_parse_model_response_handles_invalid_consolidate_with():
+    raw = json.dumps(
+        {
+            "verdict": "consolidate",
+            "confidence": 0.6,
+            "automation_value": "neutral",
+            "rationale": "merge",
+            "suggested_action": "consolidate",
+            "evidence_used": [],
+            "consolidate_with": "not-a-number",
+        }
+    )
+    parsed = parse_model_response(raw)
+    assert parsed["consolidate_with"] is None
+
+
+def test_aggregate_confidence_class_unanimous_high_is_easy_call():
+    panel = _stub_panel()
+    pm = [
+        _verdict(member=panel[0], confidence=0.92, confidence_class="easy-call"),
+        _verdict(member=panel[1], confidence=0.88, confidence_class="easy-call"),
+        _verdict(member=panel[2], confidence=0.85, confidence_class="easy-call"),
+    ]
+    cls = _aggregate_confidence_class("unanimous", 0.88, pm)
+    assert cls == "easy-call"
+
+
+def test_aggregate_confidence_class_any_do_not_act_dominates():
+    panel = _stub_panel()
+    pm = [
+        _verdict(member=panel[0], confidence=0.95, confidence_class="easy-call"),
+        _verdict(member=panel[1], confidence=0.92, confidence_class="easy-call"),
+        _verdict(member=panel[2], confidence=0.6, confidence_class="do-not-act-without-human"),
+    ]
+    cls = _aggregate_confidence_class("majority", 0.82, pm)
+    assert cls == "do-not-act-without-human"
+
+
+def test_aggregate_confidence_class_split_is_do_not_act():
+    panel = _stub_panel()
+    pm = [
+        _verdict(member=panel[0], confidence=0.9, confidence_class="easy-call"),
+        _verdict(member=panel[1], confidence=0.85, confidence_class="easy-call"),
+        _verdict(member=panel[2], confidence=0.8, confidence_class="easy-call"),
+    ]
+    cls = _aggregate_confidence_class("split", 0.85, pm)
+    assert cls == "do-not-act-without-human"
+
+
+def test_build_recommendation_carries_refined_title_and_consolidate_with():
+    panel = _stub_panel()
+    pm = [
+        _verdict(
+            member=panel[0],
+            verdict="refine",
+            refined_title="tighter scope",
+            refined_body_outline="- repro\n- proposed fix",
+            what_to_inspect="inspect line 142",
+            safety_note="reversible",
+        ),
+        _verdict(
+            member=panel[1],
+            verdict="refine",
+            what_to_inspect="check test coverage",
+        ),
+    ]
+    rec = _build_recommendation(
+        verdict="refine",
+        confidence_class="needs-spot-check",
+        consensus="majority",
+        valid=pm,
+        verdict_counts=Counter({"refine": 2}),
+        suggested="refine the issue",
+    )
+    assert rec.refined_title == "tighter scope"
+    assert "repro" in rec.refined_body_outline
+    assert "inspect line 142" in rec.inspect
+    assert "reversible" in rec.safety
+
+
+def test_build_recommendation_do_not_act_warns_loudly():
+    panel = _stub_panel()
+    pm = [
+        _verdict(
+            member=panel[0],
+            verdict="close-duplicate",
+            consolidate_with=6371,
+            what_to_inspect="check #6371",
+        ),
+    ]
+    rec = _build_recommendation(
+        verdict="close-duplicate",
+        confidence_class="do-not-act-without-human",
+        consensus="split",
+        valid=pm,
+        verdict_counts=Counter({"close-duplicate": 1, "refine": 1, "keep": 1}),
+        suggested="close as dup",
+    )
+    assert rec.consolidate_with == 6371
+    assert "DO NOT ACT" in rec.action
+
+
+def test_aggregate_verdicts_attaches_recommendation_and_confidence_class():
+    panel = _stub_panel()
+    pm = [
+        _verdict(member=panel[0], verdict="keep", confidence=0.92, confidence_class="easy-call"),
+        _verdict(member=panel[1], verdict="keep", confidence=0.9, confidence_class="easy-call"),
+        _verdict(member=panel[2], verdict="keep", confidence=0.88, confidence_class="easy-call"),
+    ]
+    agg = aggregate_verdicts(pm)
+    assert agg.confidence_class == "easy-call"
+    assert agg.recommendation is not None
+    assert "Leave the issue open" in agg.recommendation.action
+
+
+def test_aggregate_verdicts_all_errors_flag_do_not_act():
+    panel = _stub_panel()
+    pm = [_verdict(member=m, confidence=0.0, error="timeout") for m in panel]
+    agg = aggregate_verdicts(pm)
+    assert agg.confidence_class == "do-not-act-without-human"
+    assert agg.recommendation is not None
+    assert "UNSAFE" in (agg.recommendation.safety or "")
+
+
+def test_markdown_report_includes_how_to_review_guide_and_cards(tmp_path: Path):
+    panel = _stub_panel()
+    pm = [
+        _verdict(
+            member=panel[0],
+            verdict="refine",
+            refined_title="tighter scope",
+            what_to_inspect="inspect line 142",
+            safety_note="reversible",
+        ),
+        _verdict(member=panel[1], verdict="refine", confidence=0.7),
+        _verdict(member=panel[2], verdict="keep", confidence=0.6),
+    ]
+    agg = aggregate_verdicts(pm)
+    receipt = IssueDebateReceipt(
+        issue_number=99,
+        issue_title="example",
+        issue_url="https://example/99",
+        issue_author="an0mium",
+        is_automation_generated=True,
+        panel=[m.model_id for m in panel],
+        prompt="prompt",
+        per_model=[v.to_dict() for v in pm],
+        aggregate_verdict=agg.verdict,
+        aggregate_confidence=agg.confidence,
+        aggregate_consensus=agg.consensus,
+        aggregation_rationale=agg.rationale,
+        confidence_class=agg.confidence_class,
+        recommendation=agg.recommendation.to_dict() if agg.recommendation else None,
+        automation_value=agg.automation_value,
+        suggested_action=agg.suggested_action,
+        evidence={
+            "issue": {
+                "body": "Real bug in aragora/billing/cost_tracker.py line 142",
+                "labels": ["boss-stuck", "automation"],
+            },
+            "referenced_files": [
+                {"path": "aragora/billing/cost_tracker.py", "exists_in_head": True},
+            ],
+            "referenced_issues": [
+                {"number": 6371, "title": "Related broad except", "state": "OPEN"},
+            ],
+            "duplicate_candidates": [
+                {"number": 6371, "similarity": 0.62, "title": "Related broad except"},
+            ],
+        },
+        started_at="2026-05-15T00:00:00Z",
+        finished_at="2026-05-15T00:00:05Z",
+        cost_usd=0.05,
+        latency_seconds=4.5,
+    )
+    out = tmp_path / "report.md"
+    write_markdown_report(out, [receipt])
+    text = out.read_text(encoding="utf-8")
+    assert "How to review this report" in text
+    assert "Evidence summary" in text
+    assert "Per-model verdicts" in text
+    assert "Founder-facing recommendation" in text
+    assert "Confidence-class distribution" in text
+    assert "Suggested refined title" in text
+    assert "What to inspect" in text
+
+
+def test_sample_card_cli_renders_without_models(capsys: pytest.MonkeyPatch):
+    from scripts import triage_issues_via_debate as cli
+
+    rc = cli.main(["--sample-card"])
+    out = capsys.readouterr().out if hasattr(capsys, "readouterr") else ""
+    assert rc == 0
+    assert "Sample" in out or "sample" in out or "Issue Triage" in out
+    assert "How to review this report" in out
+    assert "Founder-facing recommendation" in out
+    assert "9999" in out
+
+
+def test_receipt_schema_version_is_one_dot_one():
+    from aragora.triage import RECEIPT_SCHEMA_VERSION
+
+    assert RECEIPT_SCHEMA_VERSION == "triage-receipt/1.1"

--- a/tests/scripts/test_triage_issues_via_debate.py
+++ b/tests/scripts/test_triage_issues_via_debate.py
@@ -415,6 +415,32 @@ def test_evaluate_issue_handles_model_error(tmp_path: Path):
     assert receipt.aggregate_verdict == "keep"
 
 
+def test_evaluate_issue_records_untyped_provider_exception(tmp_path: Path):
+    class ProviderSDKError(Exception):
+        pass
+
+    issue = _make_issue()
+    evidence = gather_evidence(
+        issue,
+        repo="x/y",
+        repo_root=tmp_path,
+        open_issue_index=[],
+        gh_runner=lambda args: None,
+        now_iso="2026-05-14T12:00:00Z",
+    )
+
+    async def generator(member: PanelMember, prompt: str) -> str:
+        if member.model_id == "claude-opus-4-7":
+            raise ProviderSDKError("provider overloaded")
+        return '{"verdict":"keep","confidence":0.9,"automation_value":"valuable","rationale":"r","suggested_action":"a","evidence_used":[]}'
+
+    receipt = asyncio.run(evaluate_issue(evidence, generator=generator))
+    errored = [pm for pm in receipt.per_model if pm.get("error")]
+    assert len(errored) == 1
+    assert errored[0]["error"] == "ProviderSDKError: provider overloaded"
+    assert receipt.aggregate_verdict == "keep"
+
+
 def test_evaluate_issue_handles_parse_error(tmp_path: Path):
     issue = _make_issue()
     evidence = gather_evidence(
@@ -553,11 +579,39 @@ def test_cli_budget_cap_aborts_when_projected_exceeds(
     assert "exceeds budget" in captured.out + captured.err
 
 
+def test_cli_issues_mode_uses_full_open_index_for_duplicate_evidence(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    from scripts import triage_issues_via_debate as cli
+
+    target = _make_issue(number=10, title="Narrow broad except Exception in foo")
+    duplicate = _make_issue(number=11, title="Narrow broad except Exception in bar")
+    monkeypatch.setattr(cli, "fetch_specific_issues", lambda repo, numbers, **_: [target])
+    monkeypatch.setattr(cli, "fetch_open_issues", lambda repo, **_: [target, duplicate])
+
+    rc = cli.main(
+        [
+            "--repo",
+            "x/y",
+            "--issues",
+            "10",
+            "--dry-run-prompt",
+            "--budget-usd",
+            "10",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "DUPLICATE CANDIDATES" in out
+    assert "#11" in out
+
+
 def test_jsonl_resume_skips_completed_issues(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from scripts import triage_issues_via_debate as cli
 
     issues = [_make_issue(number=i) for i in range(3)]
     monkeypatch.setattr(cli, "fetch_specific_issues", lambda repo, numbers, **_: issues)
+    monkeypatch.setattr(cli, "fetch_open_issues", lambda repo, **_: issues)
 
     output_dir = tmp_path / "run"
     output_dir.mkdir()
@@ -869,3 +923,10 @@ def test_receipt_schema_version_is_one_dot_one():
     from aragora.triage import RECEIPT_SCHEMA_VERSION
 
     assert RECEIPT_SCHEMA_VERSION == "triage-receipt/1.1"
+
+
+def test_issue_triage_guide_documents_current_receipt_schema():
+    from aragora.triage import RECEIPT_SCHEMA_VERSION
+
+    guide = (REPO_ROOT / "docs/guides/ISSUE_TRIAGE.md").read_text(encoding="utf-8")
+    assert f"Schema version: `{RECEIPT_SCHEMA_VERSION}`" in guide

--- a/tests/scripts/test_triage_issues_via_debate.py
+++ b/tests/scripts/test_triage_issues_via_debate.py
@@ -188,6 +188,26 @@ def test_gather_evidence_marks_broken_file_refs(tmp_path: Path):
     assert evidence.is_automation_generated is True
 
 
+def test_gather_evidence_marks_backslash_repo_file_refs_existing(tmp_path: Path):
+    (tmp_path / "aragora" / "triage").mkdir(parents=True)
+    (tmp_path / "aragora" / "triage" / "evidence.py").write_text("# real")
+    issue = _make_issue(
+        body=r"Windows logs mention aragora\triage\evidence.py during triage.",
+    )
+
+    evidence = gather_evidence(
+        issue,
+        repo="synaptent/aragora",
+        repo_root=tmp_path,
+        open_issue_index=[],
+        gh_runner=lambda args: None,
+        now_iso="2026-05-14T12:00:00Z",
+    )
+
+    paths = {ref["path"]: ref["exists_in_head"] for ref in evidence.referenced_files}
+    assert paths[r"aragora\triage\evidence.py"] is True
+
+
 def test_gather_evidence_suggests_duplicates(tmp_path: Path):
     target = _make_issue(number=1, title="Narrow broad except Exception in foo")
     others = [


### PR DESCRIPTION
## Summary

Builds a heterogeneous frontier panel (Claude Opus 4.7 + GPT-4.1 + Gemini 3.1 Pro) that evaluates GitHub issues against a locked rubric and writes audit-grade JSONL + markdown artifacts. The report is designed to **TEACH the founder how each verdict was reached**, not assume the founder already knows whether an issue is good.

## What the rubric now requires from each model

Per Codex's amendment, each model must emit (in addition to verdict + confidence + automation_value):

- `confidence_class` -- self-assessment of how risky it is to act: `easy-call` / `needs-spot-check` / `do-not-act-without-human`
- `evidence_used` -- specific anchors (body para, broken file ref, dup candidate number, etc.)
- `what_to_inspect` -- 2-3 sentences naming what the founder should look at to trust or challenge
- `safety_note` -- why acting on this verdict is safe (or unsafe)
- `refined_title` + `refined_body_outline` -- when verdict is `refine`
- `consolidate_with` -- target issue number when verdict is `consolidate` or `close-duplicate`

## What the report now shows per issue (founder-facing card)

1. **Evidence summary** -- body excerpt, labels, file refs (with HEAD existence check), related PRs, duplicate candidates
2. **Per-model verdicts** -- verdict, confidence, confidence_class, rationale, evidence anchors, what_to_inspect, safety_note, refined_title/body, consolidate_with
3. **Dissent block** -- when panel splits
4. **Founder-facing recommendation** -- action / why safe / what to inspect / refined title-body / consolidation target, with an explicit `DO NOT ACT WITHOUT HUMAN REVIEW` marker on `do-not-act-without-human` cards
5. **Confidence class** at top of card

Plus the report opens with a **how-to-review guide** so the founder learns the layout before reading verdicts.

## Three pre-cost inspection modes

```bash
# 1. Synthetic card (no models, no gh):
python scripts/triage_issues_via_debate.py --sample-card

# 2. Cost projection on live stratified sample:
python scripts/triage_issues_via_debate.py --sample 30 --limit-pool 200 --estimate

# 3. First-issue prompt (still no model calls):
python scripts/triage_issues_via_debate.py --sample 30 --limit-pool 200 --dry-run-prompt
```

Only after these look right should you run the real calibration:

```bash
python scripts/triage_issues_via_debate.py \
  --repo synaptent/aragora --sample 30 --limit-pool 200 \
  --budget-usd 5 \
  --output-dir .aragora/triage/calibration/$(date -u +%Y%m%dT%H%M%SZ)
```

## Scope (v1, calibration-only)

```
+ scripts/triage_issues_via_debate.py     # CLI (now with --sample-card)
+ aragora/triage/evidence.py              # GitHub + repo evidence
+ aragora/triage/issue_evaluator.py       # panel, rubric, aggregator, FounderRecommendation
+ aragora/triage/receipts.py              # IssueDebateReceipt (1.1) + founder-card renderer
M aragora/triage/__init__.py              # extend existing observability surface
+ tests/scripts/test_triage_issues_via_debate.py  # 47 tests
+ docs/guides/ISSUE_TRIAGE.md
```

## Constraints (unchanged)

- No issue comments, labels, or closures.
- No automation pause.
- No scaling beyond 30-issue calibration without separate founder approval.
- Closing remains a founder action.

## Confidence-class aggregation rules (conservative)

- Any model says `do-not-act-without-human` -> aggregate is `do-not-act-without-human`
- Panel split -> `do-not-act-without-human` (dissent is real signal)
- Unanimous + avg conf >= 0.8 + every model said `easy-call` -> `easy-call`
- Otherwise -> `needs-spot-check`

## Tests / lint

- `pytest tests/scripts/test_triage_issues_via_debate.py` -> 47 passed (added 15 for guided layer)
- `pytest tests/triage/ tests/scripts/test_triage_issues_via_debate.py` -> 117 passed
- `ruff check` + `ruff format --check` clean
- `mypy aragora/triage/ scripts/triage_issues_via_debate.py` -> no issues
- `--sample-card` live: renders 110-line founder card without invoking any model

## Receipt schema

Bumped to `triage-receipt/1.1`. 1.0 readers compatible via field defaults. Mirrors Aragora debate-receipt surface so future upgrade to full `Arena.run()` is a schema-compatible swap, not a rewrite.

## Coordination

- Draft until founder reviews sample card + 30-issue calibration.
- Does not touch Codex's #7170 (`mission_bridge.py` / `--to-mission`).
- Does not touch #7156 alerter or #7168 ledger PRs.
- PR queue 5/6 (under cap).

## Real calibration status (2026-05-15)

**Real 30-issue calibration is PENDING a successful 3-model Claude path via direct Anthropic or existing OpenRouter fallback.**

Verified locally on commit `5cd930dd5`:
- `--sample-card` -> renders 110-line founder card with TEACH-style sections, conservative confidence-class aggregation (any `do-not-act-without-human` dominates), explicit DO-NOT-ACT banner in recommendation.
- `--estimate` -> $1.98 projection for 30 issues across `claude-opus-4-7` + `gpt-4.1` + `gemini-3.1-pro-preview`.
- `--dry-run-prompt` -> clean evidence-rich prompt on first target (#7148), 4 referenced files with HEAD existence flags, rubric block fully formed.
- 47/47 CLI tests pass; 117/117 triage tests pass; ruff + mypy clean.

### Why not a 2-of-3 run

Per founder policy: heterogeneous-panel coverage is the differentiator we are calibrating, not optional. A degraded run with one Anthropic auth-error per issue would document failure modes but would not exercise the rubric across the three frontier models the report is designed for.

### Why no panel-provider feature in #7173

Aragora already supports Anthropic-agent fallback to OpenRouter at the agent layer (`aragora/agents/api_agents/anthropic.py:110` calls `get_primary_api_key("ANTHROPIC_API_KEY", allow_openrouter_fallback=True)`; `aragora/agents/api_agents/common.py:317` defers to `OPENROUTER_API_KEY` when fallback is enabled and `ANTHROPIC_API_KEY` is absent). The right behavior is to enable that existing path via `ARAGORA_OPENROUTER_FALLBACK_ENABLED=true`, NOT to expand this PR with a new `--panel openrouter-claude` feature.

### Smoke-test attempt + new blocker

Codex requested the existing fallback be exercised before falling back to 2-of-3:
```bash
ARAGORA_OPENROUTER_FALLBACK_ENABLED=true \
python scripts/triage_issues_via_debate.py \
  --repo synaptent/aragora --issues 7148 --budget-usd 1 \
  --output-dir .aragora/triage/calibration/openrouter-fallback-smoke-<ts>
```

Attempted; **the smoke was blocked one layer earlier.** Local `.env` has been intentionally blanked: every `*_API_KEY` line in `/Users/armand/Development/aragora/.env` is present but empty, with a comment noting "the runtime source of truth for these keys is AWS Secrets Manager bundle `aragora/production`." When the agent-layer fallback probe (`is_openrouter_fallback_available()`) calls `get_api_key("OPENROUTER_API_KEY", required=False)`, the config resolves through `aragora.config.secrets.get_secret` -> `SecretManager._load_from_aws` -> boto3 STS -> MFA token prompt -> EOFError under non-interactive execution. The existing Anthropic-fallback path therefore cannot be proven from the agentic harness without live AWS creds.

### Next action: founder-side, AWS-Secrets-Manager only

Security stance: model API keys are NEVER exported as raw env vars locally. `.env` is intentionally blank and is not touched. Aragora fetches keys through `aragora.config.secrets` against AWS Secrets Manager bundle `aragora/production`. The acceptable credential path is short-lived AWS/MFA credentials or AWS profile resolution from the founder's authenticated terminal. The agentic harness cannot enter MFA codes, so the founder runs the smoke directly.

```bash
cd /Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260515-034237-faf30880

# AWS Secrets Manager auth (founder's authenticated shell, with MFA already exchanged for STS creds via aws-cli / aws-vault / sso)
export AWS_PROFILE=aragora-secrets
export AWS_REGION=us-east-2
export ARAGORA_USE_SECRETS_MANAGER=true
export ARAGORA_SECRETS_STRICT=true
export ARAGORA_OPENROUTER_FALLBACK_ENABLED=true

# (Step A) one-issue smoke to prove the Anthropic path works (direct or via existing OpenRouter fallback):
python scripts/triage_issues_via_debate.py \
  --repo synaptent/aragora \
  --issues 7148 \
  --budget-usd 1 \
  --output-dir .aragora/triage/calibration/openrouter-fallback-smoke-$(date -u +%Y%m%dT%H%M%SZ)

# Inspect the receipt JSONL:
#   - 3 per-model rows present
#   - claude-opus-4-7 row: real parsed verdict, not auth error
#   - metadata still records model_id=claude-opus-4-7, agent_type=anthropic-api, raw response present
#   - report actual spend

# (Step B) if smoke succeeds, full 30-issue calibration with the same env:
python scripts/triage_issues_via_debate.py \
  --repo synaptent/aragora --sample 30 --limit-pool 200 \
  --budget-usd 5 \
  --output-dir .aragora/triage/calibration/$(date -u +%Y%m%dT%H%M%SZ)
```

Hard rules during this gate:
- Do NOT export raw `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY`.
- Do NOT edit `.env`.
- Do NOT add a panel-provider feature to #7173 (no `--panel openrouter-claude`, no swap of `DEFAULT_PANEL`).
- Do NOT run a 2-of-3 calibration; either Claude routes (direct Anthropic or existing OpenRouter fallback) or stop and report the exact traceback.

Read the resulting `report.md` against the rubric. If the report is fast and easy to navigate, the Issue Triage Review GUI (see feasibility plan in chat history) stays parked. If review is slow or hard, open the follow-up UI PR using the plan.


