### PR TITLE
fix(automation): find canonical worktrees from managed sessions

### DIFF
--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -614,6 +614,32 @@ def candidate_roots(root: Path, limit: int | None = None) -> list[Path]:
     return entries[:limit] if limit is not None else entries
 
 
+def _git_common_dir(repo: Path) -> Path | None:
+    """Return the git common dir for ``repo`` without raising on non-repos."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip()
+    return Path(raw) if raw else None
+
+
+def _default_canonical_root_candidates(repo: Path) -> list[Path]:
+    candidates = [repo / DEFAULT_CANONICAL_REL_ROOT]
+    common_dir = _git_common_dir(repo)
+    if common_dir is not None and common_dir.name == ".git":
+        candidates.append(common_dir.parent / DEFAULT_CANONICAL_REL_ROOT)
+    return candidates
+
+
 def resolve_default_roots(repo: Path) -> list[Path]:
     """Return ordered default inventory roots for ``repo``.
 
@@ -630,13 +656,14 @@ def resolve_default_roots(repo: Path) -> list[Path]:
     """
     seen: set[str] = set()
     roots: list[Path] = []
-    try:
-        canonical = (repo / DEFAULT_CANONICAL_REL_ROOT).resolve()
-    except OSError:
-        canonical = None
-    if canonical is not None and canonical.exists() and str(canonical) not in seen:
-        roots.append(canonical)
-        seen.add(str(canonical))
+    for candidate in _default_canonical_root_candidates(repo):
+        try:
+            canonical = candidate.resolve()
+        except OSError:
+            continue
+        if canonical.exists() and str(canonical) not in seen:
+            roots.append(canonical)
+            seen.add(str(canonical))
     try:
         legacy = DEFAULT_LEGACY_ROOT.resolve()
     except OSError:

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -379,6 +379,28 @@ def test_resolve_default_roots_dedups_when_paths_resolve_equal(
     assert roots == [canonical.resolve()]
 
 
+def test_resolve_default_roots_uses_git_common_dir_for_managed_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    repo = tmp_path / "repo"
+    main_canonical = repo / mod.DEFAULT_CANONICAL_REL_ROOT
+    managed_worktree = main_canonical / "codex-session"
+    git_common_dir = repo / ".git"
+    main_canonical.mkdir(parents=True)
+    managed_worktree.mkdir()
+    git_common_dir.mkdir()
+    legacy = tmp_path / "home" / ".codex" / "worktrees"
+    legacy.mkdir(parents=True)
+    monkeypatch.setattr(mod, "DEFAULT_LEGACY_ROOT", legacy)
+    monkeypatch.setattr(mod, "_git_common_dir", lambda _repo: git_common_dir)
+
+    roots = mod.resolve_default_roots(managed_worktree)
+
+    assert roots == [main_canonical.resolve(), legacy.resolve()]
+
+
 def test_candidate_roots_from_unions_entries_across_roots(tmp_path: Path) -> None:
     import codex_worktree_value_inventory as mod
 


### PR DESCRIPTION
## Summary

Follow-up to #7250. The inventory default-root expansion still missed the canonical `.worktrees/codex-auto` root when invoked from inside one of those managed worktrees, because `--repo .` resolved to the worktree itself and only checked `<worktree>/.worktrees/codex-auto` before falling back to legacy `~/.codex/worktrees`.

This patch resolves the git common dir for the invocation repo and also checks the owning repository's canonical worktree root. Legacy root fallback and explicit `--root` behavior remain unchanged.

## Dogfood

From inside a managed worktree, without explicit `--repo`:

```bash
python3 scripts/codex_worktree_value_inventory.py --json --limit 5 --size-mode none --skip-gh > /tmp/inventory-managed-worktree.json
```

Observed roots:

```text
/Users/armand/Development/aragora/.worktrees/codex-auto
/Users/armand/.codex/worktrees
```

## Validation

```bash
python3 -m pytest tests/scripts/test_codex_worktree_value_inventory.py -q
python3 -m pytest tests/scripts/test_codex_worktree_value_inventory.py tests/scripts/test_safe_worktree_cleanup.py tests/scripts/test_harvest_salvage_branches.py tests/scripts/test_harvest_rescue_classes.py -q
python3 -m ruff check scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py
python3 -m ruff format --check scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py
bash scripts/automation_pr_preflight.sh origin/main HEAD
git push origin codex/fix-worktree-inventory-managed-root  # pre-push passed without SKIP
```