### PR TITLE
fix(automation): detect squash-merged publisher branches

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -262,6 +262,24 @@ def _branch_is_merged(repo_root: Path, base: str, branch: str) -> bool:
 
 
 def _branch_patch_equivalent_to_base(repo_root: Path, base: str, branch: str) -> bool:
+    diff_proc = _run(["git", "diff", "--quiet", f"{base}...{branch}", "--"], cwd=repo_root)
+    if diff_proc.returncode == 0:
+        return True
+    if diff_proc.returncode != 1:
+        return False
+
+    paths_proc = _run(["git", "diff", "--name-only", "-z", f"{base}...{branch}"], cwd=repo_root)
+    if paths_proc.returncode == 0:
+        paths = [path for path in paths_proc.stdout.split("\0") if path]
+        if not paths:
+            return True
+        changed_files_proc = _run(
+            ["git", "diff", "--quiet", f"{base}..{branch}", "--", *paths],
+            cwd=repo_root,
+        )
+        if changed_files_proc.returncode == 0:
+            return True
+
     proc = _run(["git", "cherry", base, branch], cwd=repo_root)
     if proc.returncode != 0:
         return False

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -92,6 +92,31 @@ def test_duplicate_patch_branches_skips_older_candidate(tmp_path: Path) -> None:
     assert duplicates == {"codex/older"}
 
 
+def test_branch_patch_equivalent_to_base_detects_squash_merged_content(
+    tmp_path: Path,
+) -> None:
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.email", "codex@example.invalid")
+    _git(tmp_path, "config", "user.name", "Codex")
+    (tmp_path / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(tmp_path, "add", "file.txt")
+    _git(tmp_path, "commit", "-m", "base")
+
+    _git(tmp_path, "checkout", "-b", "codex/already-squashed")
+    (tmp_path / "file.txt").write_text("base\nbranch change\n", encoding="utf-8")
+    _git(tmp_path, "commit", "-am", "branch change")
+
+    _git(tmp_path, "checkout", "main")
+    (tmp_path / "file.txt").write_text("base\nbranch change\n", encoding="utf-8")
+    _git(tmp_path, "commit", "-am", "squash merge equivalent")
+
+    assert mod._branch_patch_equivalent_to_base(
+        tmp_path,
+        "main",
+        "codex/already-squashed",
+    )
+
+
 def test_select_publishable_branches_marks_recent_clean_branch_eligible() -> None:
     decisions = select_publishable_branches(
         [_branch("codex/recent-fix")],


### PR DESCRIPTION
## Summary
- treat publisher branches as patch-equivalent when their touched files already match the current base, matching backlog-audit semantics
- prevent already-squash-merged automation work from being republished under a different local branch name
- add a regression test for squash-merged content with different commit identity

## Validation
- pytest tests/scripts/test_publish_codex_automation_branches.py -q
- ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- ruff format --check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/publish_codex_automation_branches.py --repo /Users/armand/Development/aragora --base origin/main --branch codex/pr7234-harvest-work --limit 1 --json