### PR TITLE
fix(automation): classify GitHub CLI dial tcp connectivity failures

### DIFF
--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -8,7 +8,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 from dataclasses import asdict, dataclass
 from collections.abc import Mapping
 from pathlib import Path

--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -32,6 +32,7 @@ CONNECTIVITY_ERROR_TOKENS = (
     "could not resolve host: github.com",
     "failed to connect to github.com",
     "failed to connect to api.github.com",
+    "dial tcp",
     "network is unreachable",
     "connection timed out",
     "connection refused",

--- a/tests/scripts/test_github_cli_health.py
+++ b/tests/scripts/test_github_cli_health.py
@@ -108,6 +108,9 @@ def test_github_connectivity_error_detects_dns_lookup_failures() -> None:
     assert mod.is_github_connectivity_error(
         'Post "https://api.github.com/graphql": dial tcp: lookup github.com: no such host'
     )
+    assert mod.is_github_connectivity_error(
+        'Get "https://api.github.com/rate_limit": dial tcp 140.82.112.6:443: connect: network is unreachable'
+    )
 
 
 def test_github_connectivity_error_detects_bounded_probe_timeouts() -> None:


### PR DESCRIPTION
## Summary

Harvested Codex automation branch for GitHub CLI connectivity classification.

This adds direct `dial tcp` network-unreachable errors to the GitHub CLI connectivity classification path so automation shells do not misread sandbox/network failures as generic/unknown failures.

## Source handoff

- Branch: `codex/harvest-github-cli-dial-tcp-20260516`
- Head: `553147f682e43c0f29326edd9db0928c45cc7127`
- Source branch: `codex/swarm-5a555597-micro-3`
- Changed files: `scripts/github_cli_health.py`, `tests/scripts/test_github_cli_health.py`

## Validation from handoff

- `pytest tests/scripts/test_github_cli_health.py` -> `11 passed in 1.14s`
- `ruff check scripts/github_cli_health.py tests/scripts/test_github_cli_health.py` -> `All checks passed`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`

## Guardrails

Drafted as a harvested automation PR. No unrelated automation branches are included.