### PR TITLE
fix(automation): default outbox reconcile repo

### DIFF
--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -345,10 +345,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--repo",
-        required=True,
+        default=".",
         help=(
             "Repository root or disposable worktree used for git checks. "
-            "Outbox/receipt state defaults to this path's .aragora/ subdirectory."
+            "Outbox/receipt state defaults to this path's .aragora/ subdirectory "
+            "(default: current working directory)."
         ),
     )
     parser.add_argument("--base", default="origin/main")

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -71,6 +71,31 @@ def test_dry_run_does_not_write_report_by_default(
     assert not (tmp_path / ".aragora" / "cleanup-state").exists()
 
 
+def test_repo_defaults_to_current_working_directory(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    key = "open-pr-codex-default-repo-abc123"
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    _write_outbox_handoff(outbox_dir, branch="codex/default-repo", key=key)
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps({"idempotency_key": key, "status": "published"}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    rc = mod.main(["--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["repo"] == str(tmp_path.resolve())
+    assert payload["state_root"] == str(tmp_path.resolve())
+    assert payload["outbox_dir"] == str(outbox_dir.resolve())
+    assert payload["receipt_dir"] == str(receipt_dir.resolve())
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 1
+
+
 def test_explicit_dry_run_flag_keeps_read_only_default(
     tmp_path: Path, monkeypatch: Any, capsys: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- allow reconcile_automation_outbox.py to default --repo to the current checkout
- keep explicit --repo / --state-root behavior unchanged
- adds regression coverage for cwd-based default path resolution

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_reconcile_automation_outbox.py -p no:rerunfailures -p no:cacheprovider
- python3 -m ruff check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py
- python3 -m ruff format --check scripts/reconcile_automation_outbox.py tests/scripts/test_reconcile_automation_outbox.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- git diff --check origin/main...HEAD
- gitleaks detect --no-git --source /tmp/pr-reconcile-outbox-default-repo.patch --log-level error
- python3 scripts/reconcile_automation_outbox.py --dry-run --json
- python3 scripts/reconcile_automation_outbox.py --repo /Users/armand/Development/aragora --state-root /Users/armand/Development/aragora/.aragora --dry-run --json

Refs #7208.

Non-claims: does not run observe-outcomes --write, does not alter publisher launchd, and does not broaden automation writer scope.