### PR TITLE
fix(automation): keep Codex session overlap metadata redacted

### DIFF
--- a/scripts/list_active_agent_sessions.py
+++ b/scripts/list_active_agent_sessions.py
@@ -308,6 +308,8 @@ def read_codex_session_metadata(path: Path, *, max_lines: int = 50) -> dict[str,
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            if obj.get("type") != "session_meta":
+                continue
             payload = obj.get("payload")
             if not isinstance(payload, dict):
                 continue
@@ -326,8 +328,6 @@ def read_codex_session_metadata(path: Path, *, max_lines: int = 50) -> dict[str,
                 metadata["branch"] = branch
             if isinstance(git_payload.get("commit_hash"), str):
                 metadata["commit_hash"] = git_payload["commit_hash"]
-            if isinstance(git_payload.get("repository_url"), str):
-                metadata["repository_url"] = git_payload["repository_url"]
             if metadata:
                 return metadata
     return {}

--- a/tests/scripts/test_list_active_agent_sessions.py
+++ b/tests/scripts/test_list_active_agent_sessions.py
@@ -164,6 +164,7 @@ def test_detect_codex_cli_sessions_filters_by_age(tmp_path: Path) -> None:
     assert fresh_row["cwd"] == "/repo/worktree-a"
     assert fresh_row["branch"] == "feature/fresh"
     assert fresh_row["commit_hash"] == "abc123"
+    assert "repository_url" not in fresh_row
 
 
 def test_read_codex_session_metadata_ignores_message_content(tmp_path: Path) -> None:
@@ -203,6 +204,85 @@ def test_read_codex_session_metadata_ignores_message_content(tmp_path: Path) -> 
         "branch": "main",
         "commit_hash": "def456",
     }
+
+
+def test_read_codex_session_metadata_ignores_non_session_meta_metadata(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "session.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {
+                            "id": "wrong-thread",
+                            "source": "response",
+                            "cwd": "/wrong",
+                            "git": {"branch": "wrong"},
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "session_meta",
+                        "payload": {
+                            "id": "thread-3",
+                            "source": "exec",
+                            "cwd": "/repo/right",
+                            "git": {
+                                "branch": "refs/heads/feature/right",
+                                "commit_hash": "abc789",
+                            },
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert detector.read_codex_session_metadata(path) == {
+        "thread_id": "thread-3",
+        "source": "exec",
+        "cwd": "/repo/right",
+        "branch": "feature/right",
+        "commit_hash": "abc789",
+    }
+
+
+def test_read_codex_session_metadata_drops_repository_url(tmp_path: Path) -> None:
+    path = tmp_path / "session.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": "thread-4",
+                    "cwd": "/repo",
+                    "git": {
+                        "branch": "main",
+                        "commit_hash": "def789",
+                        "repository_url": "https://token@example.invalid/private/repo.git",
+                    },
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    metadata = detector.read_codex_session_metadata(path)
+
+    assert metadata == {
+        "thread_id": "thread-4",
+        "cwd": "/repo",
+        "branch": "main",
+        "commit_hash": "def789",
+    }
+    assert "repository_url" not in metadata
 
 
 def test_detect_codex_cli_sessions_respects_output_limit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to merged #7269. #7269 already merged before it could be updated in-place, but review found two safety gaps in the merged overlap-detector metadata path:

- raw Codex JSONL git.repository_url was emitted even though overlap detection only needs branch/cwd/commit metadata
- metadata extraction could return from a non-session_meta event before the real session_meta record

This PR keeps the detector read-only and redacted-by-default by dropping repository_url from emitted metadata and accepting metadata only from real session_meta records.

## Validation

- python3 -m pytest tests/scripts/test_list_active_agent_sessions.py -q
- python3 -m ruff check scripts/list_active_agent_sessions.py tests/scripts/test_list_active_agent_sessions.py
- python3 -m mypy scripts/list_active_agent_sessions.py --config-file=pyproject.toml
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/list_active_agent_sessions.py --json --codex-session-scan-limit 120

Dogfood result: JSON valid, 20 Codex CLI sessions scanned, overlap_count=16, has_codex_cli_overlap=True, repository_url_keys=0. Redacted summary written outside the repo at /tmp/aragora-agent-overlap-report-20260517.json.

No SKIP was used for push hooks.