### PR TITLE
feat(work): add read-only Agent Flywheel work board

### DIFF
--- a/aragora/cli/commands/work_board.py
+++ b/aragora/cli/commands/work_board.py
@@ -1,0 +1,70 @@
+"""Read-only ``aragora work`` commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from aragora.work.board import build_robot_recommendations, build_work_graph, collect_work_items
+from aragora.work.models import SCHEMA_VERSION
+
+
+def _repo_root(args: argparse.Namespace) -> Path:
+    return Path(getattr(args, "repo", ".")).expanduser().resolve()
+
+
+def _emit(payload: dict[str, Any], *, as_json: bool) -> int:
+    if as_json:
+        print(json.dumps(payload, sort_keys=True, indent=2))
+        return 0
+    print(json.dumps(payload, sort_keys=True, indent=2))
+    return 0
+
+
+def cmd_work_list(args: argparse.Namespace) -> int:
+    items, health = collect_work_items(_repo_root(args), scope=args.scope)
+    return _emit(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "scope": args.scope,
+            "count": len(items),
+            "items": [item.to_dict() for item in items],
+            "source_health": health,
+        },
+        as_json=getattr(args, "json", False),
+    )
+
+
+def cmd_work_show(args: argparse.Namespace) -> int:
+    items, health = collect_work_items(_repo_root(args), scope="all")
+    item = next((candidate for candidate in items if candidate.id == args.work_id), None)
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "id": args.work_id,
+        "found": item is not None,
+        "item": item.to_dict() if item else None,
+        "source_health": health,
+    }
+    return _emit(payload, as_json=getattr(args, "json", False))
+
+
+def cmd_work_graph(args: argparse.Namespace) -> int:
+    graph = build_work_graph(_repo_root(args), scope="all", root_id=getattr(args, "work_id", None))
+    return _emit(graph.to_dict(), as_json=getattr(args, "json", False))
+
+
+def cmd_work_robot(args: argparse.Namespace) -> int:
+    recommendations, health = build_robot_recommendations(_repo_root(args), scope="current")
+    return _emit(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "scope": "current",
+            "count": len(recommendations),
+            "recommendations": [rec.to_dict() for rec in recommendations],
+            "source_health": health,
+            "mutations": [],
+        },
+        as_json=getattr(args, "json", False),
+    )

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -188,6 +188,7 @@ Examples:
     _add_self_improve_parser(subparsers)
     _add_swarm_parser(subparsers)
     _add_tasks_parser(subparsers)
+    _add_work_parser(subparsers)
     _add_worktree_parser(subparsers)
     _add_outcome_parser(subparsers)
     _add_explain_parser(subparsers)
@@ -289,6 +290,51 @@ def _add_metrics_parser(subparsers) -> None:
         help="Write the Markdown report to this file path instead of stdout",
     )
     status.set_defaults(func=_lazy("aragora.cli.commands.agt_metrics", "cmd_metrics_status"))
+
+
+def _add_work_parser(subparsers) -> None:
+    """Add the read-only Aragora-native work board commands."""
+    work = subparsers.add_parser(
+        "work",
+        help="Inspect the read-only Aragora work board",
+        description=(
+            "Read-only Agent Flywheel kernel over PRs, automation, broker runs, "
+            "beads/convoys, and missions. This command never claims, launches, "
+            "closes, or mutates work."
+        ),
+    )
+    work_sub = work.add_subparsers(dest="work_cmd")
+
+    def add_common(p) -> None:
+        p.add_argument("--repo", default=".", help="Repository root to inspect (default: cwd)")
+        p.add_argument("--json", action="store_true", help="Emit stable JSON")
+
+    list_cmd = work_sub.add_parser("list", help="List normalized work items")
+    add_common(list_cmd)
+    list_cmd.add_argument(
+        "--scope",
+        choices=("current", "all"),
+        default="current",
+        help="current excludes terminal/historical noise; all includes context records",
+    )
+    list_cmd.set_defaults(func=_lazy("aragora.cli.commands.work_board", "cmd_work_list"))
+
+    show_cmd = work_sub.add_parser("show", help="Show one normalized work item")
+    add_common(show_cmd)
+    show_cmd.add_argument("work_id", help="Work item id, e.g. pr:7210")
+    show_cmd.set_defaults(func=_lazy("aragora.cli.commands.work_board", "cmd_work_show"))
+
+    graph_cmd = work_sub.add_parser("graph", help="Show the work dependency/context graph")
+    add_common(graph_cmd)
+    graph_cmd.add_argument("work_id", nargs="?", help="Optional root work item id")
+    graph_cmd.set_defaults(func=_lazy("aragora.cli.commands.work_board", "cmd_work_graph"))
+
+    robot_cmd = work_sub.add_parser(
+        "robot",
+        help="Rank current work into read-only actionable recommendations",
+    )
+    add_common(robot_cmd)
+    robot_cmd.set_defaults(func=_lazy("aragora.cli.commands.work_board", "cmd_work_robot"))
 
 
 def _add_markets_parser(subparsers) -> None:

--- a/aragora/module_tiers.yaml
+++ b/aragora/module_tiers.yaml
@@ -26,9 +26,9 @@ thresholds:
 summary:
   core: 21
   integrated: 89
-  experimental: 25
+  experimental: 26
   deprecated: 2
-  total: 137
+  total: 138
 
 modules:
   # --- core (21) ---
@@ -45,9 +45,9 @@ modules:
     test_file_count: 118
   - name: cli
     tier: core
-    py_files: 100
+    py_files: 103
     importer_count: 6
-    test_file_count: 111
+    test_file_count: 118
     override_reason: "aragora CLI — primary developer surface"
   - name: config
     tier: core
@@ -101,9 +101,9 @@ modules:
     override_reason: "ContinuumMemory + CritiqueStore — persistent state"
   - name: nomic
     tier: core
-    py_files: 158
-    importer_count: 90
-    test_file_count: 216
+    py_files: 159
+    importer_count: 91
+    test_file_count: 218
   - name: observability
     tier: core
     py_files: 67
@@ -257,8 +257,8 @@ modules:
   - name: epistemic
     tier: integrated
     py_files: 21
-    importer_count: 2
-    test_file_count: 20
+    importer_count: 4
+    test_file_count: 21
   - name: essay
     tier: integrated
     py_files: 6
@@ -379,7 +379,7 @@ modules:
     tier: integrated
     py_files: 6
     importer_count: 6
-    test_file_count: 11
+    test_file_count: 12
   - name: mcp
     tier: integrated
     py_files: 27
@@ -389,7 +389,7 @@ modules:
     tier: integrated
     py_files: 6
     importer_count: 1
-    test_file_count: 7
+    test_file_count: 8
   - name: migrations
     tier: integrated
     py_files: 21
@@ -469,12 +469,12 @@ modules:
     tier: integrated
     py_files: 11
     importer_count: 2
-    test_file_count: 13
+    test_file_count: 14
   - name: review
     tier: integrated
-    py_files: 12
+    py_files: 14
     importer_count: 13
-    test_file_count: 26
+    test_file_count: 28
   - name: rlm
     tier: integrated
     py_files: 31
@@ -534,7 +534,7 @@ modules:
     tier: integrated
     py_files: 102
     importer_count: 32
-    test_file_count: 159
+    test_file_count: 160
   - name: templates
     tier: integrated
     py_files: 1
@@ -596,7 +596,7 @@ modules:
     importer_count: 16
     test_file_count: 11
 
-  # --- experimental (25) ---
+  # --- experimental (26) ---
   - name: approvals
     tier: experimental
     py_files: 5
@@ -720,6 +720,11 @@ modules:
   - name: webhooks
     tier: experimental
     py_files: 2
+    importer_count: 1
+    test_file_count: 1
+  - name: work
+    tier: experimental
+    py_files: 5
     importer_count: 1
     test_file_count: 1
 

--- a/aragora/work/__init__.py
+++ b/aragora/work/__init__.py
@@ -1,0 +1,15 @@
+"""Read-only Aragora-native work board primitives."""
+
+from aragora.work.models import (
+    WorkGraph,
+    WorkItem,
+    WorkRecommendation,
+    WorkScore,
+)
+
+__all__ = [
+    "WorkGraph",
+    "WorkItem",
+    "WorkRecommendation",
+    "WorkScore",
+]

--- a/aragora/work/board.py
+++ b/aragora/work/board.py
@@ -1,0 +1,106 @@
+"""Read-only WorkItem collection and graph assembly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aragora.work.models import SCHEMA_VERSION, WorkGraph, WorkItem
+from aragora.work.scoring import build_recommendations, score_work_item
+from aragora.work.sources import (
+    collect_automation_outbox,
+    collect_automation_receipts,
+    collect_beads_and_convoys,
+    collect_broker_runs,
+    collect_github_prs,
+    collect_mission_files,
+)
+
+
+def collect_work_items(
+    repo_root: Path | str, *, scope: str = "current"
+) -> tuple[list[WorkItem], list[dict]]:
+    """Collect work items from all known read-only sources."""
+    root = Path(repo_root)
+    health: list[dict] = []
+    items: list[WorkItem] = []
+    collectors = [
+        collect_github_prs,
+        collect_automation_outbox,
+        lambda r: collect_automation_receipts(r, scope=scope),
+        lambda r: collect_broker_runs(r, scope=scope),
+        lambda r: collect_beads_and_convoys(r, scope=scope),
+        lambda r: collect_mission_files(r, scope=scope),
+    ]
+    for collector in collectors:
+        collected, source_health = collector(root)
+        items.extend(collected)
+        health.append(source_health)
+
+    if scope == "current":
+        items = [item for item in items if item.scope == "current"]
+
+    # Keep IDs stable and unique if two legacy stores expose the same raw id.
+    seen: dict[str, int] = {}
+    for item in items:
+        count = seen.get(item.id, 0)
+        seen[item.id] = count + 1
+        if count:
+            item.id = f"{item.id}#{count + 1}"
+
+    for item in items:
+        item.score = score_work_item(item)
+    items.sort(
+        key=lambda it: (it.score.total if it.score else 0.0, it.updated_at or "", it.id),
+        reverse=True,
+    )
+    return items, health
+
+
+def build_work_graph(
+    repo_root: Path | str,
+    *,
+    scope: str = "current",
+    root_id: str | None = None,
+) -> WorkGraph:
+    items, health = collect_work_items(repo_root, scope=scope)
+    by_id = {item.id: item for item in items}
+    edges: list[dict[str, str]] = []
+    for item in items:
+        for dep in item.dependencies:
+            edges.append({"from": item.id, "to": dep, "relation": "depends_on"})
+        branch = item.branch
+        if branch:
+            for other in items:
+                if other is item:
+                    continue
+                if other.branch == branch:
+                    edges.append({"from": item.id, "to": other.id, "relation": "same_branch"})
+
+    if root_id:
+        neighbors = {root_id}
+        for edge in edges:
+            if edge["from"] == root_id:
+                neighbors.add(edge["to"])
+            if edge["to"] == root_id:
+                neighbors.add(edge["from"])
+        items = [item for item in items if item.id in neighbors]
+        edges = [edge for edge in edges if edge["from"] in neighbors and edge["to"] in neighbors]
+        if root_id not in by_id:
+            health.append(
+                {"source": "work_graph", "status": "missing", "detail": f"{root_id} not found"}
+            )
+
+    return WorkGraph(
+        items=items,
+        edges=edges,
+        source_health=health,
+        root_id=root_id,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def build_robot_recommendations(
+    repo_root: Path | str, *, scope: str = "current"
+) -> tuple[list, list[dict]]:
+    items, health = collect_work_items(repo_root, scope=scope)
+    return build_recommendations(items), health

--- a/aragora/work/models.py
+++ b/aragora/work/models.py
@@ -1,0 +1,116 @@
+"""Normalized work-board models for the read-only Agent Flywheel kernel."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+SCHEMA_VERSION = "aragora.work.v1"
+
+
+@dataclass(slots=True)
+class WorkScore:
+    """Flywheel-inspired score dimensions.
+
+    All dimensions are normalized to ``[0, 1]`` where higher means "more
+    actionable now" for the operator/broker loop. ``risk`` therefore means
+    risk-controlled / safely settleable, not raw danger.
+    """
+
+    readiness: float = 0.0
+    impact: float = 0.0
+    risk: float = 0.0
+    parallel_safety: float = 0.0
+    staleness: float = 0.0
+    owner_clarity: float = 0.0
+    test_obligation: float = 0.0
+    dependency_clarity: float = 0.0
+    bead_quality: float = 0.0
+    total: float = 0.0
+    rationale: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        for key, value in list(data.items()):
+            if isinstance(value, float):
+                data[key] = round(value, 4)
+        return data
+
+
+@dataclass(slots=True)
+class WorkItem:
+    """A single normalized work unit from PRs, outbox, beads, runs, or missions."""
+
+    id: str
+    source: str
+    item_type: str
+    title: str
+    status: str = "unknown"
+    scope: str = "current"
+    url: str | None = None
+    owner: str | None = None
+    branch: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    dependencies: list[str] = field(default_factory=list)
+    evidence_refs: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    score: WorkScore | None = None
+
+    def to_dict(self, *, include_score: bool = True) -> dict[str, Any]:
+        data = asdict(self)
+        if self.score and include_score:
+            data["score"] = self.score.to_dict()
+        elif not include_score:
+            data.pop("score", None)
+        return data
+
+
+@dataclass(slots=True)
+class WorkGraph:
+    """Graph view over normalized work items."""
+
+    items: list[WorkItem] = field(default_factory=list)
+    edges: list[dict[str, str]] = field(default_factory=list)
+    source_health: list[dict[str, Any]] = field(default_factory=list)
+    root_id: str | None = None
+    schema_version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "root_id": self.root_id,
+            "items": [item.to_dict() for item in self.items],
+            "edges": list(self.edges),
+            "source_health": list(self.source_health),
+        }
+
+
+@dataclass(slots=True)
+class WorkRecommendation:
+    """Actionable read-only recommendation for a future broker loop."""
+
+    rank: int
+    item_id: str
+    classification: str
+    action: str
+    priority: str
+    rationale: list[str] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+    score: WorkScore = field(default_factory=WorkScore)
+    item: WorkItem | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rank": self.rank,
+            "item_id": self.item_id,
+            "classification": self.classification,
+            "action": self.action,
+            "priority": self.priority,
+            "rationale": list(self.rationale),
+            "blockers": list(self.blockers),
+            "score": self.score.to_dict(),
+            "item": self.item.to_dict(include_score=False) if self.item else None,
+        }

--- a/aragora/work/scoring.py
+++ b/aragora/work/scoring.py
@@ -1,0 +1,325 @@
+"""Scoring and routing for the read-only Aragora work board."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from aragora.work.models import WorkItem, WorkRecommendation, WorkScore
+
+RECOMMENDATION_CLASSES = {
+    "ready",
+    "needs-polish",
+    "blocked",
+    "duplicate",
+    "stale",
+    "review-only",
+    "human-gated",
+}
+
+_TERMINAL_STATUSES = {
+    "closed",
+    "completed",
+    "done",
+    "failed",
+    "cancelled",
+    "canceled",
+    "merged",
+    "already_satisfied",
+    "published",
+}
+
+_SWARM_READY_FIELDS = (
+    ("objective", "objective missing"),
+    ("context", "context missing"),
+    ("acceptance_criteria", "acceptance criteria missing"),
+    ("mutation_boundary", "mutation boundary missing"),
+    ("validation", "tests/validation missing"),
+)
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def stale_factor(updated_at: str | None, *, now: datetime | None = None) -> float:
+    """Return freshness score where 1.0 is fresh and 0.0 is very stale."""
+    parsed = _parse_time(updated_at)
+    if parsed is None:
+        return 0.45
+    current = now or datetime.now(UTC)
+    age_days = max(0.0, (current - parsed).total_seconds() / 86400.0)
+    if age_days <= 1:
+        return 1.0
+    if age_days <= 7:
+        return 0.85
+    if age_days <= 14:
+        return 0.65
+    if age_days <= 30:
+        return 0.35
+    return 0.1
+
+
+def is_current_status(status: str) -> bool:
+    return status.lower() not in _TERMINAL_STATUSES
+
+
+def _metadata_truthy(item: WorkItem, key: str) -> bool:
+    value = item.metadata.get(key)
+    if value:
+        return True
+    nested = item.metadata.get("metadata")
+    if isinstance(nested, dict):
+        nested_value = nested.get(key)
+        if nested_value:
+            return True
+    return False
+
+
+def _swarm_ready_blockers(item: WorkItem) -> list[str]:
+    blockers: list[str] = []
+    for key, message in _SWARM_READY_FIELDS:
+        if not _metadata_truthy(item, key):
+            blockers.append(message)
+    if not (item.owner or item.branch):
+        blockers.append("owner missing")
+    dependencies_declared = bool(item.dependencies) or _metadata_truthy(
+        item, "dependencies_declared"
+    )
+    if not dependencies_declared:
+        blockers.append("dependency clarity missing")
+    return blockers
+
+
+def score_work_item(item: WorkItem, *, now: datetime | None = None) -> WorkScore:
+    status = item.status.lower()
+    title = item.title.lower()
+    source = item.source
+    rationale: list[str] = []
+
+    readiness = 0.45
+    if source == "github_pr":
+        if item.metadata.get("is_draft"):
+            readiness = 0.25
+            rationale.append("draft PR is not ready for settlement")
+        elif item.metadata.get("review_decision") == "REVIEW_REQUIRED":
+            readiness = 0.62
+            rationale.append("PR is ready for focused review/settlement")
+        else:
+            readiness = 0.75
+            rationale.append("PR is non-draft and has no draft gate")
+    elif source == "automation_outbox":
+        readiness = 0.72
+        rationale.append("automation handoff is pending operator/publisher action")
+    elif source == "broker_run":
+        readiness = 0.55 if is_current_status(status) else 0.2
+        rationale.append(
+            "broker run is active" if is_current_status(status) else "broker run is historical"
+        )
+    elif source in {"bead", "convoy"}:
+        readiness = 0.58 if is_current_status(status) else 0.18
+        rationale.append(
+            "bead/convoy lifecycle is non-terminal"
+            if is_current_status(status)
+            else "bead/convoy is terminal"
+        )
+    elif source == "mission_file":
+        readiness = 0.4
+        rationale.append("mission file is context, not an active claim")
+
+    impact = {
+        "github_pr": 0.72,
+        "automation_outbox": 0.68,
+        "broker_run": 0.6,
+        "bead": 0.5,
+        "convoy": 0.56,
+        "mission_file": 0.42,
+        "automation_receipt": 0.25,
+    }.get(source, 0.4)
+    if any(token in title for token in ("block", "fix", "repair", "health", "proof", "queue")):
+        impact = min(1.0, impact + 0.12)
+        rationale.append("title signals repair/health/proof impact")
+
+    risk = 0.72
+    files = item.metadata.get("files") or []
+    if item.metadata.get("tier") in {3, 4, "3", "4"}:
+        risk -= 0.2
+        rationale.append("higher-tier semantic-risk surface")
+    if any(str(path).startswith((".github/", "scripts/")) for path in files):
+        risk -= 0.12
+    if any(str(path).startswith("docs/") for path in files):
+        risk += 0.08
+    if source == "mission_file":
+        risk += 0.08
+
+    parallel_safety = 0.65
+    if len(files) > 8:
+        parallel_safety -= 0.2
+    if source in {"automation_receipt", "mission_file"}:
+        parallel_safety += 0.15
+    if item.dependencies:
+        parallel_safety -= 0.12
+
+    staleness = stale_factor(item.updated_at or item.created_at, now=now)
+    owner_clarity = 0.85 if item.owner or item.branch else 0.35
+    if item.owner or item.branch:
+        rationale.append("owner/branch is explicit")
+
+    tests = [path for path in files if str(path).startswith("tests/")]
+    code = [path for path in files if str(path).startswith("aragora/")]
+    if code and tests:
+        test_obligation = 0.9
+    elif code:
+        test_obligation = 0.35
+        rationale.append("code surface lacks visible tests in metadata")
+    else:
+        test_obligation = 0.75
+
+    dependency_clarity = (
+        0.85 if item.dependencies or _metadata_truthy(item, "dependencies_declared") else 0.45
+    )
+    if item.dependencies:
+        rationale.append("dependencies are explicit")
+
+    bead_quality = 0.5
+    if source in {"bead", "convoy"}:
+        blockers = _swarm_ready_blockers(item)
+        present = len(_SWARM_READY_FIELDS) + 2 - len(blockers)
+        total_fields = len(_SWARM_READY_FIELDS) + 2
+        bead_quality = 0.08 + (0.82 * (present / total_fields))
+        if item.title and len(item.title) > 8:
+            bead_quality += 0.08
+        if item.dependencies:
+            bead_quality += 0.04
+        if blockers:
+            bead_quality -= 0.08 * len(blockers)
+            rationale.append("bead needs polish: " + ", ".join(blockers[:3]))
+    elif source == "github_pr":
+        bead_quality = 0.58
+    elif source == "automation_outbox":
+        bead_quality = 0.62
+
+    dimensions: dict[str, float] = {
+        "readiness": _clamp(readiness),
+        "impact": _clamp(impact),
+        "risk": _clamp(risk),
+        "parallel_safety": _clamp(parallel_safety),
+        "staleness": _clamp(staleness),
+        "owner_clarity": _clamp(owner_clarity),
+        "test_obligation": _clamp(test_obligation),
+        "dependency_clarity": _clamp(dependency_clarity),
+        "bead_quality": _clamp(bead_quality),
+    }
+    weights = {
+        "readiness": 0.22,
+        "impact": 0.16,
+        "risk": 0.12,
+        "parallel_safety": 0.1,
+        "staleness": 0.1,
+        "owner_clarity": 0.08,
+        "test_obligation": 0.08,
+        "dependency_clarity": 0.07,
+        "bead_quality": 0.07,
+    }
+    total = sum(dimensions[key] * weights[key] for key in weights)
+    return WorkScore(total=_clamp(total), rationale=rationale[:6], **dimensions)
+
+
+def classify_work_item(item: WorkItem, *, score: WorkScore | None = None) -> tuple[str, list[str]]:
+    """Classify work into the stable flywheel recommendation vocabulary."""
+    status = item.status.lower()
+    blockers: list[str] = []
+    score = score or item.score or score_work_item(item)
+
+    if status in {"already_satisfied", "published"}:
+        return "duplicate", ["receipt says work was already satisfied or published"]
+    if not is_current_status(status) or item.scope == "historical":
+        return "stale", ["terminal or historical work item"]
+    if item.metadata.get("human_gate") or item.metadata.get("tier") in {3, 4, "3", "4"}:
+        return "human-gated", ["human-gated risk surface"]
+    if item.metadata.get("blocked") or item.metadata.get("blockers"):
+        raw = item.metadata.get("blockers")
+        if isinstance(raw, list):
+            blockers.extend(str(entry) for entry in raw)
+        elif raw:
+            blockers.append(str(raw))
+        blockers.append("explicit blocker metadata")
+        return "blocked", blockers
+    if item.source == "github_pr" and item.metadata.get("is_draft"):
+        return "review-only", ["draft PR"]
+    if item.source in {"bead", "convoy", "automation_outbox"}:
+        blockers = _swarm_ready_blockers(item)
+        if blockers:
+            return "needs-polish", blockers
+    if score.bead_quality < 0.45 or score.dependency_clarity < 0.4:
+        return "needs-polish", ["weak bead quality or dependency clarity"]
+    return "ready", []
+
+
+def recommended_action(item: WorkItem) -> tuple[str, str, list[str]]:
+    blockers: list[str] = []
+    if item.source == "github_pr":
+        if item.metadata.get("is_draft"):
+            blockers.append("draft PR")
+            return "keep_draft_until_evidence_ready", "hold", blockers
+        if item.metadata.get("review_decision") == "REVIEW_REQUIRED":
+            blockers.append("human/model review required")
+        return "review_and_settle_when_policy_clean", "high", blockers
+    if item.source == "automation_outbox":
+        return "publish_or_reconcile_handoff", "high", blockers
+    if item.source == "broker_run":
+        return "inspect_broker_run", "medium", blockers
+    if item.source in {"bead", "convoy"}:
+        return "clarify_or_claim_atomic_work", "medium", blockers
+    if item.source == "mission_file":
+        return "use_as_context_for_decomposition", "low", blockers
+    return "inspect_work_item", "medium", blockers
+
+
+def build_recommendations(items: list[WorkItem]) -> list[WorkRecommendation]:
+    scored: list[WorkItem] = []
+    for item in items:
+        item.score = score_work_item(item)
+        scored.append(item)
+    scored.sort(
+        key=lambda it: (it.score.total if it.score else 0.0, it.updated_at or ""), reverse=True
+    )
+
+    recommendations: list[WorkRecommendation] = []
+    for rank, item in enumerate(scored, start=1):
+        action, priority, blockers = recommended_action(item)
+        score = item.score or WorkScore()
+        classification, class_blockers = classify_work_item(item, score=score)
+        blockers = [*blockers, *class_blockers]
+        if classification in {"human-gated", "blocked"}:
+            priority = "hold"
+        elif classification == "needs-polish" and priority == "high":
+            priority = "medium"
+        recommendations.append(
+            WorkRecommendation(
+                rank=rank,
+                item_id=item.id,
+                classification=classification,
+                action=action,
+                priority=priority,
+                blockers=blockers,
+                rationale=score.rationale,
+                score=score,
+                item=item,
+            )
+        )
+    return recommendations

--- a/aragora/work/sources.py
+++ b/aragora/work/sources.py
@@ -1,0 +1,348 @@
+"""Read-only source adapters for the Aragora work board."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from aragora.work.models import WorkItem
+from aragora.work.scoring import is_current_status, stale_factor
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _read_jsonl(path: Path, *, limit: int = 200) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return rows
+    for raw in lines[-limit:]:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict):
+            rows.append(data)
+    return rows
+
+
+def _health(source: str, status: str, detail: str, **extra: Any) -> dict[str, Any]:
+    return {"source": source, "status": status, "detail": detail, **extra}
+
+
+def _tier_from_labels(labels: list[str]) -> int | None:
+    normalized = {label.lower().replace("_", "-").strip() for label in labels}
+    for tier in (4, 3, 2, 1, 0):
+        if f"tier-{tier}" in normalized or f"tier {tier}" in normalized:
+            return tier
+    return None
+
+
+def _labels_are_human_gated(labels: list[str], tier: int | None) -> bool:
+    normalized = {label.lower().replace("_", "-").strip() for label in labels}
+    return bool(
+        (tier is not None and tier >= 3)
+        or normalized
+        & {
+            "human-gated",
+            "human-preapproval",
+            "tier-3",
+            "tier-4",
+            "semantic-risk",
+            "security",
+            "merge-authority",
+        }
+    )
+
+
+def collect_github_prs(repo_root: Path) -> tuple[list[WorkItem], dict[str, Any]]:
+    if shutil.which("gh") is None:
+        return [], _health("github_pr", "degraded", "gh executable not found")
+
+    fields = (
+        "number,title,url,state,isDraft,headRefName,headRefOid,"
+        "updatedAt,createdAt,reviewDecision,mergeStateStatus,labels,assignees"
+    )
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--limit", "50", "--json", fields],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=12,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return [], _health("github_pr", "degraded", f"gh pr list failed: {exc}")
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        return [], _health("github_pr", "degraded", detail[0] if detail else "gh pr list failed")
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return [], _health("github_pr", "degraded", "gh pr list returned non-json")
+    if not isinstance(payload, list):
+        return [], _health("github_pr", "degraded", "gh pr list returned non-list")
+
+    items: list[WorkItem] = []
+    for pr in payload:
+        if not isinstance(pr, dict):
+            continue
+        number = pr.get("number")
+        labels = [
+            str(label.get("name")) for label in pr.get("labels") or [] if isinstance(label, dict)
+        ]
+        tier = _tier_from_labels(labels)
+        assignees = [
+            str(assignee.get("login"))
+            for assignee in pr.get("assignees") or []
+            if isinstance(assignee, dict)
+        ]
+        item = WorkItem(
+            id=f"pr:{number}",
+            source="github_pr",
+            item_type="pull_request",
+            title=str(pr.get("title") or f"PR #{number}"),
+            status="draft" if pr.get("isDraft") else str(pr.get("state") or "open").lower(),
+            scope="current",
+            url=str(pr.get("url") or "") or None,
+            owner=assignees[0] if assignees else None,
+            branch=str(pr.get("headRefName") or "") or None,
+            created_at=str(pr.get("createdAt") or "") or None,
+            updated_at=str(pr.get("updatedAt") or "") or None,
+            tags=labels,
+            metadata={
+                "number": number,
+                "is_draft": bool(pr.get("isDraft")),
+                "head_sha": pr.get("headRefOid"),
+                "review_decision": pr.get("reviewDecision"),
+                "merge_state_status": pr.get("mergeStateStatus"),
+                "labels": labels,
+                "tier": tier,
+                "human_gate": _labels_are_human_gated(labels, tier),
+            },
+        )
+        items.append(item)
+    return items, _health("github_pr", "ok", f"{len(items)} open PR(s)")
+
+
+def collect_automation_outbox(repo_root: Path) -> tuple[list[WorkItem], dict[str, Any]]:
+    outbox = repo_root / ".aragora" / "automation-outbox"
+    if not outbox.exists():
+        return [], _health("automation_outbox", "missing", f"{outbox} not found")
+    items: list[WorkItem] = []
+    for path in sorted(outbox.glob("*.json")):
+        data = _read_json(path)
+        if data is None:
+            continue
+        title = str(data.get("task") or data.get("title") or data.get("summary") or path.stem)
+        branch = data.get("branch") or data.get("head_ref") or data.get("branch_name")
+        items.append(
+            WorkItem(
+                id=f"automation-outbox:{path.stem}",
+                source="automation_outbox",
+                item_type="handoff",
+                title=title,
+                status=str(data.get("status") or data.get("reason") or "pending"),
+                scope="current",
+                branch=str(branch) if branch else None,
+                updated_at=str(data.get("updated_at") or data.get("recorded_at") or "") or None,
+                evidence_refs=[str(path.relative_to(repo_root))],
+                metadata={"path": str(path), "idempotency_key": data.get("idempotency_key")},
+            )
+        )
+    return items, _health("automation_outbox", "ok", f"{len(items)} pending handoff(s)")
+
+
+def collect_automation_receipts(
+    repo_root: Path, *, scope: str
+) -> tuple[list[WorkItem], dict[str, Any]]:
+    receipts = repo_root / ".aragora" / "automation-receipts"
+    if not receipts.exists():
+        return [], _health("automation_receipt", "missing", f"{receipts} not found")
+    files = sorted(receipts.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)[:80]
+    items: list[WorkItem] = []
+    for path in files:
+        data = _read_json(path)
+        if data is None:
+            continue
+        status = str(data.get("status") or data.get("reason") or "recorded")
+        updated_at = str(data.get("recorded_at") or data.get("updated_at") or "") or None
+        active = is_current_status(status) and stale_factor(updated_at) > 0.35
+        if scope == "current" and not active:
+            continue
+        title = str(data.get("task") or data.get("idempotency_key") or path.stem)
+        items.append(
+            WorkItem(
+                id=f"automation-receipt:{path.stem}",
+                source="automation_receipt",
+                item_type="receipt",
+                title=title,
+                status=status,
+                scope="current" if active else "historical",
+                url=data.get("existing_pr_url")
+                or data.get("created_issue_url")
+                or data.get("existing_issue_url"),
+                updated_at=updated_at,
+                evidence_refs=[str(path.relative_to(repo_root))],
+                metadata={
+                    "reason": data.get("reason"),
+                    "repo": data.get("repo"),
+                    "source_file": data.get("source_file"),
+                },
+            )
+        )
+    return items, _health("automation_receipt", "ok", f"{len(items)} receipt item(s)")
+
+
+def collect_broker_runs(repo_root: Path, *, scope: str) -> tuple[list[WorkItem], dict[str, Any]]:
+    runs_dir = repo_root / ".aragora" / "agent_bridge" / "runs"
+    if not runs_dir.exists():
+        return [], _health("broker_run", "missing", f"{runs_dir} not found")
+    items: list[WorkItem] = []
+    for run_path in sorted(runs_dir.glob("*/run.json")):
+        data = _read_json(run_path)
+        if data is None:
+            continue
+        status = str(data.get("status") or "unknown")
+        active = is_current_status(status)
+        if scope == "current" and not active:
+            continue
+        run_id = str(data.get("run_id") or run_path.parent.name)
+        participants = data.get("participants") or []
+        owner = None
+        if participants and isinstance(participants[0], dict):
+            owner = str(participants[0].get("harness") or "") or None
+        items.append(
+            WorkItem(
+                id=f"broker-run:{run_id}",
+                source="broker_run",
+                item_type="broker_run",
+                title=str(data.get("task") or run_id).splitlines()[0][:180],
+                status=status,
+                scope="current" if active else "historical",
+                owner=owner,
+                created_at=str(data.get("created_at") or "") or None,
+                updated_at=str(data.get("updated_at") or data.get("completed_at") or "") or None,
+                evidence_refs=[str(run_path.relative_to(repo_root))],
+                metadata={
+                    "run_id": run_id,
+                    "next_actor": data.get("next_actor"),
+                    "worktree_path": data.get("worktree_path"),
+                    "participants": participants,
+                },
+            )
+        )
+    return items, _health("broker_run", "ok", f"{len(items)} broker run item(s)")
+
+
+def collect_beads_and_convoys(
+    repo_root: Path, *, scope: str
+) -> tuple[list[WorkItem], dict[str, Any]]:
+    items: list[WorkItem] = []
+    paths = [
+        (repo_root / ".beads" / "beads.jsonl", "bead"),
+        (repo_root / ".aragora_beads" / "beads.jsonl", "bead"),
+        (repo_root / ".aragora_beads" / "convoys.jsonl", "convoy"),
+    ]
+    for path, kind in paths:
+        if not path.exists():
+            continue
+        for row in _read_jsonl(path):
+            status = str(row.get("status") or "unknown")
+            updated_at = str(row.get("updated_at") or row.get("created_at") or "") or None
+            active = is_current_status(status) and stale_factor(updated_at) >= 0.35
+            if scope == "current" and not active:
+                continue
+            raw_id = row.get("id") or row.get("bead_id") or row.get("convoy_id")
+            if not raw_id:
+                continue
+            deps = row.get("dependencies") or row.get("depends_on") or []
+            if not isinstance(deps, list):
+                deps = []
+            items.append(
+                WorkItem(
+                    id=f"{kind}:{raw_id}",
+                    source=kind,
+                    item_type=kind,
+                    title=str(row.get("title") or row.get("name") or raw_id),
+                    status=status,
+                    scope="current" if active else "historical",
+                    owner=row.get("claimed_by") or row.get("assigned_agent"),
+                    created_at=str(row.get("created_at") or "") or None,
+                    updated_at=updated_at,
+                    dependencies=[f"{kind}:{dep}" for dep in deps],
+                    evidence_refs=[str(path.relative_to(repo_root))],
+                    tags=[str(tag) for tag in row.get("tags") or []],
+                    metadata={
+                        "priority": row.get("priority"),
+                        "bead_ids": row.get("bead_ids") or [],
+                        "metadata": row.get("metadata") or {},
+                    },
+                )
+            )
+    return items, _health("bead_convoy", "ok", f"{len(items)} bead/convoy item(s)")
+
+
+def collect_mission_files(repo_root: Path, *, scope: str) -> tuple[list[WorkItem], dict[str, Any]]:
+    mission_roots = [
+        repo_root / "docs" / "missions",
+        repo_root / ".aragora" / "goal-conductor",
+        repo_root / ".aragora" / "initiatives",
+    ]
+    items: list[WorkItem] = []
+    for root in mission_roots:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*"))[:120]:
+            if not path.is_file() or path.suffix.lower() not in {".md", ".json", ".yaml", ".yml"}:
+                continue
+            stat = path.stat()
+            updated = datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat()
+            active = stale_factor(updated) >= 0.65 and ".aragora" in path.parts
+            if scope == "current" and not active:
+                continue
+            title = path.stem
+            if path.suffix.lower() == ".md":
+                try:
+                    first = next(
+                        (
+                            line.lstrip("# ").strip()
+                            for line in path.read_text(
+                                encoding="utf-8", errors="replace"
+                            ).splitlines()
+                            if line.strip()
+                        ),
+                        "",
+                    )
+                except OSError:
+                    first = ""
+                title = first or title
+            items.append(
+                WorkItem(
+                    id=f"mission:{path.relative_to(repo_root)}",
+                    source="mission_file",
+                    item_type="mission",
+                    title=title[:180],
+                    status="context",
+                    scope="current" if active else "historical",
+                    updated_at=updated,
+                    evidence_refs=[str(path.relative_to(repo_root))],
+                    metadata={"path": str(path), "size_bytes": stat.st_size},
+                )
+            )
+    return items, _health("mission_file", "ok", f"{len(items)} mission file item(s)")

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -11,8 +11,8 @@ description: Generated Aragora CLI command catalog from live parser
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **97**
-- Total top-level invocations (including aliases): **98**
+- Canonical top-level commands: **98**
+- Total top-level invocations (including aliases): **99**
 
 ## Installation
 
@@ -135,6 +135,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |
 | `verticals` | - | Manage vertical specialist configurations | - |
+| `work` | - | Inspect the read-only Aragora work board | `graph`, `list`, `robot`, `show` |
 | `workflow` | - | Workflow engine commands | `categories`, `list`, `patterns`, `run`, `status`, `templates` |
 | `worktree` | - | Manage git worktrees for parallel agent sessions | `autopilot`, `cleanup`, `conflicts`, `create`, `fleet-claim`, `fleet-claims`, `fleet-queue-add`, `fleet-queue-list`, `fleet-queue-process-next`, `fleet-reap-claims`, `fleet-release`, `fleet-status`, `list`, `merge`, `merge-all` |
 

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 98 commands | 43.2% |
+| **CLI** | 99 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/AGENT_FLYWHEEL_ARAGORA_NATIVE.md
+++ b/docs/AGENT_FLYWHEEL_ARAGORA_NATIVE.md
@@ -1,0 +1,61 @@
+# Aragora-Native Agent Flywheel Map
+
+This document maps Agent Flywheel concepts into Aragora-native primitives. The
+first implementation is intentionally a **read-only kernel**: it observes,
+normalizes, scores, and recommends. It does not claim work, launch agents, close
+issues, send broker mail, create leases, or index CASS memory.
+
+## Concept Map
+
+| Agent Flywheel concept | Aragora-native primitive | First kernel behavior |
+|---|---|---|
+| Bead / atomic work | `WorkItem` over PRs, automation handoffs, beads, convoys, broker runs, missions | Normalize into stable JSON |
+| Board / current work | `aragora work list --scope current --json` | Exclude terminal and stale historical records |
+| Plan-space graph | `WorkGraph` | Expose dependencies, shared branches, and evidence refs |
+| Robot / next action | `aragora work robot --json` | Rank current work with explicit scoring dimensions |
+| Agent Mail | Future broker mail | Not implemented here |
+| File leases | Future work leases | Not implemented here |
+| `work pick` / execution | Future brokered claim path | Not implemented here |
+| CASS / memory review | Future review memory index | Not implemented here |
+
+## Scoring Dimensions
+
+`WorkScore` uses normalized `0..1` dimensions where higher means more
+actionable now:
+
+- `readiness`: is the item close to review, settlement, or operator action?
+- `impact`: does it affect queue health, proof, reliability, or high-value work?
+- `risk`: risk-controlled / safely settleable surface, not raw danger.
+- `parallel_safety`: can another agent work on it without conflict?
+- `staleness`: freshness of the operational signal.
+- `owner_clarity`: explicit branch, assignee, harness, or owner evidence.
+- `test_obligation`: whether code-like surfaces show nearby test evidence.
+- `dependency_clarity`: whether dependencies are explicit.
+- `bead_quality`: quality of bead/convoy-style task shape.
+
+`WorkRecommendation.classification` uses the stable routing vocabulary
+`ready`, `needs-polish`, `blocked`, `duplicate`, `stale`, `review-only`, and
+`human-gated`. The kernel only recommends; it does not claim or mutate the item.
+
+## Current-Truth Boundary
+
+`--scope current` intentionally excludes completed broker runs, terminal receipts,
+old bead records, and static mission files unless they are fresh active records.
+Use `--scope all` for audit/context views.
+
+This is the main dogfood protection: historical Claude/Factory/Codex artifacts
+remain inspectable without polluting the live operational queue.
+
+## Non-Goals For This PR
+
+- No `aragora work pick`.
+- No `aragora work ready`.
+- No broker mail.
+- No file leases.
+- No worktree creation.
+- No agent launch.
+- No issue closure.
+- No dependency on external `bd`, `bv`, `br`, Agent Mail, or CASS tools.
+
+The output is designed to be stable enough for a later brokered
+Claude/Factory/Codex decision loop.

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 98 commands | 43.2% |
+| **CLI** | 99 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4120` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1935451` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
-| Top-level modules under aragora/ | `137` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5174` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217938` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Python files under aragora/ | `4126` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1936477` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Top-level modules under aragora/ | `138` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
+| Test files (test_*.py under tests/) | `5176` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217953` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `684` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `65` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| CLI top-level command modules | `66` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `832` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `835` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **97**
-- Total top-level invocations (including aliases): **98**
+- Canonical top-level commands: **98**
+- Total top-level invocations (including aliases): **99**
 
 ## Installation
 
@@ -130,6 +130,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |
 | `verticals` | - | Manage vertical specialist configurations | - |
+| `work` | - | Inspect the read-only Aragora work board | `graph`, `list`, `robot`, `show` |
 | `workflow` | - | Workflow engine commands | `categories`, `list`, `patterns`, `run`, `status`, `templates` |
 | `worktree` | - | Manage git worktrees for parallel agent sessions | `autopilot`, `cleanup`, `conflicts`, `create`, `fleet-claim`, `fleet-claims`, `fleet-queue-add`, `fleet-queue-list`, `fleet-queue-process-next`, `fleet-reap-claims`, `fleet-release`, `fleet-status`, `list`, `merge`, `merge-all` |
 

--- a/tests/cli/test_work_board.py
+++ b/tests/cli/test_work_board.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.parser import build_parser
+from aragora.cli.commands.work_board import (
+    cmd_work_graph,
+    cmd_work_list,
+    cmd_work_robot,
+    cmd_work_show,
+)
+
+
+def _args(tmp_path: Path, **kwargs) -> argparse.Namespace:
+    defaults = {"repo": str(tmp_path), "json": True, "scope": "current", "work_id": None}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _capture_json(capsys: pytest.CaptureFixture) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def test_work_list_degrades_gracefully_without_gh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+
+    assert cmd_work_list(_args(tmp_path, scope="current")) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["schema_version"] == "aragora.work.v1"
+    assert payload["items"] == []
+    assert any(
+        h["source"] == "github_pr" and h["status"] == "degraded" for h in payload["source_health"]
+    )
+
+
+def test_work_parser_registers_read_only_robot_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["work", "robot", "--json"])
+
+    assert args.command == "work"
+    assert args.work_cmd == "robot"
+    assert args.json is True
+
+
+def test_work_list_reads_current_outbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "handoff.json").write_text(
+        json.dumps({"task": "Open PR for repair lane", "branch": "codex/repair"}),
+        encoding="utf-8",
+    )
+
+    assert cmd_work_list(_args(tmp_path, scope="current")) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["count"] == 1
+    assert payload["items"][0]["id"] == "automation-outbox:handoff"
+    assert payload["items"][0]["branch"] == "codex/repair"
+
+
+def test_work_robot_marks_tier_four_pr_human_gated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: "/usr/bin/gh")
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "number": 42,
+                        "title": "Modify merge authority parser",
+                        "url": "https://github.com/synaptent/aragora/pull/42",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "headRefName": "codex/gate",
+                        "headRefOid": "abc123",
+                        "updatedAt": _now_iso(),
+                        "createdAt": _now_iso(),
+                        "reviewDecision": "APPROVED",
+                        "mergeStateStatus": "CLEAN",
+                        "labels": [{"name": "tier-4"}],
+                        "assignees": [{"login": "codex"}],
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr("aragora.work.sources.subprocess.run", fake_run)
+
+    assert cmd_work_robot(_args(tmp_path)) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["recommendations"][0]["item_id"] == "pr:42"
+    assert payload["recommendations"][0]["classification"] == "human-gated"
+    assert payload["recommendations"][0]["item"]["metadata"]["tier"] == 4
+
+
+def test_work_show_finds_historical_receipt_in_all_scope(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    receipts.mkdir(parents=True)
+    (receipts / "done.json").write_text(
+        json.dumps(
+            {
+                "task": "Published old handoff",
+                "status": "already_satisfied",
+                "recorded_at": "2026-05-14T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cmd_work_show(_args(tmp_path, work_id="automation-receipt:done")) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["found"] is True
+    assert payload["item"]["scope"] == "historical"
+
+
+def test_work_graph_includes_bead_dependency_edges(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    bead_dir = tmp_path / ".aragora_beads"
+    bead_dir.mkdir()
+    (bead_dir / "beads.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "id": "a",
+                        "bead_type": "task",
+                        "status": "pending",
+                        "title": "A",
+                        "updated_at": _now_iso(),
+                        "dependencies": ["b"],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "id": "b",
+                        "bead_type": "task",
+                        "status": "pending",
+                        "title": "B",
+                        "updated_at": _now_iso(),
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert cmd_work_graph(_args(tmp_path, work_id="bead:a")) == 0
+    payload = _capture_json(capsys)
+
+    assert {item["id"] for item in payload["items"]} == {"bead:a", "bead:b"}
+    assert payload["edges"] == [{"from": "bead:a", "relation": "depends_on", "to": "bead:b"}]
+
+
+def test_work_robot_ranks_actionable_current_work(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    (outbox / "repair.json").write_text(
+        json.dumps({"task": "repair queue health", "branch": "codex/repair"}),
+        encoding="utf-8",
+    )
+
+    assert cmd_work_robot(_args(tmp_path)) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["mutations"] == []
+    assert payload["recommendations"][0]["item_id"] == "automation-outbox:repair"
+    assert payload["recommendations"][0]["classification"] == "needs-polish"
+    assert payload["recommendations"][0]["action"] == "publish_or_reconcile_handoff"
+
+
+def test_work_robot_emits_ready_for_polished_bead(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    bead_dir = tmp_path / ".aragora_beads"
+    bead_dir.mkdir()
+    (bead_dir / "beads.jsonl").write_text(
+        json.dumps(
+            {
+                "id": "polished",
+                "status": "pending",
+                "title": "Repair broker live capture",
+                "updated_at": _now_iso(),
+                "claimed_by": "factory",
+                "metadata": {
+                    "objective": "Capture broker-launched sessions in operator-snapshot",
+                    "context": "Desktop transcripts are historical, not live truth",
+                    "acceptance_criteria": ["snapshot shows one active broker run"],
+                    "validation": "focused bridge tests",
+                    "mutation_boundary": "read-only bridge discovery",
+                    "dependencies_declared": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cmd_work_robot(_args(tmp_path)) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["recommendations"][0]["item_id"] == "bead:polished"
+    assert payload["recommendations"][0]["classification"] == "ready"
+    assert payload["recommendations"][0]["score"]["bead_quality"] >= 0.8
+
+
+def test_work_list_current_excludes_completed_broker_runs(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: None)
+    run_dir = tmp_path / ".aragora" / "agent_bridge" / "runs" / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-1",
+                "status": "completed",
+                "task": "Old desktop transcript import",
+                "created_at": "2026-05-14T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cmd_work_list(_args(tmp_path, scope="current")) == 0
+    current = _capture_json(capsys)
+    assert current["items"] == []
+
+    assert cmd_work_list(_args(tmp_path, scope="all")) == 0
+    all_items = _capture_json(capsys)
+    assert all_items["items"][0]["id"] == "broker-run:run-1"
+    assert all_items["items"][0]["scope"] == "historical"

--- a/tests/work/test_work_scoring.py
+++ b/tests/work/test_work_scoring.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from aragora.work.models import WorkItem
+from aragora.work.scoring import build_recommendations, classify_work_item, score_work_item
+
+
+def test_score_prefers_current_non_draft_pr_with_tests() -> None:
+    item = WorkItem(
+        id="pr:1",
+        source="github_pr",
+        item_type="pull_request",
+        title="fix(queue): repair proof health",
+        status="open",
+        branch="codex/fix",
+        updated_at="2026-05-16T00:00:00+00:00",
+        metadata={
+            "is_draft": False,
+            "review_decision": "REVIEW_REQUIRED",
+            "files": ["aragora/foo.py", "tests/test_foo.py"],
+        },
+    )
+
+    score = score_work_item(item)
+
+    assert score.readiness >= 0.6
+    assert score.impact > 0.7
+    assert score.test_obligation >= 0.8
+    assert 0.0 <= score.total <= 1.0
+
+
+def test_score_penalizes_stale_terminal_bead() -> None:
+    item = WorkItem(
+        id="bead:old",
+        source="bead",
+        item_type="bead",
+        title="Old task",
+        status="completed",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+
+    score = score_work_item(item)
+
+    assert score.readiness < 0.3
+    assert score.staleness < 0.2
+
+
+def test_recommendations_are_ranked_by_total_score() -> None:
+    low = WorkItem(id="mission:x", source="mission_file", item_type="mission", title="Context")
+    high = WorkItem(
+        id="automation-outbox:x",
+        source="automation_outbox",
+        item_type="handoff",
+        title="repair queue health",
+        status="pending",
+        branch="codex/repair",
+    )
+
+    recommendations = build_recommendations([low, high])
+
+    assert recommendations[0].item_id == "automation-outbox:x"
+    assert recommendations[0].action == "publish_or_reconcile_handoff"
+    assert recommendations[0].classification == "needs-polish"
+
+
+def test_bead_missing_acceptance_criteria_needs_polish() -> None:
+    item = WorkItem(
+        id="bead:rough",
+        source="bead",
+        item_type="bead",
+        title="Repair bridge session capture",
+        status="pending",
+        owner="claude",
+        metadata={
+            "objective": "Make broker sessions visible to operator-snapshot",
+            "context": "Historical transcripts currently pollute live truth",
+            "mutation_boundary": "read-only discovery code",
+            "validation": "focused bridge tests",
+        },
+    )
+
+    score = score_work_item(item)
+    classification, blockers = classify_work_item(item, score=score)
+
+    assert score.bead_quality < 0.7
+    assert classification == "needs-polish"
+    assert "acceptance criteria missing" in blockers
+
+
+def test_complete_bounded_bead_is_ready() -> None:
+    item = WorkItem(
+        id="bead:polished",
+        source="bead",
+        item_type="bead",
+        title="Repair bridge session capture",
+        status="pending",
+        owner="claude",
+        dependencies=[],
+        metadata={
+            "objective": "Make broker sessions visible to operator-snapshot",
+            "context": "Historical transcripts currently pollute live truth",
+            "acceptance_criteria": ["operator-snapshot shows active broker runs"],
+            "mutation_boundary": "read-only discovery code",
+            "validation": "focused bridge tests",
+            "dependencies_declared": True,
+        },
+    )
+
+    score = score_work_item(item)
+    classification, blockers = classify_work_item(item, score=score)
+
+    assert score.bead_quality >= 0.8
+    assert classification == "ready"
+    assert blockers == []
+
+
+def test_human_gated_pr_is_not_auto_ready() -> None:
+    item = WorkItem(
+        id="pr:99",
+        source="github_pr",
+        item_type="pull_request",
+        title="feat: modify merge authority",
+        status="open",
+        branch="codex/gate-change",
+        metadata={
+            "is_draft": False,
+            "review_decision": "APPROVED",
+            "human_gate": True,
+            "tier": 4,
+        },
+    )
+
+    recommendations = build_recommendations([item])
+
+    assert recommendations[0].classification == "human-gated"
+    assert "human-gated risk surface" in recommendations[0].blockers


### PR DESCRIPTION
## Summary

Implements the read-only Aragora-native Agent Flywheel kernel:

- `aragora work list --scope current|all --json`
- `aragora work show <id> --json`
- `aragora work graph [<id>] --json`
- `aragora work robot --json`

Adds normalized `WorkItem`, `WorkGraph`, `WorkScore`, and `WorkRecommendation` types plus read-only source adapters over current PRs, automation outbox/receipts, broker runs, bead/convoy JSONL records, and mission files when present.

## Scope Boundaries

This PR is read-only only. It does not launch agents, create worktrees, close issues, rerun CI, call models, claim work, mark work ready, implement broker mail, implement file leases, or depend on external `bd`, `bv`, `br`, Agent Mail, or CASS tools.

## Validation

- `python3 -m pytest tests/work/test_work_scoring.py tests/cli/test_work_board.py -q -p no:randomly` -> 15 passed
- `python3 -m ruff check aragora/work aragora/cli/commands/work_board.py tests/work/test_work_scoring.py tests/cli/test_work_board.py` -> pass
- `python3 -m ruff format --check aragora/work aragora/cli/commands/work_board.py tests/work/test_work_scoring.py tests/cli/test_work_board.py` -> pass
- `python3 scripts/regenerate_metrics.py --check` -> pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> pass
- `python3 -m aragora.cli.main work robot --json` -> emits current recommendations with `mutations: []`

## Notes

The branch was rebased onto latest `origin/main`; the only conflict was generated `docs/METRICS.md`, resolved by rerunning `scripts/regenerate_metrics.py`.