### PR TITLE
feat(automation): publish recurring publication-freshness probe

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4133` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1938031` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4134` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1938146` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `139` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5183` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `218131` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `684` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5187` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `218189` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `687` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `67` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `841` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `845` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/status/AGENT_FANOUT_JOURNAL.md
+++ b/docs/status/AGENT_FANOUT_JOURNAL.md
@@ -9,3 +9,6 @@ Columns: `timestamp_utc | session_id | agent_family | phase_id | pr_number | out
 ---
 
 2026-05-17T16:56:00Z | droid-DC5A5821 | droid | P03-lane-registry-claim-helper-rebase | 7267 | finish-existing
+
+2026-05-17T17:23:00Z | droid-A5312D6A | droid | P05-publication-freshness-probe-rebase | 7261 | finish-existing
+2026-05-17T17:23:00Z | droid-A5312D6A | prompt-bug: v3 heredoc shim '/tmp/fanout_claim.py <<PYEOF ... PYEOF' still hangs in test shell; v4 must ship shim as tracked scripts/ file (see P12 deferral)

--- a/docs/status/P05-publication-freshness-probe-rebase_RECEIPT_droid-A5312D6A.md
+++ b/docs/status/P05-publication-freshness-probe-rebase_RECEIPT_droid-A5312D6A.md
@@ -1,0 +1,82 @@
+# P05-publication-freshness-probe-rebase — Session Receipt
+
+**Session ID:** droid-A5312D6A
+**Agent family:** droid (Factory Droid)
+**Generated:** 2026-05-17T17:23:00Z
+**Base SHA:** 4cd9f6a22a2e8722a1f933ee7d5a9834b34ac523 (origin/main)
+**Prompt:** v3 idempotent 12-agent fanout
+
+## Goal
+
+Finish/rebase PR #7261 (publication-freshness probe) onto current `origin/main`, re-validate, post finishing self-review, and flip it from draft to ready-for-review.
+
+## What shipped
+
+- Identified that PR #7261 was 10 commits behind current main (parent `f14f0c871` vs main `4cd9f6a22`). Hard-reset existing worktree `claude-20260517-062140-26e58382` to `origin/main`, cherry-picked the single PR commit `a5a4f1306`, produced clean `00308bd8b` with zero conflicts.
+- Re-validated: ruff check clean, ruff format clean, preflight ok (5 changed files identified), 11 tests passed.
+- Force-pushed `--force-with-lease`: `a5a4f1306...00308bd8b` to `droid/phase4-publication-freshness-probe-20260516`.
+- Posted finishing self-review comment (`#issuecomment-4471725477`) documenting the rebase, the operator decision context (#7272 closed → ship probe alone, not LaunchAgent), and cross-agent overlap check.
+- Flipped PR #7261 from draft to ready-for-review via `gh pr ready 7261`.
+- Verified: state=OPEN, draft=false, mergeable=MERGEABLE, 23 SUCCESS / 15 pending / 4 CANCELLED (from pre-rebase run) / 0 FAILURE.
+
+## PR / branch coordinates
+
+- PR URL: https://github.com/synaptent/aragora/pull/7261
+- Branch: `droid/phase4-publication-freshness-probe-20260516`
+- Head SHA before rebase: `a5a4f1306`
+- Head SHA after rebase: `00308bd8b`
+- State after this session: OPEN, **draft=false** (ready-for-review), MERGEABLE, mergeState=BLOCKED (only because still pending review)
+
+## Dogfood quorum (6 observers)
+
+1. `list_active_agent_sessions.py --json --max-pr-fetch 50 --skip-codex-desktop`
+   → `overlap_count=14, open_prs=13, worktrees=312`
+2. `agent_bridge.py operator-snapshot --json --summary-only`
+   → `active_processes=350, active_lanes=1, roles=[claude_code, codex_app_server, codex_cli, factory_droid]`
+3. `gh pr view 7261 --json statusCheckRollup`
+   → `{state=OPEN, draft=false, mergeable=MERGEABLE, checks: 23 SUCCESS, 15 pending, 4 CANCELLED (superseded), 0 FAILURE}`
+4. `docs/status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json`
+   → `generated_at=2026-05-17T14:36:42Z` (age 2.8 h, P01 fresh-skip still applies)
+5. `docs/status/generated/worktree_value_inventory/latest.json`
+   → `generated_at=2026-05-17T04:08:00Z, worktree_count=0` (publisher hasn't refreshed in 13 h, still a P07 candidate)
+6. `docs/status/generated/publication_freshness_probe/` on main
+   → does not exist yet (the directory ships with this PR; once #7261 merges, future probe-freshness queries become possible)
+
+## Reproducible commands
+
+```bash
+# Re-run the validation chain on this PR's branch
+cd /Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-062140-26e58382
+git fetch origin droid/phase4-publication-freshness-probe-20260516 main
+git log origin/main..HEAD --oneline   # expect 1 commit (00308bd8b)
+bash scripts/automation_pr_preflight.sh origin/main HEAD
+/Users/armand/Development/aragora/.venv/bin/python3 -m pytest \
+    tests/scripts/test_publish_publication_freshness_probe.py -q
+/Users/armand/Development/aragora/.venv/bin/python3 -m ruff check \
+    scripts/publish_publication_freshness_probe.py \
+    tests/scripts/test_publish_publication_freshness_probe.py
+gh pr view 7261 --json state,isDraft,mergeable,statusCheckRollup
+```
+
+## v3 prompt findings (for journal `prompt-bug:` line)
+
+- **Heredoc claim shim still hangs.** Same problem as v2: `cat > /tmp/fanout_claim.py <<'PYEOF' ... PYEOF` hung after 60s. Workaround in this session: write `/tmp/fanout_claim.py` via the file-create tool (Create tool / equivalent). v4 must ship the shim as a tracked file under `scripts/` so no agent ever has to heredoc-it.
+- **#7272 closure is a real signal.** The LaunchAgent installer PR closed 6 min after the prior session's P03 receipt commit. Reading the closure pattern, the operator wants the probe (this PR #7261) but does not want LaunchAgents installed automatically. v3's P04 lane correctly skip-classified this; v4 should preserve that.
+- **#7270 closure** similarly closes the question for P09 (no reconciliation needed — the canonical surface is #7267).
+- **Journal file is on PR #7267's branch, not main yet.** Until #7267 merges, the journal-skip rule (e) effectively never fires because the file doesn't exist on `origin/main`. Cross-session memory is therefore PR-branch-bound, which limits its reach. v4 could either (a) wait for #7267 to merge before relying on this rule, or (b) bootstrap the journal file via a tiny no-op commit to main, but option (b) is approval-required.
+
+## Deferred for parallel siblings
+
+- **P06 rescue-productize-next-class:** `docs/status/generated/rescue_productization/latest.json` is dated `2026-04-17T12:57:28Z` (30 days stale) but contains `repeated_classes`. Read that list, pick highest-occurrence unproduced class, ship per #7265 pattern. Note: a fresher publisher run may be a P07-adjacent prerequisite.
+- **P07 worktree-inventory-rerun:** publisher last ran at `04:08:00Z`, 13 h ago, with `worktree_count: 0` — likely broken or empty-result. Run `python3 scripts/publish_worktree_value_inventory.py` and inspect. If the result is genuinely empty, file a tiny investigative PR; if it produces non-empty output, ship the new `latest.json` + snapshot.
+- **P08 fastapi-observer-truth-audit:** #7257 merged. Spin up the server with `aragora serve` (dev mode) and verify `/swarm-status` returns ledger-backed truth rather than mocked output.
+- **P10 codex-automation-handoff:** run `scripts/reconcile_automation_outbox.py`.
+- **P11 stale-pr-rebase:** check #7245 (the oldest agent-prefix draft); also #7251 (a2-pr3-admission-recovery).
+- **P12 tool-gap-closure:** ship `/tmp/fanout_claim.py`'s contents as `scripts/fanout_claim_lane.py` (pure stdlib, 0 deps), plus a small test (`tests/scripts/test_fanout_claim_lane.py`) verifying atomic claim, idempotent re-claim by same owner, and conflict on different owner. ~80 lines. Solves the heredoc bug for all future fan-out sessions.
+- **P13 docs-drift:** `docs/COORDINATION.md` "Currently Active" section is stale relative to `.aragora/agent-bridge/lanes.json`. Tiny PR to point at the registry.
+- **P14 receipt-loop-settlement:** per `NEXT_STEPS_CANONICAL.md`.
+- **P15 prompt-meta-iteration:** v4 should drop the heredoc form of the shim entirely and reference a tracked file from P12. Adopt this session's `prompt-bug:` journal line as a confirmed defect rather than a hypothetical.
+
+## Lane status
+
+Released atomically after this receipt is committed. See `.aragora/agent-bridge/lanes.json`.

--- a/docs/status/PUBLICATION_FRESHNESS_PROBE_STATUS.md
+++ b/docs/status/PUBLICATION_FRESHNESS_PROBE_STATUS.md
@@ -1,0 +1,22 @@
+# Publication Freshness Probe Status
+
+Generated at: 2026-05-17T06:24:48Z
+Verdict: **drift**  (total drift: 5)
+Stale threshold: 48.0h
+
+## Canonical Metrics
+
+pass=7 warn=1 fail=2 skip=0; drift_count=3
+- [fail] canonical.km_adapters.count: observed=46, claimed=41
+- [warn] canonical.test_definitions.count: observed=159156, claimed=216016+
+- [fail] security.model_pins.frontier_aligned: observed=missing: OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO, claimed=OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO exported
+
+## Status-doc Reconciliation
+
+critical=0 warning=1 info=4 total=5; drift_count=1
+- [warning] connectors/STATUS.md: Document is 40 days old (threshold: 30d)
+
+## Benchmark Truth Artifacts
+
+stale_threshold=48.0h; drift_count=1
+- [STALE] tw-01-bounded-execution-v1: age=58.74h, coverage=complete

--- a/docs/status/SESSION_BRIEF_droid-A5312D6A.md
+++ b/docs/status/SESSION_BRIEF_droid-A5312D6A.md
@@ -1,0 +1,87 @@
+# Session Brief — droid-A5312D6A
+
+**Date:** 2026-05-17
+**Agent family:** droid (Factory Droid)
+**Session ID:** droid-A5312D6A
+**Base SHA:** 4cd9f6a22a2e8722a1f933ee7d5a9834b34ac523 (origin/main)
+**Prompt version:** v3 (idempotent 12-agent fanout)
+
+## Live state summary
+
+- Main HEAD advanced to `4cd9f6a22 [AGT-06] viah_signals bridge (#7249)`. #7249 was on the v3 hold list but merged anyway during the gap.
+- B0 truth latest.json generated_at `2026-05-17T14:36:42Z`, age 2.6 h. P01 fresh-skip applies.
+- 13 open PRs (down from 19): 4 ready, 9 draft. #7267 is now in the ready set after my prior session's P03 work.
+- Two PRs closed without merge in the last 30 min: **#7270** (parallel lane-claim writer) and **#7272** (my freshness LaunchAgent template). #7272 closed 6 min after my P03 receipt commit.
+- Active lane registry still has my P03 row marked `released` (from prior session). 354+ active agent processes.
+
+## Journal entries from last 6 h (skip-targets)
+
+The journal file lives on PR #7267's branch (`droid/phase3-lane-registry-integration-20260517`), not on `origin/main`. Reading that branch:
+- `2026-05-17T16:56:00Z | droid-DC5A5821 | droid | P03-lane-registry-claim-helper-rebase | 7267 | finish-existing`
+
+Reinforces the P03 skip below (already done by prior session).
+
+## Hold list confirmed (will not touch)
+
+- #7173 (triage calibration multi-model) — still ready/MERGEABLE/BLOCKED
+- #7215 (DIC-17 crux-followup CLI verb) — still ready/MERGEABLE/BLOCKED
+- #4990 (per prompt explicit hold)
+- #7249 — was hold-listed, but already merged into main, so naturally out of the queue
+
+## In-flight sibling agents (open draft PRs by an0mium, non-agent branch prefixes excluded)
+
+Non-agent-prefix drafts (founder-owned per v3 rule (d)):
+- #7278 review-queue keyboard sign-off (`worktree-packets-keyboard-...`)
+- #7276 AGT-05 stale-policy gate (`vision-incubator/...`)
+- #7268 settlement packet UI (`codex/...` — agent-prefix, NOT hold)
+- #7263 settlement packet docs (`worktree-open-queue-...`)
+- #7262 AGT-02 A2A reputation endpoint (`vision-incubator/...`)
+- #7259 worktree-inventory runtime budget (`codex/...` — agent-prefix, NOT hold)
+- #7252 paused-writer remediation docs (`worktree-paused-writer-...`)
+- #7251 A2 admission recovery (`droid/...` — agent-prefix, NOT hold)
+- #7245 codex insights signed digest (`worktree-codex-insights`)
+
+So the hold list expands to include: #7278, #7276, #7263, #7262, #7252, #7245.
+Agent-prefixed drafts that are NOT hold-listed: #7268, #7259, #7251, #7261, #7267.
+
+## My candidate phase list (after skip-rules)
+
+| ID | Status | Note |
+|----|--------|------|
+| P01-proof-loop-b0-refresh | **skip-fresh** | B0 age 2.6 h < 24 h |
+| P02-freshness-probe-rerun | **skip-dep** | #7261 (P05) not merged |
+| P03-lane-registry-claim-helper-rebase | **skip-done** | #7267 already ready-for-review (prior session) |
+| P04-freshness-launchagent-rebase | **skip-pr-closed** | #7272 was CLOSED without merge at 17:00:33Z |
+| P05-publication-freshness-probe-rebase | **finish-existing** | #7261 MERGEABLE, 17 SUCCESS, 0 FAILURE, draft |
+| P06-rescue-productize-next-class | open | data stale (2026-04-17) but ledger has `repeated_classes` |
+| P07-worktree-inventory-rerun | open | publisher last ran 04:08:00Z |
+| P08-fastapi-observer-truth-audit | open | #7257 merged, so audit is meaningful now |
+| P09-overlap-detector-reconcile-7270-vs-7267 | **skip-pr-closed** | #7270 CLOSED, nothing to reconcile |
+| P10-codex-automation-handoff | open | substantial |
+| P11-stale-pr-rebase | open | 9 drafts open, some old |
+| P12-tool-gap-closure | open | meta (v3 heredoc bug confirmed) |
+| P13-docs-drift-canonical | open | docs/COORDINATION.md stale "Currently Active" |
+| P14-receipt-loop-settlement | open | substantial |
+| P15-prompt-meta-iteration | open | v3 has confirmed heredoc bug → v4 candidate |
+
+## Phase I plan to claim
+
+**P05-publication-freshness-probe-rebase** — finish-existing work for PR #7261.
+Rationale: first claimable lane in canonical order. The publication-freshness probe is exactly the surface NEXT_STEPS_CANONICAL.md flags as proof-loop infrastructure; landing it unblocks P02. Also it's a clean ready-flip — no rebase needed, just verify + self-review + ready.
+
+## Deferred for parallel siblings
+
+- **P06 rescue-productize:** rescue_productization/latest.json shows `repeated_classes` (stale 2026-04-17). Pick the top-occurrence unproduced class; follow #7265 pattern.
+- **P07 worktree-inventory:** last publish 04:08:00Z (12.9 h ago); `worktree_count: 0` strongly suggests broken inventory or empty-result bug. Rerun and inspect.
+- **P08 FastAPI observer audit:** #7257 merged; now verify FastAPI `/swarm-status` actually serves ledger-backed truth on a live server boot.
+- **P10 codex-automation-handoff:** run `scripts/reconcile_automation_outbox.py`.
+- **P11 stale-pr-rebase:** #7245 oldest agent-prefix draft, candidate for rebase.
+- **P12 tool-gap-closure:** v3 heredoc hang is real (confirmed in this session). Ship `/tmp/fanout_claim.py` content as `scripts/fanout_claim_lane.py` so future agents skip the heredoc altogether. Tiny pure-stdlib PR.
+- **P13 docs-drift:** `docs/COORDINATION.md` "Currently Active" still says "No sessions currently claimed". Patch to reflect lane registry.
+- **P14 receipt-loop-settlement:** open per NEXT_STEPS_CANONICAL.md.
+- **P15 prompt-meta-iteration:** v4 should drop heredoc and document this session's findings. Could be one PR alongside P12.
+
+## Notes for the operator
+
+- v3 prompt-bug confirmed: the inline `cat > /tmp/fanout_claim.py <<'PYEOF'` heredoc still hangs in some shells. Working solution this session: write the shim via the file-write tool. v4 should ship the shim as a tracked file in `scripts/`.
+- #7270 and #7272 both closed without merge suggests an operator pass that explicitly rejected those two surfaces. Recording for journal-as-memory: future sessions should not re-attempt P04 or P09 without checking if those decisions were reversed.

--- a/docs/status/generated/publication_freshness_probe/latest.json
+++ b/docs/status/generated/publication_freshness_probe/latest.json
@@ -1,0 +1,201 @@
+{
+  "generated_at": "2026-05-17T06:24:48Z",
+  "repo_root": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-062140-26e58382",
+  "schema_version": 1,
+  "sources": {
+    "benchmark_truth_artifacts": {
+      "available": true,
+      "corpora": [
+        {
+          "age_hours": 58.74,
+          "corpus_id": "tw-01-bounded-execution-v1",
+          "coverage_status": "complete",
+          "generated_at": "2026-05-14T19:40:33Z",
+          "is_stale": true,
+          "latest_path": "status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json",
+          "stale_threshold_hours": 48.0
+        }
+      ],
+      "drift_count": 1,
+      "drift_records": [
+        {
+          "age_hours": 58.74,
+          "corpus_id": "tw-01-bounded-execution-v1",
+          "coverage_status": "complete",
+          "generated_at": "2026-05-14T19:40:33Z",
+          "is_stale": true,
+          "latest_path": "status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json",
+          "stale_threshold_hours": 48.0
+        }
+      ],
+      "stale_threshold_hours": 48.0
+    },
+    "canonical_metrics": {
+      "available": true,
+      "drift_count": 3,
+      "drift_records": [
+        {
+          "claim_id": "canonical.km_adapters.count",
+          "claimed": "41",
+          "message": "docs claim 41 adapters but live count is 46 \u2014 drift of 5. Update CANONICAL_GOALS.md or fix adapter registration.",
+          "observed": "46",
+          "status": "fail",
+          "tolerance": "+/-2"
+        },
+        {
+          "claim_id": "canonical.test_definitions.count",
+          "claimed": "216016+",
+          "message": "docs claim 216016+ tests; live count is 159156. Refresh CANONICAL_GOALS.md when drift exceeds 20%.",
+          "observed": "159156",
+          "status": "warn",
+          "tolerance": "+/-20%"
+        },
+        {
+          "claim_id": "security.model_pins.frontier_aligned",
+          "claimed": "OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO exported",
+          "message": "model_pins.py is missing exports: OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO. Restore them \u2014 consumers across 66+ files import from this single registry.",
+          "observed": "missing: OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO",
+          "status": "fail",
+          "tolerance": "exact"
+        }
+      ],
+      "manifest_id": "canonical_metrics",
+      "results": [
+        {
+          "claim_id": "canonical.km_adapters.count",
+          "claimed": "41",
+          "message": "docs claim 41 adapters but live count is 46 \u2014 drift of 5. Update CANONICAL_GOALS.md or fix adapter registration.",
+          "observed": "46",
+          "status": "fail",
+          "tolerance": "+/-2"
+        },
+        {
+          "claim_id": "canonical.python_modules.count",
+          "claimed": "135+",
+          "message": "docs claim 135+ modules; live count is 4126 \u2014 within tolerance",
+          "observed": "4126",
+          "status": "pass",
+          "tolerance": "+/-20%"
+        },
+        {
+          "claim_id": "canonical.test_definitions.count",
+          "claimed": "216016+",
+          "message": "docs claim 216016+ tests; live count is 159156. Refresh CANONICAL_GOALS.md when drift exceeds 20%.",
+          "observed": "159156",
+          "status": "warn",
+          "tolerance": "+/-20%"
+        },
+        {
+          "claim_id": "canonical.version.matches_pyproject",
+          "claimed": "2.9.0",
+          "message": "docs and pyproject.toml both report version 2.9.0",
+          "observed": "2.9.0",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "security.gitleaks.dual_stage",
+          "claimed": "gitleaks at [pre-commit, pre-push]",
+          "message": "gitleaks runs at both pre-commit and pre-push \u2014 bypass via --no-verify is caught at push time.",
+          "observed": "gitleaks block declares both stages",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "security.model_pins.frontier_aligned",
+          "claimed": "OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO exported",
+          "message": "model_pins.py is missing exports: OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO. Restore them \u2014 consumers across 66+ files import from this single registry.",
+          "observed": "missing: OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO",
+          "status": "fail",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "security.incident_log.present",
+          "claimed": "incident log + rotation schedule present",
+          "message": "2026-04-07 incident write-up and 90-day rotation schedule are intact.",
+          "observed": "both files present",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "security.openrouter_fallback.wired",
+          "claimed": "QuotaFallbackMixin on anthropic/openai/gemini agents",
+          "message": "OpenRouter universal fallback is wired on all three frontier providers.",
+          "observed": "all three frontier-provider agents inherit QuotaFallbackMixin",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "proof_carrying.crux_detector.wired",
+          "claimed": "CruxDetector + CruxClaim importable with detect_cruxes()",
+          "message": "Crux Engine substrate is wired \u2014 CruxDetector.detect_cruxes and CruxClaim dataclass both exist.",
+          "observed": "all three symbols present",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "proof_carrying.belief_network.wired",
+          "claimed": "BeliefNetwork, BeliefNode, BeliefStatus importable",
+          "message": "Provenance substrate is wired \u2014 belief.py exports the three claim-graph primitives.",
+          "observed": "all three symbols present",
+          "status": "pass",
+          "tolerance": "exact"
+        }
+      ],
+      "summary": {
+        "fail": 2,
+        "pass": 7,
+        "skip": 0,
+        "warn": 1
+      }
+    },
+    "reconcile_status_docs": {
+      "available": true,
+      "drift_count": 1,
+      "drift_records": [
+        {
+          "message": "Document is 40 days old (threshold: 30d)",
+          "severity": "warning",
+          "source": "connectors/STATUS.md"
+        }
+      ],
+      "findings": [
+        {
+          "message": "GA checklist references 3 blocker mentions",
+          "severity": "info",
+          "source": "GA_CHECKLIST.md"
+        },
+        {
+          "message": "Connectors: ~149 production, ~0 beta, ~2 stub mentions",
+          "severity": "info",
+          "source": "connectors/STATUS.md"
+        },
+        {
+          "message": "Generated OpenAPI counts: 3402 operations across 2943 paths",
+          "severity": "info",
+          "source": "docs/api/openapi_generated.json"
+        },
+        {
+          "message": "Document is 40 days old (threshold: 30d)",
+          "severity": "warning",
+          "source": "connectors/STATUS.md"
+        },
+        {
+          "message": "Execution issue map links 20 required issues",
+          "severity": "info",
+          "source": "status/ACTIVE_EXECUTION_ISSUES.md"
+        }
+      ],
+      "generated": "2026-05-17T01:24:51.494394",
+      "summary": {
+        "critical": 0,
+        "info": 4,
+        "total": 5,
+        "warning": 1
+      }
+    }
+  },
+  "stale_threshold_hours": 48.0,
+  "total_drift": 5,
+  "verdict": "drift"
+}

--- a/docs/status/generated/publication_freshness_probe/probe-20260517T062448Z.json
+++ b/docs/status/generated/publication_freshness_probe/probe-20260517T062448Z.json
@@ -1,0 +1,201 @@
+{
+  "generated_at": "2026-05-17T06:24:48Z",
+  "repo_root": "/Users/armand/Development/aragora/.worktrees/codex-auto/claude-20260517-062140-26e58382",
+  "schema_version": 1,
+  "sources": {
+    "benchmark_truth_artifacts": {
+      "available": true,
+      "corpora": [
+        {
+          "age_hours": 58.74,
+          "corpus_id": "tw-01-bounded-execution-v1",
+          "coverage_status": "complete",
+          "generated_at": "2026-05-14T19:40:33Z",
+          "is_stale": true,
+          "latest_path": "status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json",
+          "stale_threshold_hours": 48.0
+        }
+      ],
+      "drift_count": 1,
+      "drift_records": [
+        {
+          "age_hours": 58.74,
+          "corpus_id": "tw-01-bounded-execution-v1",
+          "coverage_status": "complete",
+          "generated_at": "2026-05-14T19:40:33Z",
+          "is_stale": true,
+          "latest_path": "status/generated/benchmark_truth_artifacts/tw-01-bounded-execution-v1/latest.json",
+          "stale_threshold_hours": 48.0
+        }
+      ],
+      "stale_threshold_hours": 48.0
+    },
+    "canonical_metrics": {
+      "available": true,
+      "drift_count": 3,
+      "drift_records": [
+        {
+          "claim_id": "canonical.km_adapters.count",
+          "claimed": "41",
+          "message": "docs claim 41 adapters but live count is 46 \u2014 drift of 5. Update CANONICAL_GOALS.md or fix adapter registration.",
+          "observed": "46",
+          "status": "fail",
+          "tolerance": "+/-2"
+        },
+        {
+          "claim_id": "canonical.test_definitions.count",
+          "claimed": "216016+",
+          "message": "docs claim 216016+ tests; live count is 159156. Refresh CANONICAL_GOALS.md when drift exceeds 20%.",
+          "observed": "159156",
+          "status": "warn",
+          "tolerance": "+/-20%"
+        },
+        {
+          "claim_id": "security.model_pins.frontier_aligned",
+          "claimed": "OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO exported",
+          "message": "model_pins.py is missing exports: OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO. Restore them \u2014 consumers across 66+ files import from this single registry.",
+          "observed": "missing: OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO",
+          "status": "fail",
+          "tolerance": "exact"
+        }
+      ],
+      "manifest_id": "canonical_metrics",
+      "results": [
+        {
+          "claim_id": "canonical.km_adapters.count",
+          "claimed": "41",
+          "message": "docs claim 41 adapters but live count is 46 \u2014 drift of 5. Update CANONICAL_GOALS.md or fix adapter registration.",
+          "observed": "46",
+          "status": "fail",
+          "tolerance": "+/-2"
+        },
+        {
+          "claim_id": "canonical.python_modules.count",
+          "claimed": "135+",
+          "message": "docs claim 135+ modules; live count is 4126 \u2014 within tolerance",
+          "observed": "4126",
+          "status": "pass",
+          "tolerance": "+/-20%"
+        },
+        {
+          "claim_id": "canonical.test_definitions.count",
+          "claimed": "216016+",
+          "message": "docs claim 216016+ tests; live count is 159156. Refresh CANONICAL_GOALS.md when drift exceeds 20%.",
+          "observed": "159156",
+          "status": "warn",
+          "tolerance": "+/-20%"
+        },
+        {
+          "claim_id": "canonical.version.matches_pyproject",
+          "claimed": "2.9.0",
+          "message": "docs and pyproject.toml both report version 2.9.0",
+          "observed": "2.9.0",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "security.gitleaks.dual_stage",
+          "claimed": "gitleaks at [pre-commit, pre-push]",
+          "message": "gitleaks runs at both pre-commit and pre-push \u2014 bypass via --no-verify is caught at push time.",
+          "observed": "gitleaks block declares both stages",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "security.model_pins.frontier_aligned",
+          "claimed": "OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO exported",
+          "message": "model_pins.py is missing exports: OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO. Restore them \u2014 consumers across 66+ files import from this single registry.",
+          "observed": "missing: OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO",
+          "status": "fail",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "security.incident_log.present",
+          "claimed": "incident log + rotation schedule present",
+          "message": "2026-04-07 incident write-up and 90-day rotation schedule are intact.",
+          "observed": "both files present",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "security.openrouter_fallback.wired",
+          "claimed": "QuotaFallbackMixin on anthropic/openai/gemini agents",
+          "message": "OpenRouter universal fallback is wired on all three frontier providers.",
+          "observed": "all three frontier-provider agents inherit QuotaFallbackMixin",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "proof_carrying.crux_detector.wired",
+          "claimed": "CruxDetector + CruxClaim importable with detect_cruxes()",
+          "message": "Crux Engine substrate is wired \u2014 CruxDetector.detect_cruxes and CruxClaim dataclass both exist.",
+          "observed": "all three symbols present",
+          "status": "pass",
+          "tolerance": "exact"
+        },
+        {
+          "claim_id": "proof_carrying.belief_network.wired",
+          "claimed": "BeliefNetwork, BeliefNode, BeliefStatus importable",
+          "message": "Provenance substrate is wired \u2014 belief.py exports the three claim-graph primitives.",
+          "observed": "all three symbols present",
+          "status": "pass",
+          "tolerance": "exact"
+        }
+      ],
+      "summary": {
+        "fail": 2,
+        "pass": 7,
+        "skip": 0,
+        "warn": 1
+      }
+    },
+    "reconcile_status_docs": {
+      "available": true,
+      "drift_count": 1,
+      "drift_records": [
+        {
+          "message": "Document is 40 days old (threshold: 30d)",
+          "severity": "warning",
+          "source": "connectors/STATUS.md"
+        }
+      ],
+      "findings": [
+        {
+          "message": "GA checklist references 3 blocker mentions",
+          "severity": "info",
+          "source": "GA_CHECKLIST.md"
+        },
+        {
+          "message": "Connectors: ~149 production, ~0 beta, ~2 stub mentions",
+          "severity": "info",
+          "source": "connectors/STATUS.md"
+        },
+        {
+          "message": "Generated OpenAPI counts: 3402 operations across 2943 paths",
+          "severity": "info",
+          "source": "docs/api/openapi_generated.json"
+        },
+        {
+          "message": "Document is 40 days old (threshold: 30d)",
+          "severity": "warning",
+          "source": "connectors/STATUS.md"
+        },
+        {
+          "message": "Execution issue map links 20 required issues",
+          "severity": "info",
+          "source": "status/ACTIVE_EXECUTION_ISSUES.md"
+        }
+      ],
+      "generated": "2026-05-17T01:24:51.494394",
+      "summary": {
+        "critical": 0,
+        "info": 4,
+        "total": 5,
+        "warning": 1
+      }
+    }
+  },
+  "stale_threshold_hours": 48.0,
+  "total_drift": 5,
+  "verdict": "drift"
+}

--- a/scripts/publish_publication_freshness_probe.py
+++ b/scripts/publish_publication_freshness_probe.py
@@ -1,0 +1,478 @@
+"""Publish a recurring publication-freshness probe receipt.
+
+Aggregates three existing repo-tracked drift signals into a single
+machine-readable receipt + human-readable status surface so an
+operator can answer "are the published surfaces aligned with the live
+state of the repo right now?" in one command instead of three.
+
+Inputs
+------
+1. ``scripts/check_canonical_metrics.py --all`` (--json) for the
+   canonical-claim ledger. Failures here mean repo-tracked docs are
+   numerically out of sync with the live codebase.
+2. ``scripts/reconcile_status_docs.py --json`` for status-doc
+   reconciliation findings (GA_CHECKLIST, ROADMAP, connectors STATUS,
+   etc.). Warnings here mean docs are aging past their freshness
+   policy.
+3. ``docs/status/generated/benchmark_truth_artifacts/*/latest.json``
+   for benchmark truth artifact age. Stale truth artifacts mean B0
+   measurements were not refreshed within the configured window.
+
+Outputs
+-------
+- ``docs/status/generated/publication_freshness_probe/latest.json``:
+  canonical machine-readable payload.
+- ``docs/status/generated/publication_freshness_probe/probe-<ts>.json``:
+  timestamped historical snapshot.
+- ``docs/status/PUBLICATION_FRESHNESS_PROBE_STATUS.md`` (when
+  ``--render-markdown`` is given): stable status surface.
+
+This script is intentionally additive and read-only relative to the
+sources it inspects. It never mutates the underlying canonical
+metrics, status docs, or benchmark artifacts; it only writes its own
+probe receipts into a dedicated published directory.
+
+Non-goals
+~~~~~~~~~
+- Does not regenerate any of the source data.
+- Does not import the ``aragora`` package.
+- Does not require any network or git access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PUBLISHED_ROOT = (
+    DEFAULT_REPO_ROOT / "docs" / "status" / "generated" / "publication_freshness_probe"
+)
+DEFAULT_STATUS_MD = DEFAULT_REPO_ROOT / "docs" / "status" / "PUBLICATION_FRESHNESS_PROBE_STATUS.md"
+DEFAULT_BENCHMARK_TRUTH_ROOT = (
+    DEFAULT_REPO_ROOT / "docs" / "status" / "generated" / "benchmark_truth_artifacts"
+)
+DEFAULT_STALE_HOURS = 48.0
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+def _iso(value: dt.datetime) -> str:
+    return value.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(value: Any) -> dt.datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    candidate = value.replace("Z", "+00:00")
+    try:
+        parsed = dt.datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def _hours_between(a: dt.datetime, b: dt.datetime) -> float:
+    return abs((a - b).total_seconds()) / 3600.0
+
+
+def run_canonical_metrics_probe(
+    *,
+    repo_root: Path,
+    runner: Any = None,
+) -> dict[str, Any]:
+    """Run check_canonical_metrics.py --all --json and summarise."""
+    script = repo_root / "scripts" / "check_canonical_metrics.py"
+    if not script.exists():
+        return {
+            "available": False,
+            "reason": "script not present",
+            "summary": {},
+            "results": [],
+        }
+    runner = runner or subprocess.run
+    try:
+        proc = runner(
+            [sys.executable, str(script), "--all"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=repo_root,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover
+        return {
+            "available": False,
+            "reason": f"invocation failed: {exc}",
+            "summary": {},
+            "results": [],
+        }
+    if proc.returncode not in (0, 1):
+        return {
+            "available": True,
+            "reason": f"non-zero exit ({proc.returncode}): {proc.stderr.strip()[:200]}",
+            "summary": {},
+            "results": [],
+        }
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {
+            "available": True,
+            "reason": "non-JSON output",
+            "summary": {},
+            "results": [],
+        }
+    results = payload.get("results") or []
+    counts = {"pass": 0, "warn": 0, "fail": 0, "skip": 0}
+    drift_records: list[dict[str, Any]] = []
+    for entry in results:
+        status = str(entry.get("status") or "").lower()
+        if status in counts:
+            counts[status] += 1
+        if status in ("fail", "warn"):
+            drift_records.append(
+                {
+                    "claim_id": entry.get("claim_id"),
+                    "status": status,
+                    "observed": entry.get("observed"),
+                    "claimed": entry.get("claimed"),
+                    "tolerance": entry.get("tolerance"),
+                    "message": entry.get("message"),
+                }
+            )
+    return {
+        "available": True,
+        "manifest_id": payload.get("manifest_id"),
+        "summary": counts,
+        "results": results,
+        "drift_records": drift_records,
+        "drift_count": len(drift_records),
+    }
+
+
+def run_reconcile_status_docs_probe(
+    *,
+    repo_root: Path,
+    runner: Any = None,
+) -> dict[str, Any]:
+    """Run reconcile_status_docs.py --json and summarise."""
+    script = repo_root / "scripts" / "reconcile_status_docs.py"
+    if not script.exists():
+        return {"available": False, "reason": "script not present", "summary": {}, "findings": []}
+    runner = runner or subprocess.run
+    try:
+        proc = runner(
+            [sys.executable, str(script), "--json"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=repo_root,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover
+        return {
+            "available": False,
+            "reason": f"invocation failed: {exc}",
+            "summary": {},
+            "findings": [],
+        }
+    if proc.returncode not in (0, 1):
+        return {
+            "available": True,
+            "reason": f"non-zero exit ({proc.returncode}): {proc.stderr.strip()[:200]}",
+            "summary": {},
+            "findings": [],
+        }
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {
+            "available": True,
+            "reason": "non-JSON output",
+            "summary": {},
+            "findings": [],
+        }
+    findings = payload.get("findings") or []
+    summary = payload.get("summary") or {}
+    drift_records = [
+        f for f in findings if str(f.get("severity") or "").lower() in {"critical", "warning"}
+    ]
+    return {
+        "available": True,
+        "generated": payload.get("generated"),
+        "summary": summary,
+        "findings": findings,
+        "drift_records": drift_records,
+        "drift_count": len(drift_records),
+    }
+
+
+def scan_benchmark_truth_artifacts(
+    *,
+    truth_root: Path,
+    stale_hours: float,
+    now: dt.datetime,
+) -> dict[str, Any]:
+    """Inspect every ``latest.json`` under benchmark_truth_artifacts/*."""
+    if not truth_root.exists():
+        return {
+            "available": False,
+            "reason": "truth root not present",
+            "corpora": [],
+            "drift_records": [],
+            "drift_count": 0,
+        }
+    corpora: list[dict[str, Any]] = []
+    drift: list[dict[str, Any]] = []
+    for child in sorted(truth_root.iterdir()):
+        if not child.is_dir():
+            continue
+        latest = child / "latest.json"
+        if not latest.exists():
+            continue
+        try:
+            payload = json.loads(latest.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        generated_at = _parse_iso(payload.get("generated_at"))
+        age_hours = _hours_between(now, generated_at) if generated_at else None
+        is_stale = age_hours is not None and age_hours > stale_hours
+        row = {
+            "corpus_id": child.name,
+            "latest_path": str(latest.relative_to(truth_root.parent.parent.parent)),
+            "generated_at": payload.get("generated_at"),
+            "age_hours": round(age_hours, 2) if age_hours is not None else None,
+            "is_stale": bool(is_stale),
+            "stale_threshold_hours": stale_hours,
+            "coverage_status": (payload.get("coverage") or {}).get("status"),
+        }
+        corpora.append(row)
+        if is_stale:
+            drift.append(row)
+    return {
+        "available": True,
+        "stale_threshold_hours": stale_hours,
+        "corpora": corpora,
+        "drift_records": drift,
+        "drift_count": len(drift),
+    }
+
+
+def build_published_report(
+    *,
+    repo_root: Path = DEFAULT_REPO_ROOT,
+    truth_root: Path = DEFAULT_BENCHMARK_TRUTH_ROOT,
+    stale_hours: float = DEFAULT_STALE_HOURS,
+    now: dt.datetime | None = None,
+    canonical_runner: Any = None,
+    reconcile_runner: Any = None,
+) -> dict[str, Any]:
+    """Build the full freshness-probe payload."""
+    moment = now or _utc_now()
+    canonical = run_canonical_metrics_probe(repo_root=repo_root, runner=canonical_runner)
+    reconcile = run_reconcile_status_docs_probe(repo_root=repo_root, runner=reconcile_runner)
+    benchmark = scan_benchmark_truth_artifacts(
+        truth_root=truth_root, stale_hours=stale_hours, now=moment
+    )
+
+    total_drift = (
+        int(canonical.get("drift_count") or 0)
+        + int(reconcile.get("drift_count") or 0)
+        + int(benchmark.get("drift_count") or 0)
+    )
+
+    if total_drift == 0:
+        verdict = "fresh"
+    elif total_drift <= 3:
+        verdict = "minor_drift"
+    else:
+        verdict = "drift"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _iso(moment),
+        "repo_root": str(repo_root),
+        "stale_threshold_hours": stale_hours,
+        "verdict": verdict,
+        "total_drift": total_drift,
+        "sources": {
+            "canonical_metrics": canonical,
+            "reconcile_status_docs": reconcile,
+            "benchmark_truth_artifacts": benchmark,
+        },
+    }
+
+
+def publish_report_bundle(
+    report: dict[str, Any],
+    *,
+    out_root: Path = DEFAULT_PUBLISHED_ROOT,
+    snapshot_prefix: str = "probe",
+) -> dict[str, Path]:
+    out_root.mkdir(parents=True, exist_ok=True)
+    ts = report.get("generated_at") or _iso(_utc_now())
+    sanitized = ts.replace(":", "").replace("-", "")
+    snapshot_name = f"{snapshot_prefix}-{sanitized}.json"
+    snapshot_path = out_root / snapshot_name
+    latest_path = out_root / "latest.json"
+    body = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    snapshot_path.write_text(body, encoding="utf-8")
+    latest_path.write_text(body, encoding="utf-8")
+    return {"snapshot": snapshot_path, "latest": latest_path}
+
+
+def render_status_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Publication Freshness Probe Status",
+        "",
+        f"Generated at: {report.get('generated_at')}",
+        f"Verdict: **{report.get('verdict')}**  (total drift: {report.get('total_drift')})",
+        f"Stale threshold: {report.get('stale_threshold_hours')}h",
+        "",
+        "## Canonical Metrics",
+        "",
+    ]
+    canonical = (report.get("sources") or {}).get("canonical_metrics") or {}
+    if canonical.get("available"):
+        summary = canonical.get("summary") or {}
+        lines.append(
+            "pass={pass} warn={warn} fail={fail} skip={skip}; drift_count={dc}".format(
+                **{
+                    "pass": summary.get("pass", 0),
+                    "warn": summary.get("warn", 0),
+                    "fail": summary.get("fail", 0),
+                    "skip": summary.get("skip", 0),
+                    "dc": canonical.get("drift_count", 0),
+                }
+            )
+        )
+        for record in canonical.get("drift_records") or []:
+            lines.append(
+                f"- [{record.get('status')}] {record.get('claim_id')}: "
+                f"observed={record.get('observed')}, claimed={record.get('claimed')}"
+            )
+    else:
+        lines.append(f"unavailable: {canonical.get('reason')}")
+
+    lines.extend(["", "## Status-doc Reconciliation", ""])
+    reconcile = (report.get("sources") or {}).get("reconcile_status_docs") or {}
+    if reconcile.get("available"):
+        summary = reconcile.get("summary") or {}
+        lines.append(
+            "critical={c} warning={w} info={i} total={t}; drift_count={dc}".format(
+                c=summary.get("critical", 0),
+                w=summary.get("warning", 0),
+                i=summary.get("info", 0),
+                t=summary.get("total", 0),
+                dc=reconcile.get("drift_count", 0),
+            )
+        )
+        for finding in reconcile.get("drift_records") or []:
+            lines.append(
+                f"- [{finding.get('severity')}] {finding.get('source')}: {finding.get('message')}"
+            )
+    else:
+        lines.append(f"unavailable: {reconcile.get('reason')}")
+
+    lines.extend(["", "## Benchmark Truth Artifacts", ""])
+    benchmark = (report.get("sources") or {}).get("benchmark_truth_artifacts") or {}
+    if benchmark.get("available"):
+        lines.append(
+            f"stale_threshold={benchmark.get('stale_threshold_hours')}h; "
+            f"drift_count={benchmark.get('drift_count')}"
+        )
+        for row in benchmark.get("corpora") or []:
+            marker = "STALE" if row.get("is_stale") else "ok"
+            lines.append(
+                f"- [{marker:5}] {row.get('corpus_id')}: age={row.get('age_hours')}h, "
+                f"coverage={row.get('coverage_status')}"
+            )
+    else:
+        lines.append(f"unavailable: {benchmark.get('reason')}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=DEFAULT_REPO_ROOT,
+        help=f"Repository root (default: {DEFAULT_REPO_ROOT}).",
+    )
+    parser.add_argument(
+        "--out-root",
+        type=Path,
+        default=DEFAULT_PUBLISHED_ROOT,
+        help=f"Published directory (default: {DEFAULT_PUBLISHED_ROOT}).",
+    )
+    parser.add_argument(
+        "--status-md",
+        type=Path,
+        default=DEFAULT_STATUS_MD,
+        help=f"Markdown status surface (default: {DEFAULT_STATUS_MD}).",
+    )
+    parser.add_argument(
+        "--truth-root",
+        type=Path,
+        default=DEFAULT_BENCHMARK_TRUTH_ROOT,
+        help=f"Benchmark truth artifact root (default: {DEFAULT_BENCHMARK_TRUTH_ROOT}).",
+    )
+    parser.add_argument(
+        "--stale-hours",
+        type=float,
+        default=DEFAULT_STALE_HOURS,
+        help=f"Benchmark truth artifact stale threshold in hours (default: {DEFAULT_STALE_HOURS}).",
+    )
+    parser.add_argument("--json", action="store_true", help="Print the payload to stdout as JSON.")
+    parser.add_argument(
+        "--render-markdown",
+        action="store_true",
+        help="Also write the rendered markdown status surface to --status-md.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Do not write any output files; print to stdout only.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    report = build_published_report(
+        repo_root=args.repo_root,
+        truth_root=args.truth_root,
+        stale_hours=args.stale_hours,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    if args.dry_run:
+        return 0
+    paths = publish_report_bundle(report, out_root=args.out_root)
+    if args.render_markdown:
+        args.status_md.parent.mkdir(parents=True, exist_ok=True)
+        args.status_md.write_text(render_status_markdown(report), encoding="utf-8")
+    if not args.json:
+        print(
+            f"published: latest={paths['latest']}; snapshot={paths['snapshot']}; "
+            f"verdict={report.get('verdict')}; total_drift={report.get('total_drift')}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_publish_publication_freshness_probe.py
+++ b/tests/scripts/test_publish_publication_freshness_probe.py
@@ -1,0 +1,317 @@
+"""Tests for ``scripts/publish_publication_freshness_probe.py``.
+
+The publisher invokes other scripts via ``subprocess.run``. All tests
+inject a fake ``runner`` callable to avoid spawning real processes,
+so the suite is fast and deterministic.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import publish_publication_freshness_probe as publisher  # noqa: E402
+
+
+class _Proc:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_runner(proc: _Proc) -> Any:
+    def runner(*_args: Any, **_kwargs: Any) -> _Proc:
+        return proc
+
+    return runner
+
+
+def _make_script(repo_root: Path, name: str) -> Path:
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    script_path = scripts_dir / name
+    script_path.write_text("# stub", encoding="utf-8")
+    return script_path
+
+
+def _now() -> dt.datetime:
+    return dt.datetime(2026, 5, 17, 6, 0, 0, tzinfo=dt.UTC)
+
+
+def test_run_canonical_metrics_probe_handles_missing_script(tmp_path: Path) -> None:
+    out = publisher.run_canonical_metrics_probe(repo_root=tmp_path)
+    assert out["available"] is False
+
+
+def test_run_canonical_metrics_probe_parses_results(tmp_path: Path) -> None:
+    _make_script(tmp_path, "check_canonical_metrics.py")
+    payload = {
+        "manifest_id": "canonical_metrics",
+        "results": [
+            {"claim_id": "a", "status": "pass", "observed": "1", "claimed": "1"},
+            {"claim_id": "b", "status": "warn", "observed": "10", "claimed": "1"},
+            {"claim_id": "c", "status": "fail", "observed": "0", "claimed": "1"},
+        ],
+    }
+    out = publisher.run_canonical_metrics_probe(
+        repo_root=tmp_path,
+        runner=_fake_runner(_Proc(stdout=json.dumps(payload), returncode=0)),
+    )
+    assert out["available"] is True
+    assert out["summary"] == {"pass": 1, "warn": 1, "fail": 1, "skip": 0}
+    assert out["drift_count"] == 2
+    assert {r["claim_id"] for r in out["drift_records"]} == {"b", "c"}
+
+
+def test_run_reconcile_status_docs_probe_parses_findings(tmp_path: Path) -> None:
+    _make_script(tmp_path, "reconcile_status_docs.py")
+    payload = {
+        "generated": "2026-05-17T01:21:27Z",
+        "findings": [
+            {"severity": "info", "source": "x", "message": "ok"},
+            {"severity": "warning", "source": "y", "message": "aging"},
+            {"severity": "critical", "source": "z", "message": "broken"},
+        ],
+        "summary": {"critical": 1, "warning": 1, "info": 1, "total": 3},
+    }
+    out = publisher.run_reconcile_status_docs_probe(
+        repo_root=tmp_path,
+        runner=_fake_runner(_Proc(stdout=json.dumps(payload), returncode=0)),
+    )
+    assert out["available"] is True
+    assert out["drift_count"] == 2
+    assert {f["source"] for f in out["drift_records"]} == {"y", "z"}
+
+
+def test_scan_benchmark_truth_artifacts_flags_stale(tmp_path: Path) -> None:
+    truth_root = tmp_path / "tracked" / "benchmark_truth_artifacts"
+    fresh_dir = truth_root / "tw-fresh"
+    stale_dir = truth_root / "tw-stale"
+    fresh_dir.mkdir(parents=True)
+    stale_dir.mkdir(parents=True)
+    now = _now()
+    (fresh_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": (now - dt.timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "coverage": {"status": "complete"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (stale_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": (now - dt.timedelta(hours=72)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "coverage": {"status": "complete"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = publisher.scan_benchmark_truth_artifacts(truth_root=truth_root, stale_hours=48.0, now=now)
+    assert out["available"] is True
+    assert {row["corpus_id"] for row in out["corpora"]} == {"tw-fresh", "tw-stale"}
+    fresh = next(r for r in out["corpora"] if r["corpus_id"] == "tw-fresh")
+    stale = next(r for r in out["corpora"] if r["corpus_id"] == "tw-stale")
+    assert fresh["is_stale"] is False
+    assert stale["is_stale"] is True
+    assert out["drift_count"] == 1
+
+
+def test_scan_benchmark_truth_artifacts_missing_root(tmp_path: Path) -> None:
+    out = publisher.scan_benchmark_truth_artifacts(
+        truth_root=tmp_path / "absent", stale_hours=48.0, now=_now()
+    )
+    assert out["available"] is False
+    assert out["drift_count"] == 0
+
+
+def test_build_published_report_verdict_fresh(tmp_path: Path) -> None:
+    report = publisher.build_published_report(
+        repo_root=tmp_path,
+        truth_root=tmp_path / "absent",
+        stale_hours=48.0,
+        now=_now(),
+    )
+    assert report["schema_version"] == publisher.SCHEMA_VERSION
+    assert report["generated_at"] == "2026-05-17T06:00:00Z"
+    assert report["verdict"] == "fresh"
+    assert report["total_drift"] == 0
+    assert set(report["sources"].keys()) == {
+        "canonical_metrics",
+        "reconcile_status_docs",
+        "benchmark_truth_artifacts",
+    }
+
+
+def test_build_published_report_drift(tmp_path: Path) -> None:
+    _make_script(tmp_path, "check_canonical_metrics.py")
+    _make_script(tmp_path, "reconcile_status_docs.py")
+    truth_root = tmp_path / "tracked" / "benchmark_truth_artifacts"
+    stale_dir = truth_root / "tw-stale"
+    stale_dir.mkdir(parents=True)
+    (stale_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": (_now() - dt.timedelta(hours=72)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "coverage": {"status": "complete"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    canonical_payload = {
+        "results": [
+            {"claim_id": "a", "status": "fail", "observed": "0", "claimed": "1"},
+            {"claim_id": "b", "status": "fail", "observed": "0", "claimed": "1"},
+            {"claim_id": "c", "status": "fail", "observed": "0", "claimed": "1"},
+        ]
+    }
+    reconcile_payload = {
+        "findings": [
+            {"severity": "warning", "source": "x", "message": "m"},
+            {"severity": "critical", "source": "y", "message": "m"},
+        ],
+        "summary": {"critical": 1, "warning": 1, "info": 0, "total": 2},
+    }
+    report = publisher.build_published_report(
+        repo_root=tmp_path,
+        truth_root=truth_root,
+        stale_hours=48.0,
+        now=_now(),
+        canonical_runner=_fake_runner(_Proc(stdout=json.dumps(canonical_payload))),
+        reconcile_runner=_fake_runner(_Proc(stdout=json.dumps(reconcile_payload))),
+    )
+    assert report["verdict"] == "drift"
+    assert report["total_drift"] == 6
+
+
+def test_publish_report_bundle_writes_latest_and_snapshot(tmp_path: Path) -> None:
+    out_root = tmp_path / "out"
+    paths = publisher.publish_report_bundle(
+        {
+            "schema_version": 1,
+            "generated_at": "2026-05-17T06:00:00Z",
+            "verdict": "fresh",
+        },
+        out_root=out_root,
+    )
+    assert paths["latest"].exists()
+    assert paths["snapshot"].exists()
+    payload = json.loads(paths["latest"].read_text())
+    assert payload["generated_at"] == "2026-05-17T06:00:00Z"
+    assert paths["snapshot"].name.startswith("probe-")
+
+
+def test_render_status_markdown_emits_sections() -> None:
+    sample_report = {
+        "generated_at": "2026-05-17T06:00:00Z",
+        "verdict": "drift",
+        "total_drift": 4,
+        "stale_threshold_hours": 48.0,
+        "sources": {
+            "canonical_metrics": {
+                "available": True,
+                "summary": {"pass": 6, "warn": 1, "fail": 2, "skip": 0},
+                "drift_count": 3,
+                "drift_records": [
+                    {
+                        "status": "fail",
+                        "claim_id": "x",
+                        "observed": "0",
+                        "claimed": "1",
+                    }
+                ],
+            },
+            "reconcile_status_docs": {
+                "available": True,
+                "summary": {"critical": 1, "warning": 1, "info": 0, "total": 2},
+                "drift_count": 1,
+                "drift_records": [
+                    {"severity": "warning", "source": "ROADMAP.md", "message": "old"}
+                ],
+            },
+            "benchmark_truth_artifacts": {
+                "available": True,
+                "stale_threshold_hours": 48.0,
+                "drift_count": 0,
+                "corpora": [
+                    {
+                        "corpus_id": "tw-01",
+                        "age_hours": 10.0,
+                        "coverage_status": "complete",
+                        "is_stale": False,
+                    }
+                ],
+            },
+        },
+    }
+    md = publisher.render_status_markdown(sample_report)
+    assert "# Publication Freshness Probe Status" in md
+    assert "Verdict: **drift**" in md
+    assert "## Canonical Metrics" in md
+    assert "## Status-doc Reconciliation" in md
+    assert "## Benchmark Truth Artifacts" in md
+    assert "ROADMAP.md" in md
+
+
+def test_main_dry_run_writes_nothing(tmp_path: Path, capsys: Any) -> None:
+    out_root = tmp_path / "out"
+    status_md = tmp_path / "status.md"
+    rc = publisher.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--out-root",
+            str(out_root),
+            "--status-md",
+            str(status_md),
+            "--truth-root",
+            str(tmp_path / "absent"),
+            "--json",
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+    assert payload["verdict"] == "fresh"
+    assert not out_root.exists()
+    assert not status_md.exists()
+
+
+def test_main_default_publishes_to_out_root(tmp_path: Path) -> None:
+    out_root = tmp_path / "out"
+    status_md = tmp_path / "status.md"
+    rc = publisher.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--out-root",
+            str(out_root),
+            "--status-md",
+            str(status_md),
+            "--truth-root",
+            str(tmp_path / "absent"),
+            "--render-markdown",
+        ]
+    )
+    assert rc == 0
+    assert (out_root / "latest.json").exists()
+    snapshots = list(out_root.glob("probe-*.json"))
+    assert snapshots, "expected at least one timestamped snapshot"
+    assert status_md.exists()


### PR DESCRIPTION
## Summary

Adds `scripts/publish_publication_freshness_probe.py`, a pure-stdlib
read-only publisher that joins three independent freshness signals
into a single receipt so an operator can answer **"are the published
surfaces aligned with the live state of the repo right now?"** in one
command.

## Why

Drift between repo-tracked claims and live repo state is currently
diagnosed via three separate commands:

1. `scripts/check_canonical_metrics.py --all` — canonical claim ledger
2. `scripts/reconcile_status_docs.py --json` — status-doc aging
3. inspection of `docs/status/generated/benchmark_truth_artifacts/*/latest.json`

Joining these into one receipt enables both human operators and
downstream automations (boss-loop, benchmark recurrence, codex desktop
automations) to make a single decision about whether to regenerate.

## Sources joined

| Source | Signal |
|---|---|
| `check_canonical_metrics.py --all` | claim-by-claim drift (km adapters, modules, tests, version, security) |
| `reconcile_status_docs.py --json` | doc age warnings (GA_CHECKLIST, ROADMAP, connectors STATUS, etc.) |
| `docs/status/generated/benchmark_truth_artifacts/*/latest.json` | per-corpus age vs configurable threshold |

## Outputs

- `docs/status/generated/publication_freshness_probe/latest.json`
- `docs/status/generated/publication_freshness_probe/probe-<ts>.json`
- `docs/status/PUBLICATION_FRESHNESS_PROBE_STATUS.md` (when
  `--render-markdown` is given)

## Verdict scale

| Verdict | Meaning |
|---|---|
| `fresh` | `total_drift == 0` |
| `minor_drift` | `0 < total_drift <= 3` |
| `drift` | `total_drift > 3` |

## First live snapshot on this checkout

- **verdict**: `drift`
- **total_drift**: 5
- `canonical_metrics`: 3 drift records
  - `canonical.km_adapters.count`: live 46 vs claim 41 (fail)
  - `canonical.test_definitions.count`: live ~159k vs claim 216016+ (warn)
  - `security.model_pins.frontier_aligned`: missing OPUS_4_7, GPT_5_4, GEMINI_3_1_PRO (fail)
- `reconcile_status_docs`: 1 warning
  - `connectors/STATUS.md` is 40 days old (threshold 30d)
- `benchmark_truth_artifacts`: 1 stale corpus
  - `tw-01-bounded-execution-v1` generated at 2026-05-14T19:40:33Z,
    age ~58.7h vs 48h threshold

## What's in this PR

- `scripts/publish_publication_freshness_probe.py` (new, pure stdlib)
- `tests/scripts/test_publish_publication_freshness_probe.py` (new,
  11 fixture-driven tests; no real subprocess invocations)
- `docs/status/PUBLICATION_FRESHNESS_PROBE_STATUS.md` (new, stable
  status surface)
- `docs/status/generated/publication_freshness_probe/latest.json`
  (new, canonical machine-readable payload)
- `docs/status/generated/publication_freshness_probe/
  probe-20260517T062448Z.json` (new, timestamped historical snapshot)

## Validation

- `pytest tests/scripts/test_publish_publication_freshness_probe.py`
  -> 11 passed
- `ruff check` + `ruff format --check` -> clean
- `mypy scripts/publish_publication_freshness_probe.py` -> clean
- Live dogfood with `--dry-run --json` reproduces published payload
  byte-identical except for `generated_at`
- preflight: `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Non-goals

- Does not regenerate any source data; never mutates
  `canonical_metrics`, `reconcile_status_docs`, or truth artifacts.
- Does not import the `aragora` package.
- No flag flips; no `TerminalClass` change; no `--force`.
- Pure-stdlib; no new dependencies.
