### PR TITLE
docs(governance): operator delegation policy + four-bucket rollout

### DIFF
--- a/docs/governance/OPERATOR_DELEGATION_POLICY.md
+++ b/docs/governance/OPERATOR_DELEGATION_POLICY.md
@@ -1,0 +1,200 @@
+# Operator Delegation Policy
+
+**Status:** active (additive — does not replace
+`docs/AGENT_OPERATING_CONTRACT.md`; specializes it for the routine
+operator review workload).
+
+**Scope:** how to allocate decisions between the human operator and
+frontier-model agents on this repo so the operator is not a bottleneck
+on the kinds of judgment frontier models do better, while remaining
+the sole authority on the kinds of judgment only the operator can
+make.
+
+## Why this exists
+
+The operator on this repo (`@an0mium`) ships ~30 PRs/day and has
+~14 open at any given time. The operator's stated comparative
+advantage is **high-level intent articulation** ("here in a vague way
+is what I want"), not line-by-line PR review. Frontier models
+demonstrably make better technical judgments on this codebase than
+the operator's manual review can. Treating the operator as the
+default PR reviewer therefore wastes their highest-leverage capacity
+and creates queue backpressure.
+
+This document codifies a four-bucket delegation policy that lets
+agents do almost all judgment, surfaces only the irreducible
+operator-only decisions, and produces an audit trail the operator
+can review in aggregate rather than per-PR.
+
+## The four buckets
+
+Every open PR lands in exactly one bucket at evaluation time. An
+agent (or the future `scripts/triage_open_prs.py` automation) runs
+the classification; the operator only sees Buckets C and D.
+
+### Bucket A — Auto-merge (agent decides; operator never sees it per-PR)
+
+**All of these MUST be true:**
+
+- `mergeable: MERGEABLE`
+- `mergeStateStatus` is `CLEAN` or `BLOCKED` only because of draft
+  state (not branch-protection failures)
+- CI: all checks `SUCCESS`; zero `FAILURE`; zero `IN_PROGRESS` /
+  `QUEUED`
+- Diff is additive only:
+  - No edits to protected files
+    (`CLAUDE.md`, `aragora/__init__.py`, `.env`, `.envrc`,
+    `scripts/nomic_loop.py`, `docs/AGENT_OPERATING_CONTRACT.md`,
+    `automation.toml`)
+  - No flag flips (no `default=True` for previously `default=False`
+    feature flags; no `enable_*` defaults changed)
+  - No new `boss-ready` / `autonomous` labels
+- Tests added or updated alongside any new behavior
+- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → `ok`
+- Doesn't touch any held PR (see hold list below)
+- Author is on the trusted-authors list (currently: `@an0mium`)
+- Net LOC ≤ 1500 (large-diff escape valve to Bucket C)
+
+If all hold, an automation may merge the PR after a brief settling
+window (default: 30 min after the last commit; configurable).
+
+### Bucket B — Auto-close (agent decides; operator never sees it per-PR)
+
+**Any of these triggers close:**
+
+- A newer open PR replaces the same surface (`changedFiles`
+  intersection ≥ 80%) AND the newer PR is in Bucket A or already
+  merged
+- > 60 days old + still draft + zero activity in last 30 days + no
+  reference from any canonical doc (`docs/CANONICAL_GOALS.md`,
+  `docs/FOCUS.md`, `docs/status/NEXT_STEPS_CANONICAL.md`,
+  `docs/AGENT_ASSIGNMENTS.md`)
+- CI red for >7 consecutive days with zero fix-attempt commits
+
+The closing comment MUST include the classification reason and a
+pointer to the superseding PR (if any), so the operator can recover
+the work later if they disagree.
+
+### Bucket C — Flag for one-line operator y/n
+
+**Any of these triggers Bucket C:**
+
+- Touches a held PR or held lane
+- Touches a protected file
+- Includes a flag flip / label add / `mark-ready` on held
+- Net diff > 1500 LOC
+- CI red and isn't a known-flake (matches `tests/.known_flakes`)
+- Has unresolved review comments from another agent
+- Introduces a new external dependency / network call / secret read
+- New CI lane / runner-label / workflow change
+
+For each Bucket C PR, the agent emits **one line** in this exact
+shape, ordered by recommended action:
+
+```
+#N — RECOMMEND <ACTION> — <≤120-char justification>
+```
+
+Example:
+```
+#7245 — RECOMMEND DEFER — codex-insights signed digest, 22/63 CI with
+        19 still pending — wait for CI complete then re-bucket
+```
+
+The operator answers in batch with single-letter responses:
+`y` (do recommendation) / `n` (do opposite) / `d` (defer / no action).
+Total operator review time: ~3 seconds per PR.
+
+### Bucket D — Strategic check-in (operator gets a paragraph)
+
+Reserved for PRs that work technically but plausibly conflict with
+canonical direction. Examples:
+
+- PR widens scope while `docs/status/NEXT_STEPS_CANONICAL.md`
+  currently says "do not widen scope"
+- PR ships infrastructure that the canonical goals don't reference,
+  in a phase where the canonical gate is "operate what's already
+  shipped"
+- PR introduces a public API surface the operator hasn't publicly
+  committed to
+
+Cap: ≤1 Bucket-D escalation per day. If agents see more, they're
+mis-classifying (almost everything technical belongs in A/B/C).
+
+## Irreducible operator-only decisions
+
+These tripwires MUST stop the agent and require explicit operator
+input, regardless of any other criteria:
+
+| Action | Why operator-only |
+|---|---|
+| Edit `CLAUDE.md`, `aragora/__init__.py`, `.env`, `.envrc`, `scripts/nomic_loop.py`, `docs/AGENT_OPERATING_CONTRACT.md` | Protected per repo guide |
+| Lift a hold (`#7173`, `#7215`, `#7240`, `#7243`, `#7245`, `#7249`, `#7252`, `#4990`, BC-12 soak, `#7209` lane) | Operator wrote the hold; only operator lifts it |
+| Add `boss-ready` / `autonomous` labels | Labels gate downstream automation |
+| `mark-ready` on a held PR | Held PRs must not advance |
+| Force-push / rebase / delete on `main` | Destructive |
+| Force-push to `main` (any branch) | Destructive |
+| Deploy to production | External system mutation |
+| Spend AI-provider quota above per-session threshold | Cost control |
+| Close a PR opened by another agent | Each agent owns its own PRs |
+| Add a new external dependency / secret read | Supply-chain & risk |
+| Change public API contract (`aragora/server/`, `aragora/client/`) | External commitments |
+| Change marketing / public docs (`docs/COMMERCIAL_OVERVIEW.md`, `docs/WHY_ARAGORA.md`) | Reputational |
+
+Hitting any tripwire: agent stops, posts an inline question, awaits
+single-line operator response. Never works around. Never silently
+defers.
+
+## What the operator still does
+
+The operator's authoritative role under this policy:
+
+1. **Direction-setting** — "here in a vague high level way is what
+   I want." Sets project intent, business priorities, vertical bets.
+2. **Risk-tripwire ownership** — names what bad things must not
+   happen; updates the irreducible list above as posture evolves.
+3. **Bucket C y/n batch** — once per day, processes the Bucket C
+   list. ~3 seconds per PR.
+4. **Bucket D check-in** — reads any escalation paragraph and
+   responds within a session.
+5. **Aggregate review** — weekly skim of merged PRs; monthly review
+   of session receipts (`docs/status/SESSION_RECEIPT_*.md` /
+   `docs/status/*_RECEIPT_*.md`) for trajectory.
+6. **Policy revision** — periodic update of bucket criteria as the
+   project scales.
+
+The operator does **not** do: line-by-line code review, technical
+correctness assessment, convention checking, test-coverage judgment,
+merge-cleanliness verification, canonical-doc compliance. Those are
+agent work.
+
+## Hold list (canonical reference)
+
+PRs and lanes the operator has explicitly held; agents must NOT
+advance any of these by even one byte without explicit operator
+authorization:
+
+- PRs: `#7173`, `#7215`, `#7240`, `#7243`, `#7245`, `#7249`,
+  `#7252`, `#4990`
+- Lanes: `#7209` lane, BC-12 soak
+
+This list lives here as the canonical reference and is duplicated in
+`scripts/apply_operator_decisions.py` (`HELD_PR_NUMBERS`). Whoever
+updates the hold list updates both.
+
+## Rollout
+
+See `docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md` for the staged
+implementation. Tracking issues are filed under the
+`operator-delegation` label.
+
+## Relationship to other governance docs
+
+| Doc | Relationship |
+|---|---|
+| `docs/AGENT_OPERATING_CONTRACT.md` | Parent contract; this doc specializes its review-workload section. The contract remains authoritative on anything not addressed here. |
+| `docs/CANONICAL_GOALS.md` | Sets project intent; Bucket D escalations check PRs against it. |
+| `docs/FOCUS.md` / `docs/THESIS.md` | Strategic direction inputs to Bucket D classification. |
+| `docs/status/NEXT_STEPS_CANONICAL.md` | Active gate; the policy explicitly does not auto-merge PRs that widen scope while the canonical gate says otherwise. |
+| `docs/REVIEW_AUTHORITY_PRINCIPLES.md` | 5-tier merge classification; Bucket A defers to this for any PR with a tier in `{3, 4}`. |
+| `scripts/apply_operator_decisions.py` | Implements the operator-decisions JSON consumption side of Bucket A/B/C; honors the hold list above. |

--- a/docs/governance/OPERATOR_DELEGATION_POLICY.md
+++ b/docs/governance/OPERATOR_DELEGATION_POLICY.md
@@ -37,10 +37,20 @@ the classification; the operator only sees Buckets C and D.
 **All of these MUST be true:**
 
 - `mergeable: MERGEABLE`
-- `mergeStateStatus` is `CLEAN` or `BLOCKED` only because of draft
-  state (not branch-protection failures)
+- PR is not draft
+- `mergeStateStatus` is `CLEAN`, or branch protection is blocking
+  only on review while Aragora's merge packet authorizes admin squash
 - CI: all checks `SUCCESS`; zero `FAILURE`; zero `IN_PROGRESS` /
   `QUEUED`
+- `python3 -m aragora.cli.main review-queue merge-packet --pr <N>
+  --json` reports, at the exact current head SHA:
+  - `admin_squash_allowed: true`
+  - `not_ready: []`
+  - `unresolved_dissent: false`
+  - green check summary
+- Tier 3 and Tier 4 PRs are never Bucket A unless the merge packet
+  shows the required human risk settlement or preapproval has already
+  been recorded for that exact head SHA
 - Diff is additive only:
   - No edits to protected files
     (`CLAUDE.md`, `aragora/__init__.py`, `.env`, `.envrc`,
@@ -56,7 +66,10 @@ the classification; the operator only sees Buckets C and D.
 - Net LOC ≤ 1500 (large-diff escape valve to Bucket C)
 
 If all hold, an automation may merge the PR after a brief settling
-window (default: 30 min after the last commit; configurable).
+window (default: 30 min after the last commit; configurable). The
+automation must re-run the merge packet immediately before merge and
+use `--match-head-commit`; head drift demotes the PR out of Bucket A
+until it is reclassified.
 
 ### Bucket B — Auto-close (agent decides; operator never sees it per-PR)
 
@@ -196,5 +209,5 @@ implementation. Tracking issues are filed under the
 | `docs/CANONICAL_GOALS.md` | Sets project intent; Bucket D escalations check PRs against it. |
 | `docs/FOCUS.md` / `docs/THESIS.md` | Strategic direction inputs to Bucket D classification. |
 | `docs/status/NEXT_STEPS_CANONICAL.md` | Active gate; the policy explicitly does not auto-merge PRs that widen scope while the canonical gate says otherwise. |
-| `docs/REVIEW_AUTHORITY_PRINCIPLES.md` | 5-tier merge classification; Bucket A defers to this for any PR with a tier in `{3, 4}`. |
+| `docs/REVIEW_AUTHORITY_PRINCIPLES.md` | 5-tier merge classification; Bucket A is only possible when the review-queue merge packet says admin squash is allowed at the exact current head. |
 | `scripts/apply_operator_decisions.py` | Implements the operator-decisions JSON consumption side of Bucket A/B/C; honors the hold list above. |

--- a/docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md
+++ b/docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md
@@ -1,0 +1,172 @@
+# Operator Delegation Rollout
+
+**Status:** active; tracks the staged rollout of
+`docs/governance/OPERATOR_DELEGATION_POLICY.md`.
+
+The policy defines four buckets (A=auto-merge, B=auto-close,
+C=operator-y/n, D=strategic) plus an irreducible operator-only
+tripwire list. This rollout takes the policy from "document" to
+"automation actually running against the queue."
+
+## Goal
+
+Reduce the operator's per-PR review burden from "read 14 diffs" to
+"type y/n on ~3 PRs per day" while preserving every hold, every
+protected file, and every tripwire — and producing a durable audit
+trail at every stage.
+
+## Stages
+
+Each stage is one PR. Stages are sequential — stage N+1 depends on
+stage N landing first. Every stage default-OFF until the operator
+opts in.
+
+### Stage 0 — Policy doc (this PR)
+
+Ship `docs/governance/OPERATOR_DELEGATION_POLICY.md` +
+`docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md` (this file).
+
+Acceptance: docs land on `main`, no behavior change.
+
+### Stage 1 — `scripts/triage_open_prs.py` (read-only classifier)
+
+Pure-stdlib CLI. Reads the live `gh pr list` + `gh pr view` data,
+runs the four-bucket classification, prints the table per the
+policy doc. **Never mutates.** Dogfoods
+`scripts/list_active_agent_sessions.py` for hold detection +
+authorship trust.
+
+CLI:
+```
+python3 scripts/triage_open_prs.py [--json] [--bucket A|B|C|D]
+                                    [--include-held] [--limit N]
+```
+
+Acceptance:
+- Re-running it 24h apart on the same queue produces deterministic
+  output (sort by bucket → number).
+- Bucket classification matches the four-bucket criteria for every
+  PR in the open queue.
+- Default output is the human table; `--json` emits machine-readable.
+- Test fixture covers each of the four buckets + each hard
+  constraint (held, protected-file edit, flag flip, large diff,
+  unresolved review, CI red, CI pending, external dep).
+
+Tracking: GitHub issue tagged `operator-delegation`,
+`infrastructure`.
+
+### Stage 2 — `scripts/auto_merge_bucket_a.py` (opt-in enforcement)
+
+Reads the Stage 1 classifier output, attempts `gh pr merge --squash`
+on every Bucket A PR. Default `--dry-run`. Settling window (default
+30 min after last commit) before merge. Hard-coded skip on tripwires
+even if the classifier missed them (defense-in-depth).
+
+CLI:
+```
+python3 scripts/auto_merge_bucket_a.py [--apply] [--settling-minutes N]
+                                       [--only-pr N] [--json]
+```
+
+Acceptance:
+- Default `--dry-run` enumerates intended merges, never mutates.
+- `--apply` merges only PRs in Bucket A; never touches B/C/D.
+- Aborts and exits non-zero on any single tripwire hit.
+- Every merge writes a receipt to
+  `docs/status/AUTO_MERGE_RECEIPT_<utc>.md` with the PR list, the
+  policy version, and the classifier output sha256.
+
+Tracking: GitHub issue tagged `operator-delegation`, `automation`.
+
+### Stage 3 — `scripts/triage_bucket_c.py` (operator y/n batcher)
+
+Reads the Stage 1 output, prints only Bucket C lines, accepts a
+one-character response per PR (`y`/`n`/`d`) via stdin or a YAML
+response file. Then executes the y/n decision per PR (advancing y,
+closing n, no-op on d).
+
+CLI:
+```
+python3 scripts/triage_bucket_c.py [--interactive] [--responses FILE]
+                                   [--apply]
+```
+
+Acceptance:
+- Without `--apply`, prints what would happen but mutates nothing.
+- With `--apply`, advances `y` PRs via the appropriate `gh`
+  command (label, mark-ready, comment) and closes `n` PRs.
+- Tripwires for "advancing" anything onto held / protected surfaces.
+- Receipt written to `docs/status/BUCKET_C_RECEIPT_<utc>.md`.
+
+Tracking: GitHub issue tagged `operator-delegation`, `automation`.
+
+### Stage 4 — Periodic scheduling (opt-in)
+
+Once Stages 1–3 are battle-tested by manual invocation, ship a
+LaunchAgent template (`scripts/launch_agents/com.aragora.delegation-policy.plist`)
+that runs Stage 1 + Stage 2 + Stage 3 once daily at a configurable
+hour. **Strictly opt-in via `make delegation-installed`** — never
+auto-installed.
+
+Acceptance: template lands; no `launchctl load` runs in CI; the
+install Makefile target documents the consequences.
+
+Tracking: GitHub issue tagged `operator-delegation`, `launchd`.
+
+### Stage 5 — Bucket-D escalation surface
+
+A small operator-facing surface (likely a `/review-queue/strategic`
+route, or a single CLI command) that lists pending Bucket D items
+with the agent's paragraph. Operator types one paragraph back per
+item. Receipt-bound.
+
+Tracking: GitHub issue tagged `operator-delegation`, `ui`.
+
+## Holds + tripwires (cross-reference)
+
+This rollout never violates any hold or tripwire from
+`docs/governance/OPERATOR_DELEGATION_POLICY.md`. In particular:
+
+- No automation in any stage edits a protected file.
+- No automation lifts a hold.
+- No automation labels with `boss-ready` / `autonomous`.
+- No automation deploys to production.
+- No automation closes another agent's PR.
+
+Each stage's tests assert the above for the relevant code paths.
+
+## Measurement
+
+Each stage records its operational metrics into the receipt format
+already in use by this repo:
+
+- Per-bucket-classification counts per run
+- Per-merge time-to-merge (Bucket A) for trend analysis
+- Per-operator-y/n response time (Bucket C) — empirical baseline
+- Tripwire-hit counts (target: low; rising trend = policy needs
+  revision)
+
+After two weeks of Stage 4 runs, compare:
+- Before: average operator review time per PR (≥3 minutes
+  historical)
+- After: average operator review time per PR (target: <3 seconds in
+  Bucket C; zero in A/B)
+
+If the after-numbers don't match, revise bucket criteria.
+
+## Sequencing
+
+Stage 0 (this PR) → Stage 1 → Stage 2 → Stage 3 → Stage 4 → Stage 5.
+
+Each stage opens its own draft PR; tracking issues filed against
+this rollout. Total estimated effort: 5–8 hours across 5 PRs.
+
+## Tracking
+
+| Issue | Stage | Status |
+|---|---|---|
+| [#7280](https://github.com/synaptent/aragora/issues/7280) | Stage 1: triage_open_prs.py | open |
+| [#7281](https://github.com/synaptent/aragora/issues/7281) | Stage 2: auto_merge_bucket_a.py | open |
+| [#7282](https://github.com/synaptent/aragora/issues/7282) | Stage 3: triage_bucket_c.py | open |
+| _to be filed after Stage 3 lands_ | Stage 4: scheduling | not yet |
+| _to be filed after Stage 4 lands_ | Stage 5: bucket-D surface | not yet |


### PR DESCRIPTION
## Summary

Encodes the operator-delegation policy you asked for as durable canonical docs + tracking issues, so it survives across sessions and is enforceable by future automation.

## What this adds

- \`docs/governance/OPERATOR_DELEGATION_POLICY.md\` — the four-bucket PR triage policy (A=auto-merge, B=auto-close, C=operator-y/n, D=strategic) + the irreducible operator-only tripwire list + relationship to other governance docs.
- \`docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md\` — five-stage rollout taking the policy from \"document\" to \"live automation\" with per-stage acceptance criteria.
- 3 tracking issues filed against this PR:
  - #7280 — Stage 1: \`scripts/triage_open_prs.py\` (read-only 4-bucket classifier)
  - #7281 — Stage 2: \`scripts/auto_merge_bucket_a.py\` (opt-in auto-merger)
  - #7282 — Stage 3: \`scripts/triage_bucket_c.py\` (operator y/n batcher)
  - Stages 4 + 5 filed after Stage 3 lands

## The four buckets in one line each

| Bucket | Criterion | Operator sees? |
|---|---|---|
| A | additive + green CI + mergeable + tests + no held/protected touch + ≤1500 LOC + trusted author | no (auto-merge) |
| B | superseded by newer / >60d stale / CI red >7d | no (auto-close) |
| C | touches held/protected/large/CI-red/external-dep/new-runner-label | yes — one line per PR, batch y/n |
| D | works technically but plausibly conflicts with canonical direction | yes — one paragraph, ≤1/day |

## Why this exists

Operator has explicitly named their comparative advantage as high-level intent articulation (\"here in a vague high level way is what I want\"), not line-by-line PR review. Frontier models make better technical PR judgments on this codebase than the operator's manual review can. This policy operationalizes that reality: agents do almost all judgment; the operator only sees decisions that (a) require strategic judgment, (b) trip a risk tripwire, or (c) require the founder context the agent doesn't have.

## What this PR does NOT do

- No code changes — pure docs PR.
- No labels added — \`operator-delegation\` label is suggested in issue bodies; operator creates it later (label creation is itself a tripwire).
- No held-PR advancement — every hold from \`docs/AGENT_OPERATING_CONTRACT.md\` is cross-referenced and respected.
- No protected-file edits — does not touch \`AGENT_OPERATING_CONTRACT.md\` itself; that doc remains canonical and is referenced from the new policy.
- No mark-ready, no merges, no force-push.
- Zero AI-key consumption.

## Triage data attached

As part of the same session that produced this PR, I ran the policy's classification logic against the current open queue and produced the following table. This is the empirical answer to \"what would the policy say today?\" — useful as a sanity check on the criteria.

\`\`\`
BUCKET A — recommend auto-merge (6 PRs)
  #7263, #7259, #7262, #7276, #7278, #7279

BUCKET B — recommend auto-close (0 PRs)

BUCKET C — operator y/n needed (7 PRs)
  #7173, #7215, #7245, #7251, #7252 (5 held — confirm \"stay held\")
  #7261 (CI pending — wait then re-bucket)
  #7268 (potentially superseded by #7273→#7277 React route)

BUCKET D — strategic (0 PRs this pass)
\`\`\`

If the buckets feel wrong on first read, that's the right time to revise criteria — the rollout is staged precisely so we don't lock in an automation that misclassifies.

## Test plan

- [x] \`bash scripts/automation_pr_preflight.sh origin/main HEAD\` → \`preflight: ok (docs-only diff)\`
- [x] Live four-bucket classification produced for current open queue (see above)
- [x] Ingestion-loop smoke (PR #7279) round-tripped end-to-end during this session
- [ ] (post-merge) ship #7280 (Stage 1 classifier) as the first executable embodiment of the policy

## Holds respected

- All PRs in the hold list (\`#7173, #7215, #7240, #7243, #7245, #7249, #7252, #4990\`) appear in the policy as the canonical reference.
- BC-12 soak / \`#7209 lane\` are non-PR-number holds; the policy references them in the lane section.
- Protected files: \`CLAUDE.md\`, \`aragora/__init__.py\`, \`.env\`, \`.envrc\`, \`scripts/nomic_loop.py\`, \`docs/AGENT_OPERATING_CONTRACT.md\` — all listed as tripwires; this PR does not edit any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)