### PR TITLE
feat(benchmarks): add Factory review benchmark smoke planner

### DIFF
--- a/docs/benchmarks/factory_review_benchmark_manifest.json
+++ b/docs/benchmarks/factory_review_benchmark_manifest.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "benchmark": "factory_review_droid_external_smoke",
+  "source": {
+    "article_url": "https://factory.ai/news/code-review-benchmark",
+    "benchmark_repo": "droid-code-review-evals/review-droid-benchmark",
+    "benchmark_repo_url": "https://github.com/droid-code-review-evals/review-droid-benchmark",
+    "benchmark_head_sha": "2dfbbd6edcd5eea19495e725d611cb104c9e8f4d",
+    "manifest_blob_sha": "a810d4319a798c7980deccedef1f5df8cc86568f",
+    "reported_total_prs": 50,
+    "reported_validated_golden_comments_v3": 167
+  },
+  "smoke_cases": [
+    {
+      "case_id": "droid-sentry-pr-6",
+      "repo": "droid-code-review-evals/droid-sentry",
+      "repo_url": "https://github.com/droid-code-review-evals/droid-sentry",
+      "repo_head_sha": "f0c5f5d3aff1f01804f7ebf4cd5b5952242fb62e",
+      "pr_number": 6,
+      "pr_url": "https://github.com/droid-code-review-evals/droid-sentry/pull/6",
+      "title": "Enhanced Pagination Performance for High-Volume Audit Logs",
+      "base_ref": "master",
+      "head_ref": "performance-enhancement-complete",
+      "head_sha": "cb7212e11dbdbc1813237ad129c7bc108f944e3d",
+      "validation_path": "results/review_droid_run_gpt_5p2_2026-01-28/validations/droid-sentry_pr_6_validation.json",
+      "validation_blob_sha": "29067be0cc2bc91fa32c6669436d83cd851ebbb4",
+      "validation_url": "https://raw.githubusercontent.com/droid-code-review-evals/review-droid-benchmark/main/results/review_droid_run_gpt_5p2_2026-01-28/validations/droid-sentry_pr_6_validation.json",
+      "reason": "Python runtime bug plus a known false positive in validation output"
+    },
+    {
+      "case_id": "droid-grafana-pr-1",
+      "repo": "droid-code-review-evals/droid-grafana",
+      "repo_url": "https://github.com/droid-code-review-evals/droid-grafana",
+      "repo_head_sha": "85abfff0376487a1d3b1d084da48e1aebe0a44de",
+      "pr_number": 1,
+      "pr_url": "https://github.com/droid-code-review-evals/droid-grafana/pull/1",
+      "title": "Anonymous: Add configurable device limit",
+      "base_ref": "enhance-anonymous-access",
+      "head_ref": "implement-device-limits",
+      "head_sha": "3647ba7360b8d157e4a294a650a365b6aca070d8",
+      "validation_path": "results/review_droid_run_gpt_5p2_2026-01-28/validations/droid-grafana_pr_1_validation.json",
+      "validation_blob_sha": "f1a2057d21993c39dd761ad4083c9133f4f9bf45",
+      "validation_url": "https://raw.githubusercontent.com/droid-code-review-evals/review-droid-benchmark/main/results/review_droid_run_gpt_5p2_2026-01-28/validations/droid-grafana_pr_1_validation.json",
+      "reason": "Go race-condition finding"
+    },
+    {
+      "case_id": "droid-keycloak-pr-7",
+      "repo": "droid-code-review-evals/droid-keycloak",
+      "repo_url": "https://github.com/droid-code-review-evals/droid-keycloak",
+      "repo_head_sha": "dcdbe3ecc48d6f26ef52f6b78b7a5dd5ad897eb5",
+      "pr_number": 7,
+      "pr_url": "https://github.com/droid-code-review-evals/droid-keycloak/pull/7",
+      "title": "Add HTML sanitizer for translated message resources",
+      "base_ref": "feature-html-sanitizer-baseline",
+      "head_ref": "feature-html-sanitizer-implementation",
+      "head_sha": "5d77e7ea7d431aa0a6b65904457b7471bd050e81",
+      "validation_path": "results/review_droid_run_gpt_5p2_2026-01-28/validations/droid-keycloak_pr_7_validation.json",
+      "validation_blob_sha": "95f5e20c1d6b510c96a425b63ba3ded4bd2d9442",
+      "validation_url": "https://raw.githubusercontent.com/droid-code-review-evals/review-droid-benchmark/main/results/review_droid_run_gpt_5p2_2026-01-28/validations/droid-keycloak_pr_7_validation.json",
+      "reason": "Java/properties logic and runtime findings"
+    }
+  ],
+  "guardrails": {
+    "default_executes_model_calls": false,
+    "must_use_no_publish_review": true,
+    "routing_defaults_changed": false,
+    "full_50_pr_run_authorized": false
+  }
+}

--- a/scripts/run_factory_review_benchmark_smoke.py
+++ b/scripts/run_factory_review_benchmark_smoke.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Build or execute the Factory code-review benchmark smoke run plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "docs" / "benchmarks" / "factory_review_benchmark_manifest.json"
+DEFAULT_OUTPUT = (
+    REPO_ROOT
+    / "docs"
+    / "status"
+    / "generated"
+    / "factory_review_benchmark"
+    / "smoke"
+    / "planned-run.json"
+)
+DEFAULT_ARTIFACT_ROOT = REPO_ROOT / ".aragora" / "factory-review-benchmark" / "smoke"
+REQUIRED_CASE_FIELDS = {
+    "case_id",
+    "repo",
+    "pr_number",
+    "pr_url",
+    "title",
+    "base_ref",
+    "head_ref",
+    "head_sha",
+    "validation_path",
+    "validation_url",
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"manifest not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"manifest is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError("manifest root must be a JSON object")
+    return raw
+
+
+def _validate_case(row: object, index: int) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        raise ValueError(f"smoke_cases[{index}] must be a JSON object")
+    missing = sorted(field for field in REQUIRED_CASE_FIELDS if field not in row)
+    if missing:
+        raise ValueError(f"smoke_cases[{index}] missing required fields: {', '.join(missing)}")
+    for field in REQUIRED_CASE_FIELDS:
+        if field == "pr_number":
+            if not isinstance(row[field], int) or isinstance(row[field], bool) or row[field] <= 0:
+                raise ValueError(f"smoke_cases[{index}].pr_number must be a positive integer")
+            continue
+        if not isinstance(row[field], str) or not row[field].strip():
+            raise ValueError(f"smoke_cases[{index}].{field} must be a non-empty string")
+    return dict(row)
+
+
+def _validate_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    cases = manifest.get("smoke_cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("manifest must include a non-empty smoke_cases list")
+    return [_validate_case(row, index) for index, row in enumerate(cases)]
+
+
+def _artifact_dir(artifact_root: Path, case: dict[str, Any]) -> Path:
+    repo_name = str(case["repo"]).split("/")[-1]
+    return artifact_root / repo_name / f"pr-{case['pr_number']}"
+
+
+def build_run_plan(
+    manifest: dict[str, Any],
+    *,
+    artifact_root: Path = DEFAULT_ARTIFACT_ROOT,
+    reviewer: str | None = None,
+) -> dict[str, Any]:
+    cases = _validate_manifest(manifest)
+    reviewer_args = ["--reviewer", reviewer] if reviewer else []
+    run_cases: list[dict[str, Any]] = []
+
+    for case in cases:
+        artifact_dir = _artifact_dir(artifact_root, case)
+        command = [
+            sys.executable,
+            "-m",
+            "aragora.cli.main",
+            "review-pr",
+            str(case["pr_url"]),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--no-publish-review",
+            "--json",
+            *reviewer_args,
+        ]
+        run_cases.append(
+            {
+                "case_id": case["case_id"],
+                "repo": case["repo"],
+                "pr_number": case["pr_number"],
+                "pr_url": case["pr_url"],
+                "title": case["title"],
+                "base_ref": case["base_ref"],
+                "head_ref": case["head_ref"],
+                "head_sha": case["head_sha"],
+                "expected_head_sha": case["head_sha"],
+                "validation_path": case["validation_path"],
+                "validation_url": case["validation_url"],
+                "artifact_dir": str(artifact_dir),
+                "command": command,
+                "execute_default": False,
+                "pre_execute_head_check": {
+                    "type": "github_pr_head_sha",
+                    "expected_head_sha": case["head_sha"],
+                },
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "generated_at": _utc_now(),
+        "benchmark": manifest.get("benchmark", "factory_review_droid_external_smoke"),
+        "source": manifest.get("source", {}),
+        "guardrails": {
+            "mode": "dry_run",
+            "no_publish_review": True,
+            "external_pr_comments": False,
+            "live_routing_change": False,
+        },
+        "cases": run_cases,
+    }
+
+
+def _current_pr_head_sha(pr_url: str) -> str:
+    result = subprocess.run(
+        ["gh", "pr", "view", pr_url, "--json", "headRefOid", "--jq", ".headRefOid"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ValueError(f"unable to verify current head for {pr_url}: {result.stderr.strip()}")
+    head_sha = result.stdout.strip()
+    if not head_sha:
+        raise ValueError(f"unable to verify current head for {pr_url}: empty headRefOid")
+    return head_sha
+
+
+def _verify_case_head(case: dict[str, Any]) -> None:
+    expected = str(case.get("expected_head_sha") or case.get("head_sha") or "")
+    if not expected:
+        raise ValueError(f"{case.get('case_id', '<unknown>')} has no expected head SHA")
+    actual = _current_pr_head_sha(str(case["pr_url"]))
+    if actual != expected:
+        raise ValueError(
+            f"{case['case_id']} head SHA drifted: expected {expected}, current {actual}"
+        )
+
+
+def execute_run_plan(plan: dict[str, Any]) -> dict[str, Any]:
+    executed: list[dict[str, Any]] = []
+    for case in plan["cases"]:
+        _verify_case_head(case)
+        command = list(case["command"])
+        started = _utc_now()
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+        executed.append(
+            {
+                "case_id": case["case_id"],
+                "started_at": started,
+                "finished_at": _utc_now(),
+                "returncode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        )
+    updated = dict(plan)
+    updated["guardrails"] = {**dict(plan.get("guardrails", {})), "mode": "executed"}
+    updated["executions"] = executed
+    return updated
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a dry-run execution plan for Aragora review-pr against the Factory "
+            "code-review benchmark smoke slice."
+        )
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--artifact-root", type=Path, default=DEFAULT_ARTIFACT_ROOT)
+    parser.add_argument("--reviewer", default=None)
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Run the generated review-pr commands. Default only writes the plan.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        manifest = _load_manifest(args.manifest)
+        plan = build_run_plan(manifest, artifact_root=args.artifact_root, reviewer=args.reviewer)
+        if args.execute:
+            plan = execute_run_plan(plan)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(json.dumps({"output": str(args.output), "cases": len(plan["cases"])}, sort_keys=True))
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_run_factory_review_benchmark_smoke.py
+++ b/tests/scripts/test_run_factory_review_benchmark_smoke.py
@@ -1,0 +1,126 @@
+"""Tests for the Factory review benchmark smoke planner."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import run_factory_review_benchmark_smoke as smoke  # noqa: E402
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "benchmark": "factory_review_droid_external_smoke",
+        "source": {"benchmark_repo": "droid-code-review-evals/review-droid-benchmark"},
+        "smoke_cases": [
+            {
+                "case_id": "droid-sentry-pr-6",
+                "repo": "droid-code-review-evals/droid-sentry",
+                "pr_number": 6,
+                "pr_url": "https://github.com/droid-code-review-evals/droid-sentry/pull/6",
+                "title": "Enhanced Pagination Performance for High-Volume Audit Logs",
+                "base_ref": "master",
+                "head_ref": "performance-enhancement-complete",
+                "head_sha": "cb7212e11dbdbc1813237ad129c7bc108f944e3d",
+                "validation_path": "validations/droid-sentry_pr_6_validation.json",
+                "validation_url": "https://example.test/droid-sentry_pr_6_validation.json",
+            }
+        ],
+    }
+
+
+def test_build_run_plan_defaults_to_no_publish_dry_run(tmp_path: Path) -> None:
+    plan = smoke.build_run_plan(_manifest(), artifact_root=tmp_path / "artifacts")
+
+    assert plan["guardrails"]["mode"] == "dry_run"
+    assert plan["guardrails"]["no_publish_review"] is True
+    assert plan["guardrails"]["external_pr_comments"] is False
+    assert plan["guardrails"]["live_routing_change"] is False
+    assert len(plan["cases"]) == 1
+
+    case = plan["cases"][0]
+    assert case["execute_default"] is False
+    assert case["head_sha"] == "cb7212e11dbdbc1813237ad129c7bc108f944e3d"
+    assert case["expected_head_sha"] == "cb7212e11dbdbc1813237ad129c7bc108f944e3d"
+    assert case["pre_execute_head_check"] == {
+        "type": "github_pr_head_sha",
+        "expected_head_sha": "cb7212e11dbdbc1813237ad129c7bc108f944e3d",
+    }
+    assert "--no-publish-review" in case["command"]
+    assert "--json" in case["command"]
+    assert str(tmp_path / "artifacts" / "droid-sentry" / "pr-6") in case["command"]
+
+
+def test_build_run_plan_can_pin_reviewer(tmp_path: Path) -> None:
+    plan = smoke.build_run_plan(
+        _manifest(),
+        artifact_root=tmp_path / "artifacts",
+        reviewer="codex",
+    )
+
+    command = plan["cases"][0]["command"]
+    assert command[-2:] == ["--reviewer", "codex"]
+
+
+def test_manifest_rejects_missing_validation_url() -> None:
+    manifest = _manifest()
+    case = dict(manifest["smoke_cases"][0])
+    case.pop("validation_url")
+    manifest["smoke_cases"] = [case]
+
+    try:
+        smoke.build_run_plan(manifest)
+    except ValueError as exc:
+        assert "validation_url" in str(exc)
+    else:
+        raise AssertionError("missing validation_url should fail")
+
+
+def test_manifest_rejects_malformed_case() -> None:
+    manifest = _manifest()
+    manifest["smoke_cases"] = ["not-a-case"]
+
+    try:
+        smoke.build_run_plan(manifest)
+    except ValueError as exc:
+        assert "must be a JSON object" in str(exc)
+    else:
+        raise AssertionError("malformed case should fail")
+
+
+def test_verify_case_head_rejects_head_drift(monkeypatch: object) -> None:
+    manifest = _manifest()
+    plan = smoke.build_run_plan(manifest)
+    case = plan["cases"][0]
+
+    def fake_current_head_sha(pr_url: str) -> str:
+        assert pr_url == "https://github.com/droid-code-review-evals/droid-sentry/pull/6"
+        return "different-sha"
+
+    monkeypatch.setattr(smoke, "_current_pr_head_sha", fake_current_head_sha)
+
+    try:
+        smoke._verify_case_head(case)
+    except ValueError as exc:
+        assert "head SHA drifted" in str(exc)
+    else:
+        raise AssertionError("head SHA drift should fail closed")
+
+
+def test_main_writes_plan_without_execute(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    output_path = tmp_path / "plan.json"
+    manifest_path.write_text(json.dumps(_manifest()), encoding="utf-8")
+
+    assert smoke.main(["--manifest", str(manifest_path), "--output", str(output_path)]) == 0
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["guardrails"]["mode"] == "dry_run"
+    assert "executions" not in payload
+    assert payload["cases"][0]["command"][2:4] == ["aragora.cli.main", "review-pr"]


### PR DESCRIPTION
## Summary

Implements PR-1 from the Factory benchmark dogfood plan: a default-dry-run smoke planner for running Aragora `review-pr` against three externally anchored Factory benchmark PRs.

This does not execute model calls by default and always plans `--no-publish-review` commands so no external benchmark PR receives Aragora comments.

## What changed

- Adds `docs/benchmarks/factory_review_benchmark_manifest.json` with pinned Factory benchmark/corpus metadata and the 3-PR smoke slice.
- Adds `scripts/run_factory_review_benchmark_smoke.py`, which builds a JSON run plan and only executes with explicit `--execute`.
- Adds focused tests for dry-run/no-publish behavior, reviewer pinning, malformed cases, and missing validation URLs.

## Dogfood / validation

- `python3 -m aragora.cli.main review-pr --help`
- `python3 scripts/score_benchmark.py` -> terminal-truth benchmark PASS, 48/48 examples
- `python3 scripts/run_dogfood_benchmark.py --help`
- `python3 scripts/run_factory_review_benchmark_smoke.py --output /tmp/factory-review-smoke-plan.json` -> 3 cases
- `python3 -m json.tool docs/benchmarks/factory_review_benchmark_manifest.json`
- `python3 -m ruff check scripts/run_factory_review_benchmark_smoke.py tests/scripts/test_run_factory_review_benchmark_smoke.py`
- `python3 -m pytest tests/scripts/test_run_factory_review_benchmark_smoke.py -q` -> 5 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok

## Guardrails

- No live reviewer routing defaults changed.
- No full 50-PR run.
- No external PR comments.
- No AGT/DIC/Flywheel substrate.

Closes #7230.
