### PR TITLE
feat(scripts): apply operator-decisions JSON to GitHub via gh (closes packets sign-off loop)

### DIFF
--- a/docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md
+++ b/docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md
@@ -34,9 +34,9 @@
                │
                ▼  ★ THIS PR — the previously-missing edge
   ┌─────────────────────────┐
-  │  scripts/apply_operator │   (verifies payload_sha256 → walks entries
-  │  _decisions.py          │    → HEAD-drift check → gh pr review/close
-  │                         │    with binding footer in every body)
+  │  scripts/apply_operator │   (verifies payload_sha256 + receipt file
+  │  _decisions.py          │    SHA on --apply → HEAD-drift check →
+  │                         │    gh pr review/close with binding footer)
   └────────────┬────────────┘
                │
                ▼
@@ -53,8 +53,10 @@ pipeline is end-to-end actionable in a single shell command.
 ## CLI surface
 
 ```
-usage: apply_operator_decisions.py [-h] [--apply] [--dry-run] [--json]
-                                   [--only-pr N] [--skip-hold-decisions]
+usage: apply_operator_decisions.py [-h] [--apply]
+                                   [--receipt-path RECEIPT_PATH] [--dry-run]
+                                   [--json] [--only-pr N]
+                                   [--skip-hold-decisions]
                                    decisions_path
 
 Apply a downloaded aragora-operator-decisions/1.0 JSON to GitHub via `gh`.
@@ -65,6 +67,9 @@ positional arguments:
 
 options:
   --apply               Mutate GitHub state. Without this flag, nothing is sent.
+  --receipt-path        Original settlement receipt JSON. Required with
+                        --apply so the CLI independently verifies
+                        receipt_sha256 before mutating GitHub.
   --dry-run             Explicit dry-run (this is the default behaviour when
                         --apply is omitted).
   --json                Emit per-entry results as JSON to stdout.
@@ -83,10 +88,10 @@ exit codes:
 
 | decision | gh action |
 |---|---|
-| `approve_tier`      | `gh pr review N --approve --body <body>` |
-| `approve_downgrade` | `gh pr review N --approve --body "DOWNGRADED: <body>"` |
-| `request_changes`   | `gh pr review N --request-changes --body <body>` |
-| `reject`            | `gh pr close  N --comment <body>` |
+| `approve_tier`      | `gh pr review N --repo <receipt_repo> --approve --body <body>` |
+| `approve_downgrade` | `gh pr review N --repo <receipt_repo> --approve --body "DOWNGRADED: <body>"` |
+| `request_changes`   | `gh pr review N --repo <receipt_repo> --request-changes --body <body>` |
+| `reject`            | `gh pr close  N --repo <receipt_repo> --comment <body>` |
 | `hold_operator`     | no-op, print `SKIP` |
 | `null`              | no-op, print `SKIP (no decision recorded)` |
 
@@ -151,6 +156,7 @@ $ python3 scripts/apply_operator_decisions.py /tmp/example_operator_decisions.js
     {
       "decision": "approve_tier",
       "gh_command": ["gh", "pr", "review", "7280", "--approve", "--body",
+                     "--repo", "synaptent/aragora", "--approve", "--body",
                      "additive only, tests green\n\n---\nApplied from operator-decisions 91274c092a bound to packet abcdef1234"],
       "pr_number": 7280,
       "reason": "dry-run",
@@ -171,12 +177,18 @@ $ python3 scripts/apply_operator_decisions.py /tmp/example_operator_decisions.js
 ### What an `--apply` run would do
 
 For PR `7280` the `gh` invocation captured above would actually run.
-First a `gh pr view 7280 --json headRefOid` HEAD-drift check; on match,
-`gh pr review 7280 --approve --body "additive only, tests green\n\n---\n
+First a `gh pr view 7280 --repo synaptent/aragora --json headRefOid`
+HEAD-drift check; on match,
+`gh pr review 7280 --repo synaptent/aragora --approve --body "additive only, tests green\n\n---\n
 Applied from operator-decisions 91274c092a bound to packet abcdef1234"`
 is executed. On HEAD drift the script prints `DRIFT #7280` and moves on
 without applying — drift is expected when the author pushed a new
 commit between settlement and apply.
+
+`--apply` also requires `--receipt-path <original-receipt.json>` and
+recomputes that file's SHA-256 before any GitHub mutation. The downloaded
+operator-decisions file can prove its own payload hash, but live mutation
+requires the original receipt file to prove the packet binding locally.
 
 (The receipt does NOT actually apply against real PRs — that's the
 operator's call.)
@@ -184,15 +196,15 @@ operator's call.)
 ## Files added
 
 - `scripts/apply_operator_decisions.py` — pure-stdlib CLI (~325 LOC)
-- `tests/scripts/test_apply_operator_decisions.py` — 20 fixture-driven tests
+- `tests/scripts/test_apply_operator_decisions.py` — 41 fixture-driven tests
 - `docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md` — this file
 
 ## Validation
 
 ```
 $ python3 -m pytest tests/scripts/test_apply_operator_decisions.py -q
-....................                                                     [100%]
-20 passed in 1.47s
+.........................................                                [100%]
+41 passed in 0.93s
 $ ruff check scripts/apply_operator_decisions.py tests/scripts/test_apply_operator_decisions.py
 All checks passed!
 $ ruff format --check scripts/apply_operator_decisions.py tests/scripts/test_apply_operator_decisions.py
@@ -218,7 +230,10 @@ preflight: ok
 | apply reject → pr close --comment | Happy path 3 |
 | apply hold_operator → no gh call | Operator-only |
 | null decision skipped | Defensive |
-| unknown decision skipped | Defensive |
+| unknown decision fails closed | No mutation on unsupported decision IDs |
+| malformed/type-invalid row fails closed | Later bad rows block earlier mutations |
+| `--apply` requires receipt path | Original receipt file must be present before mutation |
+| receipt SHA mismatch fails closed | Downloaded payload cannot self-authorize mutation |
 | HEAD drift skips entry, exit 0 | Drift safety |
 | `--only-pr 200` touches only #200 | Filter |
 | held PR hard-skip on `--apply` | Hold-list enforcement |
@@ -248,7 +263,9 @@ python3 -m pytest tests/scripts/test_apply_operator_decisions.py -q
 python3 scripts/apply_operator_decisions.py \
     ~/Downloads/operator-decisions-2026-05-17T*.json   # dry-run
 python3 scripts/apply_operator_decisions.py \
-    ~/Downloads/operator-decisions-2026-05-17T*.json --apply
+    ~/Downloads/operator-decisions-2026-05-17T*.json \
+    --receipt-path docs/receipts/<packet-receipt>.json \
+    --apply
 ```
 
 ## Receipt self-binding

--- a/docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md
+++ b/docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md
@@ -1,0 +1,262 @@
+# Ingestion-loop receipt — operator-decisions → `gh` applier
+
+**Generated:** 2026-05-17T17:20:01Z
+**Branch:** `worktree-operator-decisions-ingestion-20260517`
+**Base:** `main` (independent of the #7273 → #7274 → #7277 → #7278 stack)
+**Surface:** `scripts/apply_operator_decisions.py`
+
+## The loop, now closed
+
+```
+            ┌────────────────────────────────────────────────────────────┐
+            │           OPERATOR SETTLEMENT-PACKET LOOP                  │
+            └────────────────────────────────────────────────────────────┘
+
+  ┌─────────────────────────┐
+  │  Settlement packet      │   (per-PR head pin + tier classification +
+  │  receipt JSON, signed   │    recommended action — already exists in
+  │  with receipt_sha256    │    docs/receipts/ from the PR #7263 family)
+  └────────────┬────────────┘
+               │
+               ▼
+  ┌─────────────────────────┐
+  │  /review-queue/packets/ │   (PR #7277 + #7278: file picker → SHA verify
+  │  [receiptId] UI         │    → keyboard sign-off → per-decision timing)
+  └────────────┬────────────┘
+               │
+               ▼  Download (signed: payload_sha256 binds the decisions)
+  ┌─────────────────────────┐
+  │ operator-decisions      │   (schema: aragora-operator-decisions/1.0;
+  │ -<utc>.json             │    each entry carries decision, comment,
+  │                         │    head_sha, first_focused_at_utc,
+  │                         │    decided_at_utc, decision_seconds)
+  └────────────┬────────────┘
+               │
+               ▼  ★ THIS PR — the previously-missing edge
+  ┌─────────────────────────┐
+  │  scripts/apply_operator │   (verifies payload_sha256 → walks entries
+  │  _decisions.py          │    → HEAD-drift check → gh pr review/close
+  │                         │    with binding footer in every body)
+  └────────────┬────────────┘
+               │
+               ▼
+  ┌─────────────────────────┐
+  │  GitHub PR state moves  │   approve / request-changes / close,
+  │  (queue clears)         │   every action audit-trailed to receipt
+  └─────────────────────────┘
+```
+
+Before this PR, the right-hand half (the download → `gh`) was missing —
+the operator could sign off in the UI but nothing applied it. Now the
+pipeline is end-to-end actionable in a single shell command.
+
+## CLI surface
+
+```
+usage: apply_operator_decisions.py [-h] [--apply] [--dry-run] [--json]
+                                   [--only-pr N] [--skip-hold-decisions]
+                                   decisions_path
+
+Apply a downloaded aragora-operator-decisions/1.0 JSON to GitHub via `gh`.
+Defaults to --dry-run.
+
+positional arguments:
+  decisions_path        Path to a downloaded operator-decisions-*.json file.
+
+options:
+  --apply               Mutate GitHub state. Without this flag, nothing is sent.
+  --dry-run             Explicit dry-run (this is the default behaviour when
+                        --apply is omitted).
+  --json                Emit per-entry results as JSON to stdout.
+  --only-pr N           Apply only to the listed PR numbers (repeatable).
+  --skip-hold-decisions Always honoured; the hold list is hard-coded and held
+                        PRs are skipped regardless of this flag.
+
+exit codes:
+  0   all entries either succeeded or were intentionally skipped
+  1   any apply step failed (per-entry detail in stderr)
+  2   payload signature mismatch / missing file / missing gh / invalid JSON
+      (refuse to apply anything)
+```
+
+### Decision mapping
+
+| decision | gh action |
+|---|---|
+| `approve_tier`      | `gh pr review N --approve --body <body>` |
+| `approve_downgrade` | `gh pr review N --approve --body "DOWNGRADED: <body>"` |
+| `request_changes`   | `gh pr review N --request-changes --body <body>` |
+| `reject`            | `gh pr close  N --comment <body>` |
+| `hold_operator`     | no-op, print `SKIP` |
+| `null`              | no-op, print `SKIP (no decision recorded)` |
+
+Every applied body ends with the binding footer so the audit trail
+is recoverable from any PR thread:
+
+```
+---
+Applied from operator-decisions <payload_sha256[:10]> bound to packet <receipt_sha256[:10]>
+```
+
+### Held PRs are hard-skipped
+
+The script carries a hard-coded `HELD_PR_NUMBERS = frozenset({4990,
+7173, 7215, 7240, 7243, 7245, 7249, 7252})`. These are skipped before
+the decision is even inspected, regardless of `--apply`. The operator
+may legitimately have recorded a hypothetical decision for one of
+these PRs during a packet review pass — the CLI refuses to advance
+any of them by even one byte of state change.
+
+## Worked example
+
+Synthetic receipt (decisions for three hypothetical PRs):
+
+```json
+{
+  "schema_version": "aragora-operator-decisions/1.0",
+  "receipt_repo": "synaptent/aragora",
+  "receipt_sha256": "abcdef1234567890000000000000000000000000000000000000000000000000",
+  "decisions": [
+    { "pr_number": 7280, "decision": "approve_tier",
+      "comment": "additive only, tests green" },
+    { "pr_number": 7281, "decision": "request_changes",
+      "comment": "missing test for the drift path" },
+    { "pr_number": 7282, "decision": "approve_downgrade",
+      "comment": "land at tier 1; tier 2 claim unsupported" }
+  ],
+  "payload_sha256": "91274c092a57e30daf8a705f9c657070788c6795ce0042d471e5dd6f952f3d48"
+}
+```
+
+### Human dry-run output (default)
+
+```
+$ python3 scripts/apply_operator_decisions.py /tmp/example_operator_decisions.json
+WOULD APPLY # 7280  approve_tier          — dry-run
+WOULD APPLY # 7281  request_changes       — dry-run
+WOULD APPLY # 7282  approve_downgrade     — dry-run
+
+DRY RUN — no PRs were touched. Re-run with --apply to commit.
+```
+
+### JSON dry-run output (with `--only-pr 7280`)
+
+```
+$ python3 scripts/apply_operator_decisions.py /tmp/example_operator_decisions.json --json --only-pr 7280
+{
+  "applied": false,
+  "payload_sha256": "91274c092a57e30daf8a705f9c657070788c6795ce0042d471e5dd6f952f3d48",
+  "receipt_sha256": "abcdef1234567890000000000000000000000000000000000000000000000000",
+  "results": [
+    {
+      "decision": "approve_tier",
+      "gh_command": ["gh", "pr", "review", "7280", "--approve", "--body",
+                     "additive only, tests green\n\n---\nApplied from operator-decisions 91274c092a bound to packet abcdef1234"],
+      "pr_number": 7280,
+      "reason": "dry-run",
+      "status": "would-apply"
+    },
+    {
+      "decision": "request_changes",
+      "gh_command": null,
+      "pr_number": 7281,
+      "reason": "not in --only-pr filter",
+      "status": "skipped"
+    },
+    ...
+  ]
+}
+```
+
+### What an `--apply` run would do
+
+For PR `7280` the `gh` invocation captured above would actually run.
+First a `gh pr view 7280 --json headRefOid` HEAD-drift check; on match,
+`gh pr review 7280 --approve --body "additive only, tests green\n\n---\n
+Applied from operator-decisions 91274c092a bound to packet abcdef1234"`
+is executed. On HEAD drift the script prints `DRIFT #7280` and moves on
+without applying — drift is expected when the author pushed a new
+commit between settlement and apply.
+
+(The receipt does NOT actually apply against real PRs — that's the
+operator's call.)
+
+## Files added
+
+- `scripts/apply_operator_decisions.py` — pure-stdlib CLI (~325 LOC)
+- `tests/scripts/test_apply_operator_decisions.py` — 20 fixture-driven tests
+- `docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md` — this file
+
+## Validation
+
+```
+$ python3 -m pytest tests/scripts/test_apply_operator_decisions.py -q
+....................                                                     [100%]
+20 passed in 1.47s
+$ ruff check scripts/apply_operator_decisions.py tests/scripts/test_apply_operator_decisions.py
+All checks passed!
+$ ruff format --check scripts/apply_operator_decisions.py tests/scripts/test_apply_operator_decisions.py
+2 files already formatted
+$ mypy scripts/apply_operator_decisions.py
+Success: no issues found in 1 source file
+$ bash scripts/automation_pr_preflight.sh origin/main HEAD
+preflight: ok
+```
+
+## Test coverage
+
+| Test | Behaviour verified |
+|---|---|
+| sig mismatch → exit 2, no gh calls | Refuses to apply on broken payload binding |
+| missing file → exit 2 | Clean error for bad path |
+| invalid JSON → exit 2 | Clean error for bad payload |
+| no gh on PATH → exit 2 | Bail before processing |
+| default dry-run does not call gh | `--apply` opt-in is enforced |
+| apply approve_tier → review --approve | Happy path 1 |
+| apply approve_downgrade prepends marker | Body convention |
+| apply request_changes → review --request-changes | Happy path 2 |
+| apply reject → pr close --comment | Happy path 3 |
+| apply hold_operator → no gh call | Operator-only |
+| null decision skipped | Defensive |
+| unknown decision skipped | Defensive |
+| HEAD drift skips entry, exit 0 | Drift safety |
+| `--only-pr 200` touches only #200 | Filter |
+| held PR hard-skip on `--apply` | Hold-list enforcement |
+| held PR skip in dry-run too | Hold-list enforcement |
+| `--json` output shape stable | Machine-readable contract |
+| footer carries both SHA prefixes | Audit trail integrity |
+| footer present even with empty comment | Audit trail always emitted |
+| gh failure returns 1 | Per-entry failure surfaces |
+
+## Holds respected
+
+- No PR mutation, no labels, draft PR only.
+- Zero AI-key consumption.
+- No `automation.toml` edit, no launchd install.
+- No held-PR advancement: PRs `#7173`, `#7215`, `#7240`, `#7243`,
+  `#7245`, `#7249`, `#7252`, `#4990` are in `HELD_PR_NUMBERS` and
+  hard-skipped by the CLI regardless of `--apply`.
+- `#7209 lane` and `BC-12 soak` are non-PR-number holds; the CLI
+  only processes PR numbers and does not touch any of those surfaces.
+
+## Reproduction
+
+```bash
+git checkout worktree-operator-decisions-ingestion-20260517
+python3 -m pytest tests/scripts/test_apply_operator_decisions.py -q
+# Then, optionally, against a real downloaded JSON:
+python3 scripts/apply_operator_decisions.py \
+    ~/Downloads/operator-decisions-2026-05-17T*.json   # dry-run
+python3 scripts/apply_operator_decisions.py \
+    ~/Downloads/operator-decisions-2026-05-17T*.json --apply
+```
+
+## Receipt self-binding
+
+SHA-256 of this file is computed after content is finalized via:
+
+```
+shasum -a 256 docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md
+```
+
+The PR description and final session response print the resulting hex.

--- a/docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md
+++ b/docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md
@@ -185,10 +185,12 @@ is executed. On HEAD drift the script prints `DRIFT #7280` and moves on
 without applying — drift is expected when the author pushed a new
 commit between settlement and apply.
 
-`--apply` also requires `--receipt-path <original-receipt.json>` and
-recomputes that file's SHA-256 before any GitHub mutation. The downloaded
+`--apply` also requires `--receipt-path <original-receipt.json>`,
+recomputes that file's SHA-256, and derives the GitHub repo from the
+receipt `pr_url` before any GitHub mutation. The downloaded
 operator-decisions file can prove its own payload hash, but live mutation
-requires the original receipt file to prove the packet binding locally.
+requires the original receipt file to prove both packet binding and repo
+binding locally.
 
 (The receipt does NOT actually apply against real PRs — that's the
 operator's call.)
@@ -196,15 +198,15 @@ operator's call.)
 ## Files added
 
 - `scripts/apply_operator_decisions.py` — pure-stdlib CLI (~325 LOC)
-- `tests/scripts/test_apply_operator_decisions.py` — 41 fixture-driven tests
+- `tests/scripts/test_apply_operator_decisions.py` — 43 fixture-driven tests
 - `docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md` — this file
 
 ## Validation
 
 ```
 $ python3 -m pytest tests/scripts/test_apply_operator_decisions.py -q
-.........................................                                [100%]
-41 passed in 0.93s
+...........................................                              [100%]
+43 passed in 0.98s
 $ ruff check scripts/apply_operator_decisions.py tests/scripts/test_apply_operator_decisions.py
 All checks passed!
 $ ruff format --check scripts/apply_operator_decisions.py tests/scripts/test_apply_operator_decisions.py
@@ -234,6 +236,7 @@ preflight: ok
 | malformed/type-invalid row fails closed | Later bad rows block earlier mutations |
 | `--apply` requires receipt path | Original receipt file must be present before mutation |
 | receipt SHA mismatch fails closed | Downloaded payload cannot self-authorize mutation |
+| receipt repo mismatch fails closed | `receipt_repo` must match the original receipt `pr_url` repo |
 | HEAD drift skips entry, exit 0 | Drift safety |
 | `--only-pr 200` touches only #200 | Filter |
 | held PR hard-skip on `--apply` | Hold-list enforcement |

--- a/scripts/apply_operator_decisions.py
+++ b/scripts/apply_operator_decisions.py
@@ -89,6 +89,7 @@ _HUMAN_PREFIX: dict[str, str] = {
 }
 
 _REPO_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_SHA256_HEX_RE = re.compile(r"^[a-f0-9]{64}$")
 _MISSING = object()
 
 
@@ -163,6 +164,16 @@ def verify_payload_sha256(raw: dict[str, Any]) -> tuple[str, str, bool]:
     canonical = canonical_json(verify_copy)
     recomputed = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     return claimed, recomputed, claimed == recomputed
+
+
+def compute_file_sha256(path: Path) -> str:
+    """Return the SHA-256 hex digest of ``path``."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _optional_str(value: Any, *, field: str, index: int) -> str | None:
@@ -277,6 +288,10 @@ def validate_payload_envelope(payload: OperatorDecisionsPayload) -> str | None:
         )
     if not payload.receipt_sha256_verified:
         return "receipt_sha256_verified must be true"
+    if not _SHA256_HEX_RE.fullmatch(payload.receipt_sha256):
+        return "receipt_sha256 must be a lowercase 64-character SHA-256 hex digest"
+    if not _SHA256_HEX_RE.fullmatch(payload.payload_sha256):
+        return "payload_sha256 must be a lowercase 64-character SHA-256 hex digest"
     if not _REPO_NAME_RE.fullmatch(payload.receipt_repo):
         return (
             "receipt_repo must be a GitHub repository in OWNER/REPO form "
@@ -490,6 +505,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Mutate GitHub state. Without this flag, nothing is sent.",
     )
     parser.add_argument(
+        "--receipt-path",
+        type=Path,
+        help=(
+            "Original settlement receipt JSON used by the packet UI. "
+            "Required with --apply so the CLI independently verifies "
+            "receipt_sha256 before mutating GitHub."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help=("Explicit dry-run (this is the default behaviour when --apply is omitted)."),
@@ -568,6 +592,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 2
 
     apply = bool(args.apply)
+    if apply:
+        receipt_path: Path | None = args.receipt_path
+        if receipt_path is None:
+            print(
+                "ERROR: --apply requires --receipt-path for receipt SHA verification.",
+                file=sys.stderr,
+            )
+            return 2
+        if not receipt_path.exists():
+            print(f"ERROR: receipt file not found: {receipt_path}", file=sys.stderr)
+            return 2
+        recomputed_receipt_sha256 = compute_file_sha256(receipt_path)
+        if recomputed_receipt_sha256 != payload.receipt_sha256:
+            print(
+                "ERROR: receipt_sha256 mismatch — payload claims "
+                f"{_short_sha(payload.receipt_sha256)} but {receipt_path} hashes to "
+                f"{_short_sha(recomputed_receipt_sha256)}. Refusing to apply.",
+                file=sys.stderr,
+            )
+            return 2
     only_prs: frozenset[int] = frozenset(args.only_pr)
 
     results = [

--- a/scripts/apply_operator_decisions.py
+++ b/scripts/apply_operator_decisions.py
@@ -58,6 +58,7 @@ from typing import Any
 # they do not appear here. Keep this list in sync with the holds
 # enumerated in the operator-decisions ingestion PR body.
 HELD_PR_NUMBERS: frozenset[int] = frozenset({4990, 7173, 7215, 7240, 7243, 7245, 7249, 7252})
+EXPECTED_SCHEMA_VERSION = "aragora-operator-decisions/1.0"
 
 # The five decision IDs ``PacketDecisionCard`` emits. Mirrors the
 # ``PacketDecisionId`` union in
@@ -203,6 +204,19 @@ def parse_payload(raw: dict[str, Any]) -> OperatorDecisionsPayload:
         decisions=tuple(decisions),
         payload_sha256=str(raw.get("payload_sha256", "")),
     )
+
+
+def validate_payload_envelope(payload: OperatorDecisionsPayload) -> str | None:
+    """Return a refusal reason when signed payload metadata is not trusted."""
+
+    if payload.schema_version != EXPECTED_SCHEMA_VERSION:
+        return (
+            "unsupported schema_version "
+            f"{payload.schema_version!r}; expected {EXPECTED_SCHEMA_VERSION!r}"
+        )
+    if not payload.receipt_sha256_verified:
+        return "receipt_sha256_verified must be true"
+    return None
 
 
 def _short_sha(sha: str) -> str:
@@ -483,6 +497,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 2
 
     payload = parse_payload(raw)
+    if reason := validate_payload_envelope(payload):
+        print(f"ERROR: refusing operator-decisions payload: {reason}", file=sys.stderr)
+        return 2
+
     apply = bool(args.apply)
     only_prs: frozenset[int] = frozenset(args.only_pr)
 

--- a/scripts/apply_operator_decisions.py
+++ b/scripts/apply_operator_decisions.py
@@ -46,6 +46,7 @@ import argparse
 import dataclasses
 import hashlib
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -87,6 +88,8 @@ _HUMAN_PREFIX: dict[str, str] = {
     STATUS_NO_DECISION: "SKIP",
 }
 
+_REPO_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
 
 @dataclasses.dataclass(frozen=True)
 class DecisionEntry:
@@ -127,6 +130,10 @@ class EntryResult:
     gh_command: list[str] | None = None
 
 
+class PayloadValidationError(ValueError):
+    """Raised when the downloaded payload is malformed or unsafe to apply."""
+
+
 def canonical_json(value: Any) -> str:
     """Canonical JSON serialization that matches the TS side.
 
@@ -157,43 +164,82 @@ def verify_payload_sha256(raw: dict[str, Any]) -> tuple[str, str, bool]:
     return claimed, recomputed, claimed == recomputed
 
 
+def _optional_str(value: Any, *, field: str, index: int) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise PayloadValidationError(f"decisions[{index}].{field} must be a string or null")
+    return value
+
+
+def _parse_decision_entry(raw: Any, *, index: int) -> DecisionEntry:
+    if not isinstance(raw, dict):
+        raise PayloadValidationError(f"decisions[{index}] must be a JSON object")
+    raw_pr_number = raw.get("pr_number")
+    if raw_pr_number is None:
+        raise PayloadValidationError(f"decisions[{index}].pr_number must be a positive integer")
+    try:
+        pr_number = int(raw_pr_number)
+    except (TypeError, ValueError) as exc:
+        raise PayloadValidationError(
+            f"decisions[{index}].pr_number must be a positive integer"
+        ) from exc
+    if pr_number <= 0:
+        raise PayloadValidationError(f"decisions[{index}].pr_number must be a positive integer")
+
+    head_sha = raw.get("head_sha")
+    if not isinstance(head_sha, str) or not head_sha:
+        raise PayloadValidationError(f"decisions[{index}].head_sha must be a non-empty string")
+
+    raw_decision = raw.get("decision")
+    decision = None if raw_decision in (None, "") else raw_decision
+    allowed_decisions = _APPLY_DECISIONS | {"hold_operator"}
+    if decision is not None:
+        if not isinstance(decision, str):
+            raise PayloadValidationError(f"decisions[{index}].decision must be a string or null")
+        if decision not in allowed_decisions:
+            raise PayloadValidationError(
+                f"decisions[{index}].decision has unsupported value {decision!r}"
+            )
+
+    comment = raw.get("comment", "")
+    if not isinstance(comment, str):
+        raise PayloadValidationError(f"decisions[{index}].comment must be a string")
+
+    raw_decision_seconds = raw.get("decision_seconds")
+    try:
+        decision_seconds = None if raw_decision_seconds is None else float(raw_decision_seconds)
+    except (TypeError, ValueError) as exc:
+        raise PayloadValidationError(
+            f"decisions[{index}].decision_seconds must be a number or null"
+        ) from exc
+
+    return DecisionEntry(
+        pr_number=pr_number,
+        head_sha=head_sha,
+        tier=_optional_str(raw.get("tier"), field="tier", index=index),
+        decision=decision,
+        comment=comment,
+        first_focused_at_utc=_optional_str(
+            raw.get("first_focused_at_utc"), field="first_focused_at_utc", index=index
+        ),
+        decided_at_utc=_optional_str(
+            raw.get("decided_at_utc"), field="decided_at_utc", index=index
+        ),
+        decision_seconds=decision_seconds,
+    )
+
+
 def parse_payload(raw: dict[str, Any]) -> OperatorDecisionsPayload:
     """Lift the raw dict into the typed payload + entries."""
 
-    decisions_raw = raw.get("decisions") or []
-    decisions: list[DecisionEntry] = []
-    for d in decisions_raw:
-        if not isinstance(d, dict):
-            continue
-        try:
-            pr_number = int(d.get("pr_number", 0))
-        except (TypeError, ValueError):
-            continue
-        if pr_number <= 0:
-            continue
-        raw_decision_seconds = d.get("decision_seconds")
-        try:
-            decision_seconds = None if raw_decision_seconds is None else float(raw_decision_seconds)
-        except (TypeError, ValueError):
-            decision_seconds = None
-        decisions.append(
-            DecisionEntry(
-                pr_number=pr_number,
-                head_sha=str(d.get("head_sha") or ""),
-                tier=(None if d.get("tier") is None else str(d.get("tier"))),
-                decision=(d.get("decision") if d.get("decision") else None),
-                comment=str(d.get("comment") or ""),
-                first_focused_at_utc=(
-                    None
-                    if d.get("first_focused_at_utc") is None
-                    else str(d.get("first_focused_at_utc"))
-                ),
-                decided_at_utc=(
-                    None if d.get("decided_at_utc") is None else str(d.get("decided_at_utc"))
-                ),
-                decision_seconds=decision_seconds,
-            )
-        )
+    decisions_raw = raw.get("decisions")
+    if not isinstance(decisions_raw, list):
+        raise PayloadValidationError("decisions must be a JSON array")
+    decisions = [
+        _parse_decision_entry(decision_raw, index=index)
+        for index, decision_raw in enumerate(decisions_raw)
+    ]
     return OperatorDecisionsPayload(
         schema_version=str(raw.get("schema_version", "")),
         generated_at_utc=str(raw.get("generated_at_utc", "")),
@@ -216,6 +262,11 @@ def validate_payload_envelope(payload: OperatorDecisionsPayload) -> str | None:
         )
     if not payload.receipt_sha256_verified:
         return "receipt_sha256_verified must be true"
+    if not _REPO_NAME_RE.fullmatch(payload.receipt_repo):
+        return (
+            "receipt_repo must be a GitHub repository in OWNER/REPO form "
+            "using only letters, numbers, '.', '_' or '-'"
+        )
     return None
 
 
@@ -245,10 +296,10 @@ def build_comment_body(entry: DecisionEntry, payload: OperatorDecisionsPayload) 
     return (main + footer) if main else footer.lstrip("\n")
 
 
-def _gh_view_head(pr_number: int) -> tuple[str | None, str]:
+def _gh_view_head(pr_number: int, *, repo: str) -> tuple[str | None, str]:
     """Return the current ``headRefOid`` for ``pr_number`` (or ``(None, err)``)."""
 
-    cmd = ["gh", "pr", "view", str(pr_number), "--json", "headRefOid"]
+    cmd = ["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", "headRefOid"]
     try:
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
     except subprocess.CalledProcessError as exc:
@@ -264,16 +315,16 @@ def _gh_view_head(pr_number: int) -> tuple[str | None, str]:
     return head, ""
 
 
-def _plan_action(entry: DecisionEntry, body: str) -> list[str] | None:
+def _plan_action(entry: DecisionEntry, body: str, *, repo: str) -> list[str] | None:
     """Return the ``gh`` argv to apply ``entry``, or ``None`` for no-op."""
 
     pr = str(entry.pr_number)
     if entry.decision in ("approve_tier", "approve_downgrade"):
-        return ["gh", "pr", "review", pr, "--approve", "--body", body]
+        return ["gh", "pr", "review", pr, "--repo", repo, "--approve", "--body", body]
     if entry.decision == "request_changes":
-        return ["gh", "pr", "review", pr, "--request-changes", "--body", body]
+        return ["gh", "pr", "review", pr, "--repo", repo, "--request-changes", "--body", body]
     if entry.decision == "reject":
-        return ["gh", "pr", "close", pr, "--comment", body]
+        return ["gh", "pr", "close", pr, "--repo", repo, "--comment", body]
     return None
 
 
@@ -318,16 +369,8 @@ def process_entry(
             reason="hold_operator (operator-only action)",
         )
 
-    if entry.decision not in _APPLY_DECISIONS:
-        return EntryResult(
-            pr_number=entry.pr_number,
-            decision=entry.decision,
-            status=STATUS_SKIPPED,
-            reason=f"unknown decision {entry.decision!r}",
-        )
-
     body = build_comment_body(entry, payload)
-    cmd = _plan_action(entry, body)
+    cmd = _plan_action(entry, body, repo=payload.receipt_repo)
     if cmd is None:
         # Defensive — _APPLY_DECISIONS membership already implies this
         # branch is unreachable, but keep the safety net for future
@@ -348,7 +391,7 @@ def process_entry(
             gh_command=cmd,
         )
 
-    live_head, err = _gh_view_head(entry.pr_number)
+    live_head, err = _gh_view_head(entry.pr_number, repo=payload.receipt_repo)
     if live_head is None:
         return EntryResult(
             pr_number=entry.pr_number,
@@ -500,7 +543,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 2
 
-    payload = parse_payload(raw)
+    try:
+        payload = parse_payload(raw)
+    except PayloadValidationError as exc:
+        print(f"ERROR: malformed operator-decisions payload: {exc}", file=sys.stderr)
+        return 2
     if reason := validate_payload_envelope(payload):
         print(f"ERROR: refusing operator-decisions payload: {reason}", file=sys.stderr)
         return 2

--- a/scripts/apply_operator_decisions.py
+++ b/scripts/apply_operator_decisions.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Apply a downloaded operator-decisions JSON to GitHub via ``gh``.
+
+Closes the loop on the ``/review-queue/packets/[receiptId]`` sign-off
+pipeline:
+
+    drop receipt → keyboard sign-off → download
+        → ``python3 scripts/apply_operator_decisions.py operator-decisions-*.json --apply``
+        → queue clears
+
+The downloaded JSON has the shape ``aragora-operator-decisions/1.0`` and
+is produced by ``PacketsClient`` in ``aragora/live/src/app/(app)/
+review-queue/packets/[receiptId]/PacketsClient.tsx``. Each entry carries
+a per-PR decision plus timing fields. This script verifies the
+payload's ``payload_sha256`` binding, then walks ``decisions[]`` and
+maps each entry to the corresponding ``gh`` action:
+
+    approve_tier       -> gh pr review N --approve         --body <body>
+    approve_downgrade  -> gh pr review N --approve         --body "DOWNGRADED: <body>"
+    request_changes    -> gh pr review N --request-changes --body <body>
+    reject             -> gh pr close  N                   --comment <body>
+    hold_operator      -> no-op (operator-only action)
+    null               -> no-op (no decision recorded)
+
+Every applied comment body ends with a binding footer so the audit
+trail is recoverable from any PR thread:
+
+    ---
+    Applied from operator-decisions <payload[:10]> bound to packet <receipt[:10]>
+
+Defaults to ``--dry-run`` so the first invocation never mutates state.
+``--apply`` is required to actually call ``gh``.
+
+Hard-coded hold list: PRs explicitly marked as operator-only / held
+elsewhere in this repo are hard-skipped regardless of the receipt's
+decision for them (the operator may have legitimately recorded a
+hypothetical decision, but the CLI refuses to advance held PRs by
+even one byte).
+
+Pure stdlib. No ``aragora.*`` imports. No third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+# Hard-coded hold list (PR numbers only). The "#7209 lane" and "BC-12
+# soak" holds from the standard repo discipline are not PR numbers, so
+# they do not appear here. Keep this list in sync with the holds
+# enumerated in the operator-decisions ingestion PR body.
+HELD_PR_NUMBERS: frozenset[int] = frozenset({4990, 7173, 7215, 7240, 7243, 7245, 7249, 7252})
+
+# The five decision IDs ``PacketDecisionCard`` emits. Mirrors the
+# ``PacketDecisionId`` union in
+# ``aragora/live/src/components/review-queue/PacketDecisionCard.tsx``.
+_APPLY_DECISIONS: frozenset[str] = frozenset(
+    {"approve_tier", "approve_downgrade", "request_changes", "reject"}
+)
+
+# Status codes used in ``EntryResult.status`` — stable strings so
+# ``--json`` consumers can switch on them.
+STATUS_APPLIED = "applied"
+STATUS_WOULD_APPLY = "would-apply"
+STATUS_HELD = "held"
+STATUS_SKIPPED = "skipped"
+STATUS_DRIFTED = "drifted"
+STATUS_FAILED = "failed"
+STATUS_NO_DECISION = "no-decision"
+
+_HUMAN_PREFIX: dict[str, str] = {
+    STATUS_APPLIED: "APPLIED",
+    STATUS_WOULD_APPLY: "WOULD APPLY",
+    STATUS_HELD: "HELD",
+    STATUS_SKIPPED: "SKIP",
+    STATUS_DRIFTED: "DRIFT",
+    STATUS_FAILED: "FAIL",
+    STATUS_NO_DECISION: "SKIP",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class DecisionEntry:
+    """One row in ``decisions[]`` from the downloaded JSON."""
+
+    pr_number: int
+    head_sha: str
+    tier: str | None
+    decision: str | None
+    comment: str
+    first_focused_at_utc: str | None
+    decided_at_utc: str | None
+    decision_seconds: float | None
+
+
+@dataclasses.dataclass(frozen=True)
+class OperatorDecisionsPayload:
+    """The top-level downloaded JSON."""
+
+    schema_version: str
+    generated_at_utc: str
+    receipt_id_hint: str
+    receipt_repo: str
+    receipt_sha256: str
+    receipt_sha256_verified: bool
+    decisions: tuple[DecisionEntry, ...]
+    payload_sha256: str
+
+
+@dataclasses.dataclass
+class EntryResult:
+    """Outcome of processing one ``decisions[]`` entry."""
+
+    pr_number: int
+    decision: str | None
+    status: str
+    reason: str
+    gh_command: list[str] | None = None
+
+
+def canonical_json(value: Any) -> str:
+    """Canonical JSON serialization that matches the TS side.
+
+    The TS-side ``canonicalJson()`` in
+    ``aragora/live/src/hooks/useReviewQueueFromPacket.ts`` writes
+    sorted-keys, comma+colon separators, no extra whitespace, and
+    preserves non-ASCII characters as-is (because ``TextEncoder``
+    encodes UTF-8). We replicate that here with ``sort_keys=True``,
+    the most-compact separators, and ``ensure_ascii=False`` so
+    Unicode survives without ``\\u`` escaping.
+    """
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def verify_payload_sha256(raw: dict[str, Any]) -> tuple[str, str, bool]:
+    """Re-derive the payload SHA-256 and compare against the claimed value.
+
+    Returns ``(claimed, recomputed, matches)``. The recomputation hashes
+    the canonical JSON of every top-level field except ``payload_sha256``
+    itself — same shape the browser used to compute it on download.
+    """
+
+    claimed = str(raw.get("payload_sha256", ""))
+    verify_copy: dict[str, Any] = {k: v for k, v in raw.items() if k != "payload_sha256"}
+    canonical = canonical_json(verify_copy)
+    recomputed = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return claimed, recomputed, claimed == recomputed
+
+
+def parse_payload(raw: dict[str, Any]) -> OperatorDecisionsPayload:
+    """Lift the raw dict into the typed payload + entries."""
+
+    decisions_raw = raw.get("decisions") or []
+    decisions: list[DecisionEntry] = []
+    for d in decisions_raw:
+        if not isinstance(d, dict):
+            continue
+        try:
+            pr_number = int(d.get("pr_number", 0))
+        except (TypeError, ValueError):
+            continue
+        if pr_number <= 0:
+            continue
+        raw_decision_seconds = d.get("decision_seconds")
+        try:
+            decision_seconds = None if raw_decision_seconds is None else float(raw_decision_seconds)
+        except (TypeError, ValueError):
+            decision_seconds = None
+        decisions.append(
+            DecisionEntry(
+                pr_number=pr_number,
+                head_sha=str(d.get("head_sha") or ""),
+                tier=(None if d.get("tier") is None else str(d.get("tier"))),
+                decision=(d.get("decision") if d.get("decision") else None),
+                comment=str(d.get("comment") or ""),
+                first_focused_at_utc=(
+                    None
+                    if d.get("first_focused_at_utc") is None
+                    else str(d.get("first_focused_at_utc"))
+                ),
+                decided_at_utc=(
+                    None if d.get("decided_at_utc") is None else str(d.get("decided_at_utc"))
+                ),
+                decision_seconds=decision_seconds,
+            )
+        )
+    return OperatorDecisionsPayload(
+        schema_version=str(raw.get("schema_version", "")),
+        generated_at_utc=str(raw.get("generated_at_utc", "")),
+        receipt_id_hint=str(raw.get("receipt_id_hint", "")),
+        receipt_repo=str(raw.get("receipt_repo", "")),
+        receipt_sha256=str(raw.get("receipt_sha256", "")),
+        receipt_sha256_verified=bool(raw.get("receipt_sha256_verified", False)),
+        decisions=tuple(decisions),
+        payload_sha256=str(raw.get("payload_sha256", "")),
+    )
+
+
+def _short_sha(sha: str) -> str:
+    return sha[:10] if sha else "(none)"
+
+
+def build_comment_body(entry: DecisionEntry, payload: OperatorDecisionsPayload) -> str:
+    """Compose the final body for ``gh pr review/close``.
+
+    For ``approve_downgrade``, prepend ``"DOWNGRADED: "`` so the audit
+    trail makes the downgrade obvious without the reader having to
+    cross-reference the original packet.
+
+    Every body ends with the binding footer carrying both 10-char SHA
+    prefixes.
+    """
+
+    main = entry.comment.strip()
+    if entry.decision == "approve_downgrade":
+        main = ("DOWNGRADED: " + main).rstrip()
+    footer = (
+        "\n\n---\n"
+        f"Applied from operator-decisions {_short_sha(payload.payload_sha256)} "
+        f"bound to packet {_short_sha(payload.receipt_sha256)}"
+    )
+    return (main + footer) if main else footer.lstrip("\n")
+
+
+def _gh_view_head(pr_number: int) -> tuple[str | None, str]:
+    """Return the current ``headRefOid`` for ``pr_number`` (or ``(None, err)``)."""
+
+    cmd = ["gh", "pr", "view", str(pr_number), "--json", "headRefOid"]
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        return None, f"gh pr view #{pr_number} failed: {stderr[:200]}"
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return None, f"gh pr view #{pr_number} returned non-JSON: {exc}"
+    head = data.get("headRefOid")
+    if not head or not isinstance(head, str):
+        return None, f"gh pr view #{pr_number} returned no headRefOid"
+    return head, ""
+
+
+def _plan_action(entry: DecisionEntry, body: str) -> list[str] | None:
+    """Return the ``gh`` argv to apply ``entry``, or ``None`` for no-op."""
+
+    pr = str(entry.pr_number)
+    if entry.decision in ("approve_tier", "approve_downgrade"):
+        return ["gh", "pr", "review", pr, "--approve", "--body", body]
+    if entry.decision == "request_changes":
+        return ["gh", "pr", "review", pr, "--request-changes", "--body", body]
+    if entry.decision == "reject":
+        return ["gh", "pr", "close", pr, "--comment", body]
+    return None
+
+
+def process_entry(
+    entry: DecisionEntry,
+    payload: OperatorDecisionsPayload,
+    *,
+    apply: bool,
+    only_prs: frozenset[int],
+) -> EntryResult:
+    """Decide what to do with a single entry — pure logic over fakes-friendly IO."""
+
+    if only_prs and entry.pr_number not in only_prs:
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_SKIPPED,
+            reason="not in --only-pr filter",
+        )
+
+    if entry.pr_number in HELD_PR_NUMBERS:
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_HELD,
+            reason=f"#{entry.pr_number} is on the hard-coded hold list",
+        )
+
+    if entry.decision is None:
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=None,
+            status=STATUS_NO_DECISION,
+            reason="no decision recorded",
+        )
+
+    if entry.decision == "hold_operator":
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_SKIPPED,
+            reason="hold_operator (operator-only action)",
+        )
+
+    if entry.decision not in _APPLY_DECISIONS:
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_SKIPPED,
+            reason=f"unknown decision {entry.decision!r}",
+        )
+
+    body = build_comment_body(entry, payload)
+    cmd = _plan_action(entry, body)
+    if cmd is None:
+        # Defensive — _APPLY_DECISIONS membership already implies this
+        # branch is unreachable, but keep the safety net for future
+        # decision IDs that get added without a mapping.
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_SKIPPED,
+            reason=f"no gh action mapped for {entry.decision!r}",
+        )
+
+    if not apply:
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_WOULD_APPLY,
+            reason="dry-run",
+            gh_command=cmd,
+        )
+
+    live_head, err = _gh_view_head(entry.pr_number)
+    if live_head is None:
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_FAILED,
+            reason=err or "gh pr view failed",
+        )
+    if live_head != entry.head_sha:
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_DRIFTED,
+            reason=(f"HEAD DRIFT: expected {entry.head_sha[:10]}, got {live_head[:10]}"),
+        )
+
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_FAILED,
+            reason=f"gh failed: {stderr[:200]}",
+            gh_command=cmd,
+        )
+
+    return EntryResult(
+        pr_number=entry.pr_number,
+        decision=entry.decision,
+        status=STATUS_APPLIED,
+        reason="ok",
+        gh_command=cmd,
+    )
+
+
+def _print_human(results: Sequence[EntryResult], applied: bool) -> None:
+    for r in results:
+        prefix = _HUMAN_PREFIX.get(r.status, r.status.upper())
+        decision_label = r.decision if r.decision else "(none)"
+        print(f"{prefix:11s} #{r.pr_number:>5d}  {decision_label:20s}  — {r.reason}")
+    if not applied:
+        print("\nDRY RUN — no PRs were touched. Re-run with --apply to commit.")
+
+
+def _print_json(
+    payload: OperatorDecisionsPayload,
+    results: Sequence[EntryResult],
+    applied: bool,
+) -> None:
+    print(
+        json.dumps(
+            {
+                "payload_sha256": payload.payload_sha256,
+                "receipt_sha256": payload.receipt_sha256,
+                "applied": applied,
+                "results": [dataclasses.asdict(r) for r in results],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="apply_operator_decisions.py",
+        description=(
+            "Apply a downloaded aragora-operator-decisions/1.0 JSON to "
+            "GitHub via `gh`. Defaults to --dry-run."
+        ),
+    )
+    parser.add_argument(
+        "decisions_path",
+        type=Path,
+        help="Path to a downloaded operator-decisions-*.json file.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Mutate GitHub state. Without this flag, nothing is sent.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=("Explicit dry-run (this is the default behaviour when --apply is omitted)."),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit per-entry results as JSON to stdout.",
+    )
+    parser.add_argument(
+        "--only-pr",
+        action="append",
+        type=int,
+        default=[],
+        metavar="N",
+        help="Apply only to the listed PR numbers (repeatable).",
+    )
+    parser.add_argument(
+        "--skip-hold-decisions",
+        action="store_true",
+        default=True,
+        help=(
+            "Always honoured; the hold list is hard-coded and held PRs "
+            "are skipped regardless of this flag."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if shutil.which("gh") is None:
+        print(
+            "ERROR: `gh` CLI not found on PATH — install gh (https://cli.github.com) and retry.",
+            file=sys.stderr,
+        )
+        return 2
+
+    decisions_path: Path = args.decisions_path
+    if not decisions_path.exists():
+        print(f"ERROR: file not found: {decisions_path}", file=sys.stderr)
+        return 2
+
+    try:
+        raw = json.loads(decisions_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON ({exc}): {decisions_path}", file=sys.stderr)
+        return 2
+
+    if not isinstance(raw, dict):
+        print("ERROR: receipt root must be a JSON object", file=sys.stderr)
+        return 2
+
+    claimed, recomputed, matches = verify_payload_sha256(raw)
+    if not matches:
+        print(
+            "ERROR: payload_sha256 mismatch — claimed "
+            f"{_short_sha(claimed)} vs recomputed {_short_sha(recomputed)}. "
+            "Refusing to apply.",
+            file=sys.stderr,
+        )
+        return 2
+
+    payload = parse_payload(raw)
+    apply = bool(args.apply)
+    only_prs: frozenset[int] = frozenset(args.only_pr)
+
+    results = [
+        process_entry(entry, payload, apply=apply, only_prs=only_prs) for entry in payload.decisions
+    ]
+
+    if args.json:
+        _print_json(payload, results, applied=apply)
+    else:
+        _print_human(results, applied=apply)
+
+    any_failed = any(r.status == STATUS_FAILED for r in results)
+    return 1 if any_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/apply_operator_decisions.py
+++ b/scripts/apply_operator_decisions.py
@@ -89,6 +89,7 @@ _HUMAN_PREFIX: dict[str, str] = {
 }
 
 _REPO_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_MISSING = object()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -197,11 +198,15 @@ def _parse_decision_entry(raw: Any, *, index: int) -> DecisionEntry:
     if not isinstance(head_sha, str) or not head_sha:
         raise PayloadValidationError(f"decisions[{index}].head_sha must be a non-empty string")
 
-    raw_decision = raw.get("decision")
-    decision = None if raw_decision in (None, "") else raw_decision
+    raw_decision = raw.get("decision", _MISSING)
+    if raw_decision is _MISSING:
+        raise PayloadValidationError(f"decisions[{index}].decision must be a string or null")
+    decision = None if raw_decision is None else raw_decision
     allowed_decisions = _APPLY_DECISIONS | {"hold_operator"}
     if decision is not None:
         if not isinstance(decision, str):
+            raise PayloadValidationError(f"decisions[{index}].decision must be a string or null")
+        if not decision:
             raise PayloadValidationError(f"decisions[{index}].decision must be a string or null")
         if decision not in allowed_decisions:
             raise PayloadValidationError(

--- a/scripts/apply_operator_decisions.py
+++ b/scripts/apply_operator_decisions.py
@@ -464,6 +464,10 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
 
+    if args.apply and args.dry_run:
+        print("ERROR: --apply and --dry-run are mutually exclusive.", file=sys.stderr)
+        return 2
+
     if shutil.which("gh") is None:
         print(
             "ERROR: `gh` CLI not found on PATH — install gh (https://cli.github.com) and retry.",

--- a/scripts/apply_operator_decisions.py
+++ b/scripts/apply_operator_decisions.py
@@ -172,19 +172,25 @@ def _optional_str(value: Any, *, field: str, index: int) -> str | None:
     return value
 
 
+def _required_payload_str(raw: dict[str, Any], field: str) -> str:
+    value = raw.get(field)
+    if not isinstance(value, str):
+        raise PayloadValidationError(f"{field} must be a string")
+    return value
+
+
+def _required_payload_bool(raw: dict[str, Any], field: str) -> bool:
+    value = raw.get(field)
+    if not isinstance(value, bool):
+        raise PayloadValidationError(f"{field} must be a boolean")
+    return value
+
+
 def _parse_decision_entry(raw: Any, *, index: int) -> DecisionEntry:
     if not isinstance(raw, dict):
         raise PayloadValidationError(f"decisions[{index}] must be a JSON object")
     raw_pr_number = raw.get("pr_number")
-    if raw_pr_number is None:
-        raise PayloadValidationError(f"decisions[{index}].pr_number must be a positive integer")
-    try:
-        pr_number = int(raw_pr_number)
-    except (TypeError, ValueError) as exc:
-        raise PayloadValidationError(
-            f"decisions[{index}].pr_number must be a positive integer"
-        ) from exc
-    if pr_number <= 0:
+    if not isinstance(raw_pr_number, int) or isinstance(raw_pr_number, bool) or raw_pr_number <= 0:
         raise PayloadValidationError(f"decisions[{index}].pr_number must be a positive integer")
 
     head_sha = raw.get("head_sha")
@@ -207,15 +213,19 @@ def _parse_decision_entry(raw: Any, *, index: int) -> DecisionEntry:
         raise PayloadValidationError(f"decisions[{index}].comment must be a string")
 
     raw_decision_seconds = raw.get("decision_seconds")
-    try:
-        decision_seconds = None if raw_decision_seconds is None else float(raw_decision_seconds)
-    except (TypeError, ValueError) as exc:
+    if raw_decision_seconds is None:
+        decision_seconds = None
+    elif isinstance(raw_decision_seconds, bool) or not isinstance(
+        raw_decision_seconds, (int, float)
+    ):
         raise PayloadValidationError(
             f"decisions[{index}].decision_seconds must be a number or null"
-        ) from exc
+        )
+    else:
+        decision_seconds = float(raw_decision_seconds)
 
     return DecisionEntry(
-        pr_number=pr_number,
+        pr_number=raw_pr_number,
         head_sha=head_sha,
         tier=_optional_str(raw.get("tier"), field="tier", index=index),
         decision=decision,
@@ -241,14 +251,14 @@ def parse_payload(raw: dict[str, Any]) -> OperatorDecisionsPayload:
         for index, decision_raw in enumerate(decisions_raw)
     ]
     return OperatorDecisionsPayload(
-        schema_version=str(raw.get("schema_version", "")),
-        generated_at_utc=str(raw.get("generated_at_utc", "")),
-        receipt_id_hint=str(raw.get("receipt_id_hint", "")),
-        receipt_repo=str(raw.get("receipt_repo", "")),
-        receipt_sha256=str(raw.get("receipt_sha256", "")),
-        receipt_sha256_verified=bool(raw.get("receipt_sha256_verified", False)),
+        schema_version=_required_payload_str(raw, "schema_version"),
+        generated_at_utc=_required_payload_str(raw, "generated_at_utc"),
+        receipt_id_hint=_required_payload_str(raw, "receipt_id_hint"),
+        receipt_repo=_required_payload_str(raw, "receipt_repo"),
+        receipt_sha256=_required_payload_str(raw, "receipt_sha256"),
+        receipt_sha256_verified=_required_payload_bool(raw, "receipt_sha256_verified"),
         decisions=tuple(decisions),
-        payload_sha256=str(raw.get("payload_sha256", "")),
+        payload_sha256=_required_payload_str(raw, "payload_sha256"),
     )
 
 

--- a/scripts/apply_operator_decisions.py
+++ b/scripts/apply_operator_decisions.py
@@ -89,6 +89,9 @@ _HUMAN_PREFIX: dict[str, str] = {
 }
 
 _REPO_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_GITHUB_PR_URL_RE = re.compile(
+    r"^https://github\.com/(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/pull/[0-9]+/?$"
+)
 _SHA256_HEX_RE = re.compile(r"^[a-f0-9]{64}$")
 _MISSING = object()
 
@@ -174,6 +177,36 @@ def compute_file_sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def extract_receipt_repo(path: Path) -> tuple[str | None, str | None]:
+    """Extract the single GitHub ``OWNER/REPO`` from a settlement receipt JSON."""
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, f"receipt file is not valid JSON: {exc}"
+    repos: set[str] = set()
+
+    def visit(value: Any) -> None:
+        if isinstance(value, dict):
+            pr_url = value.get("pr_url")
+            if isinstance(pr_url, str):
+                match = _GITHUB_PR_URL_RE.fullmatch(pr_url)
+                if match:
+                    repos.add(match.group("repo"))
+            for child in value.values():
+                visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(raw)
+    if not repos:
+        return None, "receipt file does not contain a GitHub pr_url"
+    if len(repos) != 1:
+        return None, "receipt file contains PR URLs from multiple repositories"
+    return next(iter(repos)), None
 
 
 def _optional_str(value: Any, *, field: str, index: int) -> str | None:
@@ -609,6 +642,18 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "ERROR: receipt_sha256 mismatch — payload claims "
                 f"{_short_sha(payload.receipt_sha256)} but {receipt_path} hashes to "
                 f"{_short_sha(recomputed_receipt_sha256)}. Refusing to apply.",
+                file=sys.stderr,
+            )
+            return 2
+        receipt_repo, repo_error = extract_receipt_repo(receipt_path)
+        if repo_error:
+            print(f"ERROR: cannot verify receipt repo: {repo_error}", file=sys.stderr)
+            return 2
+        if receipt_repo != payload.receipt_repo:
+            print(
+                "ERROR: receipt_repo mismatch — payload claims "
+                f"{payload.receipt_repo!r} but {receipt_path} is for {receipt_repo!r}. "
+                "Refusing to apply.",
                 file=sys.stderr,
             )
             return 2

--- a/tests/scripts/test_apply_operator_decisions.py
+++ b/tests/scripts/test_apply_operator_decisions.py
@@ -1,0 +1,420 @@
+"""Tests for ``scripts/apply_operator_decisions.py``.
+
+Fixture-driven; never invokes real ``gh``. The script under test
+opens ``subprocess.run`` via the standard module reference, so
+``monkeypatch.setattr(aod.subprocess, "run", ...)`` is sufficient
+to intercept every call. ``shutil.which`` is patched separately so
+the CLI does not bail on a missing ``gh`` binary in CI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    """Import the script as a module without polluting ``sys.path``."""
+
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "apply_operator_decisions.py"
+    spec = importlib.util.spec_from_file_location(
+        "apply_operator_decisions_under_test", script_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+aod = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+_HEAD_SHA_DEFAULT = "a" * 40  # canonical match for FakeGh's default
+_DRIFTED_HEAD = "b" * 40
+_RECEIPT_SHA = "abcdef1234" + ("0" * 54)
+
+
+def make_entry(
+    pr_number: int,
+    decision: str | None,
+    *,
+    head_sha: str = _HEAD_SHA_DEFAULT,
+    comment: str = "",
+) -> dict[str, Any]:
+    return {
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "tier": "2",
+        "decision": decision,
+        "comment": comment,
+        "first_focused_at_utc": "2026-05-17T17:00:00.000Z",
+        "decided_at_utc": "2026-05-17T17:00:05.000Z",
+        "decision_seconds": 5.0,
+    }
+
+
+def canonical_payload(decisions: list[dict[str, Any]], **overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "schema_version": "aragora-operator-decisions/1.0",
+        "generated_at_utc": "2026-05-17T17:00:00.000Z",
+        "receipt_id_hint": "open-queue-settlement-test",
+        "receipt_repo": "synaptent/aragora",
+        "receipt_sha256": _RECEIPT_SHA,
+        "receipt_sha256_verified": True,
+        "decisions": decisions,
+    }
+    base.update(overrides)
+    canonical = aod.canonical_json(base)
+    base["payload_sha256"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return base
+
+
+def write_payload(
+    tmp_path: Path,
+    decisions: list[dict[str, Any]],
+    **overrides: Any,
+) -> Path:
+    payload = canonical_payload(decisions, **overrides)
+    p = tmp_path / "operator-decisions.json"
+    p.write_text(json.dumps(payload))
+    return p
+
+
+class FakeGh:
+    """Records every subprocess.run call; returns canned results."""
+
+    def __init__(
+        self,
+        *,
+        head_oid: str = _HEAD_SHA_DEFAULT,
+        apply_succeeds: bool = True,
+    ) -> None:
+        self.head_oid = head_oid
+        self.apply_succeeds = apply_succeeds
+        self.calls: list[list[str]] = []
+
+    def run(self, cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(cmd))
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout=json.dumps({"headRefOid": self.head_oid}),
+                stderr="",
+            )
+        if not self.apply_succeeds:
+            raise subprocess.CalledProcessError(
+                returncode=1, cmd=cmd, stderr="gh failed (simulated)"
+            )
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    def review_calls(self) -> list[list[str]]:
+        return [c for c in self.calls if c[:3] == ["gh", "pr", "review"]]
+
+    def close_calls(self) -> list[list[str]]:
+        return [c for c in self.calls if c[:3] == ["gh", "pr", "close"]]
+
+
+@pytest.fixture
+def fake_gh(monkeypatch: pytest.MonkeyPatch) -> FakeGh:
+    fake = FakeGh()
+    monkeypatch.setattr(aod.subprocess, "run", fake.run)
+    monkeypatch.setattr(
+        aod.shutil,
+        "which",
+        lambda exe: "/usr/local/bin/gh" if exe == "gh" else None,
+    )
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Signature, parsing, CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_sig_mismatch_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload = canonical_payload([make_entry(100, "approve_tier")])
+    payload["payload_sha256"] = "0" * 64
+    p = tmp_path / "decisions.json"
+    p.write_text(json.dumps(payload))
+
+    rc = aod.main([str(p)])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "payload_sha256 mismatch" in capsys.readouterr().err
+
+
+def test_missing_file_returns_2(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = aod.main([str(tmp_path / "does-not-exist.json")])
+    assert rc == 2
+    assert "file not found" in capsys.readouterr().err
+
+
+def test_invalid_json_returns_2(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "garbage.json"
+    p.write_text("not valid json {{{")
+    rc = aod.main([str(p)])
+    assert rc == 2
+    assert "invalid JSON" in capsys.readouterr().err
+
+
+def test_no_gh_on_path_returns_2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(aod.shutil, "which", lambda _exe: None)
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier")])
+    rc = aod.main([str(p), "--apply"])
+    assert rc == 2
+    assert "gh` CLI not found" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Default dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_default_does_not_call_gh(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="lgtm")])
+    rc = aod.main([str(p)])
+    assert rc == 0
+    assert fake_gh.calls == []
+    out = capsys.readouterr().out
+    assert "WOULD APPLY" in out
+    assert "DRY RUN" in out
+
+
+# ---------------------------------------------------------------------------
+# Per-decision apply paths
+# ---------------------------------------------------------------------------
+
+
+def test_apply_approve_tier_calls_review_approve(tmp_path: Path, fake_gh: FakeGh) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="lgtm")])
+    rc = aod.main([str(p), "--apply"])
+    assert rc == 0
+    # First call is HEAD verify, second is the review.
+    assert fake_gh.calls[0][:3] == ["gh", "pr", "view"]
+    review = fake_gh.calls[1]
+    assert review[:5] == ["gh", "pr", "review", "100", "--approve"]
+    assert "--body" in review
+
+
+def test_apply_approve_downgrade_prepends_downgraded_marker(
+    tmp_path: Path, fake_gh: FakeGh
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_downgrade", comment="downgrade to T1")])
+    aod.main([str(p), "--apply"])
+    review = fake_gh.review_calls()[0]
+    body = review[review.index("--body") + 1]
+    assert body.startswith("DOWNGRADED:")
+
+
+def test_apply_request_changes_calls_request_changes(tmp_path: Path, fake_gh: FakeGh) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "request_changes", comment="please fix X")])
+    aod.main([str(p), "--apply"])
+    review = fake_gh.review_calls()[0]
+    assert review[:5] == ["gh", "pr", "review", "100", "--request-changes"]
+
+
+def test_apply_reject_calls_close_with_comment(tmp_path: Path, fake_gh: FakeGh) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "reject", comment="duplicate")])
+    aod.main([str(p), "--apply"])
+    close = fake_gh.close_calls()[0]
+    assert close[:4] == ["gh", "pr", "close", "100"]
+    assert "--comment" in close
+
+
+def test_apply_hold_operator_skips_without_gh_call(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "hold_operator")])
+    rc = aod.main([str(p), "--apply"])
+    assert rc == 0
+    assert fake_gh.calls == []
+    assert "operator-only" in capsys.readouterr().out
+
+
+def test_null_decision_skipped(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, None)])
+    rc = aod.main([str(p), "--apply"])
+    assert rc == 0
+    assert fake_gh.calls == []
+    assert "no decision recorded" in capsys.readouterr().out
+
+
+def test_unknown_decision_skipped(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "weird_decision")])
+    rc = aod.main([str(p), "--apply"])
+    assert rc == 0
+    assert fake_gh.calls == []
+    assert "unknown decision" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Head-SHA drift safety
+# ---------------------------------------------------------------------------
+
+
+def test_head_drift_skips_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake = FakeGh(head_oid=_DRIFTED_HEAD)
+    monkeypatch.setattr(aod.subprocess, "run", fake.run)
+    monkeypatch.setattr(
+        aod.shutil, "which", lambda exe: "/usr/local/bin/gh" if exe == "gh" else None
+    )
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier", head_sha=_HEAD_SHA_DEFAULT)])
+    rc = aod.main([str(p), "--apply"])
+    assert rc == 0
+    # Only the HEAD-view call; no review.
+    assert len(fake.calls) == 1
+    assert fake.calls[0][:3] == ["gh", "pr", "view"]
+    out = capsys.readouterr().out
+    assert "DRIFT" in out
+    assert "HEAD DRIFT" in out
+
+
+# ---------------------------------------------------------------------------
+# Filtering / hold list
+# ---------------------------------------------------------------------------
+
+
+def test_only_pr_filter_touches_only_listed(tmp_path: Path, fake_gh: FakeGh) -> None:
+    p = write_payload(
+        tmp_path,
+        [
+            make_entry(100, "approve_tier"),
+            make_entry(200, "approve_tier"),
+            make_entry(300, "approve_tier"),
+        ],
+    )
+    aod.main([str(p), "--apply", "--only-pr", "200"])
+    reviews = fake_gh.review_calls()
+    assert len(reviews) == 1
+    assert reviews[0][3] == "200"
+    # No HEAD-view for non-targets either.
+    for n in ("100", "300"):
+        assert not any(c[:4] == ["gh", "pr", "view", n] for c in fake_gh.calls)
+
+
+def test_held_pr_hard_skip(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Pick a real held PR number from the script's hard-coded list.
+    held = next(iter(aod.HELD_PR_NUMBERS))
+    p = write_payload(tmp_path, [make_entry(held, "approve_tier")])
+    rc = aod.main([str(p), "--apply"])
+    assert rc == 0
+    assert fake_gh.calls == []
+    out = capsys.readouterr().out
+    assert "HELD" in out
+    assert f"#{held}" in out
+
+
+def test_held_pr_skipped_in_dry_run_too(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    held = next(iter(aod.HELD_PR_NUMBERS))
+    p = write_payload(tmp_path, [make_entry(held, "reject")])
+    rc = aod.main([str(p)])
+    assert rc == 0
+    assert fake_gh.calls == []
+    assert "HELD" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# JSON output mode
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_shape(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="lgtm")])
+    rc = aod.main([str(p), "--json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["applied"] is False
+    assert isinstance(data["payload_sha256"], str)
+    assert isinstance(data["receipt_sha256"], str)
+    assert isinstance(data["results"], list)
+    first = data["results"][0]
+    assert first["pr_number"] == 100
+    assert first["status"] == "would-apply"
+    assert first["gh_command"][:5] == ["gh", "pr", "review", "100", "--approve"]
+
+
+# ---------------------------------------------------------------------------
+# Comment-body footer
+# ---------------------------------------------------------------------------
+
+
+def test_footer_carries_both_sha_prefixes(tmp_path: Path, fake_gh: FakeGh) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="lgtm")])
+    aod.main([str(p), "--apply"])
+    review = fake_gh.review_calls()[0]
+    body = review[review.index("--body") + 1]
+    assert "Applied from operator-decisions" in body
+    assert "bound to packet" in body
+    # The first ten chars of receipt_sha must appear verbatim in the footer.
+    assert _RECEIPT_SHA[:10] in body
+
+
+def test_footer_emits_even_when_comment_empty(tmp_path: Path, fake_gh: FakeGh) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="")])
+    aod.main([str(p), "--apply"])
+    review = fake_gh.review_calls()[0]
+    body = review[review.index("--body") + 1]
+    # Body still contains the binding line even with no operator comment.
+    assert "Applied from operator-decisions" in body
+
+
+# ---------------------------------------------------------------------------
+# Failure surfacing
+# ---------------------------------------------------------------------------
+
+
+def test_gh_failure_returns_1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = FakeGh(apply_succeeds=False)
+    monkeypatch.setattr(aod.subprocess, "run", fake.run)
+    monkeypatch.setattr(
+        aod.shutil, "which", lambda exe: "/usr/local/bin/gh" if exe == "gh" else None
+    )
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier")])
+    rc = aod.main([str(p), "--apply"])
+    # HEAD-view succeeds (its branch is independent of apply_succeeds);
+    # the review call fails → status=failed → rc=1.
+    assert rc == 1

--- a/tests/scripts/test_apply_operator_decisions.py
+++ b/tests/scripts/test_apply_operator_decisions.py
@@ -68,7 +68,7 @@ def make_entry(
     }
 
 
-def canonical_payload(decisions: list[dict[str, Any]], **overrides: Any) -> dict[str, Any]:
+def canonical_payload(decisions: list[Any], **overrides: Any) -> dict[str, Any]:
     base: dict[str, Any] = {
         "schema_version": "aragora-operator-decisions/1.0",
         "generated_at_utc": "2026-05-17T17:00:00.000Z",
@@ -86,7 +86,7 @@ def canonical_payload(decisions: list[dict[str, Any]], **overrides: Any) -> dict
 
 def write_payload(
     tmp_path: Path,
-    decisions: list[dict[str, Any]],
+    decisions: list[Any],
     **overrides: Any,
 ) -> Path:
     payload = canonical_payload(decisions, **overrides)
@@ -224,6 +224,76 @@ def test_unverified_receipt_returns_2_and_makes_no_gh_calls(
     assert "receipt_sha256_verified must be true" in capsys.readouterr().err
 
 
+def test_invalid_receipt_repo_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(
+        tmp_path,
+        [make_entry(100, "approve_tier")],
+        receipt_repo="synaptent/aragora --repo attacker/other",
+    )
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "receipt_repo must be a GitHub repository" in capsys.readouterr().err
+
+
+def test_malformed_decision_row_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier"), "not-an-object"])
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "decisions[1] must be a JSON object" in capsys.readouterr().err
+
+
+def test_invalid_pr_number_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier"), {"pr_number": "nope"}])
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "pr_number must be a positive integer" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value", "message"),
+    [
+        ("head_sha", 123, "head_sha must be a non-empty string"),
+        ("comment", {"not": "text"}, "comment must be a string"),
+        ("tier", 2, "tier must be a string or null"),
+        ("first_focused_at_utc", 7, "first_focused_at_utc must be a string or null"),
+        ("decided_at_utc", [], "decided_at_utc must be a string or null"),
+        ("decision_seconds", "slow", "decision_seconds must be a number or null"),
+    ],
+)
+def test_type_invalid_decision_row_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path,
+    fake_gh: FakeGh,
+    capsys: pytest.CaptureFixture[str],
+    field: str,
+    bad_value: Any,
+    message: str,
+) -> None:
+    entry = make_entry(100, "approve_tier")
+    entry[field] = bad_value
+    p = write_payload(tmp_path, [entry])
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert message in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Default dry-run
 # ---------------------------------------------------------------------------
@@ -265,7 +335,9 @@ def test_apply_approve_tier_calls_review_approve(tmp_path: Path, fake_gh: FakeGh
     # First call is HEAD verify, second is the review.
     assert fake_gh.calls[0][:3] == ["gh", "pr", "view"]
     review = fake_gh.calls[1]
-    assert review[:5] == ["gh", "pr", "review", "100", "--approve"]
+    assert review[:4] == ["gh", "pr", "review", "100"]
+    assert review[4:6] == ["--repo", "synaptent/aragora"]
+    assert "--approve" in review
     assert "--body" in review
 
 
@@ -283,7 +355,9 @@ def test_apply_request_changes_calls_request_changes(tmp_path: Path, fake_gh: Fa
     p = write_payload(tmp_path, [make_entry(100, "request_changes", comment="please fix X")])
     aod.main([str(p), "--apply"])
     review = fake_gh.review_calls()[0]
-    assert review[:5] == ["gh", "pr", "review", "100", "--request-changes"]
+    assert review[:4] == ["gh", "pr", "review", "100"]
+    assert review[4:6] == ["--repo", "synaptent/aragora"]
+    assert "--request-changes" in review
 
 
 def test_apply_reject_calls_close_with_comment(tmp_path: Path, fake_gh: FakeGh) -> None:
@@ -291,7 +365,23 @@ def test_apply_reject_calls_close_with_comment(tmp_path: Path, fake_gh: FakeGh) 
     aod.main([str(p), "--apply"])
     close = fake_gh.close_calls()[0]
     assert close[:4] == ["gh", "pr", "close", "100"]
+    assert close[4:6] == ["--repo", "synaptent/aragora"]
     assert "--comment" in close
+
+
+def test_apply_uses_receipt_repo_for_every_gh_call(tmp_path: Path, fake_gh: FakeGh) -> None:
+    p = write_payload(
+        tmp_path,
+        [make_entry(100, "approve_tier", comment="lgtm")],
+        receipt_repo="alternate/repo",
+    )
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 0
+    assert fake_gh.calls
+    for call in fake_gh.calls:
+        assert call[call.index("--repo") + 1] == "alternate/repo"
 
 
 def test_apply_hold_operator_skips_without_gh_call(
@@ -314,14 +404,32 @@ def test_null_decision_skipped(
     assert "no decision recorded" in capsys.readouterr().out
 
 
-def test_unknown_decision_skipped(
+def test_unknown_decision_fails_closed_before_any_gh_call(
     tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
 ) -> None:
     p = write_payload(tmp_path, [make_entry(100, "weird_decision")])
     rc = aod.main([str(p), "--apply"])
-    assert rc == 0
+    assert rc == 2
     assert fake_gh.calls == []
-    assert "unknown decision" in capsys.readouterr().out
+    assert "unsupported value" in capsys.readouterr().err
+
+
+def test_unknown_decision_in_later_row_blocks_earlier_apply(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(
+        tmp_path,
+        [
+            make_entry(100, "approve_tier"),
+            make_entry(200, "future_decision"),
+        ],
+    )
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "decisions[1].decision" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------
@@ -345,6 +453,7 @@ def test_head_drift_skips_entry(
     # Only the HEAD-view call; no review.
     assert len(fake.calls) == 1
     assert fake.calls[0][:3] == ["gh", "pr", "view"]
+    assert fake.calls[0][4:6] == ["--repo", "synaptent/aragora"]
     out = capsys.readouterr().out
     assert "DRIFT" in out
     assert "HEAD DRIFT" in out
@@ -418,7 +527,15 @@ def test_json_output_shape(
     first = data["results"][0]
     assert first["pr_number"] == 100
     assert first["status"] == "would-apply"
-    assert first["gh_command"][:5] == ["gh", "pr", "review", "100", "--approve"]
+    assert first["gh_command"][:6] == [
+        "gh",
+        "pr",
+        "review",
+        "100",
+        "--repo",
+        "synaptent/aragora",
+    ]
+    assert "--approve" in first["gh_command"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_apply_operator_decisions.py
+++ b/tests/scripts/test_apply_operator_decisions.py
@@ -192,6 +192,38 @@ def test_no_gh_on_path_returns_2(
     assert "gh` CLI not found" in capsys.readouterr().err
 
 
+def test_unsupported_schema_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(
+        tmp_path,
+        [make_entry(100, "approve_tier")],
+        schema_version="aragora-operator-decisions/0.9",
+    )
+
+    rc = aod.main([str(p)])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "unsupported schema_version" in capsys.readouterr().err
+
+
+def test_unverified_receipt_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(
+        tmp_path,
+        [make_entry(100, "approve_tier")],
+        receipt_sha256_verified=False,
+    )
+
+    rc = aod.main([str(p)])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "receipt_sha256_verified must be true" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Default dry-run
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_apply_operator_decisions.py
+++ b/tests/scripts/test_apply_operator_decisions.py
@@ -46,7 +46,7 @@ aod = _load_module()
 
 _HEAD_SHA_DEFAULT = "a" * 40  # canonical match for FakeGh's default
 _DRIFTED_HEAD = "b" * 40
-_RECEIPT_BODY = b'{"receipt":"open-queue-settlement-test"}\n'
+_RECEIPT_BODY = b'{"pr_url":"https://github.com/synaptent/aragora/pull/100"}\n'
 _RECEIPT_SHA = hashlib.sha256(_RECEIPT_BODY).hexdigest()
 
 
@@ -399,6 +399,40 @@ def test_apply_receipt_mismatch_returns_2_before_any_gh_call(
     assert "receipt_sha256 mismatch" in capsys.readouterr().err
 
 
+def test_apply_receipt_repo_mismatch_returns_2_before_any_gh_call(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(
+        tmp_path,
+        [make_entry(100, "approve_tier", comment="lgtm")],
+        receipt_repo="attacker/repo",
+    )
+
+    rc = aod.main(apply_args(tmp_path, p))
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "receipt_repo mismatch" in capsys.readouterr().err
+
+
+def test_apply_receipt_without_pr_url_returns_2_before_any_gh_call(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    receipt_body = b'{"not_pr_url":"https://github.com/synaptent/aragora/pull/100"}\n'
+    p = write_payload(
+        tmp_path,
+        [make_entry(100, "approve_tier", comment="lgtm")],
+        receipt_sha256=hashlib.sha256(receipt_body).hexdigest(),
+    )
+    receipt_path = write_receipt(tmp_path, receipt_body)
+
+    rc = aod.main([str(p), "--apply", "--receipt-path", str(receipt_path)])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "does not contain a GitHub pr_url" in capsys.readouterr().err
+
+
 def test_apply_and_dry_run_conflict_returns_2_and_makes_no_gh_calls(
     tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -458,13 +492,16 @@ def test_apply_reject_calls_close_with_comment(tmp_path: Path, fake_gh: FakeGh) 
 
 
 def test_apply_uses_receipt_repo_for_every_gh_call(tmp_path: Path, fake_gh: FakeGh) -> None:
+    receipt_body = b'{"pr_url":"https://github.com/alternate/repo/pull/100"}\n'
     p = write_payload(
         tmp_path,
         [make_entry(100, "approve_tier", comment="lgtm")],
         receipt_repo="alternate/repo",
+        receipt_sha256=hashlib.sha256(receipt_body).hexdigest(),
     )
+    receipt_path = write_receipt(tmp_path, receipt_body)
 
-    rc = aod.main(apply_args(tmp_path, p))
+    rc = aod.main([str(p), "--apply", "--receipt-path", str(receipt_path)])
 
     assert rc == 0
     assert fake_gh.calls

--- a/tests/scripts/test_apply_operator_decisions.py
+++ b/tests/scripts/test_apply_operator_decisions.py
@@ -224,6 +224,22 @@ def test_unverified_receipt_returns_2_and_makes_no_gh_calls(
     assert "receipt_sha256_verified must be true" in capsys.readouterr().err
 
 
+def test_string_receipt_verification_flag_fails_closed_before_any_gh_call(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(
+        tmp_path,
+        [make_entry(100, "approve_tier")],
+        receipt_sha256_verified="true",
+    )
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "receipt_sha256_verified must be a boolean" in capsys.readouterr().err
+
+
 def test_invalid_receipt_repo_returns_2_and_makes_no_gh_calls(
     tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -264,6 +280,20 @@ def test_invalid_pr_number_returns_2_and_makes_no_gh_calls(
     assert "pr_number must be a positive integer" in capsys.readouterr().err
 
 
+def test_string_pr_number_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    entry = make_entry(100, "approve_tier")
+    entry["pr_number"] = "100"
+    p = write_payload(tmp_path, [entry])
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "pr_number must be a positive integer" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize(
     ("field", "bad_value", "message"),
     [
@@ -272,7 +302,7 @@ def test_invalid_pr_number_returns_2_and_makes_no_gh_calls(
         ("tier", 2, "tier must be a string or null"),
         ("first_focused_at_utc", 7, "first_focused_at_utc must be a string or null"),
         ("decided_at_utc", [], "decided_at_utc must be a string or null"),
-        ("decision_seconds", "slow", "decision_seconds must be a number or null"),
+        ("decision_seconds", "5.0", "decision_seconds must be a number or null"),
     ],
 )
 def test_type_invalid_decision_row_returns_2_and_makes_no_gh_calls(

--- a/tests/scripts/test_apply_operator_decisions.py
+++ b/tests/scripts/test_apply_operator_decisions.py
@@ -241,6 +241,18 @@ def test_dry_run_default_does_not_call_gh(
     assert "DRY RUN" in out
 
 
+def test_apply_and_dry_run_conflict_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="lgtm")])
+
+    rc = aod.main([str(p), "--apply", "--dry-run"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "--apply and --dry-run are mutually exclusive" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Per-decision apply paths
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_apply_operator_decisions.py
+++ b/tests/scripts/test_apply_operator_decisions.py
@@ -462,6 +462,34 @@ def test_unknown_decision_in_later_row_blocks_earlier_apply(
     assert "decisions[1].decision" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    "entry_patch",
+    [
+        {"decision": ""},
+        {"decision": None, "_remove_decision_key": True},
+    ],
+)
+def test_empty_or_missing_decision_fails_closed_before_any_gh_call(
+    tmp_path: Path,
+    fake_gh: FakeGh,
+    capsys: pytest.CaptureFixture[str],
+    entry_patch: dict[str, Any],
+) -> None:
+    first = make_entry(100, "approve_tier")
+    malformed = make_entry(200, None)
+    if entry_patch.pop("_remove_decision_key", False):
+        malformed.pop("decision")
+    else:
+        malformed.update(entry_patch)
+    p = write_payload(tmp_path, [first, malformed])
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "decisions[1].decision must be a string or null" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Head-SHA drift safety
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_apply_operator_decisions.py
+++ b/tests/scripts/test_apply_operator_decisions.py
@@ -46,7 +46,8 @@ aod = _load_module()
 
 _HEAD_SHA_DEFAULT = "a" * 40  # canonical match for FakeGh's default
 _DRIFTED_HEAD = "b" * 40
-_RECEIPT_SHA = "abcdef1234" + ("0" * 54)
+_RECEIPT_BODY = b'{"receipt":"open-queue-settlement-test"}\n'
+_RECEIPT_SHA = hashlib.sha256(_RECEIPT_BODY).hexdigest()
 
 
 def make_entry(
@@ -93,6 +94,22 @@ def write_payload(
     p = tmp_path / "operator-decisions.json"
     p.write_text(json.dumps(payload))
     return p
+
+
+def write_receipt(tmp_path: Path, body: bytes = _RECEIPT_BODY) -> Path:
+    p = tmp_path / "settlement-receipt.json"
+    p.write_bytes(body)
+    return p
+
+
+def apply_args(tmp_path: Path, decisions_path: Path, *extra: str) -> list[str]:
+    return [
+        str(decisions_path),
+        "--apply",
+        "--receipt-path",
+        str(write_receipt(tmp_path)),
+        *extra,
+    ]
 
 
 class FakeGh:
@@ -240,6 +257,22 @@ def test_string_receipt_verification_flag_fails_closed_before_any_gh_call(
     assert "receipt_sha256_verified must be a boolean" in capsys.readouterr().err
 
 
+def test_invalid_receipt_sha_returns_2_and_makes_no_gh_calls(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(
+        tmp_path,
+        [make_entry(100, "approve_tier")],
+        receipt_sha256="not-a-sha",
+    )
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "receipt_sha256 must be a lowercase 64-character SHA-256" in capsys.readouterr().err
+
+
 def test_invalid_receipt_repo_returns_2_and_makes_no_gh_calls(
     tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -341,6 +374,31 @@ def test_dry_run_default_does_not_call_gh(
     assert "DRY RUN" in out
 
 
+def test_apply_requires_receipt_path_before_any_gh_call(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="lgtm")])
+
+    rc = aod.main([str(p), "--apply"])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "--apply requires --receipt-path" in capsys.readouterr().err
+
+
+def test_apply_receipt_mismatch_returns_2_before_any_gh_call(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="lgtm")])
+    receipt_path = write_receipt(tmp_path, b'{"receipt":"different"}\n')
+
+    rc = aod.main([str(p), "--apply", "--receipt-path", str(receipt_path)])
+
+    assert rc == 2
+    assert fake_gh.calls == []
+    assert "receipt_sha256 mismatch" in capsys.readouterr().err
+
+
 def test_apply_and_dry_run_conflict_returns_2_and_makes_no_gh_calls(
     tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -360,7 +418,7 @@ def test_apply_and_dry_run_conflict_returns_2_and_makes_no_gh_calls(
 
 def test_apply_approve_tier_calls_review_approve(tmp_path: Path, fake_gh: FakeGh) -> None:
     p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="lgtm")])
-    rc = aod.main([str(p), "--apply"])
+    rc = aod.main(apply_args(tmp_path, p))
     assert rc == 0
     # First call is HEAD verify, second is the review.
     assert fake_gh.calls[0][:3] == ["gh", "pr", "view"]
@@ -375,7 +433,7 @@ def test_apply_approve_downgrade_prepends_downgraded_marker(
     tmp_path: Path, fake_gh: FakeGh
 ) -> None:
     p = write_payload(tmp_path, [make_entry(100, "approve_downgrade", comment="downgrade to T1")])
-    aod.main([str(p), "--apply"])
+    aod.main(apply_args(tmp_path, p))
     review = fake_gh.review_calls()[0]
     body = review[review.index("--body") + 1]
     assert body.startswith("DOWNGRADED:")
@@ -383,7 +441,7 @@ def test_apply_approve_downgrade_prepends_downgraded_marker(
 
 def test_apply_request_changes_calls_request_changes(tmp_path: Path, fake_gh: FakeGh) -> None:
     p = write_payload(tmp_path, [make_entry(100, "request_changes", comment="please fix X")])
-    aod.main([str(p), "--apply"])
+    aod.main(apply_args(tmp_path, p))
     review = fake_gh.review_calls()[0]
     assert review[:4] == ["gh", "pr", "review", "100"]
     assert review[4:6] == ["--repo", "synaptent/aragora"]
@@ -392,7 +450,7 @@ def test_apply_request_changes_calls_request_changes(tmp_path: Path, fake_gh: Fa
 
 def test_apply_reject_calls_close_with_comment(tmp_path: Path, fake_gh: FakeGh) -> None:
     p = write_payload(tmp_path, [make_entry(100, "reject", comment="duplicate")])
-    aod.main([str(p), "--apply"])
+    aod.main(apply_args(tmp_path, p))
     close = fake_gh.close_calls()[0]
     assert close[:4] == ["gh", "pr", "close", "100"]
     assert close[4:6] == ["--repo", "synaptent/aragora"]
@@ -406,7 +464,7 @@ def test_apply_uses_receipt_repo_for_every_gh_call(tmp_path: Path, fake_gh: Fake
         receipt_repo="alternate/repo",
     )
 
-    rc = aod.main([str(p), "--apply"])
+    rc = aod.main(apply_args(tmp_path, p))
 
     assert rc == 0
     assert fake_gh.calls
@@ -418,7 +476,7 @@ def test_apply_hold_operator_skips_without_gh_call(
     tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
 ) -> None:
     p = write_payload(tmp_path, [make_entry(100, "hold_operator")])
-    rc = aod.main([str(p), "--apply"])
+    rc = aod.main(apply_args(tmp_path, p))
     assert rc == 0
     assert fake_gh.calls == []
     assert "operator-only" in capsys.readouterr().out
@@ -428,7 +486,7 @@ def test_null_decision_skipped(
     tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
 ) -> None:
     p = write_payload(tmp_path, [make_entry(100, None)])
-    rc = aod.main([str(p), "--apply"])
+    rc = aod.main(apply_args(tmp_path, p))
     assert rc == 0
     assert fake_gh.calls == []
     assert "no decision recorded" in capsys.readouterr().out
@@ -506,7 +564,7 @@ def test_head_drift_skips_entry(
         aod.shutil, "which", lambda exe: "/usr/local/bin/gh" if exe == "gh" else None
     )
     p = write_payload(tmp_path, [make_entry(100, "approve_tier", head_sha=_HEAD_SHA_DEFAULT)])
-    rc = aod.main([str(p), "--apply"])
+    rc = aod.main(apply_args(tmp_path, p))
     assert rc == 0
     # Only the HEAD-view call; no review.
     assert len(fake.calls) == 1
@@ -531,7 +589,7 @@ def test_only_pr_filter_touches_only_listed(tmp_path: Path, fake_gh: FakeGh) -> 
             make_entry(300, "approve_tier"),
         ],
     )
-    aod.main([str(p), "--apply", "--only-pr", "200"])
+    aod.main(apply_args(tmp_path, p, "--only-pr", "200"))
     reviews = fake_gh.review_calls()
     assert len(reviews) == 1
     assert reviews[0][3] == "200"
@@ -546,7 +604,7 @@ def test_held_pr_hard_skip(
     # Pick a real held PR number from the script's hard-coded list.
     held = next(iter(aod.HELD_PR_NUMBERS))
     p = write_payload(tmp_path, [make_entry(held, "approve_tier")])
-    rc = aod.main([str(p), "--apply"])
+    rc = aod.main(apply_args(tmp_path, p))
     assert rc == 0
     assert fake_gh.calls == []
     out = capsys.readouterr().out
@@ -603,7 +661,7 @@ def test_json_output_shape(
 
 def test_footer_carries_both_sha_prefixes(tmp_path: Path, fake_gh: FakeGh) -> None:
     p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="lgtm")])
-    aod.main([str(p), "--apply"])
+    aod.main(apply_args(tmp_path, p))
     review = fake_gh.review_calls()[0]
     body = review[review.index("--body") + 1]
     assert "Applied from operator-decisions" in body
@@ -614,7 +672,7 @@ def test_footer_carries_both_sha_prefixes(tmp_path: Path, fake_gh: FakeGh) -> No
 
 def test_footer_emits_even_when_comment_empty(tmp_path: Path, fake_gh: FakeGh) -> None:
     p = write_payload(tmp_path, [make_entry(100, "approve_tier", comment="")])
-    aod.main([str(p), "--apply"])
+    aod.main(apply_args(tmp_path, p))
     review = fake_gh.review_calls()[0]
     body = review[review.index("--body") + 1]
     # Body still contains the binding line even with no operator comment.
@@ -633,7 +691,7 @@ def test_gh_failure_returns_1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
         aod.shutil, "which", lambda exe: "/usr/local/bin/gh" if exe == "gh" else None
     )
     p = write_payload(tmp_path, [make_entry(100, "approve_tier")])
-    rc = aod.main([str(p), "--apply"])
+    rc = aod.main(apply_args(tmp_path, p))
     # HEAD-view succeeds (its branch is independent of apply_succeeds);
     # the review call fails → status=failed → rc=1.
     assert rc == 1


### PR DESCRIPTION
## Summary

Closes the loop on the `/review-queue/packets/[receiptId]` sign-off pipeline.

The PR #7273 → #7274 → #7277 → #7278 stack lets the operator drop a settlement-packet receipt, keyboard-sign-off in the browser, and download a signed `aragora-operator-decisions/1.0` JSON. Until now nothing consumed that JSON — the whole stack was decorative.

This PR adds `scripts/apply_operator_decisions.py`: a pure-stdlib CLI that verifies the `payload_sha256` binding, walks `decisions[]`, HEAD-drift-checks each PR via `gh pr view`, then maps each entry to the right `gh pr review`/`gh pr close` invocation.

## Decision mapping

| decision | gh action |
|---|---|
| `approve_tier`      | `gh pr review N --approve` |
| `approve_downgrade` | `gh pr review N --approve` (body prefixed `DOWNGRADED:`) |
| `request_changes`   | `gh pr review N --request-changes` |
| `reject`            | `gh pr close N --comment ...` |
| `hold_operator`     | no-op (operator-only) |
| `null`              | no-op (no decision recorded) |

Every applied body ends with a binding footer so the audit trail is recoverable from any PR thread:

```
---
Applied from operator-decisions <payload_sha256[:10]> bound to packet <receipt_sha256[:10]>
```

## Safety

- **Default `--dry-run`.** `--apply` is required to mutate state. Without it the CLI prints intended actions and a `DRY RUN — no PRs were touched.` footer.
- **Held PRs are hard-skipped.** `HELD_PR_NUMBERS = frozenset({4990, 7173, 7215, 7240, 7243, 7245, 7249, 7252})` is enforced before the decision is even inspected.
- **HEAD-drift check** before every apply: `gh pr view N --json headRefOid` must match the receipt's recorded `head_sha`. If drifted, the entry is skipped with `DRIFT #N (expected X, got Y)`.
- **Signature verification first.** `payload_sha256` is re-derived from canonical JSON (`json.dumps(obj, sort_keys=True, separators=(",",":"), ensure_ascii=False)`) before any other work. Mismatch → exit 2, zero `gh` calls.
- **Missing `gh` on PATH** → exit 2 with a clear message.

## Exit codes

| code | meaning |
|---|---|
| 0 | all entries either succeeded or were intentionally skipped |
| 1 | any apply step failed (per-entry detail in stderr) |
| 2 | sig mismatch / missing file / invalid JSON / no `gh` on PATH |

## Worked dry-run example

\`\`\`
$ python3 scripts/apply_operator_decisions.py operator-decisions-2026-05-17.json
WOULD APPLY # 7280  approve_tier          — dry-run
WOULD APPLY # 7281  request_changes       — dry-run
WOULD APPLY # 7282  approve_downgrade     — dry-run

DRY RUN — no PRs were touched. Re-run with --apply to commit.
\`\`\`

## Test plan

- [x] \`pytest tests/scripts/test_apply_operator_decisions.py -q\` → **20 / 20 green** (sig mismatch, missing file, invalid JSON, no-gh, dry-run, each of 5 decision types, HEAD drift, --only-pr filter, hold-list enforcement in apply + dry-run, --json shape, footer integrity, gh failure surfaces as exit 1).
- [x] \`ruff check\` clean.
- [x] \`ruff format --check\` clean.
- [x] \`mypy scripts/apply_operator_decisions.py\` clean.
- [x] \`bash scripts/automation_pr_preflight.sh origin/main HEAD\` → \`preflight: ok\`.
- [ ] (post-merge) Run dry-run against a real downloaded JSON from the packets UI; spot-check the printed gh argv; then run with --apply on a single test PR to confirm the binding-footer comment lands as expected.

## Receipt

\`docs/status/INGESTION_LOOP_RECEIPT_20260517T172001Z.md\`
SHA-256: \`2842f3bdd997263215e7436cad096f33099fe5ee2c49370f50f0eff512532c0a\`

## Dependency

**None.** This PR branches off \`main\` directly. It reads the *output* of the #7273 → #7278 stack (downloaded JSON), not the stack's source files, so it can land independently and serves whatever signed JSON the operator hands it — including JSONs produced before that stack lands (the receipt fields it requires are all in the v1.0 schema either way).

## Holds respected

- No PR mutation, no labels, draft only.
- Zero AI-key consumption.
- No \`automation.toml\` edit, no launchd install.
- No held-PR advancement (#7173, #7215, #7240, #7243, #7245, #7249, #7252, #4990 — hard-coded in \`HELD_PR_NUMBERS\` and skipped regardless of --apply).
- \`#7209 lane\` and \`BC-12 soak\` holds: the CLI only processes PR numbers, never touches those surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)