### PR TITLE
[AGT-06] Add `aragora metrics status` CLI verb (flag-gated, default OFF)

### DIFF
--- a/aragora/cli/commands/agt_metrics.py
+++ b/aragora/cli/commands/agt_metrics.py
@@ -1,17 +1,18 @@
-"""CLI command: ``aragora metrics viah``.
+"""CLI commands: ``aragora metrics viah`` and ``aragora metrics status``.
 
-Reads the ShiftLedger and prints the latest VIAH (verifiable improvements
-per agent-hour) report. See aragora.metrics.viah for the metric
-definition (issue #6067).
+Reads the ShiftLedger and prints VIAH (verifiable improvements per
+agent-hour) operator surfaces. See aragora.metrics.viah for the metric
+definition (issue #6067, AGT-06).
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
-from aragora.metrics.viah import compute_viah
+from aragora.metrics.viah import VIAH_TREND_FLAG, compute_viah, viah_trend_enabled
 from aragora.swarm.shift_ledger import DEFAULT_LEDGER_PATH, ShiftLedger
 
 
@@ -60,4 +61,41 @@ def cmd_metrics_viah(args: argparse.Namespace) -> int:
     return 0
 
 
-__all__ = ["cmd_metrics_viah"]
+def cmd_metrics_status(args: argparse.Namespace) -> int:
+    """Print the VIAH operator-truth Markdown status report.
+
+    Gated behind ARAGORA_VIAH_TREND_ENABLED (default off). When the flag
+    is set, generates a report mirroring docs/status/B0_BENCHMARK_TRUTH_STATUS.md.
+    Pass --output to write to disk instead of stdout.
+    """
+    from aragora.metrics.viah_status import generate_viah_status_report
+
+    if not viah_trend_enabled():
+        print(
+            f"error: VIAH status surface is disabled; set {VIAH_TREND_FLAG}=1 to enable",
+            file=sys.stderr,
+        )
+        return 1
+
+    raw_path = getattr(args, "ledger_path", None)
+    ledger_path = Path(raw_path).expanduser() if raw_path else Path(DEFAULT_LEDGER_PATH)
+    ledger = ShiftLedger(path=ledger_path)
+    weeks = int(getattr(args, "weeks", 4))
+
+    try:
+        report_md = generate_viah_status_report(ledger, weeks=weeks)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    output_path_str = getattr(args, "output", None)
+    if output_path_str:
+        out_path = Path(output_path_str).expanduser()
+        out_path.write_text(report_md, encoding="utf-8")
+        print(f"Written to {out_path}")
+    else:
+        print(report_md)
+    return 0
+
+
+__all__ = ["cmd_metrics_status", "cmd_metrics_viah"]

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -221,7 +221,7 @@ Examples:
 
 
 def _add_metrics_parser(subparsers) -> None:
-    """Add the 'metrics' subcommand group with a 'viah' verb."""
+    """Add the 'metrics' subcommand group with 'viah' and 'status' verbs."""
     metrics_parser = subparsers.add_parser(
         "metrics",
         help="AGT-06: read VIAH and other operator metrics",
@@ -263,6 +263,30 @@ def _add_metrics_parser(subparsers) -> None:
     )
     viah.add_argument("--json", action="store_true", help="Emit the report as JSON")
     viah.set_defaults(func=_lazy("aragora.cli.commands.agt_metrics", "cmd_metrics_viah"))
+
+    status = metrics_sub.add_parser(
+        "status",
+        help=(
+            "Print VIAH operator-truth Markdown report (gated: ARAGORA_VIAH_TREND_ENABLED=1)"
+        ),
+    )
+    status.add_argument(
+        "--ledger-path",
+        default=None,
+        help="Path to the ShiftLedger JSONL (default: DEFAULT_LEDGER_PATH)",
+    )
+    status.add_argument(
+        "--weeks",
+        type=int,
+        default=4,
+        help="Number of rolling weeks to include in the trend table (default: 4)",
+    )
+    status.add_argument(
+        "--output",
+        default=None,
+        help="Write the Markdown report to this file path instead of stdout",
+    )
+    status.set_defaults(func=_lazy("aragora.cli.commands.agt_metrics", "cmd_metrics_status"))
 
 
 def _add_markets_parser(subparsers) -> None:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -266,9 +266,7 @@ def _add_metrics_parser(subparsers) -> None:
 
     status = metrics_sub.add_parser(
         "status",
-        help=(
-            "Print VIAH operator-truth Markdown report (gated: ARAGORA_VIAH_TREND_ENABLED=1)"
-        ),
+        help=("Print VIAH operator-truth Markdown report (gated: ARAGORA_VIAH_TREND_ENABLED=1)"),
     )
     status.add_argument(
         "--ledger-path",

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -92,7 +92,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `markets` | - | AGT-04: inspect and interact with synthetic GitHub prediction markets | `list`, `predict` |
 | `mcp-server` | - | Run the MCP (Model Context Protocol) server | - |
 | `memory` | - | Memory management commands | `promote`, `query`, `stats`, `store` |
-| `metrics` | - | AGT-06: read VIAH and other operator metrics | `viah` |
+| `metrics` | - | AGT-06: read VIAH and other operator metrics | `status`, `viah` |
 | `modes` | - | List available operational modes | - |
 | `nomic` | - | Nomic loop self-improvement commands | `history`, `resume`, `run`, `status` |
 | `openclaw` | - | OpenClaw Enterprise Gateway management | `audit`, `init`, `next-steps`, `policy`, `review`, `serve`, `status`, `watch` |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -87,7 +87,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `markets` | - | AGT-04: inspect and interact with synthetic GitHub prediction markets | `list`, `predict` |
 | `mcp-server` | - | Run the MCP (Model Context Protocol) server | - |
 | `memory` | - | Memory management commands | `promote`, `query`, `stats`, `store` |
-| `metrics` | - | AGT-06: read VIAH and other operator metrics | `viah` |
+| `metrics` | - | AGT-06: read VIAH and other operator metrics | `status`, `viah` |
 | `modes` | - | List available operational modes | - |
 | `nomic` | - | Nomic loop self-improvement commands | `history`, `resume`, `run`, `status` |
 | `openclaw` | - | OpenClaw Enterprise Gateway management | `audit`, `init`, `next-steps`, `policy`, `review`, `serve`, `status`, `watch` |

--- a/tests/cli/test_agt_metrics_status.py
+++ b/tests/cli/test_agt_metrics_status.py
@@ -1,0 +1,212 @@
+"""Tests for `aragora metrics status` CLI verb (AGT-06 / #6067).
+
+Verifies flag-gating, output content, file-write mode, and the --weeks param.
+No live API calls; all I/O through tmp_path ShiftLedger fixtures.
+"""
+
+from __future__ import annotations
+
+# ── Swarm package stub ───────────────────────────────────────────────────────
+# MUST precede any aragora import; prevents aragora/swarm/__init__.py from
+# running the heavy SwarmCommander→pydantic dependency chain.
+import pathlib as _pathlib
+import sys
+import types as _types
+
+if "aragora.swarm" not in sys.modules:
+    _swarm_stub = _types.ModuleType("aragora.swarm")
+    _swarm_stub.__path__ = [str(_pathlib.Path(__file__).parents[2] / "aragora" / "swarm")]
+    _swarm_stub.__package__ = "aragora.swarm"
+    sys.modules["aragora.swarm"] = _swarm_stub
+# ─────────────────────────────────────────────────────────────────────────────
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.agt_metrics import cmd_metrics_status
+from aragora.metrics.viah import VIAH_TREND_FLAG
+from aragora.swarm.shift_ledger import ShiftLedger
+
+
+def _ts(dt: datetime) -> str:
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _seed_ledger(path: Path, entries: list[dict]) -> ShiftLedger:
+    with path.open("w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e, sort_keys=True) + "\n")
+    return ShiftLedger(path=path)
+
+
+def _args(tmp_path: Path, **kwargs) -> argparse.Namespace:
+    ledger_path = tmp_path / "ledger.jsonl"
+    if not ledger_path.exists():
+        ledger_path.write_text("", encoding="utf-8")
+    defaults: dict = {"ledger_path": str(ledger_path), "weeks": 4, "output": None}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Feature-gate tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlagGating:
+    def test_returns_nonzero_when_flag_off(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(VIAH_TREND_FLAG, raising=False)
+        rc = cmd_metrics_status(_args(tmp_path))
+        assert rc != 0
+
+    def test_prints_flag_name_to_stderr_when_off(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(VIAH_TREND_FLAG, raising=False)
+        cmd_metrics_status(_args(tmp_path))
+        assert VIAH_TREND_FLAG in capsys.readouterr().err
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+    def test_returns_zero_when_flag_set(
+        self,
+        val: str,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(VIAH_TREND_FLAG, val)
+        rc = cmd_metrics_status(_args(tmp_path))
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Output content
+# ---------------------------------------------------------------------------
+
+
+class TestOutputContent:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(VIAH_TREND_FLAG, "1")
+
+    def test_report_contains_viah_heading(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        assert cmd_metrics_status(_args(tmp_path)) == 0
+        assert "# VIAH Status" in capsys.readouterr().out
+
+    def test_report_contains_summary_section(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        assert cmd_metrics_status(_args(tmp_path)) == 0
+        assert "## Summary" in capsys.readouterr().out
+
+    def test_report_shows_rolling_trend_section(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        assert cmd_metrics_status(_args(tmp_path, weeks=2)) == 0
+        assert "Rolling Trend" in capsys.readouterr().out
+
+    def test_empty_ledger_shows_na_for_viah(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        assert cmd_metrics_status(_args(tmp_path)) == 0
+        assert "N/A (no agent-hours)" in capsys.readouterr().out
+
+    def test_active_ledger_shows_numeric_viah(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        now = datetime.now(tz=UTC)
+        ledger_path = tmp_path / "active.jsonl"
+        _seed_ledger(
+            ledger_path,
+            [
+                {
+                    "entry_type": "shift_start",
+                    "timestamp": _ts(now - timedelta(hours=4)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "shift_stop",
+                    "timestamp": _ts(now - timedelta(minutes=10)),
+                    "payload": {"shift_id": "s1"},
+                },
+                {
+                    "entry_type": "pr_merged",
+                    "timestamp": _ts(now - timedelta(hours=2)),
+                    "payload": {"pr_number": 1},
+                },
+            ],
+        )
+        assert cmd_metrics_status(_args(tmp_path, ledger_path=str(ledger_path))) == 0
+        out = capsys.readouterr().out
+        assert "N/A (no agent-hours)" not in out
+
+
+# ---------------------------------------------------------------------------
+# File output mode
+# ---------------------------------------------------------------------------
+
+
+class TestFileOutput:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(VIAH_TREND_FLAG, "1")
+
+    def test_writes_markdown_to_path(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        out_path = tmp_path / "viah_status.md"
+        assert cmd_metrics_status(_args(tmp_path, output=str(out_path))) == 0
+        assert out_path.exists()
+        assert "# VIAH Status" in out_path.read_text(encoding="utf-8")
+
+    def test_stdout_shows_written_path(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        out_path = tmp_path / "viah_status.md"
+        cmd_metrics_status(_args(tmp_path, output=str(out_path)))
+        assert str(out_path) in capsys.readouterr().out
+
+    def test_report_not_duplicated_to_stdout_when_writing_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        out_path = tmp_path / "viah_status.md"
+        cmd_metrics_status(_args(tmp_path, output=str(out_path)))
+        assert "# VIAH Status" not in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# --weeks parameter
+# ---------------------------------------------------------------------------
+
+
+class TestWeeksParam:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(VIAH_TREND_FLAG, "1")
+
+    def test_two_week_trend_shows_w0_and_w1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        assert cmd_metrics_status(_args(tmp_path, weeks=2)) == 0
+        out = capsys.readouterr().out
+        assert "W0" in out
+        assert "W1" in out
+
+    def test_four_week_trend_shows_w3(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        assert cmd_metrics_status(_args(tmp_path, weeks=4)) == 0
+        out = capsys.readouterr().out
+        assert "W3" in out
+
+    def test_default_weeks_is_four(self, tmp_path: Path) -> None:
+        args = _args(tmp_path)
+        assert args.weeks == 4

--- a/tests/cli/test_agt_metrics_status.py
+++ b/tests/cli/test_agt_metrics_status.py
@@ -159,17 +159,13 @@ class TestFileOutput:
     def _enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(VIAH_TREND_FLAG, "1")
 
-    def test_writes_markdown_to_path(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_writes_markdown_to_path(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         out_path = tmp_path / "viah_status.md"
         assert cmd_metrics_status(_args(tmp_path, output=str(out_path))) == 0
         assert out_path.exists()
         assert "# VIAH Status" in out_path.read_text(encoding="utf-8")
 
-    def test_stdout_shows_written_path(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_stdout_shows_written_path(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         out_path = tmp_path / "viah_status.md"
         cmd_metrics_status(_args(tmp_path, output=str(out_path)))
         assert str(out_path) in capsys.readouterr().out
@@ -200,9 +196,7 @@ class TestWeeksParam:
         assert "W0" in out
         assert "W1" in out
 
-    def test_four_week_trend_shows_w3(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_four_week_trend_shows_w3(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         assert cmd_metrics_status(_args(tmp_path, weeks=4)) == 0
         out = capsys.readouterr().out
         assert "W3" in out


### PR DESCRIPTION
## Slice

Wires the existing `generate_viah_status_report()` from `aragora.metrics.viah_status` into a new `aragora metrics status` subverb. The existing `aragora metrics viah` subverb computed raw VIAH numbers; `status` emits the full operator-truth Markdown report that mirrors the `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` pattern — rolling trend table, signal breakdown, caveats — suitable for piping to a status doc or reading on the CLI.

## Gating

- Default: **OFF** (flag: `ARAGORA_VIAH_TREND_ENABLED=1`)
- Live queue effect: **none** (report-only; no Arena wiring, no queue mutation, no dispatch changes)
- Advances issue: #6067 (AGT-06 — Verifiable improvements per agent-hour)

## Tests

- `TestFlagGating` (6 tests): returns non-zero when flag off; flag name in stderr; returns zero for all truthy flag values (`1`, `true`, `yes`, `on`)
- `TestOutputContent` (5 tests): `# VIAH Status` heading; `## Summary` section; `Rolling Trend` section; `N/A (no agent-hours)` on empty ledger; numeric VIAH on active ledger (no N/A)
- `TestFileOutput` (3 tests): Markdown written to `--output` path; stdout shows written path; report not duplicated to stdout when writing file
- `TestWeeksParam` (3 tests): `--weeks 2` shows `W0` and `W1`; `--weeks 4` shows `W3`; default `weeks=4`

## Validation

- `pytest tests/cli/test_agt_metrics_status.py --noconftest` — **17/17 passed**
- `ruff check aragora/cli/commands/agt_metrics.py aragora/cli/parser.py tests/cli/test_agt_metrics_status.py` — clean
- `mypy aragora/cli/commands/agt_metrics.py tests/cli/test_agt_metrics_status.py --ignore-missing-imports` — Success: no issues found in 2 source files
- Net diff: **274 LOC** (69 added to existing files + 212-line new test file − 7 removed)

## Out of scope

- `aragora metrics trend` subverb (a focused trend-only view without the full Markdown report) — separate slice, separate PR
- Automated periodic `metrics status` write to `docs/status/VIAH_STATUS.md` — separate slice; involves scheduling and CI integration
- Sidecar AGT-05 signal wiring (crux-correctness, prediction-Brier counts) — tracked under AGT-05; sidecar signals default to 0 until that path is live
- `aragora metrics viah` modifications — existing verb untouched

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGTRxDziGEGpYcZSUJFLYG)_