### PR TITLE
fix(agent-bridge): preserve gc snapshot summaries

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -1209,7 +1209,7 @@ def cmd_gc(args: argparse.Namespace) -> int:
 
     if write:
         sessions, _broker_runs, _active_broker_ids = _discover_with_broker_state(
-            include_summaries=False,
+            include_summaries=True,
             include_historical=True,
         )
         _write_session_snapshot(sessions)

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -1126,8 +1126,9 @@ def test_gc_write_preserves_historical_sessions_in_canonical_snapshot(
     _patch_bridge_paths(mod, tmp_path, monkeypatch)
     monkeypatch.setattr(mod, "_gc_tmux_candidates", lambda *, ttl_hours: [])
 
-    def fake_discover(*, include_historical: bool, **_kwargs):
+    def fake_discover(*, include_historical: bool, include_summaries: bool = True, **_kwargs):
         assert include_historical is True
+        assert include_summaries is True
         return [
             mod.Session(
                 name="claude-history",
@@ -1135,6 +1136,7 @@ def test_gc_write_preserves_historical_sessions_in_canonical_snapshot(
                 status="historical",
                 source="claude_jsonl",
                 lifecycle="historical",
+                summary="old desktop context",
             )
         ]
 
@@ -1147,3 +1149,4 @@ def test_gc_write_preserves_historical_sessions_in_canonical_snapshot(
     assert payload["dry_run"] is False
     snapshot = json.loads((bridge_dir / "sessions.json").read_text(encoding="utf-8"))
     assert [session["name"] for session in snapshot] == ["claude-history"]
+    assert snapshot[0]["summary"] == "old desktop context"


### PR DESCRIPTION
## Summary

Follow-up repair after #7190: `agent_bridge.py gc --write` should rewrite the canonical `sessions.json` with full session payloads, not summary-stripped records.

- changes `cmd_gc` to rediscover with `include_summaries=True` before `_write_session_snapshot`
- extends the historical-session snapshot regression test to assert summary preservation

## Validation

- `PYTHONPATH="$PWD" /Users/armand/Development/aragora/.venv/bin/python -m pytest -q tests/scripts/test_agent_bridge.py::test_gc_write_preserves_historical_sessions_in_canonical_snapshot tests/scripts/test_agent_bridge.py::test_gc_write_moves_stale_tmux_files_and_rewrites_snapshot -p no:rerunfailures -p no:cacheprovider` -> 2 passed
- `/Users/armand/Development/aragora/.venv/bin/ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py`
- `/Users/armand/Development/aragora/.venv/bin/ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py`
- `/Users/armand/Development/aragora/.venv/bin/mypy scripts/agent_bridge.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

## Context

Droid/Gemini rereview of #7190 at `89b2e746b` found this as a merge-blocking canonical snapshot degradation after #7190 had already been externally merged.