### PR TITLE
feat(review-queue): useReviewQueueFromPacket sibling hook (part 2/3)

### DIFF
--- a/aragora/live/__tests__/useReviewQueueFromPacket.test.ts
+++ b/aragora/live/__tests__/useReviewQueueFromPacket.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for useReviewQueueFromPacket — settlement-packet receipt -> ReviewQueuePR adapter.
+ */
+
+import { webcrypto } from 'node:crypto';
+import { TextDecoder as NodeTextDecoder, TextEncoder as NodeTextEncoder } from 'node:util';
+import { renderHook } from '@testing-library/react';
+
+// jsdom does not expose TextEncoder/TextDecoder nor `crypto.subtle`. Some
+// jsdom builds also lock `globalThis.crypto` as a non-writable getter, so
+// a plain assignment is silently ignored — use Object.defineProperty
+// to force the override.
+if (typeof globalThis.TextEncoder === 'undefined') {
+  Object.defineProperty(globalThis, 'TextEncoder', {
+    value: NodeTextEncoder,
+    configurable: true,
+    writable: true,
+  });
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  Object.defineProperty(globalThis, 'TextDecoder', {
+    value: NodeTextDecoder,
+    configurable: true,
+    writable: true,
+  });
+}
+const existingCrypto = (globalThis as { crypto?: { subtle?: unknown } }).crypto;
+if (!existingCrypto || !existingCrypto.subtle) {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+    writable: true,
+  });
+}
+
+import {
+  canonicalJson,
+  mapReceiptToReviewQueueList,
+  mapSettlementEntryToReviewQueuePR,
+  useReviewQueueFromPacket,
+  verifyReceiptSha256,
+  type SettlementReceipt,
+} from '../src/hooks/useReviewQueueFromPacket';
+
+const FIXED_NOW = new Date('2026-05-17T12:00:00.000Z');
+
+function sampleReceipt(overrides: Partial<SettlementReceipt> = {}): SettlementReceipt {
+  return {
+    schema_version: 'aragora-open-queue-settlement/1.0',
+    generated_at_utc: '2026-05-17T14:28:11.000Z',
+    repo: 'synaptent/aragora',
+    pinned_state: [
+      {
+        number: 7240,
+        head_sha: 'aaaaaaaaaaaaaaaa',
+        draft: false,
+        decision: 'REVIEW_REQUIRED',
+        merge_state: 'BLOCKED',
+        tier: '2',
+        in_flight: 1,
+        failures: 0,
+        successes: 57,
+        files_touched_count: 20,
+        recommended_action: 'review and admin-merge if quorum holds',
+      },
+      {
+        number: 7243,
+        head_sha: 'bbbbbbbbbbbbbbbb',
+        draft: true,
+        decision: 'REVIEW_REQUIRED',
+        merge_state: 'BLOCKED',
+        tier: '0',
+        in_flight: 0,
+        failures: 0,
+        successes: 3,
+        files_touched_count: 1,
+        recommended_action: 'docs-only — admin-squash any time',
+      },
+    ],
+    sha256: 'pretend-canonical-hash',
+    hmac_sha256: null,
+    signed_at_utc: null,
+    ...overrides,
+  };
+}
+
+describe('mapSettlementEntryToReviewQueuePR', () => {
+  it('maps the canonical fields into a ReviewQueuePR shape', () => {
+    const entry = sampleReceipt().pinned_state[0];
+    const pr = mapSettlementEntryToReviewQueuePR(entry, {
+      repo: 'synaptent/aragora',
+      now: FIXED_NOW,
+    });
+    expect(pr.number).toBe(7240);
+    expect(pr.head_sha).toBe('aaaaaaaaaaaaaaaa');
+    expect(pr.is_draft).toBe(false);
+    expect(pr.tier).toBe('2');
+    expect(pr.ci).toEqual({ success: 57, failure: 0, pending: 1, total: 58 });
+    expect(pr.url).toBe('https://github.com/synaptent/aragora/pull/7240');
+    expect(pr.changed_files).toBe(20);
+  });
+
+  it('uses placeholder defaults when receipt has no title/author/labels', () => {
+    const entry = sampleReceipt().pinned_state[0];
+    const pr = mapSettlementEntryToReviewQueuePR(entry, { now: FIXED_NOW });
+    expect(pr.title).toBe('(no title in receipt)');
+    expect(pr.author).toBe('(unknown)');
+    expect(pr.labels).toEqual([]);
+    expect(pr.brief_present).toBe(false);
+    expect(pr.verdict).toBeNull();
+    expect(pr.deferred).toBe(false);
+  });
+
+  it('honors supplement maps for title/author/labels', () => {
+    const entry = sampleReceipt().pinned_state[0];
+    const pr = mapSettlementEntryToReviewQueuePR(entry, {
+      repo: 'synaptent/aragora',
+      titles: { 7240: 'feat(codex): inspector' },
+      authors: { 7240: 'an0mium' },
+      labels: { 7240: ['governance'] },
+      updatedAtIso: { 7240: '2026-05-17T11:00:00.000Z' },
+      now: FIXED_NOW,
+    });
+    expect(pr.title).toBe('feat(codex): inspector');
+    expect(pr.author).toBe('an0mium');
+    expect(pr.labels).toEqual(['governance']);
+    expect(pr.age_seconds).toBe(3600);
+  });
+
+  it('emits a synthetic url when repo is not provided', () => {
+    const entry = sampleReceipt().pinned_state[0];
+    const pr = mapSettlementEntryToReviewQueuePR(entry, { now: FIXED_NOW });
+    expect(pr.url).toBe('#pr-7240');
+  });
+
+  it('preserves null tier from receipt', () => {
+    const pr = mapSettlementEntryToReviewQueuePR(
+      { number: 1, head_sha: 'x', tier: null },
+      { now: FIXED_NOW },
+    );
+    expect(pr.tier).toBeNull();
+  });
+
+  it('stringifies numeric tier values', () => {
+    const pr = mapSettlementEntryToReviewQueuePR(
+      { number: 1, head_sha: 'x', tier: 4 },
+      { now: FIXED_NOW },
+    );
+    expect(pr.tier).toBe('4');
+  });
+
+  it('clamps negative counts to zero', () => {
+    const pr = mapSettlementEntryToReviewQueuePR(
+      { number: 1, head_sha: 'x', failures: -3, in_flight: -1, successes: 2 },
+      { now: FIXED_NOW },
+    );
+    expect(pr.ci.failure).toBe(0);
+    expect(pr.ci.pending).toBe(0);
+    expect(pr.ci.success).toBe(2);
+    expect(pr.ci.total).toBe(2);
+  });
+});
+
+describe('mapReceiptToReviewQueueList', () => {
+  it('flattens pinned_state[] into a ReviewQueueListResponse', () => {
+    const receipt = sampleReceipt();
+    const list = mapReceiptToReviewQueueList(receipt);
+    expect(list.prs.length).toBe(2);
+    expect(list.total).toBe(2);
+    expect(list.visible).toBe(2);
+    expect(list.deferred_count).toBe(0);
+    expect(list.degraded).toBe(false);
+    expect(list.prs[0].number).toBe(7240);
+    expect(list.prs[1].number).toBe(7243);
+    expect(list.prs[1].is_draft).toBe(true);
+  });
+
+  it('returns empty list when pinned_state is missing', () => {
+    const list = mapReceiptToReviewQueueList({
+      pinned_state: [],
+    } as SettlementReceipt);
+    expect(list.prs).toEqual([]);
+    expect(list.total).toBe(0);
+  });
+});
+
+describe('canonicalJson', () => {
+  it('matches Python json.dumps(sort_keys=True, separators=(",", ":"))', () => {
+    expect(canonicalJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+    expect(canonicalJson([3, 2, 1])).toBe('[3,2,1]');
+    expect(canonicalJson(null)).toBe('null');
+    expect(canonicalJson(true)).toBe('true');
+    expect(canonicalJson('he"llo')).toBe('"he\\"llo"');
+  });
+
+  it('handles nested structures deterministically', () => {
+    const a = canonicalJson({ outer: { z: 1, a: 2 }, list: [{ b: 1, a: 2 }] });
+    const b = canonicalJson({ list: [{ a: 2, b: 1 }], outer: { a: 2, z: 1 } });
+    expect(a).toBe(b);
+  });
+});
+
+describe('verifyReceiptSha256', () => {
+  it('matches when the receipt was generated honestly', async () => {
+    // Build a receipt, compute its expected sha256, then re-verify.
+    const payload: SettlementReceipt = {
+      schema_version: 'aragora-open-queue-settlement/1.0',
+      generated_at_utc: '2026-05-17T00:00:00.000Z',
+      pinned_state: [
+        { number: 1, head_sha: 'a', tier: '0' },
+        { number: 2, head_sha: 'b', tier: '1' },
+      ],
+    };
+    const canonical = canonicalJson({ ...payload });
+    const bytes = new TextEncoder().encode(canonical);
+    const hash = await crypto.subtle.digest('SHA-256', bytes);
+    const sha = Array.from(new Uint8Array(hash))
+      .map((x) => x.toString(16).padStart(2, '0'))
+      .join('');
+    const signed: SettlementReceipt = { ...payload, sha256: sha };
+    const result = await verifyReceiptSha256(signed);
+    expect(result.matches).toBe(true);
+    expect(result.claimed).toBe(sha);
+    expect(result.recomputed).toBe(sha);
+  });
+
+  it('flags mismatch when the payload is tampered after signing', async () => {
+    const payload: SettlementReceipt = {
+      pinned_state: [{ number: 1, head_sha: 'a' }],
+    };
+    const canonical = canonicalJson(payload);
+    const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(canonical));
+    const sha = Array.from(new Uint8Array(hash))
+      .map((x) => x.toString(16).padStart(2, '0'))
+      .join('');
+    const tampered: SettlementReceipt = {
+      ...payload,
+      sha256: sha,
+      pinned_state: [{ number: 1, head_sha: 'TAMPERED' }],
+    };
+    const result = await verifyReceiptSha256(tampered);
+    expect(result.matches).toBe(false);
+    expect(result.claimed).toBe(sha);
+    expect(result.recomputed).not.toBe(sha);
+  });
+});
+
+describe('useReviewQueueFromPacket', () => {
+  it('returns empty state when receipt is null', () => {
+    const { result } = renderHook(() => useReviewQueueFromPacket(null));
+    expect(result.current.prs).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.receipt).toBeNull();
+  });
+
+  it('maps a receipt into the same shape useReviewQueue returns', () => {
+    const receipt = sampleReceipt();
+    const { result } = renderHook(() => useReviewQueueFromPacket(receipt));
+    expect(result.current.prs.length).toBe(2);
+    expect(result.current.total).toBe(2);
+    expect(result.current.visible).toBe(2);
+    expect(result.current.deferredCount).toBe(0);
+    expect(result.current.degraded).toBe(false);
+    expect(result.current.receipt).toBe(receipt);
+    // Tier field flows through so PR-A's badge renders correctly when this hook drives the UI.
+    expect(result.current.prs[0].tier).toBe('2');
+    expect(result.current.prs[1].tier).toBe('0');
+  });
+
+  it('passes supplements through to the mapped PRs', () => {
+    const receipt = sampleReceipt();
+    const { result } = renderHook(() =>
+      useReviewQueueFromPacket(receipt, {
+        titles: { 7240: 'inspector', 7243: 'docs refresh' },
+      }),
+    );
+    expect(result.current.prs[0].title).toBe('inspector');
+    expect(result.current.prs[1].title).toBe('docs refresh');
+  });
+
+  it('always reports isLoading=false and error=null (synchronous adapter)', () => {
+    const receipt = sampleReceipt();
+    const { result } = renderHook(() => useReviewQueueFromPacket(receipt));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/aragora/live/src/hooks/useReviewQueue.ts
+++ b/aragora/live/src/hooks/useReviewQueue.ts
@@ -35,6 +35,14 @@ export interface ReviewQueuePR {
   verdict: string | null;
   confidence: number | null;
   deferred: boolean;
+  /**
+   * Optional tier classification per `docs/REVIEW_AUTHORITY_PRINCIPLES.md`
+   * (string '0'..'4'). When absent, downstream UI hides the badge. Set by
+   * `useReviewQueueFromPacket()` when sourcing the queue from a
+   * settlement-packet receipt. (Same field PR #7273 adds to support
+   * inline tier badges; both PRs converge on the same shape.)
+   */
+  tier?: string | null;
 }
 
 export interface ReviewQueueListResponse {

--- a/aragora/live/src/hooks/useReviewQueueFromPacket.ts
+++ b/aragora/live/src/hooks/useReviewQueueFromPacket.ts
@@ -1,0 +1,252 @@
+'use client';
+
+/**
+ * useReviewQueueFromPacket — read a settlement-packet receipt (shape
+ * `aragora-open-queue-settlement/1.0`) and surface its `pinned_state[]`
+ * entries via the same `ReviewQueuePR[]` contract the live
+ * `useReviewQueue()` hook returns.
+ *
+ * Why a sibling hook (not a flag on the existing one):
+ *   - The live hook is server-backed via SWR + `/api/v1/review-queue/prs`.
+ *     A packet receipt is static client-loaded data with no refresh
+ *     interval. Mixing the two paths in one hook complicates the SWR
+ *     lifecycle for no payoff.
+ *   - The packet receipt schema is sparse (no title, author, labels) so
+ *     the mapper applies safe defaults rather than 404-ing the hook.
+ *
+ * Sequencing context: this is part 2/3 of the operator-chosen refactor
+ * of #7266 (standalone HTML operator UI) into enhancements to the
+ * existing `/review-queue` UI:
+ *   - Part 1 (#7273): add `tier?` field + `tierBadge()` helper +
+ *     ReviewQueueCard badge render.
+ *   - Part 2 (this PR): this hook.
+ *   - Part 3: add `/review-queue/packets/[receiptId]` route that uses
+ *     this hook to render the existing list components against a
+ *     packet.
+ */
+
+import { useMemo } from 'react';
+import type { CiSummary, ReviewQueuePR, ReviewQueueListResponse } from './useReviewQueue';
+
+/** One entry in `pinned_state[]` of an aragora-open-queue-settlement/1.0 receipt. */
+export interface SettlementPinnedStateEntry {
+  number: number;
+  head_sha: string;
+  draft?: boolean;
+  decision?: string | null;
+  merge_state?: string | null;
+  tier?: string | number | null;
+  in_flight?: number;
+  failures?: number;
+  successes?: number;
+  files_touched_count?: number;
+  recommended_action?: string | null;
+}
+
+/** Minimum required fields the hook reads off a settlement-packet receipt. */
+export interface SettlementReceipt {
+  schema_version?: string;
+  generated_at_utc?: string;
+  repo?: string;
+  pinned_state: SettlementPinnedStateEntry[];
+  sha256?: string;
+  hmac_sha256?: string | null;
+  signed_at_utc?: string | null;
+}
+
+/** Optional per-PR metadata supplements callers can supply (titles fetched via gh, etc.). */
+export interface ReviewQueuePacketSupplements {
+  /** Map of PR number → title; used as fallback when the receipt has no title field. */
+  titles?: Record<number, string>;
+  /** Map of PR number → author; used as fallback when the receipt has no author field. */
+  authors?: Record<number, string>;
+  /** Map of PR number → labels array; used as fallback. */
+  labels?: Record<number, string[]>;
+  /** Map of PR number → `updated_at` ISO; used to derive `age_seconds` if not in receipt. */
+  updatedAtIso?: Record<number, string>;
+}
+
+/**
+ * Map one settlement-packet entry into the shape `ReviewQueueCard` expects.
+ *
+ * Defaults applied for fields the receipt does not carry:
+ *   - title: "(no title in receipt)" unless supplements.titles[n] is set
+ *   - author: "(unknown)" unless supplements.authors[n] is set
+ *   - labels: [] unless supplements.labels[n] is set
+ *   - ci: derived from receipt counts
+ *   - brief_present/verdict/confidence: false/null/null (no brief from packet)
+ *   - deferred: false
+ *   - url: derived from repo + number if repo is provided
+ *   - age_seconds: derived from supplements.updatedAtIso[n] if provided, else null
+ */
+export function mapSettlementEntryToReviewQueuePR(
+  entry: SettlementPinnedStateEntry,
+  options: {
+    repo?: string;
+    titles?: Record<number, string>;
+    authors?: Record<number, string>;
+    labels?: Record<number, string[]>;
+    updatedAtIso?: Record<number, string>;
+    now?: Date;
+  } = {},
+): ReviewQueuePR {
+  const number = entry.number;
+  const headSha = String(entry.head_sha || '');
+  const ci: CiSummary = {
+    success: Math.max(0, Number(entry.successes ?? 0)),
+    failure: Math.max(0, Number(entry.failures ?? 0)),
+    pending: Math.max(0, Number(entry.in_flight ?? 0)),
+    total:
+      Math.max(0, Number(entry.successes ?? 0)) +
+      Math.max(0, Number(entry.failures ?? 0)) +
+      Math.max(0, Number(entry.in_flight ?? 0)),
+  };
+  const tierValue =
+    entry.tier === null || entry.tier === undefined ? null : String(entry.tier);
+  const url = options.repo
+    ? `https://github.com/${options.repo}/pull/${number}`
+    : `#pr-${number}`;
+  const title = options.titles?.[number] ?? '(no title in receipt)';
+  const author = options.authors?.[number] ?? '(unknown)';
+  const labels = options.labels?.[number] ?? [];
+  const updatedAtIso =
+    options.updatedAtIso?.[number] ?? new Date(0).toISOString();
+  let ageSeconds: number | null = null;
+  if (options.updatedAtIso?.[number]) {
+    const updatedAt = new Date(options.updatedAtIso[number]);
+    if (!Number.isNaN(updatedAt.getTime())) {
+      const now = options.now ?? new Date();
+      ageSeconds = Math.max(0, Math.floor((now.getTime() - updatedAt.getTime()) / 1000));
+    }
+  }
+  return {
+    number,
+    title,
+    url,
+    head_sha: headSha,
+    is_draft: Boolean(entry.draft),
+    author,
+    labels,
+    additions: 0,
+    deletions: 0,
+    changed_files: Math.max(0, Number(entry.files_touched_count ?? 0)),
+    created_at: updatedAtIso,
+    updated_at: updatedAtIso,
+    age_seconds: ageSeconds,
+    touched_subsystems: [],
+    ci,
+    brief_present: false,
+    verdict: null,
+    confidence: null,
+    deferred: false,
+    tier: tierValue,
+  };
+}
+
+/** Map every entry in a settlement receipt into ReviewQueuePR[]. */
+export function mapReceiptToReviewQueueList(
+  receipt: SettlementReceipt,
+  supplements: ReviewQueuePacketSupplements = {},
+  options: { now?: Date } = {},
+): ReviewQueueListResponse {
+  const prs = (receipt.pinned_state || []).map((entry) =>
+    mapSettlementEntryToReviewQueuePR(entry, {
+      repo: receipt.repo,
+      titles: supplements.titles,
+      authors: supplements.authors,
+      labels: supplements.labels,
+      updatedAtIso: supplements.updatedAtIso,
+      now: options.now,
+    }),
+  );
+  return {
+    prs,
+    total: prs.length,
+    visible: prs.length,
+    deferred_count: 0,
+    degraded: false,
+    reason: undefined,
+  };
+}
+
+/** Verify a receipt's `sha256` field matches the canonical-payload hash of everything else.
+ *
+ * The receipt's `sha256` field hashes the JSON payload BEFORE the signature
+ * fields (`sha256`, `hmac_sha256`, `signed_at_utc`) were added. Re-derive
+ * here using `crypto.subtle.digest` (Web Crypto API) so the page can show a
+ * match/mismatch indicator on load.
+ */
+export async function verifyReceiptSha256(receipt: SettlementReceipt): Promise<{
+  claimed: string;
+  recomputed: string;
+  matches: boolean;
+}> {
+  const claimed = String(receipt.sha256 ?? '');
+  // Strip signature fields the way the generator does.
+  const verifyCopy: Record<string, unknown> = { ...receipt };
+  delete verifyCopy.sha256;
+  delete verifyCopy.hmac_sha256;
+  delete verifyCopy.signed_at_utc;
+  const canonical = canonicalJson(verifyCopy);
+  const bytes = new TextEncoder().encode(canonical);
+  const hash = await crypto.subtle.digest('SHA-256', bytes);
+  const recomputed = Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return { claimed, recomputed, matches: claimed === recomputed };
+}
+
+/** Canonical JSON serialization matching python's `json.dumps(obj, sort_keys=True, separators=(',', ':'))`. */
+export function canonicalJson(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'number') return Number.isFinite(value) ? JSON.stringify(value) : 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (Array.isArray(value)) return '[' + value.map(canonicalJson).join(',') + ']';
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalJson(obj[k])).join(',') + '}';
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * React hook that adapts a settlement-packet receipt into the same
+ * `{prs, total, visible, deferredCount, degraded, reason, isLoading,
+ * error}` shape that `useReviewQueue()` returns, so the existing
+ * ReviewQueueList/Card components can render against it without changes.
+ */
+export function useReviewQueueFromPacket(
+  receipt: SettlementReceipt | null,
+  supplements: ReviewQueuePacketSupplements = {},
+): {
+  prs: ReviewQueuePR[];
+  total: number;
+  visible: number;
+  deferredCount: number;
+  degraded: boolean;
+  reason: string | undefined;
+  isLoading: boolean;
+  isValidating: boolean;
+  error: Error | null;
+  receipt: SettlementReceipt | null;
+} {
+  const mapped = useMemo<ReviewQueueListResponse | null>(() => {
+    if (!receipt) return null;
+    return mapReceiptToReviewQueueList(receipt, supplements);
+  }, [receipt, supplements]);
+
+  return {
+    prs: mapped?.prs ?? [],
+    total: mapped?.total ?? 0,
+    visible: mapped?.visible ?? 0,
+    deferredCount: mapped?.deferred_count ?? 0,
+    degraded: mapped?.degraded ?? false,
+    reason: mapped?.reason,
+    isLoading: false,
+    isValidating: false,
+    error: null,
+    receipt,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a React hook that adapts an `aragora-open-queue-settlement/1.0` receipt JSON into the same `ReviewQueuePR[]` contract the live `useReviewQueue()` hook returns. The existing `ReviewQueueList`/`ReviewQueueCard` components can then render a settlement packet without any component changes.

**Status: draft, planning-only.** Strictly additive — no backend change, no SWR coupling, no behavior change for existing live-queue users.

## Why this is a sibling hook (not a flag)

- The live hook is server-backed via SWR + `/api/v1/review-queue/prs`. A packet receipt is static, client-loaded JSON with no refresh. Mixing the two paths complicates the SWR lifecycle for no payoff.
- The packet schema is sparse (no title, author, labels) so the mapper applies safe defaults rather than 404-ing the hook.
- Sibling file means part-1 (#7273) and this PR can land in either order without conflict on the live hook file.

## What's in the new module

`aragora/live/src/hooks/useReviewQueueFromPacket.ts` (~210 LOC) exports:

| Symbol | Purpose |
|---|---|
| `SettlementReceipt`, `SettlementPinnedStateEntry` | TS types for the receipt format |
| `ReviewQueuePacketSupplements` | Optional caller-supplied titles/authors/labels maps |
| `mapSettlementEntryToReviewQueuePR(entry, options)` | Per-PR mapper with safe defaults |
| `mapReceiptToReviewQueueList(receipt, supplements)` | Whole-receipt mapper |
| `canonicalJson(value)` | JS impl matching `json.dumps(obj, sort_keys=True, separators=(',', ':'))` |
| `verifyReceiptSha256(receipt)` | Web Crypto API re-derivation of canonical-payload hash; returns `{claimed, recomputed, matches}` |
| `useReviewQueueFromPacket(receipt, supplements)` | React hook with the `useReviewQueue()` return shape |

## Files

- `aragora/live/src/hooks/useReviewQueueFromPacket.ts` (new)
- `aragora/live/src/hooks/useReviewQueue.ts` (+ `tier?: string \| null` on `ReviewQueuePR` — same field part-1 adds; convergent)
- `aragora/live/__tests__/useReviewQueueFromPacket.test.ts` (new, 17 tests)

## Tests (jest, 17 new, all passing)

| Group | Tests |
|---|---|
| `mapSettlementEntryToReviewQueuePR` | 7 — canonical map, placeholder defaults, supplements, synthetic url, null/numeric tier preservation, negative-count clamping |
| `mapReceiptToReviewQueueList` | 2 — flatten + empty case |
| `canonicalJson` | 2 — sort-key determinism, deep nesting |
| `verifyReceiptSha256` | 2 — honest receipt matches, tampered receipt fails |
| `useReviewQueueFromPacket` | 4 — empty/null, full receipt, tier flow-through (PR-A integration), supplement maps, sync adapter contract |

## Validation

- ✅ `npx jest --silent ReviewQueue useReviewQueue` → **83/83 tests pass** (66 existing + 17 new)
- ✅ `npx tsc --noEmit` → clean
- ✅ `npx eslint --max-warnings 0` on new files → clean
- ✅ `bash scripts/automation_pr_preflight.sh origin/main HEAD` → preflight ok

## Notes on the SHA-256 polyfill

Some jsdom builds lock `globalThis.crypto` as a non-writable property — plain assignment silently fails. The test file uses `Object.defineProperty(globalThis, 'crypto', {value: webcrypto, writable: true})` to force the override. Same for `TextEncoder`/`TextDecoder` from `node:util`. The hook code itself uses the standard `globalThis.crypto.subtle.digest` API; the polyfill is test-environment-only.

## Sequencing

- Part 2 of 3 in the operator-chosen refactor of #7266:
  - Part 1 (**[#7273](https://github.com/synaptent/aragora/pull/7273)**): tier badge.
  - Part 2 (this PR): packet-loader hook.
  - Part 3: `/review-queue/packets/[receiptId]` route.
- After part 3 lands, #7266 will be closed as superseded.
- Part 1 and this PR both add `tier?: string | null` to `ReviewQueuePR`. Whichever merges first leaves a no-op rebase for the other.

## Discipline

- No backend change. No flag flips. No env var changes.
- All processing is synchronous + client-only (no fetch, no SWR).
- Holds respected: #7173, #7215, #4990, #7251, #7252, #7263, #7266 (predecessor), #7270, #7271; no merge / label / mark-ready / launchd / `automation.toml` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)