### PR TITLE
test(swarm): record A2 admission productization

### DIFF
--- a/docs/benchmarks/rescue_productization.json
+++ b/docs/benchmarks/rescue_productization.json
@@ -7,6 +7,13 @@
       "target": "#5327",
       "target_kind": "issue",
       "title": "RS-07 Add a receipt-backed contract preflight path for safe admission"
+    },
+    {
+      "class": "admission_class_corpus_synthesis_v1",
+      "notes": "A2 admission-class productization for #7209: PR-1 landed via #7225 and was repaired by #7228. Corpus-aware dispatch upgrades known rev-4 corpus issues under ARAGORA_CORPUS_AWARE_DISPATCH while dispatch contract gating exposes missing credential-envelope slices as blocked_auth_failure before preflight receipt execution.",
+      "target": "#7209",
+      "target_kind": "issue",
+      "title": "A2 Productize rev-4 admission-class failures"
     }
   ]
 }

--- a/tests/swarm/test_dispatch_contract_gate.py
+++ b/tests/swarm/test_dispatch_contract_gate.py
@@ -473,8 +473,10 @@ class TestDispatchContractGate:
             "mission_context_policies": spec.mission_context_policies,
         }
 
-    def test_missing_slices_returns_blocked_outcome(self, tmp_path) -> None:
-        """Missing credential slices block dispatch before preflight."""
+    def test_missing_slices_short_circuits_as_auth_failure_without_preflight(
+        self, tmp_path
+    ) -> None:
+        """Missing credential slices block dispatch before preflight receipts run."""
         loop = _make_loop()
         issue = _make_issue(20)
         spec = MagicMock()
@@ -488,11 +490,16 @@ class TestDispatchContractGate:
                 return_value=_make_valid_contract_mock(),
             ),
             patch(
+                "aragora.swarm.dispatch_contract_gate.run_contract_preflight_receipt"
+            ) as mock_preflight_receipt,
+            patch(
                 "aragora.swarm.dispatch_contract_gate.CredentialEnvelope.from_environment"
             ) as mock_env,
         ):
             mock_env.return_value.missing_slices.return_value = ["runner"]
-            mock_env.return_value.preflight_cache_payload.return_value = {}
+            mock_env.return_value.preflight_cache_payload.return_value = {
+                "runner": {"available": False}
+            }
 
             result = dispatch_contract_gate(
                 loop,
@@ -506,8 +513,13 @@ class TestDispatchContractGate:
 
         assert result is not None
         assert result["status"] == "needs_human"
+        assert result["outcome"] == "blocked_auth_failure"
+        assert result["dispatch_contract"]["credential_envelope"] == {
+            "runner": {"available": False}
+        }
         assert "runner" in result["dispatch_contract"]["missing_slices"]
-        assert result["outcome"] in {"blocked_auth_failure", "blocked", "blocked_no_runner"}
+        assert result["dispatch_contract"]["preflight_receipts"] == []
+        mock_preflight_receipt.assert_not_called()
 
     def test_invalid_contract_returns_blocked_dict(self, tmp_path) -> None:
         """Contract admission_check=False → blocked gate dict."""

--- a/tests/swarm/test_terminal_truth_benchmark.py
+++ b/tests/swarm/test_terminal_truth_benchmark.py
@@ -25,6 +25,7 @@ from aragora.swarm.terminal_truth import (
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 FIXTURES_DIR = REPO_ROOT / "benchmarks" / "fixtures" / "swarm" / "terminal_truth"
 SCORE_SCRIPT = REPO_ROOT / "scripts" / "score_benchmark.py"
+RESCUE_PRODUCTIZATION_PATH = REPO_ROOT / "docs" / "benchmarks" / "rescue_productization.json"
 
 # Collect fixture files for parametrization
 _fixture_files = sorted(FIXTURES_DIR.glob("*.json")) if FIXTURES_DIR.is_dir() else []
@@ -101,6 +102,22 @@ def test_fixtures_cover_all_families() -> None:
             tc = classify_from_metrics(row)
             families.add(tc.family)
     assert families == {"success", "rescue", "blocked"}
+
+
+def test_rescue_productization_records_admission_class_corpus_synthesis() -> None:
+    """The #7209 admission-class rescue has a durable productization ledger entry."""
+    with RESCUE_PRODUCTIZATION_PATH.open() as fh:
+        payload = json.load(fh)
+
+    entries = payload["entries"]
+    classes = [entry["class"] for entry in entries]
+    assert len(classes) == len(set(classes))
+
+    entry = next(item for item in entries if item["class"] == "admission_class_corpus_synthesis_v1")
+    assert entry["target"] == "#7209"
+    assert entry["target_kind"] == "issue"
+    assert "#7225" in entry["notes"]
+    assert "#7228" in entry["notes"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- records the #7209 A2 admission-class productization in `docs/benchmarks/rescue_productization.json`
- hardens the dispatch-contract regression so missing credential slices produce `blocked_auth_failure` and short-circuit before preflight receipt execution
- adds a benchmark-ledger test proving the `admission_class_corpus_synthesis_v1` entry stays present and unique

## Validation
- `python3 -m pytest tests/swarm/test_dispatch_contract_gate.py tests/swarm/test_terminal_truth_benchmark.py -q` (64 passed)
- `python3 -m pytest tests/swarm/test_dispatch_followups.py tests/swarm/test_dispatch_contract_gate.py tests/swarm/test_terminal_truth_benchmark.py -q` (91 passed)
- `python3 -m json.tool docs/benchmarks/rescue_productization.json >/tmp/rescue_productization.json`
- `python3 -m ruff check tests/swarm/test_dispatch_contract_gate.py tests/swarm/test_terminal_truth_benchmark.py`
- `python3 -m ruff format --check tests/swarm/test_dispatch_contract_gate.py tests/swarm/test_terminal_truth_benchmark.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Non-claims
- Does not run H2 panels.
- Does not run `observe-outcomes --write`.
- Does not enable corpus-aware dispatch by default.
- Does not change AGT/DIC/Flywheel runtime substrate.
