### PR TITLE
[DIC-24] Add `aragora genealogy show` CLI verb (flag-gated, default OFF)

### DIFF
--- a/aragora/cli/commands/dic24_genealogy.py
+++ b/aragora/cli/commands/dic24_genealogy.py
@@ -1,0 +1,100 @@
+"""CLI command: ``aragora genealogy show``.
+
+DIC-24 operator surface for the epistemic genealogy ledger (issue #6218).
+
+Reads a JSONL store file where each line encodes one GenealogyEntry:
+    {"code_unit_id": "...", "entry_kind": "...", "entry_id": "...",
+     "checksum": "...", "timestamp": "...", "metadata": {...}}
+
+Flag: ``ARAGORA_GENEALOGY_ENABLED`` (default OFF).
+Live queue effect: none — read-only operator surface.
+Advances: issue #6218 (DIC-24).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from aragora.epistemic.genealogy import GenealogyEntry, InMemoryGenealogyStore, get_genealogy
+
+logger = logging.getLogger(__name__)
+
+_FLAG = "ARAGORA_GENEALOGY_ENABLED"
+_DEFAULT_STORE = ".aragora_genealogy.jsonl"
+
+
+def _flag_enabled() -> bool:
+    return os.environ.get(_FLAG, "").lower() in {"1", "true", "yes", "on"}
+
+
+def _load_store(path: Path) -> InMemoryGenealogyStore:
+    """Parse *path* line-by-line into an InMemoryGenealogyStore.
+
+    Malformed lines are logged at WARNING and skipped.
+    """
+    store = InMemoryGenealogyStore()
+    if not path.exists():
+        return store
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            obj: dict[str, Any] = json.loads(raw)
+            entry = GenealogyEntry(
+                entry_kind=obj["entry_kind"],  # type: ignore[arg-type]
+                entry_id=str(obj["entry_id"]),
+                checksum=str(obj["checksum"]),
+                timestamp=str(obj["timestamp"]),
+                metadata=dict(obj.get("metadata") or {}),
+            )
+            store.add(str(obj["code_unit_id"]), entry)
+        except (KeyError, ValueError, TypeError) as exc:
+            logger.warning("genealogy store line %d skipped: %s", lineno, exc)
+    return store
+
+
+def cmd_genealogy_show(args: argparse.Namespace) -> int:
+    """Show lineage for one proof-carrying code unit."""
+    if not _flag_enabled():
+        print(
+            f"error: {_FLAG} is not set; set it to '1' to enable genealogy commands",
+            file=sys.stderr,
+        )
+        return 1
+
+    code_unit_id: str = args.code_unit_id
+    store_path = Path(getattr(args, "store_file", _DEFAULT_STORE)).expanduser()
+    as_json: bool = getattr(args, "json", False)
+
+    store = _load_store(store_path)
+    try:
+        genealogy = get_genealogy(code_unit_id, store, require_enabled=True)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if as_json:
+        print(json.dumps(genealogy.to_dict(), indent=2))
+        return 0
+
+    entries = genealogy.entries
+    print(f"Genealogy: {code_unit_id}")
+    print(f"  entries       : {len(entries)}")
+    print(f"  chain_checksum: {genealogy.chain_checksum[:16]}…")
+    if entries:
+        print(f"  oldest        : {entries[0].timestamp}")
+        print(f"  newest        : {entries[-1].timestamp}")
+        print()
+        for e in entries:
+            meta = f" | {e.metadata}" if e.metadata else ""
+            print(f"  [{e.entry_kind}] {e.entry_id} @ {e.timestamp}{meta}")
+    else:
+        print("  (no entries)")
+    return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -206,11 +206,12 @@ Examples:
     _add_build_parser(subparsers)
     _add_essay_parser(subparsers)
 
-    # AGT-* operator surfaces (read-only)
+    # AGT-* / DIC-* operator surfaces (read-only)
     _add_metrics_parser(subparsers)
     _add_markets_parser(subparsers)
     _add_calibration_parser(subparsers)
     _add_cruxset_parser(subparsers)
+    _add_genealogy_parser(subparsers)  # DIC-24 / #6218
 
     return parser
 
@@ -504,6 +505,33 @@ def _add_cruxset_parser(subparsers) -> None:
         help="Re-emit the (verified) CruxSet as JSON instead of pretty-printing",
     )
     show.set_defaults(func=_lazy("aragora.cli.commands.agt_cruxset", "cmd_cruxset_show"))
+
+
+def _add_genealogy_parser(subparsers) -> None:
+    """Add the 'genealogy' subcommand group (DIC-24 / #6218).
+
+    Flag-gated: ARAGORA_GENEALOGY_ENABLED must be set.
+    Live queue effect: none (read-only operator report).
+    """
+    gp = subparsers.add_parser(
+        "genealogy",
+        help="DIC-24: inspect epistemic genealogy ledger for proof-carrying code units",
+        description=(
+            "Read-only operator surface for the epistemic genealogy ledger. "
+            "Requires ARAGORA_GENEALOGY_ENABLED=1."
+        ),
+    )
+    gp_sub = gp.add_subparsers(dest="genealogy_cmd")
+    show = gp_sub.add_parser("show", help="Show lineage for one proof-carrying code unit")
+    show.add_argument("code_unit_id", help="The code_unit_id to look up")
+    show.add_argument(
+        "--store-file",
+        dest="store_file",
+        default=".aragora_genealogy.jsonl",
+        help="Path to the genealogy JSONL store (default: .aragora_genealogy.jsonl)",
+    )
+    show.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    show.set_defaults(func=_lazy("aragora.cli.commands.dic24_genealogy", "cmd_genealogy_show"))
 
 
 def _add_ask_parser(subparsers) -> None:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -11,8 +11,8 @@ description: Generated Aragora CLI command catalog from live parser
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **95**
-- Total top-level invocations (including aliases): **96**
+- Canonical top-level commands: **96**
+- Total top-level invocations (including aliases): **97**
 
 ## Installation
 
@@ -79,6 +79,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `explain` | - | Explain a debate decision (evidence chains, vote pivots, counterfactuals) | - |
 | `export` | - | Export debate artifacts | - |
 | `gauntlet` | - | Adversarial stress-test a specification, architecture, or policy | - |
+| `genealogy` | - | DIC-24: inspect epistemic genealogy ledger for proof-carrying code units | `show` |
 | `handlers` | - | List registered HTTP handlers and routes | `list`, `routes` |
 | `healthcare` | - | Healthcare vertical: adversarial clinical decision review | `review` |
 | `idea` | - | Clarify a vague idea into a structured initiative brief | `intake`, `review`, `triage` |

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 96 commands | 43.2% |
+| **CLI** | 97 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 96 commands | 43.2% |
+| **CLI** | 97 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4115` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1933267` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4119` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1935096` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `137` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5164` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217741` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `680` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `63` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| Test files (test_*.py under tests/) | `5171` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217880` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `682` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| CLI top-level command modules | `64` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `831` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `832` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **95**
-- Total top-level invocations (including aliases): **96**
+- Canonical top-level commands: **96**
+- Total top-level invocations (including aliases): **97**
 
 ## Installation
 
@@ -74,6 +74,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `explain` | - | Explain a debate decision (evidence chains, vote pivots, counterfactuals) | - |
 | `export` | - | Export debate artifacts | - |
 | `gauntlet` | - | Adversarial stress-test a specification, architecture, or policy | - |
+| `genealogy` | - | DIC-24: inspect epistemic genealogy ledger for proof-carrying code units | `show` |
 | `handlers` | - | List registered HTTP handlers and routes | `list`, `routes` |
 | `healthcare` | - | Healthcare vertical: adversarial clinical decision review | `review` |
 | `idea` | - | Clarify a vague idea into a structured initiative brief | `intake`, `review`, `triage` |

--- a/tests/cli/test_dic24_genealogy.py
+++ b/tests/cli/test_dic24_genealogy.py
@@ -1,0 +1,146 @@
+"""Tests for aragora.cli.commands.dic24_genealogy (DIC-24 / #6218).
+
+Run with:
+    pytest tests/cli/test_dic24_genealogy.py --noconftest
+
+All tests are hermetic; tmpdir for JSONL files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands.dic24_genealogy import (
+    _FLAG,
+    cmd_genealogy_show,
+)
+
+_A = {
+    "code_unit_id": "proof_first.shift",
+    "entry_kind": "decay_signal",
+    "entry_id": "decay-001",
+    "checksum": "aabbcc",
+    "timestamp": "2026-04-25T10:00:00Z",
+}
+_B = {
+    "code_unit_id": "proof_first.shift",
+    "entry_kind": "repair_proposal",
+    "entry_id": "repair-001",
+    "checksum": "ddeeff",
+    "timestamp": "2026-04-26T12:00:00Z",
+}
+
+
+def _store(tmp_path: Path, entries: list[dict]) -> Path:
+    p = tmp_path / "gen.jsonl"
+    p.write_text("\n".join(json.dumps(e) for e in entries), encoding="utf-8")
+    return p
+
+
+def _ns(**kw) -> argparse.Namespace:
+    d = {"store_file": ".aragora_genealogy.jsonl", "json": False}
+    d.update(kw)
+    return argparse.Namespace(**d)
+
+
+# -- Flag gating --
+
+class TestFlagGating:
+    def test_exits_1_when_flag_off(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.delenv(_FLAG, raising=False)
+        assert cmd_genealogy_show(_ns(code_unit_id="x", store_file=str(_store(tmp_path, [_A])))) == 1
+
+    def test_error_message_names_flag(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.delenv(_FLAG, raising=False)
+        cmd_genealogy_show(_ns(code_unit_id="x", store_file=str(_store(tmp_path, [_A]))))
+        assert _FLAG in capsys.readouterr().err
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+    def test_flag_truthy_values_accepted(self, monkeypatch, tmp_path, val: str) -> None:
+        monkeypatch.setenv(_FLAG, val)
+        args = _ns(code_unit_id="proof_first.shift", store_file=str(_store(tmp_path, [_A])))
+        assert cmd_genealogy_show(args) == 0
+
+
+# -- show: text output --
+
+class TestShowText:
+    def test_shows_code_unit_id_and_count(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        args = _ns(code_unit_id="proof_first.shift", store_file=str(_store(tmp_path, [_A, _B])))
+        cmd_genealogy_show(args)
+        out = capsys.readouterr().out
+        assert "proof_first.shift" in out and "2" in out
+
+    def test_unknown_unit_shows_no_entries(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        args = _ns(code_unit_id="nonexistent", store_file=str(_store(tmp_path, [_A])))
+        assert cmd_genealogy_show(args) == 0
+        assert "no entries" in capsys.readouterr().out
+
+    def test_missing_store_file_ok(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        args = _ns(code_unit_id="x", store_file=str(tmp_path / "missing.jsonl"))
+        assert cmd_genealogy_show(args) == 0
+        assert "no entries" in capsys.readouterr().out
+
+    def test_entry_kind_and_id_appear_in_output(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        args = _ns(code_unit_id="proof_first.shift", store_file=str(_store(tmp_path, [_A])))
+        cmd_genealogy_show(args)
+        out = capsys.readouterr().out
+        assert "decay_signal" in out and "decay-001" in out
+
+
+# -- show: JSON output --
+
+class TestShowJson:
+    def test_json_output_has_correct_fields(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        args = _ns(code_unit_id="proof_first.shift", store_file=str(_store(tmp_path, [_A, _B])), json=True)
+        cmd_genealogy_show(args)
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["code_unit_id"] == "proof_first.shift"
+        assert payload["entry_count"] == 2
+        assert len(payload["chain_checksum"]) == 64
+
+    def test_entries_sorted_oldest_first(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        args = _ns(code_unit_id="proof_first.shift", store_file=str(_store(tmp_path, [_B, _A])), json=True)
+        cmd_genealogy_show(args)
+        ts = [e["timestamp"] for e in json.loads(capsys.readouterr().out)["entries"]]
+        assert ts == sorted(ts)
+
+    def test_json_unknown_unit_has_zero_entries(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        args = _ns(code_unit_id="no.such.unit", store_file=str(_store(tmp_path, [_A])), json=True)
+        cmd_genealogy_show(args)
+        assert json.loads(capsys.readouterr().out)["entry_count"] == 0
+
+
+# -- JSONL parsing resilience --
+
+class TestJsonlParsing:
+    def test_malformed_line_skipped(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        p = tmp_path / "bad.jsonl"
+        p.write_text(json.dumps(_A) + "\nnot-json\n" + json.dumps(_B), encoding="utf-8")
+        args = _ns(code_unit_id="proof_first.shift", store_file=str(p), json=True)
+        import io
+        import sys
+        old, sys.stdout = sys.stdout, io.StringIO()
+        rc = cmd_genealogy_show(args)
+        out, sys.stdout = sys.stdout.getvalue(), old
+        assert rc == 0 and json.loads(out)["entry_count"] == 2
+
+    def test_blank_lines_ignored(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        p = tmp_path / "blanks.jsonl"
+        p.write_text("\n\n" + json.dumps(_A) + "\n\n", encoding="utf-8")
+        args = _ns(code_unit_id="proof_first.shift", store_file=str(p), json=True)
+        cmd_genealogy_show(args)
+        assert json.loads(capsys.readouterr().out)["entry_count"] == 1

--- a/tests/cli/test_dic24_genealogy.py
+++ b/tests/cli/test_dic24_genealogy.py
@@ -49,10 +49,13 @@ def _ns(**kw) -> argparse.Namespace:
 
 # -- Flag gating --
 
+
 class TestFlagGating:
     def test_exits_1_when_flag_off(self, monkeypatch, tmp_path) -> None:
         monkeypatch.delenv(_FLAG, raising=False)
-        assert cmd_genealogy_show(_ns(code_unit_id="x", store_file=str(_store(tmp_path, [_A])))) == 1
+        assert (
+            cmd_genealogy_show(_ns(code_unit_id="x", store_file=str(_store(tmp_path, [_A])))) == 1
+        )
 
     def test_error_message_names_flag(self, monkeypatch, tmp_path, capsys) -> None:
         monkeypatch.delenv(_FLAG, raising=False)
@@ -67,6 +70,7 @@ class TestFlagGating:
 
 
 # -- show: text output --
+
 
 class TestShowText:
     def test_shows_code_unit_id_and_count(self, monkeypatch, tmp_path, capsys) -> None:
@@ -98,10 +102,13 @@ class TestShowText:
 
 # -- show: JSON output --
 
+
 class TestShowJson:
     def test_json_output_has_correct_fields(self, monkeypatch, tmp_path, capsys) -> None:
         monkeypatch.setenv(_FLAG, "1")
-        args = _ns(code_unit_id="proof_first.shift", store_file=str(_store(tmp_path, [_A, _B])), json=True)
+        args = _ns(
+            code_unit_id="proof_first.shift", store_file=str(_store(tmp_path, [_A, _B])), json=True
+        )
         cmd_genealogy_show(args)
         payload = json.loads(capsys.readouterr().out)
         assert payload["code_unit_id"] == "proof_first.shift"
@@ -110,7 +117,9 @@ class TestShowJson:
 
     def test_entries_sorted_oldest_first(self, monkeypatch, tmp_path, capsys) -> None:
         monkeypatch.setenv(_FLAG, "1")
-        args = _ns(code_unit_id="proof_first.shift", store_file=str(_store(tmp_path, [_B, _A])), json=True)
+        args = _ns(
+            code_unit_id="proof_first.shift", store_file=str(_store(tmp_path, [_B, _A])), json=True
+        )
         cmd_genealogy_show(args)
         ts = [e["timestamp"] for e in json.loads(capsys.readouterr().out)["entries"]]
         assert ts == sorted(ts)
@@ -124,6 +133,7 @@ class TestShowJson:
 
 # -- JSONL parsing resilience --
 
+
 class TestJsonlParsing:
     def test_malformed_line_skipped(self, monkeypatch, tmp_path) -> None:
         monkeypatch.setenv(_FLAG, "1")
@@ -132,6 +142,7 @@ class TestJsonlParsing:
         args = _ns(code_unit_id="proof_first.shift", store_file=str(p), json=True)
         import io
         import sys
+
         old, sys.stdout = sys.stdout, io.StringIO()
         rc = cmd_genealogy_show(args)
         out, sys.stdout = sys.stdout.getvalue(), old


### PR DESCRIPTION
## Slice

Wires the existing `GenealogyEntry` / `InMemoryGenealogyStore` / `get_genealogy` substrate from `aragora.epistemic.genealogy` (already implemented, already tested) into an operator-readable CLI surface. The new `aragora genealogy show <code_unit_id>` verb reads a JSONL store file, reconstructs the lineage chain for one proof-carrying code unit, and emits text or JSON output.

No new data model is introduced — this is purely the operator surface that was missing for DIC-24.

## Gating

- Default: **OFF** (flag: `ARAGORA_GENEALOGY_ENABLED`; exits 1 and names the flag when unset)
- Live queue effect: **none** (read-only; no Arena wiring, no queue mutation, no dispatch changes)
- Advances issue: #6218 (DIC-24 — Epistemic Genealogy ledger)

## Tests

- `TestFlagGating` (6 tests): exits 1 when flag unset; error names `ARAGORA_GENEALOGY_ENABLED`; all truthy env values (`1`, `true`, `yes`, `on`) accepted
- `TestShowText` (4 tests): shows code_unit_id and entry count; unknown unit → "no entries"; missing store file → "no entries" (not crash); entry kind and ID appear in text output
- `TestShowJson` (3 tests): JSON payload has `code_unit_id`, `entry_count`, 64-char `chain_checksum`; entries sorted oldest-first; unknown unit → `entry_count == 0`
- `TestJsonlParsing` (2 tests): malformed line skipped, valid entries still loaded; blank lines ignored

## Validation

- `pytest tests/cli/test_dic24_genealogy.py --noconftest` — **15/15 passed**
- `ruff check aragora/cli/commands/dic24_genealogy.py aragora/cli/parser.py tests/cli/test_dic24_genealogy.py` — clean
- `mypy aragora/cli/commands/dic24_genealogy.py tests/cli/test_dic24_genealogy.py --ignore-missing-imports` — Success: no issues found in 2 source files
- Net diff: **274 LOC** (100-line new command + 30-line parser addition + 146-line test file − 1 deletion)

## Out of scope

- `aragora genealogy report` (aggregate report across all units in the store) — next slice, separate PR; the `build_genealogy_report` function already exists in `aragora.epistemic.genealogy_report`
- JSONL-backed `GenealogyStore` class for production wiring — deferred to DIC-23..28 activation gate per `genealogy.py` docstring
- Linking to live receipt / KM store paths — deferred to the same gate
- `aragora genealogy ingest` (write entries to the store) — separate slice once the activation gate opens

Labels: `vision-layer`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ttszj7QcAc585Q1bPW44Wv)_