### PR TITLE
docs(settlement): static signoff UI for open-queue packet

### DIFF
--- a/docs/receipts/open-queue-settlement-20260517T142811Z.json
+++ b/docs/receipts/open-queue-settlement-20260517T142811Z.json
@@ -1,0 +1,257 @@
+{
+  "clusters": [
+    {
+      "conflict_files": [
+        "aragora/cli/commands/codex_sessions.py",
+        "aragora/cli/parser.py",
+        "aragora/codex/__init__.py",
+        "aragora/codex/desktop_inspector.py",
+        "aragora/codex/desktop_paths.py",
+        "aragora/codex/duration.py",
+        "aragora/codex/jsonl_stream.py",
+        "aragora/codex/sqlite_ro.py",
+        "aragora/module_tiers.yaml",
+        "docs-site/docs/api/cli.md",
+        "docs-site/docs/contributing/capability-matrix.md",
+        "docs/CAPABILITY_MATRIX.md",
+        "docs/METRICS.md",
+        "docs/reference/CLI_REFERENCE.md",
+        "tests/codex/__init__.py"
+      ],
+      "kind": "textual_conflict_parser_py",
+      "members": [
+        7215,
+        7240,
+        7245
+      ],
+      "note": "Each PR appends a subparser registration and a docs row; trivial conflicts but rebase needed for later PRs",
+      "recommended_order": "Land in order of stack depth: foundation first, dependents rebase"
+    },
+    {
+      "conflict_files": [
+        "scripts/codex_worktree_value_inventory.py",
+        "tests/scripts/test_codex_worktree_value_inventory.py"
+      ],
+      "kind": "operator_choice_inventory_script",
+      "members": [
+        7256,
+        7259
+      ],
+      "note": "Two PRs propose alternate approaches to the same change; should not both merge",
+      "recommended_order": "Operator chooses ONE; the other should close or rebase to subsume"
+    }
+  ],
+  "generated_at_utc": "2026-05-17T14:28:11.657846+00:00",
+  "hmac_sha256": null,
+  "holds_respected": [
+    "#7209 lane (untouchable)",
+    "#7173 (held \u2014 metadata only)",
+    "#7215 (read-only metadata only)",
+    "#4990 (held)",
+    "BC-12 soak (untouched)",
+    "AI provider key consumption",
+    "merge / label / mark-ready / launchd install / automation.toml edit"
+  ],
+  "pinned_state": [
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 7,
+      "head_sha": "29115c5e97b9cd0ab0c7910cb12e6fa09f6025b7",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7173,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 2 \u2192 admin squash allowed once green",
+      "successes": 14,
+      "tier": "2"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": false,
+      "failures": 0,
+      "files_touched_count": 8,
+      "head_sha": "0d148f13c1b281f74c207fd25560bafb11fa9186",
+      "in_flight": 1,
+      "merge_state": "BLOCKED",
+      "number": 7215,
+      "recommended_action": "WAIT: 1 check(s) still in flight; revisit when settled",
+      "successes": 11,
+      "tier": "3"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": false,
+      "failures": 0,
+      "files_touched_count": 20,
+      "head_sha": "7aa00774bf633ccd7b1a945eff427396a75e083a",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7240,
+      "recommended_action": "REQUIRES: explicit human Tier-3 risk acceptance comment at current head",
+      "successes": 71,
+      "tier": "3"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 1,
+      "head_sha": "7f9ecf28d5b9cf75df08281419104d74419c8917",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7243,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 0 \u2192 admin squash allowed once green",
+      "successes": 12,
+      "tier": "0"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 24,
+      "head_sha": "68c03eadd0762e9825293a1f28298e949a73bf28",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7245,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 3 \u2192 human risk acceptance required",
+      "successes": 16,
+      "tier": "3"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 2,
+      "files_touched_count": 2,
+      "head_sha": "7a4d310d618bfe62c90f3d76913ff2afe97b9434",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7249,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 1 \u2192 admin squash allowed once green",
+      "successes": 11,
+      "tier": "1"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 3,
+      "head_sha": "19f29eeef1fc4e72be58cdbd36064303ac14a7c4",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7251,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 1 \u2192 admin squash allowed once green",
+      "successes": 14,
+      "tier": "1"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 2,
+      "head_sha": "5961232a8231b77b9ba0e5f6a0bf689749710993",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7252,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 0 \u2192 admin squash allowed once green",
+      "successes": 11,
+      "tier": "0"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 2,
+      "head_sha": "e1b37b34853d769221644a4d4087d0205394c60d",
+      "in_flight": 6,
+      "merge_state": "BLOCKED",
+      "number": 7256,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 2 \u2192 admin squash allowed once green",
+      "successes": 1,
+      "tier": "2"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 2,
+      "head_sha": "a9b044ce7490eab1a838fcc2ba8e54fcdb42ace6",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7257,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 3 \u2192 human risk acceptance required",
+      "successes": 14,
+      "tier": "3"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 5,
+      "head_sha": "28a748d3f0c11708b95b212c84eba0d75077a2ca",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7258,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 2 \u2192 admin squash allowed once green",
+      "successes": 14,
+      "tier": "2"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 2,
+      "head_sha": "31192860afdd7f095080059f358fb16e8dccc846",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7259,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 2 \u2192 admin squash allowed once green",
+      "successes": 14,
+      "tier": "2"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 2,
+      "head_sha": "e53aa8157d00060c134993ff61584da409094083",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7260,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 2 \u2192 admin squash allowed once green",
+      "successes": 13,
+      "tier": "2"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 5,
+      "head_sha": "a5a4f130633a9cd93476474c304fb700407aff0f",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7261,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 2 \u2192 admin squash allowed once green",
+      "successes": 14,
+      "tier": "2"
+    },
+    {
+      "decision": "REVIEW_REQUIRED",
+      "draft": true,
+      "failures": 0,
+      "files_touched_count": 2,
+      "head_sha": "e8a962a2dd96670650938e5fbe145a73959fa04d",
+      "in_flight": 0,
+      "merge_state": "BLOCKED",
+      "number": 7262,
+      "recommended_action": "OPERATOR: mark ready when complete; Tier 1 \u2192 admin squash allowed once green",
+      "successes": 13,
+      "tier": "1"
+    }
+  ],
+  "pr_count_at_pin": 15,
+  "repo": "synaptent/aragora",
+  "schema_version": "aragora-open-queue-settlement/1.0",
+  "sha256": "b93358c76358bab8b1a41a2843bc4c7ee36446ce433ebab8ab301d0c359cf9a2",
+  "signed_at_utc": null
+}

--- a/docs/status/settlement-packets/2026-05-17-open-queue-settlement-context.json
+++ b/docs/status/settlement-packets/2026-05-17-open-queue-settlement-context.json
@@ -1,0 +1,296 @@
+{
+  "schema_version": "aragora-open-queue-settlement-ui-context/1.0",
+  "generated_at_utc": "2026-05-17T14:28:11.657846+00:00",
+  "repo": "synaptent/aragora",
+  "source_packet_pr": 7263,
+  "source_ui_pr": 7268,
+  "source_packet": "docs/status/settlement-packets/2026-05-17-open-queue-settlement.md",
+  "source_receipt": "docs/receipts/open-queue-settlement-20260517T142811Z.json",
+  "source_receipt_sha256": "b93358c76358bab8b1a41a2843bc4c7ee36446ce433ebab8ab301d0c359cf9a2",
+  "decision_artifact_notice": "This UI does not mutate GitHub. It only downloads an operator decision artifact bound to the pinned receipt and this context file.",
+  "recommended_use": [
+    "Attach the downloaded JSON to a follow-up operator prompt.",
+    "Optionally commit it later under docs/receipts/operator-decisions/ as explicit operator evidence.",
+    "Use it as input to a separate queue-drain lane; do not treat the download itself as a merge, approval, label, ready, close, or request-changes action."
+  ],
+  "public_exposure": {
+    "default": "local-only static worksheet",
+    "docs_site_possible": "A redacted static copy can be exposed through docs.aragora.ai or aragora.ai after the packet/context is reviewed for private PR-comment content.",
+    "live_app_caution": "The existing /review-queue backend is mutating; do not wire this worksheet into it unless a separate non-mutating settlement mode is built."
+  },
+  "clusters": [
+    {
+      "id": "parser_cli_docs_order",
+      "name": "parser.py and CLI/docs merge-order cluster",
+      "decision_type": "merge_order_required",
+      "members": [7215, 7240, 7243, 7245],
+      "summary": "These PRs touch overlapping CLI parser/docs surfaces. Later PRs will need rebase after the first lands.",
+      "operator_guidance": "Choose at most one first-settle candidate, then hold the rest until rebased. Draft members should normally stay held.",
+      "safe_default_action": "Hold the cluster until the operator chooses first-settle order.",
+      "red_flags": [
+        "Textual overlap in aragora/cli/parser.py and CLI/capability docs.",
+        "Tier-3 members require explicit human risk acceptance.",
+        "Some members are drafts or had in-flight checks at pin time."
+      ],
+      "choices": [
+        {
+          "value": "settle_7240_first",
+          "label": "Settle #7240 first",
+          "enables_approval_for": [7240],
+          "description": "#7240 was ready and green at pin time but still needs explicit Tier-3 human risk acceptance."
+        },
+        {
+          "value": "settle_7215_first",
+          "label": "Settle #7215 first",
+          "enables_approval_for": [7215],
+          "description": "#7215 had one in-flight check at pin time and remains held as read-only metadata in this packet."
+        },
+        {
+          "value": "hold_all",
+          "label": "Hold all parser/docs members",
+          "enables_approval_for": [],
+          "description": "Use when the operator wants a fresh head-pinned packet or a rebase plan before accepting any member."
+        }
+      ]
+    },
+    {
+      "id": "inventory_operator_choice",
+      "name": "worktree inventory duplicate-choice cluster",
+      "decision_type": "choose_one",
+      "members": [7256, 7259],
+      "summary": "#7256 and #7259 both change scripts/codex_worktree_value_inventory.py and should not both merge as-is.",
+      "operator_guidance": "Pick one approach, or hold both and ask the author to fold the useful pieces into one PR.",
+      "safe_default_action": "Hold both until the operator chooses one.",
+      "red_flags": [
+        "Semantic duplicate: both modify the same worktree inventory behavior.",
+        "Textual overlap in scripts/codex_worktree_value_inventory.py and its tests.",
+        "#7256 had in-flight checks at pin time."
+      ],
+      "choices": [
+        {
+          "value": "prefer_7256",
+          "label": "Prefer #7256",
+          "enables_approval_for": [7256],
+          "description": "Choose the foreign worktree preservation approach; #7259 should close or rebase."
+        },
+        {
+          "value": "prefer_7259",
+          "label": "Prefer #7259",
+          "enables_approval_for": [7259],
+          "description": "Choose the runtime-budget approach; #7256 should close or rebase."
+        },
+        {
+          "value": "hold_both",
+          "label": "Hold both",
+          "enables_approval_for": [],
+          "description": "Use when the operator wants one reconciled PR instead of choosing between duplicates."
+        }
+      ]
+    }
+  ],
+  "per_pr_context": {
+    "7173": {
+      "title": "feat(triage): calibration-only multi-model GitHub issue triage with guided founder review",
+      "intent": "Adds a calibration-only guided founder-review issue triage flow.",
+      "risk_statement": "Live CLI, automation, or observability surface. Accepting it means a new operator workflow may become part of routine triage once enabled.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft, so approval should normally wait until the author marks it ready."},
+        {"severity": "red", "label": "Held lane", "detail": "The settlement packet marks #7173 as metadata only / operator-only action."},
+        {"severity": "yellow", "label": "Tier 2", "detail": "Live CLI/automation/observability tier; approval accepts an operator-facing surface."}
+      ],
+      "blockers": ["Draft state", "Operator hold"],
+      "conflict_cluster": null,
+      "safe_default_action": "Hold unless the operator explicitly lifts the hold and the PR is ready."
+    },
+    "7215": {
+      "title": "[DIC-17] Add `aragora crux-followup` CLI verb (flag-gated, default OFF)",
+      "intent": "Adds a flag-gated crux-followup CLI command.",
+      "risk_statement": "Tier-3 public/semantic surface. Accepting it means the operator accepts behavior visible to CLI users and downstream workflows at the pinned head.",
+      "model_quorum_summary": "Multiple dogfood/review comments are recorded, including head-pinned comments and Tier-4 acceptance observations.",
+      "red_flags": [
+        {"severity": "red", "label": "In-flight check at pin", "detail": "The packet captured one pending check; approval should be refreshed after checks settle."},
+        {"severity": "red", "label": "Held metadata only", "detail": "The packet states #7215 must not be advanced by this settlement artifact."},
+        {"severity": "red", "label": "Tier 3", "detail": "Requires explicit human risk settlement at the current head."},
+        {"severity": "yellow", "label": "Parser/docs cluster", "detail": "Conflicts with #7240, #7243, and #7245 in CLI parser/docs surfaces."}
+      ],
+      "blockers": ["In-flight check at pin", "Operator hold", "Tier-3 risk settlement", "Merge-order cluster"],
+      "conflict_cluster": "parser_cli_docs_order",
+      "safe_default_action": "Hold or wait for fresh settled checks; do not approve blindly."
+    },
+    "7240": {
+      "title": "feat(codex): read-only inspector CLI for Codex Desktop sessions",
+      "intent": "Adds a read-only, redacted Codex Desktop session inspector CLI.",
+      "risk_statement": "Tier-3 public/semantic surface. Accepting it means approving a new CLI surface that reads local Codex Desktop state and emits redacted session information.",
+      "model_quorum_summary": "Large comment history with Codex security/dogfood/Kimi reviews; only the latest evidence is head-pinned to 7aa00774bf.",
+      "red_flags": [
+        {"severity": "red", "label": "Tier 3 acceptance required", "detail": "The packet requires explicit human Tier-3 risk acceptance at the pinned head."},
+        {"severity": "yellow", "label": "Parser/docs cluster", "detail": "Conflicts with #7215, #7243, and #7245 in CLI parser/docs surfaces."},
+        {"severity": "yellow", "label": "Large diff", "detail": "20 files and 2155 additions at pin time."}
+      ],
+      "blockers": ["Human Tier-3 risk acceptance", "Merge-order cluster"],
+      "conflict_cluster": "parser_cli_docs_order",
+      "safe_default_action": "Approve only with explicit Tier-3 risk note and a parser/docs order choice; otherwise hold."
+    },
+    "7243": {
+      "title": "docs: refresh metrics from current main",
+      "intent": "Refreshes docs metrics from current main.",
+      "risk_statement": "Tier-0 docs/status-only change. Main risk is stale or misleading metric documentation.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."},
+        {"severity": "yellow", "label": "Parser/docs cluster", "detail": "Shares docs surfaces with the parser/docs cluster; may need rebase after a CLI PR lands."}
+      ],
+      "blockers": ["Draft state", "Merge-order cluster"],
+      "conflict_cluster": "parser_cli_docs_order",
+      "safe_default_action": "Hold until ready or until parser/docs order is settled."
+    },
+    "7245": {
+      "title": "feat(codex): activity-intelligence layer with signed digest receipts",
+      "intent": "Adds Codex activity intelligence and signed digest receipt plumbing.",
+      "risk_statement": "Tier-3 public/semantic surface. Accepting it means approving a new activity-insight surface and receipt workflow.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."},
+        {"severity": "red", "label": "Tier 3", "detail": "Requires explicit human risk settlement."},
+        {"severity": "yellow", "label": "Parser/docs cluster", "detail": "Conflicts with #7215, #7240, and #7243 in CLI/docs surfaces."},
+        {"severity": "yellow", "label": "Large diff", "detail": "24 files and 3215 additions at pin time."}
+      ],
+      "blockers": ["Draft state", "Human Tier-3 risk acceptance", "Merge-order cluster"],
+      "conflict_cluster": "parser_cli_docs_order",
+      "safe_default_action": "Hold until ready and rebased behind the chosen parser/docs foundation."
+    },
+    "7249": {
+      "title": "[AGT-06] Add viah_signals bridge: ReputationStore -> VIAH sidecar counters (SD-2, SD-3)",
+      "intent": "Adds an internal VIAH sidecar counter bridge from ReputationStore.",
+      "risk_statement": "Tier-1 additive internal code. Main risk is carrying unused internal code if it never gets wired.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Failing checks", "detail": "The packet captured two failing checks."},
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."}
+      ],
+      "blockers": ["Failing checks", "Draft state"],
+      "conflict_cluster": null,
+      "safe_default_action": "Request changes or hold until failures are resolved."
+    },
+    "7251": {
+      "title": "feat(benchmarks): productize A2 admission-recovery scenarios for #7209 (PR-3, data+docs only)",
+      "intent": "Adds A2 admission-recovery benchmark fixtures/docs for the held #7209 lane.",
+      "risk_statement": "Tier-1 additive internal benchmark support. Main risk is accepting fixture/data shape that may bias later benchmark interpretation.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."},
+        {"severity": "red", "label": "Held lane", "detail": "The packet marks #7251 as metadata only / operator-only because it is tied to the held #7209 lane."}
+      ],
+      "blockers": ["Draft state", "Operator hold"],
+      "conflict_cluster": null,
+      "safe_default_action": "Hold unless the operator explicitly lifts the #7209-related hold."
+    },
+    "7252": {
+      "title": "docs(codex-insights): paused core-writer remediation audit (read-only)",
+      "intent": "Documents a read-only audit and remediation plan for paused core writers.",
+      "risk_statement": "Tier-0 docs/status-only change. Main risk is stale remediation guidance.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."}
+      ],
+      "blockers": ["Draft state"],
+      "conflict_cluster": null,
+      "safe_default_action": "Hold until the author marks ready."
+    },
+    "7256": {
+      "title": "fix(scripts): preserve foreign worktree inventory roots",
+      "intent": "Changes worktree inventory classification so foreign repo roots are preserved.",
+      "risk_statement": "Tier-2 live automation/observability script behavior. Accepting it changes what the inventory classifies as safe cleanup versus preserved work.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Duplicate-choice cluster", "detail": "#7256 and #7259 should not both merge as-is."},
+        {"severity": "red", "label": "In-flight checks at pin", "detail": "The packet captured six pending checks."},
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."},
+        {"severity": "yellow", "label": "Tier 2", "detail": "Live automation/observability behavior."}
+      ],
+      "blockers": ["Draft state", "In-flight checks", "Choose-one conflict with #7259"],
+      "conflict_cluster": "inventory_operator_choice",
+      "safe_default_action": "Hold unless the operator chooses #7256 over #7259 and checks settle."
+    },
+    "7257": {
+      "title": "feat(server): observer truth on FastAPI swarm-status sibling surface",
+      "intent": "Adds observer-truth handling to a FastAPI swarm-status sibling surface.",
+      "risk_statement": "Tier-3 public/semantic surface. Accepting it changes server-visible observer truth behavior.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."},
+        {"severity": "red", "label": "Tier 3", "detail": "Requires explicit human risk settlement."}
+      ],
+      "blockers": ["Draft state", "Human Tier-3 risk acceptance"],
+      "conflict_cluster": null,
+      "safe_default_action": "Hold until ready and explicitly accepted as Tier 3."
+    },
+    "7258": {
+      "title": "feat(automation): publish recurring worktree value inventory",
+      "intent": "Adds recurring publication of worktree value inventory.",
+      "risk_statement": "Tier-2 live automation/observability surface. Accepting it adds or documents recurring automation behavior around worktree inventory.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."},
+        {"severity": "yellow", "label": "Large diff", "detail": "5 files and 5903 additions at pin time."},
+        {"severity": "yellow", "label": "Tier 2", "detail": "Live automation/observability behavior."}
+      ],
+      "blockers": ["Draft state"],
+      "conflict_cluster": null,
+      "safe_default_action": "Hold until ready and reviewed for automation scheduling implications."
+    },
+    "7259": {
+      "title": "feat(scripts): bound worktree inventory runtime",
+      "intent": "Adds runtime budgeting to the worktree inventory script.",
+      "risk_statement": "Tier-2 live automation/observability script behavior. Accepting it changes runtime limits for inventory collection.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Duplicate-choice cluster", "detail": "#7256 and #7259 should not both merge as-is."},
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."},
+        {"severity": "yellow", "label": "Tier 2", "detail": "Live automation/observability behavior."}
+      ],
+      "blockers": ["Draft state", "Choose-one conflict with #7256"],
+      "conflict_cluster": "inventory_operator_choice",
+      "safe_default_action": "Hold unless the operator chooses #7259 over #7256."
+    },
+    "7260": {
+      "title": "feat(automation): read-only cross-agent overlap detector",
+      "intent": "Adds a read-only detector for active cross-agent overlap.",
+      "risk_statement": "Tier-2 automation/observability surface. Accepting it adds an operator-facing coordination script.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."},
+        {"severity": "yellow", "label": "Tier 2", "detail": "Live automation/observability behavior."}
+      ],
+      "blockers": ["Draft state"],
+      "conflict_cluster": null,
+      "safe_default_action": "Hold until ready."
+    },
+    "7261": {
+      "title": "feat(automation): publish recurring publication-freshness probe",
+      "intent": "Adds recurring publication-freshness probe outputs.",
+      "risk_statement": "Tier-2 live automation/observability surface. Accepting it adds recurring freshness publication behavior.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."},
+        {"severity": "yellow", "label": "Tier 2", "detail": "Live automation/observability behavior."}
+      ],
+      "blockers": ["Draft state"],
+      "conflict_cluster": null,
+      "safe_default_action": "Hold until ready and reviewed for publication cadence implications."
+    },
+    "7262": {
+      "title": "[AGT-02] A2A per-domain reputation read endpoint (sub-deliverable 5)",
+      "intent": "Adds an internal per-domain reputation read endpoint.",
+      "risk_statement": "Tier-1 additive internal code. Main risk is carrying an internal read surface before it has a live caller.",
+      "model_quorum_summary": "Draft at pin time; quorum not required yet.",
+      "red_flags": [
+        {"severity": "red", "label": "Draft at pin", "detail": "The packet captured this PR as draft."}
+      ],
+      "blockers": ["Draft state"],
+      "conflict_cluster": null,
+      "safe_default_action": "Hold until ready."
+    }
+  }
+}

--- a/docs/status/settlement-packets/2026-05-17-open-queue-settlement-ui.html
+++ b/docs/status/settlement-packets/2026-05-17-open-queue-settlement-ui.html
@@ -283,10 +283,146 @@
       font-size: 12px;
     }
 
+    .fact.red,
+    .flag.red {
+      border-color: rgba(163, 54, 54, 0.35);
+      color: var(--bad);
+      background: rgba(163, 54, 54, 0.07);
+    }
+
+    .fact.yellow,
+    .flag.yellow {
+      border-color: rgba(152, 89, 0, 0.35);
+      color: var(--warn);
+      background: rgba(152, 89, 0, 0.08);
+    }
+
+    .fact.green,
+    .flag.green {
+      border-color: rgba(32, 112, 68, 0.35);
+      color: var(--good);
+      background: rgba(32, 112, 68, 0.07);
+    }
+
+    .guidance {
+      margin-top: 20px;
+      padding: 16px 18px;
+      border: 1px solid rgba(152, 89, 0, 0.3);
+      border-radius: 8px;
+      background: #fff8ed;
+      color: #4a310f;
+      box-shadow: var(--shadow);
+    }
+
+    .guidance strong {
+      color: var(--warn);
+    }
+
+    .clusters {
+      display: grid;
+      gap: 14px;
+      margin-top: 20px;
+    }
+
+    .cluster-card {
+      padding: 18px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--panel);
+      box-shadow: var(--shadow);
+    }
+
+    .cluster-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 14px;
+      align-items: start;
+      margin-bottom: 10px;
+    }
+
+    .cluster-members,
+    .flag-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 10px;
+    }
+
+    .flag {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 4px 7px;
+      background: var(--panel-2);
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.25;
+    }
+
+    .cluster-options {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 8px;
+      margin-top: 14px;
+    }
+
+    .cluster-choice {
+      display: block;
+      min-height: 88px;
+      padding: 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--panel-2);
+      cursor: pointer;
+      font-size: 12px;
+      line-height: 1.3;
+    }
+
+    .cluster-choice:hover {
+      border-color: var(--accent);
+    }
+
+    .cluster-choice input {
+      margin-right: 6px;
+      accent-color: var(--accent);
+    }
+
+    .cluster-choice span {
+      display: block;
+      margin-top: 5px;
+      color: var(--muted);
+    }
+
     .recommendation {
       margin: 14px 0;
       color: var(--ink);
       font-size: 14px;
+    }
+
+    .context-block {
+      display: grid;
+      gap: 8px;
+      margin: 14px 0;
+      padding: 12px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: #fbfcfe;
+      font-size: 13px;
+    }
+
+    .context-block p {
+      margin: 0;
+    }
+
+    .approval-locked {
+      margin-top: 10px;
+      padding: 10px 12px;
+      border: 1px solid rgba(152, 89, 0, 0.32);
+      border-radius: 6px;
+      background: rgba(152, 89, 0, 0.07);
+      color: var(--warn);
+      font-size: 13px;
     }
 
     .decision-grid {
@@ -312,6 +448,15 @@
 
     .decision:hover {
       border-color: var(--accent);
+    }
+
+    .decision.disabled {
+      cursor: not-allowed;
+      opacity: 0.54;
+    }
+
+    .decision.disabled:hover {
+      border-color: var(--border);
     }
 
     .decision input {
@@ -409,6 +554,10 @@
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
+      .cluster-options {
+        grid-template-columns: 1fr;
+      }
+
       .details {
         grid-template-columns: 1fr;
       }
@@ -442,7 +591,8 @@
         <h1>Open Queue Settlement Sign-off</h1>
         <p class="subtle">
           Non-mutating operator worksheet for the 2026-05-17 settlement packet.
-          Decisions are exported locally and bound to the packet receipt hash.
+          Decisions are exported locally and bound to the packet receipt plus
+          the decision-safety context shown here.
         </p>
         <div class="meta" id="receiptMeta">
           <span class="pill">waiting for receipt</span>
@@ -450,16 +600,36 @@
       </section>
       <section class="controls" aria-label="Settlement controls">
         <button class="primary" id="exportButton" type="button" disabled>Download decisions JSON</button>
-        <button class="secondary" id="fillHoldsButton" type="button" disabled>Hold all drafts</button>
+        <button class="secondary" id="fillHoldsButton" type="button" disabled>Apply safe holds</button>
         <button class="secondary" id="clearButton" type="button" disabled>Clear choices</button>
       </section>
     </header>
 
-    <div class="status" id="status">Loading receipt from <code>../../receipts/open-queue-settlement-20260517T142811Z.json</code>.</div>
+    <div class="status" id="status">Loading receipt and context.</div>
     <div class="file-fallback" id="fileFallback">
-      <p class="subtle">If your browser blocks local fetches, load the receipt JSON manually.</p>
+      <p class="subtle">If your browser blocks local fetches, load both JSON files manually.</p>
+      <label for="receiptFile">Receipt JSON</label>
       <input id="receiptFile" type="file" accept="application/json">
+      <label for="contextFile" style="display:block;margin-top:10px;">Decision-safety context JSON</label>
+      <input id="contextFile" type="file" accept="application/json">
     </div>
+
+    <section class="guidance" aria-label="Decision safety notice">
+      <p>
+        <strong>Do not approve by default.</strong>
+        This packet is pinned evidence, not live GitHub state. Several PRs are
+        draft, held, Tier-3, failing, or members of duplicate/conflict clusters.
+        Use the cluster choices below before approving any clustered PR.
+      </p>
+      <p class="subtle" style="margin-top:8px;">
+        UI actions only create a local JSON artifact. They do not approve,
+        request changes, label, mark ready, merge, close, or call GitHub.
+      </p>
+    </section>
+
+    <section class="clusters" id="clusterPanel" aria-label="Cluster decisions">
+      <div class="cluster-card">Waiting for settlement context.</div>
+    </section>
 
     <section class="grid">
       <div class="cards" id="cards">
@@ -475,6 +645,7 @@
         <div class="summary-row"><span>Request changes</span><strong id="countRequest">0</strong></div>
         <div class="summary-row"><span>Reject</span><strong id="countReject">0</strong></div>
         <div class="summary-row"><span>Hold</span><strong id="countHold">0</strong></div>
+        <div class="summary-row"><span>Cluster choices</span><strong id="countClusters">0</strong></div>
         <div class="summary-row"><span>Receipt hash</span><strong id="shortHash">-</strong></div>
         <p class="subtle" style="margin-top:14px;font-size:13px;">
           This page does not submit anything. The downloaded JSON is the artifact
@@ -486,6 +657,7 @@
 
   <script>
     const RECEIPT_PATH = "../../receipts/open-queue-settlement-20260517T142811Z.json";
+    const CONTEXT_PATH = "2026-05-17-open-queue-settlement-context.json";
     const DECISION_TYPES = [
       ["approve", "Approve Tier"],
       ["approve_downgraded", "Approve downgraded"],
@@ -495,7 +667,10 @@
     ];
 
     let receipt = null;
+    let context = null;
+    let contextHash = null;
     const decisions = new Map();
+    const clusterChoices = new Map();
 
     const $ = (id) => document.getElementById(id);
 
@@ -539,6 +714,66 @@
       return item.draft === true || item.is_draft === true;
     }
 
+    function contextFor(item) {
+      return context?.per_pr_context?.[String(item.number)] || {};
+    }
+
+    function clusters() {
+      return Array.isArray(context?.clusters) ? context.clusters : [];
+    }
+
+    function clusterFor(id) {
+      return clusters().find((cluster) => cluster.id === id) || null;
+    }
+
+    function clusterChoiceFor(id) {
+      return clusterChoices.get(id) || "";
+    }
+
+    function flagSeverityClass(flags) {
+      if (!Array.isArray(flags) || flags.length === 0) return "green";
+      if (flags.some((flag) => flag.severity === "red")) return "red";
+      if (flags.some((flag) => flag.severity === "yellow")) return "yellow";
+      return "green";
+    }
+
+    function renderFlag(flag) {
+      if (typeof flag === "string") {
+        return `<span class="flag yellow">${escapeHtml(flag)}</span>`;
+      }
+      const severity = flag.severity || "yellow";
+      const label = flag.label || "Review";
+      const detail = flag.detail ? `: ${flag.detail}` : "";
+      return `<span class="flag ${escapeHtml(severity)}">${escapeHtml(label + detail)}</span>`;
+    }
+
+    function renderFlagList(flags, emptyText) {
+      if (!Array.isArray(flags) || flags.length === 0) {
+        return `<div class="flag-list"><span class="flag green">${escapeHtml(emptyText)}</span></div>`;
+      }
+      return `<div class="flag-list">${flags.map(renderFlag).join("")}</div>`;
+    }
+
+    function approvalDisabledReason(item) {
+      const prContext = contextFor(item);
+      const clusterId = prContext.conflict_cluster;
+      if (!clusterId) return "";
+      const cluster = clusterFor(clusterId);
+      if (!cluster) return "";
+      const choice = clusterChoiceFor(clusterId);
+      if (!choice) {
+        return `Choose a ${cluster.name} decision above before approving this PR.`;
+      }
+      const selected = (cluster.choices || []).find((entry) => entry.value === choice);
+      const enabled = Array.isArray(selected?.enables_approval_for)
+        ? selected.enables_approval_for.map(String)
+        : [];
+      if (!enabled.includes(String(item.number))) {
+        return `Current cluster choice does not allow approving #${item.number}.`;
+      }
+      return "";
+    }
+
     function decisionFor(number) {
       return decisions.get(String(number)) || null;
     }
@@ -552,6 +787,7 @@
         <span class="pill">${escapeHtml(count)} pinned PRs</span>
         <span class="pill">${escapeHtml(generated)}</span>
         <span class="pill">${escapeHtml(hmac)}</span>
+        <span class="pill">${contextHash ? `context ${escapeHtml(contextHash.slice(0, 8))}` : "context pending"}</span>
       `;
       $("shortHash").textContent = data.sha256 ? `${data.sha256.slice(0, 8)}...${data.sha256.slice(-8)}` : "-";
     }
@@ -559,6 +795,7 @@
     function render() {
       if (!receipt) return;
       const pinned = normalizePinnedState(receipt);
+      renderClusterPanel();
       $("cards").innerHTML = pinned.map(renderCard).join("");
       $("countTotal").textContent = String(pinned.length);
       $("exportButton").disabled = false;
@@ -567,16 +804,61 @@
       updateSummary();
     }
 
+    function renderClusterPanel() {
+      if (!context) {
+        $("clusterPanel").innerHTML = `<div class="cluster-card">Context not loaded. Cluster approvals remain conservative.</div>`;
+        return;
+      }
+      const clusterCards = clusters().map((cluster) => {
+        const selected = clusterChoiceFor(cluster.id);
+        const choices = (cluster.choices || []).map((choice) => `
+          <label class="cluster-choice">
+            <input type="radio" name="cluster-${escapeHtml(cluster.id)}" data-cluster="${escapeHtml(cluster.id)}"
+              value="${escapeHtml(choice.value)}" ${selected === choice.value ? "checked" : ""}>
+            <strong>${escapeHtml(choice.label)}</strong>
+            <span>${escapeHtml(choice.description || "")}</span>
+          </label>
+        `).join("");
+        return `
+          <article class="cluster-card" data-cluster-card="${escapeHtml(cluster.id)}">
+            <div class="cluster-head">
+              <div>
+                <h2>${escapeHtml(cluster.name)}</h2>
+                <p>${escapeHtml(cluster.summary || "")}</p>
+              </div>
+              <span class="pill">${escapeHtml(cluster.decision_type || "cluster")}</span>
+            </div>
+            <p class="subtle">${escapeHtml(cluster.operator_guidance || "")}</p>
+            <div class="cluster-members">
+              ${(cluster.members || []).map((member) => `<span class="fact">#${escapeHtml(member)}</span>`).join("")}
+            </div>
+            ${renderFlagList(cluster.red_flags || [], "No cluster red flags captured.")}
+            <div class="cluster-options" role="radiogroup" aria-label="${escapeHtml(cluster.name)} decision">
+              ${choices}
+            </div>
+          </article>
+        `;
+      }).join("");
+      $("clusterPanel").innerHTML = clusterCards || `<div class="cluster-card">No conflict clusters captured.</div>`;
+    }
+
     function renderCard(item) {
       const number = String(item.number);
       const tier = String(item.tier ?? "");
+      const prContext = contextFor(item);
       const existing = decisionFor(number);
       const chosen = existing?.decision || "";
       const downgradeTier = existing?.downgrade_tier ?? tier;
       const note = existing?.note || "";
       const radioName = `decision-${number}`;
+      const flags = Array.isArray(prContext.red_flags) ? prContext.red_flags : [];
+      const severity = flagSeverityClass(flags);
+      const approvalLock = approvalDisabledReason(item);
       const decisionControls = DECISION_TYPES.map(([value, label]) => {
         const checked = chosen === value ? "checked" : "";
+        const isApproval = value === "approve" || value === "approve_downgraded";
+        const disabled = isApproval && approvalLock ? "disabled" : "";
+        const title = disabled ? `title="${escapeHtml(approvalLock)}"` : "";
         const tone = value === "approve" || value === "approve_downgraded"
           ? "approve"
           : value === "request_changes"
@@ -585,8 +867,8 @@
               ? "reject"
               : "hold";
         return `
-          <label class="decision ${tone}">
-            <input type="radio" name="${radioName}" value="${value}" ${checked}
+          <label class="decision ${tone} ${disabled ? "disabled" : ""}" ${title}>
+            <input type="radio" name="${radioName}" value="${value}" ${checked} ${disabled}
               data-pr="${number}" aria-label="${escapeHtml(label)} for PR #${number}">
             <span>${escapeHtml(label)}</span>
           </label>
@@ -599,7 +881,7 @@
             <div>
               <div class="title">
                 <span class="pr-number">#${number}</span>
-                <span>${escapeHtml(item.title || `PR #${number}`)}</span>
+                <span>${escapeHtml(prContext.title || item.title || `PR #${number}`)}</span>
                 <span class="tier">T${escapeHtml(tier)}</span>
               </div>
               <div class="head-sha">${escapeHtml(item.head_sha || "")}</div>
@@ -607,14 +889,27 @@
                 <span class="fact">${isDraft(item) ? "draft" : "ready"}</span>
                 <span class="fact">${escapeHtml(item.decision || "decision unknown")}</span>
                 <span class="fact">${escapeHtml(item.merge_state || "merge unknown")}</span>
-                <span class="fact">failures ${escapeHtml(item.failures ?? 0)}</span>
-                <span class="fact">in flight ${escapeHtml(item.in_flight ?? 0)}</span>
+                <span class="fact ${Number(item.failures || 0) > 0 ? "red" : "green"}">failures ${escapeHtml(item.failures ?? 0)}</span>
+                <span class="fact ${Number(item.in_flight || 0) > 0 ? "yellow" : "green"}">in flight ${escapeHtml(item.in_flight ?? 0)}</span>
                 <span class="fact">${escapeHtml(item.files_touched_count ?? "?")} files</span>
+                <span class="fact ${severity}">${severity === "green" ? "no red flags captured" : `${severity} flags`}</span>
+                ${prContext.conflict_cluster ? `<span class="fact yellow">cluster ${escapeHtml(prContext.conflict_cluster)}</span>` : ""}
               </div>
             </div>
           </div>
 
+          <div class="context-block">
+            <p><strong>What this does:</strong> ${escapeHtml(prContext.intent || "No one-line intent captured in the settlement context.")}</p>
+            <p><strong>Why this may need care:</strong> ${escapeHtml(prContext.risk_statement || "No risk statement captured.")}</p>
+            <p><strong>Evidence:</strong> ${escapeHtml(prContext.model_quorum_summary || "No evidence summary captured.")}</p>
+            <p><strong>Safe default:</strong> ${escapeHtml(prContext.safe_default_action || "Make an explicit operator decision.")}</p>
+          </div>
+
+          ${renderFlagList(flags, "No red flags captured in context.")}
+
           <p class="recommendation">${escapeHtml(item.recommended_action || "No recommendation captured.")}</p>
+
+          ${approvalLock ? `<div class="approval-locked">${escapeHtml(approvalLock)}</div>` : ""}
 
           <div class="decision-grid" role="radiogroup" aria-label="Operator decision for PR #${number}">
             ${decisionControls}
@@ -669,20 +964,42 @@
       $("countRequest").textContent = String(counts.request_changes);
       $("countReject").textContent = String(counts.reject);
       $("countHold").textContent = String(counts.hold);
+      $("countClusters").textContent = `${clusterChoices.size}/${clusters().length}`;
     }
 
     function clearChoices() {
       decisions.clear();
+      clusterChoices.clear();
       render();
+    }
+
+    function clearDisallowedApprovals() {
+      if (!receipt) return;
+      for (const item of normalizePinnedState(receipt)) {
+        const key = String(item.number);
+        const entry = decisions.get(key);
+        if (!entry || !["approve", "approve_downgraded"].includes(entry.decision)) continue;
+        const disabledReason = approvalDisabledReason(item);
+        if (disabledReason) {
+          decisions.set(key, {
+            ...entry,
+            decision: null,
+            note: entry.note || disabledReason
+          });
+        }
+      }
     }
 
     function holdAllDrafts() {
       for (const item of normalizePinnedState(receipt)) {
-        if (isDraft(item)) {
+        const prContext = contextFor(item);
+        const hasRedFlag = Array.isArray(prContext.red_flags)
+          && prContext.red_flags.some((flag) => flag.severity === "red");
+        if (isDraft(item) || hasRedFlag || prContext.conflict_cluster) {
           setDecision(item.number, {
             decision: "hold",
             downgrade_tier: null,
-            note: "Held because packet row was draft at pin time."
+            note: prContext.safe_default_action || "Held by safe-default worksheet action."
           });
         }
       }
@@ -694,28 +1011,47 @@
       const rows = pinned.map((item) => {
         const key = String(item.number);
         const entry = decisions.get(key) || {};
+        const prContext = contextFor(item);
         return {
           pr: Number(item.number),
+          title: prContext.title || item.title || `PR #${item.number}`,
           head_sha: item.head_sha || "",
           receipt_tier: String(item.tier ?? ""),
           decision: entry.decision || "undecided",
           downgrade_tier: entry.decision === "approve_downgraded" ? String(entry.downgrade_tier ?? "") : null,
-          note: entry.note || ""
+          note: entry.note || "",
+          conflict_cluster: prContext.conflict_cluster || null,
+          safe_default_action: prContext.safe_default_action || null,
+          red_flags_seen: Array.isArray(prContext.red_flags)
+            ? prContext.red_flags.map((flag) => typeof flag === "string" ? flag : flag.label)
+            : []
         };
       });
+      const cluster_choices = clusters().map((cluster) => ({
+        cluster_id: cluster.id,
+        name: cluster.name,
+        choice: clusterChoiceFor(cluster.id) || "undecided"
+      }));
       const payload = {
         schema_version: "aragora-open-queue-operator-decisions/1.0",
         generated_at_utc: new Date().toISOString(),
+        non_mutating_notice: context?.decision_artifact_notice
+          || "This does not mutate GitHub. It only records local operator decisions.",
         source_packet: "docs/status/settlement-packets/2026-05-17-open-queue-settlement.md",
         source_receipt: "docs/receipts/open-queue-settlement-20260517T142811Z.json",
         source_receipt_sha256: receipt.sha256 || null,
         source_receipt_schema: receipt.schema_version || null,
+        source_context: CONTEXT_PATH,
+        source_context_sha256: contextHash,
         repo: receipt.repo || "synaptent/aragora",
         pr_count_at_pin: receipt.pr_count_at_pin ?? rows.length,
+        cluster_choices,
         decisions: rows
       };
       payload.decisions_sha256 = await sha256Hex(canonicalize({
         source_receipt_sha256: payload.source_receipt_sha256,
+        source_context_sha256: payload.source_context_sha256,
+        cluster_choices: payload.cluster_choices,
         decisions: payload.decisions
       }));
       return payload;
@@ -746,8 +1082,33 @@
       receipt = data;
       updateMeta(data);
       render();
-      $("fileFallback").classList.remove("visible");
-      setStatus(`Loaded ${normalizePinnedState(data).length} pinned PRs from receipt <code>${escapeHtml(data.sha256 || "no hash")}</code>.`, "good");
+      if (context) $("fileFallback").classList.remove("visible");
+      setStatus(
+        context
+          ? `Loaded ${normalizePinnedState(data).length} pinned PRs and decision-safety context.`
+          : `Loaded ${normalizePinnedState(data).length} pinned PRs from receipt <code>${escapeHtml(data.sha256 || "no hash")}</code>. Loading context.`,
+        "good"
+      );
+    }
+
+    async function loadContextFromText(text) {
+      const data = JSON.parse(text);
+      if (!data.per_pr_context || !Array.isArray(data.clusters)) {
+        throw new Error("context is missing per_pr_context or clusters");
+      }
+      context = data;
+      contextHash = await sha256Hex(text);
+      if (receipt) {
+        updateMeta(receipt);
+        render();
+        $("fileFallback").classList.remove("visible");
+      }
+      setStatus(
+        receipt
+          ? `Loaded receipt and decision-safety context. Context hash <code>${escapeHtml(contextHash)}</code>.`
+          : `Loaded decision-safety context <code>${escapeHtml(contextHash)}</code>. Load the receipt next.`,
+        "good"
+      );
     }
 
     async function loadReceipt() {
@@ -755,8 +1116,11 @@
         const response = await fetch(RECEIPT_PATH, { cache: "no-store" });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         await loadReceiptFromText(await response.text());
+        const contextResponse = await fetch(CONTEXT_PATH, { cache: "no-store" });
+        if (!contextResponse.ok) throw new Error(`context HTTP ${contextResponse.status}`);
+        await loadContextFromText(await contextResponse.text());
       } catch (error) {
-        setStatus(`Could not fetch receipt automatically: ${escapeHtml(error.message)}. Serve from <code>docs/</code> or load the receipt file below.`, "bad");
+        setStatus(`Could not fetch all settlement inputs automatically: ${escapeHtml(error.message)}. Serve from <code>docs/</code> or load the receipt file below.`, "bad");
         $("fileFallback").classList.add("visible");
       }
     }
@@ -767,6 +1131,12 @@
         setDecision(target.dataset.pr, { decision: target.value });
         return;
       }
+      if (target.matches("input[type='radio'][data-cluster]")) {
+        clusterChoices.set(target.dataset.cluster, target.value);
+        clearDisallowedApprovals();
+        render();
+        return;
+      }
       if (target.matches("select[data-pr]")) {
         setDecision(target.dataset.pr, { downgrade_tier: target.value });
         return;
@@ -775,6 +1145,11 @@
         target.files[0].text()
           .then(loadReceiptFromText)
           .catch((error) => setStatus(`Receipt load failed: ${escapeHtml(error.message)}`, "bad"));
+      }
+      if (target.id === "contextFile" && target.files?.[0]) {
+        target.files[0].text()
+          .then(loadContextFromText)
+          .catch((error) => setStatus(`Context load failed: ${escapeHtml(error.message)}`, "bad"));
       }
     });
 

--- a/docs/status/settlement-packets/2026-05-17-open-queue-settlement-ui.html
+++ b/docs/status/settlement-packets/2026-05-17-open-queue-settlement-ui.html
@@ -1,0 +1,795 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Open Queue Settlement Sign-off</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --panel-2: #f1f4f8;
+      --ink: #1b2430;
+      --muted: #637084;
+      --border: #d8dee8;
+      --accent: #176d75;
+      --accent-2: #0f4f57;
+      --warn: #985900;
+      --bad: #a33636;
+      --good: #207044;
+      --hold: #5e548e;
+      --shadow: 0 16px 45px rgba(28, 39, 55, 0.11);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      line-height: 1.45;
+    }
+
+    button,
+    input,
+    select,
+    textarea {
+      font: inherit;
+    }
+
+    .shell {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 28px 20px 72px;
+    }
+
+    header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 20px;
+      align-items: start;
+      padding: 28px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+    }
+
+    h1 {
+      margin: 0 0 10px;
+      font-size: 28px;
+      line-height: 1.1;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      margin: 0 0 12px;
+      font-size: 16px;
+      letter-spacing: 0;
+    }
+
+    p {
+      margin: 0;
+    }
+
+    code {
+      padding: 2px 5px;
+      border-radius: 4px;
+      background: var(--panel-2);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+      overflow-wrap: anywhere;
+    }
+
+    .subtle {
+      color: var(--muted);
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 26px;
+      padding: 3px 9px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: var(--panel-2);
+      color: var(--muted);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      min-width: 260px;
+    }
+
+    .primary,
+    .secondary {
+      min-height: 40px;
+      border: 1px solid transparent;
+      border-radius: 6px;
+      padding: 9px 14px;
+      cursor: pointer;
+    }
+
+    .primary {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .primary:hover {
+      background: var(--accent-2);
+    }
+
+    .secondary {
+      background: var(--panel);
+      color: var(--accent);
+      border-color: var(--border);
+    }
+
+    .secondary:hover {
+      border-color: var(--accent);
+    }
+
+    .secondary:disabled,
+    .primary:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    .status {
+      margin-top: 18px;
+      padding: 12px 14px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--panel);
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .status.good {
+      border-color: rgba(32, 112, 68, 0.35);
+      color: var(--good);
+      background: rgba(32, 112, 68, 0.06);
+    }
+
+    .status.bad {
+      border-color: rgba(163, 54, 54, 0.35);
+      color: var(--bad);
+      background: rgba(163, 54, 54, 0.06);
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 320px;
+      gap: 20px;
+      margin-top: 20px;
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+    }
+
+    .panel-pad {
+      padding: 20px;
+    }
+
+    .summary {
+      position: sticky;
+      top: 16px;
+      align-self: start;
+    }
+
+    .summary-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 10px 0;
+      border-top: 1px solid var(--border);
+      font-size: 14px;
+    }
+
+    .summary-row:first-of-type {
+      border-top: 0;
+    }
+
+    .summary-row strong {
+      font-variant-numeric: tabular-nums;
+    }
+
+    .cards {
+      display: grid;
+      gap: 14px;
+    }
+
+    .card {
+      padding: 18px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+
+    .card-head {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 16px;
+      align-items: start;
+    }
+
+    .title {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 7px;
+      font-weight: 700;
+      font-size: 16px;
+    }
+
+    .pr-number {
+      color: var(--accent);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .tier {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 34px;
+      height: 24px;
+      border-radius: 999px;
+      color: #fff;
+      background: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .head-sha {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      color: var(--muted);
+      font-size: 12px;
+      overflow-wrap: anywhere;
+    }
+
+    .facts {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 10px;
+    }
+
+    .fact {
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 4px 7px;
+      color: var(--muted);
+      background: var(--panel-2);
+      font-size: 12px;
+    }
+
+    .recommendation {
+      margin: 14px 0;
+      color: var(--ink);
+      font-size: 14px;
+    }
+
+    .decision-grid {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    .decision {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      min-height: 42px;
+      padding: 8px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--panel-2);
+      cursor: pointer;
+      font-size: 12px;
+      line-height: 1.2;
+    }
+
+    .decision:hover {
+      border-color: var(--accent);
+    }
+
+    .decision input {
+      margin: 0;
+      accent-color: var(--accent);
+    }
+
+    .decision.approve {
+      color: var(--good);
+    }
+
+    .decision.request {
+      color: var(--warn);
+    }
+
+    .decision.reject {
+      color: var(--bad);
+    }
+
+    .decision.hold {
+      color: var(--hold);
+    }
+
+    .details {
+      display: grid;
+      grid-template-columns: 180px minmax(0, 1fr);
+      gap: 8px 12px;
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid var(--border);
+      font-size: 13px;
+    }
+
+    .details label {
+      color: var(--muted);
+    }
+
+    .downgrade-row {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    select,
+    textarea {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: #fff;
+      color: var(--ink);
+      padding: 8px 10px;
+    }
+
+    textarea {
+      min-height: 64px;
+      resize: vertical;
+    }
+
+    .empty {
+      padding: 28px;
+      text-align: center;
+      color: var(--muted);
+    }
+
+    .file-fallback {
+      display: none;
+      margin-top: 12px;
+      padding: 12px;
+      border: 1px dashed var(--border);
+      border-radius: 6px;
+      background: var(--panel-2);
+    }
+
+    .file-fallback.visible {
+      display: block;
+    }
+
+    @media (max-width: 980px) {
+      header,
+      .grid,
+      .card-head {
+        grid-template-columns: 1fr;
+      }
+
+      .summary {
+        position: static;
+      }
+
+      .controls {
+        min-width: 0;
+      }
+
+      .decision-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .details {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 560px) {
+      .shell {
+        padding: 14px 10px 48px;
+      }
+
+      header,
+      .panel-pad,
+      .card {
+        padding: 16px;
+      }
+
+      h1 {
+        font-size: 23px;
+      }
+
+      .decision-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header>
+      <section>
+        <h1>Open Queue Settlement Sign-off</h1>
+        <p class="subtle">
+          Non-mutating operator worksheet for the 2026-05-17 settlement packet.
+          Decisions are exported locally and bound to the packet receipt hash.
+        </p>
+        <div class="meta" id="receiptMeta">
+          <span class="pill">waiting for receipt</span>
+        </div>
+      </section>
+      <section class="controls" aria-label="Settlement controls">
+        <button class="primary" id="exportButton" type="button" disabled>Download decisions JSON</button>
+        <button class="secondary" id="fillHoldsButton" type="button" disabled>Hold all drafts</button>
+        <button class="secondary" id="clearButton" type="button" disabled>Clear choices</button>
+      </section>
+    </header>
+
+    <div class="status" id="status">Loading receipt from <code>../../receipts/open-queue-settlement-20260517T142811Z.json</code>.</div>
+    <div class="file-fallback" id="fileFallback">
+      <p class="subtle">If your browser blocks local fetches, load the receipt JSON manually.</p>
+      <input id="receiptFile" type="file" accept="application/json">
+    </div>
+
+    <section class="grid">
+      <div class="cards" id="cards">
+        <div class="panel empty">Receipt not loaded yet.</div>
+      </div>
+
+      <aside class="panel panel-pad summary" aria-label="Decision summary">
+        <h2>Decision Summary</h2>
+        <div class="summary-row"><span>Packet PRs</span><strong id="countTotal">0</strong></div>
+        <div class="summary-row"><span>Decided</span><strong id="countDecided">0</strong></div>
+        <div class="summary-row"><span>Approve</span><strong id="countApprove">0</strong></div>
+        <div class="summary-row"><span>Approve downgraded</span><strong id="countDowngrade">0</strong></div>
+        <div class="summary-row"><span>Request changes</span><strong id="countRequest">0</strong></div>
+        <div class="summary-row"><span>Reject</span><strong id="countReject">0</strong></div>
+        <div class="summary-row"><span>Hold</span><strong id="countHold">0</strong></div>
+        <div class="summary-row"><span>Receipt hash</span><strong id="shortHash">-</strong></div>
+        <p class="subtle" style="margin-top:14px;font-size:13px;">
+          This page does not submit anything. The downloaded JSON is the artifact
+          to commit, attach, or use as explicit operator sign-off.
+        </p>
+      </aside>
+    </section>
+  </main>
+
+  <script>
+    const RECEIPT_PATH = "../../receipts/open-queue-settlement-20260517T142811Z.json";
+    const DECISION_TYPES = [
+      ["approve", "Approve Tier"],
+      ["approve_downgraded", "Approve downgraded"],
+      ["request_changes", "Request changes"],
+      ["reject", "Reject"],
+      ["hold", "Hold"]
+    ];
+
+    let receipt = null;
+    const decisions = new Map();
+
+    const $ = (id) => document.getElementById(id);
+
+    function setStatus(message, tone = "") {
+      const el = $("status");
+      el.className = `status ${tone}`.trim();
+      el.innerHTML = message;
+    }
+
+    function escapeHtml(value) {
+      return String(value ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+    }
+
+    function canonicalize(value) {
+      if (Array.isArray(value)) {
+        return `[${value.map(canonicalize).join(",")}]`;
+      }
+      if (value && typeof value === "object") {
+        return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`).join(",")}}`;
+      }
+      return JSON.stringify(value);
+    }
+
+    async function sha256Hex(text) {
+      const bytes = new TextEncoder().encode(text);
+      const digest = await crypto.subtle.digest("SHA-256", bytes);
+      return Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, "0")).join("");
+    }
+
+    function normalizePinnedState(data) {
+      const pinned = Array.isArray(data.pinned_state) ? data.pinned_state : [];
+      return [...pinned].sort((a, b) => Number(a.number) - Number(b.number));
+    }
+
+    function isDraft(item) {
+      return item.draft === true || item.is_draft === true;
+    }
+
+    function decisionFor(number) {
+      return decisions.get(String(number)) || null;
+    }
+
+    function updateMeta(data) {
+      const generated = data.generated_at_utc || "unknown generation time";
+      const count = data.pr_count_at_pin ?? normalizePinnedState(data).length;
+      const hmac = data.hmac_sha256 ? "HMAC signed" : "unsigned receipt";
+      $("receiptMeta").innerHTML = `
+        <span class="pill">${escapeHtml(data.repo || "unknown repo")}</span>
+        <span class="pill">${escapeHtml(count)} pinned PRs</span>
+        <span class="pill">${escapeHtml(generated)}</span>
+        <span class="pill">${escapeHtml(hmac)}</span>
+      `;
+      $("shortHash").textContent = data.sha256 ? `${data.sha256.slice(0, 8)}...${data.sha256.slice(-8)}` : "-";
+    }
+
+    function render() {
+      if (!receipt) return;
+      const pinned = normalizePinnedState(receipt);
+      $("cards").innerHTML = pinned.map(renderCard).join("");
+      $("countTotal").textContent = String(pinned.length);
+      $("exportButton").disabled = false;
+      $("fillHoldsButton").disabled = false;
+      $("clearButton").disabled = false;
+      updateSummary();
+    }
+
+    function renderCard(item) {
+      const number = String(item.number);
+      const tier = String(item.tier ?? "");
+      const existing = decisionFor(number);
+      const chosen = existing?.decision || "";
+      const downgradeTier = existing?.downgrade_tier ?? tier;
+      const note = existing?.note || "";
+      const radioName = `decision-${number}`;
+      const decisionControls = DECISION_TYPES.map(([value, label]) => {
+        const checked = chosen === value ? "checked" : "";
+        const tone = value === "approve" || value === "approve_downgraded"
+          ? "approve"
+          : value === "request_changes"
+            ? "request"
+            : value === "reject"
+              ? "reject"
+              : "hold";
+        return `
+          <label class="decision ${tone}">
+            <input type="radio" name="${radioName}" value="${value}" ${checked}
+              data-pr="${number}" aria-label="${escapeHtml(label)} for PR #${number}">
+            <span>${escapeHtml(label)}</span>
+          </label>
+        `;
+      }).join("");
+
+      return `
+        <article class="card" data-pr="${number}">
+          <div class="card-head">
+            <div>
+              <div class="title">
+                <span class="pr-number">#${number}</span>
+                <span>${escapeHtml(item.title || `PR #${number}`)}</span>
+                <span class="tier">T${escapeHtml(tier)}</span>
+              </div>
+              <div class="head-sha">${escapeHtml(item.head_sha || "")}</div>
+              <div class="facts">
+                <span class="fact">${isDraft(item) ? "draft" : "ready"}</span>
+                <span class="fact">${escapeHtml(item.decision || "decision unknown")}</span>
+                <span class="fact">${escapeHtml(item.merge_state || "merge unknown")}</span>
+                <span class="fact">failures ${escapeHtml(item.failures ?? 0)}</span>
+                <span class="fact">in flight ${escapeHtml(item.in_flight ?? 0)}</span>
+                <span class="fact">${escapeHtml(item.files_touched_count ?? "?")} files</span>
+              </div>
+            </div>
+          </div>
+
+          <p class="recommendation">${escapeHtml(item.recommended_action || "No recommendation captured.")}</p>
+
+          <div class="decision-grid" role="radiogroup" aria-label="Operator decision for PR #${number}">
+            ${decisionControls}
+          </div>
+
+          <div class="details">
+            <label for="downgrade-${number}">Downgrade tier</label>
+            <div class="downgrade-row">
+              <select id="downgrade-${number}" data-pr="${number}">
+                ${["0", "1", "2", "3", "4"].map((candidate) => `
+                  <option value="${candidate}" ${String(downgradeTier) === candidate ? "selected" : ""}>Tier ${candidate}</option>
+                `).join("")}
+              </select>
+              <span class="subtle">Used only for "Approve downgraded".</span>
+            </div>
+
+            <label for="note-${number}">Operator note</label>
+            <textarea id="note-${number}" data-pr="${number}" placeholder="Optional reason, blocker, or acceptance note.">${escapeHtml(note)}</textarea>
+          </div>
+        </article>
+      `;
+    }
+
+    function setDecision(prNumber, patch) {
+      const key = String(prNumber);
+      const current = decisions.get(key) || {
+        pr: Number(prNumber),
+        head_sha: normalizePinnedState(receipt).find((item) => String(item.number) === key)?.head_sha || "",
+        decision: null,
+        downgrade_tier: null,
+        note: ""
+      };
+      decisions.set(key, { ...current, ...patch });
+      updateSummary();
+    }
+
+    function updateSummary() {
+      const values = Array.from(decisions.values()).filter((entry) => entry.decision);
+      const counts = {
+        approve: 0,
+        approve_downgraded: 0,
+        request_changes: 0,
+        reject: 0,
+        hold: 0
+      };
+      for (const entry of values) {
+        if (entry.decision in counts) counts[entry.decision] += 1;
+      }
+      $("countDecided").textContent = String(values.length);
+      $("countApprove").textContent = String(counts.approve);
+      $("countDowngrade").textContent = String(counts.approve_downgraded);
+      $("countRequest").textContent = String(counts.request_changes);
+      $("countReject").textContent = String(counts.reject);
+      $("countHold").textContent = String(counts.hold);
+    }
+
+    function clearChoices() {
+      decisions.clear();
+      render();
+    }
+
+    function holdAllDrafts() {
+      for (const item of normalizePinnedState(receipt)) {
+        if (isDraft(item)) {
+          setDecision(item.number, {
+            decision: "hold",
+            downgrade_tier: null,
+            note: "Held because packet row was draft at pin time."
+          });
+        }
+      }
+      render();
+    }
+
+    async function buildDecisionArtifact() {
+      const pinned = normalizePinnedState(receipt);
+      const rows = pinned.map((item) => {
+        const key = String(item.number);
+        const entry = decisions.get(key) || {};
+        return {
+          pr: Number(item.number),
+          head_sha: item.head_sha || "",
+          receipt_tier: String(item.tier ?? ""),
+          decision: entry.decision || "undecided",
+          downgrade_tier: entry.decision === "approve_downgraded" ? String(entry.downgrade_tier ?? "") : null,
+          note: entry.note || ""
+        };
+      });
+      const payload = {
+        schema_version: "aragora-open-queue-operator-decisions/1.0",
+        generated_at_utc: new Date().toISOString(),
+        source_packet: "docs/status/settlement-packets/2026-05-17-open-queue-settlement.md",
+        source_receipt: "docs/receipts/open-queue-settlement-20260517T142811Z.json",
+        source_receipt_sha256: receipt.sha256 || null,
+        source_receipt_schema: receipt.schema_version || null,
+        repo: receipt.repo || "synaptent/aragora",
+        pr_count_at_pin: receipt.pr_count_at_pin ?? rows.length,
+        decisions: rows
+      };
+      payload.decisions_sha256 = await sha256Hex(canonicalize({
+        source_receipt_sha256: payload.source_receipt_sha256,
+        decisions: payload.decisions
+      }));
+      return payload;
+    }
+
+    async function exportDecisions() {
+      if (!receipt) return;
+      const payload = await buildDecisionArtifact();
+      const text = `${JSON.stringify(payload, null, 2)}\n`;
+      const blob = new Blob([text], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const stamp = new Date().toISOString().replaceAll(":", "").replaceAll("-", "").split(".")[0] + "Z";
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `operator-decisions-open-queue-settlement-${stamp}.json`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+      setStatus(`Downloaded decisions JSON with binding <code>${payload.decisions_sha256}</code>.`, "good");
+    }
+
+    async function loadReceiptFromText(text) {
+      const data = JSON.parse(text);
+      if (!Array.isArray(data.pinned_state)) {
+        throw new Error("receipt is missing pinned_state array");
+      }
+      receipt = data;
+      updateMeta(data);
+      render();
+      $("fileFallback").classList.remove("visible");
+      setStatus(`Loaded ${normalizePinnedState(data).length} pinned PRs from receipt <code>${escapeHtml(data.sha256 || "no hash")}</code>.`, "good");
+    }
+
+    async function loadReceipt() {
+      try {
+        const response = await fetch(RECEIPT_PATH, { cache: "no-store" });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        await loadReceiptFromText(await response.text());
+      } catch (error) {
+        setStatus(`Could not fetch receipt automatically: ${escapeHtml(error.message)}. Serve from <code>docs/</code> or load the receipt file below.`, "bad");
+        $("fileFallback").classList.add("visible");
+      }
+    }
+
+    document.addEventListener("change", (event) => {
+      const target = event.target;
+      if (target.matches("input[type='radio'][data-pr]")) {
+        setDecision(target.dataset.pr, { decision: target.value });
+        return;
+      }
+      if (target.matches("select[data-pr]")) {
+        setDecision(target.dataset.pr, { downgrade_tier: target.value });
+        return;
+      }
+      if (target.id === "receiptFile" && target.files?.[0]) {
+        target.files[0].text()
+          .then(loadReceiptFromText)
+          .catch((error) => setStatus(`Receipt load failed: ${escapeHtml(error.message)}`, "bad"));
+      }
+    });
+
+    document.addEventListener("input", (event) => {
+      const target = event.target;
+      if (target.matches("textarea[data-pr]")) {
+        setDecision(target.dataset.pr, { note: target.value });
+      }
+    });
+
+    $("exportButton").addEventListener("click", exportDecisions);
+    $("clearButton").addEventListener("click", clearChoices);
+    $("fillHoldsButton").addEventListener("click", holdAllDrafts);
+
+    loadReceipt();
+  </script>
+</body>
+</html>

--- a/docs/status/settlement-packets/2026-05-17-open-queue-settlement.md
+++ b/docs/status/settlement-packets/2026-05-17-open-queue-settlement.md
@@ -1,0 +1,521 @@
+# Open queue settlement packet — 2026-05-17
+
+> **Read-only operator settlement packet.** This document does not mutate any PR. Each per-PR recommendation is cryptographically bound to a specific head SHA via the receipt referenced below. Operator signs off by editing the sign-off matrix in section 5 or by replying with explicit decisions.
+
+## Header
+
+- **Repo**: synaptent/aragora
+- **Generated**: 2026-05-17T14:28:11.657846+00:00
+- **PR count at pin**: 15 (prompt said 'currently 10'; live count is 15 — drift since the recommendation was produced)
+- **Receipt**: `docs/receipts/open-queue-settlement-20260517T142811Z.json`
+- **SHA-256**: `b93358c76358bab8b1a41a2843bc4c7ee36446ce433ebab8ab301d0c359cf9a2`
+- **HMAC**: _unsigned (ARAGORA_CONTEXT_SIGNING_KEY not set in this environment; operator can re-emit with key set)_
+- **Tier source**: `docs/REVIEW_AUTHORITY_PRINCIPLES.md` (lines 26-38)
+
+## Tier reference (from docs/REVIEW_AUTHORITY_PRINCIPLES.md)
+
+| Tier | Class | Requirement | Settlement |
+|---|---|---|---|
+| 0 | Docs/tests/status only | Green required checks + 1 model review/dogfood | Admin squash allowed |
+| 1 | Additive internal code, no live caller | Green + 2 model signals (1 adversarial/dogfood) | Admin squash allowed |
+| 2 | Live automation/CLI/observability | Green + 2 heterogeneous models + dogfood + no dissent | Admin squash allowed |
+| 3 | Semantic/persistence/security/public API | Model quorum + explicit human risk settlement | Human risk acceptance required |
+| 4 | Secrets/deployment/policy/merge-gate | Human preapproval before implementation AND before merge | Human preapproval required |
+
+## Executive summary
+
+| # | Head | Draft? | Decision | Merge | F | IF | T | Recommended action |
+|---|---|---|---|---|---|---|---|---|
+| **#7173** | `29115c5e97` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **2** | OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green |
+| **#7215** | `0d148f13c1` | ready | REVIEW_REQUIRED | BLOCKED | 0 | 1 | **3** | WAIT: 1 check(s) still in flight; revisit when settled |
+| **#7240** | `7aa00774bf` | ready | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **3** | REQUIRES: explicit human Tier-3 risk acceptance comment at current head |
+| **#7243** | `7f9ecf28d5` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **0** | OPERATOR: mark ready when complete; Tier 0 → admin squash allowed once green |
+| **#7245** | `68c03eadd0` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **3** | OPERATOR: mark ready when complete; Tier 3 → human risk acceptance required |
+| **#7249** | `7a4d310d61` | draft | REVIEW_REQUIRED | BLOCKED | 2 | 0 | **1** | OPERATOR: mark ready when complete; Tier 1 → admin squash allowed once green |
+| **#7251** | `19f29eeef1` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **1** | OPERATOR: mark ready when complete; Tier 1 → admin squash allowed once green |
+| **#7252** | `5961232a82` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **0** | OPERATOR: mark ready when complete; Tier 0 → admin squash allowed once green |
+| **#7256** | `e1b37b3485` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 6 | **2** | OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green |
+| **#7257** | `a9b044ce74` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **3** | OPERATOR: mark ready when complete; Tier 3 → human risk acceptance required |
+| **#7258** | `28a748d3f0` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **2** | OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green |
+| **#7259** | `31192860af` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **2** | OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green |
+| **#7260** | `e53aa8157d` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **2** | OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green |
+| **#7261** | `a5a4f13063` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **2** | OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green |
+| **#7262** | `e8a962a2dd` | draft | REVIEW_REQUIRED | BLOCKED | 0 | 0 | **1** | OPERATOR: mark ready when complete; Tier 1 → admin squash allowed once green |
+
+_F = failures, IF = in-flight, T = tier_
+
+## Clusters
+
+### parser.py + CLI/docs cluster (mandatory merge order)
+
+**Members**: #7215, #7240, #7245
+
+**Shared files** (conflict-prone):
+- `aragora/cli/commands/codex_sessions.py`
+- `aragora/cli/parser.py`
+- `aragora/codex/__init__.py`
+- `aragora/codex/desktop_inspector.py`
+- `aragora/codex/desktop_paths.py`
+- `aragora/codex/duration.py`
+- `aragora/codex/jsonl_stream.py`
+- `aragora/codex/sqlite_ro.py`
+- `aragora/module_tiers.yaml`
+- `docs-site/docs/api/cli.md`
+- `docs-site/docs/contributing/capability-matrix.md`
+- `docs/CAPABILITY_MATRIX.md`
+- `docs/METRICS.md`
+- `docs/reference/CLI_REFERENCE.md`
+- `tests/codex/__init__.py`
+
+**Recommended merge order**: whichever PR is fastest to settle goes first (foundation); the other(s) rebase. Each PR adds one subparser registration in `aragora/cli/parser.py` and one row in CLI/capability docs — trivial conflicts but rebase required.
+
+### codex_worktree_value_inventory.py cluster (operator-choice)
+
+**Members**: #7256, #7259
+
+**Shared files**:
+- `scripts/codex_worktree_value_inventory.py`
+- `tests/scripts/test_codex_worktree_value_inventory.py`
+
+**Operator decision required**: these PRs propose alternate approaches to the same change. They should NOT both merge — pick ONE; the other should close or rebase to subsume the chosen approach.
+
+## Per-PR detail
+
+### #7173 — feat(triage): calibration-only multi-model GitHub issue triage with guided founder review
+
+- **Head SHA**: `29115c5e97b9cd0ab0c7910cb12e6fa09f6025b7`
+- **Branch**: `claude/triage-issues-via-debate-20260515` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=14, in-flight=0, failures=0
+- **Diff**: +3505 / −14 across 7 files
+- **Updated**: 2026-05-17T06:15
+
+- **Tier**: **2** — live CLI / automation / observability surface
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Live automation / CLI / observability surface change. Accept: any newly added CLI verb becomes a public operator surface; any new automation will fire on its schedule once enabled. Reversible by revert + un-install of any installed launchd jobs.
+
+- **Conflicts / overlap**: none with other open PRs
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green
+
+
+### #7215 — [DIC-17] Add `aragora crux-followup` CLI verb (flag-gated, default OFF)
+
+- **Head SHA**: `0d148f13c1b281f74c207fd25560bafb11fa9186`
+- **Branch**: `vision-incubator/dic-17-crux-followup-cli` → `main`
+- **Author**: `an0mium`
+- **Draft**: False
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=11, in-flight=1, failures=0
+- **Diff**: +435 / −12 across 8 files
+- **Updated**: 2026-05-17T14:26
+
+- **Tier**: **3** — semantic correctness / persistence / security / public API surface
+
+- **Model-quorum evidence (from PR comments)**:
+    - 2026-05-16T18:01  `aragora_code_review_bot` by `github-actions` [no head pin in comment]
+    - 2026-05-16T18:05  `codex_focused_dogfood` by `an0mium` [head-pinned to `0d148f13c1`]
+    - 2026-05-16T18:28  `droid_kimi_review` by `an0mium` [head-pinned to `0d148f13c1`]
+    - 2026-05-16T18:28  `droid_kimi_review` by `an0mium` [head-pinned to `0d148f13c1`]
+    - 2026-05-16T19:22  `codex_focused_dogfood` by `an0mium` [head-pinned to `0d148f13c1`]
+    - 2026-05-16T23:16  `tier4_acceptance` by `an0mium` [head-pinned to `0d148f13c1`]
+    - 2026-05-17T14:24  `tier4_acceptance` by `an0mium` [head-pinned to `0d148f13c1`]
+    - 2026-05-17T14:26  `tier4_acceptance` by `an0mium` [head-pinned to `0d148f13c1`]
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Semantic / persistence / security / public API surface change. Accept: behavioral changes visible to downstream consumers (SDK users, API clients, persisted data shape). Requires explicit human risk settlement comment at current head.
+
+- **Conflicts / overlap**: shares files with #7240, #7243, #7245
+
+- **Recommended action**: WAIT: 1 check(s) still in flight; revisit when settled
+
+
+### #7240 — feat(codex): read-only inspector CLI for Codex Desktop sessions
+
+- **Head SHA**: `7aa00774bf633ccd7b1a945eff427396a75e083a`
+- **Branch**: `worktree-codex-desktop-inspector` → `main`
+- **Author**: `an0mium`
+- **Draft**: False
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=71, in-flight=0, failures=0
+- **Diff**: +2155 / −39 across 20 files
+- **Updated**: 2026-05-17T06:24
+
+- **Tier**: **3** — semantic correctness / persistence / security / public API surface
+
+- **Model-quorum evidence (from PR comments)**:
+    - 2026-05-16T23:24  `codex_security_check` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:25  `codex_focused_dogfood` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:28  `codex_focused_dogfood` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:29  `droid_kimi_review` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:30  `droid_kimi_review` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:33  `codex_focused_dogfood` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:34  `droid_kimi_review` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:37  `codex_security_check` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:43  `aragora_code_review_bot` by `github-actions` [no head pin in comment]
+    - 2026-05-16T23:48  `codex_focused_dogfood` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:49  `droid_kimi_review` by `an0mium` [no head pin in comment]
+    - 2026-05-16T23:50  `droid_kimi_review` by `an0mium` [no head pin in comment]
+    - 2026-05-17T01:36  `tier4_acceptance` by `an0mium` [no head pin in comment]
+    - 2026-05-17T01:50  `findings_review` by `an0mium` [no head pin in comment]
+    - 2026-05-17T03:38  `codex_security_check` by `an0mium` [no head pin in comment]
+    - 2026-05-17T05:00  `codex_focused_dogfood` by `an0mium` [no head pin in comment]
+    - 2026-05-17T05:00  `droid_kimi_review` by `an0mium` [no head pin in comment]
+    - 2026-05-17T06:13  `droid_kimi_review` by `an0mium` [no head pin in comment]
+    - 2026-05-17T06:22  `codex_focused_dogfood` by `an0mium` [head-pinned to `7aa00774bf`]
+    - 2026-05-17T06:24  `droid_kimi_review` by `an0mium` [head-pinned to `7aa00774bf`]
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Semantic / persistence / security / public API surface change. Accept: behavioral changes visible to downstream consumers (SDK users, API clients, persisted data shape). Requires explicit human risk settlement comment at current head.
+
+- **Conflicts / overlap**: shares files with #7215, #7243, #7245
+
+- **Recommended action**: REQUIRES: explicit human Tier-3 risk acceptance comment at current head
+
+
+### #7243 — docs: refresh metrics from current main
+
+- **Head SHA**: `7f9ecf28d5b9cf75df08281419104d74419c8917`
+- **Branch**: `codex/harvest-metrics-refresh-20260516` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=12, in-flight=0, failures=0
+- **Diff**: +3 / −3 across 1 files
+- **Updated**: 2026-05-16T23:23
+
+- **Tier**: **0** — docs-only / tests-only / status report
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Docs/tests/status-only change touching 1 file(s). Accept: documentation drift if any of the listed paths become canonical surfaces later. Reversible by revert.
+
+- **Conflicts / overlap**: shares files with #7215, #7240, #7245
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 0 → admin squash allowed once green
+
+
+### #7245 — feat(codex): activity-intelligence layer with signed digest receipts
+
+- **Head SHA**: `68c03eadd0762e9825293a1f28298e949a73bf28`
+- **Branch**: `worktree-codex-insights` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=16, in-flight=0, failures=0
+- **Diff**: +3215 / −18 across 24 files
+- **Updated**: 2026-05-17T01:52
+
+- **Tier**: **3** — semantic correctness / persistence / security / public API surface
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Semantic / persistence / security / public API surface change. Accept: behavioral changes visible to downstream consumers (SDK users, API clients, persisted data shape). Requires explicit human risk settlement comment at current head.
+
+- **Conflicts / overlap**: shares files with #7215, #7240, #7243
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 3 → human risk acceptance required
+
+
+### #7249 — [AGT-06] Add viah_signals bridge: ReputationStore → VIAH sidecar counters (SD-2, SD-3)
+
+- **Head SHA**: `7a4d310d618bfe62c90f3d76913ff2afe97b9434`
+- **Branch**: `vision-incubator/agt-06-viah-signals-bridge` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=11, in-flight=0, failures=2
+- **Diff**: +286 / −0 across 2 files
+- **Updated**: 2026-05-17T00:21
+
+- **Tier**: **1** — additive internal code, no live caller and no public API effect
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Additive internal code with no live caller. Accept: dead code if the additive surface is never wired; minor maintenance burden. Reversible by revert.
+
+- **Conflicts / overlap**: none with other open PRs
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 1 → admin squash allowed once green
+
+
+### #7251 — feat(benchmarks): productize A2 admission-recovery scenarios for #7209 (PR-3, data+docs only)
+
+- **Head SHA**: `19f29eeef1fc4e72be58cdbd36064303ac14a7c4`
+- **Branch**: `droid/a2-pr3-admission-recovery-rescue-map-and-fixtures-20260516` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=14, in-flight=0, failures=0
+- **Diff**: +353 / −0 across 3 files
+- **Updated**: 2026-05-17T01:38
+
+- **Tier**: **1** — additive internal code, no live caller and no public API effect
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Additive internal code with no live caller. Accept: dead code if the additive surface is never wired; minor maintenance burden. Reversible by revert.
+
+- **Conflicts / overlap**: none with other open PRs
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 1 → admin squash allowed once green
+
+
+### #7252 — docs(codex-insights): paused core-writer remediation audit (read-only)
+
+- **Head SHA**: `5961232a8231b77b9ba0e5f6a0bf689749710993`
+- **Branch**: `worktree-paused-writer-remediation` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=11, in-flight=0, failures=0
+- **Diff**: +287 / −0 across 2 files
+- **Updated**: 2026-05-17T01:35
+
+- **Tier**: **0** — docs-only / tests-only / status report
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Docs/tests/status-only change touching 2 file(s). Accept: documentation drift if any of the listed paths become canonical surfaces later. Reversible by revert.
+
+- **Conflicts / overlap**: none with other open PRs
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 0 → admin squash allowed once green
+
+
+### #7256 — fix(scripts): preserve foreign worktree inventory roots
+
+- **Head SHA**: `e1b37b34853d769221644a4d4087d0205394c60d`
+- **Branch**: `codex/inventory-foreign-repo-preserve-20260516` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=1, in-flight=6, failures=0
+- **Diff**: +100 / −0 across 2 files
+- **Updated**: 2026-05-17T14:27
+
+- **Tier**: **2** — live CLI / automation / observability surface
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Live automation / CLI / observability surface change. Accept: any newly added CLI verb becomes a public operator surface; any new automation will fire on its schedule once enabled. Reversible by revert + un-install of any installed launchd jobs.
+
+- **Conflicts / overlap**: shares files with #7259
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green
+
+
+### #7257 — feat(server): observer truth on FastAPI swarm-status sibling surface
+
+- **Head SHA**: `a9b044ce7490eab1a838fcc2ba8e54fcdb42ace6`
+- **Branch**: `droid/phase1-fastapi-observer-truth-20260516` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=14, in-flight=0, failures=0
+- **Diff**: +169 / −1 across 2 files
+- **Updated**: 2026-05-17T01:55
+
+- **Tier**: **3** — semantic correctness / persistence / security / public API surface
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Semantic / persistence / security / public API surface change. Accept: behavioral changes visible to downstream consumers (SDK users, API clients, persisted data shape). Requires explicit human risk settlement comment at current head.
+
+- **Conflicts / overlap**: none with other open PRs
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 3 → human risk acceptance required
+
+
+### #7258 — feat(automation): publish recurring worktree value inventory
+
+- **Head SHA**: `28a748d3f0c11708b95b212c84eba0d75077a2ca`
+- **Branch**: `droid/phase2-worktree-value-inventory-20260516v2` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=14, in-flight=0, failures=0
+- **Diff**: +5903 / −0 across 5 files
+- **Updated**: 2026-05-17T06:07
+
+- **Tier**: **2** — live CLI / automation / observability surface
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Live automation / CLI / observability surface change. Accept: any newly added CLI verb becomes a public operator surface; any new automation will fire on its schedule once enabled. Reversible by revert + un-install of any installed launchd jobs.
+
+- **Conflicts / overlap**: none with other open PRs
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green
+
+
+### #7259 — feat(scripts): bound worktree inventory runtime
+
+- **Head SHA**: `31192860afdd7f095080059f358fb16e8dccc846`
+- **Branch**: `codex/worktree-inventory-runtime-budget-20260517` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=14, in-flight=0, failures=0
+- **Diff**: +221 / −13 across 2 files
+- **Updated**: 2026-05-17T06:11
+
+- **Tier**: **2** — live CLI / automation / observability surface
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Live automation / CLI / observability surface change. Accept: any newly added CLI verb becomes a public operator surface; any new automation will fire on its schedule once enabled. Reversible by revert + un-install of any installed launchd jobs.
+
+- **Conflicts / overlap**: shares files with #7256
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green
+
+
+### #7260 — feat(automation): read-only cross-agent overlap detector
+
+- **Head SHA**: `e53aa8157d00060c134993ff61584da409094083`
+- **Branch**: `droid/phase3-list-active-agent-sessions-20260516` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=13, in-flight=0, failures=0
+- **Diff**: +1007 / −0 across 2 files
+- **Updated**: 2026-05-17T06:19
+
+- **Tier**: **2** — live CLI / automation / observability surface
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Live automation / CLI / observability surface change. Accept: any newly added CLI verb becomes a public operator surface; any new automation will fire on its schedule once enabled. Reversible by revert + un-install of any installed launchd jobs.
+
+- **Conflicts / overlap**: none with other open PRs
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green
+
+
+### #7261 — feat(automation): publish recurring publication-freshness probe
+
+- **Head SHA**: `a5a4f130633a9cd93476474c304fb700407aff0f`
+- **Branch**: `droid/phase4-publication-freshness-probe-20260516` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=14, in-flight=0, failures=0
+- **Diff**: +1219 / −0 across 5 files
+- **Updated**: 2026-05-17T06:27
+
+- **Tier**: **2** — live CLI / automation / observability surface
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Live automation / CLI / observability surface change. Accept: any newly added CLI verb becomes a public operator surface; any new automation will fire on its schedule once enabled. Reversible by revert + un-install of any installed launchd jobs.
+
+- **Conflicts / overlap**: none with other open PRs
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 2 → admin squash allowed once green
+
+
+### #7262 — [AGT-02] A2A per-domain reputation read endpoint (sub-deliverable 5)
+
+- **Head SHA**: `e8a962a2dd96670650938e5fbe145a73959fa04d`
+- **Branch**: `vision-incubator/agt-02-a2a-reputation-read` → `main`
+- **Author**: `an0mium`
+- **Draft**: True
+- **Decision / Merge**: REVIEW_REQUIRED / BLOCKED
+- **Checks**: success=13, in-flight=0, failures=0
+- **Diff**: +373 / −0 across 2 files
+- **Updated**: 2026-05-17T08:24
+
+- **Tier**: **1** — additive internal code, no live caller and no public API effect
+
+- **Model-quorum evidence**: N/A — draft state; no quorum required until ready
+
+- **What you're accepting (1-paragraph risk statement)**:
+    > Additive internal code with no live caller. Accept: dead code if the additive surface is never wired; minor maintenance burden. Reversible by revert.
+
+- **Conflicts / overlap**: none with other open PRs
+
+- **Recommended action**: OPERATOR: mark ready when complete; Tier 1 → admin squash allowed once green
+
+
+## Sign-off matrix
+
+Operator: tick exactly one box per PR (or write your own decision in the comments column).
+
+| # | Tier | [ ] APPROVE this tier | [ ] APPROVE downgraded | [ ] REQUEST changes | [ ] REJECT | [ ] HOLD (operator-only) | Comment |
+|---|---|---|---|---|---|---|---|
+| **#7173** | T2 | [ ] | [ ] | [ ] | [ ] | [X] |   |
+| **#7215** | T3 | [ ] | [ ] | [ ] | [ ] | [X] |   |
+| **#7240** | T3 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7243** | T0 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7245** | T3 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7249** | T1 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7251** | T1 | [ ] | [ ] | [ ] | [ ] | [X] |   |
+| **#7252** | T0 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7256** | T2 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7257** | T3 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7258** | T2 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7259** | T2 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7260** | T2 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7261** | T2 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+| **#7262** | T1 | [ ] | [ ] | [ ] | [ ] | [ ] |   |
+
+## Holds compliance
+
+This packet does not modify any of the following:
+
+- #7209 lane (untouchable)
+- #7173 (held — metadata only)
+- #7215 (read-only metadata only)
+- #4990 (held)
+- BC-12 soak (untouched)
+- AI provider key consumption
+- merge / label / mark-ready / launchd install / automation.toml edit
+
+**#7173 and #7251 specifically**: included in the packet as metadata only. Recommended action for both is `OPERATOR-ONLY` — packet does not propose any settlement; operator decides whether to lift the hold separately.
+
+**#7215 specifically**: live PR comments at head `0d148f13c1b281f74c207fd25560bafb11fa9186` contain explicit Tier-4 acceptance text from author `an0mium` (2026-05-17 06:26 UTC and earlier). This is recorded in the per-PR section as **read-only observed state**. The packet does not advance #7215 in any way; the operator's hold ('read-only metadata only') is respected.
+
+## Verification
+
+The `sha256` field inside the JSON receipt hashes the **canonical payload before the signature fields (`sha256`, `hmac_sha256`, `signed_at_utc`) were added** — not the on-disk file. To verify the binding holds:
+
+```bash
+# 1. Confirm the receipt file is well-formed and reports the expected SHA:
+python3 -c "
+import json, hashlib
+d = json.load(open('docs/receipts/open-queue-settlement-20260517T142811Z.json'))
+claimed = d.pop('sha256'); d.pop('hmac_sha256', None); d.pop('signed_at_utc', None)
+canonical = json.dumps(d, sort_keys=True, separators=(',', ':')).encode('utf-8')
+recomputed = hashlib.sha256(canonical).hexdigest()
+print('claimed   :', claimed)
+print('recomputed:', recomputed)
+print('match     :', claimed == recomputed)
+"
+
+# 2. Confirm this doc references the same SHA:
+grep -o '`b93358c7[a-f0-9]*`' docs/status/settlement-packets/2026-05-17-open-queue-settlement.md
+
+# 3. Re-derive at any time (output differs only in generated_at_utc; per-PR head_sha pins are stable until the PR pushes):
+#    gh pr list --state open --json number,headRefOid,...   # same shape as used to produce this packet
+```
+
+---
+
+_Generated by aragora session-continuation tooling — read-only synthesis from gh CLI + `docs/REVIEW_AUTHORITY_PRINCIPLES.md`. No mutation performed; no PR labels touched; no merge action taken._

--- a/docs/status/settlement-packets/README.md
+++ b/docs/status/settlement-packets/README.md
@@ -28,9 +28,11 @@ The page loads:
 
 ```text
 docs/receipts/open-queue-settlement-20260517T142811Z.json
+docs/status/settlement-packets/2026-05-17-open-queue-settlement-context.json
 ```
 
-For each pinned PR, choose one decision:
+For each pinned PR, read the "What this does", red flags, risk statement, and
+safe default before choosing a decision:
 
 - approve the captured tier
 - approve with a downgraded tier
@@ -38,10 +40,37 @@ For each pinned PR, choose one decision:
 - reject
 - hold
 
+Known duplicate/conflict groups are shown above the PR cards. Clustered PRs
+intentionally make approval awkward until a cluster-level choice is selected.
+This is meant to prevent blind approval of mutually exclusive or merge-order
+sensitive PRs.
+
 The page downloads an `operator-decisions-*.json` file. The downloaded payload
-includes the source receipt hash and a SHA-256 binding over the selected
-decisions. It does not call GitHub, mutate PRs, install anything, or write to
-the repository.
+includes:
+
+- a statement that the artifact does not mutate GitHub
+- the source receipt hash
+- the source context hash
+- cluster choices
+- per-PR decisions, red flags seen, and notes
+- a SHA-256 binding over the selected decisions and cluster choices
+
+The download is only evidence. It does not call GitHub, mutate PRs, install
+anything, edit `automation.toml`, label, mark ready, close, merge, approve, or
+request changes.
+
+Use the downloaded file by attaching it to a follow-up operator prompt, or by
+committing it later under a future `docs/receipts/operator-decisions/` path as
+explicit operator evidence for a separate queue-drain lane.
 
 If a browser blocks local file fetches, serve the directory with the command
 above or use the page's manual receipt-file picker.
+
+## Deployment note
+
+This worksheet is intentionally separate from `/review-queue`, which is backed
+by mutating review-queue endpoints. A redacted static copy can be exposed on
+`docs.aragora.ai` or `aragora.ai` later, but the raw packet/context should not be
+published publicly until it is reviewed for private PR-comment content. If this
+ever moves into the live app, it should be a separate non-mutating settlement
+mode, not the existing approval/request-changes/defer workflow.

--- a/docs/status/settlement-packets/README.md
+++ b/docs/status/settlement-packets/README.md
@@ -1,0 +1,47 @@
+# Settlement Packet Sign-off UI
+
+This directory contains static, non-mutating operator worksheets for settlement
+packets. The first worksheet is:
+
+- `2026-05-17-open-queue-settlement-ui.html`
+
+It is intentionally separate from the live `/review-queue` app. That app can
+approve, request changes, and defer PRs through the review-queue backend. This
+static page only helps the operator record decisions against an already pinned
+settlement receipt.
+
+## Use
+
+From the repository root:
+
+```bash
+python3 -m http.server 8765 --directory docs
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8765/status/settlement-packets/2026-05-17-open-queue-settlement-ui.html
+```
+
+The page loads:
+
+```text
+docs/receipts/open-queue-settlement-20260517T142811Z.json
+```
+
+For each pinned PR, choose one decision:
+
+- approve the captured tier
+- approve with a downgraded tier
+- request changes
+- reject
+- hold
+
+The page downloads an `operator-decisions-*.json` file. The downloaded payload
+includes the source receipt hash and a SHA-256 binding over the selected
+decisions. It does not call GitHub, mutate PRs, install anything, or write to
+the repository.
+
+If a browser blocks local file fetches, serve the directory with the command
+above or use the page's manual receipt-file picker.


### PR DESCRIPTION
## Summary

Adds a narrow, static sign-off worksheet for the open-queue settlement packet from #7263.

This PR is intentionally stacked on `worktree-open-queue-settlement-2026-05-17` so its diff is only the UI and README. The page loads the pinned receipt from `docs/receipts/open-queue-settlement-20260517T142811Z.json`, renders the 15 captured PR rows, and downloads a local operator-decision JSON with a SHA-256 binding over the selected decisions and source receipt hash.

## Safety boundaries

- Static HTML + README only
- No GitHub API calls
- No review-queue backend calls
- No PR mutation, labels, merge, mark-ready, close, launchd, or automation changes
- Independent from `/review-queue` and `/reviews`

## Validation

- Browser smoke via local `python3 -m http.server 8765 --directory docs`
  - receipt loaded
  - 15 cards rendered
  - sample hold + downgraded approval produced a 64-char SHA binding
  - mobile viewport had no horizontal overflow after CSS fix
- `node --check` on extracted page script
- HTML parse smoke with Python `HTMLParser`
- receipt JSON read smoke: 15 pinned rows
- `bash scripts/automation_pr_preflight.sh origin/worktree-open-queue-settlement-2026-05-17 HEAD` -> `preflight: ok`
