### PR TITLE
fix(automation): add publisher freshness compatibility entrypoint

### DIFF
--- a/scripts/check_publisher_freshness.py
+++ b/scripts/check_publisher_freshness.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Compatibility entrypoint for ``publisher_freshness_check.py``."""
+
+from __future__ import annotations
+
+from publisher_freshness_check import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_publisher_freshness_check.py
+++ b/tests/scripts/test_publisher_freshness_check.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -13,6 +14,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "publisher_freshness_check.py"
+WRAPPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "check_publisher_freshness.py"
 
 
 def _load_module() -> Any:
@@ -228,6 +230,20 @@ def test_main_json_output_includes_full_report(
     assert parsed["verdict"] == "ready"
     assert "generated_at" in parsed
     assert parsed["launchd_loaded"] is True
+
+
+def test_check_publisher_freshness_wrapper_executes_primary_script(stub_repo: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(WRAPPER_SCRIPT_PATH), "--repo", str(stub_repo), "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    parsed = json.loads(result.stdout)
+    assert parsed["cache_path"].endswith(".aragora/automation-github-status/latest.json")
+    assert "verdict" in parsed
 
 
 def test_main_accepts_status_cache_alias(


### PR DESCRIPTION
## Summary
- add `scripts/check_publisher_freshness.py` as a compatibility entrypoint for `publisher_freshness_check.py`
- add regression coverage that executes the alias and verifies it delegates to the canonical freshness check
- publishes automation outbox handoff `open-pr-codex-publisher-freshness-alias-20260515-72bd8b23`

## Validation
- `python3 -m pytest tests/scripts/test_publisher_freshness_check.py -q` -> 29 passed
- `python3 scripts/check_publisher_freshness.py --json` -> verdict ready
- `python3 -m ruff check scripts/check_publisher_freshness.py tests/scripts/test_publisher_freshness_check.py` -> clean
- `python3 -m ruff format --check scripts/check_publisher_freshness.py tests/scripts/test_publisher_freshness_check.py` -> clean
- `git diff --check origin/main...HEAD` -> clean
- `gitleaks detect --no-git --source /tmp/publisher-freshness-alias.diff --log-level error` -> clean
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok
- pre-push hooks -> passed