### PR TITLE
fix(automation): preserve PR handoffs after issue receipts

### DIFF
--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -672,6 +672,12 @@ def _receipt_satisfies_outbox(
     receipt_payload: dict[str, Any],
 ) -> bool:
     reason = str(receipt_payload.get("reason") or "").strip().lower()
+    if _is_pr_open_request(payload):
+        created_issue_url = str(receipt_payload.get("created_issue_url") or "").strip()
+        existing_issue_url = str(receipt_payload.get("existing_issue_url") or "").strip()
+        if reason in {"published", "existing_issue"} or created_issue_url or existing_issue_url:
+            return False
+
     desired_head = _outbox_desired_head(payload)
     if reason != "target_open_pr" or not desired_head:
         return True

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -258,6 +258,56 @@ def test_load_outbox_handoffs_skips_terminal_receipt_named_by_file(tmp_path: Pat
     assert mod.load_outbox_handoffs(tmp_path) == []
 
 
+@pytest.mark.parametrize(
+    ("reason", "url_key", "url"),
+    [
+        ("published", "created_issue_url", "https://github.com/synaptent/aragora/issues/7151"),
+        (
+            "existing_issue",
+            "existing_issue_url",
+            "https://github.com/synaptent/aragora/issues/6992",
+        ),
+    ],
+)
+def test_load_outbox_handoffs_keeps_pr_handoff_after_issue_receipt(
+    tmp_path: Path,
+    reason: str,
+    url_key: str,
+    url: str,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "open-pr-codex-example-abc123"
+    (outbox / "repair-branch.json").write_text(
+        json.dumps(
+            _outbox_payload(
+                repo=str(tmp_path),
+                idempotency_key=key,
+                local_evidence={"branch": "codex/example", "head": "abc123"},
+            )
+        ),
+        encoding="utf-8",
+    )
+    (receipts / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "published" if reason == "published" else "already_satisfied",
+                "reason": reason,
+                url_key: url,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    handoffs = mod.load_outbox_handoffs(tmp_path)
+
+    assert len(handoffs) == 1
+    assert handoffs[0].idempotency_key == key
+
+
 def test_load_outbox_handoffs_keeps_stale_target_pr_receipt(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary

Preserve open-PR automation handoffs when an unrelated GitHub issue receipt exists for the same idempotency key. This prevents PR handoff records from being incorrectly treated as terminal just because the publisher previously created or found an issue.

## Validation

- `PYTHONPATH=/Users/armand/Development/aragora/.worktrees/pr-7207-review /Users/armand/Development/aragora/.venv/bin/python -m pytest tests/scripts/test_publish_automation_handoffs.py -q` -> `52 passed`
- `/Users/armand/Development/aragora/.venv/bin/ruff check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` -> clean
- `/Users/armand/Development/aragora/.venv/bin/ruff format --check scripts/publish_automation_handoffs.py tests/scripts/test_publish_automation_handoffs.py` -> clean
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`

## Scope

Two-file automation hygiene fix only:

- `scripts/publish_automation_handoffs.py`
- `tests/scripts/test_publish_automation_handoffs.py`

No GitHub issue mutation logic changes and no bridge/harness changes.
