### PR TITLE
fix(automation): keep rescue report dry-run read-only

### DIFF
--- a/scripts/publish_rescue_productization_report.py
+++ b/scripts/publish_rescue_productization_report.py
@@ -404,14 +404,19 @@ def main(argv: list[str] | None = None) -> int:
         ensure_issues=bool(args.ensure_issues),
         dry_run=bool(args.dry_run),
     )
-    published = publish_report_bundle(
-        publish_dir=args.publish_dir.resolve(),
-        payload=payload,
-    )
+    published = None
+    if not args.dry_run:
+        published = publish_report_bundle(
+            publish_dir=args.publish_dir.resolve(),
+            payload=payload,
+        )
     if args.json:
         print(json.dumps(payload, indent=2))
     else:
-        print(str(published["timestamped"]))
+        if published is None:
+            print("dry-run: report bundle not published")
+        else:
+            print(str(published["timestamped"]))
     return 0
 
 

--- a/tests/scripts/test_publish_rescue_productization_report.py
+++ b/tests/scripts/test_publish_rescue_productization_report.py
@@ -107,3 +107,26 @@ def test_publish_report_bundle_writes_timestamped_and_latest(tmp_path: Path) -> 
     assert json.loads(written["latest"].read_text(encoding="utf-8"))["generated_at"] == (
         "2026-04-14T18:36:07Z"
     )
+
+
+def test_main_dry_run_does_not_publish_report_bundle(tmp_path: Path, capsys) -> None:
+    ledger = _ledger_with_events(tmp_path, [])
+    publish_dir = tmp_path / "published"
+
+    exit_code = mod.main(
+        [
+            "--path",
+            str(ledger.path),
+            "--productization-map",
+            str(tmp_path / "rescue_productization.json"),
+            "--publish-dir",
+            str(publish_dir),
+            "--dry-run",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "generated_at" in payload
+    assert not publish_dir.exists()


### PR DESCRIPTION
Harvests existing Codex automation branch `codex/salvage-rescue-productization-dry-run-20260516` from the automation outbox.

Source evidence:
- Outbox item: `.aragora/automation-outbox/open-pr-codex-salvage-rescue-productization-dry-run-20260516-0da236bf.json`
- Desired head: `0da236bfbba31ede352402c1daa7d869d67f78ba`
- Changed files: `scripts/publish_rescue_productization_report.py`, `tests/scripts/test_publish_rescue_productization_report.py`
- Existing fallback issue: #7219

Outbox validation reported:
- `python3 -m pytest -q tests/scripts/test_publish_rescue_productization_report.py -p no:rerunfailures -p no:cacheprovider` -> 3 passed in 0.89s
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok
- branch pushed to origin after pre-push hooks

Current publication note:
- Opened as draft because the branch was already pushed but is one commit behind current `origin/main` after #7216 landed.
- `git merge-tree` against current `origin/main` is conflict-free.
- I did not restack or mutate the existing active worktree for this branch.

Closes #7219.
