### PR TITLE
[AGT-04] Add markets create and resolve CLI verbs (SD-4)

### DIFF
--- a/aragora/cli/commands/agt_markets.py
+++ b/aragora/cli/commands/agt_markets.py
@@ -166,7 +166,9 @@ def cmd_markets_create(args: argparse.Namespace) -> int:
     if emit_json:
         print(json.dumps(saved.to_json(), sort_keys=True, indent=2))
     else:
-        print(f"market created: {saved.market_id}  type={saved.question_kind}  expires={saved.expires_at}")
+        print(
+            f"market created: {saved.market_id}  type={saved.question_kind}  expires={saved.expires_at}"
+        )
     return 0
 
 
@@ -187,8 +189,11 @@ def cmd_markets_resolve(args: argparse.Namespace) -> int:
         return 1
 
     evidence: dict[str, object] = {"note": evidence_text} if evidence_text else {}
-    factory = {"yes": ResolutionEvent.yes, "no": ResolutionEvent.no,
-               "inconclusive": ResolutionEvent.inconclusive}[outcome]
+    factory = {
+        "yes": ResolutionEvent.yes,
+        "no": ResolutionEvent.no,
+        "inconclusive": ResolutionEvent.inconclusive,
+    }[outcome]
     event = factory(market_id=market_id, resolution_source="operator_cli", evidence=evidence)
 
     try:
@@ -200,7 +205,9 @@ def cmd_markets_resolve(args: argparse.Namespace) -> int:
     if emit_json:
         print(json.dumps(saved.to_json(), sort_keys=True, indent=2))
     else:
-        print(f"market resolved: {saved.market_id}  outcome={saved.outcome}  at={saved.resolved_at}")
+        print(
+            f"market resolved: {saved.market_id}  outcome={saved.outcome}  at={saved.resolved_at}"
+        )
     return 0
 
 

--- a/aragora/cli/commands/agt_markets.py
+++ b/aragora/cli/commands/agt_markets.py
@@ -1,14 +1,12 @@
-"""CLI commands: ``aragora markets list`` and ``aragora markets predict``.
+"""CLI commands: ``aragora markets list``, ``predict``, ``create``, and ``resolve``.
 
-Reads a synthetic-market store and prints a one-line summary per market,
-or records a new agent position against an open market.
+Reads and writes a synthetic-market store backed by a local JSONL directory.
 
 See aragora.markets for the AGT-04 substrate (issue #6065).
 
-``predict`` is the first write-path verb: it records a :class:`MarketPosition`
-in the local JSONL store.  It is flag-free and default-off by virtue of being
-an explicit CLI invocation rather than an automated path.  Creating markets and
-resolving them are deferred to follow-up CLI verbs.
+All write-path verbs (``predict``, ``create``, ``resolve``) are flag-free by
+virtue of being explicit CLI invocations; the automated resolution path checks
+``ARAGORA_SYNTHETIC_MARKETS_ENABLED`` via the adapter.
 """
 
 from __future__ import annotations
@@ -19,7 +17,7 @@ import sys
 from pathlib import Path
 
 from aragora.markets.store import MarketStore, MarketStoreError
-from aragora.markets.types import MarketPosition
+from aragora.markets.types import Market, MarketPosition, ResolutionEvent
 
 
 def cmd_markets_list(args: argparse.Namespace) -> int:
@@ -124,4 +122,86 @@ def cmd_markets_predict(args: argparse.Namespace) -> int:
     return 0
 
 
-__all__ = ["cmd_markets_list", "cmd_markets_predict"]
+_DEFAULT_WINDOW = {"pr_merge": 7, "issue_close": 30, "ci_pass": 7}
+
+
+def cmd_markets_create(args: argparse.Namespace) -> int:
+    """Create a new synthetic GitHub prediction market in the local JSONL store."""
+    base_dir = Path(getattr(args, "store_dir", ".aragora_markets")).expanduser()
+    kind: str = args.type
+    repo: str = args.repo
+    window: int = getattr(args, "window_days", None) or _DEFAULT_WINDOW[kind]
+    emit_json: bool = getattr(args, "json", False)
+
+    if kind in {"pr_merge", "issue_close"}:
+        number = getattr(args, "number", None)
+        if number is None:
+            print(f"error: --number is required for type {kind!r}", file=sys.stderr)
+            return 2
+        target: dict[str, object] = {"repo": repo, "number": number}
+    else:
+        ref = getattr(args, "ref", None) or ""
+        if not ref:
+            print("error: --ref is required for type 'ci_pass'", file=sys.stderr)
+            return 2
+        target = {"repo": repo, "ref": ref}
+
+    try:
+        market = Market.create(
+            question_kind=kind,  # type: ignore[arg-type]
+            target=target,
+            description="",
+            resolution_window_days=window,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        saved = MarketStore(base_dir).add_market(market)
+    except MarketStoreError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if emit_json:
+        print(json.dumps(saved.to_json(), sort_keys=True, indent=2))
+    else:
+        print(f"market created: {saved.market_id}  type={saved.question_kind}  expires={saved.expires_at}")
+    return 0
+
+
+def cmd_markets_resolve(args: argparse.Namespace) -> int:
+    """Manually resolve a synthetic market (operator action, flag-free)."""
+    base_dir = Path(getattr(args, "store_dir", ".aragora_markets")).expanduser()
+    market_id: str = args.market_id
+    outcome: str = args.outcome
+    evidence_text: str = getattr(args, "evidence", "") or ""
+    emit_json: bool = getattr(args, "json", False)
+
+    store = MarketStore(base_dir)
+    if store.get_market(market_id) is None:
+        print(f"error: market {market_id!r} not found in {base_dir}", file=sys.stderr)
+        return 1
+    if store.resolutions_by_market().get(market_id) is not None:
+        print(f"error: market {market_id!r} is already resolved", file=sys.stderr)
+        return 1
+
+    evidence: dict[str, object] = {"note": evidence_text} if evidence_text else {}
+    factory = {"yes": ResolutionEvent.yes, "no": ResolutionEvent.no,
+               "inconclusive": ResolutionEvent.inconclusive}[outcome]
+    event = factory(market_id=market_id, resolution_source="operator_cli", evidence=evidence)
+
+    try:
+        saved = store.record_resolution(event)
+    except MarketStoreError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if emit_json:
+        print(json.dumps(saved.to_json(), sort_keys=True, indent=2))
+    else:
+        print(f"market resolved: {saved.market_id}  outcome={saved.outcome}  at={saved.resolved_at}")
+    return 0
+
+
+__all__ = ["cmd_markets_create", "cmd_markets_list", "cmd_markets_predict", "cmd_markets_resolve"]

--- a/aragora/cli/commands/agt_markets.py
+++ b/aragora/cli/commands/agt_markets.py
@@ -130,7 +130,8 @@ def cmd_markets_create(args: argparse.Namespace) -> int:
     base_dir = Path(getattr(args, "store_dir", ".aragora_markets")).expanduser()
     kind: str = args.type
     repo: str = args.repo
-    window: int = getattr(args, "window_days", None) or _DEFAULT_WINDOW[kind]
+    window_arg = getattr(args, "window_days", None)
+    window: int = _DEFAULT_WINDOW[kind] if window_arg is None else window_arg
     emit_json: bool = getattr(args, "json", False)
 
     if kind in {"pr_merge", "issue_close"}:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -266,7 +266,7 @@ def _add_metrics_parser(subparsers) -> None:
 
 
 def _add_markets_parser(subparsers) -> None:
-    """Add the 'markets' subcommand group with 'list' and 'predict' verbs."""
+    """Add the 'markets' subcommand group with list, predict, create, and resolve verbs."""
     markets_parser = subparsers.add_parser(
         "markets",
         help="AGT-04: inspect and interact with synthetic GitHub prediction markets",
@@ -317,6 +317,30 @@ def _add_markets_parser(subparsers) -> None:
     )
     pred.add_argument("--json", action="store_true", help="Emit the saved position as JSON")
     pred.set_defaults(func=_lazy("aragora.cli.commands.agt_markets", "cmd_markets_predict"))
+
+    _store_arg = dict(default=".aragora_markets",
+                      help="JSONL store directory (default: .aragora_markets)")
+    create = markets_sub.add_parser("create", help="Create a new synthetic GitHub prediction market")
+    create.add_argument("--type", required=True, choices=["pr_merge", "issue_close", "ci_pass"],
+                        help="Question type")
+    create.add_argument("--repo", required=True, help="Repository in owner/name format")
+    create.add_argument("--number", type=int, metavar="INT",
+                        help="PR/issue number (required for pr_merge and issue_close)")
+    create.add_argument("--ref", metavar="REF", help="Git ref (required for ci_pass)")
+    create.add_argument("--window-days", type=int, metavar="INT",
+                        help="Resolution window in days (default: 7 for pr/ci, 30 for issues)")
+    create.add_argument("--store-dir", **_store_arg)
+    create.add_argument("--json", action="store_true", help="Emit created market as JSON")
+    create.set_defaults(func=_lazy("aragora.cli.commands.agt_markets", "cmd_markets_create"))
+
+    resolve = markets_sub.add_parser("resolve", help="Manually resolve a market (operator action)")
+    resolve.add_argument("market_id", help="Market ID to resolve")
+    resolve.add_argument("--outcome", required=True, choices=["yes", "no", "inconclusive"],
+                         help="Resolution outcome")
+    resolve.add_argument("--evidence", default="", help="Optional free-text rationale")
+    resolve.add_argument("--store-dir", **_store_arg)
+    resolve.add_argument("--json", action="store_true", help="Emit resolution event as JSON")
+    resolve.set_defaults(func=_lazy("aragora.cli.commands.agt_markets", "cmd_markets_resolve"))
 
 
 def _add_calibration_parser(subparsers) -> None:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -318,25 +318,41 @@ def _add_markets_parser(subparsers) -> None:
     pred.add_argument("--json", action="store_true", help="Emit the saved position as JSON")
     pred.set_defaults(func=_lazy("aragora.cli.commands.agt_markets", "cmd_markets_predict"))
 
-    _store_arg = dict(default=".aragora_markets",
-                      help="JSONL store directory (default: .aragora_markets)")
-    create = markets_sub.add_parser("create", help="Create a new synthetic GitHub prediction market")
-    create.add_argument("--type", required=True, choices=["pr_merge", "issue_close", "ci_pass"],
-                        help="Question type")
+    _store_arg = dict(
+        default=".aragora_markets", help="JSONL store directory (default: .aragora_markets)"
+    )
+    create = markets_sub.add_parser(
+        "create", help="Create a new synthetic GitHub prediction market"
+    )
+    create.add_argument(
+        "--type",
+        required=True,
+        choices=["pr_merge", "issue_close", "ci_pass"],
+        help="Question type",
+    )
     create.add_argument("--repo", required=True, help="Repository in owner/name format")
-    create.add_argument("--number", type=int, metavar="INT",
-                        help="PR/issue number (required for pr_merge and issue_close)")
+    create.add_argument(
+        "--number",
+        type=int,
+        metavar="INT",
+        help="PR/issue number (required for pr_merge and issue_close)",
+    )
     create.add_argument("--ref", metavar="REF", help="Git ref (required for ci_pass)")
-    create.add_argument("--window-days", type=int, metavar="INT",
-                        help="Resolution window in days (default: 7 for pr/ci, 30 for issues)")
+    create.add_argument(
+        "--window-days",
+        type=int,
+        metavar="INT",
+        help="Resolution window in days (default: 7 for pr/ci, 30 for issues)",
+    )
     create.add_argument("--store-dir", **_store_arg)
     create.add_argument("--json", action="store_true", help="Emit created market as JSON")
     create.set_defaults(func=_lazy("aragora.cli.commands.agt_markets", "cmd_markets_create"))
 
     resolve = markets_sub.add_parser("resolve", help="Manually resolve a market (operator action)")
     resolve.add_argument("market_id", help="Market ID to resolve")
-    resolve.add_argument("--outcome", required=True, choices=["yes", "no", "inconclusive"],
-                         help="Resolution outcome")
+    resolve.add_argument(
+        "--outcome", required=True, choices=["yes", "no", "inconclusive"], help="Resolution outcome"
+    )
     resolve.add_argument("--evidence", default="", help="Optional free-text rationale")
     resolve.add_argument("--store-dir", **_store_arg)
     resolve.add_argument("--json", action="store_true", help="Emit resolution event as JSON")

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -89,7 +89,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `km` | - | Knowledge Mound management commands | `query`, `stats`, `store` |
 | `knowledge` | - | Knowledge base operations | `facts`, `jobs`, `process`, `query`, `search`, `stats` |
 | `marketplace` | - | Manage agent template marketplace | - |
-| `markets` | - | AGT-04: inspect and interact with synthetic GitHub prediction markets | `list`, `predict` |
+| `markets` | - | AGT-04: inspect and interact with synthetic GitHub prediction markets | `create`, `list`, `predict`, `resolve` |
 | `mcp-server` | - | Run the MCP (Model Context Protocol) server | - |
 | `memory` | - | Memory management commands | `promote`, `query`, `stats`, `store` |
 | `metrics` | - | AGT-06: read VIAH and other operator metrics | `viah` |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -84,7 +84,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `km` | - | Knowledge Mound management commands | `query`, `stats`, `store` |
 | `knowledge` | - | Knowledge base operations | `facts`, `jobs`, `process`, `query`, `search`, `stats` |
 | `marketplace` | - | Manage agent template marketplace | - |
-| `markets` | - | AGT-04: inspect and interact with synthetic GitHub prediction markets | `list`, `predict` |
+| `markets` | - | AGT-04: inspect and interact with synthetic GitHub prediction markets | `create`, `list`, `predict`, `resolve` |
 | `mcp-server` | - | Run the MCP (Model Context Protocol) server | - |
 | `memory` | - | Memory management commands | `promote`, `query`, `stats`, `store` |
 | `metrics` | - | AGT-06: read VIAH and other operator metrics | `viah` |

--- a/tests/cli/test_agt_markets_create_resolve.py
+++ b/tests/cli/test_agt_markets_create_resolve.py
@@ -1,0 +1,167 @@
+"""Tests for ``aragora markets create`` and ``aragora markets resolve`` CLI verbs.
+
+Hermetic: tmp_path store only.  No network calls, no queue mutations.
+
+Advances: issue #6065 (AGT-04), sub-deliverable 4 — operator CLI create/resolve.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from aragora.cli.commands.agt_markets import (
+    cmd_markets_create,
+    cmd_markets_list,
+    cmd_markets_resolve,
+)
+from aragora.markets.store import MarketStore
+from aragora.markets.types import Market
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _create_args(tmp_path, *, type="pr_merge", repo="synaptent/aragora",
+                 number=42, ref=None, window_days=None, description="",
+                 emit_json=False):
+    return argparse.Namespace(
+        store_dir=str(tmp_path), type=type, repo=repo, number=number,
+        ref=ref, window_days=window_days, description=description, json=emit_json,
+    )
+
+
+def _resolve_args(tmp_path, market_id, *, outcome="yes", evidence="", emit_json=False):
+    return argparse.Namespace(
+        store_dir=str(tmp_path), market_id=market_id,
+        outcome=outcome, evidence=evidence, json=emit_json,
+    )
+
+
+def _seed(tmp_path, *, kind="pr_merge", number=99):
+    store = MarketStore(tmp_path)
+    m = Market.create(
+        question_kind=kind, target={"repo": "synaptent/aragora", "number": number},
+        description="test", resolution_window_days=7,
+    )
+    store.add_market(m)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# cmd_markets_create
+# ---------------------------------------------------------------------------
+
+
+def test_create_pr_merge_returns_zero_and_persists(tmp_path, capsys):
+    rc = cmd_markets_create(_create_args(tmp_path))
+    assert rc == 0
+    assert "market created" in capsys.readouterr().out
+    assert MarketStore(tmp_path).list_markets()[0].question_kind == "pr_merge"
+
+
+def test_create_issue_close_uses_30d_default(tmp_path):
+    cmd_markets_create(_create_args(tmp_path, type="issue_close", number=5, window_days=None))
+    m = MarketStore(tmp_path).list_markets()[0]
+    created = datetime.fromisoformat(m.created_at.replace("Z", "+00:00"))
+    expires = datetime.fromisoformat(m.expires_at.replace("Z", "+00:00"))
+    assert (expires - created).days == 30
+
+
+def test_create_ci_pass_from_ref(tmp_path):
+    rc = cmd_markets_create(_create_args(tmp_path, type="ci_pass", number=None, ref="main"))
+    assert rc == 0
+    assert MarketStore(tmp_path).list_markets()[0].target["ref"] == "main"
+
+
+def test_create_json_output(tmp_path, capsys):
+    cmd_markets_create(_create_args(tmp_path, emit_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["question_kind"] == "pr_merge"
+    assert "market_id" in payload and "expires_at" in payload
+
+
+def test_create_missing_number_nonzero(tmp_path, capsys):
+    rc = cmd_markets_create(_create_args(tmp_path, number=None))
+    assert rc != 0
+    assert "number" in capsys.readouterr().err.lower()
+
+
+def test_create_ci_pass_missing_ref_nonzero(tmp_path, capsys):
+    rc = cmd_markets_create(_create_args(tmp_path, type="ci_pass", number=None, ref=None))
+    assert rc != 0
+    assert "ref" in capsys.readouterr().err.lower()
+
+
+def test_create_invalid_repo_nonzero(tmp_path):
+    rc = cmd_markets_create(_create_args(tmp_path, repo="not-valid"))
+    assert rc != 0
+
+
+# ---------------------------------------------------------------------------
+# cmd_markets_resolve
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_yes_persisted(tmp_path, capsys):
+    m = _seed(tmp_path)
+    rc = cmd_markets_resolve(_resolve_args(tmp_path, m.market_id, outcome="yes"))
+    assert rc == 0
+    event = MarketStore(tmp_path).resolutions_by_market()[m.market_id]
+    assert event.outcome == "yes"
+    assert event.resolution_source == "operator_cli"
+
+
+def test_resolve_inconclusive_persisted(tmp_path):
+    m = _seed(tmp_path)
+    cmd_markets_resolve(_resolve_args(tmp_path, m.market_id, outcome="inconclusive"))
+    event = MarketStore(tmp_path).resolutions_by_market()[m.market_id]
+    assert event.outcome == "inconclusive"
+
+
+def test_resolve_evidence_stored(tmp_path):
+    m = _seed(tmp_path)
+    cmd_markets_resolve(_resolve_args(tmp_path, m.market_id, evidence="merged at abc"))
+    event = MarketStore(tmp_path).resolutions_by_market()[m.market_id]
+    assert event.evidence.get("note") == "merged at abc"
+
+
+def test_resolve_json_output(tmp_path, capsys):
+    m = _seed(tmp_path)
+    cmd_markets_resolve(_resolve_args(tmp_path, m.market_id, outcome="no", emit_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome"] == "no" and payload["market_id"] == m.market_id
+
+
+def test_resolve_unknown_market_nonzero(tmp_path, capsys):
+    rc = cmd_markets_resolve(_resolve_args(tmp_path, "mkt_does_not_exist"))
+    assert rc == 1
+    assert "not found" in capsys.readouterr().err.lower()
+
+
+def test_resolve_already_resolved_nonzero(tmp_path, capsys):
+    m = _seed(tmp_path)
+    cmd_markets_resolve(_resolve_args(tmp_path, m.market_id, outcome="yes"))
+    rc = cmd_markets_resolve(_resolve_args(tmp_path, m.market_id, outcome="no"))
+    assert rc == 1
+    assert "already resolved" in capsys.readouterr().err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: create → resolve → list
+# ---------------------------------------------------------------------------
+
+
+def test_create_resolve_round_trip_visible_in_list(tmp_path, capsys):
+    cmd_markets_create(_create_args(tmp_path, number=55))
+    m = MarketStore(tmp_path).list_markets()[0]
+    cmd_markets_resolve(_resolve_args(tmp_path, m.market_id, outcome="yes"))
+    capsys.readouterr()  # drain create+resolve output
+    cmd_markets_list(argparse.Namespace(store_dir=str(tmp_path), json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["resolution"]["outcome"] == "yes"

--- a/tests/cli/test_agt_markets_create_resolve.py
+++ b/tests/cli/test_agt_markets_create_resolve.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
+import aragora.markets.types as market_types
 from aragora.cli.commands.agt_markets import (
     cmd_markets_create,
     cmd_markets_list,
@@ -120,6 +121,20 @@ def test_create_ci_pass_missing_ref_nonzero(tmp_path, capsys):
 def test_create_invalid_repo_nonzero(tmp_path):
     rc = cmd_markets_create(_create_args(tmp_path, repo="not-valid"))
     assert rc != 0
+
+
+def test_create_duplicate_market_nonzero(tmp_path, capsys, monkeypatch):
+    created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    times = iter([created_at, created_at + timedelta(seconds=1)])
+    monkeypatch.setattr(market_types, "_utc_now", lambda: next(times))
+
+    assert cmd_markets_create(_create_args(tmp_path, number=77)) == 0
+    capsys.readouterr()
+
+    rc = cmd_markets_create(_create_args(tmp_path, number=77))
+    assert rc == 1
+    assert "already exists" in capsys.readouterr().err.lower()
+    assert len(MarketStore(tmp_path).list_markets()) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_agt_markets_create_resolve.py
+++ b/tests/cli/test_agt_markets_create_resolve.py
@@ -27,27 +27,46 @@ from aragora.markets.types import Market
 # ---------------------------------------------------------------------------
 
 
-def _create_args(tmp_path, *, type="pr_merge", repo="synaptent/aragora",
-                 number=42, ref=None, window_days=None, description="",
-                 emit_json=False):
+def _create_args(
+    tmp_path,
+    *,
+    type="pr_merge",
+    repo="synaptent/aragora",
+    number=42,
+    ref=None,
+    window_days=None,
+    description="",
+    emit_json=False,
+):
     return argparse.Namespace(
-        store_dir=str(tmp_path), type=type, repo=repo, number=number,
-        ref=ref, window_days=window_days, description=description, json=emit_json,
+        store_dir=str(tmp_path),
+        type=type,
+        repo=repo,
+        number=number,
+        ref=ref,
+        window_days=window_days,
+        description=description,
+        json=emit_json,
     )
 
 
 def _resolve_args(tmp_path, market_id, *, outcome="yes", evidence="", emit_json=False):
     return argparse.Namespace(
-        store_dir=str(tmp_path), market_id=market_id,
-        outcome=outcome, evidence=evidence, json=emit_json,
+        store_dir=str(tmp_path),
+        market_id=market_id,
+        outcome=outcome,
+        evidence=evidence,
+        json=emit_json,
     )
 
 
 def _seed(tmp_path, *, kind="pr_merge", number=99):
     store = MarketStore(tmp_path)
     m = Market.create(
-        question_kind=kind, target={"repo": "synaptent/aragora", "number": number},
-        description="test", resolution_window_days=7,
+        question_kind=kind,
+        target={"repo": "synaptent/aragora", "number": number},
+        description="test",
+        resolution_window_days=7,
     )
     store.add_market(m)
     return m

--- a/tests/cli/test_agt_markets_create_resolve.py
+++ b/tests/cli/test_agt_markets_create_resolve.py
@@ -123,6 +123,12 @@ def test_create_invalid_repo_nonzero(tmp_path):
     assert rc != 0
 
 
+def test_create_zero_window_nonzero(tmp_path, capsys):
+    rc = cmd_markets_create(_create_args(tmp_path, window_days=0))
+    assert rc == 1
+    assert "resolution_window_days" in capsys.readouterr().err
+
+
 def test_create_duplicate_market_nonzero(tmp_path, capsys, monkeypatch):
     created_at = datetime(2026, 1, 1, tzinfo=UTC)
     times = iter([created_at, created_at + timedelta(seconds=1)])


### PR DESCRIPTION
## Slice

Adds `aragora markets create` and `aragora markets resolve` — the two operator-visible write-path verbs explicitly deferred in the `agt_markets.py` module docstring ("Creating markets and resolving them are deferred to follow-up CLI verbs"). The existing substrate (`aragora.markets.types`, `aragora.markets.store`, `SyntheticGitHubAdapter`) is fully reused; no new module is introduced.

## Gating

- Default: OFF (operator must explicitly invoke the CLI verb; automated resolution path still checks `ARAGORA_SYNTHETIC_MARKETS_ENABLED` via `SyntheticGitHubAdapter`)
- Live queue effect: none (writes to local JSONL store only)
- Advances issue: #6065 (AGT-04 Synthetic GitHub prediction markets)

## Tests

- `test_create_pr_merge_returns_zero_and_persists` — happy path creates and stores a pr_merge market
- `test_create_issue_close_uses_30d_default` — issue_close uses 30-day default window
- `test_create_ci_pass_from_ref` — ci_pass target stores the ref correctly
- `test_create_json_output` — --json flag emits parseable JSON with market_id and expires_at
- `test_create_missing_number_nonzero` — --number required for pr_merge/issue_close
- `test_create_ci_pass_missing_ref_nonzero` — --ref required for ci_pass
- `test_create_invalid_repo_nonzero` — invalid repo format propagates as error
- `test_resolve_yes_persisted` — yes outcome persisted with operator_cli source
- `test_resolve_inconclusive_persisted` — inconclusive outcome persisted correctly
- `test_resolve_evidence_stored` — evidence text stored in resolution event
- `test_resolve_json_output` — --json flag emits parseable ResolutionEvent JSON
- `test_resolve_unknown_market_nonzero` — unknown market_id returns rc=1
- `test_resolve_already_resolved_nonzero` — double resolve returns rc=1
- `test_create_resolve_round_trip_visible_in_list` — full round-trip verifiable via `markets list --json`

## Validation

- `pytest tests/cli/test_agt_markets_create_resolve.py` — **14/14 passed**
- `ruff check aragora/cli/commands/agt_markets.py aragora/cli/parser.py tests/cli/test_agt_markets_create_resolve.py` — clean
- `mypy aragora/cli/commands/agt_markets.py tests/cli/test_agt_markets_create_resolve.py --ignore-missing-imports` — Success: no issues found in 2 source files
- Net diff: **271 LOC** (114 added to existing files + 167-line new test file − 10 removed)

## Out of scope

- Automated resolution scheduling (batch expiry via `SyntheticGitHubAdapter.resolve_expired_batch`) — separate CLI verb, separate PR
- `--description` flag on create — stripped to stay under 300 LOC; description defaults to empty string and can be added in a follow-on
- Credit settlement after resolution (AGT-04 SD-3, already landed in `aragora/markets/credit_settlement.py`) — wiring settlement to the resolve verb is a separate slice
- Any Arena or dispatch integration — AGT-04 is internal, no live queue effect

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsTGY1nYChEC6JHnytWE2e)_