### PR TITLE
[AGT-02] A2A per-domain reputation read endpoint (sub-deliverable 5)

### DIFF
--- a/aragora/protocols/a2a/reputation.py
+++ b/aragora/protocols/a2a/reputation.py
@@ -1,22 +1,15 @@
 """A2A agent reputation read endpoint — AGT-02 / #6063 sub-deliverable 5.
 
-Machine-readable per-domain reputation summary so external agents can
-discover their own (or a peer agent's) epistemic track record without
-reading the human-facing reputation dashboard.
+Machine-readable per-domain reputation summary for external agents.
 
-Gate: ``ARAGORA_A2A_REPUTATION_ENABLED`` (default off).  Dataclasses are
-always importable; :func:`read_agent_reputation` and
-:func:`read_all_agents` raise :class:`ReputationEndpointError` when the
-gate is off.
+Gate: ``ARAGORA_A2A_REPUTATION_ENABLED`` (default off). Dataclasses are
+always importable; read functions raise :class:`ReputationEndpointError`
+when the gate is off.
 
-**Read-only.** This module has no write path.  Reputation deltas are
-recorded only by the AGT-05 settlement flow
-(:mod:`aragora.reputation.settlement`).
+Read-only: no write path. Deltas are recorded only by the AGT-05
+settlement flow (:mod:`aragora.reputation.settlement`).
 
-Out of scope: HTTP routes, pagination, decay policy configuration,
-per-domain threshold enforcement, on-chain reads (deferred to the
-ERC-8004 KM adapter wiring in a follow-on PR).
-
+Out of scope: HTTP routes, pagination, on-chain ERC-8004 reads (deferred).
 Advances: AGT-02 (#6063) sub-deliverable 5.
 See also: ``docs/plans/AGENT_CONSUMER_SURFACE.md`` §S5.
 """
@@ -64,13 +57,7 @@ class ReputationEndpointError(RuntimeError):
 
 @dataclass(frozen=True)
 class DomainReputationSlice:
-    """Reputation summary for one domain within an agent's track record.
-
-    ``score`` is the time-decayed running sum of all deltas in this domain.
-    ``delta_count`` is the raw count (including reversed deltas).
-    ``most_recent_delta_at`` is the ISO-8601 timestamp of the latest delta,
-    or ``None`` when the agent has no deltas in this domain.
-    """
+    """Per-domain reputation summary within an agent's track record."""
 
     domain: str
     score: float
@@ -88,15 +75,7 @@ class DomainReputationSlice:
 
 @dataclass(frozen=True)
 class AgentReputationView:
-    """Agent-readable reputation summary for one agent.
-
-    Returned by :func:`read_agent_reputation`.  Callers can serialise
-    directly via :meth:`to_dict`.
-
-    ``overall_score`` is the decayed aggregate across all domains.
-    ``domains`` is sorted alphabetically for stable serialisation.
-    ``queried_at`` is the ISO-8601 UTC timestamp of this read.
-    """
+    """Agent-readable reputation summary for one agent."""
 
     agent_id: str
     schema_version: str
@@ -123,14 +102,12 @@ def _domain_slices(
     apply_decay: bool,
     now: datetime,
 ) -> tuple[DomainReputationSlice, ...]:
-    """Build per-domain slices from the raw delta history."""
     from aragora.reputation.store import _decay_weight  # type: ignore[attr-defined]
 
     raw_deltas = store.deltas_for(agent_id)
     if not raw_deltas:
         return ()
 
-    # Group by domain
     by_domain: dict[str, list[Any]] = {}
     for d in raw_deltas:
         by_domain.setdefault(d.domain, []).append(d)
@@ -142,13 +119,12 @@ def _domain_slices(
             if apply_decay
             else sum(d.delta for d in deltas)
         )
-        most_recent = max((d.applied_at for d in deltas), default=None)
         slices.append(
             DomainReputationSlice(
                 domain=domain,
                 score=score,
                 delta_count=len(deltas),
-                most_recent_delta_at=most_recent,
+                most_recent_delta_at=max((d.applied_at for d in deltas), default=None),
             )
         )
     return tuple(slices)
@@ -163,31 +139,19 @@ def read_agent_reputation(
 ) -> AgentReputationView:
     """Return the per-domain reputation view for *agent_id*.
 
-    When *agent_id* has no recorded deltas the view is returned with
-    ``overall_score=0.0`` and an empty ``domains`` list — the endpoint
-    never raises for unknown agents.
-
-    Args:
-        agent_id: The agent whose reputation is being read.
-        store: Live :class:`~aragora.reputation.store.ReputationStore`.
-        apply_decay: Apply exponential time-decay (default True).
-        now: Reference timestamp for decay calculation; defaults to UTC now.
+    Unknown agents return a zero-score view; this never raises for missing agents.
 
     Raises:
-        ReputationEndpointError: When ``ARAGORA_A2A_REPUTATION_ENABLED``
-            is not set.
+        ReputationEndpointError: When ``ARAGORA_A2A_REPUTATION_ENABLED`` is not set.
     """
     _require_enabled()
     reference = now or datetime.now(tz=UTC)
-    overall = store.get_score(agent_id, apply_decay=apply_decay)
-    raw_deltas = store.deltas_for(agent_id)
-    slices = _domain_slices(agent_id, store, apply_decay=apply_decay, now=reference)
     return AgentReputationView(
         agent_id=agent_id,
         schema_version=AGENT_REPUTATION_SCHEMA_VERSION,
-        overall_score=overall,
-        delta_count=len(raw_deltas),
-        domains=slices,
+        overall_score=store.get_score(agent_id, apply_decay=apply_decay),
+        delta_count=len(store.deltas_for(agent_id)),
+        domains=_domain_slices(agent_id, store, apply_decay=apply_decay, now=reference),
         queried_at=reference.isoformat().replace("+00:00", "Z"),
     )
 
@@ -198,15 +162,10 @@ def read_all_agents(
     apply_decay: bool = True,
     now: datetime | None = None,
 ) -> list[AgentReputationView]:
-    """Return reputation views for every agent in *store*, sorted by overall score.
-
-    The list is sorted descending by ``overall_score`` so the top agent
-    comes first.  Agents with identical scores are sub-sorted by
-    ``agent_id`` for determinism.
+    """Return views for every agent in *store*, sorted descending by overall score.
 
     Raises:
-        ReputationEndpointError: When ``ARAGORA_A2A_REPUTATION_ENABLED``
-            is not set.
+        ReputationEndpointError: When ``ARAGORA_A2A_REPUTATION_ENABLED`` is not set.
     """
     _require_enabled()
     reference = now or datetime.now(tz=UTC)

--- a/aragora/protocols/a2a/reputation.py
+++ b/aragora/protocols/a2a/reputation.py
@@ -1,0 +1,217 @@
+"""A2A agent reputation read endpoint — AGT-02 / #6063 sub-deliverable 5.
+
+Machine-readable per-domain reputation summary so external agents can
+discover their own (or a peer agent's) epistemic track record without
+reading the human-facing reputation dashboard.
+
+Gate: ``ARAGORA_A2A_REPUTATION_ENABLED`` (default off).  Dataclasses are
+always importable; :func:`read_agent_reputation` and
+:func:`read_all_agents` raise :class:`ReputationEndpointError` when the
+gate is off.
+
+**Read-only.** This module has no write path.  Reputation deltas are
+recorded only by the AGT-05 settlement flow
+(:mod:`aragora.reputation.settlement`).
+
+Out of scope: HTTP routes, pagination, decay policy configuration,
+per-domain threshold enforcement, on-chain reads (deferred to the
+ERC-8004 KM adapter wiring in a follow-on PR).
+
+Advances: AGT-02 (#6063) sub-deliverable 5.
+See also: ``docs/plans/AGENT_CONSUMER_SURFACE.md`` §S5.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aragora.reputation.store import ReputationStore
+
+AGENT_REPUTATION_SCHEMA_VERSION = "1.0"
+_FLAG = "ARAGORA_A2A_REPUTATION_ENABLED"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+__all__ = [
+    "AGENT_REPUTATION_SCHEMA_VERSION",
+    "AgentReputationView",
+    "DomainReputationSlice",
+    "ReputationEndpointError",
+    "read_agent_reputation",
+    "read_all_agents",
+    "reputation_endpoint_enabled",
+]
+
+
+def reputation_endpoint_enabled() -> bool:
+    """Return True when the AGT-02 reputation read endpoint is active."""
+    return os.environ.get(_FLAG, "").strip().lower() in _TRUTHY
+
+
+def _require_enabled() -> None:
+    if not reputation_endpoint_enabled():
+        raise ReputationEndpointError(
+            f"A2A reputation endpoint is disabled; set {_FLAG}=1 to enable."
+        )
+
+
+class ReputationEndpointError(RuntimeError):
+    """Raised when the read endpoint is called while the feature gate is off."""
+
+
+@dataclass(frozen=True)
+class DomainReputationSlice:
+    """Reputation summary for one domain within an agent's track record.
+
+    ``score`` is the time-decayed running sum of all deltas in this domain.
+    ``delta_count`` is the raw count (including reversed deltas).
+    ``most_recent_delta_at`` is the ISO-8601 timestamp of the latest delta,
+    or ``None`` when the agent has no deltas in this domain.
+    """
+
+    domain: str
+    score: float
+    delta_count: int
+    most_recent_delta_at: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "domain": self.domain,
+            "score": round(self.score, 6),
+            "delta_count": self.delta_count,
+            "most_recent_delta_at": self.most_recent_delta_at,
+        }
+
+
+@dataclass(frozen=True)
+class AgentReputationView:
+    """Agent-readable reputation summary for one agent.
+
+    Returned by :func:`read_agent_reputation`.  Callers can serialise
+    directly via :meth:`to_dict`.
+
+    ``overall_score`` is the decayed aggregate across all domains.
+    ``domains`` is sorted alphabetically for stable serialisation.
+    ``queried_at`` is the ISO-8601 UTC timestamp of this read.
+    """
+
+    agent_id: str
+    schema_version: str
+    overall_score: float
+    delta_count: int
+    domains: tuple[DomainReputationSlice, ...]
+    queried_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "agent_id": self.agent_id,
+            "overall_score": round(self.overall_score, 6),
+            "delta_count": self.delta_count,
+            "domains": [s.to_dict() for s in self.domains],
+            "queried_at": self.queried_at,
+        }
+
+
+def _domain_slices(
+    agent_id: str,
+    store: "ReputationStore",
+    *,
+    apply_decay: bool,
+    now: datetime,
+) -> tuple[DomainReputationSlice, ...]:
+    """Build per-domain slices from the raw delta history."""
+    from aragora.reputation.store import _decay_weight  # type: ignore[attr-defined]
+
+    raw_deltas = store.deltas_for(agent_id)
+    if not raw_deltas:
+        return ()
+
+    # Group by domain
+    by_domain: dict[str, list[Any]] = {}
+    for d in raw_deltas:
+        by_domain.setdefault(d.domain, []).append(d)
+
+    slices: list[DomainReputationSlice] = []
+    for domain, deltas in sorted(by_domain.items()):
+        score = (
+            sum(d.delta * _decay_weight(d, now) for d in deltas)
+            if apply_decay
+            else sum(d.delta for d in deltas)
+        )
+        most_recent = max((d.applied_at for d in deltas), default=None)
+        slices.append(
+            DomainReputationSlice(
+                domain=domain,
+                score=score,
+                delta_count=len(deltas),
+                most_recent_delta_at=most_recent,
+            )
+        )
+    return tuple(slices)
+
+
+def read_agent_reputation(
+    agent_id: str,
+    store: "ReputationStore",
+    *,
+    apply_decay: bool = True,
+    now: datetime | None = None,
+) -> AgentReputationView:
+    """Return the per-domain reputation view for *agent_id*.
+
+    When *agent_id* has no recorded deltas the view is returned with
+    ``overall_score=0.0`` and an empty ``domains`` list — the endpoint
+    never raises for unknown agents.
+
+    Args:
+        agent_id: The agent whose reputation is being read.
+        store: Live :class:`~aragora.reputation.store.ReputationStore`.
+        apply_decay: Apply exponential time-decay (default True).
+        now: Reference timestamp for decay calculation; defaults to UTC now.
+
+    Raises:
+        ReputationEndpointError: When ``ARAGORA_A2A_REPUTATION_ENABLED``
+            is not set.
+    """
+    _require_enabled()
+    reference = now or datetime.now(tz=UTC)
+    overall = store.get_score(agent_id, apply_decay=apply_decay)
+    raw_deltas = store.deltas_for(agent_id)
+    slices = _domain_slices(agent_id, store, apply_decay=apply_decay, now=reference)
+    return AgentReputationView(
+        agent_id=agent_id,
+        schema_version=AGENT_REPUTATION_SCHEMA_VERSION,
+        overall_score=overall,
+        delta_count=len(raw_deltas),
+        domains=slices,
+        queried_at=reference.isoformat().replace("+00:00", "Z"),
+    )
+
+
+def read_all_agents(
+    store: "ReputationStore",
+    *,
+    apply_decay: bool = True,
+    now: datetime | None = None,
+) -> list[AgentReputationView]:
+    """Return reputation views for every agent in *store*, sorted by overall score.
+
+    The list is sorted descending by ``overall_score`` so the top agent
+    comes first.  Agents with identical scores are sub-sorted by
+    ``agent_id`` for determinism.
+
+    Raises:
+        ReputationEndpointError: When ``ARAGORA_A2A_REPUTATION_ENABLED``
+            is not set.
+    """
+    _require_enabled()
+    reference = now or datetime.now(tz=UTC)
+    views = [
+        read_agent_reputation(aid, store, apply_decay=apply_decay, now=reference)
+        for aid in store.agent_ids()
+    ]
+    return sorted(views, key=lambda v: (-v.overall_score, v.agent_id))

--- a/tests/protocols/a2a/test_reputation.py
+++ b/tests/protocols/a2a/test_reputation.py
@@ -1,0 +1,221 @@
+"""Tests for the AGT-02 A2A reputation read endpoint (issue #6063 sub-deliverable 5)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.protocols.a2a.reputation import (
+    AGENT_REPUTATION_SCHEMA_VERSION,
+    AgentReputationView,
+    DomainReputationSlice,
+    ReputationEndpointError,
+    read_agent_reputation,
+    read_all_agents,
+    reputation_endpoint_enabled,
+)
+from aragora.reputation.store import ReputationStore
+from aragora.reputation.types import DOMAIN_DEBATE_POSITION, DOMAIN_PREDICTION_MARKET, ReputationDelta
+
+_FLAG = "ARAGORA_A2A_REPUTATION_ENABLED"
+
+
+def _delta(
+    *,
+    agent_id: str,
+    domain: str,
+    delta: float,
+    delta_id: str = "d1",
+    applied_at: str | None = None,
+    decay_half_life_days: float | None = None,
+) -> ReputationDelta:
+    return ReputationDelta(
+        delta_id=delta_id,
+        agent_id=agent_id,
+        domain=domain,
+        claim_id="cl1",
+        resolution_id="res1",
+        delta=delta,
+        scoring_rule="binary",
+        applied_at=applied_at or datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
+        decay_half_life_days=decay_half_life_days,
+        reason={},
+    )
+
+
+@pytest.fixture()
+def store() -> ReputationStore:
+    return ReputationStore()
+
+
+@pytest.fixture()
+def enabled_store(store: ReputationStore, monkeypatch: pytest.MonkeyPatch) -> ReputationStore:
+    monkeypatch.setenv(_FLAG, "1")
+    return store
+
+
+# --- Feature flag ---
+
+
+def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    assert reputation_endpoint_enabled() is False
+
+
+@pytest.mark.parametrize("v", ["1", "true", "yes", "on"])
+def test_enabled_truthy(monkeypatch: pytest.MonkeyPatch, v: str) -> None:
+    monkeypatch.setenv(_FLAG, v)
+    assert reputation_endpoint_enabled() is True
+
+
+def test_read_blocked_when_disabled(
+    store: ReputationStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    with pytest.raises(ReputationEndpointError, match=_FLAG):
+        read_agent_reputation("agent-1", store)
+
+
+def test_read_all_blocked_when_disabled(
+    store: ReputationStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    with pytest.raises(ReputationEndpointError, match=_FLAG):
+        read_all_agents(store)
+
+
+# --- read_agent_reputation ---
+
+
+def test_unknown_agent_returns_zero(enabled_store: ReputationStore) -> None:
+    view = read_agent_reputation("nobody", enabled_store)
+    assert view.agent_id == "nobody"
+    assert view.overall_score == 0.0
+    assert view.delta_count == 0
+    assert view.domains == ()
+    assert view.schema_version == AGENT_REPUTATION_SCHEMA_VERSION
+
+
+def test_single_domain_score(enabled_store: ReputationStore) -> None:
+    enabled_store.record_delta(
+        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=0.8, delta_id="d1")
+    )
+    view = read_agent_reputation("a1", enabled_store)
+    assert view.overall_score == pytest.approx(0.8)
+    assert view.delta_count == 1
+    assert len(view.domains) == 1
+    assert view.domains[0].domain == DOMAIN_PREDICTION_MARKET
+    assert view.domains[0].score == pytest.approx(0.8)
+    assert view.domains[0].delta_count == 1
+
+
+def test_multi_domain_slices(enabled_store: ReputationStore) -> None:
+    enabled_store.record_delta(
+        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1")
+    )
+    enabled_store.record_delta(
+        _delta(agent_id="a1", domain=DOMAIN_DEBATE_POSITION, delta=0.5, delta_id="d2")
+    )
+    view = read_agent_reputation("a1", enabled_store)
+    assert view.overall_score == pytest.approx(1.5)
+    assert view.delta_count == 2
+    domain_names = {s.domain for s in view.domains}
+    assert domain_names == {DOMAIN_PREDICTION_MARKET, DOMAIN_DEBATE_POSITION}
+    # Domains are sorted alphabetically
+    assert view.domains == tuple(sorted(view.domains, key=lambda s: s.domain))
+
+
+def test_schema_version_present(enabled_store: ReputationStore) -> None:
+    view = read_agent_reputation("ax", enabled_store)
+    assert view.schema_version == AGENT_REPUTATION_SCHEMA_VERSION
+
+
+def test_queried_at_is_utc(enabled_store: ReputationStore) -> None:
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=UTC)
+    view = read_agent_reputation("ax", enabled_store, now=now)
+    assert "2026-05-17" in view.queried_at
+
+
+def test_to_dict_shape(enabled_store: ReputationStore) -> None:
+    enabled_store.record_delta(
+        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=2.0, delta_id="d1")
+    )
+    d = read_agent_reputation("a1", enabled_store).to_dict()
+    assert set(d) >= {"schema_version", "agent_id", "overall_score", "delta_count", "domains", "queried_at"}
+    assert d["domains"][0]["domain"] == DOMAIN_PREDICTION_MARKET
+
+
+def test_decay_reduces_score(enabled_store: ReputationStore) -> None:
+    old_time = (datetime.now(tz=UTC) - timedelta(days=30)).isoformat().replace("+00:00", "Z")
+    enabled_store.record_delta(
+        _delta(
+            agent_id="a1",
+            domain=DOMAIN_PREDICTION_MARKET,
+            delta=1.0,
+            delta_id="d1",
+            applied_at=old_time,
+            decay_half_life_days=7.0,
+        )
+    )
+    decayed = read_agent_reputation("a1", enabled_store, apply_decay=True).overall_score
+    raw = read_agent_reputation("a1", enabled_store, apply_decay=False).overall_score
+    assert raw == pytest.approx(1.0)
+    assert decayed < raw
+
+
+def test_most_recent_delta_at_populated(enabled_store: ReputationStore) -> None:
+    ts = "2026-05-01T10:00:00Z"
+    enabled_store.record_delta(
+        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1", applied_at=ts)
+    )
+    view = read_agent_reputation("a1", enabled_store)
+    assert view.domains[0].most_recent_delta_at == ts
+
+
+# --- read_all_agents ---
+
+
+def test_read_all_agents_empty(enabled_store: ReputationStore) -> None:
+    assert read_all_agents(enabled_store) == []
+
+
+def test_read_all_agents_returns_all(enabled_store: ReputationStore) -> None:
+    enabled_store.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1"))
+    enabled_store.record_delta(_delta(agent_id="a2", domain=DOMAIN_PREDICTION_MARKET, delta=2.0, delta_id="d2"))
+    views = read_all_agents(enabled_store)
+    agent_ids = {v.agent_id for v in views}
+    assert agent_ids == {"a1", "a2"}
+
+
+def test_read_all_agents_sorted_desc_by_score(enabled_store: ReputationStore) -> None:
+    enabled_store.record_delta(_delta(agent_id="low", domain=DOMAIN_PREDICTION_MARKET, delta=0.1, delta_id="d1"))
+    enabled_store.record_delta(_delta(agent_id="high", domain=DOMAIN_PREDICTION_MARKET, delta=5.0, delta_id="d2"))
+    views = read_all_agents(enabled_store)
+    assert views[0].agent_id == "high"
+    assert views[1].agent_id == "low"
+
+
+def test_read_all_agents_stable_sort_on_tie(enabled_store: ReputationStore) -> None:
+    for aid in ["beta", "alpha"]:
+        enabled_store.record_delta(
+            _delta(agent_id=aid, domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id=f"d-{aid}")
+        )
+    views = read_all_agents(enabled_store)
+    # Equal scores → alphabetical by agent_id
+    assert views[0].agent_id == "alpha"
+    assert views[1].agent_id == "beta"
+
+
+def test_domain_slice_to_dict(enabled_store: ReputationStore) -> None:
+    s = DomainReputationSlice(
+        domain=DOMAIN_PREDICTION_MARKET,
+        score=1.5,
+        delta_count=3,
+        most_recent_delta_at="2026-05-01T10:00:00Z",
+    )
+    d = s.to_dict()
+    assert d["domain"] == DOMAIN_PREDICTION_MARKET
+    assert d["score"] == pytest.approx(1.5)
+    assert d["delta_count"] == 3
+    assert d["most_recent_delta_at"] == "2026-05-01T10:00:00Z"

--- a/tests/protocols/a2a/test_reputation.py
+++ b/tests/protocols/a2a/test_reputation.py
@@ -14,18 +14,35 @@ from aragora.protocols.a2a.reputation import (
     reputation_endpoint_enabled,
 )
 from aragora.reputation.store import ReputationStore
-from aragora.reputation.types import DOMAIN_DEBATE_POSITION, DOMAIN_PREDICTION_MARKET, ReputationDelta
+from aragora.reputation.types import (
+    DOMAIN_DEBATE_POSITION,
+    DOMAIN_PREDICTION_MARKET,
+    ReputationDelta,
+)
 
 _FLAG = "ARAGORA_A2A_REPUTATION_ENABLED"
 
 
-def _delta(*, agent_id: str, domain: str, delta: float, delta_id: str = "d1",
-           applied_at: str | None = None, decay_half_life_days: float | None = None) -> ReputationDelta:
+def _delta(
+    *,
+    agent_id: str,
+    domain: str,
+    delta: float,
+    delta_id: str = "d1",
+    applied_at: str | None = None,
+    decay_half_life_days: float | None = None,
+) -> ReputationDelta:
     return ReputationDelta(
-        delta_id=delta_id, agent_id=agent_id, domain=domain, claim_id="cl1",
-        resolution_id="res1", delta=delta, scoring_rule="binary",
+        delta_id=delta_id,
+        agent_id=agent_id,
+        domain=domain,
+        claim_id="cl1",
+        resolution_id="res1",
+        delta=delta,
+        scoring_rule="binary",
         applied_at=applied_at or datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
-        decay_half_life_days=decay_half_life_days, reason={},
+        decay_half_life_days=decay_half_life_days,
+        reason={},
     )
 
 
@@ -42,6 +59,7 @@ def enabled(store: ReputationStore, monkeypatch: pytest.MonkeyPatch) -> Reputati
 
 # --- Feature flag ---
 
+
 def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     assert reputation_endpoint_enabled() is False
@@ -53,19 +71,24 @@ def test_enabled_truthy(monkeypatch: pytest.MonkeyPatch, v: str) -> None:
     assert reputation_endpoint_enabled() is True
 
 
-def test_read_blocked_when_disabled(store: ReputationStore, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_read_blocked_when_disabled(
+    store: ReputationStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     with pytest.raises(ReputationEndpointError, match=_FLAG):
         read_agent_reputation("a", store)
 
 
-def test_read_all_blocked_when_disabled(store: ReputationStore, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_read_all_blocked_when_disabled(
+    store: ReputationStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     with pytest.raises(ReputationEndpointError, match=_FLAG):
         read_all_agents(store)
 
 
 # --- read_agent_reputation ---
+
 
 def test_unknown_agent_zero(enabled: ReputationStore) -> None:
     v = read_agent_reputation("nobody", enabled)
@@ -76,7 +99,9 @@ def test_unknown_agent_zero(enabled: ReputationStore) -> None:
 
 
 def test_single_domain(enabled: ReputationStore) -> None:
-    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=0.8, delta_id="d1"))
+    enabled.record_delta(
+        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=0.8, delta_id="d1")
+    )
     v = read_agent_reputation("a1", enabled)
     assert v.overall_score == pytest.approx(0.8)
     assert len(v.domains) == 1
@@ -85,8 +110,12 @@ def test_single_domain(enabled: ReputationStore) -> None:
 
 
 def test_multi_domain_slices(enabled: ReputationStore) -> None:
-    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1"))
-    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_DEBATE_POSITION, delta=0.5, delta_id="d2"))
+    enabled.record_delta(
+        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1")
+    )
+    enabled.record_delta(
+        _delta(agent_id="a1", domain=DOMAIN_DEBATE_POSITION, delta=0.5, delta_id="d2")
+    )
     v = read_agent_reputation("a1", enabled)
     assert v.overall_score == pytest.approx(1.5)
     assert {s.domain for s in v.domains} == {DOMAIN_PREDICTION_MARKET, DOMAIN_DEBATE_POSITION}
@@ -94,17 +123,36 @@ def test_multi_domain_slices(enabled: ReputationStore) -> None:
 
 
 def test_to_dict_has_required_keys(enabled: ReputationStore) -> None:
-    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=2.0, delta_id="d1"))
+    enabled.record_delta(
+        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=2.0, delta_id="d1")
+    )
     d = read_agent_reputation("a1", enabled).to_dict()
-    assert {"schema_version", "agent_id", "overall_score", "delta_count", "domains", "queried_at"} <= d.keys()
+    assert {
+        "schema_version",
+        "agent_id",
+        "overall_score",
+        "delta_count",
+        "domains",
+        "queried_at",
+    } <= d.keys()
 
 
 def test_decay_reduces_score(enabled: ReputationStore) -> None:
     old = (datetime.now(tz=UTC) - timedelta(days=30)).isoformat().replace("+00:00", "Z")
-    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0,
-                                delta_id="d1", applied_at=old, decay_half_life_days=7.0))
-    assert read_agent_reputation("a1", enabled, apply_decay=True).overall_score < \
-           read_agent_reputation("a1", enabled, apply_decay=False).overall_score
+    enabled.record_delta(
+        _delta(
+            agent_id="a1",
+            domain=DOMAIN_PREDICTION_MARKET,
+            delta=1.0,
+            delta_id="d1",
+            applied_at=old,
+            decay_half_life_days=7.0,
+        )
+    )
+    assert (
+        read_agent_reputation("a1", enabled, apply_decay=True).overall_score
+        < read_agent_reputation("a1", enabled, apply_decay=False).overall_score
+    )
 
 
 def test_queried_at_uses_supplied_now(enabled: ReputationStore) -> None:
@@ -114,27 +162,36 @@ def test_queried_at_uses_supplied_now(enabled: ReputationStore) -> None:
 
 def test_most_recent_delta_at(enabled: ReputationStore) -> None:
     ts = "2026-05-01T10:00:00Z"
-    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0,
-                                delta_id="d1", applied_at=ts))
+    enabled.record_delta(
+        _delta(
+            agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1", applied_at=ts
+        )
+    )
     assert read_agent_reputation("a1", enabled).domains[0].most_recent_delta_at == ts
 
 
 # --- read_all_agents ---
+
 
 def test_read_all_empty(enabled: ReputationStore) -> None:
     assert read_all_agents(enabled) == []
 
 
 def test_read_all_sorted_desc(enabled: ReputationStore) -> None:
-    enabled.record_delta(_delta(agent_id="low", domain=DOMAIN_PREDICTION_MARKET, delta=0.1, delta_id="d1"))
-    enabled.record_delta(_delta(agent_id="high", domain=DOMAIN_PREDICTION_MARKET, delta=5.0, delta_id="d2"))
+    enabled.record_delta(
+        _delta(agent_id="low", domain=DOMAIN_PREDICTION_MARKET, delta=0.1, delta_id="d1")
+    )
+    enabled.record_delta(
+        _delta(agent_id="high", domain=DOMAIN_PREDICTION_MARKET, delta=5.0, delta_id="d2")
+    )
     views = read_all_agents(enabled)
     assert views[0].agent_id == "high"
 
 
 def test_read_all_stable_sort_on_tie(enabled: ReputationStore) -> None:
     for aid in ["beta", "alpha"]:
-        enabled.record_delta(_delta(agent_id=aid, domain=DOMAIN_PREDICTION_MARKET,
-                                    delta=1.0, delta_id=f"d-{aid}"))
+        enabled.record_delta(
+            _delta(agent_id=aid, domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id=f"d-{aid}")
+        )
     views = read_all_agents(enabled)
     assert views[0].agent_id == "alpha"  # alpha < beta alphabetically

--- a/tests/protocols/a2a/test_reputation.py
+++ b/tests/protocols/a2a/test_reputation.py
@@ -8,8 +8,6 @@ import pytest
 
 from aragora.protocols.a2a.reputation import (
     AGENT_REPUTATION_SCHEMA_VERSION,
-    AgentReputationView,
-    DomainReputationSlice,
     ReputationEndpointError,
     read_agent_reputation,
     read_all_agents,
@@ -21,26 +19,13 @@ from aragora.reputation.types import DOMAIN_DEBATE_POSITION, DOMAIN_PREDICTION_M
 _FLAG = "ARAGORA_A2A_REPUTATION_ENABLED"
 
 
-def _delta(
-    *,
-    agent_id: str,
-    domain: str,
-    delta: float,
-    delta_id: str = "d1",
-    applied_at: str | None = None,
-    decay_half_life_days: float | None = None,
-) -> ReputationDelta:
+def _delta(*, agent_id: str, domain: str, delta: float, delta_id: str = "d1",
+           applied_at: str | None = None, decay_half_life_days: float | None = None) -> ReputationDelta:
     return ReputationDelta(
-        delta_id=delta_id,
-        agent_id=agent_id,
-        domain=domain,
-        claim_id="cl1",
-        resolution_id="res1",
-        delta=delta,
-        scoring_rule="binary",
+        delta_id=delta_id, agent_id=agent_id, domain=domain, claim_id="cl1",
+        resolution_id="res1", delta=delta, scoring_rule="binary",
         applied_at=applied_at or datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
-        decay_half_life_days=decay_half_life_days,
-        reason={},
+        decay_half_life_days=decay_half_life_days, reason={},
     )
 
 
@@ -50,13 +35,12 @@ def store() -> ReputationStore:
 
 
 @pytest.fixture()
-def enabled_store(store: ReputationStore, monkeypatch: pytest.MonkeyPatch) -> ReputationStore:
+def enabled(store: ReputationStore, monkeypatch: pytest.MonkeyPatch) -> ReputationStore:
     monkeypatch.setenv(_FLAG, "1")
     return store
 
 
 # --- Feature flag ---
-
 
 def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
@@ -69,17 +53,13 @@ def test_enabled_truthy(monkeypatch: pytest.MonkeyPatch, v: str) -> None:
     assert reputation_endpoint_enabled() is True
 
 
-def test_read_blocked_when_disabled(
-    store: ReputationStore, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_blocked_when_disabled(store: ReputationStore, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     with pytest.raises(ReputationEndpointError, match=_FLAG):
-        read_agent_reputation("agent-1", store)
+        read_agent_reputation("a", store)
 
 
-def test_read_all_blocked_when_disabled(
-    store: ReputationStore, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_all_blocked_when_disabled(store: ReputationStore, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     with pytest.raises(ReputationEndpointError, match=_FLAG):
         read_all_agents(store)
@@ -87,135 +67,74 @@ def test_read_all_blocked_when_disabled(
 
 # --- read_agent_reputation ---
 
-
-def test_unknown_agent_returns_zero(enabled_store: ReputationStore) -> None:
-    view = read_agent_reputation("nobody", enabled_store)
-    assert view.agent_id == "nobody"
-    assert view.overall_score == 0.0
-    assert view.delta_count == 0
-    assert view.domains == ()
-    assert view.schema_version == AGENT_REPUTATION_SCHEMA_VERSION
+def test_unknown_agent_zero(enabled: ReputationStore) -> None:
+    v = read_agent_reputation("nobody", enabled)
+    assert v.overall_score == 0.0
+    assert v.delta_count == 0
+    assert v.domains == ()
+    assert v.schema_version == AGENT_REPUTATION_SCHEMA_VERSION
 
 
-def test_single_domain_score(enabled_store: ReputationStore) -> None:
-    enabled_store.record_delta(
-        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=0.8, delta_id="d1")
-    )
-    view = read_agent_reputation("a1", enabled_store)
-    assert view.overall_score == pytest.approx(0.8)
-    assert view.delta_count == 1
-    assert len(view.domains) == 1
-    assert view.domains[0].domain == DOMAIN_PREDICTION_MARKET
-    assert view.domains[0].score == pytest.approx(0.8)
-    assert view.domains[0].delta_count == 1
+def test_single_domain(enabled: ReputationStore) -> None:
+    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=0.8, delta_id="d1"))
+    v = read_agent_reputation("a1", enabled)
+    assert v.overall_score == pytest.approx(0.8)
+    assert len(v.domains) == 1
+    assert v.domains[0].domain == DOMAIN_PREDICTION_MARKET
+    assert v.domains[0].score == pytest.approx(0.8)
 
 
-def test_multi_domain_slices(enabled_store: ReputationStore) -> None:
-    enabled_store.record_delta(
-        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1")
-    )
-    enabled_store.record_delta(
-        _delta(agent_id="a1", domain=DOMAIN_DEBATE_POSITION, delta=0.5, delta_id="d2")
-    )
-    view = read_agent_reputation("a1", enabled_store)
-    assert view.overall_score == pytest.approx(1.5)
-    assert view.delta_count == 2
-    domain_names = {s.domain for s in view.domains}
-    assert domain_names == {DOMAIN_PREDICTION_MARKET, DOMAIN_DEBATE_POSITION}
-    # Domains are sorted alphabetically
-    assert view.domains == tuple(sorted(view.domains, key=lambda s: s.domain))
+def test_multi_domain_slices(enabled: ReputationStore) -> None:
+    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1"))
+    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_DEBATE_POSITION, delta=0.5, delta_id="d2"))
+    v = read_agent_reputation("a1", enabled)
+    assert v.overall_score == pytest.approx(1.5)
+    assert {s.domain for s in v.domains} == {DOMAIN_PREDICTION_MARKET, DOMAIN_DEBATE_POSITION}
+    assert v.domains == tuple(sorted(v.domains, key=lambda s: s.domain))  # alphabetical
 
 
-def test_schema_version_present(enabled_store: ReputationStore) -> None:
-    view = read_agent_reputation("ax", enabled_store)
-    assert view.schema_version == AGENT_REPUTATION_SCHEMA_VERSION
+def test_to_dict_has_required_keys(enabled: ReputationStore) -> None:
+    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=2.0, delta_id="d1"))
+    d = read_agent_reputation("a1", enabled).to_dict()
+    assert {"schema_version", "agent_id", "overall_score", "delta_count", "domains", "queried_at"} <= d.keys()
 
 
-def test_queried_at_is_utc(enabled_store: ReputationStore) -> None:
+def test_decay_reduces_score(enabled: ReputationStore) -> None:
+    old = (datetime.now(tz=UTC) - timedelta(days=30)).isoformat().replace("+00:00", "Z")
+    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0,
+                                delta_id="d1", applied_at=old, decay_half_life_days=7.0))
+    assert read_agent_reputation("a1", enabled, apply_decay=True).overall_score < \
+           read_agent_reputation("a1", enabled, apply_decay=False).overall_score
+
+
+def test_queried_at_uses_supplied_now(enabled: ReputationStore) -> None:
     now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=UTC)
-    view = read_agent_reputation("ax", enabled_store, now=now)
-    assert "2026-05-17" in view.queried_at
+    assert "2026-05-17" in read_agent_reputation("x", enabled, now=now).queried_at
 
 
-def test_to_dict_shape(enabled_store: ReputationStore) -> None:
-    enabled_store.record_delta(
-        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=2.0, delta_id="d1")
-    )
-    d = read_agent_reputation("a1", enabled_store).to_dict()
-    assert set(d) >= {"schema_version", "agent_id", "overall_score", "delta_count", "domains", "queried_at"}
-    assert d["domains"][0]["domain"] == DOMAIN_PREDICTION_MARKET
-
-
-def test_decay_reduces_score(enabled_store: ReputationStore) -> None:
-    old_time = (datetime.now(tz=UTC) - timedelta(days=30)).isoformat().replace("+00:00", "Z")
-    enabled_store.record_delta(
-        _delta(
-            agent_id="a1",
-            domain=DOMAIN_PREDICTION_MARKET,
-            delta=1.0,
-            delta_id="d1",
-            applied_at=old_time,
-            decay_half_life_days=7.0,
-        )
-    )
-    decayed = read_agent_reputation("a1", enabled_store, apply_decay=True).overall_score
-    raw = read_agent_reputation("a1", enabled_store, apply_decay=False).overall_score
-    assert raw == pytest.approx(1.0)
-    assert decayed < raw
-
-
-def test_most_recent_delta_at_populated(enabled_store: ReputationStore) -> None:
+def test_most_recent_delta_at(enabled: ReputationStore) -> None:
     ts = "2026-05-01T10:00:00Z"
-    enabled_store.record_delta(
-        _delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1", applied_at=ts)
-    )
-    view = read_agent_reputation("a1", enabled_store)
-    assert view.domains[0].most_recent_delta_at == ts
+    enabled.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0,
+                                delta_id="d1", applied_at=ts))
+    assert read_agent_reputation("a1", enabled).domains[0].most_recent_delta_at == ts
 
 
 # --- read_all_agents ---
 
-
-def test_read_all_agents_empty(enabled_store: ReputationStore) -> None:
-    assert read_all_agents(enabled_store) == []
-
-
-def test_read_all_agents_returns_all(enabled_store: ReputationStore) -> None:
-    enabled_store.record_delta(_delta(agent_id="a1", domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id="d1"))
-    enabled_store.record_delta(_delta(agent_id="a2", domain=DOMAIN_PREDICTION_MARKET, delta=2.0, delta_id="d2"))
-    views = read_all_agents(enabled_store)
-    agent_ids = {v.agent_id for v in views}
-    assert agent_ids == {"a1", "a2"}
+def test_read_all_empty(enabled: ReputationStore) -> None:
+    assert read_all_agents(enabled) == []
 
 
-def test_read_all_agents_sorted_desc_by_score(enabled_store: ReputationStore) -> None:
-    enabled_store.record_delta(_delta(agent_id="low", domain=DOMAIN_PREDICTION_MARKET, delta=0.1, delta_id="d1"))
-    enabled_store.record_delta(_delta(agent_id="high", domain=DOMAIN_PREDICTION_MARKET, delta=5.0, delta_id="d2"))
-    views = read_all_agents(enabled_store)
+def test_read_all_sorted_desc(enabled: ReputationStore) -> None:
+    enabled.record_delta(_delta(agent_id="low", domain=DOMAIN_PREDICTION_MARKET, delta=0.1, delta_id="d1"))
+    enabled.record_delta(_delta(agent_id="high", domain=DOMAIN_PREDICTION_MARKET, delta=5.0, delta_id="d2"))
+    views = read_all_agents(enabled)
     assert views[0].agent_id == "high"
-    assert views[1].agent_id == "low"
 
 
-def test_read_all_agents_stable_sort_on_tie(enabled_store: ReputationStore) -> None:
+def test_read_all_stable_sort_on_tie(enabled: ReputationStore) -> None:
     for aid in ["beta", "alpha"]:
-        enabled_store.record_delta(
-            _delta(agent_id=aid, domain=DOMAIN_PREDICTION_MARKET, delta=1.0, delta_id=f"d-{aid}")
-        )
-    views = read_all_agents(enabled_store)
-    # Equal scores → alphabetical by agent_id
-    assert views[0].agent_id == "alpha"
-    assert views[1].agent_id == "beta"
-
-
-def test_domain_slice_to_dict(enabled_store: ReputationStore) -> None:
-    s = DomainReputationSlice(
-        domain=DOMAIN_PREDICTION_MARKET,
-        score=1.5,
-        delta_count=3,
-        most_recent_delta_at="2026-05-01T10:00:00Z",
-    )
-    d = s.to_dict()
-    assert d["domain"] == DOMAIN_PREDICTION_MARKET
-    assert d["score"] == pytest.approx(1.5)
-    assert d["delta_count"] == 3
-    assert d["most_recent_delta_at"] == "2026-05-01T10:00:00Z"
+        enabled.record_delta(_delta(agent_id=aid, domain=DOMAIN_PREDICTION_MARKET,
+                                    delta=1.0, delta_id=f"d-{aid}"))
+    views = read_all_agents(enabled)
+    assert views[0].agent_id == "alpha"  # alpha < beta alphabetically


### PR DESCRIPTION
## Slice
Adds `aragora/protocols/a2a/reputation.py` — a flag-gated, read-only adapter that surfaces per-domain reputation summaries for external agents via `read_agent_reputation()` and `read_all_agents()`. This is sub-deliverable 5 of AGT-02 per `docs/plans/AGENT_CONSUMER_SURFACE.md` §S5: "Reputation read endpoint (read-only)."

## Gating
- Default: OFF (flag: `ARAGORA_A2A_REPUTATION_ENABLED`)
- Live queue effect: none — contract-only module, no HTTP routes wired
- Advances issue: AGT-02 (#6063)

## Tests
- `test_disabled_by_default` / `test_enabled_truthy` — flag guard enforced, all four truthy values accepted
- `test_read_blocked_when_disabled` / `test_read_all_blocked_when_disabled` — `ReputationEndpointError` raised when gate is off
- `test_unknown_agent_zero` — zero-score view returned for agents with no deltas
- `test_single_domain` / `test_multi_domain_slices` — correct scores and `DomainReputationSlice` structure
- `test_to_dict_has_required_keys` — serialised shape matches spec
- `test_decay_reduces_score` — decayed score < raw score for a 30-day-old delta with 7-day half-life
- `test_queried_at_uses_supplied_now` / `test_most_recent_delta_at` — timestamp fields accurate
- `test_read_all_empty` / `test_read_all_sorted_desc` / `test_read_all_stable_sort_on_tie` — list semantics correct

## Validation
- `pytest tests/protocols/a2a/test_reputation.py` — 17 passed
- `ruff check aragora/protocols/a2a/reputation.py tests/protocols/a2a/test_reputation.py` — clean
- `mypy aragora/protocols/a2a/reputation.py --ignore-missing-imports` — clean

## Out of scope
- HTTP route wiring (`GET /api/v1/a2a/agents/<id>/reputation`) — follow-on PR after gate opens
- Pagination — not needed at this data scale
- On-chain ERC-8004 reads — deferred to KM adapter wiring (reputation.py reads from in-memory `ReputationStore` only)
- Reputation **write** path — intentionally excluded; writes land only in AGT-05 settlement flow
- Sub-deliverables 1–4 and 6 of AGT-02 — already shipped in `a2a/{client,server,discovery,receipts}.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_019PwoHE9RFz2KArkNDDu5kr)_