### PR TITLE
fix(automation): remove unused github_cli_health import

### DIFF
--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -8,7 +8,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 from dataclasses import asdict, dataclass
 from collections.abc import Mapping
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Harvests one unharvested Codex candidate: `codex/swarm-3844d54a-micro-1` at `2f95c3df3c6ffe7c8c9ad0f981ee16aad43e6ae7`.
- Removes an unused `sys` import from `scripts/github_cli_health.py`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_github_cli_health.py -p no:rerunfailures -p no:cacheprovider` (11 passed)
- `python3 -m ruff check scripts/github_cli_health.py tests/scripts/test_github_cli_health.py`
- `python3 -m mypy scripts/github_cli_health.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`