### PR TITLE
feat(codex): activity-intelligence layer with signed digest receipts

### DIFF
--- a/aragora/cli/commands/codex_insights.py
+++ b/aragora/cli/commands/codex_insights.py
@@ -196,13 +196,24 @@ def cmd_codex_insights_digest(args: argparse.Namespace) -> int:
             if digest.hmac_sha256
             else "unsigned (ARAGORA_CONTEXT_SIGNING_KEY not set)"
         )
-        print(f"wrote {target} (sha256={digest.sha256[:12]}..., {signing_note})")
+        km_result: dict[str, Any] | None = None
         if args.ingest_km:
             ok, detail = ingest_digest_into_km(target)
-            if ok:
-                print(f"km: ingested ({detail})")
-            else:
-                print(f"km: skipped — {detail}", file=sys.stderr)
+            km_result = {"ok": ok, "detail": detail}
+        if args.json:
+            payload = digest.to_dict()
+            payload["receipt_path"] = str(target)
+            payload["signing_note"] = signing_note
+            if km_result is not None:
+                payload["km_ingest"] = km_result
+            _emit_json(payload)
+        else:
+            print(f"wrote {target} (sha256={digest.sha256[:12]}..., {signing_note})")
+            if km_result is not None:
+                if km_result["ok"]:
+                    print(f"km: ingested ({km_result['detail']})")
+                else:
+                    print(f"km: skipped — {km_result['detail']}", file=sys.stderr)
     else:
         if args.json:
             _emit_json(digest.to_dict())

--- a/aragora/cli/commands/codex_insights.py
+++ b/aragora/cli/commands/codex_insights.py
@@ -1,0 +1,211 @@
+"""CLI handlers for ``aragora codex insights {summary, anomalies, crossref, digest}``.
+
+Analysis layer over the read-only Codex Desktop inspector. Read-only with one
+opt-in write: ``digest --emit-receipt`` writes a signed JSON document under
+``.aragora/codex_insights/``.
+
+Heavy imports deferred to invocation time (matches ``aragora/cli/backup.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _parse_since(value: str):  # type: ignore[no-untyped-def]
+    from aragora.codex.duration import parse_duration
+
+    return parse_duration(value)
+
+
+def _resolve_paths(args: argparse.Namespace):  # type: ignore[no-untyped-def]
+    from aragora.codex.desktop_paths import resolve
+
+    return resolve(getattr(args, "codex_home", None))
+
+
+def _emit_json(payload: Any) -> None:
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True, default=str)
+    sys.stdout.write("\n")
+
+
+def _format_kv_block(title: str, items: dict[str, Any]) -> str:
+    if not items:
+        return f"{title}: (empty)"
+    lines = [title + ":"]
+    for key in sorted(
+        items, key=lambda k: -float(items[k]) if isinstance(items[k], (int, float)) else 0
+    ):
+        lines.append(f"    {items[key]!s:>10}  {key}")
+    return "\n".join(lines)
+
+
+def cmd_codex_insights_summary(args: argparse.Namespace) -> int:
+    """Aggregate session patterns across the analyzed window."""
+    from aragora.codex.insights import summarize_patterns
+
+    try:
+        since = _parse_since(args.since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    paths = _resolve_paths(args)
+    if not paths.sqlite_path.exists():
+        print(
+            f"error: Codex Desktop state DB not found at {paths.sqlite_path}",
+            file=sys.stderr,
+        )
+        return 1
+    pattern, pairs = summarize_patterns(
+        since=since,
+        include_archived=args.include_archived,
+        paths=paths,
+    )
+    if args.json:
+        _emit_json(
+            {
+                "patterns": pattern.to_dict(),
+                "thread_count": len(pairs),
+            }
+        )
+        return 0
+    print(f"Window:    {since} ({len(pairs)} threads scanned)")
+    print(f"Tokens:    {pattern.total_tokens_used:,}")
+    print(f"Distinct cwds: {pattern.distinct_cwds}")
+    print(
+        f"Duration:  p50={pattern.duration_seconds_p50:.1f}s  p95={pattern.duration_seconds_p95:.1f}s"
+    )
+    print(f"Abandoned: {pattern.abandoned_count} (silent rollouts > 10m)")
+    print(_format_kv_block("Models", pattern.model_distribution))
+    print(_format_kv_block("Tool calls", pattern.tool_call_distribution))
+    return 0
+
+
+def cmd_codex_insights_anomalies(args: argparse.Namespace) -> int:
+    """Detect stuck / runaway / over-budget sessions."""
+    from aragora.codex.insights import detect_anomalies, summarize_patterns
+
+    try:
+        since = _parse_since(args.since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    paths = _resolve_paths(args)
+    if not paths.sqlite_path.exists():
+        print(
+            f"error: Codex Desktop state DB not found at {paths.sqlite_path}",
+            file=sys.stderr,
+        )
+        return 1
+    _, pairs = summarize_patterns(
+        since=since,
+        include_archived=args.include_archived,
+        paths=paths,
+    )
+    anomalies = detect_anomalies(
+        pairs,
+        token_cap=args.token_cap,
+        runaway_tool_calls=args.runaway_tool_calls,
+        stuck_turn_minutes=args.stuck_turn_minutes,
+    )
+    if args.json:
+        _emit_json([a.to_dict() for a in anomalies])
+        return 0
+    if not anomalies:
+        print(f"(no anomalies in last {since})")
+        return 0
+    print(f"{len(anomalies)} anomalies in last {since}:\n")
+    for a in anomalies:
+        print(f"  [{a.severity.upper():6}] {a.kind:24}  {a.thread_id[:12]}")
+        print(f"           {a.detail}")
+    return 0
+
+
+def cmd_codex_insights_crossref(args: argparse.Namespace) -> int:
+    """Cross-reference active sessions to PR/issue references found in metadata."""
+    from aragora.codex.insights import crossref_work_board, summarize_patterns
+
+    try:
+        since = _parse_since(args.since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    paths = _resolve_paths(args)
+    if not paths.sqlite_path.exists():
+        print(
+            f"error: Codex Desktop state DB not found at {paths.sqlite_path}",
+            file=sys.stderr,
+        )
+        return 1
+    _, pairs = summarize_patterns(
+        since=since,
+        include_archived=args.include_archived,
+        paths=paths,
+    )
+    crossref = crossref_work_board(pairs)
+    if args.json:
+        _emit_json([c.to_dict() for c in crossref])
+        return 0
+    print(f"Cross-references for last {since}:\n")
+    for c in crossref:
+        if not c.pr_references and not c.issue_references and not c.git_branch:
+            continue
+        refs = sorted(set(c.pr_references) | set(c.issue_references))
+        print(f"  {c.thread_id[:12]}  branch={c.git_branch or '-'}  refs={','.join(refs) or '-'}")
+    return 0
+
+
+def cmd_codex_insights_digest(args: argparse.Namespace) -> int:
+    """Build a complete digest. With --emit-receipt, persist to disk."""
+    from aragora.codex.insights import (
+        build_digest,
+        ingest_digest_into_km,
+        persist_digest,
+    )
+
+    try:
+        since = _parse_since(args.since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    paths = _resolve_paths(args)
+    if not paths.sqlite_path.exists():
+        print(
+            f"error: Codex Desktop state DB not found at {paths.sqlite_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    digest = build_digest(
+        since=since,
+        include_archived=args.include_archived,
+        paths=paths,
+    )
+
+    if args.emit_receipt:
+        target = persist_digest(
+            digest,
+            root=Path(args.receipt_dir) if args.receipt_dir else None,
+        )
+        signing_note = (
+            f"signed (hmac_sha256={digest.hmac_sha256[:12]}...)"
+            if digest.hmac_sha256
+            else "unsigned (ARAGORA_CONTEXT_SIGNING_KEY not set)"
+        )
+        print(f"wrote {target} (sha256={digest.sha256[:12]}..., {signing_note})")
+        if args.ingest_km:
+            ok, detail = ingest_digest_into_km(target)
+            if ok:
+                print(f"km: ingested ({detail})")
+            else:
+                print(f"km: skipped — {detail}", file=sys.stderr)
+    else:
+        if args.json:
+            _emit_json(digest.to_dict())
+        else:
+            print(json.dumps(digest.to_dict(), indent=2, sort_keys=True, default=str))
+    return 0

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -3263,6 +3263,104 @@ def _add_codex_parser(subparsers) -> None:
         func=_lazy("aragora.cli.commands.codex_sessions", "cmd_codex_sessions_tail")
     )
 
+    insights = codex_sub.add_parser(
+        "insights",
+        help="Analyze Codex Desktop activity (patterns, anomalies, digests)",
+        description=(
+            "Read-only analysis over the inspector: aggregate patterns, detect "
+            "anomalies (runaway / stuck / over-budget), cross-reference work, "
+            "and emit signed daily digest receipts."
+        ),
+    )
+    insights_sub = insights.add_subparsers(dest="codex_insights_cmd")
+
+    def add_insights_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--codex-home",
+            default=None,
+            help="Override Codex Desktop home dir (default: $ARAGORA_CODEX_HOME or ~/.codex)",
+        )
+        p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+        p.add_argument(
+            "--since",
+            default="4h",
+            help="Time window (e.g. 30m, 4h, 1d). Default: 4h.",
+        )
+        p.add_argument(
+            "--include-archived",
+            action="store_true",
+            help="Include archived threads (default: exclude)",
+        )
+
+    summary_cmd = insights_sub.add_parser(
+        "summary",
+        help="Aggregate session patterns (models, tool calls, durations, abandoned count)",
+    )
+    add_insights_common(summary_cmd)
+    summary_cmd.set_defaults(
+        func=_lazy("aragora.cli.commands.codex_insights", "cmd_codex_insights_summary")
+    )
+
+    anomalies_cmd = insights_sub.add_parser(
+        "anomalies",
+        help="Flag stuck / runaway / over-budget sessions",
+    )
+    add_insights_common(anomalies_cmd)
+    anomalies_cmd.add_argument(
+        "--token-cap",
+        type=int,
+        default=100_000,
+        help="Flag sessions with tokens_used >= this value (default: 100000)",
+    )
+    anomalies_cmd.add_argument(
+        "--runaway-tool-calls",
+        type=int,
+        default=200,
+        help="Flag sessions with >= this many tool calls in the scanned window (default: 200)",
+    )
+    anomalies_cmd.add_argument(
+        "--stuck-turn-minutes",
+        type=int,
+        default=5,
+        help="Flag sessions whose last event is a turn_start silent for > N minutes (default: 5)",
+    )
+    anomalies_cmd.set_defaults(
+        func=_lazy("aragora.cli.commands.codex_insights", "cmd_codex_insights_anomalies")
+    )
+
+    crossref_cmd = insights_sub.add_parser(
+        "crossref",
+        help="Map sessions to PR/issue references found in their metadata",
+    )
+    add_insights_common(crossref_cmd)
+    crossref_cmd.set_defaults(
+        func=_lazy("aragora.cli.commands.codex_insights", "cmd_codex_insights_crossref")
+    )
+
+    digest_cmd = insights_sub.add_parser(
+        "digest",
+        help="Build (and optionally persist + KM-ingest) a full daily digest",
+    )
+    add_insights_common(digest_cmd)
+    digest_cmd.add_argument(
+        "--emit-receipt",
+        action="store_true",
+        help="Write the digest JSON to .aragora/codex_insights/digest-<ts>.json",
+    )
+    digest_cmd.add_argument(
+        "--receipt-dir",
+        default=None,
+        help="Override receipt output directory (default: .aragora/codex_insights/)",
+    )
+    digest_cmd.add_argument(
+        "--ingest-km",
+        action="store_true",
+        help="After --emit-receipt, ingest into Aragora KM via 'aragora km store' (best-effort)",
+    )
+    digest_cmd.set_defaults(
+        func=_lazy("aragora.cli.commands.codex_insights", "cmd_codex_insights_digest")
+    )
+
 
 def _add_swarm_parser(subparsers) -> None:
     """Add the 'swarm' subcommand for swarm commander."""

--- a/aragora/codex/insights.py
+++ b/aragora/codex/insights.py
@@ -21,6 +21,7 @@ from .desktop_inspector import (
     SessionSummary,
     ThreadSummary,
     list_active_threads,
+    redact_display,
     summarize_session,
 )
 from .desktop_paths import CodexDesktopPaths
@@ -148,6 +149,10 @@ def _is_abandoned(thread: ThreadSummary, summary: SessionSummary, *, now: dateti
     return silence_seconds > 600
 
 
+def _redacted_path(value: Path) -> str:
+    return redact_display(value) or ""
+
+
 def summarize_patterns(
     *,
     since: timedelta,
@@ -231,7 +236,7 @@ def detect_anomalies(
             anomalies.append(
                 Anomaly(
                     thread_id=thread.id,
-                    rollout_path=str(summary.rollout_path),
+                    rollout_path=_redacted_path(summary.rollout_path),
                     kind="runaway_tool_calls",
                     severity="high",
                     detail=(
@@ -251,7 +256,7 @@ def detect_anomalies(
             anomalies.append(
                 Anomaly(
                     thread_id=thread.id,
-                    rollout_path=str(summary.rollout_path),
+                    rollout_path=_redacted_path(summary.rollout_path),
                     kind="token_cap_exceeded",
                     severity="medium",
                     detail=(f"tokens_used={thread.tokens_used} >= cap={token_cap}"),
@@ -278,7 +283,7 @@ def detect_anomalies(
             anomalies.append(
                 Anomaly(
                     thread_id=thread.id,
-                    rollout_path=str(summary.rollout_path),
+                    rollout_path=_redacted_path(summary.rollout_path),
                     kind="stuck_turn",
                     severity="medium",
                     detail=(
@@ -347,7 +352,7 @@ def crossref_work_board(
         crossrefs.append(
             WorkCrossref(
                 thread_id=thread.id,
-                rollout_path=str(summary.rollout_path),
+                rollout_path=_redacted_path(summary.rollout_path),
                 cwd=thread.cwd,
                 git_branch=thread.git_branch,
                 pr_references=tuple(sorted(set(pr_refs))),
@@ -396,7 +401,7 @@ def build_digest(
     inspector_summaries = tuple(
         {
             "thread_id": t.id,
-            "rollout_path": str(s.rollout_path),
+            "rollout_path": _redacted_path(s.rollout_path),
             "events_scanned": s.events_scanned,
             "truncated": s.truncated,
             "event_type_counts": dict(s.event_type_counts),

--- a/aragora/codex/insights.py
+++ b/aragora/codex/insights.py
@@ -1,0 +1,493 @@
+"""Analysis layer over the read-only Codex Desktop inspector.
+
+Aggregates inspector data into operator-actionable signals: patterns,
+anomalies, work-board cross-references, and signed daily digests. All
+operations are read-only; the only writes this module performs go under
+``.aragora/codex_insights/`` (aragora workspace) for digest receipts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from .desktop_inspector import (
+    SessionSummary,
+    ThreadSummary,
+    list_active_threads,
+    summarize_session,
+)
+from .desktop_paths import CodexDesktopPaths
+
+DEFAULT_RECEIPT_ROOT = Path(".aragora/codex_insights")
+DEFAULT_TOKEN_ANOMALY_THRESHOLD = 100_000
+DEFAULT_REPEATED_TOOL_CALL_THRESHOLD = 5
+DEFAULT_STUCK_TURN_MINUTES = 5
+DEFAULT_RUNAWAY_TOOL_CALLS = 200
+INSPECTOR_SCHEMA_VERSION = "1.0.0"
+
+
+@dataclass(frozen=True, slots=True)
+class SessionPattern:
+    """Aggregate patterns across the analyzed window."""
+
+    window_seconds: int
+    thread_count: int
+    archived_excluded: bool
+    model_distribution: dict[str, int]
+    tool_call_distribution: dict[str, int]
+    total_tokens_used: int
+    distinct_cwds: int
+    duration_seconds_p50: float
+    duration_seconds_p95: float
+    abandoned_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class Anomaly:
+    """One flagged anomaly in a session."""
+
+    thread_id: str
+    rollout_path: str
+    kind: str  # runaway_tool_calls | stuck_turn | token_cap_exceeded | repeated_tool_call
+    severity: str  # low | medium | high
+    detail: str
+    evidence: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkCrossref:
+    """Map of one session to PRs/issues/branches it appears to touch."""
+
+    thread_id: str
+    rollout_path: str
+    cwd: str
+    git_branch: str | None
+    pr_references: tuple[str, ...]
+    issue_references: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "thread_id": self.thread_id,
+            "rollout_path": self.rollout_path,
+            "cwd": self.cwd,
+            "git_branch": self.git_branch,
+            "pr_references": list(self.pr_references),
+            "issue_references": list(self.issue_references),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Digest:
+    """A complete intelligence digest covering a window."""
+
+    schema_version: str
+    window_since: str
+    window_until: str
+    thread_count: int
+    patterns: SessionPattern
+    anomalies: tuple[Anomaly, ...]
+    crossref: tuple[WorkCrossref, ...]
+    inspector_summaries: tuple[dict[str, Any], ...]
+    sha256: str
+    hmac_sha256: str | None = None
+    signed_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "window_since": self.window_since,
+            "window_until": self.window_until,
+            "thread_count": self.thread_count,
+            "patterns": self.patterns.to_dict(),
+            "anomalies": [a.to_dict() for a in self.anomalies],
+            "crossref": [c.to_dict() for c in self.crossref],
+            "inspector_summaries": list(self.inspector_summaries),
+            "sha256": self.sha256,
+            "hmac_sha256": self.hmac_sha256,
+            "signed_at": self.signed_at,
+        }
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    idx = max(0, min(len(sorted_vals) - 1, int(round(pct * (len(sorted_vals) - 1)))))
+    return float(sorted_vals[idx])
+
+
+def _session_duration_seconds(summary: SessionSummary) -> float:
+    if summary.started_at is None or summary.last_event_at is None:
+        return 0.0
+    return max(0.0, (summary.last_event_at - summary.started_at).total_seconds())
+
+
+def _is_abandoned(thread: ThreadSummary, summary: SessionSummary, *, now: datetime) -> bool:
+    """A thread is 'abandoned' if its last event is far behind its updated_at marker.
+
+    Codex Desktop bumps ``updated_at`` on UI focus changes; if the rollout file
+    has been silent for >10 minutes while the thread is still ticking via UI,
+    it suggests the agent stopped emitting work.
+    """
+    if summary.last_event_at is None:
+        return True
+    silence_seconds = (now - summary.last_event_at).total_seconds()
+    return silence_seconds > 600
+
+
+def summarize_patterns(
+    *,
+    since: timedelta,
+    include_archived: bool = False,
+    paths: CodexDesktopPaths | None = None,
+    max_events_per_summary: int = 1500,
+) -> tuple[SessionPattern, list[tuple[ThreadSummary, SessionSummary]]]:
+    """Return aggregate patterns + the per-thread summaries used to build them.
+
+    The second return value is exposed so callers (anomalies, digest) can
+    re-use the same summaries without re-walking each rollout file.
+    """
+    threads = list_active_threads(
+        since=since,
+        include_archived=include_archived,
+        paths=paths,
+    )
+    now = datetime.now(UTC)
+    per_thread: list[tuple[ThreadSummary, SessionSummary]] = []
+    tool_call_counts: Counter[str] = Counter()
+    model_counts: Counter[str] = Counter()
+    durations: list[float] = []
+    abandoned = 0
+    total_tokens = 0
+    cwds: set[str] = set()
+
+    for thread in threads:
+        if not thread.rollout_path.exists():
+            continue
+        summary = summarize_session(thread.rollout_path, max_events=max_events_per_summary)
+        per_thread.append((thread, summary))
+        for name, count in summary.tool_call_counts.items():
+            tool_call_counts[name] += count
+        if thread.model:
+            model_counts[thread.model] += 1
+        durations.append(_session_duration_seconds(summary))
+        if _is_abandoned(thread, summary, now=now):
+            abandoned += 1
+        total_tokens += thread.tokens_used
+        if thread.cwd:
+            cwds.add(thread.cwd)
+
+    pattern = SessionPattern(
+        window_seconds=int(since.total_seconds()),
+        thread_count=len(threads),
+        archived_excluded=not include_archived,
+        model_distribution=dict(model_counts),
+        tool_call_distribution=dict(tool_call_counts),
+        total_tokens_used=total_tokens,
+        distinct_cwds=len(cwds),
+        duration_seconds_p50=_percentile(durations, 0.5),
+        duration_seconds_p95=_percentile(durations, 0.95),
+        abandoned_count=abandoned,
+    )
+    return pattern, per_thread
+
+
+def detect_anomalies(
+    pairs: list[tuple[ThreadSummary, SessionSummary]],
+    *,
+    token_cap: int = DEFAULT_TOKEN_ANOMALY_THRESHOLD,
+    runaway_tool_calls: int = DEFAULT_RUNAWAY_TOOL_CALLS,
+    stuck_turn_minutes: int = DEFAULT_STUCK_TURN_MINUTES,
+) -> list[Anomaly]:
+    """Return a list of anomalies detected across the (thread, summary) pairs.
+
+    Anomalies in order of typical severity:
+    - ``runaway_tool_calls``: aggregate tool calls in window > ``runaway_tool_calls``
+      with no recent user turn
+    - ``stuck_turn``: last event is ``turn_start`` (or similar) with no
+      matching completion and silence exceeds ``stuck_turn_minutes``
+    - ``token_cap_exceeded``: thread.tokens_used > ``token_cap``
+    """
+    now = datetime.now(UTC)
+    anomalies: list[Anomaly] = []
+    stuck_window = timedelta(minutes=stuck_turn_minutes)
+
+    for thread, summary in pairs:
+        total_tool_calls = sum(summary.tool_call_counts.values())
+        if total_tool_calls >= runaway_tool_calls:
+            anomalies.append(
+                Anomaly(
+                    thread_id=thread.id,
+                    rollout_path=str(summary.rollout_path),
+                    kind="runaway_tool_calls",
+                    severity="high",
+                    detail=(
+                        f"{total_tool_calls} tool calls in scanned window "
+                        f"({summary.events_scanned} events, "
+                        f"{'truncated' if summary.truncated else 'complete'})"
+                    ),
+                    evidence={
+                        "tool_call_counts": dict(summary.tool_call_counts),
+                        "events_scanned": summary.events_scanned,
+                        "truncated": summary.truncated,
+                    },
+                )
+            )
+
+        if thread.tokens_used >= token_cap:
+            anomalies.append(
+                Anomaly(
+                    thread_id=thread.id,
+                    rollout_path=str(summary.rollout_path),
+                    kind="token_cap_exceeded",
+                    severity="medium",
+                    detail=(f"tokens_used={thread.tokens_used} >= cap={token_cap}"),
+                    evidence={"tokens_used": thread.tokens_used, "cap": token_cap},
+                )
+            )
+
+        # Stuck-turn heuristic: more turn_starts than turn_completes AND the
+        # session has been silent past the threshold. Using the count delta is
+        # more robust than trying to read "last event type" from aggregate
+        # counts (which only tell us frequency, not order).
+        turn_starts = sum(
+            c for k, c in summary.event_type_counts.items() if k.endswith("turn_start")
+        )
+        turn_completes = sum(
+            c for k, c in summary.event_type_counts.items() if k.endswith("turn_complete")
+        )
+        if (
+            summary.last_event_at is not None
+            and (now - summary.last_event_at) > stuck_window
+            and turn_starts > turn_completes
+        ):
+            silence_min = int((now - summary.last_event_at).total_seconds() // 60)
+            anomalies.append(
+                Anomaly(
+                    thread_id=thread.id,
+                    rollout_path=str(summary.rollout_path),
+                    kind="stuck_turn",
+                    severity="medium",
+                    detail=(
+                        f"last event silence={silence_min}m (threshold={stuck_turn_minutes}m), "
+                        f"turn_starts={turn_starts} > turn_completes={turn_completes}"
+                    ),
+                    evidence={
+                        "last_event_at": summary.last_event_at.isoformat(),
+                        "stuck_threshold_minutes": stuck_turn_minutes,
+                        "turn_starts": turn_starts,
+                        "turn_completes": turn_completes,
+                    },
+                )
+            )
+
+    # Order high → medium → low so operators see the worst first.
+    severity_rank = {"high": 0, "medium": 1, "low": 2}
+    anomalies.sort(key=lambda a: (severity_rank.get(a.severity, 9), a.thread_id))
+    return anomalies
+
+
+_PR_PATTERN = "#"
+
+
+def _scan_pr_issue_refs(text: str) -> tuple[list[str], list[str]]:
+    """Extract simple ``#N`` references from arbitrary text.
+
+    We don't try to distinguish PR vs issue from the bare ``#N`` form since
+    that requires a GitHub round-trip; the caller can disambiguate later via
+    ``gh pr view`` if needed. We return all matches in both lists for now.
+    """
+    refs: list[str] = []
+    if not text:
+        return [], []
+    i = 0
+    while i < len(text):
+        if text[i] == _PR_PATTERN and i + 1 < len(text) and text[i + 1].isdigit():
+            j = i + 1
+            while j < len(text) and text[j].isdigit():
+                j += 1
+            number = text[i + 1 : j]
+            if number and len(number) <= 8:
+                refs.append(f"#{number}")
+            i = j
+        else:
+            i += 1
+    return refs, refs
+
+
+def crossref_work_board(
+    pairs: list[tuple[ThreadSummary, SessionSummary]],
+) -> list[WorkCrossref]:
+    """Cross-reference each session to PR/issue references found in metadata."""
+    crossrefs: list[WorkCrossref] = []
+    for thread, summary in pairs:
+        text = " ".join(
+            [
+                thread.title or "",
+                thread.first_user_message or "",
+                summary.first_user_message or "",
+                summary.last_user_message or "",
+                thread.git_branch or "",
+            ]
+        )
+        pr_refs, issue_refs = _scan_pr_issue_refs(text)
+        crossrefs.append(
+            WorkCrossref(
+                thread_id=thread.id,
+                rollout_path=str(summary.rollout_path),
+                cwd=thread.cwd,
+                git_branch=thread.git_branch,
+                pr_references=tuple(sorted(set(pr_refs))),
+                issue_references=tuple(sorted(set(issue_refs))),
+            )
+        )
+    return crossrefs
+
+
+def _sha256_of_payload(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _try_hmac_sign(payload_sha: str) -> str | None:
+    """Best-effort HMAC sign via the existing context_signing key."""
+    try:
+        from aragora.security.context_signing import get_signing_key
+
+        key = get_signing_key()
+    except Exception:
+        return None
+    if not key:
+        return None
+    import hmac
+
+    return hmac.new(key, payload_sha.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def build_digest(
+    *,
+    since: timedelta,
+    include_archived: bool = False,
+    paths: CodexDesktopPaths | None = None,
+    max_events_per_summary: int = 1500,
+) -> Digest:
+    """Build a complete signed digest covering the analyzed window."""
+    pattern, pairs = summarize_patterns(
+        since=since,
+        include_archived=include_archived,
+        paths=paths,
+        max_events_per_summary=max_events_per_summary,
+    )
+    anomalies = detect_anomalies(pairs)
+    crossref = crossref_work_board(pairs)
+    inspector_summaries = tuple(
+        {
+            "thread_id": t.id,
+            "rollout_path": str(s.rollout_path),
+            "events_scanned": s.events_scanned,
+            "truncated": s.truncated,
+            "event_type_counts": dict(s.event_type_counts),
+            "tool_call_counts": dict(s.tool_call_counts),
+            "model_provider": s.model_provider,
+        }
+        for t, s in pairs
+    )
+
+    now = datetime.now(UTC)
+    window_since = (now - since).isoformat()
+    window_until = now.isoformat()
+    payload: dict[str, Any] = {
+        "schema_version": INSPECTOR_SCHEMA_VERSION,
+        "window_since": window_since,
+        "window_until": window_until,
+        "thread_count": pattern.thread_count,
+        "patterns": pattern.to_dict(),
+        "anomalies": [a.to_dict() for a in anomalies],
+        "crossref": [c.to_dict() for c in crossref],
+        "inspector_summaries": list(inspector_summaries),
+    }
+    sha = _sha256_of_payload(payload)
+    hmac_signature = _try_hmac_sign(sha)
+
+    return Digest(
+        schema_version=INSPECTOR_SCHEMA_VERSION,
+        window_since=window_since,
+        window_until=window_until,
+        thread_count=pattern.thread_count,
+        patterns=pattern,
+        anomalies=tuple(anomalies),
+        crossref=tuple(crossref),
+        inspector_summaries=inspector_summaries,
+        sha256=sha,
+        hmac_sha256=hmac_signature,
+        signed_at=now.isoformat() if hmac_signature else None,
+    )
+
+
+def persist_digest(
+    digest: Digest,
+    *,
+    root: Path | None = None,
+    timestamp: datetime | None = None,
+) -> Path:
+    """Write the digest as a JSON file under ``.aragora/codex_insights/`` (or override)."""
+    output_root = root or DEFAULT_RECEIPT_ROOT
+    output_root.mkdir(parents=True, exist_ok=True)
+    when = timestamp or datetime.now(UTC)
+    suffix = when.strftime("%Y%m%dT%H%M%SZ")
+    target = output_root / f"digest-{suffix}.json"
+    target.write_text(
+        json.dumps(digest.to_dict(), indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def ingest_digest_into_km(
+    digest_path: Path,
+    *,
+    label: str = "codex-insights-digest",
+    timeout_seconds: float = 30.0,
+) -> tuple[bool, str]:
+    """Best-effort: ingest a digest via the existing ``aragora km store`` CLI.
+
+    Returns ``(ok, detail)`` rather than raising — KM may be offline locally
+    and we don't want to fail the whole insights pipeline on that.
+    """
+    if not digest_path.exists():
+        return False, f"digest file not found: {digest_path}"
+    cmd = [
+        "aragora",
+        "km",
+        "store",
+        "--source",
+        label,
+        "--text",
+        f"@{digest_path}",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        return False, f"km ingest invocation failed: {exc}"
+    if result.returncode != 0:
+        return False, (result.stderr or result.stdout or "km store returned non-zero").strip()
+    return True, (result.stdout or "ok").strip()

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -56,7 +56,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `build` | - | Turn a vague idea into executed, reviewed, merged code | - |
 | `calibration` | - | AGT-03.3: per-agent rolling-window Brier reports from market data | `leaderboard`, `report` |
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
-| `codex` | - | Read-only inspector for Codex Desktop local state | `sessions` |
+| `codex` | - | Read-only inspector for Codex Desktop local state | `insights`, `sessions` |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,13 +12,13 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4135` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1938322` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4140` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1940668` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `139` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5188` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `218203` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5191` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `218282` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `687` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
-| CLI top-level command modules | `68` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
+| CLI top-level command modules | `69` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
 | @require_permission decorator calls | `1365` | `aragora/` | `git grep -E '@require_permission\(' -- aragora \| wc -l` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `845` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `848` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4140` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1940668` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1940684` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `139` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5191` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `218282` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `218285` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `687` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `69` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -51,7 +51,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `build` | - | Turn a vague idea into executed, reviewed, merged code | - |
 | `calibration` | - | AGT-03.3: per-agent rolling-window Brier reports from market data | `leaderboard`, `report` |
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
-| `codex` | - | Read-only inspector for Codex Desktop local state | `sessions` |
+| `codex` | - | Read-only inspector for Codex Desktop local state | `insights`, `sessions` |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |

--- a/scripts/install_codex_insights_digest_launchd.sh
+++ b/scripts/install_codex_insights_digest_launchd.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Install a launchd job that emits one Codex insights digest per interval.
+#
+# Adapts the same shape as scripts/install_codex_automation_publisher_launchd.sh
+# so operators familiar with the publisher have one mental model for both.
+#
+# Defaults: every 3600 seconds (1 hour), logs to .aragora/overnight/codex-insights-digest.log.
+
+set -euo pipefail
+
+SCRIPT_REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+first_worktree_root() {
+    git -C "${SCRIPT_REPO_ROOT}" worktree list --porcelain 2>/dev/null \
+        | awk 'NR == 1 && $1 == "worktree" { sub(/^worktree /, ""); print; exit }'
+}
+
+REPO_ROOT="${ARAGORA_CODEX_INSIGHTS_REPO_ROOT:-}"
+if [[ -z "${REPO_ROOT}" ]]; then
+    CANONICAL_REPO_ROOT="$(first_worktree_root || true)"
+    if [[ -n "${CANONICAL_REPO_ROOT}" && -f "${CANONICAL_REPO_ROOT}/scripts/run_codex_insights_digest.sh" ]]; then
+        REPO_ROOT="${CANONICAL_REPO_ROOT}"
+    else
+        REPO_ROOT="${SCRIPT_REPO_ROOT}"
+    fi
+fi
+LABEL="com.aragora.codex-insights-digest"
+LAUNCHD_DOMAIN="gui/$(id -u)"
+INTERVAL_SECONDS=3600
+LOG_PATH="${REPO_ROOT}/.aragora/overnight/codex-insights-digest.log"
+SINCE="1h"
+INGEST_KM="1"
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/install_codex_insights_digest_launchd.sh [options]
+
+Options:
+  --interval-seconds <n>        launchd StartInterval (default: 3600 = hourly)
+  --since <duration>            ARAGORA_CODEX_INSIGHTS_SINCE window passed to digest (default: 1h)
+  --no-ingest-km                Disable km ingestion of each digest (default: enabled)
+  --log-path <file>             Log file path (default: .aragora/overnight/codex-insights-digest.log)
+  --help                        Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --interval-seconds)
+            INTERVAL_SECONDS="${2:-3600}"
+            shift 2
+            ;;
+        --since)
+            SINCE="${2:-1h}"
+            shift 2
+            ;;
+        --no-ingest-km)
+            INGEST_KM="0"
+            shift
+            ;;
+        --log-path)
+            LOG_PATH="${2:-}"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if ! [[ "${INTERVAL_SECONDS}" =~ ^[0-9]+$ ]]; then
+    echo "interval must be numeric" >&2
+    exit 2
+fi
+
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+mkdir -p "$(dirname "${PLIST_PATH}")"
+mkdir -p "$(dirname "${LOG_PATH}")"
+
+cat >"${PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>cd "${REPO_ROOT}" &amp;&amp; ARAGORA_CODEX_INSIGHTS_SINCE="${SINCE}" ARAGORA_CODEX_INSIGHTS_INGEST_KM="${INGEST_KM}" ./scripts/run_codex_insights_digest.sh</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>${INTERVAL_SECONDS}</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>WorkingDirectory</key>
+  <string>${REPO_ROOT}</string>
+  <key>StandardOutPath</key>
+  <string>${LOG_PATH}</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_PATH}</string>
+</dict>
+</plist>
+EOF
+
+launchctl bootout "${LAUNCHD_DOMAIN}/${LABEL}" >/dev/null 2>&1 || true
+launchctl bootstrap "${LAUNCHD_DOMAIN}" "${PLIST_PATH}"
+
+echo "Installed launchd job: ${LABEL}"
+echo "Plist:    ${PLIST_PATH}"
+echo "Log:      ${LOG_PATH}"
+echo "Interval: ${INTERVAL_SECONDS}s"
+echo "Since:    ${SINCE}"
+echo "KM ingest: ${INGEST_KM}"
+echo
+echo "Inspect with:  python3 scripts/probe_boss_loop_launchd.py --no-kickstart --label ${LABEL}"
+echo "Uninstall:     launchctl bootout ${LAUNCHD_DOMAIN}/${LABEL}; rm '${PLIST_PATH}'"

--- a/scripts/run_codex_insights_digest.sh
+++ b/scripts/run_codex_insights_digest.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run one Codex insights digest cycle. Designed for periodic invocation via
+# launchd or cron.
+#
+# Reads ~/.codex/ via the aragora codex inspector (read-only), emits a
+# SHA-256-bound JSON receipt to .aragora/codex_insights/, and best-effort
+# ingests it into the Aragora Knowledge Mound via `aragora km store`.
+#
+# Exits 0 on success; non-zero on aragora CLI failure. Designed to be safe
+# under launchd KeepAlive — never blocks indefinitely.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+SINCE="${ARAGORA_CODEX_INSIGHTS_SINCE:-1h}"
+INGEST_KM="${ARAGORA_CODEX_INSIGHTS_INGEST_KM:-1}"
+RECEIPT_DIR="${ARAGORA_CODEX_INSIGHTS_RECEIPT_DIR:-${REPO_ROOT}/.aragora/codex_insights}"
+ARAGORA_PYTHON="${ARAGORA_PYTHON:-}"
+
+mkdir -p "${RECEIPT_DIR}"
+
+if [[ -z "${ARAGORA_PYTHON}" ]]; then
+    if [[ -x "${REPO_ROOT}/.venv/bin/python3" ]]; then
+        ARAGORA_PYTHON="${REPO_ROOT}/.venv/bin/python3"
+    elif command -v python3 >/dev/null 2>&1; then
+        ARAGORA_PYTHON="$(command -v python3)"
+    else
+        echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') ERROR: no python3 found" >&2
+        exit 2
+    fi
+fi
+
+DIGEST_ARGS=(codex insights digest "--since" "${SINCE}" "--emit-receipt" "--receipt-dir" "${RECEIPT_DIR}")
+if [[ "${INGEST_KM}" == "1" || "${INGEST_KM,,}" == "true" ]]; then
+    DIGEST_ARGS+=("--ingest-km")
+fi
+
+echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') START aragora codex insights digest (since=${SINCE}, receipt_dir=${RECEIPT_DIR})"
+if ! "${ARAGORA_PYTHON}" -m aragora.cli.main "${DIGEST_ARGS[@]}"; then
+    rc=$?
+    echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') ERROR digest exited rc=${rc}" >&2
+    exit "${rc}"
+fi
+echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') OK digest cycle complete"

--- a/tests/codex/test_cli_codex_insights.py
+++ b/tests/codex/test_cli_codex_insights.py
@@ -1,0 +1,128 @@
+"""CLI surface tests for ``aragora codex insights {summary,anomalies,crossref,digest}``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from aragora.cli.commands import codex_insights as cli
+
+
+def _args(**kwargs) -> argparse.Namespace:  # type: ignore[no-untyped-def]
+    base = {
+        "codex_home": None,
+        "json": False,
+        "since": "4h",
+        "include_archived": False,
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+# -- summary ------------------------------------------------------------------
+
+
+def test_cli_summary_text(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_insights_summary(_args())
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Window:" in out
+    assert "Tokens:" in out
+    assert "Tool calls" in out
+
+
+def test_cli_summary_json(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_insights_summary(_args(json=True))
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert "patterns" in payload
+    assert payload["thread_count"] >= 1
+
+
+def test_cli_summary_bad_since(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_insights_summary(_args(since="nonsense"))
+    assert rc == 2
+    assert "invalid duration" in capsys.readouterr().err
+
+
+# -- anomalies ----------------------------------------------------------------
+
+
+def test_cli_anomalies_text(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_insights_anomalies(
+        _args(token_cap=100_000, runaway_tool_calls=200, stuck_turn_minutes=5)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    # No anomalies expected in the small synthetic fixture, but exit code should be 0.
+    assert "anomalies" in out or "(no anomalies" in out
+
+
+def test_cli_anomalies_json(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_insights_anomalies(
+        _args(json=True, token_cap=100_000, runaway_tool_calls=200, stuck_turn_minutes=5)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert isinstance(payload, list)
+
+
+# -- crossref -----------------------------------------------------------------
+
+
+def test_cli_crossref_text(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_insights_crossref(_args())
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Cross-references" in out
+
+
+def test_cli_crossref_json(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_insights_crossref(_args(json=True))
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert isinstance(payload, list)
+
+
+# -- digest -------------------------------------------------------------------
+
+
+def test_cli_digest_to_stdout(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_insights_digest(
+        _args(json=True, emit_receipt=False, receipt_dir=None, ingest_km=False)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert "sha256" in payload
+    assert "patterns" in payload
+
+
+def test_cli_digest_emit_receipt_writes_file(
+    fake_codex_home,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:  # type: ignore[no-untyped-def]
+    receipt_dir = tmp_path / "receipts"
+    rc = cli.cmd_codex_insights_digest(
+        _args(
+            json=False,
+            emit_receipt=True,
+            receipt_dir=str(receipt_dir),
+            ingest_km=False,
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "wrote" in out
+    files = list(receipt_dir.glob("digest-*.json"))
+    assert len(files) == 1
+    payload = json.loads(files[0].read_text(encoding="utf-8"))
+    assert payload["schema_version"]
+    assert payload["sha256"]

--- a/tests/codex/test_cli_codex_insights.py
+++ b/tests/codex/test_cli_codex_insights.py
@@ -126,3 +126,28 @@ def test_cli_digest_emit_receipt_writes_file(
     payload = json.loads(files[0].read_text(encoding="utf-8"))
     assert payload["schema_version"]
     assert payload["sha256"]
+
+
+def test_cli_digest_emit_receipt_json_is_machine_readable(
+    fake_codex_home,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:  # type: ignore[no-untyped-def]
+    receipt_dir = tmp_path / "receipts"
+    rc = cli.cmd_codex_insights_digest(
+        _args(
+            json=True,
+            emit_receipt=True,
+            receipt_dir=str(receipt_dir),
+            ingest_km=False,
+        )
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["schema_version"]
+    assert payload["sha256"]
+    assert payload["receipt_path"].startswith(str(receipt_dir))
+    assert "signing_note" in payload
+    assert list(receipt_dir.glob("digest-*.json"))

--- a/tests/codex/test_insights.py
+++ b/tests/codex/test_insights.py
@@ -180,6 +180,18 @@ def test_crossref_extracts_pr_and_issue_refs(tmp_path: Path) -> None:
     assert "#7240" in refs
 
 
+def test_crossref_redacts_secret_rollout_path(tmp_path: Path) -> None:
+    rollout = tmp_path / "sk-or-v1-abcdefghijklmnopqrstuvwxyz" / "r.jsonl"
+    rollout.parent.mkdir()
+    rollout.write_text("{}\n", encoding="utf-8")
+    thread = _make_thread(id="secret-path", rollout=rollout, title="Working on #7240")
+    summary = _make_summary(rollout)
+
+    crossref = insights.crossref_work_board([(thread, summary)])
+
+    assert "sk-or-v1-abcdefghijklmnopqrstuvwxyz" not in crossref[0].rollout_path
+
+
 def test_crossref_handles_no_refs(tmp_path: Path) -> None:
     rollout = tmp_path / "r.jsonl"
     rollout.write_text("{}\n", encoding="utf-8")
@@ -209,6 +221,15 @@ def test_build_digest_has_required_fields(fake_codex_home) -> None:  # type: ign
     assert "anomalies" in payload
     assert "crossref" in payload
     assert "inspector_summaries" in payload
+
+
+def test_build_digest_redacts_secret_rollout_paths(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    digest = insights.build_digest(since=timedelta(hours=4), include_archived=True)
+    payload = json.dumps(digest.to_dict(), sort_keys=True)
+
+    assert "sk-or-v1-abcdefghijklmnopqrstuvwxyz" not in payload
+    assert "ghp_FAKELEAK" not in payload
+    assert "sk-proj-FAKE-LEAK" not in payload
 
 
 def test_build_digest_is_deterministic_for_same_window(fake_codex_home) -> None:  # type: ignore[no-untyped-def]

--- a/tests/codex/test_insights.py
+++ b/tests/codex/test_insights.py
@@ -1,0 +1,276 @@
+"""Tests for the codex activity-intelligence analysis layer."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aragora.codex import insights
+from aragora.codex.desktop_inspector import SessionSummary, ThreadSummary
+from aragora.codex.desktop_paths import resolve
+
+
+def _make_thread(
+    *,
+    id: str,
+    title: str = "t",
+    model: str = "gpt-5.4",
+    tokens: int = 100,
+    branch: str | None = "main",
+    archived: bool = False,
+    rollout: Path,
+    first_user_message: str = "please fix #6009",
+) -> ThreadSummary:
+    now = datetime.now(UTC)
+    return ThreadSummary(
+        id=id,
+        title=title,
+        cwd="/repo",
+        model=model,
+        rollout_path=rollout,
+        created_at=now - timedelta(hours=1),
+        updated_at=now,
+        tokens_used=tokens,
+        archived=archived,
+        git_sha=None,
+        git_branch=branch,
+        source="vscode",
+        first_user_message=first_user_message,
+    )
+
+
+def _make_summary(
+    rollout: Path,
+    *,
+    tool_calls: dict[str, int] | None = None,
+    events_scanned: int = 10,
+    last_event_age_minutes: float | None = 1.0,
+    last_event_type: str | None = "agent_message",
+    model: str | None = "openai",
+    first_user: str = "fix #5908 please",
+    last_user: str = "thanks",
+) -> SessionSummary:
+    started = datetime.now(UTC) - timedelta(minutes=30)
+    last = (
+        datetime.now(UTC) - timedelta(minutes=last_event_age_minutes)
+        if last_event_age_minutes is not None
+        else None
+    )
+    counts = {"agent_message": 4, "tool_call": sum((tool_calls or {}).values())}
+    if last_event_type:
+        counts[last_event_type] = counts.get(last_event_type, 0) + 1
+    return SessionSummary(
+        rollout_path=rollout,
+        events_scanned=events_scanned,
+        truncated=False,
+        event_type_counts=counts,
+        tool_call_counts=tool_calls or {},
+        first_user_message=first_user,
+        last_user_message=last_user,
+        model_provider=model,
+        started_at=started,
+        last_event_at=last,
+    )
+
+
+# -- summarize_patterns -------------------------------------------------------
+
+
+def test_summarize_patterns_aggregates_threads(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    pattern, pairs = insights.summarize_patterns(since=timedelta(hours=4))
+    assert pattern.thread_count >= 2  # fixture has 2 recent threads
+    assert pattern.archived_excluded is True
+    assert pattern.distinct_cwds >= 1
+    # tool call distribution is non-empty (recent rollout has a Read call)
+    assert pattern.tool_call_distribution
+    assert all(isinstance(v, int) for v in pattern.tool_call_distribution.values())
+
+
+def test_summarize_patterns_window_excludes_old(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    pattern, _ = insights.summarize_patterns(since=timedelta(minutes=1))
+    # 10-minute-old fixtures are outside a 1-minute window.
+    assert pattern.thread_count == 0
+
+
+# -- detect_anomalies ---------------------------------------------------------
+
+
+def test_detect_anomalies_runaway_tool_calls(tmp_path: Path) -> None:
+    rollout = tmp_path / "r.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    thread = _make_thread(id="a", rollout=rollout)
+    summary = _make_summary(rollout, tool_calls={"Read": 300})
+    anomalies = insights.detect_anomalies(
+        [(thread, summary)],
+        runaway_tool_calls=200,
+    )
+    kinds = {a.kind for a in anomalies}
+    assert "runaway_tool_calls" in kinds
+    assert any(a.severity == "high" for a in anomalies if a.kind == "runaway_tool_calls")
+
+
+def test_detect_anomalies_token_cap_exceeded(tmp_path: Path) -> None:
+    rollout = tmp_path / "r.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    thread = _make_thread(id="b", rollout=rollout, tokens=999_999)
+    summary = _make_summary(rollout, tool_calls={"Read": 1})
+    anomalies = insights.detect_anomalies(
+        [(thread, summary)],
+        token_cap=100_000,
+    )
+    assert any(a.kind == "token_cap_exceeded" for a in anomalies)
+
+
+def test_detect_anomalies_stuck_turn(tmp_path: Path) -> None:
+    rollout = tmp_path / "r.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    thread = _make_thread(id="c", rollout=rollout)
+    summary = _make_summary(
+        rollout,
+        tool_calls={"Read": 1},
+        last_event_age_minutes=20.0,
+        last_event_type="turn_start",
+    )
+    anomalies = insights.detect_anomalies(
+        [(thread, summary)],
+        stuck_turn_minutes=5,
+    )
+    assert any(a.kind == "stuck_turn" for a in anomalies)
+
+
+def test_detect_anomalies_returns_empty_when_clean(tmp_path: Path) -> None:
+    rollout = tmp_path / "r.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    thread = _make_thread(id="d", rollout=rollout, tokens=10)
+    summary = _make_summary(rollout, tool_calls={"Read": 1})
+    assert insights.detect_anomalies([(thread, summary)]) == []
+
+
+def test_detect_anomalies_sorted_high_first(tmp_path: Path) -> None:
+    rollout = tmp_path / "r.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    high_thread = _make_thread(id="high", rollout=rollout)
+    high_summary = _make_summary(rollout, tool_calls={"Read": 500})
+    medium_thread = _make_thread(id="med", rollout=rollout, tokens=999_999)
+    medium_summary = _make_summary(rollout, tool_calls={"Read": 5})
+    anomalies = insights.detect_anomalies(
+        [(medium_thread, medium_summary), (high_thread, high_summary)]
+    )
+    assert anomalies[0].severity == "high"
+
+
+# -- crossref_work_board ------------------------------------------------------
+
+
+def test_crossref_extracts_pr_and_issue_refs(tmp_path: Path) -> None:
+    rollout = tmp_path / "r.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    thread = _make_thread(id="e", rollout=rollout, title="Working on #7240")
+    summary = _make_summary(rollout, first_user="please fix #5908 and review #6009")
+    crossref = insights.crossref_work_board([(thread, summary)])
+    assert len(crossref) == 1
+    refs = set(crossref[0].pr_references)
+    assert "#5908" in refs
+    assert "#6009" in refs
+    assert "#7240" in refs
+
+
+def test_crossref_handles_no_refs(tmp_path: Path) -> None:
+    rollout = tmp_path / "r.jsonl"
+    rollout.write_text("{}\n", encoding="utf-8")
+    thread = _make_thread(
+        id="f",
+        rollout=rollout,
+        title="just a chat",
+        first_user_message="hello world",
+    )
+    summary = _make_summary(rollout, first_user="hello", last_user="bye")
+    crossref = insights.crossref_work_board([(thread, summary)])
+    assert crossref[0].pr_references == ()
+    assert crossref[0].issue_references == ()
+
+
+# -- build_digest -------------------------------------------------------------
+
+
+def test_build_digest_has_required_fields(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    digest = insights.build_digest(since=timedelta(hours=4))
+    assert digest.schema_version == insights.INSPECTOR_SCHEMA_VERSION
+    assert digest.thread_count >= 2
+    assert digest.sha256
+    assert len(digest.sha256) == 64
+    payload = digest.to_dict()
+    assert "patterns" in payload
+    assert "anomalies" in payload
+    assert "crossref" in payload
+    assert "inspector_summaries" in payload
+
+
+def test_build_digest_is_deterministic_for_same_window(fake_codex_home) -> None:  # type: ignore[no-untyped-def]
+    # Two digests built in quick succession differ in window_until timestamps
+    # but the patterns section should match (same threads, same counts).
+    first = insights.build_digest(since=timedelta(hours=4))
+    second = insights.build_digest(since=timedelta(hours=4))
+    assert first.patterns.thread_count == second.patterns.thread_count
+    assert first.patterns.tool_call_distribution == second.patterns.tool_call_distribution
+
+
+def test_digest_hmac_is_set_when_key_present(
+    fake_codex_home, monkeypatch: pytest.MonkeyPatch
+) -> None:  # type: ignore[no-untyped-def]
+    import base64
+
+    monkeypatch.setenv(
+        "ARAGORA_CONTEXT_SIGNING_KEY",
+        base64.b64encode(b"test-signing-key-bytes").decode("ascii"),
+    )
+    digest = insights.build_digest(since=timedelta(hours=4))
+    assert digest.hmac_sha256 is not None
+    assert digest.signed_at is not None
+
+
+def test_digest_hmac_is_none_when_key_absent(
+    fake_codex_home, monkeypatch: pytest.MonkeyPatch
+) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("ARAGORA_CONTEXT_SIGNING_KEY", raising=False)
+    digest = insights.build_digest(since=timedelta(hours=4))
+    assert digest.hmac_sha256 is None
+    assert digest.signed_at is None
+
+
+# -- persist_digest -----------------------------------------------------------
+
+
+def test_persist_digest_writes_json(fake_codex_home, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    digest = insights.build_digest(since=timedelta(hours=4))
+    target = insights.persist_digest(digest, root=tmp_path)
+    assert target.exists()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["sha256"] == digest.sha256
+    assert payload["schema_version"] == insights.INSPECTOR_SCHEMA_VERSION
+
+
+# -- ingest_digest_into_km ----------------------------------------------------
+
+
+def test_ingest_digest_into_km_handles_missing_aragora(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    digest_path = tmp_path / "d.json"
+    digest_path.write_text("{}", encoding="utf-8")
+    # Force PATH so 'aragora' resolves to nothing.
+    monkeypatch.setenv("PATH", "/usr/nowhere")
+    ok, detail = insights.ingest_digest_into_km(digest_path, timeout_seconds=2.0)
+    assert ok is False
+    assert detail
+
+
+def test_ingest_digest_into_km_returns_false_for_missing_file(tmp_path: Path) -> None:
+    ok, detail = insights.ingest_digest_into_km(tmp_path / "missing.json")
+    assert ok is False
+    assert "not found" in detail


### PR DESCRIPTION
## Summary

Builds on **#7240** (the read-only inspector). Adds `aragora codex insights {summary, anomalies, crossref, digest}` — an analysis layer that turns inspector data into actionable signals: aggregate patterns, runtime anomalies, work-board cross-references, and signed daily digest receipts.

The operator question shifts from *"what is happening in Codex Desktop?"* to *"what does that activity mean, and is anything stuck, drifting, or worth promoting?"*

## CLI

```bash
aragora codex insights summary   --since 4h [--json]
aragora codex insights anomalies --since 24h [--json] [--token-cap N] [--runaway-tool-calls N] [--stuck-turn-minutes N]
aragora codex insights crossref  --since 4h [--json]
aragora codex insights digest    --since 24h [--emit-receipt] [--ingest-km] [--receipt-dir PATH]
```

## Live dogfood (this machine's `~/.codex/` — 10,419 threads, 6.4 GB)

| Command | Result |
|---|---|
| `insights summary --since 4h` | 48 threads scanned, 12.8B tokens, 24 abandoned (silent > 10m), gpt-5.5 dominant |
| `insights anomalies --since 24h` | **225 real anomalies** — most are `token_cap_exceeded` with multi-billion-token sessions visible |
| `insights crossref --since 4h` | Auto-mapped active sessions to live PRs: **#7240** (this PR's predecessor), **#7173**, **#6371**, **#7240**, dozens of historical issue refs |
| `insights digest --since 4h --emit-receipt` | Wrote 61 KB SHA-256-bound JSON receipt to `.aragora/codex_insights/digest-20260516T232740Z.json` |

## Anomaly classes

| Kind | Severity | Heuristic |
|---|---|---|
| `runaway_tool_calls` | high | Aggregate tool calls in scanned window ≥ `--runaway-tool-calls` (default 200) |
| `stuck_turn` | medium | `turn_start` count > `turn_complete` count AND last event silent past `--stuck-turn-minutes` (default 5) |
| `token_cap_exceeded` | medium | `thread.tokens_used` ≥ `--token-cap` (default 100,000) |

## Receipt format

`digest --emit-receipt` writes a SHA-256-bound JSON document to `.aragora/codex_insights/digest-<utc-ts>.json` containing:

- Schema version, pinned analysis window (`window_since` / `window_until`)
- All redacted aggregate patterns (model mix, tool-call distribution, duration p50/p95, abandoned count)
- All anomalies (with thread id, rollout path, severity, detail, evidence)
- All cross-references (thread → PR/issue refs found in metadata)
- Per-thread inspector summaries (counts only, no transcript content)
- SHA-256 hash of the canonical JSON payload
- Optional HMAC-SHA256 signature when `ARAGORA_CONTEXT_SIGNING_KEY` is set (existing G1 provenance key)

## Reuse (dogfooded, no reinvention)

- **`aragora.codex.desktop_inspector`** (#7240) — `list_active_threads`, `summarize_session`, `iter_session_events` as the data foundation
- **`aragora.security.context_signing.get_signing_key`** — HMAC-SHA256 signing via the existing G1 provenance key (base64-encoded env var)
- **`aragora km store`** CLI — best-effort Knowledge Mound ingestion of the digest

## Discipline (test-enforced)

- Insights never read raw rollouts directly; always go through the inspector so redaction stays centralized
- No mutation of `~/.codex/` (same contract as the inspector)
- No network or AI-provider imports in the analysis layer
- Receipt sign step is best-effort: unsigned digests still emit with a `unsigned (ARAGORA_CONTEXT_SIGNING_KEY not set)` warning rather than silently dropping the signature
- All tests on synthetic fixtures (no real session content committed)

## Validation

- [x] `pytest tests/codex/ -q` → **61 passed** (36 from #7240 + 25 new)
- [x] `ruff check` clean on new files
- [x] `mypy` clean (9 source files in scope)
- [x] Live dogfood confirmed end-to-end (see table above)

## Sequencing

- **Depends on #7240** (inspector). This PR's diff includes the inspector commits transitively; once #7240 merges, rebasing this branch onto main will reduce the diff to just the insights additions.
- Does **not** consume AI provider keys; the rotation gate does not apply.
- Independent of the active #7209 lane, #7215, and the soak track.
- **No `boss-ready` / `autonomous` labels.**

## Out of scope (deferred)

- HTTP/WebSocket dashboard handler
- Scheduled hourly digest (`aragora schedule` integration) — Phase 2 of the plan
- `work robot` integration to surface anomalies as priority recommendations — Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)