### PR TITLE
feat(automation): add codex worktree value inventory

### DIFF
--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -1,0 +1,833 @@
+#!/usr/bin/env python3
+"""Read-only value inventory for Codex-home Aragora worktrees.
+
+This script classifies local checkouts under ``/Users/armand/.codex/worktrees``
+so automation can harvest useful work before any cleanup attempt. It never
+removes paths or branches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from audit_codex_branch_backlog import (  # noqa: E402
+    DEFAULT_OUTBOX_DIR,
+    DEFAULT_RECEIPT_DIR,
+    _commit_prefix_matches,
+    is_patch_equivalent,
+    terminal_receipted_handoff_branch_heads,
+    unresolved_outbox_handoff_branches,
+)
+
+SCHEMA = "aragora-worktree-harvest/1.0"
+DEFAULT_ROOT = Path.home() / ".codex" / "worktrees"
+DEFAULT_LEDGER_ROOT = Path(".aragora/worktree-harvest")
+ACTIVE_SESSION_FILES = (
+    ".claude-session-active",
+    ".codex_session_active",
+    ".nomic-session-active",
+)
+VALUE_CLASSES = (
+    "active_or_dirty",
+    "open_pr_or_outbox",
+    "receipt_protected",
+    "unique_unharvested",
+    "patch_equivalent_or_merged",
+    "unregistered_git_residue",
+    "no_git_cache_residue",
+    "lookup_failed",
+)
+CLEANUP_CLASSES = {
+    "patch_equivalent_or_merged",
+    "unregistered_git_residue",
+    "no_git_cache_residue",
+}
+PROTECTED_CLASSES = {
+    "active_or_dirty",
+    "open_pr_or_outbox",
+    "receipt_protected",
+    "lookup_failed",
+}
+
+
+@dataclass(frozen=True)
+class WorktreeEntry:
+    path: Path
+    branch: str | None
+
+
+@dataclass
+class GitInfo:
+    is_repo: bool = False
+    repo_path: str | None = None
+    registered_worktree: bool = False
+    branch: str | None = None
+    head: str | None = None
+    ahead: int | None = None
+    behind: int | None = None
+    dirty: bool = False
+    patch_equivalent_to_base: bool = False
+    lookup_failed: bool = False
+    lookup_errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class WorktreeCandidate:
+    candidate_id: str
+    path: str
+    repo_path: str | None
+    size_bytes: int | None
+    size_lookup_failed: bool
+    mtime: str | None
+    classification: str
+    decision: str
+    cleanup_candidate: bool
+    proof: list[str]
+    active_session: bool
+    lock_files: list[str]
+    git: GitInfo
+    links: dict[str, Any]
+    next_action: str
+
+
+@dataclass
+class InventoryContext:
+    repo: Path
+    base: str
+    base_sha: str | None
+    outbox_dir: Path
+    receipt_dir: Path
+    worktrees_by_path: dict[str, WorktreeEntry]
+    unresolved_outbox_branches: set[str]
+    terminal_receipt_branch_heads: dict[str, set[str | None]]
+    skip_gh: bool
+    git_timeout: int
+    gh_timeout: int
+    patch_timeout: int
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def run_cmd(args: list[str], cwd: Path, *, timeout: int) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        stderr = str(exc)
+        if isinstance(exc, subprocess.TimeoutExpired):
+            stderr = f"command timed out after {timeout}s: {' '.join(args)}"
+        return subprocess.CompletedProcess(args=args, returncode=124, stdout="", stderr=stderr)
+
+
+def run_git(args: list[str], cwd: Path, *, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    return run_cmd(["git", *args], cwd, timeout=timeout)
+
+
+def resolve_repo(path: Path) -> Path:
+    proc = run_git(["rev-parse", "--show-toplevel"], path)
+    if proc.returncode != 0:
+        raise SystemExit(proc.stderr.strip() or f"not a git repository: {path}")
+    return Path(proc.stdout.strip()).resolve()
+
+
+def resolve_ref(repo: Path, ref: str, *, timeout: int = 30) -> str | None:
+    proc = run_git(["rev-parse", "--verify", ref], repo, timeout=timeout)
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def parse_worktree_list(repo: Path, *, timeout: int = 30) -> dict[str, WorktreeEntry]:
+    proc = run_git(["worktree", "list", "--porcelain"], repo, timeout=timeout)
+    if proc.returncode != 0:
+        return {}
+
+    entries: dict[str, WorktreeEntry] = {}
+    current_path: Path | None = None
+    current_branch: str | None = None
+
+    def flush() -> None:
+        if current_path is None:
+            return
+        entries[str(current_path.resolve())] = WorktreeEntry(
+            path=current_path.resolve(),
+            branch=current_branch,
+        )
+
+    for line in proc.stdout.splitlines():
+        if line.startswith("worktree "):
+            flush()
+            current_path = Path(line.removeprefix("worktree ").strip())
+            current_branch = None
+        elif line.startswith("branch "):
+            current_branch = line.removeprefix("branch refs/heads/").strip()
+    flush()
+    return entries
+
+
+def json_files(path: Path) -> list[Path]:
+    if not path.exists():
+        return []
+    return sorted(item for item in path.glob("*.json") if item.is_file())
+
+
+def load_json_mapping(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def branch_matches_receipt(
+    branch: str | None,
+    head: str | None,
+    receipt_branch_heads: dict[str, set[str | None]],
+) -> bool:
+    if not branch:
+        return False
+    heads = receipt_branch_heads.get(branch, set())
+    if not heads:
+        return False
+    if not head:
+        return None in heads
+    return any(
+        receipt_head is None or _commit_prefix_matches(receipt_head, head) for receipt_head in heads
+    )
+
+
+def outbox_files_for_branch(outbox_dir: Path, branch: str | None) -> list[str]:
+    if not branch:
+        return []
+    matches: list[str] = []
+    for path in json_files(outbox_dir):
+        payload = load_json_mapping(path)
+        if payload is None:
+            continue
+        text = json.dumps(payload, sort_keys=True)
+        if branch in text:
+            matches.append(str(path))
+    return matches
+
+
+def receipt_files_for_branch(receipt_dir: Path, branch: str | None) -> list[str]:
+    if not branch:
+        return []
+    matches: list[str] = []
+    for path in json_files(receipt_dir):
+        payload = load_json_mapping(path)
+        if payload is None:
+            continue
+        text = json.dumps(payload, sort_keys=True)
+        if branch in text:
+            matches.append(str(path))
+    return matches
+
+
+def find_repo_path(candidate_root: Path) -> Path | None:
+    for path in (candidate_root, candidate_root / "aragora"):
+        if (path / ".git").exists():
+            return path
+    return None
+
+
+def active_lock_files(candidate_root: Path, repo_path: Path | None) -> list[str]:
+    roots = [candidate_root]
+    if repo_path is not None and repo_path != candidate_root:
+        roots.append(repo_path)
+    found: list[str] = []
+    for root in roots:
+        for name in ACTIVE_SESSION_FILES:
+            if (root / name).exists():
+                found.append(str(root / name))
+    return sorted(found)
+
+
+def has_active_session(candidate_root: Path, repo_path: Path | None) -> bool:
+    if active_lock_files(candidate_root, repo_path):
+        return True
+    for root in (candidate_root, repo_path):
+        if root is None or not root.exists():
+            continue
+        try:
+            for item in root.glob(".claude-session-anchor"):
+                if item.exists():
+                    return True
+        except OSError:
+            return True
+    return False
+
+
+def git_status_dirty(repo_path: Path, *, timeout: int) -> tuple[bool, bool, str | None]:
+    proc = run_git(["status", "--porcelain"], repo_path, timeout=timeout)
+    if proc.returncode != 0:
+        return True, True, proc.stderr.strip() or "git status failed"
+    return bool(proc.stdout.strip()), False, None
+
+
+def git_branch(
+    repo_path: Path, registered: WorktreeEntry | None, *, timeout: int
+) -> tuple[str | None, bool, str | None]:
+    if registered and registered.branch:
+        return registered.branch, False, None
+    proc = run_git(["rev-parse", "--abbrev-ref", "HEAD"], repo_path, timeout=timeout)
+    if proc.returncode != 0:
+        return None, True, proc.stderr.strip() or "branch lookup failed"
+    branch = proc.stdout.strip()
+    if not branch or branch == "HEAD":
+        return None, False, None
+    return branch, False, None
+
+
+def git_head(repo_path: Path, *, timeout: int) -> tuple[str | None, bool, str | None]:
+    proc = run_git(["rev-parse", "HEAD"], repo_path, timeout=timeout)
+    if proc.returncode != 0:
+        return None, True, proc.stderr.strip() or "head lookup failed"
+    return proc.stdout.strip() or None, False, None
+
+
+def git_ahead_behind(
+    repo_path: Path, base: str, rev: str, *, timeout: int
+) -> tuple[int | None, int | None, bool, str | None]:
+    proc = run_git(
+        ["rev-list", "--left-right", "--count", f"{base}...{rev}"], repo_path, timeout=timeout
+    )
+    if proc.returncode != 0:
+        return None, None, True, proc.stderr.strip() or "ahead/behind lookup failed"
+    try:
+        behind_text, ahead_text = proc.stdout.split()
+        return int(ahead_text), int(behind_text), False, None
+    except ValueError:
+        return None, None, True, f"unexpected ahead/behind output: {proc.stdout!r}"
+
+
+def lookup_open_prs(
+    repo: Path, branch: str | None, *, timeout: int, skip_gh: bool
+) -> tuple[list[dict[str, Any]], bool, str | None]:
+    if not branch or skip_gh:
+        return [], False, None
+    proc = run_cmd(
+        ["gh", "pr", "list", "--state", "open", "--head", branch, "--json", "number,title,url"],
+        repo,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        return [], True, proc.stderr.strip() or "gh pr lookup failed"
+    try:
+        payload = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return [], True, f"failed to parse gh pr output: {exc}"
+    if not isinstance(payload, list):
+        return [], True, "gh pr output was not a list"
+    return [item for item in payload if isinstance(item, dict)], False, None
+
+
+def measure_sizes(
+    paths: list[Path], *, mode: str, timeout: int
+) -> tuple[dict[str, int | None], set[str]]:
+    if mode == "none":
+        return {str(path): None for path in paths}, set()
+    if not paths:
+        return {}, set()
+    if mode == "stat":
+        sizes: dict[str, int | None] = {}
+        stat_failed: set[str] = set()
+        for path in paths:
+            try:
+                sizes[str(path)] = path.stat().st_blocks * 512
+            except OSError:
+                sizes[str(path)] = None
+                stat_failed.add(str(path))
+        return sizes, stat_failed
+
+    proc = run_cmd(["du", "-sk", *[str(path) for path in paths]], Path("/"), timeout=timeout)
+    sizes = {str(path): None for path in paths}
+    du_failed: set[str] = set()
+    if proc.returncode != 0:
+        return sizes, {str(path) for path in paths}
+    for line in proc.stdout.splitlines():
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        try:
+            sizes[str(Path(parts[1]))] = int(parts[0]) * 1024
+        except ValueError:
+            du_failed.add(str(Path(parts[1])))
+    for path_text, size in sizes.items():
+        if size is None:
+            du_failed.add(path_text)
+    return sizes, du_failed
+
+
+def candidate_id(path: Path, repo_path: Path | None) -> str:
+    raw = f"{path.resolve()}|{repo_path.resolve() if repo_path else ''}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def candidate_mtime(path: Path) -> str | None:
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, UTC).replace(microsecond=0).isoformat()
+    except OSError:
+        return None
+
+
+def classify_candidate(
+    candidate_root: Path,
+    *,
+    context: InventoryContext,
+    size_bytes: int | None,
+    size_lookup_failed: bool,
+) -> WorktreeCandidate:
+    repo_path = find_repo_path(candidate_root)
+    active_session = has_active_session(candidate_root, repo_path)
+    lock_files = active_lock_files(candidate_root, repo_path)
+    git = GitInfo(is_repo=repo_path is not None, repo_path=str(repo_path) if repo_path else None)
+    proof: list[str] = []
+    links: dict[str, Any] = {
+        "open_prs": [],
+        "outbox_files": [],
+        "receipt_files": [],
+    }
+
+    if repo_path is None:
+        if active_session or lock_files:
+            classification = "active_or_dirty"
+            proof.append("active session marker present without git metadata")
+        else:
+            classification = "no_git_cache_residue"
+            proof.append("no git metadata at candidate root or candidate/aragora path")
+        return build_candidate(
+            candidate_root,
+            repo_path,
+            size_bytes,
+            size_lookup_failed,
+            classification,
+            active_session,
+            lock_files,
+            git,
+            links,
+            proof,
+        )
+
+    registered = context.worktrees_by_path.get(str(repo_path.resolve()))
+    git.registered_worktree = registered is not None
+
+    branch, branch_failed, branch_error = git_branch(
+        repo_path, registered, timeout=context.git_timeout
+    )
+    git.branch = branch
+    if branch_failed:
+        git.lookup_failed = True
+        git.lookup_errors.append(branch_error or "branch lookup failed")
+    head, head_failed, head_error = git_head(repo_path, timeout=context.git_timeout)
+    git.head = head
+    if head_failed:
+        git.lookup_failed = True
+        git.lookup_errors.append(head_error or "head lookup failed")
+
+    dirty, dirty_failed, dirty_error = git_status_dirty(repo_path, timeout=context.git_timeout)
+    git.dirty = dirty
+    if dirty_failed:
+        git.lookup_failed = True
+        git.lookup_errors.append(dirty_error or "git status failed")
+
+    rev = branch or head
+    if rev and context.base_sha is not None:
+        ahead, behind, divergence_failed, divergence_error = git_ahead_behind(
+            repo_path,
+            context.base,
+            rev,
+            timeout=context.git_timeout,
+        )
+        git.ahead = ahead
+        git.behind = behind
+        if divergence_failed:
+            git.lookup_failed = True
+            git.lookup_errors.append(divergence_error or "ahead/behind lookup failed")
+    elif rev:
+        git.lookup_failed = True
+        git.lookup_errors.append(f"base ref not found: {context.base}")
+
+    open_prs, open_pr_failed, open_pr_error = lookup_open_prs(
+        context.repo,
+        branch,
+        timeout=context.gh_timeout,
+        skip_gh=context.skip_gh,
+    )
+    links["open_prs"] = open_prs
+    if open_pr_failed:
+        git.lookup_failed = True
+        git.lookup_errors.append(open_pr_error or "open PR lookup failed")
+
+    links["outbox_files"] = outbox_files_for_branch(context.outbox_dir, branch)
+    links["receipt_files"] = receipt_files_for_branch(context.receipt_dir, branch)
+    outbox_protected = bool(branch and branch in context.unresolved_outbox_branches)
+    receipt_protected = branch_matches_receipt(
+        branch,
+        head,
+        context.terminal_receipt_branch_heads,
+    )
+
+    if active_session or lock_files or dirty:
+        classification = "active_or_dirty"
+        if active_session:
+            proof.append("active session marker present")
+        if lock_files:
+            proof.append("active lock file present")
+        if dirty:
+            proof.append("git status is dirty or unavailable")
+    elif git.lookup_failed:
+        classification = "lookup_failed"
+        proof.extend(git.lookup_errors or ["one or more git/GitHub lookups failed"])
+    elif open_prs or outbox_protected:
+        classification = "open_pr_or_outbox"
+        if open_prs:
+            proof.append("open PR exists for branch")
+        if outbox_protected:
+            proof.append("unresolved automation outbox references branch")
+    elif receipt_protected:
+        classification = "receipt_protected"
+        proof.append("terminal automation receipt references branch/head")
+    elif git.ahead and git.ahead > 0:
+        patch_equivalent = False
+        try:
+            patch_equivalent = is_patch_equivalent(
+                repo_path,
+                context.base,
+                rev or "HEAD",
+                timeout=context.patch_timeout,
+            )
+        except Exception as exc:
+            git.lookup_failed = True
+            git.lookup_errors.append(f"patch equivalence failed: {exc}")
+            classification = "lookup_failed"
+            proof.append("patch equivalence lookup failed")
+        else:
+            git.patch_equivalent_to_base = patch_equivalent
+            if patch_equivalent:
+                classification = "patch_equivalent_or_merged"
+                proof.append("branch is patch-equivalent to base")
+            else:
+                classification = "unique_unharvested"
+                proof.append("branch has unique commits or diff ahead of base")
+    elif git.registered_worktree:
+        classification = "patch_equivalent_or_merged"
+        proof.append("registered git worktree has no unique commits ahead of base")
+    else:
+        classification = "unregistered_git_residue"
+        proof.append("git checkout is not registered in git worktree list")
+
+    return build_candidate(
+        candidate_root,
+        repo_path,
+        size_bytes,
+        size_lookup_failed,
+        classification,
+        active_session,
+        lock_files,
+        git,
+        links,
+        proof,
+    )
+
+
+def build_candidate(
+    candidate_root: Path,
+    repo_path: Path | None,
+    size_bytes: int | None,
+    size_lookup_failed: bool,
+    classification: str,
+    active_session: bool,
+    lock_files: list[str],
+    git: GitInfo,
+    links: dict[str, Any],
+    proof: list[str],
+) -> WorktreeCandidate:
+    cleanup_candidate = classification in CLEANUP_CLASSES and not active_session and not git.dirty
+    if classification == "unique_unharvested":
+        decision = "harvest_candidate"
+        next_action = "inspect diff and harvest into a fresh branch or handoff"
+    elif cleanup_candidate:
+        decision = "cleanup_candidate"
+        next_action = "fresh safe_worktree_cleanup.py inspect is required before any removal"
+    elif classification in PROTECTED_CLASSES:
+        decision = "preserve"
+        next_action = "preserve until blocker clears or value is harvested"
+    else:
+        decision = "preserve"
+        next_action = "review classification before cleanup"
+    return WorktreeCandidate(
+        candidate_id=candidate_id(candidate_root, repo_path),
+        path=str(candidate_root),
+        repo_path=str(repo_path) if repo_path else None,
+        size_bytes=size_bytes,
+        size_lookup_failed=size_lookup_failed,
+        mtime=candidate_mtime(candidate_root),
+        classification=classification,
+        decision=decision,
+        cleanup_candidate=cleanup_candidate,
+        proof=proof,
+        active_session=active_session,
+        lock_files=lock_files,
+        git=git,
+        links=links,
+        next_action=next_action,
+    )
+
+
+def candidate_roots(root: Path, limit: int | None = None) -> list[Path]:
+    if not root.exists():
+        return []
+    entries = sorted(
+        (entry for entry in root.iterdir() if entry.is_dir()),
+        key=lambda path: path.name,
+    )
+    return entries[:limit] if limit is not None else entries
+
+
+def build_summary(candidates: list[WorktreeCandidate]) -> dict[str, Any]:
+    counts = Counter(candidate.classification for candidate in candidates)
+    bytes_by_class: dict[str, int] = dict.fromkeys(VALUE_CLASSES, 0)
+    known_bytes = 0
+    size_lookup_failures = 0
+    for candidate in candidates:
+        if candidate.size_bytes is None:
+            size_lookup_failures += 1
+            continue
+        known_bytes += candidate.size_bytes
+        bytes_by_class[candidate.classification] = (
+            bytes_by_class.get(candidate.classification, 0) + candidate.size_bytes
+        )
+
+    def top(filter_fn: Any) -> list[dict[str, Any]]:
+        selected = [candidate for candidate in candidates if filter_fn(candidate)]
+        selected.sort(key=lambda item: item.size_bytes or -1, reverse=True)
+        return [
+            {
+                "path": candidate.path,
+                "classification": candidate.classification,
+                "size_bytes": candidate.size_bytes,
+                "branch": candidate.git.branch,
+                "head": candidate.git.head,
+                "decision": candidate.decision,
+                "proof": candidate.proof,
+            }
+            for candidate in selected[:20]
+        ]
+
+    return {
+        "total_candidates": len(candidates),
+        "classified_candidates": sum(counts.values()),
+        "unknown_candidates": counts.get("lookup_failed", 0),
+        "count_by_class": {name: counts.get(name, 0) for name in VALUE_CLASSES},
+        "bytes_by_class": bytes_by_class,
+        "known_size_bytes": known_bytes,
+        "size_lookup_failures": size_lookup_failures,
+        "inventory_coverage": (
+            1.0 if not candidates else (len(candidates) - size_lookup_failures) / len(candidates)
+        ),
+        "cleanup_candidate_count": sum(
+            1 for candidate in candidates if candidate.cleanup_candidate
+        ),
+        "harvest_candidate_count": counts.get("unique_unharvested", 0),
+        "top_protected_size_users": top(
+            lambda candidate: candidate.classification in PROTECTED_CLASSES
+        ),
+        "top_cleanup_candidates": top(lambda candidate: candidate.cleanup_candidate),
+        "top_unique_unharvested": top(
+            lambda candidate: candidate.classification == "unique_unharvested"
+        ),
+    }
+
+
+def inventory(
+    *,
+    root: Path,
+    repo: Path,
+    base: str,
+    outbox_dir: Path,
+    receipt_dir: Path,
+    limit: int | None,
+    size_mode: str,
+    size_timeout: int,
+    skip_gh: bool,
+    git_timeout: int,
+    gh_timeout: int,
+    patch_timeout: int,
+) -> dict[str, Any]:
+    repo = resolve_repo(repo)
+    base_sha = resolve_ref(repo, base, timeout=git_timeout)
+    roots = candidate_roots(root, limit)
+    sizes, size_failures = measure_sizes(roots, mode=size_mode, timeout=size_timeout)
+    context = InventoryContext(
+        repo=repo,
+        base=base,
+        base_sha=base_sha,
+        outbox_dir=outbox_dir if outbox_dir.is_absolute() else repo / outbox_dir,
+        receipt_dir=receipt_dir if receipt_dir.is_absolute() else repo / receipt_dir,
+        worktrees_by_path=parse_worktree_list(repo, timeout=git_timeout),
+        unresolved_outbox_branches=unresolved_outbox_handoff_branches(
+            repo,
+            outbox_dir=outbox_dir,
+            receipt_dir=receipt_dir,
+        ),
+        terminal_receipt_branch_heads=terminal_receipted_handoff_branch_heads(
+            repo,
+            outbox_dir=outbox_dir,
+            receipt_dir=receipt_dir,
+        ),
+        skip_gh=skip_gh,
+        git_timeout=git_timeout,
+        gh_timeout=gh_timeout,
+        patch_timeout=patch_timeout,
+    )
+    candidates = [
+        classify_candidate(
+            path,
+            context=context,
+            size_bytes=sizes.get(str(path)),
+            size_lookup_failed=str(path) in size_failures,
+        )
+        for path in roots
+    ]
+    now = utc_now().isoformat()
+    payload = {
+        "schema": SCHEMA,
+        "generated_at": now,
+        "root": str(root),
+        "repo": str(repo),
+        "base": base,
+        "base_sha": base_sha,
+        "size_mode": size_mode,
+        "limit": limit,
+        "summary": build_summary(candidates),
+        "candidates": [asdict(candidate) for candidate in candidates],
+    }
+    return payload
+
+
+def atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+
+
+def write_ledger(ledger_root: Path, payload: dict[str, Any]) -> dict[str, str]:
+    generated = str(payload["generated_at"]).replace(":", "").replace("-", "")
+    snapshot_path = ledger_root / "snapshots" / f"{generated}.json"
+    latest_path = ledger_root / "latest.json"
+    ledger_path = ledger_root / "ledger.jsonl"
+    snapshot_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    atomic_write(snapshot_path, snapshot_text)
+    atomic_write(latest_path, snapshot_text)
+    event = {
+        "schema": SCHEMA,
+        "event_id": hashlib.sha256(snapshot_text.encode("utf-8")).hexdigest()[:16],
+        "event_type": "inventory",
+        "created_at": payload["generated_at"],
+        "actor": "codex-worktree-value-inventory",
+        "root": payload["root"],
+        "summary": payload["summary"],
+        "snapshot": str(snapshot_path),
+    }
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True) + "\n")
+    return {
+        "snapshot": str(snapshot_path),
+        "latest": str(latest_path),
+        "ledger": str(ledger_path),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only inventory of Codex-home worktree value and cleanup candidates."
+    )
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--repo", type=Path, default=Path("."))
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--outbox-dir", type=Path, default=DEFAULT_OUTBOX_DIR)
+    parser.add_argument("--receipt-dir", type=Path, default=DEFAULT_RECEIPT_DIR)
+    parser.add_argument("--ledger-root", type=Path, default=DEFAULT_LEDGER_ROOT)
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--size-mode", choices=("du", "stat", "none"), default="du")
+    parser.add_argument("--size-timeout", type=int, default=300)
+    parser.add_argument("--git-timeout", type=int, default=30)
+    parser.add_argument("--gh-timeout", type=int, default=30)
+    parser.add_argument("--patch-timeout", type=int, default=45)
+    parser.add_argument("--skip-gh", action="store_true")
+    parser.add_argument("--write-ledger", action="store_true")
+    parser.add_argument("--dry-run", action="store_true", help="Suppress ledger writes.")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = inventory(
+        root=args.root.expanduser().resolve(),
+        repo=args.repo,
+        base=args.base,
+        outbox_dir=args.outbox_dir,
+        receipt_dir=args.receipt_dir,
+        limit=args.limit,
+        size_mode=args.size_mode,
+        size_timeout=args.size_timeout,
+        skip_gh=args.skip_gh,
+        git_timeout=args.git_timeout,
+        gh_timeout=args.gh_timeout,
+        patch_timeout=args.patch_timeout,
+    )
+    if args.write_ledger and not args.dry_run:
+        payload["ledger_written"] = write_ledger(args.ledger_root, payload)
+    else:
+        payload["ledger_written"] = None
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        summary = payload["summary"]
+        print(f"root: {payload['root']}")
+        print(f"candidates: {summary['total_candidates']}")
+        print(f"coverage: {summary['inventory_coverage']:.2%}")
+        print(f"cleanup_candidates: {summary['cleanup_candidate_count']}")
+        print(f"harvest_candidates: {summary['harvest_candidate_count']}")
+        print("classes:")
+        for name, count in summary["count_by_class"].items():
+            print(f"  {name}: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -1,0 +1,314 @@
+"""Tests for scripts/codex_worktree_value_inventory.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path() -> Generator[None, None, None]:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+def _context(tmp_path: Path, **overrides: Any) -> Any:
+    import codex_worktree_value_inventory as mod
+
+    values: dict[str, Any] = {
+        "repo": tmp_path,
+        "base": "origin/main",
+        "base_sha": "base-sha",
+        "outbox_dir": tmp_path / ".aragora" / "automation-outbox",
+        "receipt_dir": tmp_path / ".aragora" / "automation-receipts",
+        "worktrees_by_path": {},
+        "unresolved_outbox_branches": set(),
+        "terminal_receipt_branch_heads": {},
+        "skip_gh": False,
+        "git_timeout": 1,
+        "gh_timeout": 1,
+        "patch_timeout": 1,
+    }
+    values.update(overrides)
+    outbox_dir = values["outbox_dir"]
+    receipt_dir = values["receipt_dir"]
+    assert isinstance(outbox_dir, Path)
+    assert isinstance(receipt_dir, Path)
+    outbox_dir.mkdir(parents=True, exist_ok=True)
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    return mod.InventoryContext(**values)
+
+
+def _candidate(tmp_path: Path, name: str = "abcd", *, repo: bool = True) -> Path:
+    root = tmp_path / name
+    root.mkdir(parents=True)
+    if repo:
+        repo_path = root / "aragora"
+        repo_path.mkdir()
+        (repo_path / ".git").mkdir()
+    return root
+
+
+def _stub_clean_git(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    branch: str | None = "codex/test",
+    head: str | None = "abcdef123456",
+    ahead: int | None = 0,
+    behind: int | None = 0,
+    dirty: bool = False,
+    open_prs: list[dict[str, Any]] | None = None,
+    open_pr_failed: bool = False,
+    patch_equivalent: bool = False,
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    monkeypatch.setattr(mod, "git_branch", lambda *_args, **_kwargs: (branch, False, None))
+    monkeypatch.setattr(mod, "git_head", lambda *_args, **_kwargs: (head, False, None))
+    monkeypatch.setattr(mod, "git_status_dirty", lambda *_args, **_kwargs: (dirty, False, None))
+    monkeypatch.setattr(
+        mod,
+        "git_ahead_behind",
+        lambda *_args, **_kwargs: (ahead, behind, False, None),
+    )
+    monkeypatch.setattr(
+        mod,
+        "lookup_open_prs",
+        lambda *_args, **_kwargs: (
+            open_prs or [],
+            open_pr_failed,
+            "open PR lookup failed" if open_pr_failed else None,
+        ),
+    )
+    monkeypatch.setattr(mod, "is_patch_equivalent", lambda *_args, **_kwargs: patch_equivalent)
+
+
+def test_no_git_cache_residue_is_cleanup_candidate(tmp_path: Path) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path, repo=False)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "no_git_cache_residue"
+    assert candidate.cleanup_candidate is True
+    assert candidate.decision == "cleanup_candidate"
+
+
+def test_no_git_active_marker_is_preserved(tmp_path: Path) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path, repo=False)
+    (root / ".codex_session_active").write_text("active\n")
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "active_or_dirty"
+    assert candidate.cleanup_candidate is False
+    assert candidate.decision == "preserve"
+
+
+def test_dirty_repo_takes_priority_over_unique_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=3, dirty=True)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "active_or_dirty"
+    assert "git status is dirty or unavailable" in candidate.proof
+
+
+def test_open_pr_classification_blocks_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(
+        monkeypatch,
+        ahead=2,
+        open_prs=[{"number": 1, "title": "PR", "url": "https://example.test/pr/1"}],
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "open_pr_or_outbox"
+    assert candidate.cleanup_candidate is False
+
+
+def test_unresolved_outbox_classification_blocks_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path, unresolved_outbox_branches={"codex/test"}),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "open_pr_or_outbox"
+    assert "unresolved automation outbox references branch" in candidate.proof
+
+
+def test_terminal_receipt_classification_blocks_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, head="abcdef123456")
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path, terminal_receipt_branch_heads={"codex/test": {"abcdef1"}}),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "receipt_protected"
+    assert candidate.cleanup_candidate is False
+
+
+def test_unique_unharvested_when_ahead_and_not_patch_equivalent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.decision == "harvest_candidate"
+    assert candidate.cleanup_candidate is False
+
+
+def test_patch_equivalent_ahead_work_is_cleanup_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=True)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "patch_equivalent_or_merged"
+    assert candidate.cleanup_candidate is True
+
+
+def test_lookup_failure_preserves_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=0, open_pr_failed=True)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(tmp_path),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "lookup_failed"
+    assert candidate.cleanup_candidate is False
+    assert "open PR lookup failed" in candidate.git.lookup_errors
+
+
+def test_summary_reports_top_cleanup_and_harvest_candidates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    cleanup_root = _candidate(tmp_path, "cleanup")
+    unique_root = _candidate(tmp_path, "unique")
+    _stub_clean_git(monkeypatch, ahead=0)
+    cleanup = mod.classify_candidate(
+        cleanup_root,
+        context=_context(tmp_path),
+        size_bytes=2048,
+        size_lookup_failed=False,
+    )
+    _stub_clean_git(monkeypatch, ahead=1, patch_equivalent=False)
+    unique = mod.classify_candidate(
+        unique_root,
+        context=_context(tmp_path),
+        size_bytes=4096,
+        size_lookup_failed=False,
+    )
+
+    summary = mod.build_summary([cleanup, unique])
+
+    assert summary["cleanup_candidate_count"] == 1
+    assert summary["harvest_candidate_count"] == 1
+    assert summary["top_cleanup_candidates"][0]["path"] == str(cleanup_root)
+    assert summary["top_unique_unharvested"][0]["path"] == str(unique_root)
+
+
+def test_write_ledger_creates_snapshot_latest_and_jsonl(tmp_path: Path) -> None:
+    import codex_worktree_value_inventory as mod
+
+    payload = {
+        "schema": mod.SCHEMA,
+        "generated_at": "2026-05-16T17:00:00+00:00",
+        "root": "/tmp/root",
+        "summary": {"total_candidates": 0},
+    }
+
+    written = mod.write_ledger(tmp_path / "ledger", payload)
+
+    assert Path(written["snapshot"]).is_file()
+    assert Path(written["latest"]).is_file()
+    ledger_lines = Path(written["ledger"]).read_text(encoding="utf-8").splitlines()
+    assert len(ledger_lines) == 1
+    assert json.loads(ledger_lines[0])["event_type"] == "inventory"


### PR DESCRIPTION
## Summary
- Adds `scripts/codex_worktree_value_inventory.py`, a read-only inventory for `/Users/armand/.codex/worktrees` that classifies Codex-home checkouts by preservation/value/cleanup signals.
- Writes optional local harvest ledger snapshots under a caller-provided ledger root; no deletion, branch deletion, cleanup apply, PR creation, or issue mutation path exists in the script.
- Adds focused tests for active/dirty preservation, open PR/outbox protection, receipt protection, unique-harvest candidates, patch-equivalent/merged cleanup candidates, no-git residue, lookup failures, summaries, and ledger writes.

## Dogfood
- `python3 scripts/codex_worktree_value_inventory.py --root /Users/armand/.codex/worktrees --size-mode du --size-timeout 120 --limit 50 --skip-gh --json --dry-run`
- Sample result: 50 candidates, 40 `active_or_dirty`, 8 `patch_equivalent_or_merged`, 2 `unique_unharvested`, 0 lookup failures, 8 cleanup candidates, 2 harvest candidates, 16.14 GiB measured, 100% sample size coverage.
- Ledger smoke used `/tmp/codex-worktree-harvest-ledger` and wrote `latest.json`, a timestamped snapshot, and `ledger.jsonl` without touching repo-tracked state.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_codex_worktree_value_inventory.py tests/scripts/test_safe_worktree_cleanup.py tests/scripts/test_audit_codex_branch_backlog.py -p no:rerunfailures -p no:cacheprovider` -> 77 passed
- `python3 -m ruff check scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py`
- `python3 -m ruff format --check scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py`
- `python3 -m mypy scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py --ignore-missing-imports`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Safety
- Read-only by default.
- `--write-ledger` only writes local inventory artifacts; `--dry-run` suppresses those writes.
- No cleanup command is included; cleanup still requires a separate fresh `safe_worktree_cleanup.py inspect` and future receipt/proof gate.
