### PR TITLE
feat(codex): add read-only Desktop session inspector

### DIFF
--- a/aragora/cli/commands/codex_sessions.py
+++ b/aragora/cli/commands/codex_sessions.py
@@ -1,0 +1,278 @@
+"""CLI handlers for ``aragora codex sessions {list,show,tail}``.
+
+Read-only inspector for Codex Desktop local state. All output is secret-redacted
+by default; full-transcript output (``--full``) writes to a file under
+``.aragora/codex_sessions/`` unless ``--out -`` forces stdout.
+
+Heavy imports are deferred to invocation time so adding this CLI does not slow
+``aragora --help`` startup (see ``aragora/cli/backup.py`` for the same pattern).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_OUTPUT_ROOT = Path(".aragora/codex_sessions")
+DEFAULT_SINCE = "4h"
+DEFAULT_LIMIT = 50
+DEFAULT_MAX_EVENTS = 2000
+DEFAULT_TAIL_INTERVAL_SECONDS = 5.0
+
+
+def _parse_since(value: str) -> "Any":
+    from aragora.codex.duration import parse_duration
+
+    return parse_duration(value)
+
+
+def _resolve_paths(args: argparse.Namespace) -> "Any":
+    from aragora.codex.desktop_paths import resolve
+
+    return resolve(getattr(args, "codex_home", None))
+
+
+def _print_json(payload: Any) -> None:
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True, default=str)
+    sys.stdout.write("\n")
+
+
+def _format_table(rows: list[dict[str, Any]], columns: list[tuple[str, str]]) -> str:
+    if not rows:
+        return "(no rows)"
+    widths = {key: len(label) for key, label in columns}
+    for row in rows:
+        for key, _ in columns:
+            value = str(row.get(key, ""))
+            widths[key] = max(widths[key], len(value))
+    header = "  ".join(label.ljust(widths[key]) for key, label in columns)
+    separator = "  ".join("-" * widths[key] for key, _ in columns)
+    body = "\n".join(
+        "  ".join(str(row.get(key, "")).ljust(widths[key]) for key, _ in columns) for row in rows
+    )
+    return f"{header}\n{separator}\n{body}"
+
+
+def cmd_codex_sessions_list(args: argparse.Namespace) -> int:
+    """List Codex Desktop threads updated within ``--since``."""
+    from aragora.codex.desktop_inspector import humanize_ago, list_active_threads, truncate
+
+    try:
+        since = _parse_since(args.since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    paths = _resolve_paths(args)
+    if not paths.sqlite_path.exists():
+        print(
+            f"error: Codex Desktop state DB not found at {paths.sqlite_path}\n"
+            f"       Override the location via {paths.__class__.__name__} or "
+            "set ARAGORA_CODEX_HOME.",
+            file=sys.stderr,
+        )
+        return 1
+
+    threads = list_active_threads(
+        since=since,
+        include_archived=args.include_archived,
+        limit=args.limit,
+        paths=paths,
+    )
+
+    if args.json:
+        _print_json([t.to_dict() for t in threads])
+        return 0
+
+    now = datetime.now(UTC)
+    rows = [
+        {
+            "id": t.id[:12],
+            "ago": humanize_ago(t.updated_at, now=now),
+            "model": (t.model or "")[:24],
+            "tokens": str(t.tokens_used),
+            "branch": (t.git_branch or "")[:18],
+            "cwd": truncate(t.cwd, width=40),
+            "title": truncate(t.title or "(no title)", width=60),
+        }
+        for t in threads
+    ]
+    table = _format_table(
+        rows,
+        columns=[
+            ("id", "ID"),
+            ("ago", "AGO"),
+            ("model", "MODEL"),
+            ("tokens", "TOKENS"),
+            ("branch", "BRANCH"),
+            ("cwd", "CWD"),
+            ("title", "TITLE"),
+        ],
+    )
+    print(table)
+    print(f"\n{len(rows)} thread(s) updated since {since}.")
+    return 0
+
+
+def _resolve_rollout(
+    target: str, args: argparse.Namespace
+) -> "tuple[Path, str | None] | tuple[None, None]":
+    """Resolve ``target`` (thread id or path) to a (rollout_path, thread_id) pair."""
+    from aragora.codex.desktop_inspector import find_thread
+
+    candidate = Path(target).expanduser()
+    if candidate.exists() and candidate.is_file():
+        return candidate, None
+    paths = _resolve_paths(args)
+    if not paths.sqlite_path.exists():
+        return None, None
+    summary = find_thread(target, paths=paths)
+    if summary is None:
+        return None, None
+    return summary.rollout_path, summary.id
+
+
+def cmd_codex_sessions_show(args: argparse.Namespace) -> int:
+    """Summarize one session; with ``--full`` write the redacted transcript to a file."""
+    from aragora.codex.desktop_inspector import (
+        find_thread,
+        iter_session_events,
+        summarize_session,
+    )
+
+    rollout, thread_id = _resolve_rollout(args.target, args)
+    if rollout is None or not rollout.exists():
+        print(
+            f"error: could not resolve '{args.target}' to a rollout file\n"
+            "       Pass a thread id (or 8+ char prefix) or a rollout path.",
+            file=sys.stderr,
+        )
+        return 1
+
+    paths = _resolve_paths(args)
+    thread = find_thread(thread_id, paths=paths) if thread_id else None
+    summary = summarize_session(rollout, max_events=args.max_events)
+
+    if not args.full:
+        if args.json:
+            payload = {
+                "thread": thread.to_dict() if thread else None,
+                "summary": summary.to_dict(),
+            }
+            _print_json(payload)
+            return 0
+        if thread:
+            print(f"Thread:    {thread.id}")
+            print(f"Title:     {thread.title or '(no title)'}")
+            print(f"Cwd:       {thread.cwd}")
+            print(f"Model:     {thread.model or '(unknown)'}")
+            print(f"Updated:   {thread.updated_at.isoformat()}")
+            print(f"Tokens:    {thread.tokens_used}")
+            if thread.git_branch:
+                print(f"Branch:    {thread.git_branch}")
+            if thread.git_sha:
+                print(f"Sha:       {thread.git_sha[:12]}")
+        print(f"Rollout:   {summary.rollout_path}")
+        print(f"Scanned:   {summary.events_scanned}{' (truncated)' if summary.truncated else ''}")
+        if summary.event_type_counts:
+            print("Events:")
+            for name, count in sorted(summary.event_type_counts.items(), key=lambda kv: -kv[1]):
+                print(f"    {count:6}  {name}")
+        if summary.tool_call_counts:
+            print("Tool calls:")
+            for name, count in sorted(summary.tool_call_counts.items(), key=lambda kv: -kv[1]):
+                print(f"    {count:6}  {name}")
+        if summary.first_user_message:
+            print("First user:")
+            for line in summary.first_user_message.splitlines()[:5]:
+                print(f"    {line}")
+        if summary.last_user_message and summary.last_user_message != summary.first_user_message:
+            print("Last user:")
+            for line in summary.last_user_message.splitlines()[:5]:
+                print(f"    {line}")
+        return 0
+
+    # --full path
+    out_arg = args.out or ""
+    if out_arg == "-":
+        out_handle = sys.stdout
+        out_path: Path | None = None
+    else:
+        out_path = (
+            Path(out_arg).expanduser()
+            if out_arg
+            else DEFAULT_OUTPUT_ROOT / f"{(thread_id or rollout.stem)}.jsonl"
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_handle = out_path.open("w", encoding="utf-8")
+
+    written = 0
+    bytes_written = 0
+    try:
+        for event in iter_session_events(rollout, redact=True):
+            line = json.dumps(event, sort_keys=True, default=str)
+            out_handle.write(line + "\n")
+            written += 1
+            bytes_written += len(line) + 1
+    finally:
+        if out_path is not None:
+            out_handle.close()
+
+    if out_path is not None:
+        print(f"wrote {out_path} ({written} events, {bytes_written} bytes redacted)")
+    return 0
+
+
+def cmd_codex_sessions_tail(args: argparse.Namespace) -> int:
+    """Poll active sessions and print new redacted events as they arrive.
+
+    Default ``--since 4h`` window controls which sessions are watched. The
+    loop never exits on its own; ``Ctrl-C`` to stop. Suitable for piping to
+    grep or pumping into the Monitor tool.
+    """
+    from aragora.codex.desktop_inspector import iter_session_events_from_offset, list_active_threads
+
+    try:
+        since = _parse_since(args.since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    paths = _resolve_paths(args)
+    if not paths.sqlite_path.exists():
+        print(f"error: Codex Desktop state DB not found at {paths.sqlite_path}", file=sys.stderr)
+        return 1
+
+    # Track byte offsets per rollout so each poll only emits new events.
+    offsets: dict[Path, int] = {}
+    try:
+        while True:
+            threads = list_active_threads(since=since, paths=paths)
+            for thread in threads:
+                rollout = thread.rollout_path
+                if not rollout.exists():
+                    continue
+                current_size = rollout.stat().st_size
+                prev = offsets.get(rollout, current_size if args.from_start is False else 0)
+                if current_size <= prev:
+                    offsets[rollout] = current_size
+                    continue
+                for event, next_offset in iter_session_events_from_offset(
+                    rollout,
+                    offset=prev,
+                    redact=True,
+                ):
+                    if not event:
+                        offsets[rollout] = next_offset
+                        continue
+                    serialized = json.dumps(event, sort_keys=True, default=str)
+                    print(f"{thread.id[:12]}  {serialized}")
+                    offsets[rollout] = next_offset
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -198,6 +198,7 @@ Examples:
     _add_ideacloud_parser(subparsers)
     _add_signing_parser(subparsers)
     _add_inbox_wedge_parser(subparsers)
+    _add_codex_parser(subparsers)
     _add_triage_parser(subparsers)
     _add_ralph_parser(subparsers)
     _add_assess_parser(subparsers)
@@ -3138,6 +3139,117 @@ def _add_triage_parser(subparsers) -> None:
     from aragora.cli.commands.triage import add_triage_parser
 
     add_triage_parser(subparsers)
+
+
+def _add_codex_parser(subparsers) -> None:
+    """Add the 'codex' read-only inspector commands for Codex Desktop state."""
+    codex = subparsers.add_parser(
+        "codex",
+        help="Read-only inspector for Codex Desktop local state",
+        description=(
+            "Surface Codex Desktop sessions/threads from ~/.codex/ as redacted, "
+            "read-only data. Never writes to ~/.codex/, makes no network calls, "
+            "and consumes no AI provider keys."
+        ),
+    )
+    codex_sub = codex.add_subparsers(dest="codex_cmd")
+
+    sessions = codex_sub.add_parser(
+        "sessions",
+        help="Inspect Codex Desktop sessions/threads",
+        description="List, summarize, or tail Codex Desktop sessions (read-only).",
+    )
+    sessions_sub = sessions.add_subparsers(dest="codex_sessions_cmd")
+
+    def add_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--codex-home",
+            default=None,
+            help="Override Codex Desktop home dir (default: $ARAGORA_CODEX_HOME or ~/.codex)",
+        )
+        p.add_argument("--json", action="store_true", help="Emit JSON instead of a table")
+
+    list_cmd = sessions_sub.add_parser("list", help="List threads updated within --since window")
+    add_common(list_cmd)
+    list_cmd.add_argument(
+        "--since",
+        default="4h",
+        help="Time window (e.g. 30m, 4h, 1d, 90s). Default: 4h.",
+    )
+    list_cmd.add_argument(
+        "--include-archived",
+        action="store_true",
+        help="Include archived threads (default: exclude)",
+    )
+    list_cmd.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum number of threads to return (default: 50, 0 = no limit)",
+    )
+    list_cmd.set_defaults(
+        func=_lazy("aragora.cli.commands.codex_sessions", "cmd_codex_sessions_list")
+    )
+
+    show_cmd = sessions_sub.add_parser(
+        "show",
+        help="Summarize one session by thread id (or 8+ char prefix) or rollout path",
+    )
+    add_common(show_cmd)
+    show_cmd.add_argument(
+        "target",
+        help="Thread id, id prefix (>=8 chars), or path to a rollout JSONL file",
+    )
+    show_cmd.add_argument(
+        "--full",
+        action="store_true",
+        help=(
+            "Write the full redacted transcript. Default writes to a file under "
+            ".aragora/codex_sessions/<id>.jsonl; use --out - to force stdout."
+        ),
+    )
+    show_cmd.add_argument(
+        "--out",
+        default="",
+        help=(
+            "Output destination for --full. '-' for stdout, '' (default) for "
+            ".aragora/codex_sessions/<id>.jsonl, or any explicit path."
+        ),
+    )
+    show_cmd.add_argument(
+        "--max-events",
+        type=int,
+        default=2000,
+        help="Max events to scan when summarizing (default: 2000; ignored when --full).",
+    )
+    show_cmd.set_defaults(
+        func=_lazy("aragora.cli.commands.codex_sessions", "cmd_codex_sessions_show")
+    )
+
+    tail_cmd = sessions_sub.add_parser(
+        "tail",
+        help="Poll active sessions and print new redacted events as they arrive",
+    )
+    add_common(tail_cmd)
+    tail_cmd.add_argument(
+        "--since",
+        default="4h",
+        help="Time window selecting which sessions to watch (default: 4h)",
+    )
+    tail_cmd.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="Polling interval in seconds (default: 5.0)",
+    )
+    tail_cmd.add_argument(
+        "--from-start",
+        action="store_true",
+        help="On startup, replay all events from each active session (default: tail-only).",
+    )
+    tail_cmd.set_defaults(
+        func=_lazy("aragora.cli.commands.codex_sessions", "cmd_codex_sessions_tail")
+    )
 
 
 def _add_swarm_parser(subparsers) -> None:

--- a/aragora/codex/__init__.py
+++ b/aragora/codex/__init__.py
@@ -1,0 +1,6 @@
+"""Read-only inspectors for Codex Desktop local state.
+
+This package surfaces Codex Desktop session/thread activity (rollout JSONL +
+SQLite state) into aragora as a read-only operator tool. Nothing under this
+package writes to ``~/.codex/`` or makes network/AI-key calls.
+"""

--- a/aragora/codex/desktop_inspector.py
+++ b/aragora/codex/desktop_inspector.py
@@ -1,0 +1,454 @@
+"""Read-only inspector for Codex Desktop sessions and threads.
+
+Surfaces canonical thread metadata from ``state_5.sqlite`` and full session
+transcripts from rollout JSONL files, with mandatory secret redaction on any
+surfaced content.
+
+This module is intentionally network-free and writes nothing to ``~/.codex/``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from aragora.debate.security_barrier import SecurityBarrier
+
+from .desktop_paths import CodexDesktopPaths, resolve
+from .jsonl_stream import iter_jsonl
+from .sqlite_ro import sqlite_ro
+
+# Extra redaction patterns layered on top of SecurityBarrier defaults to
+# cover GitHub tokens, AWS access key IDs, and the OpenRouter prefix that the
+# SecurityBarrier default ``sk-[…]`` pattern technically covers but worth
+# being explicit about.
+_EXTRA_REDACTION_PATTERNS = (
+    r"gh[pousr]_[A-Za-z0-9_]{20,}",
+    r"AKIA[0-9A-Z]{16}",
+    r"sk-or-v1-[A-Za-z0-9]+",
+)
+
+
+def _build_barrier() -> SecurityBarrier:
+    barrier = SecurityBarrier()
+    for pattern in _EXTRA_REDACTION_PATTERNS:
+        barrier.add_pattern(pattern)
+    return barrier
+
+
+@dataclass(frozen=True, slots=True)
+class ThreadSummary:
+    """Canonical metadata about one Codex Desktop thread.
+
+    Pulled from the ``threads`` table in ``state_5.sqlite``. All string fields
+    are redacted at construction time so that a thread whose title contains a
+    leaked secret cannot leak it back through this object.
+    """
+
+    id: str
+    title: str
+    cwd: str
+    model: str | None
+    rollout_path: Path
+    created_at: datetime
+    updated_at: datetime
+    tokens_used: int
+    archived: bool
+    git_sha: str | None
+    git_branch: str | None
+    source: str
+    first_user_message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "cwd": self.cwd,
+            "model": self.model,
+            "rollout_path": str(self.rollout_path),
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "tokens_used": self.tokens_used,
+            "archived": self.archived,
+            "git_sha": self.git_sha,
+            "git_branch": self.git_branch,
+            "source": self.source,
+            "first_user_message": self.first_user_message,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSummary:
+    """Aggregate view of one rollout JSONL.
+
+    Built by scanning up to ``max_events`` events. All string content
+    (messages, titles) is already redacted.
+    """
+
+    rollout_path: Path
+    events_scanned: int
+    truncated: bool
+    event_type_counts: dict[str, int]
+    tool_call_counts: dict[str, int]
+    first_user_message: str
+    last_user_message: str
+    model_provider: str | None
+    started_at: datetime | None
+    last_event_at: datetime | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rollout_path": str(self.rollout_path),
+            "events_scanned": self.events_scanned,
+            "truncated": self.truncated,
+            "event_type_counts": dict(self.event_type_counts),
+            "tool_call_counts": dict(self.tool_call_counts),
+            "first_user_message": self.first_user_message,
+            "last_user_message": self.last_user_message,
+            "model_provider": self.model_provider,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "last_event_at": self.last_event_at.isoformat() if self.last_event_at else None,
+        }
+
+
+def _to_datetime(epoch_value: Any) -> datetime:
+    """Best-effort conversion of integer/float epoch values into aware UTC datetimes.
+
+    Codex Desktop stores some columns as seconds-since-epoch and others as
+    milliseconds; we normalize by sniffing magnitude.
+    """
+    try:
+        n = int(epoch_value)
+    except (TypeError, ValueError):
+        return datetime.fromtimestamp(0, tz=UTC)
+    # Anything past ~3000-01-01 in seconds (32503680000) is almost certainly
+    # milliseconds. Use that boundary to distinguish.
+    if n > 32503680000:
+        return datetime.fromtimestamp(n / 1000.0, tz=UTC)
+    return datetime.fromtimestamp(n, tz=UTC)
+
+
+def _extract_text(payload: Any) -> str:
+    """Pull a flat text excerpt out of a Codex event payload.
+
+    Handles the common shapes:
+    - ``{"role": "user", "content": [{"type": "text", "text": "..."}]}``
+    - ``{"role": "user", "content": "..."}``
+    - ``{"text": "..."}``
+    """
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, dict):
+        content = payload.get("content") or payload.get("text") or payload.get("message") or ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict):
+                    text_value = item.get("text") or item.get("content") or ""
+                    if isinstance(text_value, str):
+                        parts.append(text_value)
+            return "\n".join(parts)
+    return ""
+
+
+def list_active_threads(
+    *,
+    since: timedelta,
+    include_archived: bool = False,
+    limit: int | None = None,
+    paths: CodexDesktopPaths | None = None,
+) -> list[ThreadSummary]:
+    """Return Codex Desktop threads updated within the last ``since`` window.
+
+    Threads are read from ``state_5.sqlite`` (read-only) and sorted newest
+    first by ``updated_at``. Title and first-user-message fields are redacted
+    so the returned objects are safe to print to a terminal.
+    """
+    paths = paths or resolve()
+    barrier = _build_barrier()
+    cutoff = datetime.now(UTC) - since
+    cutoff_epoch = int(cutoff.timestamp())
+
+    rows: list[ThreadSummary] = []
+    sql = """
+        SELECT
+            id, COALESCE(title, '') AS title, cwd,
+            COALESCE(model, '') AS model,
+            rollout_path,
+            created_at, updated_at,
+            tokens_used,
+            archived,
+            git_sha, git_branch,
+            source,
+            COALESCE(first_user_message, '') AS first_user_message
+        FROM threads
+        WHERE updated_at >= ?
+    """
+    if not include_archived:
+        sql += " AND archived = 0"
+    sql += " ORDER BY updated_at DESC"
+    if limit is not None and limit > 0:
+        sql += f" LIMIT {int(limit)}"
+
+    with sqlite_ro(paths.sqlite_path) as conn:
+        cursor = conn.execute(sql, (cutoff_epoch,))
+        for row in cursor:
+            rows.append(
+                ThreadSummary(
+                    id=row["id"],
+                    title=barrier.redact(row["title"] or ""),
+                    cwd=row["cwd"],
+                    model=row["model"] or None,
+                    rollout_path=Path(row["rollout_path"]),
+                    created_at=_to_datetime(row["created_at"]),
+                    updated_at=_to_datetime(row["updated_at"]),
+                    tokens_used=int(row["tokens_used"] or 0),
+                    archived=bool(row["archived"]),
+                    git_sha=row["git_sha"],
+                    git_branch=row["git_branch"],
+                    source=row["source"],
+                    first_user_message=barrier.redact(row["first_user_message"] or ""),
+                )
+            )
+    return rows
+
+
+def find_thread(thread_id: str, *, paths: CodexDesktopPaths | None = None) -> ThreadSummary | None:
+    """Look up a single thread by id (or id-prefix of at least 8 chars).
+
+    Returns ``None`` if no thread matches. Prefix matches are accepted to
+    avoid forcing operators to paste the full UUID.
+    """
+    paths = paths or resolve()
+    barrier = _build_barrier()
+    cleaned = thread_id.strip()
+    if len(cleaned) < 8:
+        return None
+    pattern = cleaned + "%"
+    sql = """
+        SELECT
+            id, COALESCE(title, '') AS title, cwd,
+            COALESCE(model, '') AS model,
+            rollout_path,
+            created_at, updated_at,
+            tokens_used,
+            archived,
+            git_sha, git_branch,
+            source,
+            COALESCE(first_user_message, '') AS first_user_message
+        FROM threads
+        WHERE id = ? OR id LIKE ?
+        ORDER BY updated_at DESC
+        LIMIT 1
+    """
+    with sqlite_ro(paths.sqlite_path) as conn:
+        row = conn.execute(sql, (cleaned, pattern)).fetchone()
+    if row is None:
+        return None
+    return ThreadSummary(
+        id=row["id"],
+        title=barrier.redact(row["title"] or ""),
+        cwd=row["cwd"],
+        model=row["model"] or None,
+        rollout_path=Path(row["rollout_path"]),
+        created_at=_to_datetime(row["created_at"]),
+        updated_at=_to_datetime(row["updated_at"]),
+        tokens_used=int(row["tokens_used"] or 0),
+        archived=bool(row["archived"]),
+        git_sha=row["git_sha"],
+        git_branch=row["git_branch"],
+        source=row["source"],
+        first_user_message=barrier.redact(row["first_user_message"] or ""),
+    )
+
+
+def iter_session_events(
+    rollout_path: str | Path,
+    *,
+    redact: bool = True,
+) -> Iterator[dict[str, Any]]:
+    """Yield one event dict per rollout JSONL line.
+
+    With ``redact=True`` (the default), every string value reachable from the
+    event is replaced by :class:`SecurityBarrier`'s redaction. Callers must
+    pass ``redact=False`` explicitly to opt out — and even then, this module
+    will never log unredacted content itself.
+    """
+    barrier = _build_barrier() if redact else None
+    for event in iter_jsonl(rollout_path, strict=False):
+        if barrier is not None:
+            event = barrier.redact_dict(event)
+        yield event
+
+
+def iter_session_events_from_offset(
+    rollout_path: str | Path,
+    *,
+    offset: int,
+    redact: bool = True,
+) -> Iterator[tuple[dict[str, Any], int]]:
+    """Yield redacted events added after ``offset`` plus their raw byte offset.
+
+    ``tail`` needs raw file offsets, not lengths of re-serialized redacted JSON.
+    If a live rollout ends with a partial JSON object, stop before that line and
+    leave the caller's offset unchanged for the incomplete event.
+    """
+    barrier = _build_barrier() if redact else None
+    path = Path(rollout_path).expanduser()
+    with path.open("rb") as handle:
+        handle.seek(max(0, offset))
+        while True:
+            start = handle.tell()
+            raw = handle.readline()
+            if not raw:
+                break
+            try:
+                line = raw.decode("utf-8").strip()
+            except UnicodeDecodeError:
+                handle.seek(start)
+                break
+            if not line:
+                yield {}, handle.tell()
+                continue
+            try:
+                event = json.loads(line)
+            except ValueError:
+                # Treat malformed trailing content as an in-progress write.
+                handle.seek(start)
+                break
+            if not isinstance(event, dict):
+                continue
+            if barrier is not None:
+                event = barrier.redact_dict(event)
+            yield event, handle.tell()
+
+
+def summarize_session(
+    rollout_path: str | Path,
+    *,
+    max_events: int = 2000,
+) -> SessionSummary:
+    """Walk up to ``max_events`` events from a rollout file and return a summary.
+
+    Counts events by ``type``, counts tool calls by tool name, captures the
+    first and last user messages (redacted), and notes the model provider
+    seen in the session_meta event when present.
+    """
+    barrier = _build_barrier()
+    event_type_counts: dict[str, int] = {}
+    tool_call_counts: dict[str, int] = {}
+    first_user: str = ""
+    last_user: str = ""
+    model_provider: str | None = None
+    started_at: datetime | None = None
+    last_event_at: datetime | None = None
+    scanned = 0
+    truncated = False
+
+    for event in iter_jsonl(rollout_path, strict=False):
+        scanned += 1
+        if scanned > max_events:
+            truncated = True
+            break
+        event_type = str(event.get("type") or "")
+        if event_type:
+            event_type_counts[event_type] = event_type_counts.get(event_type, 0) + 1
+
+        timestamp_raw = event.get("timestamp")
+        if timestamp_raw:
+            try:
+                # Codex rollout timestamps are ISO-8601 strings.
+                parsed = datetime.fromisoformat(str(timestamp_raw).replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=UTC)
+                last_event_at = parsed
+                if started_at is None:
+                    started_at = parsed
+            except ValueError:
+                pass
+
+        payload = event.get("payload") or {}
+        if isinstance(payload, dict):
+            if model_provider is None:
+                candidate = payload.get("model_provider")
+                if isinstance(candidate, str) and candidate:
+                    model_provider = candidate
+
+            role = str(payload.get("role") or "")
+            if role == "user":
+                text = barrier.redact(_extract_text(payload))
+                if text:
+                    if not first_user:
+                        first_user = text
+                    last_user = text
+
+            tool_name = (
+                payload.get("tool_name")
+                or payload.get("name")
+                or (payload.get("tool_call") or {}).get("name")
+                if isinstance(payload.get("tool_call"), dict)
+                else payload.get("tool_name") or payload.get("name")
+            )
+            if isinstance(tool_name, str) and tool_name and event_type.endswith("tool_call"):
+                tool_call_counts[tool_name] = tool_call_counts.get(tool_name, 0) + 1
+
+    return SessionSummary(
+        rollout_path=Path(rollout_path),
+        events_scanned=scanned if not truncated else max_events,
+        truncated=truncated,
+        event_type_counts=event_type_counts,
+        tool_call_counts=tool_call_counts,
+        first_user_message=first_user,
+        last_user_message=last_user,
+        model_provider=model_provider,
+        started_at=started_at,
+        last_event_at=last_event_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lightweight helpers — kept small so the CLI module can stay thin.
+# ---------------------------------------------------------------------------
+
+
+def humanize_ago(when: datetime, *, now: datetime | None = None) -> str:
+    """Return a short human-friendly delta like ``3m`` / ``2h`` / ``5d``."""
+    now = now or datetime.now(UTC)
+    delta = now - when
+    seconds = max(0, int(delta.total_seconds()))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def truncate(value: str, *, width: int) -> str:
+    """Truncate ``value`` to ``width`` characters with a trailing ellipsis if cut."""
+    if width <= 0 or len(value) <= width:
+        return value
+    if width <= 1:
+        return value[:width]
+    return value[: width - 1] + "…"
+
+
+@dataclass(frozen=True, slots=True)
+class _SafetyMarker:
+    """Sentinel for tests asserting that no inflight imports leak network usage."""
+
+    forbidden_imports: tuple[str, ...] = field(
+        default=("httpx", "requests", "openai", "anthropic", "urllib.request")
+    )
+
+
+SAFETY_MARKER = _SafetyMarker()

--- a/aragora/codex/desktop_paths.py
+++ b/aragora/codex/desktop_paths.py
@@ -1,0 +1,51 @@
+"""Canonical paths for Codex Desktop local state.
+
+All paths are derived from a single ``home`` directory (default ``~/.codex``)
+that can be overridden via the ``ARAGORA_CODEX_HOME`` environment variable for
+tests and alternate installs.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_CODEX_HOME = Path("~/.codex").expanduser()
+HOME_ENV_VAR = "ARAGORA_CODEX_HOME"
+
+
+@dataclass(frozen=True, slots=True)
+class CodexDesktopPaths:
+    """Frozen view of the Codex Desktop on-disk layout.
+
+    Build via :func:`resolve` to honor ``ARAGORA_CODEX_HOME``.
+    """
+
+    home: Path
+
+    @property
+    def sqlite_path(self) -> Path:
+        return self.home / "state_5.sqlite"
+
+    @property
+    def sessions_root(self) -> Path:
+        return self.home / "sessions"
+
+    @property
+    def global_state_path(self) -> Path:
+        return self.home / ".codex-global-state.json"
+
+    @property
+    def session_index_path(self) -> Path:
+        return self.home / "session_index.jsonl"
+
+
+def resolve(home: str | os.PathLike[str] | None = None) -> CodexDesktopPaths:
+    """Return canonical paths, honoring ``ARAGORA_CODEX_HOME`` when ``home`` is None."""
+    if home is not None:
+        return CodexDesktopPaths(home=Path(home))
+    override = os.environ.get(HOME_ENV_VAR)
+    if override:
+        return CodexDesktopPaths(home=Path(override).expanduser())
+    return CodexDesktopPaths(home=DEFAULT_CODEX_HOME)

--- a/aragora/codex/duration.py
+++ b/aragora/codex/duration.py
@@ -1,0 +1,31 @@
+"""Tiny duration-string parser for the codex inspector CLI.
+
+Accepts ``<int><unit>`` where unit is ``s``, ``m``, ``h``, or ``d``. Centralizing
+this here (rather than depending on a heavier package) keeps the codex inspector
+free of additional imports.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+
+_PATTERN = re.compile(r"^\s*(\d+)\s*([smhd])\s*$")
+_UNIT_TO_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def parse_duration(value: str) -> timedelta:
+    """Parse ``"4h" | "30m" | "1d" | "90s"`` into a :class:`timedelta`.
+
+    Raises ``ValueError`` with a clear message on bad input. Zero durations are
+    allowed (``"0s"``); negative durations are not (the regex rejects ``-``).
+    """
+    match = _PATTERN.match(value or "")
+    if match is None:
+        raise ValueError(
+            f"invalid duration {value!r}: expected '<int><unit>' with unit in s|m|h|d "
+            "(e.g. '4h', '30m', '1d', '90s')"
+        )
+    amount = int(match.group(1))
+    unit = match.group(2)
+    return timedelta(seconds=amount * _UNIT_TO_SECONDS[unit])

--- a/aragora/codex/jsonl_stream.py
+++ b/aragora/codex/jsonl_stream.py
@@ -1,0 +1,46 @@
+"""Streaming JSONL reader for Codex Desktop rollout files.
+
+Rollout files can be tens or hundreds of MB. Callers must never slurp them
+whole — iterate line by line via :func:`iter_jsonl`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from os import PathLike
+from pathlib import Path
+from typing import Any
+
+
+def iter_jsonl(path: str | PathLike[str], *, strict: bool = True) -> Iterator[dict[str, Any]]:
+    """Yield one parsed dict per non-blank line of ``path``.
+
+    Blank lines are skipped silently. In strict mode, malformed JSON lines
+    raise :class:`json.JSONDecodeError` with the file path and line number
+    attached in the message so failures are debuggable without re-reading the
+    file. In non-strict mode, iteration stops at the first malformed line; this
+    is useful for live Codex rollout files that may end with a partially written
+    JSON object.
+    """
+    abs_path = Path(path).expanduser()
+    with abs_path.open("r", encoding="utf-8") as handle:
+        for lineno, raw in enumerate(handle, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                if not strict:
+                    break
+                raise json.JSONDecodeError(
+                    f"{exc.msg} ({abs_path}:{lineno})",
+                    exc.doc,
+                    exc.pos,
+                ) from None
+            if isinstance(obj, dict):
+                yield obj
+            # Silently skip non-object lines — rollouts may contain stray
+            # arrays or scalars from legacy event schemas, and the inspector
+            # is intentionally tolerant of unknown shapes.

--- a/aragora/codex/sqlite_ro.py
+++ b/aragora/codex/sqlite_ro.py
@@ -1,0 +1,34 @@
+"""Read-only SQLite access for the Codex Desktop state database.
+
+Opens the underlying SQLite file with the ``mode=ro`` URI so the connection
+cannot acquire a write lock. The live Codex Desktop app holds a separate write
+handle on this file (WAL mode is in use); the read-only mode here is the
+discipline that keeps the inspector from interfering with it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from os import PathLike
+from pathlib import Path
+
+
+@contextmanager
+def sqlite_ro(path: str | PathLike[str]) -> Iterator[sqlite3.Connection]:
+    """Yield a read-only :class:`sqlite3.Connection` for ``path``.
+
+    The connection is closed on context exit. ``row_factory`` is set to
+    :class:`sqlite3.Row` so callers can use column-name access. Attempting any
+    write through the returned connection raises
+    :class:`sqlite3.OperationalError` from SQLite itself.
+    """
+    abs_path = Path(path).expanduser().resolve()
+    uri = f"file:{abs_path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    try:
+        conn.row_factory = sqlite3.Row
+        yield conn
+    finally:
+        conn.close()

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -11,8 +11,8 @@ description: Generated Aragora CLI command catalog from live parser
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **98**
-- Total top-level invocations (including aliases): **99**
+- Canonical top-level commands: **99**
+- Total top-level invocations (including aliases): **100**
 
 ## Installation
 
@@ -56,6 +56,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `build` | - | Turn a vague idea into executed, reviewed, merged code | - |
 | `calibration` | - | AGT-03.3: per-agent rolling-window Brier reports from market data | `leaderboard`, `report` |
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
+| `codex` | - | Read-only inspector for Codex Desktop local state | `sessions` |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 99 commands | 43.2% |
+| **CLI** | 100 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 99 commands | 43.2% |
+| **CLI** | 100 commands | 43.2% |
 | **SDK (Python)** | 191 namespaces | 70.3% |
 | **SDK (TypeScript)** | 190 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4126` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1936828` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
-| Top-level modules under aragora/ | `138` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5177` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217977` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Python files under aragora/ | `4133` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1937728` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Top-level modules under aragora/ | `139` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
+| Test files (test_*.py under tests/) | `5179` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `218013` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `684` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `66` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| CLI top-level command modules | `67` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4126` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1936477` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1936828` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `138` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5176` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `217953` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5177` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `217977` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `684` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `66` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **98**
-- Total top-level invocations (including aliases): **99**
+- Canonical top-level commands: **99**
+- Total top-level invocations (including aliases): **100**
 
 ## Installation
 
@@ -51,6 +51,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `build` | - | Turn a vague idea into executed, reviewed, merged code | - |
 | `calibration` | - | AGT-03.3: per-agent rolling-window Brier reports from market data | `leaderboard`, `report` |
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
+| `codex` | - | Read-only inspector for Codex Desktop local state | `sessions` |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |

--- a/tests/codex/conftest.py
+++ b/tests/codex/conftest.py
@@ -1,0 +1,334 @@
+"""Shared fixtures for the aragora codex inspector tests.
+
+Builds a synthetic Codex Desktop home (``state_5.sqlite`` + rollout JSONLs)
+in a tmp dir so tests never touch the real ``~/.codex`` tree.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+# Thread schema mirrors the live Codex Desktop ``state_5.sqlite`` shape (the
+# subset the inspector reads from). Times are seconds-since-epoch ints.
+_CREATE_THREADS = """
+CREATE TABLE threads (
+    id TEXT PRIMARY KEY,
+    rollout_path TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    model_provider TEXT NOT NULL,
+    cwd TEXT NOT NULL,
+    title TEXT NOT NULL,
+    sandbox_policy TEXT NOT NULL,
+    approval_mode TEXT NOT NULL,
+    tokens_used INTEGER NOT NULL DEFAULT 0,
+    has_user_event INTEGER NOT NULL DEFAULT 0,
+    archived INTEGER NOT NULL DEFAULT 0,
+    archived_at INTEGER,
+    git_sha TEXT,
+    git_branch TEXT,
+    git_origin_url TEXT,
+    cli_version TEXT NOT NULL DEFAULT '',
+    first_user_message TEXT NOT NULL DEFAULT '',
+    agent_nickname TEXT,
+    agent_role TEXT,
+    memory_mode TEXT NOT NULL DEFAULT 'enabled',
+    model TEXT,
+    reasoning_effort TEXT,
+    agent_path TEXT,
+    created_at_ms INTEGER,
+    updated_at_ms INTEGER,
+    thread_source TEXT,
+    preview TEXT NOT NULL DEFAULT ''
+);
+"""
+
+
+@dataclass(frozen=True)
+class FakeCodexHome:
+    home: Path
+    recent_thread_id: str
+    recent_rollout: Path
+    archived_thread_id: str
+    old_thread_id: str
+    secret_titled_thread_id: str
+
+
+def _write_rollout(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for event in events:
+            handle.write(json.dumps(event) + "\n")
+
+
+@pytest.fixture
+def fake_codex_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[FakeCodexHome]:
+    home = tmp_path / "codex"
+    home.mkdir()
+    monkeypatch.setenv("ARAGORA_CODEX_HOME", str(home))
+
+    db_path = home / "state_5.sqlite"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(_CREATE_THREADS)
+        conn.commit()
+
+        now = int(time.time())
+        ten_minutes_ago = now - 600
+        one_day_ago = now - 86400
+        ten_days_ago = now - 10 * 86400
+
+        recent_id = "019e3222-3e45-7920-90f4-203877f24690"
+        recent_rollout = home / "sessions" / "2026" / "05" / "16" / f"rollout-{recent_id}.jsonl"
+        _write_rollout(
+            recent_rollout,
+            events=[
+                {
+                    "timestamp": "2026-05-16T13:52:45.000Z",
+                    "type": "session_meta",
+                    "payload": {
+                        "id": recent_id,
+                        "cwd": "/Users/test/repo",
+                        "model_provider": "openai",
+                    },
+                },
+                {
+                    "timestamp": "2026-05-16T13:53:00.000Z",
+                    "type": "turn_start",
+                    "payload": {"type": "turn_start", "turn_id": "t1"},
+                },
+                {
+                    "timestamp": "2026-05-16T13:53:05.000Z",
+                    "type": "agent_message",
+                    "payload": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Please review my code with sk-proj-FAKE-LEAK-12345 attached",
+                            },
+                        ],
+                    },
+                },
+                {
+                    "timestamp": "2026-05-16T13:53:10.000Z",
+                    "type": "tool_call",
+                    "payload": {"tool_name": "Read", "tool_call": {"name": "Read"}},
+                },
+                {
+                    "timestamp": "2026-05-16T13:53:15.000Z",
+                    "type": "tool_response",
+                    "payload": {"tool_name": "Read"},
+                },
+                {
+                    "timestamp": "2026-05-16T13:53:20.000Z",
+                    "type": "agent_message",
+                    "payload": {
+                        "role": "user",
+                        "content": "Authorization: Bearer ghp_FAKELEAK12345678901234",
+                    },
+                },
+            ],
+        )
+
+        old_id = "019cccc0-0000-0000-0000-000000000001"
+        old_rollout = home / "sessions" / "2026" / "03" / "01" / f"rollout-{old_id}.jsonl"
+        _write_rollout(
+            old_rollout,
+            events=[
+                {
+                    "timestamp": "2026-03-01T00:00:00.000Z",
+                    "type": "session_meta",
+                    "payload": {"model_provider": "anthropic"},
+                },
+            ],
+        )
+
+        archived_id = "019cccc0-0000-0000-0000-000000000002"
+        archived_rollout = home / "sessions" / "2026" / "04" / "01" / f"rollout-{archived_id}.jsonl"
+        _write_rollout(
+            archived_rollout,
+            events=[
+                {
+                    "timestamp": "2026-04-01T00:00:00.000Z",
+                    "type": "session_meta",
+                    "payload": {"model_provider": "openai"},
+                },
+            ],
+        )
+
+        secret_titled_id = "019e3222-9999-7920-90f4-203877f24690"
+        secret_rollout = (
+            home / "sessions" / "2026" / "05" / "16" / f"rollout-{secret_titled_id}.jsonl"
+        )
+        _write_rollout(
+            secret_rollout,
+            events=[
+                {
+                    "timestamp": "2026-05-16T14:00:00.000Z",
+                    "type": "session_meta",
+                    "payload": {"model_provider": "openai"},
+                },
+            ],
+        )
+
+        rows = [
+            (
+                recent_id,
+                str(recent_rollout),
+                ten_minutes_ago,
+                ten_minutes_ago,
+                "vscode",
+                "openai",
+                "/Users/test/repo",
+                "Recent debugging thread",
+                "workspace",
+                "auto",
+                1234,
+                1,
+                0,
+                None,
+                "abc1234",
+                "main",
+                "https://github.com/test/repo",
+                "0.42.0",
+                "Please look at this issue",
+                None,
+                None,
+                "enabled",
+                "gpt-5.4",
+                "medium",
+                None,
+                ten_minutes_ago * 1000,
+                ten_minutes_ago * 1000,
+                "vscode",
+                "Recent debugging thread preview",
+            ),
+            (
+                secret_titled_id,
+                str(secret_rollout),
+                ten_minutes_ago,
+                ten_minutes_ago,
+                "vscode",
+                "openai",
+                "/Users/test/repo",
+                "leaked sk-proj-FAKE-LEAK-XYZ thread",
+                "workspace",
+                "auto",
+                500,
+                1,
+                0,
+                None,
+                None,
+                None,
+                None,
+                "0.42.0",
+                "User asked about Bearer ghp_FAKELEAK1234567890ABCD",
+                None,
+                None,
+                "enabled",
+                "claude-opus-4-7",
+                None,
+                None,
+                ten_minutes_ago * 1000,
+                ten_minutes_ago * 1000,
+                "vscode",
+                "secret titled preview",
+            ),
+            (
+                archived_id,
+                str(archived_rollout),
+                one_day_ago,
+                one_day_ago,
+                "vscode",
+                "openai",
+                "/Users/test/archived",
+                "Archived but recent thread",
+                "workspace",
+                "auto",
+                42,
+                1,
+                1,
+                one_day_ago,
+                None,
+                None,
+                None,
+                "0.42.0",
+                "",
+                None,
+                None,
+                "enabled",
+                "gpt-5.4",
+                None,
+                None,
+                one_day_ago * 1000,
+                one_day_ago * 1000,
+                "vscode",
+                "",
+            ),
+            (
+                old_id,
+                str(old_rollout),
+                ten_days_ago,
+                ten_days_ago,
+                "vscode",
+                "anthropic",
+                "/Users/test/repo",
+                "Old thread out of window",
+                "workspace",
+                "auto",
+                100,
+                1,
+                0,
+                None,
+                None,
+                None,
+                None,
+                "0.40.0",
+                "",
+                None,
+                None,
+                "enabled",
+                "claude-opus-4-6",
+                None,
+                None,
+                ten_days_ago * 1000,
+                ten_days_ago * 1000,
+                "vscode",
+                "",
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO threads (
+                id, rollout_path, created_at, updated_at, source, model_provider,
+                cwd, title, sandbox_policy, approval_mode, tokens_used,
+                has_user_event, archived, archived_at, git_sha, git_branch,
+                git_origin_url, cli_version, first_user_message, agent_nickname,
+                agent_role, memory_mode, model, reasoning_effort, agent_path,
+                created_at_ms, updated_at_ms, thread_source, preview
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                      ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    yield FakeCodexHome(
+        home=home,
+        recent_thread_id=recent_id,
+        recent_rollout=recent_rollout,
+        archived_thread_id=archived_id,
+        old_thread_id=old_id,
+        secret_titled_thread_id=secret_titled_id,
+    )

--- a/tests/codex/test_cli_codex_sessions.py
+++ b/tests/codex/test_cli_codex_sessions.py
@@ -1,0 +1,168 @@
+"""CLI surface tests for ``aragora codex sessions {list,show}``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands import codex_sessions as cli
+
+
+def _args(**kwargs) -> argparse.Namespace:  # type: ignore[no-untyped-def]
+    base = {
+        "codex_home": None,
+        "json": False,
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+# -- list ---------------------------------------------------------------------
+
+
+def test_cli_list_table_output(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_list(_args(since="4h", include_archived=False, limit=50))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert fake_codex_home.recent_thread_id[:12] in out
+    assert "AGO" in out  # table header
+    assert "TITLE" in out
+    # archived excluded by default
+    assert fake_codex_home.archived_thread_id[:12] not in out
+
+
+def test_cli_list_json_output(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_list(_args(since="4h", include_archived=False, limit=50, json=True))
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    ids = [row["id"] for row in payload]
+    assert fake_codex_home.recent_thread_id in ids
+
+
+def test_cli_list_redacts_titles(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_list(_args(since="4h", include_archived=False, limit=50))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "sk-proj-FAKE-LEAK-XYZ" not in out
+    assert "ghp_FAKELEAK" not in out
+
+
+def test_cli_list_bad_since(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_list(_args(since="nonsense", include_archived=False, limit=50))
+    assert rc == 2
+    assert "invalid duration" in capsys.readouterr().err
+
+
+# -- show ---------------------------------------------------------------------
+
+
+def test_cli_show_summary_default(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_show(
+        _args(
+            target=fake_codex_home.recent_thread_id,
+            full=False,
+            out="",
+            max_events=2000,
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Rollout:" in out
+    assert "Events:" in out
+    assert "agent_message" in out
+
+
+def test_cli_show_json_summary(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_show(
+        _args(
+            target=fake_codex_home.recent_thread_id,
+            full=False,
+            out="",
+            max_events=2000,
+            json=True,
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["thread"]["id"] == fake_codex_home.recent_thread_id
+    assert "event_type_counts" in payload["summary"]
+
+
+def test_cli_show_full_writes_to_file_by_default(
+    fake_codex_home,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:  # type: ignore[no-untyped-def]
+    # Force --full output under a tmp cwd so we don't pollute the repo's .aragora/.
+    monkeypatch.chdir(tmp_path)
+    rc = cli.cmd_codex_sessions_show(
+        _args(
+            target=fake_codex_home.recent_thread_id,
+            full=True,
+            out="",
+            max_events=2000,
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    expected = tmp_path / cli.DEFAULT_OUTPUT_ROOT / f"{fake_codex_home.recent_thread_id}.jsonl"
+    assert expected.exists()
+    # CLI emits the destination as it was constructed (relative when DEFAULT_OUTPUT_ROOT is relative).
+    assert "wrote" in out
+    assert f"{fake_codex_home.recent_thread_id}.jsonl" in out
+    content = expected.read_text(encoding="utf-8")
+    assert "sk-proj-FAKE-LEAK-12345" not in content
+    assert "ghp_FAKELEAK12345678901234" not in content
+    # Each line must be valid JSON.
+    for line in content.splitlines():
+        json.loads(line)
+
+
+def test_cli_show_full_to_stdout(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_show(
+        _args(
+            target=fake_codex_home.recent_thread_id,
+            full=True,
+            out="-",
+            max_events=2000,
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "sk-proj-FAKE-LEAK-12345" not in out
+    assert "[REDACTED]" in out
+
+
+def test_cli_show_resolves_rollout_path(
+    fake_codex_home, capsys: pytest.CaptureFixture[str]
+) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_show(
+        _args(
+            target=str(fake_codex_home.recent_rollout),
+            full=False,
+            out="",
+            max_events=2000,
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Rollout:" in out
+
+
+def test_cli_show_unknown_target(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_show(
+        _args(
+            target="ffffffffabcd",
+            full=False,
+            out="",
+            max_events=2000,
+        )
+    )
+    assert rc == 1
+    assert "could not resolve" in capsys.readouterr().err

--- a/tests/codex/test_desktop_inspector.py
+++ b/tests/codex/test_desktop_inspector.py
@@ -1,0 +1,246 @@
+"""Tests for the codex desktop inspector data layer."""
+
+from __future__ import annotations
+
+import inspect as _inspect
+import json
+import sqlite3
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.codex import desktop_inspector as inspector
+from aragora.codex.desktop_paths import resolve
+from aragora.codex.duration import parse_duration
+from aragora.codex.jsonl_stream import iter_jsonl
+from aragora.codex.sqlite_ro import sqlite_ro
+
+
+# -- duration -----------------------------------------------------------------
+
+
+def test_parse_duration_supports_all_units() -> None:
+    assert parse_duration("90s") == timedelta(seconds=90)
+    assert parse_duration("30m") == timedelta(minutes=30)
+    assert parse_duration("4h") == timedelta(hours=4)
+    assert parse_duration("1d") == timedelta(days=1)
+
+
+def test_parse_duration_strips_whitespace() -> None:
+    assert parse_duration("  4h  ") == timedelta(hours=4)
+
+
+def test_parse_duration_rejects_garbage() -> None:
+    for value in ("4", "h", "4hours", "-1h", "", "4.5h"):
+        with pytest.raises(ValueError):
+            parse_duration(value)
+
+
+# -- paths --------------------------------------------------------------------
+
+
+def test_resolve_honors_env_var(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    paths = resolve()
+    assert paths.home == fake_codex_home.home
+    assert paths.sqlite_path == fake_codex_home.home / "state_5.sqlite"
+    assert paths.sessions_root == fake_codex_home.home / "sessions"
+    assert paths.global_state_path.name == ".codex-global-state.json"
+
+
+# -- jsonl stream -------------------------------------------------------------
+
+
+def test_iter_jsonl_is_streaming() -> None:
+    assert _inspect.isgeneratorfunction(iter_jsonl)
+
+
+def test_iter_jsonl_skips_blank_lines(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.jsonl"
+    sample.write_text('{"a":1}\n\n{"b":2}\n', encoding="utf-8")
+    assert list(iter_jsonl(sample)) == [{"a": 1}, {"b": 2}]
+
+
+def test_iter_jsonl_raises_with_line_context(tmp_path: Path) -> None:
+    sample = tmp_path / "bad.jsonl"
+    sample.write_text('{"a":1}\nnot json\n', encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError) as excinfo:
+        list(iter_jsonl(sample))
+    assert "bad.jsonl:2" in excinfo.value.msg
+
+
+def test_iter_jsonl_non_strict_stops_at_partial_line(tmp_path: Path) -> None:
+    sample = tmp_path / "partial.jsonl"
+    sample.write_text('{"a":1}\n{"partial":', encoding="utf-8")
+    assert list(iter_jsonl(sample, strict=False)) == [{"a": 1}]
+
+
+# -- sqlite read-only ---------------------------------------------------------
+
+
+def test_sqlite_ro_rejects_writes(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    with sqlite_ro(fake_codex_home.home / "state_5.sqlite") as conn:
+        with pytest.raises(sqlite3.OperationalError) as excinfo:
+            conn.execute(
+                "INSERT INTO threads (id, rollout_path, created_at, updated_at, source,"
+                " model_provider, cwd, title, sandbox_policy, approval_mode) VALUES"
+                " (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("x", "x", 0, 0, "s", "p", "c", "t", "sp", "ap"),
+            )
+        assert "readonly" in str(excinfo.value).lower()
+
+
+# -- inspector listing --------------------------------------------------------
+
+
+def test_list_active_threads_default_window(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    threads = inspector.list_active_threads(since=timedelta(hours=4))
+    ids = [t.id for t in threads]
+    assert fake_codex_home.recent_thread_id in ids
+    assert fake_codex_home.secret_titled_thread_id in ids
+    assert fake_codex_home.archived_thread_id not in ids  # archived excluded by default
+    assert fake_codex_home.old_thread_id not in ids
+
+
+def test_list_active_threads_window_excludes_older(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    threads = inspector.list_active_threads(since=timedelta(minutes=5))
+    ids = [t.id for t in threads]
+    # 10-minute-old threads should be outside a 5-minute window.
+    assert fake_codex_home.recent_thread_id not in ids
+
+
+def test_list_active_threads_include_archived(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    threads = inspector.list_active_threads(since=timedelta(days=2), include_archived=True)
+    ids = [t.id for t in threads]
+    assert fake_codex_home.archived_thread_id in ids
+
+
+def test_list_active_threads_redacts_secrets_in_title_and_message(
+    fake_codex_home,
+) -> None:  # type: ignore[no-untyped-def]
+    threads = inspector.list_active_threads(since=timedelta(hours=4))
+    secret_thread = next(t for t in threads if t.id == fake_codex_home.secret_titled_thread_id)
+    assert "sk-proj-FAKE-LEAK-XYZ" not in secret_thread.title
+    assert "[REDACTED]" in secret_thread.title
+    assert "ghp_FAKELEAK" not in secret_thread.first_user_message
+
+
+# -- inspector summarize ------------------------------------------------------
+
+
+def test_summarize_session_counts_events_and_tools(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    summary = inspector.summarize_session(fake_codex_home.recent_rollout)
+    assert summary.event_type_counts.get("agent_message") == 2
+    assert summary.event_type_counts.get("tool_call") == 1
+    assert summary.event_type_counts.get("session_meta") == 1
+    assert summary.tool_call_counts.get("Read") == 1
+    assert summary.model_provider == "openai"
+    assert summary.first_user_message
+    assert summary.last_user_message
+
+
+def test_summarize_session_redacts_user_messages(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    summary = inspector.summarize_session(fake_codex_home.recent_rollout)
+    combined = summary.first_user_message + " " + summary.last_user_message
+    assert "sk-proj-FAKE-LEAK-12345" not in combined
+    assert "ghp_FAKELEAK12345678901234" not in combined
+    assert "[REDACTED]" in combined
+
+
+def test_summarize_session_truncates_to_max_events(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    # max_events of 2 should mark truncated and stop reporting later events.
+    summary = inspector.summarize_session(fake_codex_home.recent_rollout, max_events=2)
+    assert summary.truncated is True
+    assert summary.events_scanned == 2
+
+
+def test_summarize_session_tolerates_partial_trailing_line(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    with fake_codex_home.recent_rollout.open("a", encoding="utf-8") as handle:
+        handle.write('{"type": "agent_message", "payload":')
+    summary = inspector.summarize_session(fake_codex_home.recent_rollout)
+    assert summary.event_type_counts.get("agent_message") == 2
+
+
+# -- inspector full event stream ---------------------------------------------
+
+
+def test_iter_session_events_redacts_by_default(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    events = list(inspector.iter_session_events(fake_codex_home.recent_rollout))
+    serialized = json.dumps(events, default=str)
+    assert "sk-proj-FAKE-LEAK-12345" not in serialized
+    assert "ghp_FAKELEAK12345678901234" not in serialized
+    assert "Bearer ghp_FAKELEAK12345678901234" not in serialized
+
+
+def test_iter_session_events_tolerates_partial_trailing_line(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    with fake_codex_home.recent_rollout.open("a", encoding="utf-8") as handle:
+        handle.write('{"type": "agent_message", "payload":')
+    events = list(inspector.iter_session_events(fake_codex_home.recent_rollout))
+    assert len(events) == 6
+
+
+def test_iter_session_events_from_offset_uses_raw_offsets(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    rollout = fake_codex_home.recent_rollout
+    first_line_len = len(rollout.read_text(encoding="utf-8").splitlines()[0]) + 1
+    events = list(inspector.iter_session_events_from_offset(rollout, offset=first_line_len))
+    assert events
+    assert events[0][0]["type"] == "turn_start"
+    assert events[-1][1] == rollout.stat().st_size
+
+
+def test_iter_session_events_opt_out_returns_raw(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    events = list(inspector.iter_session_events(fake_codex_home.recent_rollout, redact=False))
+    serialized = json.dumps(events, default=str)
+    # Opt-out is honored — secrets pass through. This proves redaction is *doing*
+    # something and is not a no-op.
+    assert "sk-proj-FAKE-LEAK-12345" in serialized
+
+
+# -- find_thread --------------------------------------------------------------
+
+
+def test_find_thread_accepts_prefix(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    prefix = fake_codex_home.recent_thread_id[:8]
+    thread = inspector.find_thread(prefix)
+    assert thread is not None
+    assert thread.id == fake_codex_home.recent_thread_id
+
+
+def test_find_thread_rejects_short_prefix(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    assert inspector.find_thread("abc") is None
+
+
+def test_find_thread_returns_none_on_miss(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    assert inspector.find_thread("ffffffff-ffff-ffff-ffff-ffffffffffff") is None
+
+
+# -- safety: no network imports in this package ------------------------------
+
+
+def test_codex_package_has_no_network_or_provider_imports() -> None:
+    package_root = Path(inspector.__file__).resolve().parent
+    forbidden = (
+        "import httpx",
+        "import requests",
+        "import openai",
+        "import anthropic",
+        "from openai",
+        "from anthropic",
+        "from urllib.request",
+    )
+    for source in package_root.glob("*.py"):
+        text = source.read_text(encoding="utf-8")
+        for term in forbidden:
+            assert term not in text, f"{source.name} should not contain {term!r}"
+
+
+# -- safety: read-only contract on home directory ----------------------------
+
+
+def test_inspector_does_not_modify_home(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    pre_mtimes = {p: p.stat().st_mtime_ns for p in fake_codex_home.home.rglob("*") if p.is_file()}
+    inspector.list_active_threads(since=timedelta(hours=4))
+    inspector.summarize_session(fake_codex_home.recent_rollout)
+    list(inspector.iter_session_events(fake_codex_home.recent_rollout))
+    post_mtimes = {p: p.stat().st_mtime_ns for p in fake_codex_home.home.rglob("*") if p.is_file()}
+    assert pre_mtimes == post_mtimes


### PR DESCRIPTION
Adds a local-only, read-only Codex Desktop session inspector under `aragora codex sessions`.

Scope:
- Discovers Codex Desktop thread metadata from local `~/.codex/state_5.sqlite` using read-only SQLite mode.
- Summarizes and exports rollout JSONL sessions from local Codex session files.
- Supports last-window filtering via `--since`, JSON output for automation, and full transcript export via `show --full`.
- Full transcript output defaults to a local file under `.aragora/codex_sessions/`; stdout is used for summaries/JSON unless `--out -` is explicitly passed.
- Redaction is enabled by default for displayed/exported content. The CLI does not expose a `--no-redact` flag.

Security / privacy boundaries:
- Local filesystem only; no network calls, no provider API calls, no raw API key exports.
- No process killing, no worktree deletion, no branch deletion, no GitHub mutation.
- Reads `~/.codex`; does not write to `~/.codex`.
- Tolerates missing targets and partially-written rollout JSONL files without crashing the inspector path.
- Draft intentionally: full session content is sensitive even when redacted, so this should receive model/security review before being marked ready.

Validation:
```sh
python3 -m pytest tests/codex -q  # 36 passed
python3 -m aragora.cli.main codex sessions --help
python3 -m aragora.cli.main codex sessions list --since 24h --limit 20 --json
python3 -m aragora.cli.main codex sessions show <local-session-id> --json
python3 -m aragora.cli.main codex sessions show <local-session-id> --full --out /tmp/codex-sessions-dogfood-full.jsonl
python3 -m ruff check aragora/codex aragora/cli/commands/codex_sessions.py tests/codex
python3 -m ruff format --check aragora/codex aragora/cli/commands/codex_sessions.py tests/codex
python3 -m mypy aragora/codex aragora/cli/commands/codex_sessions.py tests/codex --ignore-missing-imports --no-incremental --cache-dir /tmp/mypy-codex-desktop-inspector
python3 scripts/generate_cli_reference.py --check
python3 scripts/check_capability_matrix_sync.py
python3 scripts/regenerate_metrics.py --check
python3 scripts/reconcile_status_docs.py --strict --output /tmp/codex-desktop-inspector-reconciliation.md
bash scripts/automation_pr_preflight.sh origin/main HEAD
```

Dogfood redaction smoke on a real local rollout wrote 13 redacted events / 141421 bytes to `/tmp/codex-sessions-dogfood-full.jsonl`; precise token-like checks for OpenAI project keys, OpenRouter keys, long generic `sk-` keys, GitHub tokens, AWS access keys, and Bearer tokens all returned 0 matches.
