### PR TITLE
fix(agent-bridge): make current broker state canonical

### DIFF
--- a/aragora/swarm/agent_bridge/harnesses/__init__.py
+++ b/aragora/swarm/agent_bridge/harnesses/__init__.py
@@ -47,6 +47,7 @@ register("claude", ClaudeTransport)
 register("claude_code", ClaudeTransport)
 register("codex", CodexTransport)
 register("droid", DroidTransport)
+register("factory", DroidTransport)
 
 __all__ = [
     "ClaudeTransport",

--- a/aragora/swarm/agent_bridge/harnesses/base.py
+++ b/aragora/swarm/agent_bridge/harnesses/base.py
@@ -75,9 +75,7 @@ class Transport(ABC):
         command, session_id = self._build_launch_command(prompt)
         process = self._run_command(command)
         if process.returncode != 0:
-            raise TransportLaunchError(
-                process.stderr.strip() or process.stdout.strip() or self.harness
-            )
+            raise TransportLaunchError(self._process_error_message(process))
         parsed = self.parse_output(
             process.stdout,
             allowed_roles=allowed_roles,
@@ -100,9 +98,7 @@ class Transport(ABC):
         command = self._build_resume_command(session_id, prompt)
         process = self._run_command(command)
         if process.returncode != 0:
-            raise TransportResumeError(
-                process.stderr.strip() or process.stdout.strip() or self.harness
-            )
+            raise TransportResumeError(self._process_error_message(process))
         parsed = self.parse_output(
             process.stdout,
             allowed_roles=allowed_roles,
@@ -147,10 +143,19 @@ class Transport(ABC):
         return self._runner(
             command,
             cwd=self.cwd,
+            stdin=subprocess.DEVNULL,
             text=True,
             capture_output=True,
             check=False,
         )
+
+    def _process_error_message(self, process: subprocess.CompletedProcess[str]) -> str:
+        parts: list[str] = []
+        if process.stdout.strip():
+            parts.append("stdout:\n" + process.stdout.strip()[:4000])
+        if process.stderr.strip():
+            parts.append("stderr:\n" + process.stderr.strip()[:4000])
+        return "\n".join(parts) if parts else self.harness
 
     def _cli_option_args(self, extra_reserved: Sequence[str] = ()) -> list[str]:
         args: list[str] = []

--- a/docs/guides/CONDUCTOR_WORKFLOW.md
+++ b/docs/guides/CONDUCTOR_WORKFLOW.md
@@ -66,7 +66,15 @@ aragora worktree fleet-status --json
 aragora worktree fleet-claims --json
 aragora worktree fleet-queue-list --json
 aragora worktree autopilot status --json
+python3 scripts/agent_bridge.py operator-snapshot --json --summary-only
+python3 scripts/agent_bridge.py gc --json
 ```
+
+`operator-snapshot` is current-first: brokered runs and live tmux sessions are
+operational truth. Standalone Claude/Factory desktop chats are historical
+context unless they were launched through the bridge/broker or explicitly
+imported into a run receipt. Use `--include-historical` or `--scope all` only
+when auditing old transcript context.
 
 Useful low-level recovery commands when sessions are churny:
 

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -238,6 +238,26 @@ def discover(
     return [session for session in sessions if _is_current_session(session)]
 
 
+def _discover_with_broker_state(
+    *,
+    include_summaries: bool = True,
+    include_historical: bool = True,
+    broker_runs: list[dict[str, Any]] | None = None,
+) -> tuple[list[Session], list[dict[str, Any]], set[str]]:
+    runs = _load_broker_run_summaries() if broker_runs is None else broker_runs
+    active_broker_ids = _active_broker_session_ids(runs)
+    try:
+        sessions = discover(
+            include_summaries=include_summaries,
+            include_historical=include_historical,
+            active_broker_session_ids=active_broker_ids,
+        )
+    except TypeError:
+        # Compatibility for tests or older in-process callers that monkeypatch discover().
+        sessions = discover()
+    return sessions, runs, active_broker_ids
+
+
 def _discover_tmux_fallback() -> list[Session]:
     """Minimal fallback when agent_bridge_sessions is not available."""
     sessions: list[Session] = []
@@ -283,6 +303,10 @@ def _write_session_snapshot(sessions: list[Session]) -> None:
     snapshot = [{"timestamp": timestamp, **s.to_dict()} for s in sessions]
     snapshot_file = _bridge_file_for_write(SESSION_SNAPSHOT_FILE)
     _atomic_write_json(snapshot_file, snapshot)
+
+
+def _filter_current_sessions(sessions: list[Session]) -> list[Session]:
+    return [session for session in sessions if _is_current_session(session)]
 
 
 def _now_iso() -> str:
@@ -708,7 +732,7 @@ def _read_tmux_log(name: str, lines: int) -> list[str]:
 
 
 def cmd_sessions(args: argparse.Namespace) -> int:
-    sessions = discover()
+    sessions, _broker_runs, _active_broker_ids = _discover_with_broker_state()
     _write_session_snapshot(sessions)
     if args.json:
         print(json.dumps([s.to_dict() for s in sessions], indent=2))
@@ -909,7 +933,7 @@ def cmd_read_all(args: argparse.Namespace) -> int:
 
 
 def cmd_lanes(args: argparse.Namespace) -> int:
-    sessions = discover()
+    sessions, _broker_runs, _active_broker_ids = _discover_with_broker_state()
     _enrich_prs(sessions)
     _write_session_snapshot(sessions)
     records = _sync_lane_records(_load_lane_registry(), sessions)
@@ -948,7 +972,7 @@ def cmd_lanes(args: argparse.Namespace) -> int:
 
 def cmd_health(args: argparse.Namespace) -> int:
     """Report stale worktrees, ambiguous lane ownership, and dead sessions."""
-    sessions = discover()
+    sessions, _broker_runs, _active_broker_ids = _discover_with_broker_state()
     _enrich_prs(sessions)
     records = _sync_lane_records(_load_lane_registry(), sessions)
 
@@ -1001,16 +1025,16 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     include_historical = bool(getattr(args, "include_historical", False)) or (
         getattr(args, "scope", "current") == "all"
     )
-    broker_runs = _load_broker_run_summaries()
-    active_broker_ids = _active_broker_session_ids(broker_runs)
-    sessions = discover(
+    discovered_sessions, broker_runs, _active_broker_ids = _discover_with_broker_state(
         include_summaries=not summary_only,
-        include_historical=include_historical,
-        active_broker_session_ids=active_broker_ids,
+        include_historical=include_historical or not summary_only,
+    )
+    sessions = (
+        discovered_sessions if include_historical else _filter_current_sessions(discovered_sessions)
     )
     if not summary_only:
-        _enrich_prs(sessions)
-        _write_session_snapshot(sessions)
+        _enrich_prs(discovered_sessions)
+        _write_session_snapshot(discovered_sessions)
     records = _sync_lane_records(_load_lane_registry(), sessions)
 
     issues = _collect_health_issues(sessions, records)
@@ -1117,6 +1141,8 @@ def _gc_tmux_candidates(*, ttl_hours: int) -> list[dict[str, Any]]:
     if agent_bridge_sessions is None or not TMUX_SESSIONS_DIR.exists():
         return []
     candidates: list[dict[str, Any]] = []
+    broker_runs = _load_broker_run_summaries()
+    active_broker_session_ids = _active_broker_session_ids(broker_runs)
     records = agent_bridge_sessions.load_tmux_sessions(
         repo_root=CANONICAL_REPO_ROOT,
         tmux_dir=TMUX_SESSIONS_DIR,
@@ -1127,6 +1153,7 @@ def _gc_tmux_candidates(*, ttl_hours: int) -> list[dict[str, Any]]:
             source=record.source,
             status=record.status,
             updated_at=record.updated_at,
+            active_broker_session_ids=active_broker_session_ids,
             session_id=record.session_id,
             ttl_hours=ttl_hours,
         )
@@ -1181,7 +1208,10 @@ def cmd_gc(args: argparse.Namespace) -> int:
         )
 
     if write:
-        sessions = discover(include_summaries=False, include_historical=False)
+        sessions, _broker_runs, _active_broker_ids = _discover_with_broker_state(
+            include_summaries=False,
+            include_historical=True,
+        )
         _write_session_snapshot(sessions)
 
     payload = {

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -24,6 +24,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -31,6 +32,7 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import UTC
 from datetime import datetime
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -62,6 +64,9 @@ if agent_bridge_sessions is not None:
     except (OSError, RuntimeError, ValueError):
         CANONICAL_REPO_ROOT = REPO_ROOT
 ACTIVE_LANE_STATUSES = {"active", "running", "pending", "queued", "claimed"}
+CURRENT_SESSION_LIFECYCLES = {"live", "active_broker"}
+HISTORICAL_SESSION_LIFECYCLES = {"historical", "dead", "stale", "orphaned"}
+DEFAULT_STALE_TTL_HOURS = 24
 
 
 def _state_root_bridge_dir() -> Path:
@@ -124,11 +129,15 @@ class Session:
     agent: str
     status: str = "unknown"
     source: str = ""
+    lifecycle: str = ""
     tmux_target: str = ""
     branch: str = ""
     worktree: str = ""
     session_id: str = ""
+    updated_at: str = ""
     summary: str = ""
+    log_file: str = ""
+    transcript_file: str = ""
     pr_number: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -171,7 +180,12 @@ class LaneRecord:
         )
 
 
-def discover(*, include_summaries: bool = True) -> list[Session]:
+def discover(
+    *,
+    include_summaries: bool = True,
+    include_historical: bool = True,
+    active_broker_session_ids: set[str] | None = None,
+) -> list[Session]:
     """Discover all sessions via agent_bridge_sessions.
 
     Falls back to minimal tmux-only discovery if agent_bridge_sessions
@@ -189,23 +203,39 @@ def discover(*, include_summaries: bool = True) -> list[Session]:
             tmux_target = ""
             if r.status == "alive" and r.source == "tmux":
                 tmux_target = f"{TMUX_SESSION}:{r.name}"
+            lifecycle = _session_lifecycle(
+                source=r.source,
+                status=r.status,
+                updated_at=r.updated_at,
+                active_broker_session_ids=active_broker_session_ids,
+                session_id=r.session_id,
+            )
+            if not include_historical and lifecycle not in CURRENT_SESSION_LIFECYCLES:
+                continue
             sessions.append(
                 Session(
                     name=r.name,
                     agent=r.agent,
-                    status=r.status,
+                    status=_session_status_for_lifecycle(r.status, lifecycle),
                     source=r.source,
+                    lifecycle=lifecycle,
                     tmux_target=tmux_target,
                     branch=r.branch or "",
                     worktree=r.cwd or "",
                     session_id=r.session_id,
+                    updated_at=r.updated_at or "",
                     summary=r.summary or "",
+                    log_file=r.log_file or "",
+                    transcript_file=r.transcript_file or "",
                 )
             )
         return sessions
 
     # Fallback: minimal tmux-only discovery
-    return _discover_tmux_fallback()
+    sessions = _discover_tmux_fallback()
+    if include_historical:
+        return sessions
+    return [session for session in sessions if _is_current_session(session)]
 
 
 def _discover_tmux_fallback() -> list[Session]:
@@ -233,12 +263,15 @@ def _discover_tmux_fallback() -> list[Session]:
             continue
         name = meta.get("name", meta_file.stem)
         is_alive = name in alive
+        status = "alive" if is_alive else "dead"
+        lifecycle = _session_lifecycle(source="tmux", status=status, updated_at=None)
         sessions.append(
             Session(
                 name=name,
                 agent=meta.get("agent", "unknown"),
-                status="alive" if is_alive else "dead",
+                status=_session_status_for_lifecycle(status, lifecycle),
                 source="tmux",
+                lifecycle=lifecycle,
                 tmux_target=f"{TMUX_SESSION}:{name}" if is_alive else "",
             )
         )
@@ -254,6 +287,71 @@ def _write_session_snapshot(sessions: list[Session]) -> None:
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        text = value.strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(text)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+    except ValueError:
+        return None
+
+
+def _is_older_than(value: str | None, *, hours: int) -> bool:
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        return False
+    return parsed < datetime.now(UTC) - timedelta(hours=hours)
+
+
+def _session_lifecycle(
+    *,
+    source: str,
+    status: str,
+    updated_at: str | None,
+    active_broker_session_ids: set[str] | None = None,
+    session_id: str = "",
+    ttl_hours: int = DEFAULT_STALE_TTL_HOURS,
+) -> str:
+    active_broker_session_ids = active_broker_session_ids or set()
+    if session_id and session_id in active_broker_session_ids:
+        return "active_broker"
+    if source == "tmux":
+        if status == "alive":
+            return "live"
+        if status == "dead":
+            return "stale" if _is_older_than(updated_at, hours=ttl_hours) else "dead"
+        return "unknown"
+    if source == "claude_jsonl":
+        return "historical"
+    if status == "alive":
+        return "live"
+    if status == "dead":
+        return "dead"
+    return "unknown"
+
+
+def _session_status_for_lifecycle(status: str, lifecycle: str) -> str:
+    if lifecycle in {"historical", "stale", "orphaned", "active_broker", "live"}:
+        return lifecycle
+    return status
+
+
+def _is_current_session(session: Session) -> bool:
+    lifecycle = session.lifecycle or _session_lifecycle(
+        source=session.source,
+        status=session.status,
+        updated_at=session.updated_at,
+        session_id=session.session_id,
+    )
+    return lifecycle in CURRENT_SESSION_LIFECYCLES or session.status == "alive"
 
 
 def _load_lane_registry() -> list[LaneRecord]:
@@ -292,6 +390,56 @@ def _sync_lane_records(records: list[LaneRecord], sessions: list[Session]) -> li
     return records
 
 
+def _load_broker_run_summaries() -> list[dict[str, Any]]:
+    try:
+        from aragora.swarm.agent_bridge.store import BridgeStore
+    except ImportError:
+        return []
+
+    try:
+        store = BridgeStore(CANONICAL_REPO_ROOT)
+        runs = []
+        for run_path in store.runs_root().glob("*/run.json"):
+            run = store.load_run(run_path.parent.name)
+            try:
+                registry = store.load_sessions(run.run_id)
+                sessions = {role: session.to_dict() for role, session in registry.sessions.items()}
+            except (OSError, TypeError, json.JSONDecodeError, KeyError):
+                sessions = {}
+            runs.append(
+                {
+                    "run_id": run.run_id,
+                    "status": run.status,
+                    "updated_at": run.updated_at,
+                    "next_actor": run.next_actor,
+                    "last_turn_index": run.last_turn_index,
+                    "participants": [participant.to_dict() for participant in run.participants],
+                    "sessions": sessions,
+                }
+            )
+        runs.sort(key=lambda item: str(item.get("updated_at", "")), reverse=True)
+        return runs
+    except (OSError, TypeError, json.JSONDecodeError, KeyError, ValueError):
+        return []
+
+
+def _active_broker_session_ids(broker_runs: list[dict[str, Any]]) -> set[str]:
+    ids: set[str] = set()
+    for run in broker_runs:
+        if run.get("status") not in ACTIVE_LANE_STATUSES and run.get("status") != "awaiting_human":
+            continue
+        sessions = run.get("sessions", {})
+        if not isinstance(sessions, dict):
+            continue
+        for raw_session in sessions.values():
+            if not isinstance(raw_session, dict):
+                continue
+            session_id = raw_session.get("session_id")
+            if isinstance(session_id, str) and session_id:
+                ids.add(session_id)
+    return ids
+
+
 def _is_repo_root_path(path: str) -> bool:
     try:
         return Path(path).resolve() == CANONICAL_REPO_ROOT.resolve()
@@ -316,8 +464,14 @@ def _collect_health_issues(
     for s in sessions:
         if not s.worktree:
             continue
+        lifecycle = s.lifecycle or _session_lifecycle(
+            source=s.source,
+            status=s.status,
+            updated_at=s.updated_at,
+            session_id=s.session_id,
+        )
         worktree_exists = Path(s.worktree).is_dir()
-        if s.status == "dead":
+        if lifecycle in {"dead", "stale", "orphaned"} or s.status == "dead":
             if worktree_exists and not _is_repo_root_path(s.worktree):
                 issues.append(
                     {
@@ -328,11 +482,7 @@ def _collect_health_issues(
                 )
             continue
         if not worktree_exists:
-            if (
-                s.status == "unknown"
-                and s.source == "claude_jsonl"
-                and s.name not in active_lane_owners
-            ):
+            if lifecycle == "historical" and s.name not in active_lane_owners:
                 continue
             issues.append(
                 {
@@ -848,7 +998,16 @@ def cmd_health(args: argparse.Namespace) -> int:
 def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     """Output a unified operator snapshot combining sessions, lanes, and health."""
     summary_only = bool(getattr(args, "summary_only", False))
-    sessions = discover(include_summaries=not summary_only)
+    include_historical = bool(getattr(args, "include_historical", False)) or (
+        getattr(args, "scope", "current") == "all"
+    )
+    broker_runs = _load_broker_run_summaries()
+    active_broker_ids = _active_broker_session_ids(broker_runs)
+    sessions = discover(
+        include_summaries=not summary_only,
+        include_historical=include_historical,
+        active_broker_session_ids=active_broker_ids,
+    )
     if not summary_only:
         _enrich_prs(sessions)
         _write_session_snapshot(sessions)
@@ -859,12 +1018,20 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     snapshot: dict[str, Any] = {
         "timestamp": _now_iso(),
         "sessions": [s.to_dict() for s in sessions],
+        "broker_runs": broker_runs,
         "lanes": [r.to_dict() for r in records],
         "health": {"ok": len(issues) == 0, "issues": issues},
         "summary": {
             "total_sessions": len(sessions),
             "alive_sessions": sum(1 for s in sessions if s.status == "alive"),
+            "live_sessions": sum(1 for s in sessions if _is_current_session(s)),
             "dead_sessions": sum(1 for s in sessions if s.status == "dead"),
+            "historical_sessions": sum(
+                1 for s in sessions if (s.lifecycle or s.status) in HISTORICAL_SESSION_LIFECYCLES
+            ),
+            "active_broker_runs": sum(
+                1 for run in broker_runs if run.get("status") in {"running", "awaiting_human"}
+            ),
             "active_lanes": sum(1 for r in records if r.status in ACTIVE_LANE_STATUSES),
             "conflict_lanes": sum(1 for r in records if r.status == "conflict"),
             "health_issues": len(issues),
@@ -873,6 +1040,7 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     if summary_only:
         snapshot.pop("sessions")
         snapshot.pop("lanes")
+        snapshot.pop("broker_runs")
         snapshot["records_omitted"] = True
 
     if args.json:
@@ -883,8 +1051,9 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     print(f"Operator Snapshot @ {snapshot['timestamp']}")
     print("=" * 80)
     print(
-        f"Sessions: {summary['alive_sessions']} alive / {summary['dead_sessions']} dead / {summary['total_sessions']} total"
+        f"Sessions: {summary['live_sessions']} live / {summary['historical_sessions']} historical / {summary['total_sessions']} total"
     )
+    print(f"Broker:   {summary['active_broker_runs']} active run(s)")
     print(f"Lanes:    {summary['active_lanes']} active / {summary['conflict_lanes']} conflict")
     health_status = "OK" if snapshot["health"]["ok"] else f"{summary['health_issues']} issue(s)"
     print(f"Health:   {health_status}")
@@ -941,6 +1110,97 @@ def cmd_tmux_map(args: argparse.Namespace) -> int:
                 print(f"{parts[0]:<40} {parts[1]:<8} {parts[2]}")
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         print("tmux not available.")
+    return 0
+
+
+def _gc_tmux_candidates(*, ttl_hours: int) -> list[dict[str, Any]]:
+    if agent_bridge_sessions is None or not TMUX_SESSIONS_DIR.exists():
+        return []
+    candidates: list[dict[str, Any]] = []
+    records = agent_bridge_sessions.load_tmux_sessions(
+        repo_root=CANONICAL_REPO_ROOT,
+        tmux_dir=TMUX_SESSIONS_DIR,
+        include_summaries=False,
+    )
+    for record in records:
+        lifecycle = _session_lifecycle(
+            source=record.source,
+            status=record.status,
+            updated_at=record.updated_at,
+            session_id=record.session_id,
+            ttl_hours=ttl_hours,
+        )
+        if lifecycle != "stale":
+            continue
+        meta_path = TMUX_SESSIONS_DIR / f"{record.name}.meta.json"
+        files = [meta_path]
+        if record.log_file:
+            files.append(Path(record.log_file))
+        existing_files = [path for path in files if path.exists()]
+        if not existing_files:
+            continue
+        candidates.append(
+            {
+                "name": record.name,
+                "lifecycle": lifecycle,
+                "updated_at": record.updated_at,
+                "reason": f"dead bridge-owned tmux session older than {ttl_hours}h",
+                "files": [str(path) for path in existing_files],
+            }
+        )
+    return candidates
+
+
+def cmd_gc(args: argparse.Namespace) -> int:
+    ttl_hours = max(1, int(args.ttl_hours))
+    write = bool(args.write)
+    candidates = _gc_tmux_candidates(ttl_hours=ttl_hours)
+    archive_dir = TMUX_SESSIONS_DIR / "archive" / datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    actions: list[dict[str, Any]] = []
+
+    for candidate in candidates:
+        archived_files: list[str] = []
+        for raw_path in candidate["files"]:
+            source = Path(raw_path)
+            destination = archive_dir / source.name
+            if write:
+                archive_dir.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(source), str(destination))
+                archived_files.append(str(destination))
+            else:
+                archived_files.append(str(destination))
+        actions.append(
+            {
+                "action": "archive_tmux_session",
+                "name": candidate["name"],
+                "reason": candidate["reason"],
+                "dry_run": not write,
+                "files": candidate["files"],
+                "archive_files": archived_files,
+            }
+        )
+
+    if write:
+        sessions = discover(include_summaries=False, include_historical=False)
+        _write_session_snapshot(sessions)
+
+    payload = {
+        "ok": True,
+        "dry_run": not write,
+        "ttl_hours": ttl_hours,
+        "archive_dir": str(archive_dir),
+        "actions": actions,
+        "external_transcripts_touched": False,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return 0
+    if not actions:
+        print("No stale bridge-owned tmux sessions to archive.")
+        return 0
+    for action in actions:
+        mode = "would archive" if action["dry_run"] else "archived"
+        print(f"{mode}: {action['name']} ({len(action['files'])} file(s))")
     return 0
 
 
@@ -1013,6 +1273,13 @@ def main() -> int:
     sub.add_parser(
         "health", parents=[json_parent], help="Check for stale worktrees and lane conflicts"
     )
+    gc_p = sub.add_parser(
+        "gc",
+        parents=[json_parent],
+        help="Archive stale bridge-owned tmux metadata/logs; dry-run by default.",
+    )
+    gc_p.add_argument("--write", action="store_true", help="Apply archive actions")
+    gc_p.add_argument("--ttl-hours", type=int, default=DEFAULT_STALE_TTL_HOURS)
     operator_snapshot_p = sub.add_parser(
         "operator-snapshot",
         parents=[json_parent],
@@ -1022,6 +1289,17 @@ def main() -> int:
         "--summary-only",
         action="store_true",
         help="Omit session and lane records from output for compact automation checks.",
+    )
+    operator_snapshot_p.add_argument(
+        "--include-historical",
+        action="store_true",
+        help="Include historical Claude/Factory transcript records in the snapshot.",
+    )
+    operator_snapshot_p.add_argument(
+        "--scope",
+        choices=("current", "all"),
+        default="current",
+        help="Snapshot scope. Default 'current' includes live bridge truth only.",
     )
 
     args = parser.parse_args()
@@ -1039,6 +1317,7 @@ def main() -> int:
         "lanes": cmd_lanes,
         "tmux-map": cmd_tmux_map,
         "health": cmd_health,
+        "gc": cmd_gc,
         "operator-snapshot": cmd_operator_snapshot,
     }
     return cmds[args.command](args)

--- a/scripts/agent_bridge_supervise.py
+++ b/scripts/agent_bridge_supervise.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
@@ -51,6 +52,7 @@ _WAIT_MARKERS = (
 )
 _BLOCKED_MARKERS = ("blocked", "stuck", "needs human", "conflict")
 _REVIEW_MARKERS = ("ready for review", "re-review", "green", "merge when green")
+_DEFAULT_MAX_RECORDS = 20
 
 
 @dataclass(slots=True)
@@ -601,17 +603,53 @@ def _decide_lane(
     )
 
 
-def collect_supervisor_snapshot() -> SupervisorSnapshot:
-    sessions = agent_bridge.discover()
-    agent_bridge._enrich_prs(sessions)  # noqa: SLF001
-    records = agent_bridge._sync_lane_records(  # noqa: SLF001
-        agent_bridge._load_lane_registry(),  # noqa: SLF001
-        sessions,
-    )
+def _discover_current_sessions() -> list[agent_bridge.Session]:
+    try:
+        return agent_bridge.discover(include_historical=False)
+    except TypeError:
+        return agent_bridge.discover()
+
+
+def collect_supervisor_snapshot(*, max_records: int | None = None) -> SupervisorSnapshot:
+    warnings: list[str] = []
+    if max_records is None:
+        try:
+            max_records = int(
+                os.environ.get("ARAGORA_AGENT_BRIDGE_SUPERVISE_MAX_RECORDS", _DEFAULT_MAX_RECORDS)
+            )
+        except ValueError:
+            max_records = _DEFAULT_MAX_RECORDS
+    try:
+        sessions = _discover_current_sessions()
+    except Exception as exc:
+        return SupervisorSnapshot(
+            generated_at=_now_iso(),
+            decisions=[],
+            warnings=[f"session discovery degraded: {exc}"],
+        )
+
+    try:
+        agent_bridge._enrich_prs(sessions)  # noqa: SLF001
+        records = agent_bridge._sync_lane_records(  # noqa: SLF001
+            agent_bridge._load_lane_registry(),  # noqa: SLF001
+            sessions,
+        )
+    except Exception as exc:
+        warnings.append(f"lane registry degraded: {exc}")
+        records = []
     if not records:
         records = _synthetic_lane_records(sessions)
 
-    pr_truth_by_branch, warnings = _load_pr_truth(records)
+    if len(records) > max_records:
+        warnings.append(f"supervisor record cap applied: {max_records}/{len(records)}")
+        records = records[:max_records]
+
+    try:
+        pr_truth_by_branch, pr_warnings = _load_pr_truth(records)
+        warnings.extend(pr_warnings)
+    except Exception as exc:
+        pr_truth_by_branch = {}
+        warnings.append(f"pr truth degraded: {exc}")
     session_map = {session.name: session for session in sessions}
     decisions: list[LaneDecision] = []
 

--- a/scripts/agent_bridge_supervise.py
+++ b/scripts/agent_bridge_supervise.py
@@ -145,6 +145,11 @@ def _session_text(session: agent_bridge.Session | None) -> str:
     return "\n".join(line for line in lines if line)
 
 
+def _session_is_current(session: agent_bridge.Session) -> bool:
+    lifecycle = session.lifecycle or session.status
+    return session.status == "alive" or lifecycle in agent_bridge.CURRENT_SESSION_LIFECYCLES
+
+
 def _run_git(worktree: Path, *args: str) -> subprocess.CompletedProcess[str]:
     cmd = ["git", "-C", str(worktree), *args]
     try:
@@ -405,7 +410,7 @@ def _decide_lane(
             evidence=evidence,
         )
 
-    if session.status != "alive":
+    if not _session_is_current(session):
         return LaneDecision(
             lane_id=record.lane_id,
             owner_session=record.owner_session,
@@ -604,6 +609,11 @@ def _decide_lane(
 
 
 def _discover_current_sessions() -> list[agent_bridge.Session]:
+    if hasattr(agent_bridge, "_discover_with_broker_state"):
+        sessions, _broker_runs, _active_broker_ids = agent_bridge._discover_with_broker_state(  # noqa: SLF001
+            include_historical=False
+        )
+        return sessions
     try:
         return agent_bridge.discover(include_historical=False)
     except TypeError:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -337,13 +338,17 @@ def test_operator_snapshot_summary_only_json_omits_records(
     _patch_bridge_paths(mod, tmp_path, monkeypatch)
     discover_include_summaries: list[bool] = []
 
-    def fake_discover(*, include_summaries: bool = True):
+    def fake_discover(
+        *, include_summaries: bool = True, include_historical: bool = True, **_kwargs
+    ):
         discover_include_summaries.append(include_summaries)
+        assert include_historical is False
         return [
             mod.Session(
                 name="codex-main",
                 agent="codex",
                 status="alive",
+                lifecycle="live",
                 branch="codex/example",
                 worktree=str(tmp_path),
             )
@@ -374,8 +379,141 @@ def test_operator_snapshot_summary_only_json_omits_records(
     assert payload["records_omitted"] is True
     assert payload["summary"]["total_sessions"] == 1
     assert payload["summary"]["alive_sessions"] == 1
+    assert payload["summary"]["live_sessions"] == 1
+    assert payload["summary"]["historical_sessions"] == 0
     assert payload["health"] == {"ok": True, "issues": []}
     assert discover_include_summaries == [False]
+
+
+def test_session_lifecycle_classifies_claude_transcripts_as_historical() -> None:
+    import agent_bridge as mod
+
+    lifecycle = mod._session_lifecycle(
+        source="claude_jsonl",
+        status="unknown",
+        updated_at="2026-05-15T00:00:00Z",
+        session_id="claude-session",
+    )
+
+    assert lifecycle == "historical"
+    assert mod._session_status_for_lifecycle("unknown", lifecycle) == "historical"
+
+
+def test_discover_excludes_historical_transcripts_by_default_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bridge as mod
+
+    record = SimpleNamespace(
+        name="claude-deadbeef",
+        agent="claude",
+        status="unknown",
+        source="claude_jsonl",
+        tmux_target="",
+        branch="main",
+        cwd="/tmp/old",
+        session_id="deadbeef",
+        updated_at="2026-05-15T00:00:00Z",
+        summary="old desktop chat",
+        log_file=None,
+        transcript_file="/tmp/claude.jsonl",
+    )
+    monkeypatch.setattr(
+        mod.agent_bridge_sessions,
+        "collect_sessions",
+        lambda **_kwargs: [record],
+    )
+
+    assert mod.discover(include_historical=False) == []
+    all_sessions = mod.discover(include_historical=True)
+    assert all_sessions[0].status == "historical"
+    assert all_sessions[0].lifecycle == "historical"
+
+
+def test_operator_snapshot_include_historical_restores_transcript_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+
+    def fake_discover(*, include_historical: bool, **_kwargs):
+        if not include_historical:
+            return []
+        return [
+            mod.Session(
+                name="claude-history",
+                agent="claude",
+                status="historical",
+                source="claude_jsonl",
+                lifecycle="historical",
+            )
+        ]
+
+    monkeypatch.setattr(mod, "discover", fake_discover)
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod, "_load_lane_registry", lambda: [])
+    monkeypatch.setattr(mod, "_load_broker_run_summaries", lambda: [])
+
+    assert (
+        mod.cmd_operator_snapshot(
+            argparse.Namespace(
+                json=True,
+                summary_only=False,
+                include_historical=True,
+                scope="current",
+            )
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["historical_sessions"] == 1
+    assert payload["sessions"][0]["name"] == "claude-history"
+
+
+def test_operator_snapshot_includes_broker_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod, "_load_lane_registry", lambda: [])
+    monkeypatch.setattr(
+        mod,
+        "_load_broker_run_summaries",
+        lambda: [
+            {
+                "run_id": "bridge-next-work",
+                "status": "running",
+                "updated_at": "2026-05-15T15:00:00Z",
+                "next_actor": "critic",
+                "last_turn_index": 1,
+                "participants": [],
+                "sessions": {},
+            }
+        ],
+    )
+
+    assert (
+        mod.cmd_operator_snapshot(
+            argparse.Namespace(
+                json=True,
+                summary_only=False,
+                include_historical=False,
+                scope="current",
+            )
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["active_broker_runs"] == 1
+    assert payload["broker_runs"][0]["run_id"] == "bridge-next-work"
 
 
 def test_cmd_launch_invokes_tmux_launcher_for_droid(
@@ -699,3 +837,89 @@ def test_health_reports_claimed_claude_transcript_missing_worktree(tmp_path: Pat
             "detail": f"worktree path missing: {removed_worktree}",
         }
     ]
+
+
+def test_gc_dry_run_archives_only_bridge_owned_tmux_candidates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    tmux_dir = tmp_path / "tmux"
+    tmux_dir.mkdir()
+    meta = tmux_dir / "factory-old.meta.json"
+    log = tmux_dir / "factory-old.log"
+    meta.write_text("{}", encoding="utf-8")
+    log.write_text("old log", encoding="utf-8")
+    transcript = tmp_path / "claude.jsonl"
+    transcript.write_text("external transcript", encoding="utf-8")
+    monkeypatch.setattr(mod, "TMUX_SESSIONS_DIR", tmux_dir)
+    monkeypatch.setattr(
+        mod.agent_bridge_sessions,
+        "load_tmux_sessions",
+        lambda **_kwargs: [
+            SimpleNamespace(
+                name="factory-old",
+                source="tmux",
+                status="dead",
+                updated_at="2026-05-13T00:00:00Z",
+                session_id="factory-old",
+                log_file=str(log),
+            )
+        ],
+    )
+
+    rc = mod.cmd_gc(argparse.Namespace(json=True, write=False, ttl_hours=24))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["external_transcripts_touched"] is False
+    assert payload["actions"][0]["name"] == "factory-old"
+    assert meta.exists()
+    assert log.exists()
+    assert transcript.exists()
+
+
+def test_gc_write_moves_stale_tmux_files_and_rewrites_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    bridge_dir = tmp_path / "bridge"
+    tmux_dir = tmp_path / "tmux"
+    tmux_dir.mkdir()
+    meta = tmux_dir / "factory-old.meta.json"
+    log = tmux_dir / "factory-old.log"
+    meta.write_text("{}", encoding="utf-8")
+    log.write_text("old log", encoding="utf-8")
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "TMUX_SESSIONS_DIR", tmux_dir)
+    monkeypatch.setattr(
+        mod.agent_bridge_sessions,
+        "load_tmux_sessions",
+        lambda **_kwargs: [
+            SimpleNamespace(
+                name="factory-old",
+                source="tmux",
+                status="dead",
+                updated_at="2026-05-13T00:00:00Z",
+                session_id="factory-old",
+                log_file=str(log),
+            )
+        ],
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+
+    rc = mod.cmd_gc(argparse.Namespace(json=True, write=True, ttl_hours=24))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is False
+    assert not meta.exists()
+    assert not log.exists()
+    assert Path(payload["actions"][0]["archive_files"][0]).exists()
+    assert json.loads((bridge_dir / "sessions.json").read_text(encoding="utf-8")) == []

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -430,6 +430,39 @@ def test_discover_excludes_historical_transcripts_by_default_when_requested(
     assert all_sessions[0].lifecycle == "historical"
 
 
+def test_discover_keeps_active_broker_session_current(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bridge as mod
+
+    record = SimpleNamespace(
+        name="droid-broker",
+        agent="droid",
+        status="dead",
+        source="tmux",
+        tmux_target="",
+        branch="codex/bridge",
+        cwd="/tmp/bridge",
+        session_id="broker-session",
+        updated_at="2026-05-13T00:00:00Z",
+        summary="broker-owned droid lane",
+        log_file=None,
+        transcript_file=None,
+    )
+    monkeypatch.setattr(
+        mod.agent_bridge_sessions,
+        "collect_sessions",
+        lambda **_kwargs: [record],
+    )
+
+    sessions = mod.discover(
+        include_historical=False,
+        active_broker_session_ids={"broker-session"},
+    )
+
+    assert len(sessions) == 1
+    assert sessions[0].status == "active_broker"
+    assert sessions[0].lifecycle == "active_broker"
+
+
 def test_operator_snapshot_include_historical_restores_transcript_records(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -471,6 +504,58 @@ def test_operator_snapshot_include_historical_restores_transcript_records(
     payload = json.loads(capsys.readouterr().out)
     assert payload["summary"]["historical_sessions"] == 1
     assert payload["sessions"][0]["name"] == "claude-history"
+
+
+def test_operator_snapshot_current_output_preserves_full_canonical_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    bridge_dir = tmp_path / "bridge"
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+
+    def fake_discover(*, include_historical: bool, **_kwargs):
+        assert include_historical is True
+        return [
+            mod.Session(
+                name="codex-live",
+                agent="codex",
+                status="alive",
+                lifecycle="live",
+            ),
+            mod.Session(
+                name="claude-history",
+                agent="claude",
+                status="historical",
+                source="claude_jsonl",
+                lifecycle="historical",
+            ),
+        ]
+
+    monkeypatch.setattr(mod, "discover", fake_discover)
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod, "_load_lane_registry", lambda: [])
+    monkeypatch.setattr(mod, "_load_broker_run_summaries", lambda: [])
+
+    assert (
+        mod.cmd_operator_snapshot(
+            argparse.Namespace(
+                json=True,
+                summary_only=False,
+                include_historical=False,
+                scope="current",
+            )
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [session["name"] for session in payload["sessions"]] == ["codex-live"]
+    assert payload["summary"]["historical_sessions"] == 0
+    snapshot = json.loads((bridge_dir / "sessions.json").read_text(encoding="utf-8"))
+    assert [session["name"] for session in snapshot] == ["codex-live", "claude-history"]
 
 
 def test_operator_snapshot_includes_broker_runs(
@@ -748,6 +833,62 @@ def test_health_reports_dead_non_root_worktree(
     ]
 
 
+def test_health_ignores_dead_tmux_session_kept_current_by_broker_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    root = tmp_path / "repo"
+    worktree = tmp_path / "broker-worktree"
+    root.mkdir()
+    worktree.mkdir()
+    monkeypatch.setattr(mod, "REPO_ROOT", root)
+    monkeypatch.setattr(mod, "CANONICAL_REPO_ROOT", root)
+    monkeypatch.setattr(
+        mod,
+        "_load_broker_run_summaries",
+        lambda: [
+            {
+                "run_id": "broker-run",
+                "status": "running",
+                "sessions": {"critic": {"session_id": "broker-session"}},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        mod.agent_bridge_sessions,
+        "collect_sessions",
+        lambda **_kwargs: [
+            SimpleNamespace(
+                name="droid-broker",
+                agent="droid",
+                status="dead",
+                source="tmux",
+                branch="codex/bridge",
+                cwd=str(worktree),
+                session_id="broker-session",
+                updated_at="2026-05-13T00:00:00Z",
+                summary="broker-owned droid lane",
+                log_file=None,
+                transcript_file=None,
+            )
+        ],
+    )
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod, "_load_lane_registry", lambda: [])
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *args, **kwargs: argparse.Namespace(returncode=1, stdout="", stderr=""),
+    )
+
+    assert mod.cmd_health(argparse.Namespace(json=True)) == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True, "issues": []}
+
+
 def test_health_ignores_dead_session_with_removed_worktree(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -882,6 +1023,55 @@ def test_gc_dry_run_archives_only_bridge_owned_tmux_candidates(
     assert transcript.exists()
 
 
+def test_gc_dry_run_skips_stale_tmux_session_kept_current_by_broker_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    tmux_dir = tmp_path / "tmux"
+    tmux_dir.mkdir()
+    meta = tmux_dir / "factory-broker.meta.json"
+    log = tmux_dir / "factory-broker.log"
+    meta.write_text("{}", encoding="utf-8")
+    log.write_text("broker log", encoding="utf-8")
+    monkeypatch.setattr(mod, "TMUX_SESSIONS_DIR", tmux_dir)
+    monkeypatch.setattr(
+        mod,
+        "_load_broker_run_summaries",
+        lambda: [
+            {
+                "run_id": "broker-run",
+                "status": "running",
+                "sessions": {"critic": {"session_id": "factory-broker"}},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        mod.agent_bridge_sessions,
+        "load_tmux_sessions",
+        lambda **_kwargs: [
+            SimpleNamespace(
+                name="factory-broker",
+                source="tmux",
+                status="dead",
+                updated_at="2026-05-13T00:00:00Z",
+                session_id="factory-broker",
+                log_file=str(log),
+            )
+        ],
+    )
+
+    rc = mod.cmd_gc(argparse.Namespace(json=True, write=False, ttl_hours=24))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["actions"] == []
+    assert meta.exists()
+    assert log.exists()
+
+
 def test_gc_write_moves_stale_tmux_files_and_rewrites_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -923,3 +1113,37 @@ def test_gc_write_moves_stale_tmux_files_and_rewrites_snapshot(
     assert not log.exists()
     assert Path(payload["actions"][0]["archive_files"][0]).exists()
     assert json.loads((bridge_dir / "sessions.json").read_text(encoding="utf-8")) == []
+
+
+def test_gc_write_preserves_historical_sessions_in_canonical_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    bridge_dir = tmp_path / "bridge"
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "_gc_tmux_candidates", lambda *, ttl_hours: [])
+
+    def fake_discover(*, include_historical: bool, **_kwargs):
+        assert include_historical is True
+        return [
+            mod.Session(
+                name="claude-history",
+                agent="claude",
+                status="historical",
+                source="claude_jsonl",
+                lifecycle="historical",
+            )
+        ]
+
+    monkeypatch.setattr(mod, "discover", fake_discover)
+
+    rc = mod.cmd_gc(argparse.Namespace(json=True, write=True, ttl_hours=24))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is False
+    snapshot = json.loads((bridge_dir / "sessions.json").read_text(encoding="utf-8"))
+    assert [session["name"] for session in snapshot] == ["claude-history"]

--- a/tests/scripts/test_agent_bridge_supervise.py
+++ b/tests/scripts/test_agent_bridge_supervise.py
@@ -283,3 +283,61 @@ def test_main_once_json_renders_snapshot(
     payload = json.loads(capsys.readouterr().out)
     assert payload["lanes"][0]["next_action"] == "send_followup"
     assert payload["warnings"] == ["gh unavailable"]
+
+
+def test_collect_supervisor_snapshot_caps_records_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bridge_supervise as mod
+
+    sessions = [
+        mod.agent_bridge.Session(
+            name="codex-one",
+            agent="codex",
+            status="alive",
+            lifecycle="live",
+            worktree="/tmp/one",
+        ),
+        mod.agent_bridge.Session(
+            name="codex-two",
+            agent="codex",
+            status="alive",
+            lifecycle="live",
+            worktree="/tmp/two",
+        ),
+    ]
+    records = [
+        mod.agent_bridge.LaneRecord(lane_id="one", owner_session="codex-one", status="active"),
+        mod.agent_bridge.LaneRecord(lane_id="two", owner_session="codex-two", status="active"),
+    ]
+    monkeypatch.setattr(mod, "_discover_current_sessions", lambda: sessions)
+    monkeypatch.setattr(mod.agent_bridge, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod.agent_bridge, "_load_lane_registry", lambda: records)
+    monkeypatch.setattr(mod.agent_bridge, "_sync_lane_records", lambda loaded, _sessions: loaded)
+    monkeypatch.setattr(mod, "_load_pr_truth", lambda _records: ({}, []))
+    monkeypatch.setattr(
+        mod,
+        "_inspect_worktree",
+        lambda _path: mod.WorktreeStatus(state="clean"),
+    )
+
+    snapshot = mod.collect_supervisor_snapshot(max_records=1)
+
+    assert len(snapshot.decisions) == 1
+    assert snapshot.warnings == ["supervisor record cap applied: 1/2"]
+
+
+def test_collect_supervisor_snapshot_fails_open_on_discovery_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bridge_supervise as mod
+
+    def explode() -> list[mod.agent_bridge.Session]:
+        raise RuntimeError("tmux inventory unavailable")
+
+    monkeypatch.setattr(mod, "_discover_current_sessions", explode)
+
+    snapshot = mod.collect_supervisor_snapshot()
+
+    assert snapshot.decisions == []
+    assert snapshot.warnings == ["session discovery degraded: tmux inventory unavailable"]

--- a/tests/scripts/test_agent_bridge_supervise.py
+++ b/tests/scripts/test_agent_bridge_supervise.py
@@ -327,6 +327,59 @@ def test_collect_supervisor_snapshot_caps_records_and_warns(
     assert snapshot.warnings == ["supervisor record cap applied: 1/2"]
 
 
+def test_collect_supervisor_snapshot_treats_active_broker_session_as_current(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent_bridge_supervise as mod
+
+    session = mod.agent_bridge.Session(
+        name="droid-broker",
+        agent="droid",
+        status="active_broker",
+        lifecycle="active_broker",
+        branch="codex/bridge",
+        worktree=str(tmp_path),
+        session_id="broker-session",
+    )
+    records = [
+        mod.agent_bridge.LaneRecord(
+            lane_id="bridge-current",
+            owner_session="droid-broker",
+            status="active",
+            branch="codex/bridge",
+            worktree=str(tmp_path),
+        )
+    ]
+    pr_truth = mod.PRTruth(
+        branch="codex/bridge",
+        number=7190,
+        url="https://github.com/synaptent/aragora/pull/7190",
+        is_draft=False,
+        checks_bucket="pass",
+    )
+    monkeypatch.setattr(
+        mod.agent_bridge,
+        "_discover_with_broker_state",
+        lambda **_kwargs: ([session], [{"run_id": "broker-run"}], {"broker-session"}),
+    )
+    monkeypatch.setattr(mod.agent_bridge, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod.agent_bridge, "_load_lane_registry", lambda: records)
+    monkeypatch.setattr(mod.agent_bridge, "_sync_lane_records", lambda loaded, _sessions: loaded)
+    monkeypatch.setattr(mod, "_load_pr_truth", lambda _records: ({"codex/bridge": pr_truth}, []))
+    monkeypatch.setattr(
+        mod,
+        "_inspect_worktree",
+        lambda _path: mod.WorktreeStatus(state="clean"),
+    )
+
+    snapshot = mod.collect_supervisor_snapshot()
+
+    assert len(snapshot.decisions) == 1
+    assert snapshot.decisions[0].next_action == "ready_for_review"
+    assert "owner session is active_broker" not in snapshot.decisions[0].reason
+
+
 def test_collect_supervisor_snapshot_fails_open_on_discovery_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/swarm/agent_bridge/test_harnesses_codex.py
+++ b/tests/swarm/agent_bridge/test_harnesses_codex.py
@@ -18,9 +18,11 @@ class FakeRunner:
     def __init__(self, stdout: str) -> None:
         self.stdout = stdout
         self.commands: list[list[str]] = []
+        self.kwargs: list[dict[str, object]] = []
 
-    def __call__(self, command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+    def __call__(self, command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         self.commands.append(command)
+        self.kwargs.append(kwargs)
         return subprocess.CompletedProcess(command, 0, stdout=self.stdout, stderr="")
 
 
@@ -48,6 +50,7 @@ def test_codex_launch_parses_thread_started_agent_messages_and_usage(tmp_path: P
         "gpt-5.4",
         "Review the plan",
     ]
+    assert fake_runner.kwargs[0]["stdin"] == subprocess.DEVNULL
 
 
 def test_codex_plaintext_fallback_parses_session_id_and_footer(tmp_path: Path) -> None:

--- a/tests/swarm/agent_bridge/test_harnesses_droid.py
+++ b/tests/swarm/agent_bridge/test_harnesses_droid.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 from aragora.swarm.agent_bridge.harnesses.droid import DroidTransport
+from aragora.swarm.agent_bridge.harnesses import create_transport
 
 
 def _fixture_text(name: str) -> str:
@@ -102,3 +103,14 @@ def test_droid_resume_uses_session_flag(tmp_path: Path) -> None:
         "16329fce-3484-47a4-ad98-6676fdfb7477",
         "--cwd",
     ]
+
+
+def test_factory_harness_alias_uses_droid_transport(tmp_path: Path) -> None:
+    transport = create_transport(
+        "factory",
+        cwd=tmp_path,
+        binary_resolver=lambda _: "/usr/bin/droid",
+    )
+
+    assert isinstance(transport, DroidTransport)
+    assert transport.harness == "droid"


### PR DESCRIPTION
## Summary

Stabilizes the local agent bridge as a current-first control plane:

- adds session lifecycle classification so standalone Claude JSONL transcripts become `historical`, not noisy `unknown` live sessions
- makes `operator-snapshot` default to current truth only while allowing historical audit via `--include-historical` / `--scope all`
- includes broker runs in operator snapshots and summary counts
- adds `agent_bridge.py gc` dry-run/default hygiene for stale bridge-owned tmux metadata/logs; `--write` archives only those bridge-owned files and never touches external transcripts
- aliases broker harness `factory` to the existing Droid transport
- bounds/fails-open `agent_bridge_supervise.py --once` so degraded session/PR truth produces warnings instead of a hung operator feed
- documents that standalone Claude/Factory desktop chats are historical unless launched through bridge/broker or imported into a run receipt

## Validation

- `PYTHONPATH="$PWD" /Users/armand/Development/aragora/.venv/bin/python -m pytest tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_supervise.py tests/swarm/agent_bridge/test_harnesses_droid.py tests/scripts/test_agent_bridge_broker.py tests/swarm/agent_bridge/test_broker.py tests/swarm/agent_bridge/test_store.py tests/swarm/agent_bridge/test_types.py tests/handlers/test_agent_bridge_handler.py tests/openapi/test_agent_bridge_endpoints.py -q` -> 72 passed
- `/Users/armand/Development/aragora/.venv/bin/ruff check scripts/agent_bridge.py scripts/agent_bridge_supervise.py aragora/swarm/agent_bridge/harnesses/__init__.py tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_supervise.py tests/swarm/agent_bridge/test_harnesses_droid.py`
- `/Users/armand/Development/aragora/.venv/bin/ruff format --check scripts/agent_bridge.py scripts/agent_bridge_supervise.py aragora/swarm/agent_bridge/harnesses/__init__.py tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_supervise.py tests/swarm/agent_bridge/test_harnesses_droid.py`
- `/Users/armand/Development/aragora/.venv/bin/mypy scripts/agent_bridge.py scripts/agent_bridge_supervise.py aragora/swarm/agent_bridge/harnesses/__init__.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `PYTHONPATH="$PWD" timeout 15 /Users/armand/Development/aragora/.venv/bin/python scripts/agent_bridge_supervise.py --once --json | python3 -m json.tool`
- `PYTHONPATH="$PWD" /Users/armand/Development/aragora/.venv/bin/python scripts/agent_bridge.py operator-snapshot --json --summary-only`
- `PYTHONPATH="$PWD" /Users/armand/Development/aragora/.venv/bin/python scripts/agent_bridge.py gc --json` dry-run only; no files archived

## Dogfood note

This PR deliberately does not launch real Claude/Factory/Codex model turns. The real brokered next-work-selection dogfood should run after #7186 lands, from an AWS-authenticated founder terminal using Secrets Manager and no raw API key exports.
