### PR TITLE
feat(swarm): corpus-aware dispatch upgrade (PR-1 of #7209, flag-gated)

### DIFF
--- a/aragora/swarm/dispatch_followups.py
+++ b/aragora/swarm/dispatch_followups.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import subprocess
 from datetime import datetime, timezone
@@ -30,6 +31,198 @@ logger = logging.getLogger(__name__)
 
 _MARKDOWN_BULLET_RE = re.compile(r"^[-*]\s+(?:\[[ xX]\]\s+)?(?P<text>.+)$")
 _ACCEPTANCE_SECTION_HEADINGS = {"acceptance", "acceptance criteria"}
+
+# ---------------------------------------------------------------------------
+# PR-1 of #7209 — corpus-aware dispatch upgrade (flag-gated, default OFF)
+#
+# When ``ARAGORA_CORPUS_AWARE_DISPATCH`` is truthy and the issue under
+# dispatch is a member of ``docs/benchmarks/corpus.json::issues`` whose
+# ``execution_class`` is in the PR-1 whitelist, augment under-specified
+# specs with the corpus row's ``scope_hint`` + ``known_constraints`` and
+# an ``execution_class``-specific acceptance-criteria template so the
+# dispatch contract gate no longer rejects the spec as
+# ``blocked_not_dispatch_bounded``.
+#
+# Default behaviour is unchanged.  See docs/plans/
+# 2026-05-16-a2-admission-class-productization.md for the full plan.
+# ---------------------------------------------------------------------------
+
+_CORPUS_AWARE_DISPATCH_ENV = "ARAGORA_CORPUS_AWARE_DISPATCH"
+_CORPUS_AWARE_DISPATCH_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_CORPUS_AWARE_DISPATCH_WHITELIST = frozenset(
+    {
+        "missing_test_coverage",
+        "small_refactor",
+        "validation_tightening",
+        "exception_narrowing",
+    }
+)
+_CORPUS_AWARE_DISPATCH_CORPUS_RELPATH = Path("docs/benchmarks/corpus.json")
+
+# Per ``execution_class`` rendered acceptance-criteria templates.  Each
+# class lists the bounded-target shape the worker should hit.  ``{scope}``
+# is rendered as the comma-joined list of ``scope_hint`` paths to keep the
+# bullet self-contained.  Templates intentionally restate the constraint
+# in operator-readable form because the corpus row's ``known_constraints``
+# already lands as ``spec.constraints`` separately.
+_EXECUTION_CLASS_ACCEPTANCE_TEMPLATES: dict[str, tuple[str, ...]] = {
+    "missing_test_coverage": (
+        "Add unit tests covering happy path and at least one edge case for the modules listed under File Scope ({scope}).",
+        "`pytest` over the new test file exits 0.",
+        "Do not modify production code under `aragora/` unless strictly required by the test scaffold.",
+    ),
+    "small_refactor": (
+        "Refactor is scoped to the files listed under File Scope ({scope}); no other production files are modified.",
+        "`pytest` for tests covering the scoped files continues to exit 0.",
+        "Public API of the refactored modules is unchanged.",
+    ),
+    "validation_tightening": (
+        "Tighten input validation in the files listed under File Scope ({scope}) so the constraints under ``known_constraints`` are enforced.",
+        "Existing valid inputs continue to be accepted; new tests exercise at least one rejected-input case.",
+        "`pytest` for tests covering the scoped files exits 0.",
+    ),
+    "exception_narrowing": (
+        "Replace broad ``except Exception`` / bare ``except:`` in the files listed under File Scope ({scope}) with explicit exception classes per ``known_constraints``.",
+        "`ruff check` over the scoped files passes.",
+        "`pytest` for tests covering the scoped files exits 0.",
+    ),
+}
+
+
+def _corpus_aware_dispatch_enabled() -> bool:
+    """True iff ``ARAGORA_CORPUS_AWARE_DISPATCH`` resolves to a truthy value."""
+    raw = os.environ.get(_CORPUS_AWARE_DISPATCH_ENV, "")
+    return str(raw or "").strip().lower() in _CORPUS_AWARE_DISPATCH_TRUTHY
+
+
+def _corpus_path_for(repo_root: Path | None) -> Path:
+    """Resolve the canonical corpus path under ``repo_root``."""
+    base = Path(repo_root) if repo_root is not None else Path.cwd()
+    return base / _CORPUS_AWARE_DISPATCH_CORPUS_RELPATH
+
+
+def _load_corpus_entry_for_issue(
+    issue_number: int,
+    *,
+    repo_root: Path,
+) -> dict[str, Any] | None:
+    """Look up an issue's corpus row.
+
+    Returns ``None`` when the corpus file is missing, unparseable, or the
+    issue is not a recorded member.  Read-on-each-call (no cache): the
+    corpus file is small and dispatch hits this path at most once per
+    bounded admission attempt.
+    """
+    if not issue_number or int(issue_number) <= 0:
+        return None
+    corpus_path = _corpus_path_for(repo_root)
+    try:
+        raw = corpus_path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    issues = data.get("issues") if isinstance(data, dict) else None
+    if not isinstance(issues, list):
+        return None
+    target = int(issue_number)
+    for entry in issues:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            if int(entry.get("issue_id", 0) or 0) == target:
+                return entry
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _augment_spec_from_corpus(spec: SwarmSpec, corpus_entry: dict[str, Any]) -> None:
+    """Mutate ``spec`` in place with corpus row's file scope + constraints + acceptance criteria."""
+    scope_hint = [
+        str(path).strip()
+        for path in (corpus_entry.get("scope_hint") or [])
+        if str(path or "").strip()
+    ]
+    known_constraints = [
+        str(item).strip()
+        for item in (corpus_entry.get("known_constraints") or [])
+        if str(item or "").strip()
+    ]
+    execution_class = str(corpus_entry.get("execution_class", "") or "").strip()
+
+    if scope_hint:
+        spec.file_scope_hints = _ordered_unique([*spec.file_scope_hints, *scope_hint])
+
+    if known_constraints:
+        spec.constraints = _ordered_unique([*spec.constraints, *known_constraints])
+
+    templates = _EXECUTION_CLASS_ACCEPTANCE_TEMPLATES.get(execution_class, ())
+    if templates:
+        scope_text = ", ".join(scope_hint) if scope_hint else "see scope_hint"
+        rendered: list[str] = []
+        for template in templates:
+            try:
+                rendered.append(template.format(scope=scope_text))
+            except (KeyError, IndexError):
+                rendered.append(template)
+        spec.acceptance_criteria = _ordered_unique([*spec.acceptance_criteria, *rendered])
+
+
+def maybe_upgrade_dispatch_spec_from_corpus(
+    *,
+    issue: Any,
+    spec: SwarmSpec,
+    repo_root: Path,
+) -> SwarmSpec:
+    """Augment an under-specified spec from the bounded-execution corpus.
+
+    No-op (returns ``spec`` unchanged) when any of the following hold:
+
+    * ``ARAGORA_CORPUS_AWARE_DISPATCH`` is OFF (default).
+    * ``spec`` is already ``is_dispatch_bounded()``.
+    * The issue is not a member of ``docs/benchmarks/corpus.json::issues``.
+    * The corpus row's ``execution_class`` is not in the PR-1 whitelist
+      (``missing_test_coverage``, ``small_refactor``, ``validation_tightening``,
+      ``exception_narrowing``).
+
+    Otherwise mutates ``spec`` in place with the corpus row's
+    ``scope_hint`` (→ ``file_scope_hints``), ``known_constraints``
+    (→ ``constraints``), and an ``execution_class``-specific acceptance
+    template (→ ``acceptance_criteria``) and returns it.
+
+    Identity-preserving: the returned spec is always the same object
+    that was passed in.  Callers may chain into the existing
+    title-category heuristic without surprise.
+    """
+    if not _corpus_aware_dispatch_enabled():
+        return spec
+    if spec.is_dispatch_bounded():
+        return spec
+    issue_number = getattr(issue, "number", None)
+    if not issue_number:
+        return spec
+    try:
+        issue_number_int = int(issue_number)
+    except (TypeError, ValueError):
+        return spec
+    corpus_entry = _load_corpus_entry_for_issue(issue_number_int, repo_root=repo_root)
+    if corpus_entry is None:
+        return spec
+    execution_class = str(corpus_entry.get("execution_class", "") or "").strip()
+    if execution_class not in _CORPUS_AWARE_DISPATCH_WHITELIST:
+        return spec
+
+    _augment_spec_from_corpus(spec, corpus_entry)
+    logger.info(
+        "corpus_aware_dispatch_augmented issue=#%s execution_class=%s scope_hint_count=%s",
+        issue_number_int,
+        execution_class,
+        len(corpus_entry.get("scope_hint") or []),
+    )
+    return spec
 
 
 def _ordered_unique(values: list[str]) -> list[str]:
@@ -71,6 +264,18 @@ def maybe_upgrade_dispatch_spec(
     repo_root: Path,
 ) -> SwarmSpec:
     """Try upgrading an under-specified issue before blocking dispatch."""
+    if spec.is_dispatch_bounded():
+        return spec
+
+    # PR-1 of #7209: corpus-aware augmentation runs first when the flag is
+    # ON, so rev-4 corpus members with whitelisted execution classes can be
+    # bounded even when the title-category heuristic doesn't fire.  Flag is
+    # OFF by default; this is a strict no-op otherwise.
+    spec = maybe_upgrade_dispatch_spec_from_corpus(
+        issue=issue,
+        spec=spec,
+        repo_root=repo_root,
+    )
     if spec.is_dispatch_bounded():
         return spec
 
@@ -259,6 +464,7 @@ __all__ = [
     "enforce_acceptance_binding",
     "inject_closes_into_published_pr",
     "maybe_upgrade_dispatch_spec",
+    "maybe_upgrade_dispatch_spec_from_corpus",
     "maybe_upgrade_on_contract_drift",
     "upgrade_on_contract_drift",
     "upgrade_unbounded_spec",

--- a/tests/swarm/test_dispatch_followups.py
+++ b/tests/swarm/test_dispatch_followups.py
@@ -12,6 +12,7 @@ from aragora.swarm.dispatch_followups import (
     enforce_acceptance_binding,
     inject_closes_into_published_pr,
     maybe_upgrade_dispatch_spec,
+    maybe_upgrade_dispatch_spec_from_corpus,
 )
 from aragora.swarm.issue_upgrader import UpgradedIssue
 from aragora.swarm.spec import SwarmSpec
@@ -450,3 +451,213 @@ def test_inject_closes_into_published_pr_refuses_invalid_inputs() -> None:
         )["action"]
         == "skipped"
     )
+
+
+# ---------------------------------------------------------------------------
+# PR-1 of #7209 — corpus-aware dispatch upgrade tests (flag-gated, default OFF)
+# ---------------------------------------------------------------------------
+
+
+def _write_corpus(repo_root: Path, issues: list[dict]) -> None:
+    """Materialize a minimal docs/benchmarks/corpus.json under ``repo_root``."""
+    target = repo_root / "docs" / "benchmarks"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "corpus.json").write_text(
+        json.dumps({"corpus_id": "tw-01-bounded-execution-v1", "issues": issues}),
+        encoding="utf-8",
+    )
+
+
+def _corpus_issue(
+    issue_id: int,
+    *,
+    execution_class: str = "missing_test_coverage",
+    scope_hint: list[str] | None = None,
+    known_constraints: list[str] | None = None,
+) -> dict:
+    return {
+        "issue_id": issue_id,
+        "execution_class": execution_class,
+        "scope_hint": list(
+            scope_hint
+            if scope_hint is not None
+            else [
+                "aragora/utils/sql_helpers.py",
+                "tests/utils/test_sql_helpers.py",
+            ]
+        ),
+        "known_constraints": list(
+            known_constraints
+            if known_constraints is not None
+            else [
+                "add unit tests covering happy and edge cases for the named module",
+                "do not modify production code under aragora/ unless strictly required by the test scaffold",
+            ]
+        ),
+    }
+
+
+def test_corpus_aware_dispatch_off_by_default_returns_spec_unchanged(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("ARAGORA_CORPUS_AWARE_DISPATCH", raising=False)
+    _write_corpus(tmp_path, [_corpus_issue(5185)])
+    issue = SimpleNamespace(
+        number=5185, title="[B0-cohort] Add unit tests for utils/sql_helpers.py"
+    )
+    spec = SwarmSpec(raw_goal="Add tests")
+
+    result = maybe_upgrade_dispatch_spec_from_corpus(issue=issue, spec=spec, repo_root=tmp_path)
+
+    assert result is spec
+    assert not spec.is_dispatch_bounded()
+    assert spec.file_scope_hints == []
+    assert spec.acceptance_criteria == []
+    assert spec.constraints == []
+
+
+def test_corpus_aware_dispatch_on_corpus_member_whitelisted_augments_spec(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("ARAGORA_CORPUS_AWARE_DISPATCH", "1")
+    _write_corpus(tmp_path, [_corpus_issue(5185)])
+    issue = SimpleNamespace(
+        number=5185, title="[B0-cohort] Add unit tests for utils/sql_helpers.py"
+    )
+    spec = SwarmSpec(raw_goal="Add tests")
+
+    result = maybe_upgrade_dispatch_spec_from_corpus(issue=issue, spec=spec, repo_root=tmp_path)
+
+    assert result is spec
+    assert spec.is_dispatch_bounded()
+    assert "aragora/utils/sql_helpers.py" in spec.file_scope_hints
+    assert "tests/utils/test_sql_helpers.py" in spec.file_scope_hints
+    assert any("happy path" in c and "edge case" in c for c in spec.acceptance_criteria), (
+        spec.acceptance_criteria
+    )
+    assert any("pytest" in c for c in spec.acceptance_criteria), spec.acceptance_criteria
+    assert any("production code" in c for c in spec.acceptance_criteria), spec.acceptance_criteria
+    assert "add unit tests covering happy and edge cases for the named module" in spec.constraints
+
+
+def test_corpus_aware_dispatch_on_non_corpus_issue_returns_unchanged(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("ARAGORA_CORPUS_AWARE_DISPATCH", "1")
+    _write_corpus(tmp_path, [_corpus_issue(5185)])
+    # Issue #9999 is not in the corpus.
+    issue = SimpleNamespace(number=9999, title="Some random feature request")
+    spec = SwarmSpec(raw_goal="Add tests")
+
+    result = maybe_upgrade_dispatch_spec_from_corpus(issue=issue, spec=spec, repo_root=tmp_path)
+
+    assert result is spec
+    assert not spec.is_dispatch_bounded()
+    assert spec.file_scope_hints == []
+    assert spec.acceptance_criteria == []
+    assert spec.constraints == []
+
+
+def test_corpus_aware_dispatch_on_non_whitelisted_execution_class_returns_unchanged(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("ARAGORA_CORPUS_AWARE_DISPATCH", "1")
+    # ``schema_migration`` is intentionally outside the PR-1 whitelist.
+    _write_corpus(
+        tmp_path,
+        [_corpus_issue(7777, execution_class="schema_migration")],
+    )
+    issue = SimpleNamespace(number=7777, title="Run a database migration")
+    spec = SwarmSpec(raw_goal="Migrate")
+
+    result = maybe_upgrade_dispatch_spec_from_corpus(issue=issue, spec=spec, repo_root=tmp_path)
+
+    assert result is spec
+    assert not spec.is_dispatch_bounded()
+    assert spec.file_scope_hints == []
+    assert spec.acceptance_criteria == []
+    assert spec.constraints == []
+
+
+def test_corpus_aware_dispatch_already_bounded_spec_is_untouched(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("ARAGORA_CORPUS_AWARE_DISPATCH", "1")
+    _write_corpus(tmp_path, [_corpus_issue(5185)])
+    issue = SimpleNamespace(
+        number=5185, title="[B0-cohort] Add unit tests for utils/sql_helpers.py"
+    )
+    spec = SwarmSpec(
+        raw_goal="Add tests",
+        acceptance_criteria=["existing criterion"],
+        file_scope_hints=["existing/path.py"],
+    )
+
+    result = maybe_upgrade_dispatch_spec_from_corpus(issue=issue, spec=spec, repo_root=tmp_path)
+
+    assert result is spec
+    # Already-bounded spec must not be merged with corpus row -- we short-circuit
+    # so as not to widen scope behind the operator's back.
+    assert spec.acceptance_criteria == ["existing criterion"]
+    assert spec.file_scope_hints == ["existing/path.py"]
+    assert spec.constraints == []
+
+
+def test_corpus_aware_dispatch_handles_each_whitelisted_execution_class(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("ARAGORA_CORPUS_AWARE_DISPATCH", "1")
+    for execution_class in (
+        "missing_test_coverage",
+        "small_refactor",
+        "validation_tightening",
+        "exception_narrowing",
+    ):
+        sub_root = tmp_path / execution_class
+        _write_corpus(
+            sub_root,
+            [_corpus_issue(5185, execution_class=execution_class)],
+        )
+        issue = SimpleNamespace(number=5185, title=f"corpus issue for {execution_class}")
+        spec = SwarmSpec(raw_goal="goal")
+        result = maybe_upgrade_dispatch_spec_from_corpus(issue=issue, spec=spec, repo_root=sub_root)
+        assert result.is_dispatch_bounded(), execution_class
+        assert spec.acceptance_criteria, execution_class
+
+
+def test_corpus_aware_dispatch_missing_corpus_file_is_safe(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("ARAGORA_CORPUS_AWARE_DISPATCH", "1")
+    # ``tmp_path`` has no docs/benchmarks/corpus.json -- read should fall back silently.
+    issue = SimpleNamespace(
+        number=5185, title="[B0-cohort] Add unit tests for utils/sql_helpers.py"
+    )
+    spec = SwarmSpec(raw_goal="Add tests")
+
+    result = maybe_upgrade_dispatch_spec_from_corpus(issue=issue, spec=spec, repo_root=tmp_path)
+
+    assert result is spec
+    assert not spec.is_dispatch_bounded()
+
+
+def test_maybe_upgrade_dispatch_spec_chains_into_corpus_path(monkeypatch, tmp_path: Path) -> None:
+    """End-to-end: ``maybe_upgrade_dispatch_spec`` consults the corpus first."""
+    monkeypatch.setenv("ARAGORA_CORPUS_AWARE_DISPATCH", "1")
+    _write_corpus(tmp_path, [_corpus_issue(5185)])
+    issue = SimpleNamespace(
+        number=5185,
+        title="[B0-cohort] Add unit tests for utils/sql_helpers.py",
+    )
+    spec = SwarmSpec(raw_goal="Add tests")
+
+    # When corpus path bounds the spec, the heuristic upgrader must NOT be called.
+    with patch("aragora.swarm.dispatch_followups.upgrade_issue_heuristic") as heuristic_mock:
+        result = maybe_upgrade_dispatch_spec(
+            issue=issue,
+            spec=spec,
+            sanitized_issue_body="body",
+            repo_root=tmp_path,
+        )
+
+    assert result is spec
+    assert spec.is_dispatch_bounded()
+    heuristic_mock.assert_not_called()


### PR DESCRIPTION
## Summary

PR-1 of the A2 admission-class productization plan (#7221, refs #7209). Adds a flag-gated, default-OFF helper that augments under-specified dispatch specs from `docs/benchmarks/corpus.json` when the issue is a whitelisted rev-4 corpus member.

## What changed

`aragora/swarm/dispatch_followups.py`
- Adds module-level constants: `ARAGORA_CORPUS_AWARE_DISPATCH` env name, truthy set, 4-class whitelist (`missing_test_coverage`, `small_refactor`, `validation_tightening`, `exception_narrowing`), corpus-path relpath, and per-execution-class acceptance templates.
- Adds private helpers: `_corpus_aware_dispatch_enabled`, `_corpus_path_for`, `_load_corpus_entry_for_issue`, `_augment_spec_from_corpus`.
- Adds public helper: `maybe_upgrade_dispatch_spec_from_corpus(issue=..., spec=..., repo_root=...) -> SwarmSpec`. Identity-preserving (always returns the same spec object). Strict no-op when flag is OFF, when spec is already bounded, when issue is not in corpus, or when execution_class is not whitelisted.
- Chains the new helper inside `maybe_upgrade_dispatch_spec` before the existing title-category heuristic so corpus-bounded specs do not invoke `upgrade_issue_heuristic`. When the flag is OFF, the chain is a no-op and the existing path runs unchanged.
- Exports `maybe_upgrade_dispatch_spec_from_corpus` in `__all__`.

`tests/swarm/test_dispatch_followups.py`
- 8 new tests covering: flag-off no-op, flag-on corpus augment, non-corpus no-op, non-whitelisted execution-class no-op, already-bounded short-circuit, all 4 whitelisted execution classes, missing corpus file safety, and chain integration into `maybe_upgrade_dispatch_spec`.

## Acceptance criteria (from #7221)

| Criterion | Status |
|---|---|
| When the flag is OFF, current behaviour is unchanged | yes — tests `test_corpus_aware_dispatch_off_by_default_returns_spec_unchanged` + `test_maybe_upgrade_dispatch_spec_uses_issue_category_for_unbounded_spec` (existing) cover this end to end |
| When flag is ON and issue is whitelisted rev-4 corpus member, sparse bodies may be upgraded using `scope_hint` + `known_constraints` + `execution_class` | yes — `test_corpus_aware_dispatch_on_corpus_member_whitelisted_augments_spec` |
| Non-corpus issues unchanged | yes — `test_corpus_aware_dispatch_on_non_corpus_issue_returns_unchanged` |
| Non-whitelisted execution classes unchanged | yes — `test_corpus_aware_dispatch_on_non_whitelisted_execution_class_returns_unchanged` |
| Focused tests added | yes (8 tests) |
| ruff clean | yes — `ruff check` + `ruff format --check` pass |
| Preflight ok | yes — `bash scripts/automation_pr_preflight.sh origin/main HEAD` reports `preflight: ok` |

## Out of scope (per #7221 PR-1 scope answers)

- No credential-envelope preflight changes (PR-2 territory).
- No `TerminalClass` enum changes.
- No fixtures under `benchmarks/fixtures/` (PR-3 territory; PR-1 fully proves its behaviour with stdlib `tmp_path` corpus fixtures).
- No `docs/benchmarks/rescue_productization.json` change (PR-3).
- No flag promotion to default-ON.
- Does not touch #7173, #7215, #7220, #7222.

## Test run

```
pytest tests/swarm/test_dispatch_followups.py -q
26 passed in 1.33s
```

```
pytest tests/swarm/test_dispatch_followups.py tests/swarm/test_boss_worker_lifecycle.py -q
119 passed in 7.90s
```

```
ruff check aragora/swarm/dispatch_followups.py tests/swarm/test_dispatch_followups.py
All checks passed!
```

```
bash scripts/automation_pr_preflight.sh origin/main HEAD
preflight: ok
```

## Diff summary

```
aragora/swarm/dispatch_followups.py    | 206 ++++++++++++++++++++++++++++++++
tests/swarm/test_dispatch_followups.py | 211 +++++++++++++++++++++++++++++++++
2 files changed, 417 insertions(+)
```

Within the 300 LOC source / 200 LOC tests budget set in #7221.

## Authorization + plan alignment

- Founder sentence 2026-05-16: "Proceed with #7209 PR-1 only: corpus-aware dispatch upgrade."
- Plan: #7221 (`docs/plans/2026-05-16-a2-admission-class-productization.md`)
- Tracking issue: #7209

## Rollback

`git revert <merge-commit>` or `unset ARAGORA_CORPUS_AWARE_DISPATCH` — flag-OFF gives default behaviour identical to today.

Refs: #7209
Plan: #7221