### PR TITLE
fix(automation): serialize lane claim registry writes

### DIFF
--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -22,8 +22,9 @@ Design constraints (kept tight so this script can be used during
 bootstraps and from any agent):
 
 - Pure Python stdlib, no aragora package import.
-- Read-modify-write the JSON array atomically (write to ``<file>.tmp``,
-  rename).
+- Serialize the read-modify-write under a sibling lock file when ``fcntl``
+  is available, while preserving atomic file integrity via write to
+  ``<file>.tmp`` + rename.
 - Schema matches ``LaneRecord`` exactly so the existing agent_bridge
   reader picks it up without modification: ``lane_id``, ``owner_session``,
   ``goal``, ``source``, ``status``, ``next_action``, ``updated_at``,
@@ -37,10 +38,9 @@ bootstraps and from any agent):
 - Never deletes rows. Never writes a lane row with a missing
   ``lane_id`` or empty ``owner_session``.
 - Never invokes git, gh, or any network call.
-- Per-file lock via ``fcntl.flock`` on POSIX is best-effort; on
-  platforms without ``fcntl`` we fall back to the read-modify-write
-  with rename and accept a tiny TOCTOU window. Concurrent claims to
-  *different* lane ids are safe under both paths.
+- Per-file lock via ``fcntl.flock`` on POSIX serializes concurrent claims.
+  On platforms without ``fcntl`` we fall back to atomic rename-only and
+  accept a small TOCTOU window.
 
 Usage:
 
@@ -61,6 +61,8 @@ claim.
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterator
+from contextlib import contextmanager
 import datetime as dt
 import json
 import os
@@ -68,6 +70,11 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Any
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - exercised only on non-POSIX systems.
+    _fcntl = None  # type: ignore[assignment]
 
 DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
 REPO_LANE_RELATIVE_PATH = Path(".aragora") / "agent-bridge" / "lanes.json"
@@ -147,6 +154,20 @@ def _atomic_write(path: Path, rows: list[dict[str, Any]]) -> None:
         raise
 
 
+@contextmanager
+def _registry_write_lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    with lock_path.open("a", encoding="utf-8") as lock_fh:
+        if _fcntl is not None:
+            _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if _fcntl is not None:
+                _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_UN)
+
+
 def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for key in LANE_RECORD_KEYS:
@@ -182,46 +203,47 @@ def claim_lane(
     if status not in ALLOWED_STATUSES:
         raise ValueError(f"status {status!r} is not in {sorted(ALLOWED_STATUSES)}")
 
-    rows = _read_existing(registry_path)
-    timestamp = updated_at or _utc_now_iso()
+    with _registry_write_lock(registry_path):
+        rows = _read_existing(registry_path)
+        timestamp = updated_at or _utc_now_iso()
 
-    new_row: dict[str, Any] = {
-        "lane_id": lane_id,
-        "owner_session": owner_session,
-        "goal": goal,
-        "source": source,
-        "status": status,
-        "next_action": next_action,
-        "updated_at": timestamp,
-        "branch": branch,
-        "worktree": worktree,
-        "pr_number": pr_number,
-        "conflict_session": conflict_session,
-        "conflict_reason": conflict_reason,
-    }
-    normalized = _normalize_row(new_row)
+        new_row: dict[str, Any] = {
+            "lane_id": lane_id,
+            "owner_session": owner_session,
+            "goal": goal,
+            "source": source,
+            "status": status,
+            "next_action": next_action,
+            "updated_at": timestamp,
+            "branch": branch,
+            "worktree": worktree,
+            "pr_number": pr_number,
+            "conflict_session": conflict_session,
+            "conflict_reason": conflict_reason,
+        }
+        normalized = _normalize_row(new_row)
 
-    out_rows: list[dict[str, Any]] = []
-    replaced = False
-    for existing in rows:
-        existing_id = str(existing.get("lane_id") or "")
-        if existing_id != lane_id:
-            out_rows.append(existing)
-            continue
-        existing_owner = str(existing.get("owner_session") or "")
-        if existing_owner and existing_owner != owner_session and not force:
-            raise ClaimError(
-                f"lane_id={lane_id!r} already claimed by "
-                f"owner_session={existing_owner!r}; refusing to overwrite "
-                f"(use --force to override or pick a different lane id)"
-            )
-        replaced = True
-        out_rows.append(normalized)
-    if not replaced:
-        out_rows.append(normalized)
+        out_rows: list[dict[str, Any]] = []
+        replaced = False
+        for existing in rows:
+            existing_id = str(existing.get("lane_id") or "")
+            if existing_id != lane_id:
+                out_rows.append(existing)
+                continue
+            existing_owner = str(existing.get("owner_session") or "")
+            if existing_owner and existing_owner != owner_session and not force:
+                raise ClaimError(
+                    f"lane_id={lane_id!r} already claimed by "
+                    f"owner_session={existing_owner!r}; refusing to overwrite "
+                    f"(use --force to override or pick a different lane id)"
+                )
+            replaced = True
+            out_rows.append(normalized)
+        if not replaced:
+            out_rows.append(normalized)
 
-    _atomic_write(registry_path, out_rows)
-    return normalized
+        _atomic_write(registry_path, out_rows)
+        return normalized
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -126,6 +126,85 @@ def test_other_lanes_are_preserved_during_claim(tmp_registry: Path) -> None:
     assert lane_ids == ["lane-a", "lane-b"]
 
 
+def _spawn_cli_claim(
+    registry: Path,
+    *,
+    lane_id: str,
+    owner_session: str,
+) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--lane-id",
+            lane_id,
+            "--owner-session",
+            owner_session,
+            "--registry-path",
+            str(registry),
+            "--json",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _collect_claim_processes(
+    processes: list[subprocess.Popen[str]],
+) -> list[tuple[int, str, str]]:
+    results: list[tuple[int, str, str]] = []
+    for proc in processes:
+        stdout, stderr = proc.communicate(timeout=30)
+        results.append((proc.returncode, stdout, stderr))
+    return results
+
+
+def test_concurrent_different_lane_claims_are_preserved(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+    expected_lane_ids = [f"lane-{idx:02d}" for idx in range(16)]
+
+    results = _collect_claim_processes(
+        [
+            _spawn_cli_claim(
+                registry,
+                lane_id=lane_id,
+                owner_session=f"owner-{idx:02d}",
+            )
+            for idx, lane_id in enumerate(expected_lane_ids)
+        ]
+    )
+
+    assert all(returncode == 0 for returncode, _stdout, _stderr in results), results
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    lane_ids = sorted(row["lane_id"] for row in payload)
+    assert lane_ids == expected_lane_ids
+
+
+def test_concurrent_same_lane_claims_do_not_both_succeed(tmp_path: Path) -> None:
+    registry = tmp_path / "lanes.json"
+
+    results = _collect_claim_processes(
+        [
+            _spawn_cli_claim(
+                registry,
+                lane_id="shared-lane",
+                owner_session=f"owner-{idx:02d}",
+            )
+            for idx in range(12)
+        ]
+    )
+
+    successes = [stdout for returncode, stdout, _stderr in results if returncode == 0]
+    conflicts = [stderr for returncode, _stdout, stderr in results if returncode == 2]
+    assert len(successes) == 1, results
+    assert len(conflicts) == 11, results
+    assert all("already claimed" in stderr for stderr in conflicts)
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    assert len(payload) == 1
+    assert payload[0]["owner_session"] == json.loads(successes[0])["owner_session"]
+
+
 def test_conflict_status_round_trips(tmp_registry: Path) -> None:
     claim_module.claim_lane(
         registry_path=tmp_registry,


### PR DESCRIPTION
## Summary

Follow-up to #7267. #7267 merged at `e5db3a6d212901637855d1094c926e6c42fea909` before the concurrency repair could be pushed. The merged helper has atomic temp-file replacement, but its read-modify-write path is not serialized, so concurrent different-lane claims can silently lose rows.

This PR keeps the #7267 scope and adds POSIX `fcntl.flock` around the full read/compare/write section while preserving the atomic temp-file write + `os.replace` for file integrity.

## Files

- `scripts/claim_active_agent_lane.py`
- `tests/scripts/test_claim_active_agent_lane.py`

## Validation

- `python3 -m pytest tests/scripts/test_claim_active_agent_lane.py -q` -> `20 passed`
- `python3 -m ruff check scripts/claim_active_agent_lane.py scripts/list_active_agent_sessions.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_list_active_agent_sessions.py` -> `All checks passed!`
- `python3 -m ruff format --check scripts/claim_active_agent_lane.py scripts/list_active_agent_sessions.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_list_active_agent_sessions.py` -> `4 files already formatted`
- `python3 -m mypy scripts/claim_active_agent_lane.py scripts/list_active_agent_sessions.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_list_active_agent_sessions.py --ignore-missing-imports --no-incremental` -> `Success: no issues found in 4 source files`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`
- temp-only dogfood proof -> two concurrent different-lane claims returned 0 and registry persisted both rows: `['dogfood-00', 'dogfood-01']`

## Full requested pytest caveat

`python3 -m pytest tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_list_active_agent_sessions.py -q` currently fails in three `tests/scripts/test_list_active_agent_sessions.py` tests because current `origin/main` requires the `codex_cli_sessions` keyword argument when calling `build_overlap_report()`. This PR does not touch that file by instruction; `git diff origin/main...HEAD` is limited to the two files above.

## Concurrency proof

Before the lock repair, the new subprocess test for concurrent different-lane claims failed with all claim processes returning success but only 13/16 lane rows persisted. After the repair, the same test passes and the temp-only dogfood check preserves both rows.
