### PR TITLE
fix(review-pr): harden advisory no-fixer mode

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -30,6 +30,7 @@ _STATUS_REVIEW_EVENT_BY_STATUS = {
     "changes_requested": "REQUEST_CHANGES",
     "blocked_nonreviewable": "COMMENT",
 }
+_OPTIONAL_AGENT_PLACEHOLDERS = {"", "none", "null"}
 
 
 @dataclass(slots=True)
@@ -132,6 +133,13 @@ def add_review_pr_parser(subparsers) -> None:
     parser.set_defaults(func=cmd_review_pr)
 
 
+def _normalize_optional_agent(value: object) -> str | None:
+    normalized = str(value or "").strip()
+    if normalized.lower() in _OPTIONAL_AGENT_PLACEHOLDERS:
+        return None
+    return normalized
+
+
 def cmd_review_pr(args: argparse.Namespace) -> int:
     repo_root = resolve_repo_root(Path.cwd())
     result = asyncio.run(
@@ -140,7 +148,7 @@ def cmd_review_pr(args: argparse.Namespace) -> int:
             repo_root=repo_root,
             repo_override=getattr(args, "repo", None),
             reviewer=str(getattr(args, "reviewer", "claude") or "claude"),
-            fixer=str(getattr(args, "fixer", "")).strip() or None,
+            fixer=_normalize_optional_agent(getattr(args, "fixer", None)),
             auto_rerun=bool(getattr(args, "auto_rerun", False)),
             artifact_root=Path(getattr(args, "artifact_dir", "")).resolve()
             if getattr(args, "artifact_dir", None)
@@ -174,10 +182,15 @@ async def run_review_pr_loop(
     advisory_only: bool = True,
     publish_review: bool = True,
 ) -> dict[str, Any]:
+    fixer = _normalize_optional_agent(fixer)
     target = _fetch_pr_target(pr_ref, repo_override=repo_override, repo_root=repo_root)
     run_dir = _artifact_run_dir(repo_root, target.number, artifact_root=artifact_root)
     review_runs: list[dict[str, Any]] = []
     fix_run: dict[str, Any] | None = None
+    observed_head_sha_before = target.head_sha
+    observed_head_sha_after = target.head_sha
+    head_sha_stale = False
+    stale_reason: str | None = None
 
     diff_text = _fetch_pr_diff(target)
     _write_text(run_dir / "review-1.diff", diff_text)
@@ -192,7 +205,25 @@ async def run_review_pr_loop(
     _write_json(run_dir / "review-1.json", asdict(review))
 
     final_status = review.status
-    if fixer and review.status == "changes_requested":
+    refreshed_after_review = _fetch_pr_target(
+        str(target.number),
+        repo_override=target.repo,
+        repo_root=repo_root,
+    )
+    observed_head_sha_after = refreshed_after_review.head_sha
+    if (
+        observed_head_sha_before
+        and observed_head_sha_after
+        and observed_head_sha_before != observed_head_sha_after
+    ):
+        head_sha_stale = True
+        final_status = "blocked_nonreviewable"
+        stale_reason = (
+            f"PR head changed during review: {observed_head_sha_before} -> "
+            f"{observed_head_sha_after}"
+        )
+
+    if not head_sha_stale and fixer and review.status == "changes_requested":
         fix = await _run_fix_pass(
             target=target,
             review=review,
@@ -228,6 +259,7 @@ async def run_review_pr_loop(
         "pr": asdict(target),
         "reviewer": reviewer,
         "fixer": fixer,
+        "fixer_requested": fixer is not None,
         "auto_rerun": auto_rerun,
         "github_review_mode": "advisory" if advisory_only else "status",
         "artifact_dir": str(run_dir),
@@ -235,8 +267,20 @@ async def run_review_pr_loop(
         "fix_run": fix_run,
         "final_status": final_status,
         "publish_review": publish_review,
+        "observed_head_sha_before": observed_head_sha_before,
+        "observed_head_sha_after": observed_head_sha_after,
+        "head_sha_stale": head_sha_stale,
+        "stale_reason": stale_reason,
     }
-    if publish_review:
+    if head_sha_stale:
+        payload["github_review"] = {
+            "posted": False,
+            "event": None,
+            "mode": "advisory" if advisory_only else "status",
+            "url": None,
+            "error": stale_reason,
+        }
+    elif publish_review:
         payload["github_review"] = await _publish_review_outcome(
             target=target,
             review_runs=review_runs,

--- a/tests/cli/commands/test_review_pr.py
+++ b/tests/cli/commands/test_review_pr.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 from dataclasses import asdict
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -91,7 +92,7 @@ async def test_run_review_pr_loop_review_only_writes_artifact(
         )
 
     monkeypatch.setattr(review_pr, "_run_review_pass", _fake_review)
-    published: dict[str, object] = {}
+    published: dict[str, Any] = {}
 
     async def _fake_publish(**kwargs: object) -> dict[str, object]:
         published.update(kwargs)
@@ -333,7 +334,7 @@ async def test_run_review_pr_loop_auto_reruns_after_fix(
 
     monkeypatch.setattr(review_pr, "_run_review_pass", _fake_review)
     monkeypatch.setattr(review_pr, "_run_fix_pass", _fake_fix)
-    published: dict[str, object] = {}
+    published: dict[str, Any] = {}
 
     async def _fake_publish(**kwargs: object) -> dict[str, object]:
         published.update(kwargs)

--- a/tests/cli/commands/test_review_pr.py
+++ b/tests/cli/commands/test_review_pr.py
@@ -61,6 +61,14 @@ def test_review_pr_parser_accepts_no_publish_flag() -> None:
     assert args.publish_review is False
 
 
+def test_normalize_optional_agent_rejects_placeholder_none() -> None:
+    assert review_pr._normalize_optional_agent(None) is None
+    assert review_pr._normalize_optional_agent("") is None
+    assert review_pr._normalize_optional_agent("None") is None
+    assert review_pr._normalize_optional_agent("null") is None
+    assert review_pr._normalize_optional_agent(" codex ") == "codex"
+
+
 @pytest.mark.asyncio
 async def test_run_review_pr_loop_review_only_writes_artifact(
     tmp_path: Path,
@@ -172,12 +180,106 @@ async def test_run_review_pr_loop_skips_github_review_when_publish_disabled(
 
 
 @pytest.mark.asyncio
+async def test_review_pr_loop_changes_requested_without_fixer_does_not_run_fix_pass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    sample_target: review_pr.PullRequestTarget,
+) -> None:
+    monkeypatch.setattr(review_pr, "_fetch_pr_target", lambda *_, **__: sample_target)
+    monkeypatch.setattr(review_pr, "_fetch_pr_diff", lambda *_: "diff --git a/foo b/foo\n+bad\n")
+
+    async def _fake_review(**_: object) -> review_pr.ReviewPass:
+        return review_pr.ReviewPass(
+            reviewer="claude",
+            reviewed_at="2026-03-21T10:00:00+00:00",
+            status="changes_requested",
+            summary="Fix the crash",
+            findings=[{"title": "Crash", "body": "Fix it", "priority": "P1"}],
+            candidate={"label": "claude:max-01"},
+            attempts=[],
+            raw_response="{}",
+        )
+
+    async def _should_not_fix(**_: object) -> review_pr.FixPass:
+        raise AssertionError("_run_fix_pass should not be called without a real fixer")
+
+    monkeypatch.setattr(review_pr, "_run_review_pass", _fake_review)
+    monkeypatch.setattr(review_pr, "_run_fix_pass", _should_not_fix)
+
+    result = await review_pr.run_review_pr_loop(
+        pr_ref="1137",
+        repo_root=tmp_path,
+        reviewer="claude",
+        fixer="None",
+        artifact_root=tmp_path / "artifacts",
+        publish_review=False,
+    )
+
+    assert result["final_status"] == "changes_requested"
+    assert result["fixer"] is None
+    assert result["fixer_requested"] is False
+    assert result["fix_run"] is None
+    assert not (Path(result["artifact_dir"]) / "fix.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_review_pr_loop_detects_head_sha_drift_before_publish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    sample_target: review_pr.PullRequestTarget,
+) -> None:
+    refreshed_target = review_pr.PullRequestTarget(
+        **{
+            **asdict(sample_target),
+            "head_sha": "def456",
+        }
+    )
+    targets = [sample_target, refreshed_target]
+    monkeypatch.setattr(review_pr, "_fetch_pr_target", lambda *_, **__: targets.pop(0))
+    monkeypatch.setattr(review_pr, "_fetch_pr_diff", lambda *_: "diff --git a/foo b/foo\n+ok\n")
+
+    async def _fake_review(**_: object) -> review_pr.ReviewPass:
+        return review_pr.ReviewPass(
+            reviewer="claude",
+            reviewed_at="2026-03-21T10:00:00+00:00",
+            status="passed",
+            summary="Looks good",
+            findings=[],
+            candidate={"label": "claude:max-01"},
+            attempts=[],
+            raw_response="{}",
+        )
+
+    async def _should_not_publish(**_: object) -> dict[str, object]:
+        raise AssertionError("_publish_review_outcome should not be called for a stale review")
+
+    monkeypatch.setattr(review_pr, "_run_review_pass", _fake_review)
+    monkeypatch.setattr(review_pr, "_publish_review_outcome", _should_not_publish)
+
+    result = await review_pr.run_review_pr_loop(
+        pr_ref="1137",
+        repo_root=tmp_path,
+        reviewer="claude",
+        artifact_root=tmp_path / "artifacts",
+        publish_review=True,
+    )
+
+    assert result["final_status"] == "blocked_nonreviewable"
+    assert result["head_sha_stale"] is True
+    assert result["observed_head_sha_before"] == "abc123"
+    assert result["observed_head_sha_after"] == "def456"
+    assert result["github_review"]["posted"] is False
+    assert "changed during review" in result["github_review"]["error"]
+
+
+@pytest.mark.asyncio
 async def test_run_review_pr_loop_auto_reruns_after_fix(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     sample_target: review_pr.PullRequestTarget,
 ) -> None:
     fetched_targets = [
+        sample_target,
         sample_target,
         review_pr.PullRequestTarget(
             **{


### PR DESCRIPTION
## Summary
- normalize optional fixer values so placeholders like `None`/`null` do not launch fixer workers
- mark whether a fixer was actually requested in `review-pr` artifacts
- detect PR head drift after review and fail closed without publishing stale review output

## Validation
- `python3 -m pytest tests/cli/commands/test_review_pr.py -q`
- `python3 -m ruff check aragora/cli/commands/review_pr.py tests/cli/commands/test_review_pr.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- pre-push hooks passed without `SKIP`