### PR TITLE
fix(swarm): repair corpus-aware dispatch gating

### DIFF
--- a/aragora/swarm/boss_worker_lifecycle.py
+++ b/aragora/swarm/boss_worker_lifecycle.py
@@ -759,6 +759,16 @@ async def dispatch_issue(
     elif validation_contract:
         spec.acceptance_criteria = list(validation_contract)
 
+    # PR-1 of #7209 must run before the validation-contract early exit:
+    # rev-4 corpus members can be sparse precisely because the corpus row
+    # carries the missing bounded scope, constraints, and acceptance shape.
+    spec = dispatch_followups_mod.maybe_upgrade_dispatch_spec(
+        issue=issue,
+        spec=spec,
+        sanitized_issue_body=sanitized_issue_body,
+        repo_root=Path.cwd(),
+    )
+
     if loop.config.require_validation_contract and not bool(
         getattr(spec, "acceptance_criteria", None)
     ):

--- a/aragora/swarm/dispatch_followups.py
+++ b/aragora/swarm/dispatch_followups.py
@@ -37,11 +37,11 @@ _ACCEPTANCE_SECTION_HEADINGS = {"acceptance", "acceptance criteria"}
 #
 # When ``ARAGORA_CORPUS_AWARE_DISPATCH`` is truthy and the issue under
 # dispatch is a member of ``docs/benchmarks/corpus.json::issues`` whose
-# ``execution_class`` is in the PR-1 whitelist, augment under-specified
-# specs with the corpus row's ``scope_hint`` + ``known_constraints`` and
-# an ``execution_class``-specific acceptance-criteria template so the
-# dispatch contract gate no longer rejects the spec as
-# ``blocked_not_dispatch_bounded``.
+# ``execution_class`` and terminal history are in the PR-1 whitelists,
+# augment under-specified specs with the corpus row's ``scope_hint`` +
+# ``known_constraints`` and an ``execution_class``-specific
+# acceptance-criteria template so the dispatch contract gate no longer
+# rejects the spec as ``blocked_not_dispatch_bounded``.
 #
 # Default behaviour is unchanged.  See docs/plans/
 # 2026-05-16-a2-admission-class-productization.md for the full plan.
@@ -55,6 +55,12 @@ _CORPUS_AWARE_DISPATCH_WHITELIST = frozenset(
         "small_refactor",
         "validation_tightening",
         "exception_narrowing",
+    }
+)
+_CORPUS_AWARE_DISPATCH_TERMINAL_WHITELIST = frozenset(
+    {
+        "blocked_not_dispatch_bounded",
+        "blocked_auth_failure",
     }
 )
 _CORPUS_AWARE_DISPATCH_CORPUS_RELPATH = Path("docs/benchmarks/corpus.json")
@@ -171,6 +177,17 @@ def _augment_spec_from_corpus(spec: SwarmSpec, corpus_entry: dict[str, Any]) -> 
         spec.acceptance_criteria = _ordered_unique([*spec.acceptance_criteria, *rendered])
 
 
+def _corpus_terminal_classes(corpus_entry: dict[str, Any]) -> set[str]:
+    """Return normalized terminal classes recorded for a corpus row."""
+    provenance = corpus_entry.get("dispatch_provenance")
+    if not isinstance(provenance, dict):
+        return set()
+    classes = provenance.get("terminal_classes")
+    if not isinstance(classes, list):
+        return set()
+    return {str(item).strip() for item in classes if str(item or "").strip()}
+
+
 def maybe_upgrade_dispatch_spec_from_corpus(
     *,
     issue: Any,
@@ -187,6 +204,8 @@ def maybe_upgrade_dispatch_spec_from_corpus(
     * The corpus row's ``execution_class`` is not in the PR-1 whitelist
       (``missing_test_coverage``, ``small_refactor``, ``validation_tightening``,
       ``exception_narrowing``).
+    * The corpus row's terminal history does not include a PR-1 admission class
+      (``blocked_not_dispatch_bounded`` or ``blocked_auth_failure``).
 
     Otherwise mutates ``spec`` in place with the corpus row's
     ``scope_hint`` (→ ``file_scope_hints``), ``known_constraints``
@@ -214,12 +233,16 @@ def maybe_upgrade_dispatch_spec_from_corpus(
     execution_class = str(corpus_entry.get("execution_class", "") or "").strip()
     if execution_class not in _CORPUS_AWARE_DISPATCH_WHITELIST:
         return spec
+    terminal_classes = _corpus_terminal_classes(corpus_entry)
+    if not (terminal_classes & _CORPUS_AWARE_DISPATCH_TERMINAL_WHITELIST):
+        return spec
 
     _augment_spec_from_corpus(spec, corpus_entry)
     logger.info(
-        "corpus_aware_dispatch_augmented issue=#%s execution_class=%s scope_hint_count=%s",
+        "corpus_aware_dispatch_augmented issue=#%s execution_class=%s terminal_classes=%s scope_hint_count=%s",
         issue_number_int,
         execution_class,
+        ",".join(sorted(terminal_classes)),
         len(corpus_entry.get("scope_hint") or []),
     )
     return spec

--- a/tests/swarm/test_boss_worker_lifecycle.py
+++ b/tests/swarm/test_boss_worker_lifecycle.py
@@ -1029,6 +1029,36 @@ class TestDispatchIssuePreDispatchGate:
         m.extract_issue_validation_contract = real_mod.extract_issue_validation_contract
         return m
 
+    def test_corpus_upgrade_runs_before_required_validation_contract_block(self):
+        loop = self._make_gate_dispatch_loop(require_validation_contract=True)
+        issue = _make_issue(
+            number=5185,
+            title="[B0-cohort] Add unit tests for utils/sql_helpers.py",
+            body="Task: add tests for aragora/utils/sql_helpers.py",
+        )
+        module_mock = self._build_module_mock()
+
+        def _upgrade_from_corpus(**kwargs):
+            spec = kwargs["spec"]
+            spec.acceptance_criteria = ["pytest -q tests/utils/test_sql_helpers.py"]
+            spec.file_scope_hints = [
+                "aragora/utils/sql_helpers.py",
+                "tests/utils/test_sql_helpers.py",
+            ]
+            return spec
+
+        with patch(
+            "aragora.swarm.boss_worker_lifecycle._boss_loop_module", return_value=module_mock
+        ):
+            with patch(
+                "aragora.swarm.dispatch_followups.maybe_upgrade_dispatch_spec",
+                side_effect=_upgrade_from_corpus,
+            ) as upgrade_mock:
+                result = asyncio.run(dispatch_issue(loop, issue, _fresh_result()))
+
+        assert result["status"] == "completed"
+        upgrade_mock.assert_called()
+
     def test_gate_sanitation_fail_returns_needs_human(self):
         loop = self._make_gate_dispatch_loop()
         issue = _make_issue()

--- a/tests/swarm/test_dispatch_followups.py
+++ b/tests/swarm/test_dispatch_followups.py
@@ -474,6 +474,7 @@ def _corpus_issue(
     execution_class: str = "missing_test_coverage",
     scope_hint: list[str] | None = None,
     known_constraints: list[str] | None = None,
+    terminal_classes: list[str] | None = None,
 ) -> dict:
     return {
         "issue_id": issue_id,
@@ -494,6 +495,13 @@ def _corpus_issue(
                 "do not modify production code under aragora/ unless strictly required by the test scaffold",
             ]
         ),
+        "dispatch_provenance": {
+            "terminal_classes": list(
+                terminal_classes
+                if terminal_classes is not None
+                else ["blocked_not_dispatch_bounded"]
+            )
+        },
     }
 
 
@@ -569,6 +577,30 @@ def test_corpus_aware_dispatch_on_non_whitelisted_execution_class_returns_unchan
     )
     issue = SimpleNamespace(number=7777, title="Run a database migration")
     spec = SwarmSpec(raw_goal="Migrate")
+
+    result = maybe_upgrade_dispatch_spec_from_corpus(issue=issue, spec=spec, repo_root=tmp_path)
+
+    assert result is spec
+    assert not spec.is_dispatch_bounded()
+    assert spec.file_scope_hints == []
+    assert spec.acceptance_criteria == []
+    assert spec.constraints == []
+
+
+def test_corpus_aware_dispatch_on_non_admission_terminal_class_returns_unchanged(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("ARAGORA_CORPUS_AWARE_DISPATCH", "1")
+    _write_corpus(
+        tmp_path,
+        [
+            _corpus_issue(
+                5426, execution_class="small_refactor", terminal_classes=["deliverable_pr_created"]
+            )
+        ],
+    )
+    issue = SimpleNamespace(number=5426, title="Add operator-snapshot subcommand")
+    spec = SwarmSpec(raw_goal="Add a command")
 
     result = maybe_upgrade_dispatch_spec_from_corpus(issue=issue, spec=spec, repo_root=tmp_path)
 


### PR DESCRIPTION
## Summary

Follow-up repair for #7225 after a delayed Droid/GPT-5 review found two real gaps in the merged corpus-aware dispatch upgrade:

- corpus augmentation ran after the `require_validation_contract` early exit, so sparse corpus issues could still stop before the upgrade path
- corpus augmentation was gated by `execution_class` only, not by `dispatch_provenance.terminal_classes`, so flag-on behavior could apply to corpus rows outside the intended admission-failure slice

This keeps `ARAGORA_CORPUS_AWARE_DISPATCH` default-off and narrows the flag-on path to rows with both a whitelisted execution class and terminal history containing `blocked_not_dispatch_bounded` or `blocked_auth_failure`.

## Validation

- `python3 -m pytest tests/swarm/test_dispatch_followups.py tests/swarm/test_boss_worker_lifecycle.py -q -p no:rerunfailures -p no:cacheprovider` -> 121 passed
- `python3 -m ruff check aragora/swarm/dispatch_followups.py aragora/swarm/boss_worker_lifecycle.py tests/swarm/test_dispatch_followups.py tests/swarm/test_boss_worker_lifecycle.py` -> passed
- `python3 -m ruff format --check aragora/swarm/dispatch_followups.py aragora/swarm/boss_worker_lifecycle.py tests/swarm/test_dispatch_followups.py tests/swarm/test_boss_worker_lifecycle.py` -> passed
- `python3 -m mypy aragora/swarm/dispatch_followups.py aragora/swarm/boss_worker_lifecycle.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok

Note: mypy over the full changed test file set still hits existing `method-assign` errors in `tests/swarm/test_boss_worker_lifecycle.py`, so the source-file mypy check is the meaningful static proof here.
