### PR TITLE
feat(scripts): triage_open_prs.py — Stage 1 four-bucket classifier (closes #7280)

### DIFF
--- a/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
+++ b/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
@@ -119,7 +119,13 @@ wins; first match returns):
 5. **C** if CI red (recent)
 6. **C** if any check is `IN_PROGRESS` / `QUEUED`
 7. **B** if draft + `created_at ≥ 60d` + `updated_at ≥ 30d`
-8. **B** if a newer open PR has ≥80% file overlap + zero CI failures
+8. **B** if a newer open PR has ≥80% file overlap AND the newer PR
+   would itself qualify for Bucket A (i.e. `_would_qualify_for_bucket_a`
+   returns True — same gates as Bucket A above except for the
+   supersede check itself). This closes Codex's Gap #3 from the
+   #7285 review: a draft / held / CI-pending / merge-packet-blocked /
+   non-trusted / protected-file / large / dirty candidate cannot
+   supersede an older PR.
 9. **C** if author ∉ `TRUSTED_AUTHORS`
 10. **C** if `is_draft` (reason: `draft`, action: `READY?`)
 11. **C** if `mergeable != MERGEABLE`
@@ -135,12 +141,12 @@ Bucket D is reserved for future enhancement — strategic mismatch
 with canonical direction is not auto-classifiable from `gh` metadata
 alone.
 
-## Tests (46 new, all green)
+## Tests (57 new, all green)
 
 ```
 $ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
-..............................................                           [100%]
-46 passed
+.........................................................                [100%]
+57 passed in 1.45s
 ```
 
 | Group | Tests | Coverage |
@@ -148,6 +154,7 @@ $ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
 | TestBucketA | 9 | Clean additive ready-to-merge → A; draft → C `READY?`; BLOCKED → C; missing merge-packet → C; not_ready → C; admin false → C; head mismatch → C; Tier 3 without settlement → C; Tier 3 with settlement → A |
 | TestBucketCTripwires | 14 | Held PR; protected file (CLAUDE.md, automation.toml, aragora/__init__.py); large diff; CI red recent; CI pending; CI cancelled/non-green; non-trusted author; not mergeable (CONFLICTING); merge state DIRTY; merge state BEHIND; code without tests; pure-docs-doesnt-trip-rule (negative); review CHANGES_REQUESTED |
 | TestBucketB | 7 | CI red 7+ days; stale draft over threshold; stale but recent (negative); ready PR not marked stale (negative); supersede by newer clean PR; no supersede when overlap too low (negative); no supersede when newer has CI failure (negative) |
+| **TestSupersedeRequiresBucketAEligibility** | **11** | **(NEW — closes Codex Gap #3)** Draft superseder rejected; held superseder rejected; CI-pending superseder rejected; missing-merge-packet superseder rejected; non-trusted superseder rejected; protected-file-edit superseder rejected; large-diff superseder rejected; DIRTY superseder rejected; BLOCKED superseder rejected; CHANGES_REQUESTED superseder rejected; fully-eligible superseder still fires (regression check) |
 | TestPrecedence | 3 | Held beats all other tripwires; protected beats large diff; CI-red-7d beats supersede |
 | TestCliOutput | 8 | Human output; JSON output; bucket filter; missing --from-json file; invalid --from-json JSON; non-array root; no gh on PATH; deterministic output across runs |
 | TestEdgeCases | 4 | Empty PR list; PR with zero files; PR with empty author dict; reason capped at 200 chars |
@@ -156,7 +163,7 @@ $ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
 
 ```
 $ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
-38 passed in 1.26s
+57 passed in 1.45s
 $ ruff check scripts/triage_open_prs.py tests/scripts/test_triage_open_prs.py
 All checks passed!
 $ ruff format --check scripts/triage_open_prs.py tests/scripts/test_triage_open_prs.py

--- a/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
+++ b/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
@@ -1,0 +1,185 @@
+# Triage classifier receipt — Stage 1 of Operator Delegation rollout
+
+**Generated:** 2026-05-17T18:06:06Z
+**Branch:** `worktree-triage-classifier-20260517`
+**Closes:** [#7280](https://github.com/synaptent/aragora/issues/7280) — Stage 1: `scripts/triage_open_prs.py`
+**Policy:** `docs/governance/OPERATOR_DELEGATION_POLICY.md` (from PR #7283; will rebase clean once #7283 lands)
+**Rollout:** `docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md` (Stage 1 of 5)
+
+## What shipped
+
+`scripts/triage_open_prs.py` — read-only four-bucket classifier that
+reproduces today's Bucket A/B/C/D triage table from live `gh pr list`
+data. Pure-stdlib (argparse, dataclasses, datetime, json, shutil,
+subprocess, sys, pathlib, typing). No `aragora.*` imports. Zero AI-key
+consumption. Never mutates GitHub state.
+
+## CLI surface
+
+```
+usage: triage_open_prs.py [-h] [--json] [--bucket {A,B,C,D}]
+                          [--include-held] [--limit LIMIT]
+                          [--from-json FROM_JSON]
+
+Read-only four-bucket PR triage classifier per
+docs/governance/OPERATOR_DELEGATION_POLICY.md.
+
+options:
+  --json                Emit JSON instead of human table.
+  --bucket {A,B,C,D}    Filter to one bucket only.
+  --include-held        Always include held PRs (default: yes).
+  --limit LIMIT         Max PRs to fetch from gh (default: 100).
+  --from-json FROM_JSON Read PR data from JSON file (for tests / offline).
+```
+
+## Worked example — live run against current queue
+
+Output of `python3 scripts/triage_open_prs.py` at 2026-05-17T18:06Z:
+
+```
+BUCKET A — recommend AUTO-MERGE
+  #7251 — MERGE — green CI (17/67), 353 LOC, 3 files, tests present, author=an0mium
+  #7259 — MERGE — green CI (17/66), 234 LOC, 2 files, tests present, author=an0mium
+  #7262 — MERGE — green CI (16/68), 373 LOC, 2 files, tests present, author=an0mium
+  #7263 — MERGE — green CI (14/34), 778 LOC, 2 files, tests present, author=an0mium
+  #7276 — MERGE — green CI (16/68), 290 LOC, 2 files, tests present, author=an0mium
+  #7278 — MERGE — green CI (5/8), 792 LOC, 5 files, tests present, author=an0mium
+  #7279 — MERGE — green CI (17/67), 1185 LOC, 3 files, tests present, author=an0mium
+  #7283 — MERGE — green CI (14/34), 372 LOC, 2 files, tests present, author=an0mium
+
+BUCKET B — recommend AUTO-CLOSE
+  (none)
+
+BUCKET C — needs operator y/n
+  #7173 — STAY HELD — held (#7173 is on the policy hold list)
+  #7215 — STAY HELD — held (#7215 is on the policy hold list)
+  #7245 — STAY HELD — held (#7245 is on the policy hold list)
+  #7252 — STAY HELD — held (#7252 is on the policy hold list)
+  #7268 — DECIDE — large diff (1542 LOC > 1500)
+
+BUCKET D — strategic check-in
+  (none)
+
+summary: A: 8  B: 0  C: 5  D: 0    total: 13
+```
+
+### Sanity-check vs. earlier manual triage
+
+The same triage was produced manually earlier this session. The
+mechanical classifier diverged from the manual triage in one place —
+and the classifier was right:
+
+- I called **#7251 "held"** based on memory; the canonical hold list
+  in the policy doc is `{4990, 7173, 7215, 7240, 7243, 7245, 7249,
+  7252}` — `#7251 is NOT on it`. The classifier correctly put it in A.
+- The classifier also caught #7283 (the policy PR opened earlier this
+  session) and #7268 (Codex's settlement UI — flagged C for large
+  diff at 1542 LOC, just above the 1500 cap).
+- `#7261` was open during the earlier manual triage but landed
+  between then and now — the classifier reflects live state.
+
+This is exactly the operator-delegation premise: the mechanical
+classifier reproduces the manual judgment more accurately, faster,
+and without the operator (or a frontier-model agent) having to hold
+the hold list in working memory.
+
+## Bucket precedence
+
+The classifier evaluates buckets in this order (most-restrictive
+wins; first match returns):
+
+1. **C** if `pr_number ∈ HELD_PR_NUMBERS`
+2. **C** if any changed file is in `PROTECTED_PATHS`
+3. **C** if `additions + deletions > 1500`
+4. **B** if CI red AND `updated_at` ≥ 7 days ago
+5. **C** if CI red (recent)
+6. **C** if any check is `IN_PROGRESS` / `QUEUED`
+7. **B** if draft + `created_at ≥ 60d` + `updated_at ≥ 30d`
+8. **B** if a newer open PR has ≥80% file overlap + zero CI failures
+9. **C** if author ∉ `TRUSTED_AUTHORS`
+10. **C** if `mergeable != MERGEABLE`
+11. **C** if `mergeStateStatus ∉ {CLEAN, BLOCKED}`
+12. **C** if there are code files but no test files
+13. **C** if `reviewDecision == CHANGES_REQUESTED`
+14. **A** otherwise
+
+Bucket D is reserved for future enhancement — strategic mismatch
+with canonical direction is not auto-classifiable from `gh` metadata
+alone.
+
+## Tests (38 new, all green)
+
+```
+$ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
+......................................                                   [100%]
+38 passed in 1.26s
+```
+
+| Group | Tests | Coverage |
+|---|---|---|
+| TestBucketA | 2 | Clean additive (CLEAN); clean additive on draft (BLOCKED) |
+| TestBucketCTripwires | 13 | Held PR; protected file (CLAUDE.md, automation.toml, aragora/__init__.py); large diff; CI red recent; CI pending; non-trusted author; not mergeable (CONFLICTING); merge state DIRTY; merge state BEHIND; code without tests; pure-docs-doesnt-trip-rule (negative); review CHANGES_REQUESTED |
+| TestBucketB | 7 | CI red 7+ days; stale draft over threshold; stale but recent (negative); ready PR not marked stale (negative); supersede by newer clean PR; no supersede when overlap too low (negative); no supersede when newer has CI failure (negative) |
+| TestPrecedence | 3 | Held beats all other tripwires; protected beats large diff; CI-red-7d beats supersede |
+| TestCliOutput | 8 | Human output; JSON output; bucket filter; missing --from-json file; invalid --from-json JSON; non-array root; no gh on PATH; deterministic output across runs |
+| TestEdgeCases | 4 | Empty PR list; PR with zero files; PR with empty author dict; reason capped at 200 chars |
+
+## Validation
+
+```
+$ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
+38 passed in 1.26s
+$ ruff check scripts/triage_open_prs.py tests/scripts/test_triage_open_prs.py
+All checks passed!
+$ ruff format --check scripts/triage_open_prs.py tests/scripts/test_triage_open_prs.py
+2 files already formatted
+$ mypy scripts/triage_open_prs.py
+Success: no issues found in 1 source file
+$ bash scripts/automation_pr_preflight.sh origin/main HEAD
+preflight: ok
+```
+
+## How this fits the rollout
+
+| Stage | Status |
+|---|---|
+| Stage 0 — policy doc + rollout doc | shipped as PR #7283 |
+| **Stage 1 — this PR (triage_open_prs.py)** | **shipped (this receipt)** |
+| Stage 2 — auto_merge_bucket_a.py | tracked as #7281, depends on this |
+| Stage 3 — triage_bucket_c.py | tracked as #7282, depends on this |
+| Stage 4 — scheduling (LaunchAgent template) | not yet filed |
+| Stage 5 — Bucket-D escalation surface | not yet filed |
+
+The Stage 2 + 3 scripts will consume this classifier's `--json`
+output rather than re-implement the classification, so this is the
+single source of bucket truth going forward.
+
+## Holds respected
+
+- No PR mutation, no labels, draft only.
+- Zero AI-key consumption.
+- Held PRs (`#7173, #7215, #7240, #7243, #7245, #7249, #7252,
+  #4990`) hard-coded in `HELD_PR_NUMBERS`; the classifier puts every
+  one of them in Bucket C with reason "held" — never recommends A or B.
+- No `automation.toml` edit, no launchd install.
+- No protected-file edits (`CLAUDE.md`, `aragora/__init__.py`, `.env`,
+  `.envrc`, `scripts/nomic_loop.py`, `docs/AGENT_OPERATING_CONTRACT.md`,
+  `automation.toml`).
+
+## Reproduction
+
+```bash
+git checkout worktree-triage-classifier-20260517
+python3 -m pytest tests/scripts/test_triage_open_prs.py -q
+python3 scripts/triage_open_prs.py            # live human table
+python3 scripts/triage_open_prs.py --json     # live JSON
+python3 scripts/triage_open_prs.py --bucket C # only operator-y/n items
+```
+
+## Receipt self-binding
+
+```
+shasum -a 256 docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
+```
+
+The PR description and final session response print the resulting hex.

--- a/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
+++ b/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
@@ -14,6 +14,13 @@ data. Pure-stdlib (argparse, dataclasses, datetime, json, shutil,
 subprocess, sys, pathlib, typing). No `aragora.*` imports. Zero AI-key
 consumption. Never mutates GitHub state.
 
+**2026-05-17T18:50:41Z audit patch:** Bucket A is now exact-head gated in
+this classifier, not deferred to Stage 2. Otherwise-eligible candidates
+must have a current `aragora review-queue merge-packet --pr <N> --json`
+result with `admin_squash_allowed=true`, `not_ready=[]`,
+`unresolved_dissent=false`, a matching head SHA, and Tier 3/4 settlement
+or preapproval if applicable. Without that proof, the PR remains Bucket C.
+
 ## CLI surface
 
 ```
@@ -77,9 +84,8 @@ Mid-session, the operator tightened Bucket A criteria in
 - **`mergeStateStatus == CLEAN`** (new — `BLOCKED` no longer qualifies)
 - `aragora review-queue merge-packet` reports `admin_squash_allowed=true`,
   `not_ready=[]`, `unresolved_dissent=false` at the **exact** current
-  head SHA (deferred to Stage 2 — see classifier docstring)
+  head SHA
 - Tier 3 / Tier 4 PRs need explicit risk-settlement at exact head SHA
-  (deferred to Stage 2)
 - Existing: green CI, additive, tests, ≤1500 LOC, trusted author,
   no held PRs, no protected files
 
@@ -120,25 +126,27 @@ wins; first match returns):
 12. **C** if `mergeStateStatus != CLEAN`
 13. **C** if there are code files but no test files
 14. **C** if `reviewDecision == CHANGES_REQUESTED`
-15. **A** otherwise (still subject to Stage 2's deep merge-packet +
-    tier checks before any actual merge)
+15. **C** if the exact-head merge packet does not authorize admin squash
+    or reports `not_ready`, unresolved dissent, head drift, or missing
+    Tier 3/4 settlement/preapproval
+16. **A** otherwise
 
 Bucket D is reserved for future enhancement — strategic mismatch
 with canonical direction is not auto-classifiable from `gh` metadata
 alone.
 
-## Tests (39 new, all green)
+## Tests (46 new, all green)
 
 ```
 $ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
-.......................................                                  [100%]
-39 passed in 1.04s
+..............................................                           [100%]
+46 passed
 ```
 
 | Group | Tests | Coverage |
 |---|---|---|
-| TestBucketA | 3 | Clean additive ready-to-merge → A; draft → C `READY?`; BLOCKED → C |
-| TestBucketCTripwires | 13 | Held PR; protected file (CLAUDE.md, automation.toml, aragora/__init__.py); large diff; CI red recent; CI pending; non-trusted author; not mergeable (CONFLICTING); merge state DIRTY; merge state BEHIND; code without tests; pure-docs-doesnt-trip-rule (negative); review CHANGES_REQUESTED |
+| TestBucketA | 9 | Clean additive ready-to-merge → A; draft → C `READY?`; BLOCKED → C; missing merge-packet → C; not_ready → C; admin false → C; head mismatch → C; Tier 3 without settlement → C; Tier 3 with settlement → A |
+| TestBucketCTripwires | 14 | Held PR; protected file (CLAUDE.md, automation.toml, aragora/__init__.py); large diff; CI red recent; CI pending; CI cancelled/non-green; non-trusted author; not mergeable (CONFLICTING); merge state DIRTY; merge state BEHIND; code without tests; pure-docs-doesnt-trip-rule (negative); review CHANGES_REQUESTED |
 | TestBucketB | 7 | CI red 7+ days; stale draft over threshold; stale but recent (negative); ready PR not marked stale (negative); supersede by newer clean PR; no supersede when overlap too low (negative); no supersede when newer has CI failure (negative) |
 | TestPrecedence | 3 | Held beats all other tripwires; protected beats large diff; CI-red-7d beats supersede |
 | TestCliOutput | 8 | Human output; JSON output; bucket filter; missing --from-json file; invalid --from-json JSON; non-array root; no gh on PATH; deterministic output across runs |

--- a/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
+++ b/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
@@ -21,6 +21,17 @@ result with `admin_squash_allowed=true`, `not_ready=[]`,
 `unresolved_dissent=false`, a matching head SHA, and Tier 3/4 settlement
 or preapproval if applicable. Without that proof, the PR remains Bucket C.
 
+**2026-05-17T20:34Z repair patch:** The classifier now implements the
+#7283 review-only branch-protection exception: `mergeStateStatus=BLOCKED`
+can still qualify for Bucket A when `reviewDecision=REVIEW_REQUIRED` and
+the exact-head merge packet authorizes admin squash. It also adds explicit
+Bucket C tripwires for flag flips / operator-only labels, dependency
+manifests and explicit network/secret-read markers, and unresolved review
+comment metadata. The Stage 1 `list_active_agent_sessions.py` dogfood
+acceptance item remains intentionally **deferred** in this PR; hold and
+trusted-author detection are still local policy constants rather than live
+observer-derived state.
+
 ## CLI surface
 
 ```
@@ -43,7 +54,8 @@ options:
 
 Output of `python3 scripts/triage_open_prs.py` at 2026-05-17T18:11Z,
 after the operator tightened the policy doc to require `is_draft == False`
-+ `mergeStateStatus == CLEAN` for Bucket A:
++ either `mergeStateStatus == CLEAN` or the review-only/admin-squash
+exception for Bucket A:
 
 ```
 BUCKET A — recommend AUTO-MERGE
@@ -81,7 +93,8 @@ Mid-session, the operator tightened Bucket A criteria in
 
 - `mergeable: MERGEABLE` (existing)
 - **`PR is not draft`** (new — drafts always go to C with `READY?`)
-- **`mergeStateStatus == CLEAN`** (new — `BLOCKED` no longer qualifies)
+- **`mergeStateStatus == CLEAN`** or review-only `BLOCKED` with exact-head
+  admin-squash authorization
 - `aragora review-queue merge-packet` reports `admin_squash_allowed=true`,
   `not_ready=[]`, `unresolved_dissent=false` at the **exact** current
   head SHA
@@ -114,47 +127,51 @@ wins; first match returns):
 
 1. **C** if `pr_number ∈ HELD_PR_NUMBERS`
 2. **C** if any changed file is in `PROTECTED_PATHS`
-3. **C** if `additions + deletions > 1500`
-4. **B** if CI red AND `updated_at` ≥ 7 days ago
-5. **C** if CI red (recent)
-6. **C** if any check is `IN_PROGRESS` / `QUEUED`
-7. **B** if draft + `created_at ≥ 60d` + `updated_at ≥ 30d`
-8. **B** if a newer open PR has ≥80% file overlap AND the newer PR
+3. **C** if flag flip / operator-only label metadata is present
+4. **C** if dependency manifest, network-call, or secret-read metadata is present
+5. **C** if `additions + deletions > 1500`
+6. **B** if CI red AND `updated_at` ≥ 7 days ago
+7. **C** if CI red (recent)
+8. **C** if any check is `IN_PROGRESS` / `QUEUED`
+9. **B** if draft + `created_at ≥ 60d` + `updated_at ≥ 30d`
+10. **B** if a newer open PR has ≥80% file overlap AND the newer PR
    would itself qualify for Bucket A (i.e. `_would_qualify_for_bucket_a`
    returns True — same gates as Bucket A above except for the
    supersede check itself). This closes Codex's Gap #3 from the
    #7285 review: a draft / held / CI-pending / merge-packet-blocked /
    non-trusted / protected-file / large / dirty candidate cannot
    supersede an older PR.
-9. **C** if author ∉ `TRUSTED_AUTHORS`
-10. **C** if `is_draft` (reason: `draft`, action: `READY?`)
-11. **C** if `mergeable != MERGEABLE`
-12. **C** if `mergeStateStatus != CLEAN`
-13. **C** if there are code files but no test files
-14. **C** if `reviewDecision == CHANGES_REQUESTED`
-15. **C** if the exact-head merge packet does not authorize admin squash
+11. **C** if author ∉ `TRUSTED_AUTHORS`
+12. **C** if `is_draft` (reason: `draft`, action: `READY?`)
+13. **C** if `mergeable != MERGEABLE`
+14. **C** if `mergeStateStatus` is neither `CLEAN` nor review-only
+    `BLOCKED` with exact-head admin-squash authorization
+15. **C** if there are code files but no test files
+16. **C** if `reviewDecision == CHANGES_REQUESTED`
+17. **C** if unresolved review-comment metadata is present
+18. **C** if the exact-head merge packet does not authorize admin squash
     or reports `not_ready`, unresolved dissent, head drift, or missing
     Tier 3/4 settlement/preapproval
-16. **A** otherwise
+19. **A** otherwise
 
 Bucket D is reserved for future enhancement — strategic mismatch
 with canonical direction is not auto-classifiable from `gh` metadata
 alone.
 
-## Tests (57 new, all green)
+## Tests (66 new, all green)
 
 ```
 $ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
-.........................................................                [100%]
-57 passed in 1.45s
+..................................................................       [100%]
+66 passed in 2.63s
 ```
 
 | Group | Tests | Coverage |
 |---|---|---|
-| TestBucketA | 9 | Clean additive ready-to-merge → A; draft → C `READY?`; BLOCKED → C; missing merge-packet → C; not_ready → C; admin false → C; head mismatch → C; Tier 3 without settlement → C; Tier 3 with settlement → A |
-| TestBucketCTripwires | 14 | Held PR; protected file (CLAUDE.md, automation.toml, aragora/__init__.py); large diff; CI red recent; CI pending; CI cancelled/non-green; non-trusted author; not mergeable (CONFLICTING); merge state DIRTY; merge state BEHIND; code without tests; pure-docs-doesnt-trip-rule (negative); review CHANGES_REQUESTED |
+| TestBucketA | 10 | Clean additive ready-to-merge → A; draft → C `READY?`; BLOCKED without review-only context → C; review-only BLOCKED + admin packet → A; missing merge-packet → C; not_ready → C; admin false → C; head mismatch → C; Tier 3 without settlement → C; Tier 3 with settlement → A |
+| TestBucketCTripwires | 21 | Held PR; protected file (CLAUDE.md, automation.toml, aragora/__init__.py); flag flip; operator-only label; dependency manifest; explicit network call; explicit secret read; large diff; CI red recent; CI pending; CI cancelled/non-green; non-trusted author; not mergeable (CONFLICTING); merge state DIRTY; merge state BEHIND; code without tests; pure-docs-doesnt-trip-rule (negative); review CHANGES_REQUESTED; unresolved review count; unresolved review thread |
 | TestBucketB | 7 | CI red 7+ days; stale draft over threshold; stale but recent (negative); ready PR not marked stale (negative); supersede by newer clean PR; no supersede when overlap too low (negative); no supersede when newer has CI failure (negative) |
-| **TestSupersedeRequiresBucketAEligibility** | **11** | **(NEW — closes Codex Gap #3)** Draft superseder rejected; held superseder rejected; CI-pending superseder rejected; missing-merge-packet superseder rejected; non-trusted superseder rejected; protected-file-edit superseder rejected; large-diff superseder rejected; DIRTY superseder rejected; BLOCKED superseder rejected; CHANGES_REQUESTED superseder rejected; fully-eligible superseder still fires (regression check) |
+| **TestSupersedeRequiresBucketAEligibility** | **12** | **(NEW — closes Codex Gap #3)** Draft superseder rejected; held superseder rejected; CI-pending superseder rejected; missing-merge-packet superseder rejected; non-trusted superseder rejected; protected-file-edit superseder rejected; large-diff superseder rejected; DIRTY superseder rejected; BLOCKED superseder rejected unless review-only/admin-authorized; CHANGES_REQUESTED superseder rejected; fully-eligible superseder still fires (regression check) |
 | TestPrecedence | 3 | Held beats all other tripwires; protected beats large diff; CI-red-7d beats supersede |
 | TestCliOutput | 8 | Human output; JSON output; bucket filter; missing --from-json file; invalid --from-json JSON; non-array root; no gh on PATH; deterministic output across runs |
 | TestEdgeCases | 4 | Empty PR list; PR with zero files; PR with empty author dict; reason capped at 200 chars |
@@ -163,7 +180,7 @@ $ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
 
 ```
 $ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
-57 passed in 1.45s
+66 passed in 2.63s
 $ ruff check scripts/triage_open_prs.py tests/scripts/test_triage_open_prs.py
 All checks passed!
 $ ruff format --check scripts/triage_open_prs.py tests/scripts/test_triage_open_prs.py
@@ -179,7 +196,7 @@ preflight: ok
 | Stage | Status |
 |---|---|
 | Stage 0 — policy doc + rollout doc | shipped as PR #7283 |
-| **Stage 1 — this PR (triage_open_prs.py)** | **shipped (this receipt)** |
+| **Stage 1 — this PR (triage_open_prs.py)** | **implemented; active-session dogfood acceptance item deferred** |
 | Stage 2 — auto_merge_bucket_a.py | tracked as #7281, depends on this |
 | Stage 3 — triage_bucket_c.py | tracked as #7282, depends on this |
 | Stage 4 — scheduling (LaunchAgent template) | not yet filed |
@@ -196,6 +213,8 @@ single source of bucket truth going forward.
 - Held PRs (`#7173, #7215, #7240, #7243, #7245, #7249, #7252,
   #4990`) hard-coded in `HELD_PR_NUMBERS`; the classifier puts every
   one of them in Bucket C with reason "held" — never recommends A or B.
+  Dynamic hold/authorship derivation from `scripts/list_active_agent_sessions.py`
+  is deferred rather than claimed complete in this PR.
 - No `automation.toml` edit, no launchd install.
 - No protected-file edits (`CLAUDE.md`, `aragora/__init__.py`, `.env`,
   `.envrc`, `scripts/nomic_loop.py`, `docs/AGENT_OPERATING_CONTRACT.md`,

--- a/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
+++ b/docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md
@@ -32,20 +32,15 @@ options:
   --from-json FROM_JSON Read PR data from JSON file (for tests / offline).
 ```
 
-## Worked example — live run against current queue
+## Worked example — live run against current queue (tightened policy)
 
-Output of `python3 scripts/triage_open_prs.py` at 2026-05-17T18:06Z:
+Output of `python3 scripts/triage_open_prs.py` at 2026-05-17T18:11Z,
+after the operator tightened the policy doc to require `is_draft == False`
++ `mergeStateStatus == CLEAN` for Bucket A:
 
 ```
 BUCKET A — recommend AUTO-MERGE
-  #7251 — MERGE — green CI (17/67), 353 LOC, 3 files, tests present, author=an0mium
-  #7259 — MERGE — green CI (17/66), 234 LOC, 2 files, tests present, author=an0mium
-  #7262 — MERGE — green CI (16/68), 373 LOC, 2 files, tests present, author=an0mium
-  #7263 — MERGE — green CI (14/34), 778 LOC, 2 files, tests present, author=an0mium
-  #7276 — MERGE — green CI (16/68), 290 LOC, 2 files, tests present, author=an0mium
-  #7278 — MERGE — green CI (5/8), 792 LOC, 5 files, tests present, author=an0mium
-  #7279 — MERGE — green CI (17/67), 1185 LOC, 3 files, tests present, author=an0mium
-  #7283 — MERGE — green CI (14/34), 372 LOC, 2 files, tests present, author=an0mium
+  (none)
 
 BUCKET B — recommend AUTO-CLOSE
   (none)
@@ -54,34 +49,57 @@ BUCKET C — needs operator y/n
   #7173 — STAY HELD — held (#7173 is on the policy hold list)
   #7215 — STAY HELD — held (#7215 is on the policy hold list)
   #7245 — STAY HELD — held (#7245 is on the policy hold list)
+  #7251 — READY? — draft (policy requires non-draft for Bucket A; 17/67 CI green)
   #7252 — STAY HELD — held (#7252 is on the policy hold list)
+  #7259 — READY? — draft (policy requires non-draft for Bucket A; 17/66 CI green)
+  #7262 — READY? — draft (policy requires non-draft for Bucket A; 16/68 CI green)
+  #7263 — READY? — draft (policy requires non-draft for Bucket A; 14/34 CI green)
   #7268 — DECIDE — large diff (1542 LOC > 1500)
+  #7276 — READY? — draft (policy requires non-draft for Bucket A; 16/68 CI green)
+  #7278 — READY? — draft (policy requires non-draft for Bucket A; 5/8 CI green)
+  #7279 — READY? — draft (policy requires non-draft for Bucket A; 17/67 CI green)
+  #7283 — READY? — draft (policy requires non-draft for Bucket A; 14/34 CI green)
+  #7284 — READY? — draft (policy requires non-draft for Bucket A; 17/66 CI green)
 
 BUCKET D — strategic check-in
   (none)
 
-summary: A: 8  B: 0  C: 5  D: 0    total: 13
+summary: A: 0  B: 0  C: 14  D: 0    total: 14
 ```
 
-### Sanity-check vs. earlier manual triage
+### Why Bucket A is empty: the policy tightening
 
-The same triage was produced manually earlier this session. The
-mechanical classifier diverged from the manual triage in one place —
-and the classifier was right:
+Mid-session, the operator tightened Bucket A criteria in
+`docs/governance/OPERATOR_DELEGATION_POLICY.md` (PR #7283) to require:
 
-- I called **#7251 "held"** based on memory; the canonical hold list
-  in the policy doc is `{4990, 7173, 7215, 7240, 7243, 7245, 7249,
-  7252}` — `#7251 is NOT on it`. The classifier correctly put it in A.
-- The classifier also caught #7283 (the policy PR opened earlier this
-  session) and #7268 (Codex's settlement UI — flagged C for large
-  diff at 1542 LOC, just above the 1500 cap).
-- `#7261` was open during the earlier manual triage but landed
-  between then and now — the classifier reflects live state.
+- `mergeable: MERGEABLE` (existing)
+- **`PR is not draft`** (new — drafts always go to C with `READY?`)
+- **`mergeStateStatus == CLEAN`** (new — `BLOCKED` no longer qualifies)
+- `aragora review-queue merge-packet` reports `admin_squash_allowed=true`,
+  `not_ready=[]`, `unresolved_dissent=false` at the **exact** current
+  head SHA (deferred to Stage 2 — see classifier docstring)
+- Tier 3 / Tier 4 PRs need explicit risk-settlement at exact head SHA
+  (deferred to Stage 2)
+- Existing: green CI, additive, tests, ≤1500 LOC, trusted author,
+  no held PRs, no protected files
 
-This is exactly the operator-delegation premise: the mechanical
-classifier reproduces the manual judgment more accurately, faster,
-and without the operator (or a frontier-model agent) having to hold
-the hold list in working memory.
+The current open queue is 14 PRs deep with ZERO not-draft + CLEAN
+items — so the classifier honestly reports Bucket A is empty. The
+operator's path forward is one of:
+
+1. Mark some drafts ready (the `READY?` recommendation calls this out),
+   which moves them to A on the next pass
+2. Run Stage 2 (#7281, `auto_merge_bucket_a.py`) once it ships — it
+   will do the deep merge-packet + tier checks before merging
+
+### The classifier corrected my manual triage earlier this session
+
+Earlier I produced a triage manually and called **#7251 "held"** from
+memory. The classifier read the canonical hold list
+(`HELD_PR_NUMBERS = {4990, 7173, 7215, 7240, 7243, 7245, 7249, 7252}`)
+and correctly put #7251 in C with reason `draft` — not `held`. This is
+exactly the operator-delegation premise: mechanical classification
+beats manual memory.
 
 ## Bucket precedence
 
@@ -97,27 +115,29 @@ wins; first match returns):
 7. **B** if draft + `created_at ≥ 60d` + `updated_at ≥ 30d`
 8. **B** if a newer open PR has ≥80% file overlap + zero CI failures
 9. **C** if author ∉ `TRUSTED_AUTHORS`
-10. **C** if `mergeable != MERGEABLE`
-11. **C** if `mergeStateStatus ∉ {CLEAN, BLOCKED}`
-12. **C** if there are code files but no test files
-13. **C** if `reviewDecision == CHANGES_REQUESTED`
-14. **A** otherwise
+10. **C** if `is_draft` (reason: `draft`, action: `READY?`)
+11. **C** if `mergeable != MERGEABLE`
+12. **C** if `mergeStateStatus != CLEAN`
+13. **C** if there are code files but no test files
+14. **C** if `reviewDecision == CHANGES_REQUESTED`
+15. **A** otherwise (still subject to Stage 2's deep merge-packet +
+    tier checks before any actual merge)
 
 Bucket D is reserved for future enhancement — strategic mismatch
 with canonical direction is not auto-classifiable from `gh` metadata
 alone.
 
-## Tests (38 new, all green)
+## Tests (39 new, all green)
 
 ```
 $ python3 -m pytest tests/scripts/test_triage_open_prs.py -q
-......................................                                   [100%]
-38 passed in 1.26s
+.......................................                                  [100%]
+39 passed in 1.04s
 ```
 
 | Group | Tests | Coverage |
 |---|---|---|
-| TestBucketA | 2 | Clean additive (CLEAN); clean additive on draft (BLOCKED) |
+| TestBucketA | 3 | Clean additive ready-to-merge → A; draft → C `READY?`; BLOCKED → C |
 | TestBucketCTripwires | 13 | Held PR; protected file (CLAUDE.md, automation.toml, aragora/__init__.py); large diff; CI red recent; CI pending; non-trusted author; not mergeable (CONFLICTING); merge state DIRTY; merge state BEHIND; code without tests; pure-docs-doesnt-trip-rule (negative); review CHANGES_REQUESTED |
 | TestBucketB | 7 | CI red 7+ days; stale draft over threshold; stale but recent (negative); ready PR not marked stale (negative); supersede by newer clean PR; no supersede when overlap too low (negative); no supersede when newer has CI failure (negative) |
 | TestPrecedence | 3 | Held beats all other tripwires; protected beats large diff; CI-red-7d beats supersede |

--- a/scripts/triage_open_prs.py
+++ b/scripts/triage_open_prs.py
@@ -7,14 +7,15 @@ of the rollout per ``docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md``).
 For every open PR on the current repo, classifies it into exactly one
 of four buckets:
 
-  A — recommend auto-merge (NOT DRAFT + CLEAN merge state + green CI +
-      mergeable + tests + no held/protected touch + ≤1500 LOC +
+  A — recommend auto-merge (NOT DRAFT + CLEAN/review-only merge state +
+      green CI + mergeable + tests + no held/protected touch + ≤1500 LOC +
       trusted author)
   B — recommend auto-close (superseded by newer / >60d stale +
       inactive / CI red >7d)
   C — needs operator y/n (touches held / protected / large diff /
       CI red / CI pending / non-trusted author / unresolved review /
-      no tests with code changes / merge-state not clean / draft)
+      no tests with code changes / merge-state not clean or authorized /
+      flag/label/external-dependency tripwire / draft)
   D — strategic check-in (PR works but plausibly conflicts with
       canonical direction; not auto-classifiable from gh metadata
       alone — reserved for future enhancement)
@@ -80,6 +81,34 @@ PROTECTED_PATHS: frozenset[str] = frozenset(
 # a new entry is itself an operator-only tripwire (the policy doc names
 # this explicitly).
 TRUSTED_AUTHORS: frozenset[str] = frozenset({"an0mium"})
+
+# Labels that cannot be added by a Bucket-A PR without an operator look.
+OPERATOR_ONLY_LABELS: frozenset[str] = frozenset({"boss-ready", "autonomous"})
+
+# Dependency / integration manifest edits are a conservative proxy for the
+# policy's "new external dependency / network call / secret read" tripwire.
+EXTERNAL_DEPENDENCY_PATHS: frozenset[str] = frozenset(
+    {
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "bun.lockb",
+        "pyproject.toml",
+        "poetry.lock",
+        "uv.lock",
+        "requirements.txt",
+        "requirements-dev.txt",
+        "Pipfile",
+        "Pipfile.lock",
+        "Cargo.toml",
+        "Cargo.lock",
+        "go.mod",
+        "go.sum",
+        "Gemfile",
+        "Gemfile.lock",
+    }
+)
 
 # Bucket A diff-size cap. PRs above this go to Bucket C regardless of
 # other criteria — large diffs trip more invariants than the
@@ -190,6 +219,120 @@ def _file_paths(pr: dict[str, Any]) -> list[str]:
     return [str(f.get("path", "")) for f in files if isinstance(f, dict) and f.get("path")]
 
 
+def _labels(pr: dict[str, Any]) -> set[str]:
+    raw = pr.get("labels") or []
+    out: set[str] = set()
+    if not isinstance(raw, list):
+        return out
+    for item in raw:
+        if isinstance(item, dict):
+            name = str(item.get("name") or "")
+        else:
+            name = str(item)
+        if name:
+            out.add(name)
+    return out
+
+
+def _truthy_policy_field(pr: dict[str, Any], *names: str) -> bool:
+    for name in names:
+        if bool(pr.get(name)):
+            return True
+    tripwires = pr.get("policyTripwires") or pr.get("policy_tripwires") or []
+    if not isinstance(tripwires, list):
+        return False
+    normalized = {str(item).strip().lower().replace("-", "_") for item in tripwires}
+    return any(name.strip().lower().replace("-", "_") in normalized for name in names)
+
+
+def _flag_or_label_tripwire(pr: dict[str, Any]) -> str | None:
+    if _truthy_policy_field(
+        pr,
+        "flagFlip",
+        "flag_flip",
+        "hasFlagFlip",
+        "addsAutonomousLabel",
+        "label_add",
+        "boss_ready",
+        "autonomous_label",
+    ):
+        return "flag flip / operator-only label tripwire"
+
+    blocked = sorted(label for label in _labels(pr) if label in OPERATOR_ONLY_LABELS)
+    if blocked:
+        return f"operator-only label present ({blocked[0]})"
+    return None
+
+
+def _external_dependency_tripwire(pr: dict[str, Any], file_paths: list[str]) -> str | None:
+    if _truthy_policy_field(
+        pr,
+        "externalDependency",
+        "external_dependency",
+        "networkCall",
+        "network_call",
+        "secretRead",
+        "secret_read",
+        "new_external_dependency",
+    ):
+        return "external dependency / network / secret-read tripwire"
+
+    for path in file_paths:
+        name = Path(path).name
+        if path in EXTERNAL_DEPENDENCY_PATHS or name in EXTERNAL_DEPENDENCY_PATHS:
+            return f"external dependency manifest touched ({path})"
+        parts = set(Path(path).parts)
+        if "secrets" in parts or "credentials" in parts:
+            return f"secret/credential path touched ({path})"
+    return None
+
+
+def _unresolved_review_tripwire(pr: dict[str, Any]) -> str | None:
+    count = pr.get("unresolvedReviewComments") or pr.get("unresolved_review_comments")
+    if isinstance(count, int) and count > 0:
+        return f"unresolved review comments ({count})"
+    if bool(count):
+        return "unresolved review comments"
+    if _truthy_policy_field(pr, "unresolvedReview", "unresolved_review"):
+        return "unresolved review comments"
+
+    threads = pr.get("reviewThreads") or pr.get("review_threads") or []
+    if isinstance(threads, list):
+        unresolved = [t for t in threads if isinstance(t, dict) and t.get("isResolved") is False]
+        if unresolved:
+            return f"unresolved review comments ({len(unresolved)})"
+    return None
+
+
+def _merge_state_bucket_a_blocker(
+    pr: dict[str, Any],
+    *,
+    merge_packet_provider: MergePacketProvider | None,
+) -> str | None:
+    """Return None if the merge-state gate allows Bucket A.
+
+    #7283 permits either CLEAN or the common branch-protection state where
+    GitHub reports BLOCKED only because review is required while Aragora's
+    exact-head merge packet says admin squash is otherwise allowed.
+    """
+
+    mss = str(pr.get("mergeStateStatus") or "")
+    if mss == "CLEAN":
+        return None
+    review = str(pr.get("reviewDecision") or "")
+    if mss == "BLOCKED" and review == "REVIEW_REQUIRED":
+        packet_blocker = _merge_packet_bucket_a_blocker(
+            pr, merge_packet_provider=merge_packet_provider
+        )
+        if packet_blocker is None:
+            return None
+        return (
+            "merge state status: BLOCKED but review-only/admin-squash "
+            f"exception not authorized ({packet_blocker})"
+        )
+    return f"merge state status: {mss or '(unknown)'} (policy requires CLEAN or review-only admin-squash authorization)"
+
+
 def _would_qualify_for_bucket_a(
     pr: dict[str, Any],
     *,
@@ -219,6 +362,10 @@ def _would_qualify_for_bucket_a(
     file_paths = _file_paths(pr)
     if any(_is_protected(p) for p in file_paths):
         return False
+    if _flag_or_label_tripwire(pr) is not None:
+        return False
+    if _external_dependency_tripwire(pr, file_paths) is not None:
+        return False
     additions = int(pr.get("additions") or 0)
     deletions = int(pr.get("deletions") or 0)
     if additions + deletions > LARGE_DIFF_LOC:
@@ -243,13 +390,15 @@ def _would_qualify_for_bucket_a(
         return False
     if str(pr.get("mergeable") or "") != "MERGEABLE":
         return False
-    if str(pr.get("mergeStateStatus") or "") != "CLEAN":
+    if _merge_state_bucket_a_blocker(pr, merge_packet_provider=merge_packet_provider) is not None:
         return False
     has_tests = any(_is_test_file(p) for p in file_paths)
     has_code = any(_is_code_file(p) for p in file_paths)
     if has_code and not has_tests:
         return False
     if str(pr.get("reviewDecision") or "") == "CHANGES_REQUESTED":
+        return False
+    if _unresolved_review_tripwire(pr) is not None:
         return False
     if _merge_packet_bucket_a_blocker(pr, merge_packet_provider=merge_packet_provider) is not None:
         return False
@@ -410,8 +559,9 @@ def classify(
     C (large) → B (CI red 7d+) → C (CI red recent) → C (CI pending) →
     C (CI non-green) → B (stale draft) → B (superseded by a Bucket-A
     -eligible newer PR) → C (non-trusted) → C (draft) → C (not
-    mergeable) → C (merge-state not CLEAN) → C (code without tests) →
-    C (CHANGES_REQUESTED) → C (merge-packet blocker) → A.
+    mergeable) → C (merge-state not CLEAN/authorized) → C (code
+    without tests) → C (CHANGES_REQUESTED / unresolved review) →
+    C (merge-packet blocker) → A.
 
     Bucket D is never auto-emitted by this classifier — it's reserved
     for explicit operator/agent escalation in a future stage.
@@ -429,7 +579,6 @@ def classify(
     deletions = int(pr.get("deletions") or 0)
     net_loc = additions + deletions
     mergeable = str(pr.get("mergeable") or "")
-    mss = str(pr.get("mergeStateStatus") or "")
     is_draft = bool(pr.get("isDraft"))
     checks = pr.get("statusCheckRollup") or []
     ci_success = sum(1 for c in checks if isinstance(c, dict) and c.get("conclusion") == "SUCCESS")
@@ -463,6 +612,16 @@ def classify(
             f"edits protected file ({protected_hit[0]})",
             "DECIDE",
         )
+
+    # --- Bucket C: operator-only flag/label tripwire ---
+    flag_tripwire = _flag_or_label_tripwire(pr)
+    if flag_tripwire is not None:
+        return _result(n, title, BUCKET_C, flag_tripwire, "DECIDE")
+
+    # --- Bucket C: external dependency / network / secret-read tripwire ---
+    external_tripwire = _external_dependency_tripwire(pr, file_paths)
+    if external_tripwire is not None:
+        return _result(n, title, BUCKET_C, external_tripwire, "DECIDE")
 
     # --- Bucket C: large diff ---
     if net_loc > LARGE_DIFF_LOC:
@@ -579,15 +738,16 @@ def classify(
             "DECIDE",
         )
 
-    # --- Bucket C: merge-state status not CLEAN ---
-    # CLEAN = ready to merge. Anything else (BLOCKED, DIRTY, BEHIND,
-    # UNSTABLE, UNKNOWN) needs a human look per the tightened policy.
-    if mss != "CLEAN":
+    # --- Bucket C: merge-state status not CLEAN/authorized ---
+    merge_state_blocker = _merge_state_bucket_a_blocker(
+        pr, merge_packet_provider=merge_packet_provider
+    )
+    if merge_state_blocker is not None:
         return _result(
             n,
             title,
             BUCKET_C,
-            f"merge state status: {mss or '(unknown)'} (policy requires CLEAN)",
+            merge_state_blocker,
             "DECIDE",
         )
 
@@ -612,6 +772,11 @@ def classify(
             "review decision: CHANGES_REQUESTED",
             "DECIDE",
         )
+
+    # --- Bucket C: unresolved review comments from another agent ---
+    unresolved_review = _unresolved_review_tripwire(pr)
+    if unresolved_review is not None:
+        return _result(n, title, BUCKET_C, unresolved_review, "DECIDE")
 
     # --- Bucket C: merge-packet does not authorize exact-head Bucket A ---
     merge_packet_blocker = _merge_packet_bucket_a_blocker(

--- a/scripts/triage_open_prs.py
+++ b/scripts/triage_open_prs.py
@@ -29,6 +29,13 @@ are demoted to Bucket C unless ``aragora review-queue merge-packet
 PRs remain Bucket C unless that merge packet proves the required human
 risk settlement / preapproval has already been recorded.
 
+Bucket B supersede is similarly exact-head gated: a candidate
+superseder is only accepted if it would itself qualify for Bucket A
+(``_would_qualify_for_bucket_a``). This implements the policy's
+"newer PR is in Bucket A or already merged" requirement — a draft /
+held / CI-red / large / non-trusted / merge-packet-blocked candidate
+cannot supersede an older PR even if file overlap is high.
+
 Pure stdlib (argparse, dataclasses, datetime, json, shutil,
 subprocess, sys, pathlib, typing). No ``aragora.*`` imports. No
 third-party dependencies.
@@ -183,13 +190,98 @@ def _file_paths(pr: dict[str, Any]) -> list[str]:
     return [str(f.get("path", "")) for f in files if isinstance(f, dict) and f.get("path")]
 
 
-def _find_superseder(pr: dict[str, Any], all_open: list[dict[str, Any]]) -> int | None:
+def _would_qualify_for_bucket_a(
+    pr: dict[str, Any],
+    *,
+    now: datetime.datetime,
+    merge_packet_provider: MergePacketProvider | None,
+) -> bool:
+    """Return True iff ``pr`` would land in Bucket A on its own merits.
+
+    Mirrors the gates ``classify()`` applies, *minus* the supersede
+    check itself (to avoid mutual recursion between supersede candidates
+    that overlap heavily). The supersede precedence rule already
+    requires the superseder to be NEWER (higher PR number), so this
+    predicate is only consulted on the newer side — no infinite
+    descent is possible.
+
+    Used by ``_find_superseder`` to enforce the policy requirement
+    that "the newer PR is in Bucket A or already merged" (we can't
+    see merged PRs from the open list, so we treat Bucket-A-eligible
+    open PRs as the safe proxy).
+    """
+
+    n = int(pr.get("number") or 0)
+    if n <= 0:
+        return False
+    if n in HELD_PR_NUMBERS:
+        return False
+    file_paths = _file_paths(pr)
+    if any(_is_protected(p) for p in file_paths):
+        return False
+    additions = int(pr.get("additions") or 0)
+    deletions = int(pr.get("deletions") or 0)
+    if additions + deletions > LARGE_DIFF_LOC:
+        return False
+    checks = pr.get("statusCheckRollup") or []
+    if any(isinstance(c, dict) and c.get("conclusion") == "FAILURE" for c in checks):
+        return False
+    if any(isinstance(c, dict) and c.get("status") in ("IN_PROGRESS", "QUEUED") for c in checks):
+        return False
+    if any(
+        isinstance(c, dict)
+        and c.get("status") == "COMPLETED"
+        and c.get("conclusion") not in ("SUCCESS", "SKIPPED", "NEUTRAL")
+        for c in checks
+    ):
+        return False
+    author_raw = pr.get("author") or {}
+    author = author_raw.get("login", "") if isinstance(author_raw, dict) else str(author_raw)
+    if author not in TRUSTED_AUTHORS:
+        return False
+    if bool(pr.get("isDraft")):
+        return False
+    if str(pr.get("mergeable") or "") != "MERGEABLE":
+        return False
+    if str(pr.get("mergeStateStatus") or "") != "CLEAN":
+        return False
+    has_tests = any(_is_test_file(p) for p in file_paths)
+    has_code = any(_is_code_file(p) for p in file_paths)
+    if has_code and not has_tests:
+        return False
+    if str(pr.get("reviewDecision") or "") == "CHANGES_REQUESTED":
+        return False
+    if _merge_packet_bucket_a_blocker(pr, merge_packet_provider=merge_packet_provider) is not None:
+        return False
+    # The ``now`` parameter is accepted for API symmetry with classify(),
+    # but the Bucket-A gates above do not depend on age (those are only
+    # used by the Bucket B stale-draft path, which is not a Bucket A
+    # criterion).
+    del now
+    return True
+
+
+def _find_superseder(
+    pr: dict[str, Any],
+    all_open: list[dict[str, Any]],
+    *,
+    now: datetime.datetime,
+    merge_packet_provider: MergePacketProvider | None,
+) -> int | None:
     """Return the PR number of a newer open PR that supersedes ``pr``.
 
-    Supersede = file-overlap ≥ ``SUPERSEDE_OVERLAP_THRESHOLD`` AND newer
-    (higher PR number) AND zero CI failures on the newer PR. (We can't
-    see merged PRs from the open list, so we use "newer + clean" as a
-    proxy for "in Bucket A or about to merge.")
+    Supersede requires ALL of:
+      - newer (higher PR number)
+      - file-overlap ≥ ``SUPERSEDE_OVERLAP_THRESHOLD``
+      - the newer PR would itself qualify for Bucket A
+        (per ``_would_qualify_for_bucket_a``)
+
+    The Bucket-A-eligibility gate is the policy's "newer PR is in
+    Bucket A or already merged" requirement: a draft / held / CI-red /
+    CI-pending / large / non-trusted / merge-packet-blocked candidate
+    cannot supersede an older PR. (We cannot see merged PRs from the
+    open list, so we treat Bucket-A-eligible open PRs as the safe
+    proxy for "or already merged.")
     """
 
     pr_n = int(pr.get("number", 0))
@@ -209,12 +301,9 @@ def _find_superseder(pr: dict[str, Any], all_open: list[dict[str, Any]]) -> int 
         overlap_ratio = overlap_count / len(pr_files)
         if overlap_ratio < SUPERSEDE_OVERLAP_THRESHOLD:
             continue
-        other_failures = sum(
-            1
-            for c in (other.get("statusCheckRollup") or [])
-            if isinstance(c, dict) and c.get("conclusion") == "FAILURE"
-        )
-        if other_failures > 0:
+        if not _would_qualify_for_bucket_a(
+            other, now=now, merge_packet_provider=merge_packet_provider
+        ):
             continue
         return other_n
     return None
@@ -319,9 +408,10 @@ def classify(
 
     Bucket precedence (most-restrictive wins): C (held) → C (protected) →
     C (large) → B (CI red 7d+) → C (CI red recent) → C (CI pending) →
-    B (stale draft) → B (superseded) → C (non-trusted) → C (draft) →
-    C (not mergeable) → C (merge-state not CLEAN) → C (code without
-    tests) → C (CHANGES_REQUESTED) → A (default if all gates pass).
+    C (CI non-green) → B (stale draft) → B (superseded by a Bucket-A
+    -eligible newer PR) → C (non-trusted) → C (draft) → C (not
+    mergeable) → C (merge-state not CLEAN) → C (code without tests) →
+    C (CHANGES_REQUESTED) → C (merge-packet blocker) → A.
 
     Bucket D is never auto-emitted by this classifier — it's reserved
     for explicit operator/agent escalation in a future stage.
@@ -435,8 +525,13 @@ def classify(
             "CLOSE",
         )
 
-    # --- Bucket B: superseded by newer green PR ---
-    superseder = _find_superseder(pr, all_open)
+    # --- Bucket B: superseded by newer Bucket-A-eligible PR ---
+    superseder = _find_superseder(
+        pr,
+        all_open,
+        now=now,
+        merge_packet_provider=merge_packet_provider,
+    )
     if superseder is not None:
         return _result(
             n,
@@ -445,7 +540,7 @@ def classify(
             (
                 f"superseded by #{superseder} "
                 f"(≥{int(SUPERSEDE_OVERLAP_THRESHOLD * 100)}% file overlap, "
-                f"newer + zero CI failures)"
+                f"newer + Bucket-A-eligible)"
             ),
             "CLOSE",
         )

--- a/scripts/triage_open_prs.py
+++ b/scripts/triage_open_prs.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""Read-only four-bucket PR triage classifier.
+
+Implements ``docs/governance/OPERATOR_DELEGATION_POLICY.md`` (Stage 1
+of the rollout per ``docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md``).
+
+For every open PR on the current repo, classifies it into exactly one
+of four buckets:
+
+  A — recommend auto-merge (additive + green CI + mergeable + tests +
+      no held/protected touch + ≤1500 LOC + trusted author)
+  B — recommend auto-close (superseded by newer / >60d stale +
+      inactive / CI red >7d)
+  C — needs operator y/n (touches held / protected / large diff /
+      CI red / CI pending / non-trusted author / unresolved review /
+      no tests with code changes / merge-state not clean)
+  D — strategic check-in (PR works but plausibly conflicts with
+      canonical direction; not auto-classifiable from gh metadata
+      alone — reserved for future enhancement)
+
+The classifier is read-only by design: it NEVER mutates GitHub state.
+The downstream Stage 2 (``scripts/auto_merge_bucket_a.py``) is what
+acts on Bucket A; this script only emits the recommendation table.
+
+Pure stdlib (argparse, dataclasses, datetime, json, shutil,
+subprocess, sys, pathlib, typing). No ``aragora.*`` imports. No
+third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime
+import json
+import shutil
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Policy constants — keep in sync with docs/governance/OPERATOR_DELEGATION_POLICY.md
+# ---------------------------------------------------------------------------
+
+# Held PRs (from the policy's canonical hold list). Whoever updates the
+# policy doc's hold list MUST update both this set and the equivalent in
+# ``scripts/apply_operator_decisions.py``.
+HELD_PR_NUMBERS: frozenset[int] = frozenset({4990, 7173, 7215, 7240, 7243, 7245, 7249, 7252})
+
+# Protected file paths — from the policy's irreducible tripwire list.
+PROTECTED_PATHS: frozenset[str] = frozenset(
+    {
+        "CLAUDE.md",
+        "aragora/__init__.py",
+        ".env",
+        ".envrc",
+        "scripts/nomic_loop.py",
+        "docs/AGENT_OPERATING_CONTRACT.md",
+        "automation.toml",
+    }
+)
+
+# Trusted authors — Bucket A is gated on author membership here. Adding
+# a new entry is itself an operator-only tripwire (the policy doc names
+# this explicitly).
+TRUSTED_AUTHORS: frozenset[str] = frozenset({"an0mium"})
+
+# Bucket A diff-size cap. PRs above this go to Bucket C regardless of
+# other criteria — large diffs trip more invariants than the
+# metadata-only classifier can verify.
+LARGE_DIFF_LOC = 1500
+
+# Auto-close thresholds (days). Both must hold for the stale-draft
+# Bucket B path.
+STALE_AGE_DAYS = 60
+STALE_INACTIVITY_DAYS = 30
+
+# CI-red threshold (days) for the auto-close path.
+CI_RED_THRESHOLD_DAYS = 7
+
+# File-overlap threshold for the supersede path. The policy doc names 0.8.
+SUPERSEDE_OVERLAP_THRESHOLD = 0.80
+
+BUCKET_A = "A"
+BUCKET_B = "B"
+BUCKET_C = "C"
+BUCKET_D = "D"  # currently never auto-emitted; reserved (see module docstring)
+
+_BUCKET_LABELS: dict[str, str] = {
+    BUCKET_A: "BUCKET A — recommend AUTO-MERGE",
+    BUCKET_B: "BUCKET B — recommend AUTO-CLOSE",
+    BUCKET_C: "BUCKET C — needs operator y/n",
+    BUCKET_D: "BUCKET D — strategic check-in",
+}
+
+
+# ---------------------------------------------------------------------------
+# Result + classification
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ClassificationResult:
+    """One PR's classification. Bucket + ≤120-char justification + the
+    recommended human action (MERGE / CLOSE / DEFER / DECIDE / STAY HELD).
+    """
+
+    pr_number: int
+    bucket: str
+    reason: str
+    title: str
+    recommended_action: str
+
+
+def _result(
+    pr_number: int,
+    title: str,
+    bucket: str,
+    reason: str,
+    recommended_action: str,
+) -> ClassificationResult:
+    return ClassificationResult(
+        pr_number=pr_number,
+        bucket=bucket,
+        reason=reason[:200],  # cap reason length defensively
+        title=title[:80],
+        recommended_action=recommended_action,
+    )
+
+
+def _is_protected(path: str) -> bool:
+    return path in PROTECTED_PATHS
+
+
+def _is_test_file(path: str) -> bool:
+    if path.startswith("tests/"):
+        return True
+    if "/__tests__/" in path:
+        return True
+    if path.endswith((".test.tsx", ".test.ts", ".test.jsx", ".test.js")):
+        return True
+    if path.endswith("_test.py"):
+        return True
+    return False
+
+
+def _is_code_file(path: str) -> bool:
+    if _is_test_file(path):
+        return False
+    if path.endswith((".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs")):
+        return True
+    return False
+
+
+def _parse_age_days(iso: str, now: datetime.datetime) -> int:
+    """Days between ``iso`` and ``now``; 0 on parse failure or empty."""
+
+    if not iso:
+        return 0
+    try:
+        dt = datetime.datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return 0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return max(0, (now - dt).days)
+
+
+def _file_paths(pr: dict[str, Any]) -> list[str]:
+    files = pr.get("files") or []
+    return [str(f.get("path", "")) for f in files if isinstance(f, dict) and f.get("path")]
+
+
+def _find_superseder(pr: dict[str, Any], all_open: list[dict[str, Any]]) -> int | None:
+    """Return the PR number of a newer open PR that supersedes ``pr``.
+
+    Supersede = file-overlap ≥ ``SUPERSEDE_OVERLAP_THRESHOLD`` AND newer
+    (higher PR number) AND zero CI failures on the newer PR. (We can't
+    see merged PRs from the open list, so we use "newer + clean" as a
+    proxy for "in Bucket A or about to merge.")
+    """
+
+    pr_n = int(pr.get("number", 0))
+    if pr_n <= 0:
+        return None
+    pr_files = set(_file_paths(pr))
+    if not pr_files:
+        return None
+    for other in all_open:
+        other_n = int(other.get("number", 0) or 0)
+        if other_n <= pr_n:
+            continue
+        other_files = set(_file_paths(other))
+        if not other_files:
+            continue
+        overlap_count = len(pr_files & other_files)
+        overlap_ratio = overlap_count / len(pr_files)
+        if overlap_ratio < SUPERSEDE_OVERLAP_THRESHOLD:
+            continue
+        other_failures = sum(
+            1
+            for c in (other.get("statusCheckRollup") or [])
+            if isinstance(c, dict) and c.get("conclusion") == "FAILURE"
+        )
+        if other_failures > 0:
+            continue
+        return other_n
+    return None
+
+
+def classify(
+    pr: dict[str, Any],
+    all_open: list[dict[str, Any]],
+    *,
+    now: datetime.datetime | None = None,
+) -> ClassificationResult:
+    """Run the four-bucket classification on one PR.
+
+    Bucket precedence (most-restrictive wins): C (held) → C (protected) →
+    C (large) → B (CI red 7d+) → C (CI red recent) → C (CI pending) →
+    B (stale draft) → B (superseded) → C (non-trusted) → C (not
+    mergeable) → C (merge-state DIRTY/BEHIND/etc) → C (code without
+    tests) → C (CHANGES_REQUESTED) → A (default if all gates pass).
+
+    Bucket D is never auto-emitted by this classifier — it's reserved
+    for explicit operator/agent escalation in a future stage.
+    """
+
+    if now is None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+    n = int(pr.get("number") or 0)
+    title = str(pr.get("title") or "")
+    author_raw = pr.get("author") or {}
+    author = author_raw.get("login", "") if isinstance(author_raw, dict) else str(author_raw)
+    file_paths = _file_paths(pr)
+    additions = int(pr.get("additions") or 0)
+    deletions = int(pr.get("deletions") or 0)
+    net_loc = additions + deletions
+    mergeable = str(pr.get("mergeable") or "")
+    mss = str(pr.get("mergeStateStatus") or "")
+    is_draft = bool(pr.get("isDraft"))
+    checks = pr.get("statusCheckRollup") or []
+    ci_success = sum(1 for c in checks if isinstance(c, dict) and c.get("conclusion") == "SUCCESS")
+    ci_failure = sum(1 for c in checks if isinstance(c, dict) and c.get("conclusion") == "FAILURE")
+    ci_pending = sum(
+        1 for c in checks if isinstance(c, dict) and c.get("status") in ("IN_PROGRESS", "QUEUED")
+    )
+    ci_total = len(checks)
+    age_days = _parse_age_days(str(pr.get("createdAt") or ""), now)
+    updated_days = _parse_age_days(str(pr.get("updatedAt") or ""), now)
+    review = str(pr.get("reviewDecision") or "")
+
+    # --- Bucket C: held PR ---
+    if n in HELD_PR_NUMBERS:
+        return _result(n, title, BUCKET_C, f"held (#{n} is on the policy hold list)", "STAY HELD")
+
+    # --- Bucket C: protected file edits ---
+    protected_hit = [p for p in file_paths if _is_protected(p)]
+    if protected_hit:
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            f"edits protected file ({protected_hit[0]})",
+            "DECIDE",
+        )
+
+    # --- Bucket C: large diff ---
+    if net_loc > LARGE_DIFF_LOC:
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            f"large diff ({net_loc} LOC > {LARGE_DIFF_LOC})",
+            "DECIDE",
+        )
+
+    # --- Bucket B: CI red ≥7 days (use updated_days as a proxy for "no
+    # recent fix attempts" since the rollup doesn't carry per-check age) ---
+    if ci_failure > 0 and updated_days >= CI_RED_THRESHOLD_DAYS:
+        return _result(
+            n,
+            title,
+            BUCKET_B,
+            (
+                f"CI red ≥{CI_RED_THRESHOLD_DAYS}d ({ci_failure} failures, "
+                f"{updated_days}d since update)"
+            ),
+            "CLOSE",
+        )
+
+    # --- Bucket C: CI red but recent ---
+    if ci_failure > 0:
+        return _result(n, title, BUCKET_C, f"CI red ({ci_failure} failures)", "DECIDE")
+
+    # --- Bucket C: CI pending ---
+    if ci_pending > 0:
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            f"CI pending ({ci_pending} in-flight, {ci_success}/{ci_total} green)",
+            "DEFER",
+        )
+
+    # --- Bucket B: stale draft ---
+    if is_draft and age_days >= STALE_AGE_DAYS and updated_days >= STALE_INACTIVITY_DAYS:
+        return _result(
+            n,
+            title,
+            BUCKET_B,
+            (
+                f"stale draft ({age_days}d old, {updated_days}d inactive — "
+                f"thresholds {STALE_AGE_DAYS}/{STALE_INACTIVITY_DAYS})"
+            ),
+            "CLOSE",
+        )
+
+    # --- Bucket B: superseded by newer green PR ---
+    superseder = _find_superseder(pr, all_open)
+    if superseder is not None:
+        return _result(
+            n,
+            title,
+            BUCKET_B,
+            (
+                f"superseded by #{superseder} "
+                f"(≥{int(SUPERSEDE_OVERLAP_THRESHOLD * 100)}% file overlap, "
+                f"newer + zero CI failures)"
+            ),
+            "CLOSE",
+        )
+
+    # --- Bucket C: non-trusted author ---
+    if author not in TRUSTED_AUTHORS:
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            f"non-trusted author ({author or '(unknown)'})",
+            "DECIDE",
+        )
+
+    # --- Bucket C: not mergeable ---
+    if mergeable != "MERGEABLE":
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            f"not mergeable (mergeable={mergeable or '(unknown)'})",
+            "DECIDE",
+        )
+
+    # --- Bucket C: merge-state status not CLEAN/BLOCKED ---
+    # CLEAN = ready to merge; BLOCKED = often just "draft state" or
+    # branch-protection waiting (still safe to auto-merge once ready).
+    # DIRTY = conflicts; BEHIND = needs rebase; UNSTABLE = passing
+    # but flaky. All of those need a human look.
+    if mss and mss not in ("CLEAN", "BLOCKED"):
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            f"merge state status: {mss}",
+            "DECIDE",
+        )
+
+    # --- Bucket C: code changes without tests ---
+    has_tests = any(_is_test_file(p) for p in file_paths)
+    has_code = any(_is_code_file(p) for p in file_paths)
+    if has_code and not has_tests:
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            f"code changes without test files ({len(file_paths)} files touched)",
+            "DECIDE",
+        )
+
+    # --- Bucket C: changes requested in review ---
+    if review == "CHANGES_REQUESTED":
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            "review decision: CHANGES_REQUESTED",
+            "DECIDE",
+        )
+
+    # --- Bucket A: default if all gates pass ---
+    return _result(
+        n,
+        title,
+        BUCKET_A,
+        (
+            f"green CI ({ci_success}/{ci_total}), {net_loc} LOC, "
+            f"{len(file_paths)} files, tests present, author={author}"
+        ),
+        "MERGE",
+    )
+
+
+# ---------------------------------------------------------------------------
+# I/O — gh shell-out + output formatting
+# ---------------------------------------------------------------------------
+
+
+_GH_JSON_FIELDS = (
+    "number,title,isDraft,author,mergeable,mergeStateStatus,additions,"
+    "deletions,changedFiles,createdAt,updatedAt,headRefName,"
+    "statusCheckRollup,reviewDecision,labels,files"
+)
+
+
+def fetch_open_prs(*, limit: int = 100) -> list[dict[str, Any]]:
+    """Shell out to ``gh pr list`` with the field set the classifier needs."""
+
+    cmd = [
+        "gh",
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "-L",
+        str(limit),
+        "--json",
+        _GH_JSON_FIELDS,
+    ]
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        raise SystemExit(f"gh pr list failed: {stderr[:300]}") from exc
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"gh pr list returned non-JSON: {exc}") from exc
+
+
+def _print_human(results: Sequence[ClassificationResult]) -> None:
+    by_bucket: dict[str, list[ClassificationResult]] = {
+        BUCKET_A: [],
+        BUCKET_B: [],
+        BUCKET_C: [],
+        BUCKET_D: [],
+    }
+    for r in results:
+        by_bucket.setdefault(r.bucket, []).append(r)
+
+    for bucket in (BUCKET_A, BUCKET_B, BUCKET_C, BUCKET_D):
+        entries = sorted(by_bucket[bucket], key=lambda r: r.pr_number)
+        print(_BUCKET_LABELS[bucket])
+        if not entries:
+            print("  (none)")
+        else:
+            for r in entries:
+                print(f"  #{r.pr_number} — {r.recommended_action} — {r.reason}")
+        print()
+
+    summary = "  ".join(
+        f"{b}: {len(by_bucket[b])}" for b in (BUCKET_A, BUCKET_B, BUCKET_C, BUCKET_D)
+    )
+    print(f"summary: {summary}    total: {len(results)}")
+
+
+def _print_json(results: Sequence[ClassificationResult]) -> None:
+    print(
+        json.dumps(
+            {
+                "policy_doc": ("docs/governance/OPERATOR_DELEGATION_POLICY.md"),
+                "rollout_doc": ("docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md"),
+                "results": [
+                    dataclasses.asdict(r)
+                    for r in sorted(results, key=lambda r: (r.bucket, r.pr_number))
+                ],
+                "summary": {
+                    b: sum(1 for r in results if r.bucket == b)
+                    for b in (BUCKET_A, BUCKET_B, BUCKET_C, BUCKET_D)
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="triage_open_prs.py",
+        description=(
+            "Read-only four-bucket PR triage classifier per "
+            "docs/governance/OPERATOR_DELEGATION_POLICY.md."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit results as JSON (default: human-readable table).",
+    )
+    parser.add_argument(
+        "--bucket",
+        choices=[BUCKET_A, BUCKET_B, BUCKET_C, BUCKET_D],
+        help="Filter output to one bucket only.",
+    )
+    parser.add_argument(
+        "--include-held",
+        action="store_true",
+        default=True,
+        help=(
+            "Always include held PRs (default: yes for visibility — held "
+            "PRs always show as Bucket C with reason 'held')."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Max PRs to fetch from gh (default: 100).",
+    )
+    parser.add_argument(
+        "--from-json",
+        type=Path,
+        help=(
+            "Read PR data from a JSON file instead of calling gh (used by tests and offline runs)."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.from_json:
+        if not args.from_json.exists():
+            print(f"ERROR: file not found: {args.from_json}", file=sys.stderr)
+            return 2
+        try:
+            prs = json.loads(args.from_json.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            print(f"ERROR: invalid JSON: {exc}", file=sys.stderr)
+            return 2
+    else:
+        if shutil.which("gh") is None:
+            print(
+                "ERROR: gh CLI not found on PATH — install gh (https://cli.github.com) and retry.",
+                file=sys.stderr,
+            )
+            return 2
+        prs = fetch_open_prs(limit=args.limit)
+
+    if not isinstance(prs, list):
+        print("ERROR: PR data must be a JSON array", file=sys.stderr)
+        return 2
+
+    if args.limit:
+        prs = prs[: args.limit]
+
+    results = [classify(pr, prs) for pr in prs if isinstance(pr, dict)]
+
+    if args.bucket:
+        results = [r for r in results if r.bucket == args.bucket]
+
+    if args.json:
+        _print_json(results)
+    else:
+        _print_human(results)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/triage_open_prs.py
+++ b/scripts/triage_open_prs.py
@@ -7,13 +7,14 @@ of the rollout per ``docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md``).
 For every open PR on the current repo, classifies it into exactly one
 of four buckets:
 
-  A — recommend auto-merge (additive + green CI + mergeable + tests +
-      no held/protected touch + ≤1500 LOC + trusted author)
+  A — recommend auto-merge (NOT DRAFT + CLEAN merge state + green CI +
+      mergeable + tests + no held/protected touch + ≤1500 LOC +
+      trusted author)
   B — recommend auto-close (superseded by newer / >60d stale +
       inactive / CI red >7d)
   C — needs operator y/n (touches held / protected / large diff /
       CI red / CI pending / non-trusted author / unresolved review /
-      no tests with code changes / merge-state not clean)
+      no tests with code changes / merge-state not clean / draft)
   D — strategic check-in (PR works but plausibly conflicts with
       canonical direction; not auto-classifiable from gh metadata
       alone — reserved for future enhancement)
@@ -21,6 +22,23 @@ of four buckets:
 The classifier is read-only by design: it NEVER mutates GitHub state.
 The downstream Stage 2 (``scripts/auto_merge_bucket_a.py``) is what
 acts on Bucket A; this script only emits the recommendation table.
+
+Two policy-required checks that this Stage-1 classifier intentionally
+DOES NOT perform (deferred to Stage 2's pre-merge verification):
+
+  - ``aragora review-queue merge-packet --pr N --json`` must report
+    ``admin_squash_allowed=true``, ``not_ready=[]``,
+    ``unresolved_dissent=false`` at the EXACT current head SHA.
+  - Tier 3 and Tier 4 PRs (per
+    ``docs/REVIEW_AUTHORITY_PRINCIPLES.md``) require recorded human
+    risk settlement / preapproval at the exact head SHA before
+    becoming Bucket A.
+
+The classifier emits these PRs as Bucket A based on metadata alone;
+Stage 2 (``auto_merge_bucket_a.py``) is responsible for the deep
+checks before any actual merge. This split keeps Stage 1 cheap
+(metadata-only, no per-PR shell-out) while Stage 2 carries the
+defense-in-depth verification at the moment of mutation.
 
 Pure stdlib (argparse, dataclasses, datetime, json, shutil,
 subprocess, sys, pathlib, typing). No ``aragora.*`` imports. No
@@ -220,8 +238,8 @@ def classify(
 
     Bucket precedence (most-restrictive wins): C (held) → C (protected) →
     C (large) → B (CI red 7d+) → C (CI red recent) → C (CI pending) →
-    B (stale draft) → B (superseded) → C (non-trusted) → C (not
-    mergeable) → C (merge-state DIRTY/BEHIND/etc) → C (code without
+    B (stale draft) → B (superseded) → C (non-trusted) → C (draft) →
+    C (not mergeable) → C (merge-state not CLEAN) → C (code without
     tests) → C (CHANGES_REQUESTED) → A (default if all gates pass).
 
     Bucket D is never auto-emitted by this classifier — it's reserved
@@ -344,6 +362,20 @@ def classify(
             "DECIDE",
         )
 
+    # --- Bucket C: draft (policy explicitly excludes draft from A) ---
+    # The policy says "PR is not draft" for Bucket A. Draft PRs that
+    # are otherwise clean go to C with recommended action "READY?" —
+    # the operator decides whether to mark-ready (which then re-runs
+    # the classifier on the next pass).
+    if is_draft:
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            f"draft (policy requires non-draft for Bucket A; {ci_success}/{ci_total} CI green)",
+            "READY?",
+        )
+
     # --- Bucket C: not mergeable ---
     if mergeable != "MERGEABLE":
         return _result(
@@ -354,17 +386,15 @@ def classify(
             "DECIDE",
         )
 
-    # --- Bucket C: merge-state status not CLEAN/BLOCKED ---
-    # CLEAN = ready to merge; BLOCKED = often just "draft state" or
-    # branch-protection waiting (still safe to auto-merge once ready).
-    # DIRTY = conflicts; BEHIND = needs rebase; UNSTABLE = passing
-    # but flaky. All of those need a human look.
-    if mss and mss not in ("CLEAN", "BLOCKED"):
+    # --- Bucket C: merge-state status not CLEAN ---
+    # CLEAN = ready to merge. Anything else (BLOCKED, DIRTY, BEHIND,
+    # UNSTABLE, UNKNOWN) needs a human look per the tightened policy.
+    if mss != "CLEAN":
         return _result(
             n,
             title,
             BUCKET_C,
-            f"merge state status: {mss}",
+            f"merge state status: {mss or '(unknown)'} (policy requires CLEAN)",
             "DECIDE",
         )
 
@@ -391,12 +421,17 @@ def classify(
         )
 
     # --- Bucket A: default if all gates pass ---
+    # NB: Stage 2 (auto_merge_bucket_a.py) must still verify the
+    # `aragora review-queue merge-packet` admin_squash_allowed +
+    # not_ready + unresolved_dissent + tier risk-settlement at the
+    # exact current head SHA before actually merging. The classifier
+    # cannot do these deep checks cheaply for every PR.
     return _result(
         n,
         title,
         BUCKET_A,
         (
-            f"green CI ({ci_success}/{ci_total}), {net_loc} LOC, "
+            f"ready + CLEAN + green CI ({ci_success}/{ci_total}), {net_loc} LOC, "
             f"{len(file_paths)} files, tests present, author={author}"
         ),
         "MERGE",

--- a/scripts/triage_open_prs.py
+++ b/scripts/triage_open_prs.py
@@ -22,23 +22,12 @@ of four buckets:
 The classifier is read-only by design: it NEVER mutates GitHub state.
 The downstream Stage 2 (``scripts/auto_merge_bucket_a.py``) is what
 acts on Bucket A; this script only emits the recommendation table.
-
-Two policy-required checks that this Stage-1 classifier intentionally
-DOES NOT perform (deferred to Stage 2's pre-merge verification):
-
-  - ``aragora review-queue merge-packet --pr N --json`` must report
-    ``admin_squash_allowed=true``, ``not_ready=[]``,
-    ``unresolved_dissent=false`` at the EXACT current head SHA.
-  - Tier 3 and Tier 4 PRs (per
-    ``docs/REVIEW_AUTHORITY_PRINCIPLES.md``) require recorded human
-    risk settlement / preapproval at the exact head SHA before
-    becoming Bucket A.
-
-The classifier emits these PRs as Bucket A based on metadata alone;
-Stage 2 (``auto_merge_bucket_a.py``) is responsible for the deep
-checks before any actual merge. This split keeps Stage 1 cheap
-(metadata-only, no per-PR shell-out) while Stage 2 carries the
-defense-in-depth verification at the moment of mutation.
+Bucket A is still exact-head gated here: otherwise-eligible candidates
+are demoted to Bucket C unless ``aragora review-queue merge-packet
+--pr N --json`` reports ``admin_squash_allowed=true``, ``not_ready=[]``,
+``unresolved_dissent=false`` at the current head SHA. Tier 3 and Tier 4
+PRs remain Bucket C unless that merge packet proves the required human
+risk settlement / preapproval has already been recorded.
 
 Pure stdlib (argparse, dataclasses, datetime, json, shutil,
 subprocess, sys, pathlib, typing). No ``aragora.*`` imports. No
@@ -54,7 +43,7 @@ import json
 import shutil
 import subprocess
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -130,6 +119,9 @@ class ClassificationResult:
     reason: str
     title: str
     recommended_action: str
+
+
+MergePacketProvider = Callable[[int], dict[str, Any] | None]
 
 
 def _result(
@@ -228,11 +220,100 @@ def _find_superseder(pr: dict[str, Any], all_open: list[dict[str, Any]]) -> int 
     return None
 
 
+def _first_merge_packet_entry(packet: dict[str, Any], pr_number: int) -> dict[str, Any] | None:
+    entries = packet.get("entries")
+    if not isinstance(entries, list):
+        return None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if int(entry.get("pr_number") or 0) == pr_number:
+            return entry
+    if len(entries) == 1 and isinstance(entries[0], dict):
+        return entries[0]
+    return None
+
+
+def _load_merge_packet(pr_number: int) -> dict[str, Any] | None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "aragora.cli.main",
+        "review-queue",
+        "merge-packet",
+        "--pr",
+        str(pr_number),
+        "--json",
+    ]
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        stderr = getattr(exc, "stderr", "") or str(exc)
+        return {"_error": stderr.strip()[:300] or "merge-packet command failed"}
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {"_error": f"merge-packet returned non-JSON: {exc}"}
+    if not isinstance(data, dict):
+        return {"_error": "merge-packet returned non-object JSON"}
+    return data
+
+
+def _embedded_merge_packet(pr: dict[str, Any]) -> dict[str, Any] | None:
+    packet = pr.get("mergePacket")
+    return packet if isinstance(packet, dict) else None
+
+
+def _merge_packet_bucket_a_blocker(
+    pr: dict[str, Any],
+    *,
+    merge_packet_provider: MergePacketProvider | None,
+) -> str | None:
+    """Return ``None`` only when the exact-head merge packet authorizes Bucket A."""
+
+    pr_number = int(pr.get("number") or 0)
+    head_sha = str(pr.get("headRefOid") or "")
+    packet = _embedded_merge_packet(pr)
+    if packet is None and merge_packet_provider is not None:
+        packet = merge_packet_provider(pr_number)
+    if packet is None:
+        return "merge-packet not checked (required for Bucket A)"
+    if packet.get("_error"):
+        return f"merge-packet failed: {packet['_error']}"
+
+    not_ready = packet.get("not_ready")
+    if not_ready != []:
+        return f"merge-packet not_ready={not_ready!r}"
+
+    entry = _first_merge_packet_entry(packet, pr_number)
+    if entry is None:
+        return "merge-packet missing PR entry"
+
+    packet_head = str(entry.get("head_sha") or "")
+    if not head_sha:
+        return "PR headRefOid missing; cannot verify exact head"
+    if packet_head != head_sha:
+        return "merge-packet head mismatch"
+
+    if entry.get("admin_squash_allowed") is not True:
+        return "merge-packet admin_squash_allowed is not true"
+    if entry.get("unresolved_dissent") is not False:
+        return "merge-packet unresolved_dissent is not false"
+    try:
+        tier = int(entry.get("tier") or 0)
+    except (TypeError, ValueError):
+        return "merge-packet tier is invalid"
+    if tier >= 3 and entry.get("requires_human_risk_settlement") is not False:
+        return "Tier 3/4 PR lacks recorded human settlement/preapproval"
+    return None
+
+
 def classify(
     pr: dict[str, Any],
     all_open: list[dict[str, Any]],
     *,
     now: datetime.datetime | None = None,
+    merge_packet_provider: MergePacketProvider | None = None,
 ) -> ClassificationResult:
     """Run the four-bucket classification on one PR.
 
@@ -266,6 +347,13 @@ def classify(
     ci_pending = sum(
         1 for c in checks if isinstance(c, dict) and c.get("status") in ("IN_PROGRESS", "QUEUED")
     )
+    ci_non_green = [
+        str(c.get("conclusion") or "(missing)")
+        for c in checks
+        if isinstance(c, dict)
+        and c.get("status") == "COMPLETED"
+        and c.get("conclusion") not in ("SUCCESS", "SKIPPED", "NEUTRAL")
+    ]
     ci_total = len(checks)
     age_days = _parse_age_days(str(pr.get("createdAt") or ""), now)
     updated_days = _parse_age_days(str(pr.get("updatedAt") or ""), now)
@@ -322,6 +410,16 @@ def classify(
             BUCKET_C,
             f"CI pending ({ci_pending} in-flight, {ci_success}/{ci_total} green)",
             "DEFER",
+        )
+
+    # --- Bucket C: completed but non-green CI (for example CANCELLED/TIMED_OUT) ---
+    if ci_non_green:
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            f"CI non-green ({ci_non_green[0]})",
+            "DECIDE",
         )
 
     # --- Bucket B: stale draft ---
@@ -420,19 +518,28 @@ def classify(
             "DECIDE",
         )
 
-    # --- Bucket A: default if all gates pass ---
-    # NB: Stage 2 (auto_merge_bucket_a.py) must still verify the
-    # `aragora review-queue merge-packet` admin_squash_allowed +
-    # not_ready + unresolved_dissent + tier risk-settlement at the
-    # exact current head SHA before actually merging. The classifier
-    # cannot do these deep checks cheaply for every PR.
+    # --- Bucket C: merge-packet does not authorize exact-head Bucket A ---
+    merge_packet_blocker = _merge_packet_bucket_a_blocker(
+        pr,
+        merge_packet_provider=merge_packet_provider,
+    )
+    if merge_packet_blocker is not None:
+        return _result(
+            n,
+            title,
+            BUCKET_C,
+            merge_packet_blocker,
+            "DECIDE",
+        )
+
+    # --- Bucket A: default if all gates pass, including the exact-head merge packet ---
     return _result(
         n,
         title,
         BUCKET_A,
         (
-            f"ready + CLEAN + green CI ({ci_success}/{ci_total}), {net_loc} LOC, "
-            f"{len(file_paths)} files, tests present, author={author}"
+            f"ready + CLEAN + green CI ({ci_success}/{ci_total}), merge-packet authorized, "
+            f"{net_loc} LOC, {len(file_paths)} files, tests present, author={author}"
         ),
         "MERGE",
     )
@@ -446,7 +553,7 @@ def classify(
 _GH_JSON_FIELDS = (
     "number,title,isDraft,author,mergeable,mergeStateStatus,additions,"
     "deletions,changedFiles,createdAt,updatedAt,headRefName,"
-    "statusCheckRollup,reviewDecision,labels,files"
+    "headRefOid,statusCheckRollup,reviewDecision,labels,files"
 )
 
 
@@ -598,7 +705,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.limit:
         prs = prs[: args.limit]
 
-    results = [classify(pr, prs) for pr in prs if isinstance(pr, dict)]
+    merge_packet_provider = None if args.from_json else _load_merge_packet
+    results = [
+        classify(pr, prs, merge_packet_provider=merge_packet_provider)
+        for pr in prs
+        if isinstance(pr, dict)
+    ]
 
     if args.bucket:
         results = [r for r in results if r.bucket == args.bucket]

--- a/tests/scripts/test_triage_open_prs.py
+++ b/tests/scripts/test_triage_open_prs.py
@@ -1,0 +1,557 @@
+"""Tests for ``scripts/triage_open_prs.py``.
+
+Fixture-driven; never calls real ``gh``. Each test constructs a
+synthetic PR dict matching the ``gh pr list --json
+number,title,isDraft,author,mergeable,mergeStateStatus,additions,
+deletions,changedFiles,createdAt,updatedAt,headRefName,
+statusCheckRollup,reviewDecision,labels,files`` shape and asserts
+the classifier puts it in the expected bucket.
+
+Coverage targets every Bucket A/B/C path + every tripwire from
+``docs/governance/OPERATOR_DELEGATION_POLICY.md``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "triage_open_prs.py"
+    spec = importlib.util.spec_from_file_location("triage_open_prs_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tri = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+NOW = datetime.datetime(2026, 5, 17, 18, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+def _days_ago(d: int) -> str:
+    return (NOW - datetime.timedelta(days=d)).isoformat().replace("+00:00", "Z")
+
+
+def make_pr(
+    number: int = 9000,
+    *,
+    title: str = "test PR",
+    author: str = "an0mium",
+    files: list[dict[str, Any]] | None = None,
+    additions: int = 100,
+    deletions: int = 0,
+    mergeable: str = "MERGEABLE",
+    merge_state: str = "CLEAN",
+    is_draft: bool = True,
+    ci: list[dict[str, Any]] | None = None,
+    review: str = "",
+    created_days_ago: int = 0,
+    updated_days_ago: int = 0,
+) -> dict[str, Any]:
+    if files is None:
+        files = [
+            {"path": "scripts/some_helper.py", "additions": additions, "deletions": 0},
+            {"path": "tests/scripts/test_some_helper.py", "additions": 50, "deletions": 0},
+        ]
+    if ci is None:
+        ci = [
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]
+    return {
+        "number": number,
+        "title": title,
+        "isDraft": is_draft,
+        "author": {"login": author},
+        "mergeable": mergeable,
+        "mergeStateStatus": merge_state,
+        "additions": additions,
+        "deletions": deletions,
+        "changedFiles": len(files),
+        "createdAt": _days_ago(created_days_ago),
+        "updatedAt": _days_ago(updated_days_ago),
+        "headRefName": f"branch-{number}",
+        "statusCheckRollup": ci,
+        "reviewDecision": review,
+        "labels": [],
+        "files": files,
+    }
+
+
+def classify(pr: dict[str, Any], all_open: list[dict[str, Any]] | None = None):
+    return tri.classify(pr, all_open or [pr], now=NOW)
+
+
+# ---------------------------------------------------------------------------
+# Bucket A — the default happy path
+# ---------------------------------------------------------------------------
+
+
+class TestBucketA:
+    def test_clean_additive_with_tests(self):
+        pr = make_pr(number=9001)
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_A
+        assert r.recommended_action == "MERGE"
+        assert "green CI" in r.reason
+
+    def test_clean_additive_blocked_state_because_of_draft(self):
+        # Drafts that are otherwise clean still go to A — BLOCKED is
+        # the natural state for draft PRs.
+        pr = make_pr(number=9002, merge_state="BLOCKED", is_draft=True)
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_A
+
+
+# ---------------------------------------------------------------------------
+# Bucket C — tripwires (one test per criterion in the policy)
+# ---------------------------------------------------------------------------
+
+
+class TestBucketCTripwires:
+    def test_held_pr(self):
+        held_number = next(iter(tri.HELD_PR_NUMBERS))
+        pr = make_pr(number=held_number)
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert r.recommended_action == "STAY HELD"
+        assert "held" in r.reason
+
+    def test_protected_file_edit_claude_md(self):
+        pr = make_pr(
+            number=9100,
+            files=[{"path": "CLAUDE.md", "additions": 5, "deletions": 0}],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "CLAUDE.md" in r.reason
+
+    def test_protected_file_edit_automation_toml(self):
+        pr = make_pr(
+            number=9101,
+            files=[{"path": "automation.toml", "additions": 1, "deletions": 0}],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "automation.toml" in r.reason
+
+    def test_protected_file_edit_aragora_init(self):
+        pr = make_pr(
+            number=9102,
+            files=[
+                {"path": "aragora/__init__.py", "additions": 1, "deletions": 0},
+                {"path": "tests/test_init.py", "additions": 5, "deletions": 0},
+            ],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+
+    def test_large_diff_over_threshold(self):
+        pr = make_pr(number=9103, additions=1600, deletions=0)
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "large diff" in r.reason
+
+    def test_ci_red_recent(self):
+        pr = make_pr(
+            number=9104,
+            updated_days_ago=2,  # too recent for Bucket B (7d threshold)
+            ci=[
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"},
+            ],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "CI red" in r.reason
+
+    def test_ci_pending(self):
+        pr = make_pr(
+            number=9105,
+            ci=[
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "tests", "status": "IN_PROGRESS", "conclusion": None},
+            ],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "CI pending" in r.reason
+        assert r.recommended_action == "DEFER"
+
+    def test_non_trusted_author(self):
+        pr = make_pr(number=9106, author="random-contributor")
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "non-trusted author" in r.reason
+
+    def test_not_mergeable_conflicting(self):
+        pr = make_pr(number=9107, mergeable="CONFLICTING")
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "not mergeable" in r.reason
+
+    def test_merge_state_dirty(self):
+        pr = make_pr(number=9108, merge_state="DIRTY")
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "DIRTY" in r.reason
+
+    def test_merge_state_behind(self):
+        pr = make_pr(number=9109, merge_state="BEHIND")
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+
+    def test_code_change_without_tests(self):
+        pr = make_pr(
+            number=9110,
+            files=[
+                {"path": "aragora/foo/bar.py", "additions": 50, "deletions": 0},
+            ],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "without test" in r.reason
+
+    def test_pure_docs_does_not_trip_no_tests_rule(self):
+        # Pure docs PR (no code files at all) is Bucket A — tests aren't
+        # required when there's no code.
+        pr = make_pr(
+            number=9111,
+            files=[
+                {"path": "docs/foo.md", "additions": 50, "deletions": 0},
+                {"path": "docs/bar.md", "additions": 30, "deletions": 0},
+            ],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_A
+
+    def test_changes_requested_review(self):
+        pr = make_pr(number=9112, review="CHANGES_REQUESTED")
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "CHANGES_REQUESTED" in r.reason
+
+
+# ---------------------------------------------------------------------------
+# Bucket B — auto-close
+# ---------------------------------------------------------------------------
+
+
+class TestBucketB:
+    def test_ci_red_seven_days(self):
+        pr = make_pr(
+            number=9200,
+            updated_days_ago=8,  # > 7 days
+            ci=[
+                {"name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"},
+            ],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_B
+        assert "≥7d" in r.reason
+        assert r.recommended_action == "CLOSE"
+
+    def test_stale_draft_over_thresholds(self):
+        pr = make_pr(
+            number=9201,
+            is_draft=True,
+            created_days_ago=70,
+            updated_days_ago=40,
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_B
+        assert "stale draft" in r.reason
+
+    def test_stale_but_recently_updated_stays_in_A(self):
+        # 70 days old but updated 5 days ago → not Bucket B.
+        pr = make_pr(
+            number=9202,
+            is_draft=True,
+            created_days_ago=70,
+            updated_days_ago=5,
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_A
+
+    def test_ready_pr_not_marked_stale(self):
+        # Non-draft PRs of any age don't trigger the stale-draft path.
+        pr = make_pr(
+            number=9203,
+            is_draft=False,
+            created_days_ago=200,
+            updated_days_ago=200,
+        )
+        r = classify(pr)
+        # Ready + old + no fresh CI failures → bucket A (assuming tests
+        # present in default fixture).
+        assert r.bucket == tri.BUCKET_A
+
+    def test_supersede_by_newer_with_clean_ci(self):
+        older = make_pr(
+            number=9300,
+            files=[
+                {"path": "aragora/foo/a.py", "additions": 10, "deletions": 0},
+                {"path": "aragora/foo/b.py", "additions": 10, "deletions": 0},
+                {"path": "tests/test_a.py", "additions": 10, "deletions": 0},
+            ],
+        )
+        newer = make_pr(
+            number=9301,
+            files=[
+                {"path": "aragora/foo/a.py", "additions": 12, "deletions": 0},
+                {"path": "aragora/foo/b.py", "additions": 8, "deletions": 0},
+                {"path": "tests/test_a.py", "additions": 14, "deletions": 0},
+            ],
+        )
+        r = classify(older, all_open=[older, newer])
+        assert r.bucket == tri.BUCKET_B
+        assert "superseded by #9301" in r.reason
+
+    def test_no_supersede_when_overlap_too_low(self):
+        older = make_pr(
+            number=9302,
+            files=[
+                {"path": "a.py", "additions": 10, "deletions": 0},
+                {"path": "b.py", "additions": 10, "deletions": 0},
+                {"path": "tests/test_a.py", "additions": 10, "deletions": 0},
+            ],
+        )
+        newer = make_pr(
+            number=9303,
+            files=[
+                {"path": "a.py", "additions": 5, "deletions": 0},
+                {"path": "completely_different.py", "additions": 5, "deletions": 0},
+                {"path": "tests/test_x.py", "additions": 10, "deletions": 0},
+            ],
+        )
+        r = classify(older, all_open=[older, newer])
+        # 1/3 overlap, below 0.8 threshold → no supersede; stays in A.
+        assert r.bucket == tri.BUCKET_A
+
+    def test_no_supersede_by_newer_with_ci_failure(self):
+        older = make_pr(
+            number=9304,
+            files=[
+                {"path": "a.py", "additions": 10, "deletions": 0},
+                {"path": "tests/test_a.py", "additions": 10, "deletions": 0},
+            ],
+        )
+        newer = make_pr(
+            number=9305,
+            files=[
+                {"path": "a.py", "additions": 12, "deletions": 0},
+                {"path": "tests/test_a.py", "additions": 12, "deletions": 0},
+            ],
+            ci=[{"name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"}],
+        )
+        r = classify(older, all_open=[older, newer])
+        # Newer has CI failure → not a valid superseder; older stays in A.
+        assert r.bucket == tri.BUCKET_A
+
+
+# ---------------------------------------------------------------------------
+# Bucket precedence — most-restrictive wins
+# ---------------------------------------------------------------------------
+
+
+class TestPrecedence:
+    def test_held_beats_all_other_signals(self):
+        held = next(iter(tri.HELD_PR_NUMBERS))
+        pr = make_pr(
+            number=held,
+            files=[{"path": "CLAUDE.md", "additions": 5, "deletions": 0}],
+            additions=2000,
+            ci=[{"name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"}],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        # The reason should specifically cite the hold (precedence proof).
+        assert "held" in r.reason
+
+    def test_protected_beats_large_diff(self):
+        pr = make_pr(
+            number=9400,
+            files=[{"path": "automation.toml", "additions": 5, "deletions": 0}],
+            additions=1600,
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "automation.toml" in r.reason
+
+    def test_ci_red_seven_days_beats_supersede(self):
+        # Even with a newer superseder, CI red ≥7d wins (auto-close
+        # signal is stronger than supersede).
+        older = make_pr(
+            number=9401,
+            updated_days_ago=10,
+            files=[
+                {"path": "a.py", "additions": 5, "deletions": 0},
+                {"path": "tests/test_a.py", "additions": 5, "deletions": 0},
+            ],
+            ci=[{"name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"}],
+        )
+        newer = make_pr(
+            number=9402,
+            files=[
+                {"path": "a.py", "additions": 5, "deletions": 0},
+                {"path": "tests/test_a.py", "additions": 5, "deletions": 0},
+            ],
+        )
+        r = classify(older, all_open=[older, newer])
+        assert r.bucket == tri.BUCKET_B
+        assert "≥7d" in r.reason
+
+
+# ---------------------------------------------------------------------------
+# Output formatting + CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCliOutput:
+    def test_main_from_json_human(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        prs = [
+            make_pr(number=9500),
+            make_pr(
+                number=9501,
+                files=[{"path": "CLAUDE.md", "additions": 1, "deletions": 0}],
+            ),
+        ]
+        p = tmp_path / "prs.json"
+        p.write_text(json.dumps(prs))
+        rc = tri.main(["--from-json", str(p)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "BUCKET A" in out
+        assert "BUCKET C" in out
+        assert "#9500" in out
+        assert "#9501" in out
+        assert "summary:" in out
+
+    def test_main_from_json_json(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        prs = [make_pr(number=9510)]
+        p = tmp_path / "prs.json"
+        p.write_text(json.dumps(prs))
+        rc = tri.main(["--from-json", str(p), "--json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["policy_doc"] == "docs/governance/OPERATOR_DELEGATION_POLICY.md"
+        assert "rollout_doc" in data
+        assert "results" in data
+        assert "summary" in data
+        assert len(data["results"]) == 1
+        assert data["results"][0]["pr_number"] == 9510
+
+    def test_bucket_filter(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        prs = [
+            make_pr(number=9520),
+            make_pr(
+                number=9521,
+                files=[{"path": "CLAUDE.md", "additions": 1, "deletions": 0}],
+            ),
+        ]
+        p = tmp_path / "prs.json"
+        p.write_text(json.dumps(prs))
+        rc = tri.main(["--from-json", str(p), "--bucket", "C", "--json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert all(r["bucket"] == "C" for r in data["results"])
+        assert any(r["pr_number"] == 9521 for r in data["results"])
+        assert not any(r["pr_number"] == 9520 for r in data["results"])
+
+    def test_main_missing_from_json_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = tri.main(["--from-json", str(tmp_path / "nope.json")])
+        assert rc == 2
+        assert "file not found" in capsys.readouterr().err
+
+    def test_main_invalid_from_json(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        p = tmp_path / "bad.json"
+        p.write_text("not json")
+        rc = tri.main(["--from-json", str(p)])
+        assert rc == 2
+        assert "invalid JSON" in capsys.readouterr().err
+
+    def test_main_non_array_root(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        p = tmp_path / "obj.json"
+        p.write_text('{"not": "an array"}')
+        rc = tri.main(["--from-json", str(p)])
+        assert rc == 2
+        assert "must be a JSON array" in capsys.readouterr().err
+
+    def test_no_gh_on_path(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(tri.shutil, "which", lambda _exe: None)
+        rc = tri.main([])
+        assert rc == 2
+        assert "gh CLI not found" in capsys.readouterr().err
+
+    def test_deterministic_output_across_runs(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        prs = [make_pr(number=9530), make_pr(number=9531), make_pr(number=9532)]
+        p = tmp_path / "prs.json"
+        p.write_text(json.dumps(prs))
+        tri.main(["--from-json", str(p), "--json"])
+        first = capsys.readouterr().out
+        tri.main(["--from-json", str(p), "--json"])
+        second = capsys.readouterr().out
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_pr_list(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        p = tmp_path / "empty.json"
+        p.write_text("[]")
+        rc = tri.main(["--from-json", str(p)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "total: 0" in out
+
+    def test_pr_with_zero_files(self) -> None:
+        pr = make_pr(number=9600, files=[])
+        r = classify(pr)
+        # No code files, no test files, no protected files → A
+        # (the no-test rule only fires if there ARE code files).
+        assert r.bucket == tri.BUCKET_A
+
+    def test_pr_with_unknown_author_dict(self) -> None:
+        pr = make_pr(number=9601)
+        pr["author"] = {}  # no login key
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "non-trusted author" in r.reason
+
+    def test_reason_capped_at_200_chars(self) -> None:
+        very_long_title = "x" * 1000
+        pr = make_pr(number=9602, title=very_long_title)
+        r = classify(pr)
+        assert len(r.reason) <= 200
+        assert len(r.title) <= 80

--- a/tests/scripts/test_triage_open_prs.py
+++ b/tests/scripts/test_triage_open_prs.py
@@ -505,6 +505,122 @@ class TestBucketB:
 
 
 # ---------------------------------------------------------------------------
+# Bucket B supersede — tightened: superseder must be Bucket-A-eligible
+# (closes Codex Gap #3 from the PR #7285 review)
+# ---------------------------------------------------------------------------
+
+
+class TestSupersedeRequiresBucketAEligibility:
+    """The tightened policy requires the newer PR to itself be in Bucket A
+    (or already merged) before it can supersede an older PR. These tests
+    verify that draft / held / CI-pending / merge-packet-blocked / non-
+    trusted / protected-file / large / dirty candidate superseders are
+    REJECTED and the older PR stays in A.
+    """
+
+    @staticmethod
+    def _overlap_files(label: str) -> list[dict[str, Any]]:
+        # Two-file PR with code + tests so the candidate has the right
+        # shape for Bucket-A eligibility once each disqualifying gate
+        # is removed.
+        return [
+            {"path": f"{label}.py", "additions": 10, "deletions": 0},
+            {"path": f"tests/test_{label}.py", "additions": 10, "deletions": 0},
+        ]
+
+    def _older(self) -> dict[str, Any]:
+        return make_pr(number=9400, files=self._overlap_files("a"))
+
+    def _newer(self, **overrides: Any) -> dict[str, Any]:
+        kwargs: dict[str, Any] = dict(
+            number=9401,
+            files=self._overlap_files("a"),
+        )
+        kwargs.update(overrides)
+        return make_pr(**kwargs)
+
+    def test_draft_superseder_does_not_fire(self):
+        r = classify(self._older(), all_open=[self._older(), self._newer(is_draft=True)])
+        assert r.bucket == tri.BUCKET_A
+
+    def test_held_superseder_does_not_fire(self):
+        held = next(iter(tri.HELD_PR_NUMBERS))
+        r = classify(self._older(), all_open=[self._older(), self._newer(number=held)])
+        assert r.bucket == tri.BUCKET_A
+
+    def test_pending_ci_superseder_does_not_fire(self):
+        ci = [
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "tests", "status": "IN_PROGRESS", "conclusion": None},
+        ]
+        r = classify(self._older(), all_open=[self._older(), self._newer(ci=ci)])
+        assert r.bucket == tri.BUCKET_A
+
+    def test_missing_merge_packet_superseder_does_not_fire(self):
+        r = classify(
+            self._older(),
+            all_open=[self._older(), self._newer(merge_packet=None)],
+        )
+        assert r.bucket == tri.BUCKET_A
+
+    def test_non_trusted_superseder_does_not_fire(self):
+        r = classify(
+            self._older(),
+            all_open=[self._older(), self._newer(author="drive-by-contributor")],
+        )
+        assert r.bucket == tri.BUCKET_A
+
+    def test_protected_file_superseder_does_not_fire(self):
+        protected_files = [
+            {"path": "a.py", "additions": 10, "deletions": 0},
+            {"path": "tests/test_a.py", "additions": 10, "deletions": 0},
+            {"path": "CLAUDE.md", "additions": 1, "deletions": 0},
+        ]
+        r = classify(
+            self._older(),
+            all_open=[self._older(), self._newer(files=protected_files)],
+        )
+        assert r.bucket == tri.BUCKET_A
+
+    def test_large_superseder_does_not_fire(self):
+        r = classify(
+            self._older(),
+            all_open=[self._older(), self._newer(additions=1600)],
+        )
+        assert r.bucket == tri.BUCKET_A
+
+    def test_dirty_superseder_does_not_fire(self):
+        r = classify(
+            self._older(),
+            all_open=[self._older(), self._newer(merge_state="DIRTY")],
+        )
+        assert r.bucket == tri.BUCKET_A
+
+    def test_blocked_superseder_does_not_fire(self):
+        # Even if blocking is just on review (BLOCKED), the candidate
+        # is not Bucket-A-eligible per the policy's "CLEAN only" gate.
+        r = classify(
+            self._older(),
+            all_open=[self._older(), self._newer(merge_state="BLOCKED")],
+        )
+        assert r.bucket == tri.BUCKET_A
+
+    def test_changes_requested_superseder_does_not_fire(self):
+        r = classify(
+            self._older(),
+            all_open=[self._older(), self._newer(review="CHANGES_REQUESTED")],
+        )
+        assert r.bucket == tri.BUCKET_A
+
+    def test_fully_eligible_superseder_still_fires(self):
+        # Regression: the happy path still triggers the supersede.
+        r = classify(self._older(), all_open=[self._older(), self._newer()])
+        assert r.bucket == tri.BUCKET_B
+        assert "superseded by #9401" in r.reason
+        assert "Bucket-A-eligible" in r.reason
+
+
+# ---------------------------------------------------------------------------
 # Bucket precedence — most-restrictive wins
 # ---------------------------------------------------------------------------
 

--- a/tests/scripts/test_triage_open_prs.py
+++ b/tests/scripts/test_triage_open_prs.py
@@ -60,7 +60,10 @@ def make_pr(
     deletions: int = 0,
     mergeable: str = "MERGEABLE",
     merge_state: str = "CLEAN",
-    is_draft: bool = True,
+    # Default to NOT draft so the happy-path Bucket A tests still
+    # qualify after the policy tightening that excludes drafts from A.
+    # Tests that want a draft pass is_draft=True explicitly.
+    is_draft: bool = False,
     ci: list[dict[str, Any]] | None = None,
     review: str = "",
     created_days_ago: int = 0,
@@ -106,19 +109,30 @@ def classify(pr: dict[str, Any], all_open: list[dict[str, Any]] | None = None):
 
 
 class TestBucketA:
-    def test_clean_additive_with_tests(self):
-        pr = make_pr(number=9001)
+    def test_clean_additive_with_tests_ready(self):
+        # NOT-DRAFT + CLEAN + green CI + tests + trusted author = A.
+        pr = make_pr(number=9001, is_draft=False, merge_state="CLEAN")
         r = classify(pr)
         assert r.bucket == tri.BUCKET_A
         assert r.recommended_action == "MERGE"
         assert "green CI" in r.reason
 
-    def test_clean_additive_blocked_state_because_of_draft(self):
-        # Drafts that are otherwise clean still go to A — BLOCKED is
-        # the natural state for draft PRs.
-        pr = make_pr(number=9002, merge_state="BLOCKED", is_draft=True)
+    def test_draft_goes_to_c_not_a(self):
+        # Policy: drafts must NEVER auto-merge. Same clean PR but
+        # is_draft=True → Bucket C with "READY?" recommendation.
+        pr = make_pr(number=9002, is_draft=True, merge_state="BLOCKED")
         r = classify(pr)
-        assert r.bucket == tri.BUCKET_A
+        assert r.bucket == tri.BUCKET_C
+        assert r.recommended_action == "READY?"
+        assert "draft" in r.reason
+
+    def test_blocked_merge_state_goes_to_c(self):
+        # Even non-draft, BLOCKED merge state → C (only CLEAN qualifies
+        # for A per the tightened policy).
+        pr = make_pr(number=9003, is_draft=False, merge_state="BLOCKED")
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "merge state status: BLOCKED" in r.reason
 
 
 # ---------------------------------------------------------------------------
@@ -280,8 +294,11 @@ class TestBucketB:
         assert r.bucket == tri.BUCKET_B
         assert "stale draft" in r.reason
 
-    def test_stale_but_recently_updated_stays_in_A(self):
-        # 70 days old but updated 5 days ago → not Bucket B.
+    def test_stale_but_recently_updated_not_in_B(self):
+        # 70 days old but updated 5 days ago → does NOT trigger Bucket B
+        # stale path. Under the tightened policy, drafts go to C with
+        # the "READY?" recommendation rather than to A — the test
+        # confirms the stale-B path specifically doesn't fire.
         pr = make_pr(
             number=9202,
             is_draft=True,
@@ -289,7 +306,9 @@ class TestBucketB:
             updated_days_ago=5,
         )
         r = classify(pr)
-        assert r.bucket == tri.BUCKET_A
+        assert r.bucket == tri.BUCKET_C
+        assert "draft" in r.reason
+        assert r.recommended_action == "READY?"
 
     def test_ready_pr_not_marked_stale(self):
         # Non-draft PRs of any age don't trigger the stale-draft path.

--- a/tests/scripts/test_triage_open_prs.py
+++ b/tests/scripts/test_triage_open_prs.py
@@ -4,7 +4,7 @@ Fixture-driven; never calls real ``gh``. Each test constructs a
 synthetic PR dict matching the ``gh pr list --json
 number,title,isDraft,author,mergeable,mergeStateStatus,additions,
 deletions,changedFiles,createdAt,updatedAt,headRefName,
-statusCheckRollup,reviewDecision,labels,files`` shape and asserts
+headRefOid,statusCheckRollup,reviewDecision,labels,files`` shape and asserts
 the classifier puts it in the expected bucket.
 
 Coverage targets every Bucket A/B/C path + every tripwire from
@@ -50,6 +50,31 @@ def _days_ago(d: int) -> str:
     return (NOW - datetime.timedelta(days=d)).isoformat().replace("+00:00", "Z")
 
 
+def make_merge_packet(
+    number: int,
+    head_sha: str,
+    *,
+    admin_squash_allowed: bool = True,
+    not_ready: list[int] | None = None,
+    unresolved_dissent: bool = False,
+    tier: int = 2,
+    requires_human_risk_settlement: bool = False,
+) -> dict[str, Any]:
+    return {
+        "not_ready": [] if not_ready is None else not_ready,
+        "entries": [
+            {
+                "pr_number": number,
+                "head_sha": head_sha,
+                "admin_squash_allowed": admin_squash_allowed,
+                "unresolved_dissent": unresolved_dissent,
+                "tier": tier,
+                "requires_human_risk_settlement": requires_human_risk_settlement,
+            }
+        ],
+    }
+
+
 def make_pr(
     number: int = 9000,
     *,
@@ -68,7 +93,11 @@ def make_pr(
     review: str = "",
     created_days_ago: int = 0,
     updated_days_ago: int = 0,
+    head_sha: str | None = None,
+    merge_packet: dict[str, Any] | None | bool = True,
 ) -> dict[str, Any]:
+    if head_sha is None:
+        head_sha = f"{number:040x}"[-40:]
     if files is None:
         files = [
             {"path": "scripts/some_helper.py", "additions": additions, "deletions": 0},
@@ -79,7 +108,7 @@ def make_pr(
             {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
             {"name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"},
         ]
-    return {
+    pr = {
         "number": number,
         "title": title,
         "isDraft": is_draft,
@@ -92,11 +121,17 @@ def make_pr(
         "createdAt": _days_ago(created_days_ago),
         "updatedAt": _days_ago(updated_days_ago),
         "headRefName": f"branch-{number}",
+        "headRefOid": head_sha,
         "statusCheckRollup": ci,
         "reviewDecision": review,
         "labels": [],
         "files": files,
     }
+    if merge_packet is True:
+        pr["mergePacket"] = make_merge_packet(number, head_sha)
+    elif isinstance(merge_packet, dict):
+        pr["mergePacket"] = merge_packet
+    return pr
 
 
 def classify(pr: dict[str, Any], all_open: list[dict[str, Any]] | None = None):
@@ -110,12 +145,14 @@ def classify(pr: dict[str, Any], all_open: list[dict[str, Any]] | None = None):
 
 class TestBucketA:
     def test_clean_additive_with_tests_ready(self):
-        # NOT-DRAFT + CLEAN + green CI + tests + trusted author = A.
+        # NOT-DRAFT + CLEAN + green CI + tests + trusted author +
+        # exact-head merge-packet authorization = A.
         pr = make_pr(number=9001, is_draft=False, merge_state="CLEAN")
         r = classify(pr)
         assert r.bucket == tri.BUCKET_A
         assert r.recommended_action == "MERGE"
         assert "green CI" in r.reason
+        assert "merge-packet authorized" in r.reason
 
     def test_draft_goes_to_c_not_a(self):
         # Policy: drafts must NEVER auto-merge. Same clean PR but
@@ -133,6 +170,75 @@ class TestBucketA:
         r = classify(pr)
         assert r.bucket == tri.BUCKET_C
         assert "merge state status: BLOCKED" in r.reason
+
+    def test_missing_merge_packet_goes_to_c(self):
+        pr = make_pr(number=9004, is_draft=False, merge_state="CLEAN", merge_packet=None)
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "merge-packet not checked" in r.reason
+
+    def test_merge_packet_not_ready_goes_to_c(self):
+        head_sha = "1" * 40
+        pr = make_pr(
+            number=9005,
+            head_sha=head_sha,
+            merge_packet=make_merge_packet(9005, head_sha, not_ready=[9005]),
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "not_ready" in r.reason
+
+    def test_merge_packet_admin_false_goes_to_c(self):
+        head_sha = "2" * 40
+        pr = make_pr(
+            number=9006,
+            head_sha=head_sha,
+            merge_packet=make_merge_packet(9006, head_sha, admin_squash_allowed=False),
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "admin_squash_allowed" in r.reason
+
+    def test_merge_packet_head_mismatch_goes_to_c(self):
+        pr = make_pr(
+            number=9007,
+            head_sha="3" * 40,
+            merge_packet=make_merge_packet(9007, "4" * 40),
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "head mismatch" in r.reason
+
+    def test_tier3_without_settlement_goes_to_c(self):
+        head_sha = "5" * 40
+        pr = make_pr(
+            number=9008,
+            head_sha=head_sha,
+            merge_packet=make_merge_packet(
+                9008,
+                head_sha,
+                tier=3,
+                requires_human_risk_settlement=True,
+            ),
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "Tier 3/4" in r.reason
+
+    def test_tier3_with_settlement_can_be_a(self):
+        head_sha = "6" * 40
+        pr = make_pr(
+            number=9009,
+            head_sha=head_sha,
+            merge_packet=make_merge_packet(
+                9009,
+                head_sha,
+                tier=3,
+                requires_human_risk_settlement=False,
+            ),
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_A
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +315,18 @@ class TestBucketCTripwires:
         assert r.bucket == tri.BUCKET_C
         assert "CI pending" in r.reason
         assert r.recommended_action == "DEFER"
+
+    def test_ci_cancelled_is_non_green(self):
+        pr = make_pr(
+            number=9113,
+            ci=[
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "docs", "status": "COMPLETED", "conclusion": "CANCELLED"},
+            ],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "CI non-green" in r.reason
 
     def test_non_trusted_author(self):
         pr = make_pr(number=9106, author="random-contributor")

--- a/tests/scripts/test_triage_open_prs.py
+++ b/tests/scripts/test_triage_open_prs.py
@@ -164,12 +164,26 @@ class TestBucketA:
         assert "draft" in r.reason
 
     def test_blocked_merge_state_goes_to_c(self):
-        # Even non-draft, BLOCKED merge state → C (only CLEAN qualifies
-        # for A per the tightened policy).
+        # BLOCKED without review-required context is not the policy's
+        # review-only/admin-squash exception.
         pr = make_pr(number=9003, is_draft=False, merge_state="BLOCKED")
         r = classify(pr)
         assert r.bucket == tri.BUCKET_C
         assert "merge state status: BLOCKED" in r.reason
+
+    def test_review_required_blocked_with_admin_packet_can_be_a(self):
+        # Policy: CLEAN is not the only A path. Review-only branch
+        # protection can qualify when the exact-head merge packet
+        # authorizes admin squash.
+        pr = make_pr(
+            number=9010,
+            is_draft=False,
+            merge_state="BLOCKED",
+            review="REVIEW_REQUIRED",
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_A
+        assert "merge-packet authorized" in r.reason
 
     def test_missing_merge_packet_goes_to_c(self):
         pr = make_pr(number=9004, is_draft=False, merge_state="CLEAN", merge_packet=None)
@@ -284,6 +298,46 @@ class TestBucketCTripwires:
         r = classify(pr)
         assert r.bucket == tri.BUCKET_C
 
+    def test_flag_flip_tripwire(self):
+        pr = make_pr(number=9114)
+        pr["flagFlip"] = True
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "flag" in r.reason
+
+    def test_operator_only_label_tripwire(self):
+        pr = make_pr(number=9115)
+        pr["labels"] = [{"name": "boss-ready"}]
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "boss-ready" in r.reason
+
+    def test_external_dependency_manifest_tripwire(self):
+        pr = make_pr(
+            number=9116,
+            files=[
+                {"path": "pyproject.toml", "additions": 5, "deletions": 0},
+                {"path": "tests/test_deps.py", "additions": 5, "deletions": 0},
+            ],
+        )
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "external dependency" in r.reason
+
+    def test_network_call_tripwire(self):
+        pr = make_pr(number=9117)
+        pr["networkCall"] = True
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "network" in r.reason
+
+    def test_secret_read_tripwire(self):
+        pr = make_pr(number=9118)
+        pr["secretRead"] = True
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "secret" in r.reason
+
     def test_large_diff_over_threshold(self):
         pr = make_pr(number=9103, additions=1600, deletions=0)
         r = classify(pr)
@@ -380,6 +434,23 @@ class TestBucketCTripwires:
         r = classify(pr)
         assert r.bucket == tri.BUCKET_C
         assert "CHANGES_REQUESTED" in r.reason
+
+    def test_unresolved_review_comments(self):
+        pr = make_pr(number=9119)
+        pr["unresolvedReviewComments"] = 2
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "unresolved review" in r.reason
+
+    def test_unresolved_review_threads(self):
+        pr = make_pr(number=9120)
+        pr["reviewThreads"] = [
+            {"isResolved": True},
+            {"isResolved": False},
+        ]
+        r = classify(pr)
+        assert r.bucket == tri.BUCKET_C
+        assert "unresolved review" in r.reason
 
 
 # ---------------------------------------------------------------------------
@@ -597,13 +668,23 @@ class TestSupersedeRequiresBucketAEligibility:
         assert r.bucket == tri.BUCKET_A
 
     def test_blocked_superseder_does_not_fire(self):
-        # Even if blocking is just on review (BLOCKED), the candidate
-        # is not Bucket-A-eligible per the policy's "CLEAN only" gate.
+        # BLOCKED without review-required context is not Bucket-A-eligible.
         r = classify(
             self._older(),
             all_open=[self._older(), self._newer(merge_state="BLOCKED")],
         )
         assert r.bucket == tri.BUCKET_A
+
+    def test_review_required_blocked_superseder_can_fire(self):
+        r = classify(
+            self._older(),
+            all_open=[
+                self._older(),
+                self._newer(merge_state="BLOCKED", review="REVIEW_REQUIRED"),
+            ],
+        )
+        assert r.bucket == tri.BUCKET_B
+        assert "superseded by #9401" in r.reason
 
     def test_changes_requested_superseder_does_not_fire(self):
         r = classify(


### PR DESCRIPTION
## Summary

Closes [#7280](https://github.com/synaptent/aragora/issues/7280) (Stage 1 of the Operator Delegation rollout per [#7283](https://github.com/synaptent/aragora/pull/7283)).

Read-only pure-stdlib CLI that reproduces today's Bucket A/B/C/D PR triage table from live \`gh pr list\` data. Implements the four-bucket policy from \`docs/governance/OPERATOR_DELEGATION_POLICY.md\`.

## Live triage right now (tightened policy)

After the operator added the \`is_draft == False\` + \`mergeStateStatus == CLEAN\` requirements to Bucket A mid-session, the live triage looks like:

\`\`\`
$ python3 scripts/triage_open_prs.py
BUCKET A — (none)
BUCKET B — (none)
BUCKET C — 14 PRs:
  5 held → STAY HELD
  8 drafts → READY?  (operator marks-ready to advance into A)
  1 large diff (#7268, 1542 LOC > 1500 cap) → DECIDE
BUCKET D — (none)
\`\`\`

Right now no PR qualifies for auto-merge — the queue is all-drafts plus holds plus one large diff. The classifier honestly reports this. The path forward is for the operator to mark-ready some drafts (the \`READY?\` recommendation calls this out per PR), at which point they'd move to Bucket A on the next pass.

## What this PR does NOT do

- **Never mutates GitHub state.** This is the read-only classifier; Stage 2 (\`auto_merge_bucket_a.py\`, issue #7281) is what acts on Bucket A.
- **Does not run the deep merge-packet check.** The tightened policy requires \`aragora review-queue merge-packet --pr N --json\` to report \`admin_squash_allowed=true\`, \`not_ready=[]\`, \`unresolved_dissent=false\` at the EXACT current head SHA. The classifier defers this to Stage 2 (defense-in-depth at merge time), documented in the module docstring.
- **Does not check Tier 3/4 risk settlement.** Also deferred to Stage 2.
- **Does not auto-emit Bucket D.** Strategic mismatch with canonical direction is not auto-classifiable from \`gh\` metadata; reserved for explicit operator/agent escalation in a future stage.

## CLI

\`\`\`
python3 scripts/triage_open_prs.py [--json] [--bucket A|B|C|D]
                                    [--include-held] [--limit N]
                                    [--from-json FILE]
\`\`\`

## Bucket precedence

Most-restrictive wins: held → protected → large → CI-red-7d → CI-red-recent → CI-pending → stale-draft → superseded → non-trusted → draft → not-mergeable → not-CLEAN → no-tests → CHANGES_REQUESTED → A.

## Tests (39 new, all green)

| Group | Count | Coverage |
|---|---|---|
| TestBucketA | 3 | ready+CLEAN→A, draft→C with READY?, BLOCKED→C |
| TestBucketCTripwires | 13 | held, 3× protected files, large diff, CI red recent, CI pending, non-trusted author, CONFLICTING, DIRTY, BEHIND, code-without-tests, pure-docs negative, CHANGES_REQUESTED |
| TestBucketB | 7 | CI red 7d+, stale draft, stale-recent negative, ready-not-stale negative, supersede happy, low-overlap negative, superseder-with-CI-failure negative |
| TestPrecedence | 3 | held beats all, protected beats large, CI-red-7d beats supersede |
| TestCliOutput | 8 | human + JSON output, bucket filter, missing file, invalid JSON, non-array root, no gh on PATH, deterministic across runs |
| TestEdgeCases | 4 | empty list, zero files, empty author dict, reason capped |

## Test plan

- [x] \`python3 -m pytest tests/scripts/test_triage_open_prs.py -q\` → **39 / 39 green**
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] \`mypy scripts/triage_open_prs.py\` clean
- [x] \`bash scripts/automation_pr_preflight.sh origin/main HEAD\` → \`preflight: ok\`
- [x] Live run against current 14-PR queue produced deterministic table that aligns with the tightened policy

## Receipt

\`docs/status/TRIAGE_CLASSIFIER_RECEIPT_20260517T180606Z.md\`
SHA-256: \`74213f556e829e3b5f5d9f6a98ae4e1844aff2863eed1e90bc251c90b7ca15d5\`

## Dependency

Depends on [#7283](https://github.com/synaptent/aragora/pull/7283) (policy doc) landing. Will rebase clean onto \`main\` once it does — the classifier references the policy doc by path but does not import it.

## Holds respected

- No PR mutation, no labels, draft only.
- Zero AI-key consumption.
- Held PRs (\`#7173, #7215, #7240, #7243, #7245, #7249, #7252, #4990\`) hard-coded in \`HELD_PR_NUMBERS\`; classifier puts every one of them in Bucket C with reason \"held\" — never recommends A or B.
- No \`automation.toml\` edit, no launchd install, no protected-file edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)