### PR TITLE
[AGT-06] Add viah_signals bridge: ReputationStore → VIAH sidecar counters (SD-2, SD-3)

### DIFF
--- a/aragora/metrics/viah_signals.py
+++ b/aragora/metrics/viah_signals.py
@@ -1,0 +1,104 @@
+"""AGT-06 sidecar signal bridge: ReputationStore → VIAH counters (AGT-05 → AGT-06).
+
+Supplies the two integer sidecar parameters that :func:`aragora.metrics.viah.compute_viah`
+accepts as defaults-to-zero until AGT-05 settlement is live:
+
+- :func:`count_crux_resolutions_correct` — SD-2: cruxes correctly resolved (positive delta)
+- :func:`count_predictions_above_brier_threshold` — SD-3: prediction-market predictions
+  at or below the Brier quality threshold (lower Brier = better calibration)
+
+Both return 0 when ``ARAGORA_VIAH_TREND_ENABLED`` is unset.
+Advances issue #6067 (AGT-06 SD-2, SD-3).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from aragora.reputation.types import DOMAIN_CRUX_RESOLUTION, DOMAIN_PREDICTION_MARKET
+
+if TYPE_CHECKING:
+    from aragora.reputation.store import ReputationStore
+
+_VIAH_FLAG = "ARAGORA_VIAH_TREND_ENABLED"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+DEFAULT_BRIER_THRESHOLD = 0.25
+
+
+def _signals_enabled() -> bool:
+    return os.environ.get(_VIAH_FLAG, "").strip().lower() in _TRUTHY
+
+
+def _dt(iso: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone(UTC)
+    except (ValueError, TypeError):
+        return None
+
+
+def count_crux_resolutions_correct(
+    store: "ReputationStore",
+    *,
+    window_hours: float = 168.0,
+    now: datetime | None = None,
+) -> int:
+    """Count ``DOMAIN_CRUX_RESOLUTION`` deltas with positive payout within *window_hours*.
+
+    A positive delta means the agent's crux position matched the eventual resolution
+    outcome (AGT-06 SD-2). Returns 0 when ``ARAGORA_VIAH_TREND_ENABLED`` is not set.
+    """
+    if not _signals_enabled():
+        return 0
+    ref = (now or datetime.now(UTC)).astimezone(UTC)
+    cutoff = ref - timedelta(hours=window_hours)
+    count = 0
+    for agent_id in store.agent_ids():
+        for d in store.deltas_for(agent_id):
+            if d.domain != DOMAIN_CRUX_RESOLUTION or d.delta <= 0:
+                continue
+            dt = _dt(d.applied_at)
+            if dt is not None and dt >= cutoff:
+                count += 1
+    return count
+
+
+def count_predictions_above_brier_threshold(
+    store: "ReputationStore",
+    *,
+    window_hours: float = 168.0,
+    brier_threshold: float = DEFAULT_BRIER_THRESHOLD,
+    now: datetime | None = None,
+) -> int:
+    """Count ``DOMAIN_PREDICTION_MARKET`` predictions with Brier ≤ *brier_threshold* in window.
+
+    Only ``brier_proper``-scored deltas store ``reason["brier"]``; deltas without that
+    key are skipped to avoid double-counting binary-scored positions.
+    Returns 0 when ``ARAGORA_VIAH_TREND_ENABLED`` is not set.
+    """
+    if not _signals_enabled():
+        return 0
+    if not (0.0 <= brier_threshold <= 1.0):
+        raise ValueError(f"brier_threshold must be in [0, 1]; got {brier_threshold!r}")
+    ref = (now or datetime.now(UTC)).astimezone(UTC)
+    cutoff = ref - timedelta(hours=window_hours)
+    count = 0
+    for agent_id in store.agent_ids():
+        for d in store.deltas_for(agent_id):
+            if d.domain != DOMAIN_PREDICTION_MARKET:
+                continue
+            brier = d.reason.get("brier")
+            if brier is None or brier > brier_threshold:
+                continue
+            dt = _dt(d.applied_at)
+            if dt is not None and dt >= cutoff:
+                count += 1
+    return count
+
+
+__all__ = [
+    "DEFAULT_BRIER_THRESHOLD",
+    "count_crux_resolutions_correct",
+    "count_predictions_above_brier_threshold",
+]

--- a/tests/metrics/test_viah_signals.py
+++ b/tests/metrics/test_viah_signals.py
@@ -27,10 +27,15 @@ _OLD = (_NOW - timedelta(hours=200)).isoformat().replace("+00:00", "Z")
 def _crux_delta(agent: str = "a", delta: float = 1.0, at: str = _RECENT) -> ReputationDelta:
     return ReputationDelta(
         delta_id=f"rep_crux_{agent}_{at[:10]}",
-        agent_id=agent, domain=DOMAIN_CRUX_RESOLUTION,
-        claim_id=f"c_{agent}", resolution_id=f"r_{agent}",
-        delta=delta, scoring_rule="binary", applied_at=at,
-        decay_half_life_days=30.0, reason={"correct": delta > 0},
+        agent_id=agent,
+        domain=DOMAIN_CRUX_RESOLUTION,
+        claim_id=f"c_{agent}",
+        resolution_id=f"r_{agent}",
+        delta=delta,
+        scoring_rule="binary",
+        applied_at=at,
+        decay_half_life_days=30.0,
+        reason={"correct": delta > 0},
     )
 
 
@@ -38,9 +43,13 @@ def _mkt_delta(agent: str = "a", brier: float = 0.1, at: str = _RECENT) -> Reput
     stake, pf = 10, 1.0 - 2.0 * brier
     return ReputationDelta(
         delta_id=f"rep_mkt_{agent}_{at[:10]}",
-        agent_id=agent, domain=DOMAIN_PREDICTION_MARKET,
-        claim_id=f"cm_{agent}", resolution_id=f"rm_{agent}",
-        delta=stake * pf, scoring_rule="brier_proper", applied_at=at,
+        agent_id=agent,
+        domain=DOMAIN_PREDICTION_MARKET,
+        claim_id=f"cm_{agent}",
+        resolution_id=f"rm_{agent}",
+        delta=stake * pf,
+        scoring_rule="brier_proper",
+        applied_at=at,
         decay_half_life_days=30.0,
         reason={"brier": brier, "payout_fraction": pf, "stake_units": stake},
     )
@@ -87,9 +96,7 @@ def test_crux_positive_delta_in_window(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.parametrize("delta", [-1.0, 0.0])
-def test_crux_non_positive_delta_not_counted(
-    monkeypatch: pytest.MonkeyPatch, delta: float
-) -> None:
+def test_crux_non_positive_delta_not_counted(monkeypatch: pytest.MonkeyPatch, delta: float) -> None:
     monkeypatch.setenv(_FLAG, "1")
     s = ReputationStore()
     s.record_delta(_crux_delta(delta=delta))
@@ -152,11 +159,20 @@ def test_pred_old_delta_not_counted(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_pred_no_brier_key_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(_FLAG, "1")
     s = ReputationStore()
-    s.record_delta(ReputationDelta(
-        delta_id="rep_nob", agent_id="x", domain=DOMAIN_PREDICTION_MARKET,
-        claim_id="c1", resolution_id="r1", delta=5.0, scoring_rule="binary",
-        applied_at=_RECENT, decay_half_life_days=None, reason={"correct": True},
-    ))
+    s.record_delta(
+        ReputationDelta(
+            delta_id="rep_nob",
+            agent_id="x",
+            domain=DOMAIN_PREDICTION_MARKET,
+            claim_id="c1",
+            resolution_id="r1",
+            delta=5.0,
+            scoring_rule="binary",
+            applied_at=_RECENT,
+            decay_half_life_days=None,
+            reason={"correct": True},
+        )
+    )
     assert count_predictions_above_brier_threshold(s, now=_NOW) == 0
 
 

--- a/tests/metrics/test_viah_signals.py
+++ b/tests/metrics/test_viah_signals.py
@@ -1,0 +1,182 @@
+"""Tests for aragora.metrics.viah_signals (AGT-06 SD-2 / SD-3)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.metrics.viah_signals import (
+    DEFAULT_BRIER_THRESHOLD,
+    count_crux_resolutions_correct,
+    count_predictions_above_brier_threshold,
+)
+from aragora.reputation.store import ReputationStore
+from aragora.reputation.types import (
+    DOMAIN_CRUX_RESOLUTION,
+    DOMAIN_PREDICTION_MARKET,
+    ReputationDelta,
+)
+
+_FLAG = "ARAGORA_VIAH_TREND_ENABLED"
+_NOW = datetime(2026, 5, 17, 12, 0, 0, tzinfo=UTC)
+_RECENT = (_NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+_OLD = (_NOW - timedelta(hours=200)).isoformat().replace("+00:00", "Z")
+
+
+def _crux_delta(agent: str = "a", delta: float = 1.0, at: str = _RECENT) -> ReputationDelta:
+    return ReputationDelta(
+        delta_id=f"rep_crux_{agent}_{at[:10]}",
+        agent_id=agent, domain=DOMAIN_CRUX_RESOLUTION,
+        claim_id=f"c_{agent}", resolution_id=f"r_{agent}",
+        delta=delta, scoring_rule="binary", applied_at=at,
+        decay_half_life_days=30.0, reason={"correct": delta > 0},
+    )
+
+
+def _mkt_delta(agent: str = "a", brier: float = 0.1, at: str = _RECENT) -> ReputationDelta:
+    stake, pf = 10, 1.0 - 2.0 * brier
+    return ReputationDelta(
+        delta_id=f"rep_mkt_{agent}_{at[:10]}",
+        agent_id=agent, domain=DOMAIN_PREDICTION_MARKET,
+        claim_id=f"cm_{agent}", resolution_id=f"rm_{agent}",
+        delta=stake * pf, scoring_rule="brier_proper", applied_at=at,
+        decay_half_life_days=30.0,
+        reason={"brier": brier, "payout_fraction": pf, "stake_units": stake},
+    )
+
+
+# --- Flag gating (both functions) ---
+
+
+def test_flag_off_crux_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    s = ReputationStore()
+    s.record_delta(_crux_delta(delta=5.0))
+    assert count_crux_resolutions_correct(s, now=_NOW) == 0
+
+
+def test_flag_off_pred_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    s = ReputationStore()
+    s.record_delta(_mkt_delta(brier=0.01))
+    assert count_predictions_above_brier_threshold(s, now=_NOW) == 0
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_truthy_flag_enables_crux(monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+    monkeypatch.setenv(_FLAG, val)
+    s = ReputationStore()
+    s.record_delta(_crux_delta(delta=2.0))
+    assert count_crux_resolutions_correct(s, now=_NOW) == 1
+
+
+# --- count_crux_resolutions_correct ---
+
+
+def test_crux_empty_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert count_crux_resolutions_correct(ReputationStore(), now=_NOW) == 0
+
+
+def test_crux_positive_delta_in_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(_crux_delta(delta=1.0))
+    assert count_crux_resolutions_correct(s, now=_NOW) == 1
+
+
+@pytest.mark.parametrize("delta", [-1.0, 0.0])
+def test_crux_non_positive_delta_not_counted(
+    monkeypatch: pytest.MonkeyPatch, delta: float
+) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(_crux_delta(delta=delta))
+    assert count_crux_resolutions_correct(s, now=_NOW) == 0
+
+
+def test_crux_old_delta_not_counted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(_crux_delta(delta=3.0, at=_OLD))
+    assert count_crux_resolutions_correct(s, window_hours=168.0, now=_NOW) == 0
+
+
+def test_crux_multiple_agents_and_window_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    for agent in ["a", "b", "c"]:
+        s.record_delta(_crux_delta(agent=agent, delta=1.0, at=_RECENT))
+    s.record_delta(_crux_delta(agent="d", delta=-1.0, at=_RECENT))
+    s.record_delta(_crux_delta(agent="e", delta=2.0, at=_OLD))
+    assert count_crux_resolutions_correct(s, window_hours=168.0, now=_NOW) == 3
+
+
+def test_crux_ignores_prediction_market_domain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(_mkt_delta(brier=0.01))
+    assert count_crux_resolutions_correct(s, now=_NOW) == 0
+
+
+# --- count_predictions_above_brier_threshold ---
+
+
+def test_pred_empty_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    assert count_predictions_above_brier_threshold(ReputationStore(), now=_NOW) == 0
+
+
+def test_pred_good_brier_counted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(_mkt_delta(brier=DEFAULT_BRIER_THRESHOLD))
+    assert count_predictions_above_brier_threshold(s, now=_NOW) == 1
+
+
+def test_pred_brier_above_threshold_not_counted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(_mkt_delta(brier=0.40))
+    assert count_predictions_above_brier_threshold(s, now=_NOW) == 0
+
+
+def test_pred_old_delta_not_counted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(_mkt_delta(brier=0.01, at=_OLD))
+    assert count_predictions_above_brier_threshold(s, window_hours=168.0, now=_NOW) == 0
+
+
+def test_pred_no_brier_key_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(ReputationDelta(
+        delta_id="rep_nob", agent_id="x", domain=DOMAIN_PREDICTION_MARKET,
+        claim_id="c1", resolution_id="r1", delta=5.0, scoring_rule="binary",
+        applied_at=_RECENT, decay_half_life_days=None, reason={"correct": True},
+    ))
+    assert count_predictions_above_brier_threshold(s, now=_NOW) == 0
+
+
+def test_pred_custom_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(_mkt_delta(agent="a", brier=0.10))
+    s.record_delta(_mkt_delta(agent="b", brier=0.30))
+    assert count_predictions_above_brier_threshold(s, brier_threshold=0.15, now=_NOW) == 1
+    assert count_predictions_above_brier_threshold(s, brier_threshold=0.35, now=_NOW) == 2
+
+
+def test_pred_invalid_threshold_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    with pytest.raises(ValueError, match="brier_threshold"):
+        count_predictions_above_brier_threshold(ReputationStore(), brier_threshold=1.5, now=_NOW)
+
+
+def test_pred_ignores_crux_domain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    s = ReputationStore()
+    s.record_delta(_crux_delta(delta=5.0))
+    assert count_predictions_above_brier_threshold(s, now=_NOW) == 0


### PR DESCRIPTION
## Slice

Adds `aragora/metrics/viah_signals.py` — the AGT-05 → AGT-06 bridge that supplies the two sidecar integer parameters `compute_viah()` currently accepts as default-zero while AGT-05 settlement is pre-wired: `count_crux_resolutions_correct()` (SD-2) and `count_predictions_above_brier_threshold()` (SD-3). Both functions query a `ReputationStore` by domain and time window, returning counts that feed directly into the VIAH formula.

## Gating

- Default: **OFF** (flag: `ARAGORA_VIAH_TREND_ENABLED`; both functions return `0` when the flag is not set)
- Live queue effect: **none** (read-only computation over `ReputationStore`; no Arena wiring, no dispatch changes, no boss loop mutation)
- Advances issue: #6067 (AGT-06 — VIAH productivity metric, SD-2 crux-correctness signal + SD-3 prediction-Brier signal)

## Tests

- `test_flag_off_crux_returns_zero` — flag unset → always 0
- `test_flag_off_pred_returns_zero` — flag unset → always 0
- `test_truthy_flag_enables_crux[1/true/yes/on]` — all four truthy values activate
- `test_crux_empty_store` — empty store → 0
- `test_crux_positive_delta_in_window` — positive `DOMAIN_CRUX_RESOLUTION` delta in window → counted
- `test_crux_non_positive_delta_not_counted[-1.0/0.0]` — negative/zero deltas excluded
- `test_crux_old_delta_not_counted` — delta outside `window_hours` → excluded
- `test_crux_multiple_agents_and_window_filter` — 3 agents positive + 1 negative + 1 old → count=3
- `test_crux_ignores_prediction_market_domain` — wrong domain → 0
- `test_pred_empty_store` — empty store → 0
- `test_pred_good_brier_counted` — Brier at threshold (0.25) → counted
- `test_pred_brier_above_threshold_not_counted` — Brier 0.40 → excluded
- `test_pred_old_delta_not_counted` — outside window → excluded
- `test_pred_no_brier_key_skipped` — binary-scored delta without `reason["brier"]` → skipped
- `test_pred_custom_threshold` — threshold 0.15 / 0.35 with two agents → correct split
- `test_pred_invalid_threshold_raises` — threshold > 1.0 → `ValueError`
- `test_pred_ignores_crux_domain` — `DOMAIN_CRUX_RESOLUTION` delta → 0

## Validation

- `pytest tests/metrics/test_viah_signals.py --noconftest` — **21 passed**
- `ruff check aragora/metrics/viah_signals.py tests/metrics/test_viah_signals.py` — clean
- `mypy aragora/metrics/viah_signals.py tests/metrics/test_viah_signals.py --ignore-missing-imports` — Success: no issues found in 2 source files
- Net diff: **286 LOC** (104-line implementation + 182-line test file)

## Out of scope

- Wiring `viah_signals` into `compute_viah()` call sites — that is the production integration step once `ARAGORA_VIAH_TREND_ENABLED` is cleared for the live path; a one-line caller change in `viah_status.py`
- `ReputationStore` persistence / JSONL load path — `viah_signals` works with the in-memory store already tested by `test_viah_persistence.py`
- `team_selector` dispatch-eligibility integration — deferred to AGT-05 follow-on PR

Labels: `vision-layer`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmewnPUdDK9WjQtfXnAxp4)_