### PR TITLE
feat(automation): publish recurring worktree value inventory

### DIFF
--- a/docs/status/WORKTREE_VALUE_INVENTORY_STATUS.md
+++ b/docs/status/WORKTREE_VALUE_INVENTORY_STATUS.md
@@ -1,0 +1,93 @@
+# Worktree Value Inventory Status
+
+Last updated: 2026-05-17T04:08:00Z
+
+This repo-tracked status surface captures the most recent run of `scripts/codex_worktree_value_inventory.py` against the canonical and legacy Aragora worktree roots, classifying each checkout as preserve / harvest_candidate / cleanup_candidate.
+
+## Summary
+
+- Source inventory: `/private/tmp/wvi_canonical.json`
+- Base ref: `origin/main`
+- Roots: `/Users/armand/Development/aragora/.worktrees/codex-auto`
+- Total candidates: `45`
+- Active sessions: `12`
+- Registered worktrees: `30`
+- Candidates with open PR: `0`
+- Dirty checkouts: `0`
+
+## Classifications
+
+- `active_or_dirty`: 12
+- `no_git_cache_residue`: 3
+- `patch_equivalent_or_merged`: 2
+- `unique_unharvested`: 28
+
+## Decisions
+
+- `cleanup_candidate`: 5
+- `harvest_candidate`: 28
+- `preserve`: 12
+
+## Harvest Candidates
+
+| Path | Branch | Classification | Ahead | Behind | Dirty | Active |
+| --- | --- | --- | --- | --- | --- | --- |
+| `ragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881` | `droid/a2-pr3-admission-recovery-rescue-map-and-fixtures-20260516` | `unique_unharvested` | 1 | 2 | no | no |
+| `ragora/.worktrees/codex-auto/claude-20260517-014513-4b437897` | `droid/phase1-fastapi-observer-truth-20260516` | `unique_unharvested` | 1 | 1 | no | no |
+| `aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793` | `codex/corpus-aware-dispatch-upgrade-7209` | `unique_unharvested` | 1 | 16 | no | no |
+| `aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471` | `codex/review-pr-advisory-hardening` | `unique_unharvested` | 1 | 12 | no | no |
+| `aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a` | `-` | `unique_unharvested` | 1 | 2 | no | no |
+| `aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b` | `codex/agent-bridge-process-census` | `unique_unharvested` | 1 | 1 | no | no |
+| `elopment/aragora/.worktrees/codex-auto/codex-activity-repair` | `-` | `unique_unharvested` | 7 | 12 | no | no |
+| `ees/codex-auto/harvest-github-cli-health-unused-sys-20260516` | `codex/harvest-github-cli-health-unused-sys-20260516` | `unique_unharvested` | 1 | 12 | no | no |
+| `agora/.worktrees/codex-auto/harvest-metrics-refresh-20260516` | `codex/harvest-metrics-refresh-20260516` | `unique_unharvested` | 1 | 6 | no | no |
+| `ees/codex-auto/harvest-preflight-rescue-guard-tests-20260516` | `codex/harvest-preflight-rescue-guard-tests-20260516` | `unique_unharvested` | 2 | 12 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1` | `codex/swarm-3844d54a-micro-1` | `unique_unharvested` | 1 | 12 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2` | `codex/swarm-3844d54a-micro-2` | `unique_unharvested` | 1 | 12 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3` | `codex/swarm-3844d54a-micro-3` | `unique_unharvested` | 2 | 12 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4` | `codex/swarm-3844d54a-micro-4` | `unique_unharvested` | 3 | 12 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1` | `codex/swarm-5a555597-micro-1` | `unique_unharvested` | 1 | 15 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2` | `codex/swarm-5a555597-micro-2` | `unique_unharvested` | 1 | 15 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3` | `codex/swarm-5a555597-micro-3` | `unique_unharvested` | 1 | 14 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4` | `codex/swarm-5a555597-micro-4` | `unique_unharvested` | 2 | 14 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5` | `codex/swarm-5a555597-micro-5` | `unique_unharvested` | 3 | 14 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1` | `codex/swarm-5f57bb72-micro-1` | `unique_unharvested` | 1 | 20 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-2` | `codex/swarm-5f57bb72-micro-2` | `unique_unharvested` | 1 | 20 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-3` | `codex/swarm-5f57bb72-micro-3` | `unique_unharvested` | 1 | 20 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-4` | `codex/swarm-5f57bb72-micro-4` | `unique_unharvested` | 2 | 20 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-5` | `codex/swarm-5f57bb72-micro-5` | `unique_unharvested` | 4 | 20 | no | no |
+| `lopment/aragora/.worktrees/codex-auto/swarm-848a8081-micro-2` | `codex/swarm-848a8081-micro-2` | `unique_unharvested` | 1 | 22 | no | no |
+
+*Truncated: 3 additional rows omitted.*
+
+## Cleanup Candidates
+
+| Path | Branch | Classification | Ahead | Behind | Dirty | Active |
+| --- | --- | --- | --- | --- | --- | --- |
+| `ragora/.worktrees/codex-auto/claude-20260501-195315-89c3c0ad` | `-` | `no_git_cache_residue` | - | - | no | no |
+| `ragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7` | `droid/phase2-worktree-value-inventory-20260516` | `patch_equivalent_or_merged` | 0 | 1 | no | no |
+| `aragora/.worktrees/codex-auto/codex-20260422-194119-a5c0dd59` | `-` | `no_git_cache_residue` | - | - | no | no |
+| `aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4` | `codex/fix-worktree-inventory-managed-root` | `patch_equivalent_or_merged` | 1 | 1 | no | no |
+| `ent/aragora/.worktrees/codex-auto/rbac-health-fix-20260413-1` | `-` | `no_git_cache_residue` | - | - | no | no |
+
+## Preserved (active or dirty)
+
+| Path | Branch | Classification | Ahead | Behind | Dirty | Active |
+| --- | --- | --- | --- | --- | --- | --- |
+| `ragora/.worktrees/codex-auto/claude-20260430-041011-3b22a0f5` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260430-042801-d58ae59e` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260430-044410-204ba6b3` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260430-125421-513d6f8d` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260430-132040-05232470` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260430-132610-4446bddf` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260501-174558-6eed6d67` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260501-230411-bc06dedc` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260503-144747-b1c1b5ad` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260503-150130-e21247fc` | `-` | `active_or_dirty` | - | - | no | yes |
+| `ragora/.worktrees/codex-auto/claude-20260507-171638-9eaae229` | `-` | `active_or_dirty` | - | - | no | yes |
+| `aragora/.worktrees/codex-auto/codex-20260515-152237-14d11f01` | `-` | `active_or_dirty` | - | - | no | yes |
+
+## Provenance
+
+- Generator: `scripts/codex_worktree_value_inventory.py` (see PR #7250 for canonical+legacy smart roots; PR #7253/#7254 for managed-session lookup and foreign-worktree preservation).
+- Publisher: `scripts/publish_worktree_value_inventory.py` (this file). Read-only; never deletes worktrees or branches.

--- a/docs/status/generated/worktree_value_inventory/latest.json
+++ b/docs/status/generated/worktree_value_inventory/latest.json
@@ -1,0 +1,2563 @@
+{
+  "base": "origin/main",
+  "base_sha": "cacb0b959d31e1ee7cfceaa11ea9d55436bddb3c",
+  "generated_at": "2026-05-17T04:08:00Z",
+  "inventory": {
+    "base": "origin/main",
+    "base_sha": "cacb0b959d31e1ee7cfceaa11ea9d55436bddb3c",
+    "candidates": [
+      {
+        "active_session": true,
+        "candidate_id": "b6b07ce8916f6a93",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-041011-3b22a0f5",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "68f44cc9b9570506",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-042801-d58ae59e",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "3a95275d4fb9123f",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-044410-204ba6b3",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "2edd55a82fd13ceb",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-125421-513d6f8d",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "9b7ab726ed615a43",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132040-05232470",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "8c9070af493be617",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132610-4446bddf",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "d985e063a60b8d97",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-174558-6eed6d67",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "701a9b7732df875a",
+        "classification": "no_git_cache_residue",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:54:37+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-195315-89c3c0ad",
+        "proof": [
+          "no git metadata at candidate root or candidate/aragora path"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "a4abc37f208c9133",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-230411-bc06dedc",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "781ae5996039cfe7",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-144747-b1c1b5ad",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "a50a9bf3381e42f1",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-150130-e21247fc",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "a5574f97675d085d",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260507-171638-9eaae229",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "91521c56d871da4b",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 2,
+          "branch": "droid/a2-pr3-admission-recovery-rescue-map-and-fixtures-20260516",
+          "dirty": false,
+          "head": "19f29eeef1fc4e72be58cdbd36064303ac14a7c4",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:21:47+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "93aa02fec6e693fc",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 1,
+          "branch": "droid/phase1-fastapi-observer-truth-20260516",
+          "dirty": false,
+          "head": "a9b044ce7490eab1a838fcc2ba8e54fcdb42ace6",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:49:05+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "750cc0175dd603cb",
+        "classification": "patch_equivalent_or_merged",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": 0,
+          "behind": 1,
+          "branch": "droid/phase2-worktree-value-inventory-20260516",
+          "dirty": false,
+          "head": "d183d6df257b7da11749d0923609541bca0f977d",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:57:09+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7",
+        "proof": [
+          "registered git worktree has no unique commits ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "bdcc14c4aeaca260",
+        "classification": "no_git_cache_residue",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:58:23+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260422-194119-a5c0dd59",
+        "proof": [
+          "no git metadata at candidate root or candidate/aragora path"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "5c6c5859b8a76c03",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T03:58:33+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260515-152237-14d11f01",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "181b5dae3883919d",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 16,
+          "branch": "codex/corpus-aware-dispatch-upgrade-7209",
+          "dirty": false,
+          "head": "5d98398a00cb1aa90f88a1beb2885bf2b01699c0",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:35:40+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "3f6ee72b38e51d4b",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 12,
+          "branch": "codex/review-pr-advisory-hardening",
+          "dirty": false,
+          "head": "e142a649a29e3f2ff2c7695a2a89dd20f452d216",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:53:05+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "e0873f53aad7c633",
+        "classification": "patch_equivalent_or_merged",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 1,
+          "branch": "codex/fix-worktree-inventory-managed-root",
+          "dirty": false,
+          "head": "4d8b23d750394d30c50494b822268eb7e195cc12",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": true,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:42:38+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4",
+        "proof": [
+          "branch is patch-equivalent to base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "67c93400d1572728",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 2,
+          "branch": null,
+          "dirty": false,
+          "head": "19f29eeef1fc4e72be58cdbd36064303ac14a7c4",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:38:35+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "c4ffe7a522ef64c0",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 1,
+          "branch": "codex/agent-bridge-process-census",
+          "dirty": false,
+          "head": "35a1224c13d51fee216d3ec2d3f0135039bf0269",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:49:33+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "8a031d8b85edde80",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 7,
+          "behind": 12,
+          "branch": null,
+          "dirty": false,
+          "head": "68c03eadd0762e9825293a1f28298e949a73bf28",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:43:56+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "291ee78ff6099205",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 12,
+          "branch": "codex/harvest-github-cli-health-unused-sys-20260516",
+          "dirty": false,
+          "head": "723017ed917697a0d07a77388b2374913cca8ab0",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:54:05+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "38042b5dc577eeba",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 6,
+          "branch": "codex/harvest-metrics-refresh-20260516",
+          "dirty": false,
+          "head": "7f9ecf28d5b9cf75df08281419104d74419c8917",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:21:35+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "43706e9e0be1098e",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 12,
+          "branch": "codex/harvest-preflight-rescue-guard-tests-20260516",
+          "dirty": false,
+          "head": "71b58286266604da1c33c6693564af80517459ef",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T19:08:56+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "280eee20c0a2dcb3",
+        "classification": "no_git_cache_residue",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:58:23+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/rbac-health-fix-20260413-1",
+        "proof": [
+          "no git metadata at candidate root or candidate/aragora path"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "10c944cd2de1053f",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 12,
+          "branch": "codex/swarm-3844d54a-micro-1",
+          "dirty": false,
+          "head": "2f95c3df3c6ffe7c8c9ad0f981ee16aad43e6ae7",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:47:35+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "ae90c45c1e7211f6",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 12,
+          "branch": "codex/swarm-3844d54a-micro-2",
+          "dirty": false,
+          "head": "bf74992ff46434ab10d2400df6371c3fd5a0b7f9",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:50:06+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "5dd16c5f0808d1a8",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 12,
+          "branch": "codex/swarm-3844d54a-micro-3",
+          "dirty": false,
+          "head": "f79163971e50d2ac67b9775a0682f60ea43f4aec",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T19:07:45+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "0ad6e980a0fc228e",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 3,
+          "behind": 12,
+          "branch": "codex/swarm-3844d54a-micro-4",
+          "dirty": false,
+          "head": "cac02945d2078979f1117b8c627f4b991686ee91",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T19:19:42+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "5cb8de11c0ccbf7c",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 15,
+          "branch": "codex/swarm-5a555597-micro-1",
+          "dirty": false,
+          "head": "b1ff9bd8a6e49f109e618e61d4332a8e5857301e",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:41:44+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "7dc6e30a687e340c",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 15,
+          "branch": "codex/swarm-5a555597-micro-2",
+          "dirty": false,
+          "head": "bcc43c12da8e20d6183b27da4e09f6a04f8cc6b1",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:53:42+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "4e7d5f7244fba50b",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 14,
+          "branch": "codex/swarm-5a555597-micro-3",
+          "dirty": false,
+          "head": "3adfe1bf0fe7c9ab22c56faa17f86cda1a4c004e",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:53:38+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "6fd0d8d301f1dfb4",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 14,
+          "branch": "codex/swarm-5a555597-micro-4",
+          "dirty": false,
+          "head": "e922703d573dea2dd44e97edb82a3a79c83d0bf8",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:57:30+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "784539710f7171d9",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 3,
+          "behind": 14,
+          "branch": "codex/swarm-5a555597-micro-5",
+          "dirty": false,
+          "head": "c2cafc5297349bc147a27aa3a8b21582f6e1458b",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:01:21+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "b4d737b06992120b",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-1",
+          "dirty": false,
+          "head": "8b674d669d52e12ee69f6d8ad06f210d31ad0eb3",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:36:09+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "7367ec2797d1c183",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-2",
+          "dirty": false,
+          "head": "28dd329a5c3849f63feeee3b347e39f9b5cbd071",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-2"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:38:59+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-2",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-2",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "8d71d9be30a0b6c0",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-3",
+          "dirty": false,
+          "head": "e3f33ffb00671af4e19fb3a43883a1b7b1208627",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-3"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:38:55+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-3",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-3",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "a5098a4548cb1131",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-4",
+          "dirty": false,
+          "head": "b8b021ca06af4cf9fb5e6a75323ddff6ca412389",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:45:40+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-4",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "99472c710815a93f",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 4,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-5",
+          "dirty": false,
+          "head": "f47a4647a375d0522de4a4b9706178675c877fec",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-5"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:47:27+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-5",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-5",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "22603bee379d4e48",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 22,
+          "branch": "codex/swarm-848a8081-micro-2",
+          "dirty": false,
+          "head": "c20a919bb8fa11a8a6b8467fd9b955b8130cfeaf",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-2"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:10:53+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-2",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-2",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "6ed337d15f09418a",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 22,
+          "branch": "codex/swarm-848a8081-micro-3",
+          "dirty": false,
+          "head": "ea13ddf962741a0a33ead3201233712a8bb3b48b",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-3"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:10:49+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-3",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-3",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "e496a4d3790537e4",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 22,
+          "branch": "codex/swarm-848a8081-micro-4",
+          "dirty": false,
+          "head": "2c2c8e8da18df4d5a867cadf780fdb7346524a68",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:14:40+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-4",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "5dbe197364417504",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 3,
+          "behind": 22,
+          "branch": "codex/swarm-848a8081-micro-5",
+          "dirty": false,
+          "head": "e840168cd3b4aaf1513c4e87b8aa1bf57b0455e0",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-5"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:18:34+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-5",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-5",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      }
+    ],
+    "generated_at": "2026-05-17T02:07:18+00:00",
+    "ledger_written": null,
+    "limit": 50,
+    "repo": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7",
+    "root": "/Users/armand/Development/aragora/.worktrees/codex-auto",
+    "roots": [
+      "/Users/armand/Development/aragora/.worktrees/codex-auto"
+    ],
+    "schema": "aragora-worktree-harvest/1.0",
+    "size_mode": "none",
+    "summary": {
+      "bytes_by_class": {
+        "active_or_dirty": 0,
+        "lookup_failed": 0,
+        "no_git_cache_residue": 0,
+        "open_pr_or_outbox": 0,
+        "patch_equivalent_or_merged": 0,
+        "receipt_protected": 0,
+        "unique_unharvested": 0,
+        "unregistered_git_residue": 0
+      },
+      "classified_candidates": 45,
+      "cleanup_candidate_count": 5,
+      "count_by_class": {
+        "active_or_dirty": 12,
+        "lookup_failed": 0,
+        "no_git_cache_residue": 3,
+        "open_pr_or_outbox": 0,
+        "patch_equivalent_or_merged": 2,
+        "receipt_protected": 0,
+        "unique_unharvested": 28,
+        "unregistered_git_residue": 0
+      },
+      "harvest_candidate_count": 28,
+      "inventory_coverage": 0.0,
+      "known_size_bytes": 0,
+      "size_lookup_failures": 45,
+      "top_cleanup_candidates": [
+        {
+          "branch": null,
+          "classification": "no_git_cache_residue",
+          "decision": "cleanup_candidate",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-195315-89c3c0ad",
+          "proof": [
+            "no git metadata at candidate root or candidate/aragora path"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "droid/phase2-worktree-value-inventory-20260516",
+          "classification": "patch_equivalent_or_merged",
+          "decision": "cleanup_candidate",
+          "head": "d183d6df257b7da11749d0923609541bca0f977d",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7",
+          "proof": [
+            "registered git worktree has no unique commits ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "no_git_cache_residue",
+          "decision": "cleanup_candidate",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260422-194119-a5c0dd59",
+          "proof": [
+            "no git metadata at candidate root or candidate/aragora path"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/fix-worktree-inventory-managed-root",
+          "classification": "patch_equivalent_or_merged",
+          "decision": "cleanup_candidate",
+          "head": "4d8b23d750394d30c50494b822268eb7e195cc12",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4",
+          "proof": [
+            "branch is patch-equivalent to base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "no_git_cache_residue",
+          "decision": "cleanup_candidate",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/rbac-health-fix-20260413-1",
+          "proof": [
+            "no git metadata at candidate root or candidate/aragora path"
+          ],
+          "size_bytes": null
+        }
+      ],
+      "top_protected_size_users": [
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-041011-3b22a0f5",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-042801-d58ae59e",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-044410-204ba6b3",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-125421-513d6f8d",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132040-05232470",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132610-4446bddf",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-174558-6eed6d67",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-230411-bc06dedc",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-144747-b1c1b5ad",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-150130-e21247fc",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260507-171638-9eaae229",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260515-152237-14d11f01",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        }
+      ],
+      "top_unique_unharvested": [
+        {
+          "branch": "droid/a2-pr3-admission-recovery-rescue-map-and-fixtures-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "19f29eeef1fc4e72be58cdbd36064303ac14a7c4",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "droid/phase1-fastapi-observer-truth-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "a9b044ce7490eab1a838fcc2ba8e54fcdb42ace6",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/corpus-aware-dispatch-upgrade-7209",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "5d98398a00cb1aa90f88a1beb2885bf2b01699c0",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/review-pr-advisory-hardening",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "e142a649a29e3f2ff2c7695a2a89dd20f452d216",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "19f29eeef1fc4e72be58cdbd36064303ac14a7c4",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/agent-bridge-process-census",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "35a1224c13d51fee216d3ec2d3f0135039bf0269",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "68c03eadd0762e9825293a1f28298e949a73bf28",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/harvest-github-cli-health-unused-sys-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "723017ed917697a0d07a77388b2374913cca8ab0",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/harvest-metrics-refresh-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "7f9ecf28d5b9cf75df08281419104d74419c8917",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/harvest-preflight-rescue-guard-tests-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "71b58286266604da1c33c6693564af80517459ef",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-3844d54a-micro-1",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "2f95c3df3c6ffe7c8c9ad0f981ee16aad43e6ae7",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-3844d54a-micro-2",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "bf74992ff46434ab10d2400df6371c3fd5a0b7f9",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-3844d54a-micro-3",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "f79163971e50d2ac67b9775a0682f60ea43f4aec",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-3844d54a-micro-4",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "cac02945d2078979f1117b8c627f4b991686ee91",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-1",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "b1ff9bd8a6e49f109e618e61d4332a8e5857301e",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-2",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "bcc43c12da8e20d6183b27da4e09f6a04f8cc6b1",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-3",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "3adfe1bf0fe7c9ab22c56faa17f86cda1a4c004e",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-4",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "e922703d573dea2dd44e97edb82a3a79c83d0bf8",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-5",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "c2cafc5297349bc147a27aa3a8b21582f6e1458b",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5f57bb72-micro-1",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "8b674d669d52e12ee69f6d8ad06f210d31ad0eb3",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        }
+      ],
+      "total_candidates": 45,
+      "unknown_candidates": 0
+    }
+  },
+  "roots": [
+    "/Users/armand/Development/aragora/.worktrees/codex-auto"
+  ],
+  "schema_version": 1,
+  "source_inventory_path": "/private/tmp/wvi_canonical.json",
+  "summary": {
+    "active_sessions": 12,
+    "candidates_with_open_pr": 0,
+    "classifications": {
+      "active_or_dirty": 12,
+      "no_git_cache_residue": 3,
+      "patch_equivalent_or_merged": 2,
+      "unique_unharvested": 28
+    },
+    "cleanup_candidates": [
+      {
+        "active_session": false,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "no_git_cache_residue",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:54:37+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-195315-89c3c0ad"
+      },
+      {
+        "active_session": false,
+        "ahead": 0,
+        "behind": 1,
+        "branch": "droid/phase2-worktree-value-inventory-20260516",
+        "classification": "patch_equivalent_or_merged",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:57:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7"
+      },
+      {
+        "active_session": false,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "no_git_cache_residue",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:58:23+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260422-194119-a5c0dd59"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 1,
+        "branch": "codex/fix-worktree-inventory-managed-root",
+        "classification": "patch_equivalent_or_merged",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:42:38+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4"
+      },
+      {
+        "active_session": false,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "no_git_cache_residue",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:58:23+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/rbac-health-fix-20260413-1"
+      }
+    ],
+    "decisions": {
+      "cleanup_candidate": 5,
+      "harvest_candidate": 28,
+      "preserve": 12
+    },
+    "dirty_count": 0,
+    "harvest_candidates": [
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 2,
+        "branch": "droid/a2-pr3-admission-recovery-rescue-map-and-fixtures-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:21:47+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 1,
+        "branch": "droid/phase1-fastapi-observer-truth-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:49:05+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 16,
+        "branch": "codex/corpus-aware-dispatch-upgrade-7209",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:35:40+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 12,
+        "branch": "codex/review-pr-advisory-hardening",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:53:05+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 2,
+        "branch": null,
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:38:35+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 1,
+        "branch": "codex/agent-bridge-process-census",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:49:33+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b"
+      },
+      {
+        "active_session": false,
+        "ahead": 7,
+        "behind": 12,
+        "branch": null,
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T23:43:56+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 12,
+        "branch": "codex/harvest-github-cli-health-unused-sys-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:54:05+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 6,
+        "branch": "codex/harvest-metrics-refresh-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T23:21:35+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 12,
+        "branch": "codex/harvest-preflight-rescue-guard-tests-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T19:08:56+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 12,
+        "branch": "codex/swarm-3844d54a-micro-1",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:47:35+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 12,
+        "branch": "codex/swarm-3844d54a-micro-2",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:50:06+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 12,
+        "branch": "codex/swarm-3844d54a-micro-3",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T19:07:45+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3"
+      },
+      {
+        "active_session": false,
+        "ahead": 3,
+        "behind": 12,
+        "branch": "codex/swarm-3844d54a-micro-4",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T19:19:42+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 15,
+        "branch": "codex/swarm-5a555597-micro-1",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:41:44+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 15,
+        "branch": "codex/swarm-5a555597-micro-2",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:53:42+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 14,
+        "branch": "codex/swarm-5a555597-micro-3",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:53:38+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 14,
+        "branch": "codex/swarm-5a555597-micro-4",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:57:30+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4"
+      },
+      {
+        "active_session": false,
+        "ahead": 3,
+        "behind": 14,
+        "branch": "codex/swarm-5a555597-micro-5",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:01:21+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-1",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:36:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-2",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:38:59+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-2"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-3",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:38:55+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-3"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-4",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:45:40+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-4"
+      },
+      {
+        "active_session": false,
+        "ahead": 4,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-5",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:47:27+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-5"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 22,
+        "branch": "codex/swarm-848a8081-micro-2",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:10:53+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-2"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 22,
+        "branch": "codex/swarm-848a8081-micro-3",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:10:49+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-3"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 22,
+        "branch": "codex/swarm-848a8081-micro-4",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:14:40+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-4"
+      },
+      {
+        "active_session": false,
+        "ahead": 3,
+        "behind": 22,
+        "branch": "codex/swarm-848a8081-micro-5",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:18:34+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-5"
+      }
+    ],
+    "preserves": [
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-041011-3b22a0f5"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-042801-d58ae59e"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-044410-204ba6b3"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-125421-513d6f8d"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132040-05232470"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132610-4446bddf"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-174558-6eed6d67"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-230411-bc06dedc"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-144747-b1c1b5ad"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-150130-e21247fc"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260507-171638-9eaae229"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T03:58:33+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260515-152237-14d11f01"
+      }
+    ],
+    "registered_worktrees": 30,
+    "total_candidates": 45
+  }
+}

--- a/docs/status/generated/worktree_value_inventory/worktree-value-inventory-20260517T040800Z.json
+++ b/docs/status/generated/worktree_value_inventory/worktree-value-inventory-20260517T040800Z.json
@@ -1,0 +1,2563 @@
+{
+  "base": "origin/main",
+  "base_sha": "cacb0b959d31e1ee7cfceaa11ea9d55436bddb3c",
+  "generated_at": "2026-05-17T04:08:00Z",
+  "inventory": {
+    "base": "origin/main",
+    "base_sha": "cacb0b959d31e1ee7cfceaa11ea9d55436bddb3c",
+    "candidates": [
+      {
+        "active_session": true,
+        "candidate_id": "b6b07ce8916f6a93",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-041011-3b22a0f5",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "68f44cc9b9570506",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-042801-d58ae59e",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "3a95275d4fb9123f",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-044410-204ba6b3",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "2edd55a82fd13ceb",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-125421-513d6f8d",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "9b7ab726ed615a43",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132040-05232470",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "8c9070af493be617",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132610-4446bddf",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "d985e063a60b8d97",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-174558-6eed6d67",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "701a9b7732df875a",
+        "classification": "no_git_cache_residue",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:54:37+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-195315-89c3c0ad",
+        "proof": [
+          "no git metadata at candidate root or candidate/aragora path"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "a4abc37f208c9133",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-230411-bc06dedc",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "781ae5996039cfe7",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-144747-b1c1b5ad",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "a50a9bf3381e42f1",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-150130-e21247fc",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "a5574f97675d085d",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260507-171638-9eaae229",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "91521c56d871da4b",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 2,
+          "branch": "droid/a2-pr3-admission-recovery-rescue-map-and-fixtures-20260516",
+          "dirty": false,
+          "head": "19f29eeef1fc4e72be58cdbd36064303ac14a7c4",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:21:47+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "93aa02fec6e693fc",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 1,
+          "branch": "droid/phase1-fastapi-observer-truth-20260516",
+          "dirty": false,
+          "head": "a9b044ce7490eab1a838fcc2ba8e54fcdb42ace6",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:49:05+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "750cc0175dd603cb",
+        "classification": "patch_equivalent_or_merged",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": 0,
+          "behind": 1,
+          "branch": "droid/phase2-worktree-value-inventory-20260516",
+          "dirty": false,
+          "head": "d183d6df257b7da11749d0923609541bca0f977d",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:57:09+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7",
+        "proof": [
+          "registered git worktree has no unique commits ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "bdcc14c4aeaca260",
+        "classification": "no_git_cache_residue",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:58:23+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260422-194119-a5c0dd59",
+        "proof": [
+          "no git metadata at candidate root or candidate/aragora path"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": true,
+        "candidate_id": "5c6c5859b8a76c03",
+        "classification": "active_or_dirty",
+        "cleanup_candidate": false,
+        "decision": "preserve",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T03:58:33+00:00",
+        "next_action": "preserve until blocker clears or value is harvested",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260515-152237-14d11f01",
+        "proof": [
+          "active session marker present without git metadata"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "181b5dae3883919d",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 16,
+          "branch": "codex/corpus-aware-dispatch-upgrade-7209",
+          "dirty": false,
+          "head": "5d98398a00cb1aa90f88a1beb2885bf2b01699c0",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:35:40+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "3f6ee72b38e51d4b",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 12,
+          "branch": "codex/review-pr-advisory-hardening",
+          "dirty": false,
+          "head": "e142a649a29e3f2ff2c7695a2a89dd20f452d216",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:53:05+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "e0873f53aad7c633",
+        "classification": "patch_equivalent_or_merged",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 1,
+          "branch": "codex/fix-worktree-inventory-managed-root",
+          "dirty": false,
+          "head": "4d8b23d750394d30c50494b822268eb7e195cc12",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": true,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:42:38+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4",
+        "proof": [
+          "branch is patch-equivalent to base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "67c93400d1572728",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 2,
+          "branch": null,
+          "dirty": false,
+          "head": "19f29eeef1fc4e72be58cdbd36064303ac14a7c4",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:38:35+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "c4ffe7a522ef64c0",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 1,
+          "branch": "codex/agent-bridge-process-census",
+          "dirty": false,
+          "head": "35a1224c13d51fee216d3ec2d3f0135039bf0269",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:49:33+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "8a031d8b85edde80",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 7,
+          "behind": 12,
+          "branch": null,
+          "dirty": false,
+          "head": "68c03eadd0762e9825293a1f28298e949a73bf28",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:43:56+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "291ee78ff6099205",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 12,
+          "branch": "codex/harvest-github-cli-health-unused-sys-20260516",
+          "dirty": false,
+          "head": "723017ed917697a0d07a77388b2374913cca8ab0",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:54:05+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "38042b5dc577eeba",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 6,
+          "branch": "codex/harvest-metrics-refresh-20260516",
+          "dirty": false,
+          "head": "7f9ecf28d5b9cf75df08281419104d74419c8917",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T23:21:35+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "43706e9e0be1098e",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 12,
+          "branch": "codex/harvest-preflight-rescue-guard-tests-20260516",
+          "dirty": false,
+          "head": "71b58286266604da1c33c6693564af80517459ef",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T19:08:56+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "280eee20c0a2dcb3",
+        "classification": "no_git_cache_residue",
+        "cleanup_candidate": true,
+        "decision": "cleanup_candidate",
+        "git": {
+          "ahead": null,
+          "behind": null,
+          "branch": null,
+          "dirty": false,
+          "head": null,
+          "is_repo": false,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": false,
+          "repo_path": null
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-17T01:58:23+00:00",
+        "next_action": "fresh safe_worktree_cleanup.py inspect is required before any removal",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/rbac-health-fix-20260413-1",
+        "proof": [
+          "no git metadata at candidate root or candidate/aragora path"
+        ],
+        "repo_path": null,
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "10c944cd2de1053f",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 12,
+          "branch": "codex/swarm-3844d54a-micro-1",
+          "dirty": false,
+          "head": "2f95c3df3c6ffe7c8c9ad0f981ee16aad43e6ae7",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:47:35+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "ae90c45c1e7211f6",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 12,
+          "branch": "codex/swarm-3844d54a-micro-2",
+          "dirty": false,
+          "head": "bf74992ff46434ab10d2400df6371c3fd5a0b7f9",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:50:06+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "5dd16c5f0808d1a8",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 12,
+          "branch": "codex/swarm-3844d54a-micro-3",
+          "dirty": false,
+          "head": "f79163971e50d2ac67b9775a0682f60ea43f4aec",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T19:07:45+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "0ad6e980a0fc228e",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 3,
+          "behind": 12,
+          "branch": "codex/swarm-3844d54a-micro-4",
+          "dirty": false,
+          "head": "cac02945d2078979f1117b8c627f4b991686ee91",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T19:19:42+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "5cb8de11c0ccbf7c",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 15,
+          "branch": "codex/swarm-5a555597-micro-1",
+          "dirty": false,
+          "head": "b1ff9bd8a6e49f109e618e61d4332a8e5857301e",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:41:44+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "7dc6e30a687e340c",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 15,
+          "branch": "codex/swarm-5a555597-micro-2",
+          "dirty": false,
+          "head": "bcc43c12da8e20d6183b27da4e09f6a04f8cc6b1",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:53:42+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "4e7d5f7244fba50b",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 14,
+          "branch": "codex/swarm-5a555597-micro-3",
+          "dirty": false,
+          "head": "3adfe1bf0fe7c9ab22c56faa17f86cda1a4c004e",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:53:38+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "6fd0d8d301f1dfb4",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 14,
+          "branch": "codex/swarm-5a555597-micro-4",
+          "dirty": false,
+          "head": "e922703d573dea2dd44e97edb82a3a79c83d0bf8",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T17:57:30+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "784539710f7171d9",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 3,
+          "behind": 14,
+          "branch": "codex/swarm-5a555597-micro-5",
+          "dirty": false,
+          "head": "c2cafc5297349bc147a27aa3a8b21582f6e1458b",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T18:01:21+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "b4d737b06992120b",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-1",
+          "dirty": false,
+          "head": "8b674d669d52e12ee69f6d8ad06f210d31ad0eb3",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:36:09+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "7367ec2797d1c183",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-2",
+          "dirty": false,
+          "head": "28dd329a5c3849f63feeee3b347e39f9b5cbd071",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-2"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:38:59+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-2",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-2",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "8d71d9be30a0b6c0",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-3",
+          "dirty": false,
+          "head": "e3f33ffb00671af4e19fb3a43883a1b7b1208627",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-3"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:38:55+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-3",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-3",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "a5098a4548cb1131",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-4",
+          "dirty": false,
+          "head": "b8b021ca06af4cf9fb5e6a75323ddff6ca412389",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:45:40+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-4",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "99472c710815a93f",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 4,
+          "behind": 20,
+          "branch": "codex/swarm-5f57bb72-micro-5",
+          "dirty": false,
+          "head": "f47a4647a375d0522de4a4b9706178675c877fec",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-5"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:47:27+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-5",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-5",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "22603bee379d4e48",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 22,
+          "branch": "codex/swarm-848a8081-micro-2",
+          "dirty": false,
+          "head": "c20a919bb8fa11a8a6b8467fd9b955b8130cfeaf",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-2"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:10:53+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-2",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-2",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "6ed337d15f09418a",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 1,
+          "behind": 22,
+          "branch": "codex/swarm-848a8081-micro-3",
+          "dirty": false,
+          "head": "ea13ddf962741a0a33ead3201233712a8bb3b48b",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-3"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:10:49+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-3",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-3",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "e496a4d3790537e4",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 2,
+          "behind": 22,
+          "branch": "codex/swarm-848a8081-micro-4",
+          "dirty": false,
+          "head": "2c2c8e8da18df4d5a867cadf780fdb7346524a68",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-4"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:14:40+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-4",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-4",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      },
+      {
+        "active_session": false,
+        "candidate_id": "5dbe197364417504",
+        "classification": "unique_unharvested",
+        "cleanup_candidate": false,
+        "decision": "harvest_candidate",
+        "git": {
+          "ahead": 3,
+          "behind": 22,
+          "branch": "codex/swarm-848a8081-micro-5",
+          "dirty": false,
+          "head": "e840168cd3b4aaf1513c4e87b8aa1bf57b0455e0",
+          "is_repo": true,
+          "lookup_errors": [],
+          "lookup_failed": false,
+          "patch_equivalent_to_base": false,
+          "registered_worktree": true,
+          "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-5"
+        },
+        "links": {
+          "open_prs": [],
+          "outbox_files": [],
+          "receipt_files": []
+        },
+        "lock_files": [],
+        "mtime": "2026-05-16T16:18:34+00:00",
+        "next_action": "inspect diff and harvest into a fresh branch or handoff",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-5",
+        "proof": [
+          "branch has unique commits or diff ahead of base"
+        ],
+        "repo_path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-5",
+        "size_bytes": null,
+        "size_lookup_failed": false
+      }
+    ],
+    "generated_at": "2026-05-17T02:07:18+00:00",
+    "ledger_written": null,
+    "limit": 50,
+    "repo": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7",
+    "root": "/Users/armand/Development/aragora/.worktrees/codex-auto",
+    "roots": [
+      "/Users/armand/Development/aragora/.worktrees/codex-auto"
+    ],
+    "schema": "aragora-worktree-harvest/1.0",
+    "size_mode": "none",
+    "summary": {
+      "bytes_by_class": {
+        "active_or_dirty": 0,
+        "lookup_failed": 0,
+        "no_git_cache_residue": 0,
+        "open_pr_or_outbox": 0,
+        "patch_equivalent_or_merged": 0,
+        "receipt_protected": 0,
+        "unique_unharvested": 0,
+        "unregistered_git_residue": 0
+      },
+      "classified_candidates": 45,
+      "cleanup_candidate_count": 5,
+      "count_by_class": {
+        "active_or_dirty": 12,
+        "lookup_failed": 0,
+        "no_git_cache_residue": 3,
+        "open_pr_or_outbox": 0,
+        "patch_equivalent_or_merged": 2,
+        "receipt_protected": 0,
+        "unique_unharvested": 28,
+        "unregistered_git_residue": 0
+      },
+      "harvest_candidate_count": 28,
+      "inventory_coverage": 0.0,
+      "known_size_bytes": 0,
+      "size_lookup_failures": 45,
+      "top_cleanup_candidates": [
+        {
+          "branch": null,
+          "classification": "no_git_cache_residue",
+          "decision": "cleanup_candidate",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-195315-89c3c0ad",
+          "proof": [
+            "no git metadata at candidate root or candidate/aragora path"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "droid/phase2-worktree-value-inventory-20260516",
+          "classification": "patch_equivalent_or_merged",
+          "decision": "cleanup_candidate",
+          "head": "d183d6df257b7da11749d0923609541bca0f977d",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7",
+          "proof": [
+            "registered git worktree has no unique commits ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "no_git_cache_residue",
+          "decision": "cleanup_candidate",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260422-194119-a5c0dd59",
+          "proof": [
+            "no git metadata at candidate root or candidate/aragora path"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/fix-worktree-inventory-managed-root",
+          "classification": "patch_equivalent_or_merged",
+          "decision": "cleanup_candidate",
+          "head": "4d8b23d750394d30c50494b822268eb7e195cc12",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4",
+          "proof": [
+            "branch is patch-equivalent to base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "no_git_cache_residue",
+          "decision": "cleanup_candidate",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/rbac-health-fix-20260413-1",
+          "proof": [
+            "no git metadata at candidate root or candidate/aragora path"
+          ],
+          "size_bytes": null
+        }
+      ],
+      "top_protected_size_users": [
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-041011-3b22a0f5",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-042801-d58ae59e",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-044410-204ba6b3",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-125421-513d6f8d",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132040-05232470",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132610-4446bddf",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-174558-6eed6d67",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-230411-bc06dedc",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-144747-b1c1b5ad",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-150130-e21247fc",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260507-171638-9eaae229",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "active_or_dirty",
+          "decision": "preserve",
+          "head": null,
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260515-152237-14d11f01",
+          "proof": [
+            "active session marker present without git metadata"
+          ],
+          "size_bytes": null
+        }
+      ],
+      "top_unique_unharvested": [
+        {
+          "branch": "droid/a2-pr3-admission-recovery-rescue-map-and-fixtures-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "19f29eeef1fc4e72be58cdbd36064303ac14a7c4",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "droid/phase1-fastapi-observer-truth-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "a9b044ce7490eab1a838fcc2ba8e54fcdb42ace6",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/corpus-aware-dispatch-upgrade-7209",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "5d98398a00cb1aa90f88a1beb2885bf2b01699c0",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/review-pr-advisory-hardening",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "e142a649a29e3f2ff2c7695a2a89dd20f452d216",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "19f29eeef1fc4e72be58cdbd36064303ac14a7c4",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/agent-bridge-process-census",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "35a1224c13d51fee216d3ec2d3f0135039bf0269",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": null,
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "68c03eadd0762e9825293a1f28298e949a73bf28",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/harvest-github-cli-health-unused-sys-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "723017ed917697a0d07a77388b2374913cca8ab0",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/harvest-metrics-refresh-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "7f9ecf28d5b9cf75df08281419104d74419c8917",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/harvest-preflight-rescue-guard-tests-20260516",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "71b58286266604da1c33c6693564af80517459ef",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-3844d54a-micro-1",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "2f95c3df3c6ffe7c8c9ad0f981ee16aad43e6ae7",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-3844d54a-micro-2",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "bf74992ff46434ab10d2400df6371c3fd5a0b7f9",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-3844d54a-micro-3",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "f79163971e50d2ac67b9775a0682f60ea43f4aec",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-3844d54a-micro-4",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "cac02945d2078979f1117b8c627f4b991686ee91",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-1",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "b1ff9bd8a6e49f109e618e61d4332a8e5857301e",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-2",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "bcc43c12da8e20d6183b27da4e09f6a04f8cc6b1",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-3",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "3adfe1bf0fe7c9ab22c56faa17f86cda1a4c004e",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-4",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "e922703d573dea2dd44e97edb82a3a79c83d0bf8",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5a555597-micro-5",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "c2cafc5297349bc147a27aa3a8b21582f6e1458b",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        },
+        {
+          "branch": "codex/swarm-5f57bb72-micro-1",
+          "classification": "unique_unharvested",
+          "decision": "harvest_candidate",
+          "head": "8b674d669d52e12ee69f6d8ad06f210d31ad0eb3",
+          "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1",
+          "proof": [
+            "branch has unique commits or diff ahead of base"
+          ],
+          "size_bytes": null
+        }
+      ],
+      "total_candidates": 45,
+      "unknown_candidates": 0
+    }
+  },
+  "roots": [
+    "/Users/armand/Development/aragora/.worktrees/codex-auto"
+  ],
+  "schema_version": 1,
+  "source_inventory_path": "/private/tmp/wvi_canonical.json",
+  "summary": {
+    "active_sessions": 12,
+    "candidates_with_open_pr": 0,
+    "classifications": {
+      "active_or_dirty": 12,
+      "no_git_cache_residue": 3,
+      "patch_equivalent_or_merged": 2,
+      "unique_unharvested": 28
+    },
+    "cleanup_candidates": [
+      {
+        "active_session": false,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "no_git_cache_residue",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:54:37+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-195315-89c3c0ad"
+      },
+      {
+        "active_session": false,
+        "ahead": 0,
+        "behind": 1,
+        "branch": "droid/phase2-worktree-value-inventory-20260516",
+        "classification": "patch_equivalent_or_merged",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:57:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-015647-9ea8f6b7"
+      },
+      {
+        "active_session": false,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "no_git_cache_residue",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:58:23+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260422-194119-a5c0dd59"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 1,
+        "branch": "codex/fix-worktree-inventory-managed-root",
+        "classification": "patch_equivalent_or_merged",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:42:38+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013517-967984c4"
+      },
+      {
+        "active_session": false,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "no_git_cache_residue",
+        "decision": "cleanup_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:58:23+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/rbac-health-fix-20260413-1"
+      }
+    ],
+    "decisions": {
+      "cleanup_candidate": 5,
+      "harvest_candidate": 28,
+      "preserve": 12
+    },
+    "dirty_count": 0,
+    "harvest_candidates": [
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 2,
+        "branch": "droid/a2-pr3-admission-recovery-rescue-map-and-fixtures-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:21:47+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-011811-b5b49881"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 1,
+        "branch": "droid/phase1-fastapi-observer-truth-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:49:05+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-014513-4b437897"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 16,
+        "branch": "codex/corpus-aware-dispatch-upgrade-7209",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:35:40+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-171432-ae417793"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 12,
+        "branch": "codex/review-pr-advisory-hardening",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:53:05+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260516-184833-3348d471"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 2,
+        "branch": null,
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:38:35+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-013727-4aa9468a"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 1,
+        "branch": "codex/agent-bridge-process-census",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-17T01:49:33+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260517-014233-61822f8b"
+      },
+      {
+        "active_session": false,
+        "ahead": 7,
+        "behind": 12,
+        "branch": null,
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T23:43:56+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-activity-repair"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 12,
+        "branch": "codex/harvest-github-cli-health-unused-sys-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:54:05+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-github-cli-health-unused-sys-20260516"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 6,
+        "branch": "codex/harvest-metrics-refresh-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T23:21:35+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-metrics-refresh-20260516"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 12,
+        "branch": "codex/harvest-preflight-rescue-guard-tests-20260516",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T19:08:56+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/harvest-preflight-rescue-guard-tests-20260516"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 12,
+        "branch": "codex/swarm-3844d54a-micro-1",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:47:35+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-1"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 12,
+        "branch": "codex/swarm-3844d54a-micro-2",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:50:06+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-2"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 12,
+        "branch": "codex/swarm-3844d54a-micro-3",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T19:07:45+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-3"
+      },
+      {
+        "active_session": false,
+        "ahead": 3,
+        "behind": 12,
+        "branch": "codex/swarm-3844d54a-micro-4",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T19:19:42+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-3844d54a-micro-4"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 15,
+        "branch": "codex/swarm-5a555597-micro-1",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:41:44+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-1"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 15,
+        "branch": "codex/swarm-5a555597-micro-2",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:53:42+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-2"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 14,
+        "branch": "codex/swarm-5a555597-micro-3",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:53:38+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-3"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 14,
+        "branch": "codex/swarm-5a555597-micro-4",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T17:57:30+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-4"
+      },
+      {
+        "active_session": false,
+        "ahead": 3,
+        "behind": 14,
+        "branch": "codex/swarm-5a555597-micro-5",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T18:01:21+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5a555597-micro-5"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-1",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:36:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-1"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-2",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:38:59+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-2"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-3",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:38:55+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-3"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-4",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:45:40+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-4"
+      },
+      {
+        "active_session": false,
+        "ahead": 4,
+        "behind": 20,
+        "branch": "codex/swarm-5f57bb72-micro-5",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:47:27+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-5f57bb72-micro-5"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 22,
+        "branch": "codex/swarm-848a8081-micro-2",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:10:53+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-2"
+      },
+      {
+        "active_session": false,
+        "ahead": 1,
+        "behind": 22,
+        "branch": "codex/swarm-848a8081-micro-3",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:10:49+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-3"
+      },
+      {
+        "active_session": false,
+        "ahead": 2,
+        "behind": 22,
+        "branch": "codex/swarm-848a8081-micro-4",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:14:40+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-4"
+      },
+      {
+        "active_session": false,
+        "ahead": 3,
+        "behind": 22,
+        "branch": "codex/swarm-848a8081-micro-5",
+        "classification": "unique_unharvested",
+        "decision": "harvest_candidate",
+        "dirty": false,
+        "mtime": "2026-05-16T16:18:34+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/swarm-848a8081-micro-5"
+      }
+    ],
+    "preserves": [
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-041011-3b22a0f5"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-042801-d58ae59e"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-044410-204ba6b3"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-125421-513d6f8d"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132040-05232470"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260430-132610-4446bddf"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-174558-6eed6d67"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260501-230411-bc06dedc"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-144747-b1c1b5ad"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260503-150130-e21247fc"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T23:51:09+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260507-171638-9eaae229"
+      },
+      {
+        "active_session": true,
+        "ahead": null,
+        "behind": null,
+        "branch": null,
+        "classification": "active_or_dirty",
+        "decision": "preserve",
+        "dirty": false,
+        "mtime": "2026-05-16T03:58:33+00:00",
+        "path": "/Users/armand/Development/aragora/.worktrees/codex-auto/codex-20260515-152237-14d11f01"
+      }
+    ],
+    "registered_worktrees": 30,
+    "total_candidates": 45
+  }
+}

--- a/scripts/publish_worktree_value_inventory.py
+++ b/scripts/publish_worktree_value_inventory.py
@@ -2,7 +2,8 @@
 """Publish a recurring worktree value inventory snapshot.
 
 Reads the JSON payload produced by ``scripts/codex_worktree_value_inventory.py``
-and writes a small, repo-tracked summary plus the full snapshot under
+or a previously published report from this script, then writes a small,
+repo-tracked summary plus the full snapshot under
 ``docs/status/generated/worktree_value_inventory/`` together with a
 ``latest.json`` pointer. The companion status surface lives at
 ``docs/status/WORKTREE_VALUE_INVENTORY_STATUS.md``.
@@ -64,15 +65,22 @@ def load_inventory_payload(path: Path) -> dict[str, Any]:
 
     The expected schema matches ``scripts/codex_worktree_value_inventory.py
     --json`` output: a top-level object with at least ``candidates`` (list)
-    and ``roots`` (list of strings). Missing keys default to empty
-    collections so the publisher never raises on partial or future-schema
-    inventories.
+    and ``roots`` (list of strings). The function also accepts a previously
+    published report from this script and unwraps its preserved ``inventory``
+    payload, which prevents ``latest.json`` dry-runs from silently reporting an
+    empty inventory. Missing keys default to empty collections so the publisher
+    never raises on partial or future-schema inventories.
     """
     if not path.exists():
         raise FileNotFoundError(f"inventory JSON not found: {path}")
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"inventory JSON at {path} must be a JSON object")
+    nested_inventory = payload.get("inventory")
+    if isinstance(nested_inventory, dict) and (
+        "candidates" in nested_inventory or "roots" in nested_inventory
+    ):
+        return nested_inventory
     return payload
 
 
@@ -306,7 +314,8 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         required=True,
         help="Path to an inventory JSON snapshot (output of "
-        "scripts/codex_worktree_value_inventory.py --json).",
+        "scripts/codex_worktree_value_inventory.py --json) or a previously "
+        "published worktree-value-inventory report.",
     )
     parser.add_argument(
         "--publish-dir",

--- a/scripts/publish_worktree_value_inventory.py
+++ b/scripts/publish_worktree_value_inventory.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Publish a recurring worktree value inventory snapshot.
+
+Reads the JSON payload produced by ``scripts/codex_worktree_value_inventory.py``
+and writes a small, repo-tracked summary plus the full snapshot under
+``docs/status/generated/worktree_value_inventory/`` together with a
+``latest.json`` pointer. The companion status surface lives at
+``docs/status/WORKTREE_VALUE_INVENTORY_STATUS.md``.
+
+Read-only by default: ``--dry-run`` prints the summary without writing
+anything. ``--input`` lets an operator hand in a pre-captured inventory
+artifact (the inventory script can be slow when the legacy ``~/.codex/worktrees``
+root has thousands of entries, so capturing once and publishing afterwards is
+the recommended flow).
+
+This publisher is intentionally additive:
+
+- it does not run cleanup, harvest, or any GitHub-mutating action
+- it does not import any aragora subpackage; it stays a pure stdlib script
+- it never deletes prior dated artifacts (the directory acts as an audit
+  trail, mirroring the rescue-productization and B0-truth conventions)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PUBLISH_DIR = REPO_ROOT / "docs" / "status" / "generated" / "worktree_value_inventory"
+DEFAULT_STATUS_DOC = REPO_ROOT / "docs" / "status" / "WORKTREE_VALUE_INVENTORY_STATUS.md"
+SCHEMA_VERSION = 1
+
+
+def _coerce_utc_datetime(value: str | None = None) -> dt.datetime:
+    if value:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    else:
+        parsed = dt.datetime.now(dt.UTC)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC).replace(microsecond=0)
+
+
+def normalize_generated_at(value: str | None = None) -> str:
+    return _coerce_utc_datetime(value).isoformat().replace("+00:00", "Z")
+
+
+def _stable_repo_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def load_inventory_payload(path: Path) -> dict[str, Any]:
+    """Load a worktree value-inventory JSON document.
+
+    The expected schema matches ``scripts/codex_worktree_value_inventory.py
+    --json`` output: a top-level object with at least ``candidates`` (list)
+    and ``roots`` (list of strings). Missing keys default to empty
+    collections so the publisher never raises on partial or future-schema
+    inventories.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"inventory JSON not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"inventory JSON at {path} must be a JSON object")
+    return payload
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _summarize_candidates(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    classifications: Counter[str] = Counter()
+    decisions: Counter[str] = Counter()
+    active_sessions = 0
+    registered_worktrees = 0
+    dirty_count = 0
+    has_open_pr = 0
+    cleanup_candidates: list[dict[str, Any]] = []
+    harvest_candidates: list[dict[str, Any]] = []
+    preserves: list[dict[str, Any]] = []
+
+    for cand in candidates:
+        if not isinstance(cand, dict):
+            continue
+        classification = str(cand.get("classification") or "").strip() or "unknown"
+        decision = str(cand.get("decision") or "").strip() or "unknown"
+        classifications[classification] += 1
+        decisions[decision] += 1
+
+        if bool(cand.get("active_session")):
+            active_sessions += 1
+        git_block = cand.get("git") or {}
+        if isinstance(git_block, dict):
+            if bool(git_block.get("registered_worktree")):
+                registered_worktrees += 1
+            if bool(git_block.get("dirty")):
+                dirty_count += 1
+        if cand.get("links") and isinstance(cand["links"], dict):
+            if cand["links"].get("open_prs"):
+                has_open_pr += 1
+
+        row = {
+            "path": str(cand.get("path") or ""),
+            "branch": (git_block.get("branch") if isinstance(git_block, dict) else None),
+            "classification": classification,
+            "decision": decision,
+            "ahead": (_coerce_int(git_block.get("ahead")) if isinstance(git_block, dict) else None),
+            "behind": (
+                _coerce_int(git_block.get("behind")) if isinstance(git_block, dict) else None
+            ),
+            "dirty": bool(git_block.get("dirty")) if isinstance(git_block, dict) else False,
+            "active_session": bool(cand.get("active_session")),
+            "mtime": str(cand.get("mtime") or ""),
+        }
+        if decision == "cleanup_candidate":
+            cleanup_candidates.append(row)
+        elif decision == "harvest_candidate":
+            harvest_candidates.append(row)
+        elif decision == "preserve":
+            preserves.append(row)
+
+    return {
+        "total_candidates": len(candidates),
+        "active_sessions": active_sessions,
+        "registered_worktrees": registered_worktrees,
+        "dirty_count": dirty_count,
+        "candidates_with_open_pr": has_open_pr,
+        "classifications": dict(classifications),
+        "decisions": dict(decisions),
+        "cleanup_candidates": cleanup_candidates,
+        "harvest_candidates": harvest_candidates,
+        "preserves": preserves,
+    }
+
+
+def build_published_report(
+    *,
+    inventory_path: Path,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    inventory = load_inventory_payload(inventory_path)
+    candidates = inventory.get("candidates") or []
+    if not isinstance(candidates, list):
+        candidates = []
+    summary = _summarize_candidates([c for c in candidates if isinstance(c, dict)])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": normalize_generated_at(generated_at),
+        "source_inventory_path": _stable_repo_path(inventory_path),
+        "base": str(inventory.get("base") or ""),
+        "base_sha": str(inventory.get("base_sha") or ""),
+        "roots": [str(r) for r in (inventory.get("roots") or [])],
+        "summary": summary,
+        "inventory": inventory,
+    }
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def resolve_published_report_path(*, publish_dir: Path, generated_at: str) -> Path:
+    timestamp = _coerce_utc_datetime(generated_at).strftime("%Y%m%dT%H%M%SZ")
+    return publish_dir / f"worktree-value-inventory-{timestamp}.json"
+
+
+def resolve_latest_report_path(*, publish_dir: Path) -> Path:
+    return publish_dir / "latest.json"
+
+
+def publish_report_bundle(
+    *,
+    publish_dir: Path,
+    payload: dict[str, Any],
+) -> dict[str, Path]:
+    timestamped = write_json(
+        resolve_published_report_path(
+            publish_dir=publish_dir,
+            generated_at=str(payload.get("generated_at") or ""),
+        ),
+        payload,
+    )
+    latest = write_json(
+        resolve_latest_report_path(publish_dir=publish_dir),
+        payload,
+    )
+    return {"timestamped": timestamped, "latest": latest}
+
+
+def render_status_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary") or {}
+    classifications = summary.get("classifications") or {}
+    decisions = summary.get("decisions") or {}
+    cleanup_candidates = summary.get("cleanup_candidates") or []
+    harvest_candidates = summary.get("harvest_candidates") or []
+    preserves = summary.get("preserves") or []
+
+    lines: list[str] = []
+    lines.append("# Worktree Value Inventory Status\n")
+    lines.append(f"Last updated: {payload.get('generated_at', '')}\n")
+    lines.append(
+        "This repo-tracked status surface captures the most recent run of "
+        "`scripts/codex_worktree_value_inventory.py` against the canonical "
+        "and legacy Aragora worktree roots, classifying each checkout as "
+        "preserve / harvest_candidate / cleanup_candidate.\n"
+    )
+    lines.append("## Summary\n")
+    lines.append(f"- Source inventory: `{payload.get('source_inventory_path', '')}`")
+    lines.append(f"- Base ref: `{payload.get('base', '')}`")
+    lines.append(f"- Roots: `{', '.join(payload.get('roots') or []) or '(none)'}`")
+    lines.append(f"- Total candidates: `{summary.get('total_candidates', 0)}`")
+    lines.append(f"- Active sessions: `{summary.get('active_sessions', 0)}`")
+    lines.append(f"- Registered worktrees: `{summary.get('registered_worktrees', 0)}`")
+    lines.append(f"- Candidates with open PR: `{summary.get('candidates_with_open_pr', 0)}`")
+    lines.append(f"- Dirty checkouts: `{summary.get('dirty_count', 0)}`\n")
+
+    lines.append("## Classifications\n")
+    if classifications:
+        for key in sorted(classifications):
+            lines.append(f"- `{key}`: {classifications[key]}")
+    else:
+        lines.append("- (no candidates)")
+    lines.append("")
+
+    lines.append("## Decisions\n")
+    if decisions:
+        for key in sorted(decisions):
+            lines.append(f"- `{key}`: {decisions[key]}")
+    else:
+        lines.append("- (no candidates)")
+    lines.append("")
+
+    def _emit_rows(rows: list[dict[str, Any]], heading: str) -> None:
+        lines.append(f"## {heading}\n")
+        if not rows:
+            lines.append("- (none)\n")
+            return
+        lines.append("| Path | Branch | Classification | Ahead | Behind | Dirty | Active |")
+        lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+        for row in rows[:25]:
+            path = str(row.get("path") or "").replace("|", "/")
+            branch = str(row.get("branch") or "-").replace("|", "/")
+            cls = str(row.get("classification") or "-")
+            ahead = row.get("ahead")
+            behind = row.get("behind")
+            dirty = "yes" if row.get("dirty") else "no"
+            active = "yes" if row.get("active_session") else "no"
+            lines.append(
+                f"| `{path[-60:]}` | `{branch}` | `{cls}` | "
+                f"{ahead if ahead is not None else '-'} | "
+                f"{behind if behind is not None else '-'} | "
+                f"{dirty} | {active} |"
+            )
+        if len(rows) > 25:
+            lines.append(f"\n*Truncated: {len(rows) - 25} additional rows omitted.*")
+        lines.append("")
+
+    _emit_rows(harvest_candidates, "Harvest Candidates")
+    _emit_rows(cleanup_candidates, "Cleanup Candidates")
+    _emit_rows(preserves, "Preserved (active or dirty)")
+
+    lines.append("## Provenance\n")
+    lines.append(
+        "- Generator: `scripts/codex_worktree_value_inventory.py` "
+        "(see PR #7250 for canonical+legacy smart roots; PR #7253/#7254 for "
+        "managed-session lookup and foreign-worktree preservation)."
+    )
+    lines.append(
+        "- Publisher: `scripts/publish_worktree_value_inventory.py` "
+        "(this file). Read-only; never deletes worktrees or branches.\n"
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_status_markdown(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to an inventory JSON snapshot (output of "
+        "scripts/codex_worktree_value_inventory.py --json).",
+    )
+    parser.add_argument(
+        "--publish-dir",
+        type=Path,
+        default=DEFAULT_PUBLISH_DIR,
+        help=f"Directory for latest/timestamped inventory artifacts "
+        f"(default: {DEFAULT_PUBLISH_DIR})",
+    )
+    parser.add_argument(
+        "--status-doc",
+        type=Path,
+        default=DEFAULT_STATUS_DOC,
+        help=f"Path to the human-readable status surface (default: {DEFAULT_STATUS_DOC})",
+    )
+    parser.add_argument(
+        "--generated-at",
+        default=None,
+        help="Override the generated_at timestamp (ISO-8601 UTC).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the summary payload but do not write any artifacts.",
+    )
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = build_published_report(
+        inventory_path=args.input.resolve(),
+        generated_at=args.generated_at,
+    )
+    published: dict[str, Path] | None = None
+    status_path: Path | None = None
+    if not args.dry_run:
+        published = publish_report_bundle(
+            publish_dir=args.publish_dir.resolve(),
+            payload=payload,
+        )
+        status_path = write_status_markdown(
+            args.status_doc.resolve(),
+            render_status_markdown(payload),
+        )
+
+    if args.json:
+        out = {
+            "schema_version": payload["schema_version"],
+            "generated_at": payload["generated_at"],
+            "summary": payload["summary"],
+        }
+        if published is not None:
+            out["timestamped"] = _stable_repo_path(published["timestamped"])
+            out["latest"] = _stable_repo_path(published["latest"])
+        if status_path is not None:
+            out["status_doc"] = _stable_repo_path(status_path)
+        print(json.dumps(out, indent=2))
+    else:
+        summary = payload["summary"]
+        print(
+            f"worktree-value-inventory: total={summary['total_candidates']} "
+            f"harvest={len(summary['harvest_candidates'])} "
+            f"cleanup={len(summary['cleanup_candidates'])} "
+            f"preserve={len(summary['preserves'])}"
+        )
+        if published is None:
+            print("dry-run: artifacts not written")
+        else:
+            print(f"timestamped: {published['timestamped']}")
+            print(f"latest:      {published['latest']}")
+        if status_path is not None:
+            print(f"status_doc:  {status_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_publish_worktree_value_inventory.py
+++ b/tests/scripts/test_publish_worktree_value_inventory.py
@@ -138,6 +138,28 @@ def test_build_published_report_writes_canonical_keys(tmp_path: Path) -> None:
     assert payload["inventory"]["candidates"][0]["git"]["branch"] == "feature/x"
 
 
+def test_build_published_report_accepts_previous_published_report(tmp_path: Path) -> None:
+    inv = tmp_path / "inv.json"
+    inv.write_text(
+        json.dumps(_inventory_payload([_candidate(branch="feature/x")])),
+        encoding="utf-8",
+    )
+    first_payload = publisher.build_published_report(
+        inventory_path=inv, generated_at="2026-05-17T05:00:00Z"
+    )
+    latest = tmp_path / "latest.json"
+    latest.write_text(json.dumps(first_payload), encoding="utf-8")
+
+    republished = publisher.build_published_report(
+        inventory_path=latest,
+        generated_at="2026-05-17T06:00:00Z",
+    )
+
+    assert republished["source_inventory_path"].endswith("latest.json")
+    assert republished["summary"]["total_candidates"] == 1
+    assert republished["inventory"]["candidates"][0]["git"]["branch"] == "feature/x"
+
+
 def test_resolve_paths_round_trip(tmp_path: Path) -> None:
     ts = "2026-05-17T05:00:00Z"
     pub_path = publisher.resolve_published_report_path(publish_dir=tmp_path, generated_at=ts)

--- a/tests/scripts/test_publish_worktree_value_inventory.py
+++ b/tests/scripts/test_publish_worktree_value_inventory.py
@@ -1,0 +1,297 @@
+"""Focused tests for `scripts/publish_worktree_value_inventory.py`."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import publish_worktree_value_inventory as publisher  # noqa: E402
+
+
+def _inventory_payload(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "base": "origin/main",
+        "base_sha": "deadbeef" * 5,
+        "roots": ["/path/to/.worktrees/codex-auto"],
+        "candidates": candidates,
+    }
+
+
+def _candidate(
+    *,
+    path: str = "/.worktrees/codex-auto/abc",
+    branch: str | None = "feature/foo",
+    classification: str = "unique_unharvested",
+    decision: str = "harvest_candidate",
+    active_session: bool = False,
+    registered_worktree: bool = True,
+    dirty: bool = False,
+    ahead: int | None = 5,
+    behind: int | None = 1,
+    open_prs: list[str] | None = None,
+    mtime: str = "2026-05-16T00:00:00+00:00",
+) -> dict[str, Any]:
+    return {
+        "path": path,
+        "candidate_id": "x",
+        "classification": classification,
+        "cleanup_candidate": decision == "cleanup_candidate",
+        "decision": decision,
+        "active_session": active_session,
+        "git": {
+            "branch": branch,
+            "registered_worktree": registered_worktree,
+            "dirty": dirty,
+            "ahead": ahead,
+            "behind": behind,
+        },
+        "links": {
+            "open_prs": list(open_prs or []),
+            "outbox_files": [],
+            "receipt_files": [],
+        },
+        "lock_files": [],
+        "mtime": mtime,
+    }
+
+
+def test_load_inventory_payload_rejects_non_dict(tmp_path: Path) -> None:
+    path = tmp_path / "inv.json"
+    path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    with pytest.raises(ValueError):
+        publisher.load_inventory_payload(path)
+
+
+def test_load_inventory_payload_raises_when_missing(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        publisher.load_inventory_payload(tmp_path / "missing.json")
+
+
+def test_summarize_candidates_counts_three_decision_buckets() -> None:
+    summary = publisher._summarize_candidates(
+        [
+            _candidate(decision="harvest_candidate", classification="unique_unharvested"),
+            _candidate(decision="harvest_candidate", classification="unique_unharvested"),
+            _candidate(
+                decision="cleanup_candidate",
+                classification="patch_equivalent_or_merged",
+                ahead=0,
+                behind=10,
+            ),
+            _candidate(
+                decision="preserve",
+                classification="active_or_dirty",
+                active_session=True,
+                dirty=True,
+                open_prs=["https://github.com/synaptent/aragora/pull/9999"],
+            ),
+        ]
+    )
+
+    assert summary["total_candidates"] == 4
+    assert summary["active_sessions"] == 1
+    assert summary["dirty_count"] == 1
+    assert summary["candidates_with_open_pr"] == 1
+    assert summary["registered_worktrees"] == 4
+    assert summary["decisions"] == {
+        "harvest_candidate": 2,
+        "cleanup_candidate": 1,
+        "preserve": 1,
+    }
+    assert summary["classifications"] == {
+        "unique_unharvested": 2,
+        "patch_equivalent_or_merged": 1,
+        "active_or_dirty": 1,
+    }
+    assert len(summary["harvest_candidates"]) == 2
+    assert len(summary["cleanup_candidates"]) == 1
+    assert len(summary["preserves"]) == 1
+
+
+def test_build_published_report_writes_canonical_keys(tmp_path: Path) -> None:
+    inv = tmp_path / "inv.json"
+    inv.write_text(
+        json.dumps(_inventory_payload([_candidate(branch="feature/x")])),
+        encoding="utf-8",
+    )
+
+    payload = publisher.build_published_report(
+        inventory_path=inv, generated_at="2026-05-17T05:00:00Z"
+    )
+
+    assert payload["schema_version"] == publisher.SCHEMA_VERSION
+    assert payload["generated_at"] == "2026-05-17T05:00:00Z"
+    assert payload["base"] == "origin/main"
+    assert payload["base_sha"].startswith("deadbeef")
+    assert payload["roots"] == ["/path/to/.worktrees/codex-auto"]
+    assert payload["summary"]["total_candidates"] == 1
+    # The full inventory is preserved verbatim for downstream diffability.
+    assert payload["inventory"]["candidates"][0]["git"]["branch"] == "feature/x"
+
+
+def test_resolve_paths_round_trip(tmp_path: Path) -> None:
+    ts = "2026-05-17T05:00:00Z"
+    pub_path = publisher.resolve_published_report_path(publish_dir=tmp_path, generated_at=ts)
+    latest_path = publisher.resolve_latest_report_path(publish_dir=tmp_path)
+    assert pub_path.name == "worktree-value-inventory-20260517T050000Z.json"
+    assert latest_path.name == "latest.json"
+
+
+def test_publish_report_bundle_writes_two_artifacts(tmp_path: Path) -> None:
+    inv = tmp_path / "inv.json"
+    inv.write_text(
+        json.dumps(_inventory_payload([_candidate()])),
+        encoding="utf-8",
+    )
+    payload = publisher.build_published_report(
+        inventory_path=inv, generated_at="2026-05-17T05:00:00Z"
+    )
+    published = publisher.publish_report_bundle(
+        publish_dir=tmp_path / "publish",
+        payload=payload,
+    )
+
+    assert published["timestamped"].exists()
+    assert published["latest"].exists()
+    assert published["timestamped"].read_text(encoding="utf-8") == published["latest"].read_text(
+        encoding="utf-8"
+    )
+    # latest.json must be valid JSON matching schema
+    on_disk = json.loads(published["latest"].read_text(encoding="utf-8"))
+    assert on_disk["schema_version"] == publisher.SCHEMA_VERSION
+    assert on_disk["summary"]["total_candidates"] == 1
+
+
+def test_render_status_markdown_includes_key_sections(tmp_path: Path) -> None:
+    inv = tmp_path / "inv.json"
+    inv.write_text(
+        json.dumps(
+            _inventory_payload(
+                [
+                    _candidate(
+                        path="/x/.worktrees/codex-auto/feature-a",
+                        branch="feature/a",
+                        decision="harvest_candidate",
+                        classification="unique_unharvested",
+                    ),
+                    _candidate(
+                        path="/x/.worktrees/codex-auto/feature-b",
+                        branch="feature/b",
+                        decision="cleanup_candidate",
+                        classification="patch_equivalent_or_merged",
+                    ),
+                    _candidate(
+                        path="/x/.worktrees/codex-auto/active",
+                        branch="droid/x",
+                        decision="preserve",
+                        classification="active_or_dirty",
+                        active_session=True,
+                    ),
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+    payload = publisher.build_published_report(
+        inventory_path=inv, generated_at="2026-05-17T05:00:00Z"
+    )
+    md = publisher.render_status_markdown(payload)
+
+    assert md.startswith("# Worktree Value Inventory Status")
+    assert "Last updated: 2026-05-17T05:00:00Z" in md
+    assert "Total candidates: `3`" in md
+    assert "Active sessions: `1`" in md
+    assert "## Harvest Candidates" in md
+    assert "## Cleanup Candidates" in md
+    assert "## Preserved (active or dirty)" in md
+    assert "feature/a" in md
+    assert "feature/b" in md
+    assert "droid/x" in md
+    # No trailing whitespace bloat / always ends with newline
+    assert md.endswith("\n")
+
+
+def test_main_dry_run_writes_no_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    inv = tmp_path / "inv.json"
+    inv.write_text(
+        json.dumps(_inventory_payload([_candidate()])),
+        encoding="utf-8",
+    )
+    publish_dir = tmp_path / "publish"
+    status_doc = tmp_path / "WORKTREE_VALUE_INVENTORY_STATUS.md"
+
+    rc = publisher.main(
+        [
+            "--input",
+            str(inv),
+            "--publish-dir",
+            str(publish_dir),
+            "--status-doc",
+            str(status_doc),
+            "--dry-run",
+            "--generated-at",
+            "2026-05-17T05:00:00Z",
+        ]
+    )
+    assert rc == 0
+    assert not publish_dir.exists()
+    assert not status_doc.exists()
+
+    out = capsys.readouterr().out
+    assert "worktree-value-inventory:" in out
+    assert "dry-run: artifacts not written" in out
+
+
+def test_main_writes_artifacts_and_status_doc(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    inv = tmp_path / "inv.json"
+    inv.write_text(
+        json.dumps(
+            _inventory_payload(
+                [
+                    _candidate(decision="harvest_candidate"),
+                    _candidate(decision="cleanup_candidate"),
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+    publish_dir = tmp_path / "publish"
+    status_doc = tmp_path / "WORKTREE_VALUE_INVENTORY_STATUS.md"
+
+    rc = publisher.main(
+        [
+            "--input",
+            str(inv),
+            "--publish-dir",
+            str(publish_dir),
+            "--status-doc",
+            str(status_doc),
+            "--generated-at",
+            "2026-05-17T05:00:00Z",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    assert (publish_dir / "latest.json").exists()
+    assert (publish_dir / "worktree-value-inventory-20260517T050000Z.json").exists()
+    assert status_doc.exists()
+    md = status_doc.read_text(encoding="utf-8")
+    assert "Total candidates: `2`" in md
+
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["schema_version"] == publisher.SCHEMA_VERSION
+    assert parsed["summary"]["total_candidates"] == 2


### PR DESCRIPTION
## Summary

Adds a repo-tracked **worktree value inventory** status surface so the operator can see which managed worktrees are unique-unharvested, patch-equivalent, or cleanup-safe without re-running `scripts/codex_worktree_value_inventory.py`. Mirrors the existing pattern used for **TW-03 rescue productization** and **B0 benchmark truth** status surfaces.

This dogfoods the trio of inventory improvements that landed today:

- #7250 — smart canonical+legacy worktree roots
- #7253 — find canonical worktrees from managed sessions
- #7254 — preserve foreign worktrees in inventory

## Change

| File | Purpose |
|------|---------|
| `scripts/publish_worktree_value_inventory.py` | Pure-stdlib publisher; reads an inventory JSON snapshot, writes timestamped + latest pointer artifacts, and renders a markdown status doc |
| `tests/scripts/test_publish_worktree_value_inventory.py` | 9 fixture-driven tests; no network, no subprocess |
| `docs/status/WORKTREE_VALUE_INVENTORY_STATUS.md` | Human-readable stable status surface |
| `docs/status/generated/worktree_value_inventory/latest.json` | Canonical latest snapshot |
| `docs/status/generated/worktree_value_inventory/worktree-value-inventory-20260517T040800Z.json` | First dated snapshot |

## First snapshot results (canonical root only)

Source: `scripts/codex_worktree_value_inventory.py --skip-gh --size-mode none --root .worktrees/codex-auto` (~3 min run; legacy `~/.codex/worktrees` skipped because it contains 1051+ entries and would dominate the budget).

| Metric | Value |
|---|---|
| Total candidates | 45 |
| Harvest candidates | 28 (`unique_unharvested`) |
| Cleanup candidates | 5 (3 `no_git_cache_residue` + 2 `patch_equivalent_or_merged`) |
| Preserved | 12 (`active_or_dirty`, includes active sessions) |
| Dirty checkouts | 0 |
| Candidates with open PR | 0 |
| Registered worktrees | 30 |

The full inventory and per-row tables live in `docs/status/WORKTREE_VALUE_INVENTORY_STATUS.md`.

## Non-goals (explicit)

- No deletion of any worktree or branch — publisher is strictly read-only over the captured snapshot
- No GitHub-mutating action
- No `aragora` package import — pure stdlib so the publisher works during partial bootstraps
- No automatic schedule / cron / launchd hook added; operator runs the inventory + publisher manually for now
- No `TerminalClass` change, no flag flips, no live ledger writes

## Validation receipts

- `pytest tests/scripts/test_publish_worktree_value_inventory.py` -> **9 passed**
- `ruff check` + `ruff format --check` -> clean
- Live publish run against the captured inventory snapshot -> 3 artifacts written (latest.json, timestamped JSON, markdown status doc)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> **preflight: ok**

## Codex review prompts

```
Read scripts/publish_worktree_value_inventory.py and the three docs/status artifacts.
Verify:
1. The publisher only writes to the publish_dir and status_doc paths supplied (no other side effects).
2. The summary buckets (decisions/classifications) preserve totals from the source inventory.
3. The status markdown handles the empty-candidates case without crashing.
4. The latest.json content is byte-identical to the timestamped JSON for the same generated_at.
5. No new dependency, no aragora.* import, no subprocess.
```

## Follow-on (not in this PR)

- Optional: scheduled run of `codex_worktree_value_inventory --skip-gh + publish_worktree_value_inventory --input` via cron or `aragora autopilot`, once the legacy `~/.codex/worktrees` performance question is addressed (or excluded by design)
- Optional: surface the rolled-up summary in `aragora swarm shift-status` as `worktree_inventory_age_hours`

## Risk

Tier-0 / additive only. New script, new tests, new docs surface; no existing file modified.
