### PR TITLE
test(automation): cover preflight rescue guardrails

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -18,6 +18,7 @@ Checks:
   - diff has no whitespace errors
   - session/log/coordination artifacts are not committed
   - rescue productization publish artifacts are not committed
+  - synthetic preflight validation commits/scratch diffs are not published
   - source changes without test changes are called out for operator review
 EOF
 }

--- a/tests/scripts/test_automation_pr_preflight.py
+++ b/tests/scripts/test_automation_pr_preflight.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import scripts.github_cli_health as gh_health
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "automation_pr_preflight.sh"
@@ -136,6 +138,24 @@ def test_automation_pr_preflight_rejects_rescue_publish_artifacts(
     )
 
 
+def test_automation_pr_preflight_rejects_rescue_publish_latest_pointer(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/bad-rescue-latest"], cwd=repo)
+    artifact = repo / "published" / "rescue-productization" / "latest.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("{}\n", encoding="utf-8")
+    _run(["git", "add", "published/rescue-productization/latest.json"], cwd=repo)
+    _run(["git", "commit", "-m", "bad: commit rescue latest artifact"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 1
+    assert "rescue productization publish artifacts" in proc.stderr
+    assert "published/rescue-productization/latest.json" in proc.stderr
+
+
 def test_automation_pr_preflight_accepts_unrelated_latest_json(
     tmp_path: Path,
 ) -> None:
@@ -151,3 +171,9 @@ def test_automation_pr_preflight_accepts_unrelated_latest_json(
 
     assert proc.returncode == 0
     assert "preflight: ok" in proc.stdout
+
+
+def test_github_cli_health_classifies_raw_dial_tcp_errors_as_connectivity() -> None:
+    assert gh_health.is_github_connectivity_error(
+        'Get "https://api.github.com/rate_limit": dial tcp 140.82.112.5:443: i/o timeout'
+    )

--- a/tests/scripts/test_publish_rescue_productization_report.py
+++ b/tests/scripts/test_publish_rescue_productization_report.py
@@ -110,7 +110,21 @@ def test_publish_report_bundle_writes_timestamped_and_latest(tmp_path: Path) -> 
 
 
 def test_main_dry_run_does_not_publish_report_bundle(tmp_path: Path, capsys) -> None:
-    ledger = _ledger_with_events(tmp_path, [])
+    ledger = _ledger_with_events(
+        tmp_path,
+        [
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5512,
+            ),
+            RescueEvent(
+                event_type="followup_prompt",
+                reason="needs explicit next step from founder",
+                issue_number=5515,
+            ),
+        ],
+    )
     publish_dir = tmp_path / "published"
 
     exit_code = mod.main(
@@ -121,6 +135,8 @@ def test_main_dry_run_does_not_publish_report_bundle(tmp_path: Path, capsys) -> 
             str(tmp_path / "rescue_productization.json"),
             "--publish-dir",
             str(publish_dir),
+            "--repo",
+            "synaptent/aragora",
             "--dry-run",
             "--json",
         ]
@@ -128,5 +144,7 @@ def test_main_dry_run_does_not_publish_report_bundle(tmp_path: Path, capsys) -> 
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
+    assert payload["repo"] == "synaptent/aragora"
     assert "generated_at" in payload
+    assert payload["summary"]["repeated_class_count"] == 1
     assert not publish_dir.exists()


### PR DESCRIPTION
## Summary
- Harvests one unharvested Codex candidate: `codex/swarm-3844d54a-micro-3` at `f79163971e50d2ac67b9775a0682f60ea43f4aec`.
- Adds preflight help text for synthetic validation artifact rejection.
- Adds focused coverage for rescue-productization `latest.json`, dry-run reporting, and raw GitHub CLI dial-tcp connectivity classification.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_automation_pr_preflight.py tests/scripts/test_publish_rescue_productization_report.py -p no:rerunfailures -p no:cacheprovider` (12 passed)
- `python3 -m ruff check tests/scripts/test_automation_pr_preflight.py tests/scripts/test_publish_rescue_productization_report.py`
- `python3 -m mypy tests/scripts/test_automation_pr_preflight.py tests/scripts/test_publish_rescue_productization_report.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Note: an initial ruff command included `scripts/automation_pr_preflight.sh`; ruff treated the shell script as Python and failed with syntax noise, so the successful ruff validation was rerun against the changed Python files only.