### PR TITLE
fix(automation): preserve foreign worktrees in inventory

### DIFF
--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -116,6 +116,8 @@ class InventoryContext:
     repo: Path
     base: str
     base_sha: str | None
+    repo_remote_urls: set[str]
+    strict_repo_identity: bool
     outbox_dir: Path
     receipt_dir: Path
     worktrees_by_path: dict[str, WorktreeEntry]
@@ -164,6 +166,31 @@ def resolve_ref(repo: Path, ref: str, *, timeout: int = 30) -> str | None:
     if proc.returncode != 0:
         return None
     return proc.stdout.strip() or None
+
+
+def normalize_remote_url(url: str) -> str:
+    value = url.strip()
+    if value.endswith(".git"):
+        value = value[:-4]
+    if value.startswith("git@"):
+        host_path = value.removeprefix("git@").replace(":", "/", 1)
+        value = f"https://{host_path}"
+    if value.startswith("ssh://git@"):
+        value = f"https://{value.removeprefix('ssh://git@')}"
+    return value.rstrip("/").lower()
+
+
+def repo_remote_urls(repo: Path, *, timeout: int = 30) -> set[str]:
+    proc = run_git(["config", "--get-regexp", r"^remote\..*\.url$"], repo, timeout=timeout)
+    if proc.returncode != 0:
+        return set()
+    urls: set[str] = set()
+    for line in proc.stdout.splitlines():
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        urls.add(normalize_remote_url(parts[1]))
+    return urls
 
 
 def parse_worktree_list(repo: Path, *, timeout: int = 30) -> dict[str, WorktreeEntry]:
@@ -258,6 +285,22 @@ def find_repo_path(candidate_root: Path) -> Path | None:
         if (path / ".git").exists():
             return path
     return None
+
+
+def repo_identity_matches_target(
+    repo_path: Path,
+    *,
+    context: InventoryContext,
+    registered: WorktreeEntry | None,
+) -> bool:
+    if repo_path.resolve() == context.repo.resolve():
+        return True
+    if registered is not None:
+        return True
+    candidate_urls = repo_remote_urls(repo_path, timeout=context.git_timeout)
+    return bool(
+        candidate_urls and context.repo_remote_urls and candidate_urls & context.repo_remote_urls
+    )
 
 
 def active_lock_files(candidate_root: Path, repo_path: Path | None) -> list[str]:
@@ -440,6 +483,26 @@ def classify_candidate(
 
     registered = context.worktrees_by_path.get(str(repo_path.resolve()))
     git.registered_worktree = registered is not None
+
+    if context.strict_repo_identity and not repo_identity_matches_target(
+        repo_path,
+        context=context,
+        registered=registered,
+    ):
+        git.lookup_failed = True
+        git.lookup_errors.append("repo identity does not match target repo")
+        return build_candidate(
+            candidate_root,
+            repo_path,
+            size_bytes,
+            size_lookup_failed,
+            "lookup_failed",
+            active_session,
+            lock_files,
+            git,
+            links,
+            ["repo identity does not match target repo"],
+        )
 
     branch, branch_failed, branch_error = git_branch(
         repo_path, registered, timeout=context.git_timeout
@@ -744,6 +807,7 @@ def inventory(
 ) -> dict[str, Any]:
     repo = resolve_repo(repo)
     base_sha = resolve_ref(repo, base, timeout=git_timeout)
+    explicit_roots = bool(root is not None or roots)
     if roots is None:
         roots = [root] if root is not None else []
     if not roots:
@@ -754,6 +818,8 @@ def inventory(
         repo=repo,
         base=base,
         base_sha=base_sha,
+        repo_remote_urls=repo_remote_urls(repo, timeout=git_timeout),
+        strict_repo_identity=not explicit_roots,
         outbox_dir=outbox_dir if outbox_dir.is_absolute() else repo / outbox_dir,
         receipt_dir=receipt_dir if receipt_dir.is_absolute() else repo / receipt_dir,
         worktrees_by_path=parse_worktree_list(repo, timeout=git_timeout),

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -27,6 +27,8 @@ def _context(tmp_path: Path, **overrides: Any) -> Any:
         "repo": tmp_path,
         "base": "origin/main",
         "base_sha": "base-sha",
+        "repo_remote_urls": {"https://example.test/target"},
+        "strict_repo_identity": False,
         "outbox_dir": tmp_path / ".aragora" / "automation-outbox",
         "receipt_dir": tmp_path / ".aragora" / "automation-receipts",
         "worktrees_by_path": {},
@@ -89,6 +91,61 @@ def _stub_clean_git(
         ),
     )
     monkeypatch.setattr(mod, "is_patch_equivalent", lambda *_args, **_kwargs: patch_equivalent)
+
+
+def test_default_scan_preserves_foreign_repo_as_lookup_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=0)
+    monkeypatch.setattr(
+        mod, "repo_remote_urls", lambda *_args, **_kwargs: {"https://example.test/other"}
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            strict_repo_identity=True,
+            repo_remote_urls={"https://example.test/target"},
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "lookup_failed"
+    assert candidate.cleanup_candidate is False
+    assert candidate.decision == "preserve"
+    assert "repo identity does not match target repo" in candidate.proof
+    assert "repo identity does not match target repo" in candidate.git.lookup_errors
+
+
+def test_explicit_root_scan_allows_foreign_repo_for_backwards_compat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=0)
+    monkeypatch.setattr(
+        mod, "repo_remote_urls", lambda *_args, **_kwargs: {"https://example.test/other"}
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            strict_repo_identity=False,
+            repo_remote_urls={"https://example.test/target"},
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unregistered_git_residue"
+    assert candidate.cleanup_candidate is True
 
 
 def test_no_git_cache_residue_is_cleanup_candidate(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes a safety regression that landed with #7250: default inventory now scans the shared legacy `~/.codex/worktrees` root, but foreign repos under that root could be classified as Aragora cleanup/harvest candidates.

This PR keeps #7250's canonical+legacy default scan, but adds repo-identity gating for implicit/default roots. If a discovered repo is not a registered worktree of the target repo and its remote URL does not match the target repo, it is preserved as `lookup_failed` with explicit proof instead of becoming a cleanup or harvest candidate.

Explicit `--root` behavior remains backwards-compatible and permissive.

## Validation

- `python3 -m pytest tests/scripts/test_codex_worktree_value_inventory.py tests/scripts/test_safe_worktree_cleanup.py tests/scripts/test_harvest_salvage_branches.py tests/scripts/test_harvest_rescue_classes.py -q` -> 42 passed
- `python3 -m ruff check scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py` -> passed
- `python3 -m ruff format --check scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok
- Direct repro: foreign repo under default legacy `~/.codex/worktrees` now returns `classification=lookup_failed`, `decision=preserve`, `cleanup_candidate=false`
- Live smoke: default inventory against `/Users/armand/Development/aragora` still scans canonical then legacy roots and preserves active candidates
- Independent Droid/GPT-5 review: `verdict: scope-clean`, blockers none

## Scope

- Read-only inventory script only
- No cleanup command added
- No deletion path
- No branch mutation
- No change to explicit `--root` compatibility
