### PR TITLE
feat(codex): redacted session briefing router

### DIFF
--- a/aragora/cli/commands/codex_sessions.py
+++ b/aragora/cli/commands/codex_sessions.py
@@ -117,40 +117,73 @@ def _run_json_command(
         return None, f"invalid JSON: {exc}"
 
 
-def _active_lanes_from_registry(repo_root: Path) -> list[str]:
-    registry = repo_root / ".aragora" / "agent-bridge" / "lanes.json"
-    try:
-        payload = json.loads(registry.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return []
+def _normalize_lane_records(payload: Any) -> list[dict[str, Any]]:
     if isinstance(payload, dict):
         records = payload.get("lanes") or payload.get("records") or []
     elif isinstance(payload, list):
         records = payload
     else:
         records = []
-    active: list[str] = []
+    out: list[dict[str, Any]] = []
     for record in records:
         if not isinstance(record, dict):
             continue
         status = str(record.get("status") or "").lower()
-        if status in {"released", "completed", "done", "closed"}:
+        if status in {"released", "completed", "complete", "done", "closed"}:
             continue
         lane_id = record.get("lane_id") or record.get("id") or record.get("lane")
-        if lane_id:
-            active.append(str(lane_id))
-    return sorted(dict.fromkeys(active))
+        if not lane_id:
+            continue
+        out.append(
+            {
+                key: value
+                for key, value in {
+                    "lane_id": str(lane_id),
+                    "owner_session": record.get("owner_session"),
+                    "status": record.get("status"),
+                    "branch": record.get("branch"),
+                    "worktree": record.get("worktree"),
+                    "pr_number": record.get("pr_number"),
+                    "goal": record.get("goal"),
+                }.items()
+                if value not in (None, "")
+            }
+        )
+    return out
+
+
+def _active_lane_records_from_registry(repo_root: Path) -> list[dict[str, Any]]:
+    registry = repo_root / ".aragora" / "agent-bridge" / "lanes.json"
+    try:
+        payload = json.loads(registry.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    return _normalize_lane_records(payload)
+
+
+def _active_lane_records_from_bridge(repo_root: Path) -> list[dict[str, Any]]:
+    lanes, err = _run_json_command(
+        ["python3", "scripts/agent_bridge.py", "lanes", "--json"],
+        cwd=repo_root,
+    )
+    if err or not isinstance(lanes, list):
+        return []
+    return _normalize_lane_records(lanes)
 
 
 def _collect_repo_context(repo_root_arg: str | None) -> dict[str, Any]:
     if not repo_root_arg:
         return {"source": "disabled", "open_pr_count": None, "active_lanes": []}
     repo_root = Path(repo_root_arg).expanduser().resolve(strict=False)
+    lane_records = _active_lane_records_from_registry(repo_root)
+    if not lane_records:
+        lane_records = _active_lane_records_from_bridge(repo_root)
     context: dict[str, Any] = {
         "source": "repo",
         "repo_root": str(repo_root),
         "open_pr_count": None,
-        "active_lanes": _active_lanes_from_registry(repo_root),
+        "active_lanes": sorted({str(record["lane_id"]) for record in lane_records}),
+        "active_lane_records": lane_records,
         "active_sessions": None,
         "active_processes": None,
         "errors": [],
@@ -202,9 +235,46 @@ def _group_briefs(
     groups: dict[str, list[str]] = {}
     for brief in briefs:
         value = brief.get(group_by)
+        if value is None and group_by == "title":
+            value = brief.get("title_summary")
         key = str(value) if value else "(none)"
         groups.setdefault(key, []).append(str(brief.get("id") or ""))
     return groups
+
+
+def _compact_brief(row: dict[str, Any]) -> dict[str, Any]:
+    from aragora.codex.desktop_inspector import truncate
+
+    router_obj = row.get("router")
+    router: dict[str, Any] = router_obj if isinstance(router_obj, dict) else {}
+    pr_mentions = list(row.get("pr_mentions") or [])
+    files_mentioned = list(row.get("files_mentioned") or [])
+    branches_mentioned = list(row.get("branches_mentioned") or [])
+    return {
+        "id": str(row.get("id") or "")[:12],
+        "title_summary": truncate(str(row.get("title") or "(no title)"), width=72),
+        "cwd": truncate(str(row.get("cwd") or ""), width=96),
+        "branch": row.get("branch"),
+        "age": row.get("age"),
+        "prompt_needed": row.get("prompt_needed", "unknown"),
+        "prompt_needed_reason": row.get("prompt_needed_reason", "raw_signal_insufficient"),
+        "route": router.get("category"),
+        "route_reason": router.get("reason"),
+        "pr_mentions": pr_mentions[:8],
+        "pr_mention_count": len(pr_mentions),
+        "files_mentioned": files_mentioned[:8],
+        "file_mention_count": len(files_mentioned),
+        "branches_mentioned": branches_mentioned[:8],
+        "branch_mention_count": len(branches_mentioned),
+        "active_lane": row.get("active_lane"),
+        "conflict_risk": row.get("conflict_risk") or "unknown",
+        "current_likely_state": row.get("current_likely_state"),
+        "recommended_next_prompt": router.get("recommended_next_prompt"),
+    }
+
+
+def _filter_awaiting_prompts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [row for row in rows if row.get("prompt_needed") is True]
 
 
 def cmd_codex_sessions_list(args: argparse.Namespace) -> int:
@@ -300,6 +370,8 @@ def cmd_codex_sessions_brief(args: argparse.Namespace) -> int:
     if args.include_last_turns < 0:
         print("error: --include-last-turns must be >= 0", file=sys.stderr)
         return 2
+    compact = bool(getattr(args, "compact", False))
+    awaiting_prompts = bool(getattr(args, "awaiting_prompts", False))
 
     try:
         since = _parse_since(args.since)
@@ -320,6 +392,10 @@ def cmd_codex_sessions_brief(args: argparse.Namespace) -> int:
             threads = [thread]
         else:
             briefs = [paste_needed_brief(args.session).to_dict()]
+            if awaiting_prompts:
+                briefs = _filter_awaiting_prompts(briefs)
+            if compact:
+                briefs = [_compact_brief(row) for row in briefs]
             payload = {
                 "schema": "aragora-codex-sessions-brief/1.0",
                 "generated_at": datetime.now(UTC).isoformat(),
@@ -328,8 +404,10 @@ def cmd_codex_sessions_brief(args: argparse.Namespace) -> int:
                 "include_archived": bool(args.include_archived),
                 "include_last_turns": int(args.include_last_turns),
                 "group_by": args.group_by,
+                "compact": compact,
+                "awaiting_prompts": awaiting_prompts,
                 "repo_context": repo_context,
-                "count": 1,
+                "count": len(briefs),
                 "briefs": briefs,
                 "groups": _group_briefs(briefs, group_by=args.group_by),
             }
@@ -354,6 +432,10 @@ def cmd_codex_sessions_brief(args: argparse.Namespace) -> int:
         ).to_dict()
         for thread in threads
     ]
+    if awaiting_prompts:
+        briefs = _filter_awaiting_prompts(briefs)
+    if compact:
+        briefs = [_compact_brief(row) for row in briefs]
     payload = {
         "schema": "aragora-codex-sessions-brief/1.0",
         "generated_at": datetime.now(UTC).isoformat(),
@@ -363,6 +445,8 @@ def cmd_codex_sessions_brief(args: argparse.Namespace) -> int:
         "include_archived": bool(args.include_archived),
         "include_last_turns": int(args.include_last_turns),
         "group_by": args.group_by,
+        "compact": compact,
+        "awaiting_prompts": awaiting_prompts,
         "repo_context": repo_context,
         "count": len(briefs),
         "briefs": briefs,
@@ -390,11 +474,14 @@ def _format_brief_table(briefs: list[dict[str, Any]]) -> str:
         {
             "id": str(brief.get("id") or "")[:12],
             "age": brief.get("age") or "",
-            "route": (brief.get("router") or {}).get("category", ""),
+            "route": brief.get("route") or (brief.get("router") or {}).get("category", ""),
             "branch": str(brief.get("branch") or "")[:18],
             "prs": ",".join(f"#{n}" for n in brief.get("pr_mentions", [])[:4]),
             "state": truncate(str(brief.get("current_likely_state") or ""), width=52),
-            "title": truncate(str(brief.get("title") or "(no title)"), width=54),
+            "title": truncate(
+                str(brief.get("title_summary") or brief.get("title") or "(no title)"),
+                width=54,
+            ),
         }
         for brief in briefs
     ]

--- a/aragora/cli/commands/codex_sessions.py
+++ b/aragora/cli/commands/codex_sessions.py
@@ -1,8 +1,12 @@
-"""CLI handlers for ``aragora codex sessions {list,show,tail}``.
+"""CLI handlers for ``aragora codex sessions {list,brief,show,tail}``.
 
 Read-only inspector for Codex Desktop local state. All output is secret-redacted
 by default; full-transcript output (``--full``) writes to a file under
 ``.aragora/codex_sessions/`` unless ``--out -`` forces stdout.
+
+The ``brief`` subcommand may also query repository-local/GitHub state for open
+PR pressure and lane context. It still never writes to ``~/.codex`` and never
+prints raw transcript text.
 
 Heavy imports are deferred to invocation time so adding this CLI does not slow
 ``aragora --help`` startup (see ``aragora/cli/backup.py`` for the same pattern).
@@ -12,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 import time
 from datetime import UTC, datetime, timedelta
@@ -26,6 +31,7 @@ DEFAULT_SINCE = "4h"
 DEFAULT_LIMIT = 50
 DEFAULT_MAX_EVENTS = 2000
 DEFAULT_TAIL_INTERVAL_SECONDS = 5.0
+DEFAULT_LIVE_CONTEXT_TIMEOUT_SECONDS = 20
 
 
 def _parse_since(value: str) -> timedelta:
@@ -83,6 +89,122 @@ def _format_table(rows: list[dict[str, Any]], columns: list[tuple[str, str]]) ->
         "  ".join(str(row.get(key, "")).ljust(widths[key]) for key, _ in columns) for row in rows
     )
     return f"{header}\n{separator}\n{body}"
+
+
+def _run_json_command(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    timeout: int = DEFAULT_LIVE_CONTEXT_TIMEOUT_SECONDS,
+) -> tuple[Any | None, str | None]:
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, str(exc)
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or completed.stdout.strip()
+        return None, stderr[:500] if stderr else f"command exited {completed.returncode}"
+    try:
+        return json.loads(completed.stdout), None
+    except ValueError as exc:
+        return None, f"invalid JSON: {exc}"
+
+
+def _active_lanes_from_registry(repo_root: Path) -> list[str]:
+    registry = repo_root / ".aragora" / "agent-bridge" / "lanes.json"
+    try:
+        payload = json.loads(registry.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    if isinstance(payload, dict):
+        records = payload.get("lanes") or payload.get("records") or []
+    elif isinstance(payload, list):
+        records = payload
+    else:
+        records = []
+    active: list[str] = []
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        status = str(record.get("status") or "").lower()
+        if status in {"released", "completed", "done", "closed"}:
+            continue
+        lane_id = record.get("lane_id") or record.get("id") or record.get("lane")
+        if lane_id:
+            active.append(str(lane_id))
+    return sorted(dict.fromkeys(active))
+
+
+def _collect_repo_context(repo_root_arg: str | None) -> dict[str, Any]:
+    if not repo_root_arg:
+        return {"source": "disabled", "open_pr_count": None, "active_lanes": []}
+    repo_root = Path(repo_root_arg).expanduser().resolve(strict=False)
+    context: dict[str, Any] = {
+        "source": "repo",
+        "repo_root": str(repo_root),
+        "open_pr_count": None,
+        "active_lanes": _active_lanes_from_registry(repo_root),
+        "active_sessions": None,
+        "active_processes": None,
+        "errors": [],
+    }
+    prs, err = _run_json_command(
+        ["gh", "pr", "list", "--state", "open", "--limit", "80", "--json", "number"],
+        cwd=repo_root,
+    )
+    if isinstance(prs, list):
+        context["open_pr_count"] = len(prs)
+    elif err:
+        context["errors"].append({"source": "gh_pr_list", "error": err})
+
+    bridge, err = _run_json_command(
+        ["python3", "scripts/agent_bridge.py", "operator-snapshot", "--json", "--summary-only"],
+        cwd=repo_root,
+    )
+    if isinstance(bridge, dict):
+        summary = bridge.get("summary")
+        if isinstance(summary, dict):
+            context["active_sessions"] = summary.get("active_sessions")
+            context["active_processes"] = summary.get("active_processes")
+            context["bridge_active_lanes"] = summary.get("active_lanes")
+    elif err:
+        context["errors"].append({"source": "agent_bridge", "error": err})
+
+    active, err = _run_json_command(
+        ["python3", "scripts/list_active_agent_sessions.py", "--json", "--max-pr-fetch", "80"],
+        cwd=repo_root,
+    )
+    if isinstance(active, dict):
+        summary = active.get("summary")
+        if isinstance(summary, dict):
+            context["overlap_count"] = summary.get("overlap_count")
+        elif "overlap_count" in active:
+            context["overlap_count"] = active.get("overlap_count")
+    elif err:
+        context["errors"].append({"source": "list_active_agent_sessions", "error": err})
+    return context
+
+
+def _group_briefs(
+    briefs: list[dict[str, Any]],
+    *,
+    group_by: str | None,
+) -> dict[str, list[str]]:
+    if not group_by:
+        return {}
+    groups: dict[str, list[str]] = {}
+    for brief in briefs:
+        value = brief.get(group_by)
+        key = str(value) if value else "(none)"
+        groups.setdefault(key, []).append(str(brief.get("id") or ""))
+    return groups
 
 
 def cmd_codex_sessions_list(args: argparse.Namespace) -> int:
@@ -160,6 +282,134 @@ def cmd_codex_sessions_list(args: argparse.Namespace) -> int:
     print(table)
     print(f"\n{len(rows)} thread(s) updated since {since}.")
     return 0
+
+
+def cmd_codex_sessions_brief(args: argparse.Namespace) -> int:
+    """Brief recent Codex Desktop sessions and route conservative next prompts."""
+    from aragora.codex.desktop_inspector import (
+        build_session_brief,
+        find_thread,
+        list_active_threads,
+        paste_needed_brief,
+        redact_display,
+    )
+
+    if args.limit < 0:
+        print("error: --limit must be >= 0", file=sys.stderr)
+        return 2
+    if args.include_last_turns < 0:
+        print("error: --include-last-turns must be >= 0", file=sys.stderr)
+        return 2
+
+    try:
+        since = _parse_since(args.since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    paths = _resolve_paths(args)
+    if not paths.sqlite_path.exists():
+        print(_missing_db_message(paths.sqlite_path), file=sys.stderr)
+        return 1
+
+    repo_context = _collect_repo_context(getattr(args, "repo_root", None))
+    threads = []
+    if args.session:
+        thread = find_thread(args.session, paths=paths)
+        if thread is not None:
+            threads = [thread]
+        else:
+            briefs = [paste_needed_brief(args.session).to_dict()]
+            payload = {
+                "schema": "aragora-codex-sessions-brief/1.0",
+                "generated_at": datetime.now(UTC).isoformat(),
+                "codex_home": redact_display(paths.home),
+                "since": args.since,
+                "include_archived": bool(args.include_archived),
+                "include_last_turns": int(args.include_last_turns),
+                "group_by": args.group_by,
+                "repo_context": repo_context,
+                "count": 1,
+                "briefs": briefs,
+                "groups": _group_briefs(briefs, group_by=args.group_by),
+            }
+            if args.json:
+                _print_json(payload)
+            else:
+                print(_format_brief_table(briefs))
+            return 0
+    else:
+        threads = list_active_threads(
+            since=since,
+            include_archived=args.include_archived,
+            limit=args.limit,
+            paths=paths,
+        )
+
+    briefs = [
+        build_session_brief(
+            thread,
+            include_last_turns=args.include_last_turns,
+            repo_context=repo_context,
+        ).to_dict()
+        for thread in threads
+    ]
+    payload = {
+        "schema": "aragora-codex-sessions-brief/1.0",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "codex_home": redact_display(paths.home),
+        "since": args.since,
+        "since_seconds": int(since.total_seconds()),
+        "include_archived": bool(args.include_archived),
+        "include_last_turns": int(args.include_last_turns),
+        "group_by": args.group_by,
+        "repo_context": repo_context,
+        "count": len(briefs),
+        "briefs": briefs,
+        "groups": _group_briefs(briefs, group_by=args.group_by),
+    }
+    if args.json:
+        _print_json(payload)
+        return 0
+
+    print(_format_brief_table(briefs))
+    if args.group_by:
+        print("\nGroups:")
+        for key, ids in payload["groups"].items():
+            print(f"  {key}: {', '.join(id_value[:12] for id_value in ids)}")
+    print(f"\n{len(briefs)} brief(s) updated since {since}.")
+    if repo_context.get("errors"):
+        print("Live context warnings: " + str(len(repo_context["errors"])))
+    return 0
+
+
+def _format_brief_table(briefs: list[dict[str, Any]]) -> str:
+    from aragora.codex.desktop_inspector import truncate
+
+    rows = [
+        {
+            "id": str(brief.get("id") or "")[:12],
+            "age": brief.get("age") or "",
+            "route": (brief.get("router") or {}).get("category", ""),
+            "branch": str(brief.get("branch") or "")[:18],
+            "prs": ",".join(f"#{n}" for n in brief.get("pr_mentions", [])[:4]),
+            "state": truncate(str(brief.get("current_likely_state") or ""), width=52),
+            "title": truncate(str(brief.get("title") or "(no title)"), width=54),
+        }
+        for brief in briefs
+    ]
+    return _format_table(
+        rows,
+        columns=[
+            ("id", "ID"),
+            ("age", "AGE"),
+            ("route", "ROUTE"),
+            ("branch", "BRANCH"),
+            ("prs", "PRS"),
+            ("state", "STATE"),
+            ("title", "TITLE"),
+        ],
+    )
 
 
 def _resolve_rollout(

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -3157,8 +3157,9 @@ def _add_codex_parser(subparsers) -> None:
         help="Read-only inspector for Codex Desktop local state",
         description=(
             "Surface Codex Desktop sessions/threads from ~/.codex/ as redacted, "
-            "read-only data. Never writes to ~/.codex/, makes no network calls, "
-            "and consumes no AI provider keys."
+            "read-only data. Never writes to ~/.codex/ and consumes no AI "
+            "provider keys. The sessions brief command may query GitHub/repo "
+            "state for queue context unless --repo-root '' disables it."
         ),
     )
     codex.set_defaults(func=parent_help(codex))
@@ -3167,7 +3168,7 @@ def _add_codex_parser(subparsers) -> None:
     sessions = codex_sub.add_parser(
         "sessions",
         help="Inspect Codex Desktop sessions/threads",
-        description="List, summarize, or tail Codex Desktop sessions (read-only).",
+        description="List, brief, summarize, or tail Codex Desktop sessions (read-only).",
     )
     sessions.set_defaults(func=parent_help(sessions))
     sessions_sub = sessions.add_subparsers(dest="codex_sessions_cmd")
@@ -3200,6 +3201,58 @@ def _add_codex_parser(subparsers) -> None:
     )
     list_cmd.set_defaults(
         func=_lazy("aragora.cli.commands.codex_sessions", "cmd_codex_sessions_list")
+    )
+
+    brief_cmd = sessions_sub.add_parser(
+        "brief",
+        help="Brief recent sessions and route conservative next prompts",
+        description=(
+            "Build redacted Codex Desktop session briefings from local JSONL/session "
+            "metadata, then classify each session into pause/watch/review/settle/"
+            "repair/paste-needed. Raw transcript text is not emitted."
+        ),
+    )
+    add_common(brief_cmd)
+    brief_cmd.add_argument(
+        "--since",
+        default="4h",
+        help="Time window (e.g. 30m, 4h, 1d, 90s). Default: 4h.",
+    )
+    brief_cmd.add_argument(
+        "--include-archived",
+        action="store_true",
+        help="Include archived threads (default: exclude)",
+    )
+    brief_cmd.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum number of threads to brief (default: 50, 0 = no limit)",
+    )
+    brief_cmd.add_argument(
+        "--include-last-turns",
+        type=int,
+        default=0,
+        help="Include this many recent safe turn summaries, never raw transcript text.",
+    )
+    brief_cmd.add_argument(
+        "--group-by",
+        choices=("cwd", "branch", "title"),
+        default=None,
+        help="Group returned session ids by cwd, branch, or title.",
+    )
+    brief_cmd.add_argument(
+        "--session",
+        default=None,
+        help="Restrict to one thread id or id prefix; returns paste-needed if invisible.",
+    )
+    brief_cmd.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repo root used for queue/lane context (default: current directory; '' disables).",
+    )
+    brief_cmd.set_defaults(
+        func=_lazy("aragora.cli.commands.codex_sessions", "cmd_codex_sessions_brief")
     )
 
     show_cmd = sessions_sub.add_parser(

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -3236,6 +3236,16 @@ def _add_codex_parser(subparsers) -> None:
         help="Include this many recent safe turn summaries, never raw transcript text.",
     )
     brief_cmd.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact prompt-router rows instead of full briefing objects.",
+    )
+    brief_cmd.add_argument(
+        "--awaiting-prompts",
+        action="store_true",
+        help="Return only sessions whose redacted signal suggests an operator prompt is needed.",
+    )
+    brief_cmd.add_argument(
         "--group-by",
         choices=("cwd", "branch", "title"),
         default=None,

--- a/aragora/codex/desktop_inspector.py
+++ b/aragora/codex/desktop_inspector.py
@@ -474,12 +474,16 @@ def _extract_pr_mentions(text: str) -> list[int]:
     return mentions
 
 
+def _redact_structured_token(value: str) -> str:
+    return _build_barrier().redact(value)
+
+
 def _extract_file_mentions(text: str) -> list[str]:
-    return [match.group(1) for match in _FILE_RE.finditer(text)]
+    return [_redact_structured_token(match.group(1)) for match in _FILE_RE.finditer(text)]
 
 
 def _extract_branch_mentions(text: str) -> list[str]:
-    return [match.group(0) for match in _BRANCH_RE.finditer(text)]
+    return [_redact_structured_token(match.group(0)) for match in _BRANCH_RE.finditer(text)]
 
 
 def _message_role(payload: Any) -> str:

--- a/aragora/codex/desktop_inspector.py
+++ b/aragora/codex/desktop_inspector.py
@@ -208,6 +208,10 @@ class SessionBrief:
     pr_mentions: tuple[int, ...]
     files_mentioned: tuple[str, ...]
     branches_mentioned: tuple[str, ...]
+    active_lane: dict[str, Any] | None
+    conflict_risk: str
+    prompt_needed: bool | str
+    prompt_needed_reason: str
     last_user_intent_summary: str
     last_assistant_action_summary: str
     current_likely_state: str
@@ -228,6 +232,10 @@ class SessionBrief:
             "pr_mentions": list(self.pr_mentions),
             "files_mentioned": list(self.files_mentioned),
             "branches_mentioned": list(self.branches_mentioned),
+            "active_lane": self.active_lane,
+            "conflict_risk": self.conflict_risk,
+            "prompt_needed": self.prompt_needed,
+            "prompt_needed_reason": self.prompt_needed_reason,
             "last_user_intent_summary": self.last_user_intent_summary,
             "last_assistant_action_summary": self.last_assistant_action_summary,
             "current_likely_state": self.current_likely_state,
@@ -641,6 +649,74 @@ def _state_from_route(route: PromptRoute) -> str:
     return "insufficient redacted local signal; paste excerpt needed"
 
 
+def _active_lane_records(repo_context: dict[str, Any] | None) -> list[dict[str, Any]]:
+    context = repo_context or {}
+    records = context.get("active_lane_records")
+    if not isinstance(records, list):
+        return []
+    return [record for record in records if isinstance(record, dict)]
+
+
+def _redacted_lane_record(record: dict[str, Any]) -> dict[str, Any]:
+    keys = ("lane_id", "owner_session", "status", "branch", "worktree", "pr_number", "goal")
+    out: dict[str, Any] = {}
+    for key in keys:
+        value = record.get(key)
+        if value in (None, ""):
+            continue
+        if key in {"branch", "worktree", "goal"}:
+            out[key] = redact_display(str(value))
+        else:
+            out[key] = value
+    return out
+
+
+def _matching_active_lane(
+    *,
+    branch: str | None,
+    cwd: str,
+    pr_mentions: tuple[int, ...],
+    repo_context: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    branch_value = str(branch or "").strip()
+    cwd_value = str(cwd or "").strip()
+    pr_values = {int(value) for value in pr_mentions}
+    for record in _active_lane_records(repo_context):
+        lane_branch = str(record.get("branch") or "").strip()
+        lane_worktree = str(record.get("worktree") or "").strip()
+        lane_pr = record.get("pr_number")
+        if branch_value and lane_branch and branch_value == lane_branch:
+            return _redacted_lane_record(record)
+        if cwd_value and lane_worktree and cwd_value == lane_worktree:
+            return _redacted_lane_record(record)
+        if isinstance(lane_pr, int) and lane_pr in pr_values:
+            return _redacted_lane_record(record)
+    return None
+
+
+def _infer_prompt_needed(
+    *,
+    route: PromptRoute,
+    active_lane: dict[str, Any] | None,
+    last_message_role: str,
+    has_user_signal: bool,
+    has_assistant_signal: bool,
+) -> tuple[bool | str, str]:
+    if active_lane is not None:
+        return False, "active_lane_owned"
+    if route.category == "paste-needed":
+        return "unknown", "raw_signal_insufficient"
+    if last_message_role == "assistant":
+        return True, "assistant_final_recent"
+    if has_assistant_signal and route.category in {"watch", "review", "settle", "repair"}:
+        return True, "pending_operator"
+    if last_message_role == "user" and has_user_signal:
+        return False, "user_turn_latest"
+    if not has_user_signal and not has_assistant_signal:
+        return "unknown", "raw_signal_insufficient"
+    return "unknown", "raw_signal_insufficient"
+
+
 def build_session_brief(
     thread: ThreadSummary,
     *,
@@ -664,6 +740,7 @@ def build_session_brief(
     last_assistant_summary = "no assistant action found"
     has_user_signal = False
     has_assistant_signal = False
+    last_message_role = ""
     tool_names: list[str] = []
     scanned = 0
 
@@ -703,9 +780,11 @@ def build_session_brief(
             if role == "user":
                 has_user_signal = bool(text)
                 last_user_summary = summary
+                last_message_role = role
             elif role == "assistant":
                 has_assistant_signal = bool(text)
                 last_assistant_summary = summary
+                last_message_role = role
             turn_summaries.append(
                 {
                     "timestamp": event.get("timestamp"),
@@ -739,6 +818,19 @@ def build_session_brief(
     now = datetime.now(UTC)
     age_seconds = max(0, int((now - thread.updated_at).total_seconds()))
     recent_turns = tuple(turn_summaries[-include_last_turns:]) if include_last_turns else ()
+    active_lane = _matching_active_lane(
+        branch=thread.git_branch,
+        cwd=thread.cwd,
+        pr_mentions=pr_mentions,
+        repo_context=repo_context,
+    )
+    prompt_needed, prompt_needed_reason = _infer_prompt_needed(
+        route=route,
+        active_lane=active_lane,
+        last_message_role=last_message_role,
+        has_user_signal=has_user_signal,
+        has_assistant_signal=has_assistant_signal,
+    )
     return SessionBrief(
         id=thread.id,
         title=thread.title,
@@ -752,6 +844,10 @@ def build_session_brief(
         pr_mentions=pr_mentions,
         files_mentioned=files_mentioned,
         branches_mentioned=branches_mentioned,
+        active_lane=active_lane,
+        conflict_risk="active-lane-overlap" if active_lane else "none",
+        prompt_needed=prompt_needed,
+        prompt_needed_reason=prompt_needed_reason,
         last_user_intent_summary=last_user_summary,
         last_assistant_action_summary=last_assistant_summary,
         current_likely_state=_state_from_route(route),
@@ -785,6 +881,10 @@ def paste_needed_brief(session_id: str) -> SessionBrief:
         pr_mentions=(),
         files_mentioned=(),
         branches_mentioned=(),
+        active_lane=None,
+        conflict_risk="unknown",
+        prompt_needed="unknown",
+        prompt_needed_reason="raw_signal_insufficient",
         last_user_intent_summary="session not visible",
         last_assistant_action_summary="session not visible",
         current_likely_state=_state_from_route(route),

--- a/aragora/codex/desktop_inspector.py
+++ b/aragora/codex/desktop_inspector.py
@@ -10,6 +10,7 @@ This module is intentionally network-free and writes nothing to ``~/.codex/``.
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -35,6 +36,33 @@ _EXTRA_REDACTION_PATTERNS = (
 
 LIST_TITLE_WIDTH = 160
 LIST_FIRST_USER_MESSAGE_WIDTH = 240
+
+_PR_RE = re.compile(r"(?:\bPR\s*)?#(\d{2,7})\b", re.IGNORECASE)
+_FILE_RE = re.compile(
+    r"(?<![\w./-])((?:[\w.-]+/)+[\w.-]+\."
+    r"(?:py|md|json|toml|yaml|yml|txt|html|css|js|jsx|ts|tsx|sh|sql))\b"
+)
+_BRANCH_RE = re.compile(
+    r"\b(?:origin/main|main|(?:codex|droid|claude|vision-incubator|worktree|feat|fix|"
+    r"chore|docs|review)/[A-Za-z0-9._/-]+)\b"
+)
+
+_QUEUE_PRESSURE_OPEN_PR_THRESHOLD = 10
+_BROAD_BUILD_KEYWORDS = (
+    "build",
+    "implement",
+    "new pr",
+    "open pr",
+    "broad",
+    "feature",
+    "yes to all",
+    "ground up assessment",
+)
+_WATCH_KEYWORDS = ("watch", "ci", "checks", "pending", "head changed", "merge-packet")
+_REVIEW_KEYWORDS = ("review", "audit", "read-only", "exact-head review")
+_SETTLE_KEYWORDS = ("settle", "merge", "admin squash", "receipt")
+_REPAIR_KEYWORDS = ("repair", "fix", "conflict", "rebase")
+_PROMPT_CATEGORIES = {"pause", "watch", "review", "settle", "repair", "paste-needed"}
 
 
 def _rollout_path_from_db(value: str, *, paths: CodexDesktopPaths) -> Path:
@@ -140,6 +168,71 @@ class SessionSummary:
             "model_provider": self.model_provider,
             "started_at": self.started_at.isoformat() if self.started_at else None,
             "last_event_at": self.last_event_at.isoformat() if self.last_event_at else None,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PromptRoute:
+    """Conservative prompt-router output for one Codex Desktop session."""
+
+    category: str
+    reason: str
+    recommended_next_prompt: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "category": self.category,
+            "reason": self.reason,
+            "recommended_next_prompt": self.recommended_next_prompt,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SessionBrief:
+    """Redacted, queue-aware briefing for one Codex Desktop session.
+
+    Raw transcript text is intentionally absent. The brief exposes only
+    redacted metadata, bounded summaries, and structured tokens such as PR
+    numbers and repo-relative file names.
+    """
+
+    id: str
+    title: str
+    cwd: str
+    branch: str | None
+    sha: str | None
+    rollout_path: Path | None
+    updated_at: datetime | None
+    age_seconds: int | None
+    age: str | None
+    pr_mentions: tuple[int, ...]
+    files_mentioned: tuple[str, ...]
+    branches_mentioned: tuple[str, ...]
+    last_user_intent_summary: str
+    last_assistant_action_summary: str
+    current_likely_state: str
+    router: PromptRoute
+    recent_turns: tuple[dict[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "cwd": self.cwd,
+            "branch": self.branch,
+            "sha": self.sha,
+            "rollout_path": redact_display(self.rollout_path) if self.rollout_path else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "age_seconds": self.age_seconds,
+            "age": self.age,
+            "pr_mentions": list(self.pr_mentions),
+            "files_mentioned": list(self.files_mentioned),
+            "branches_mentioned": list(self.branches_mentioned),
+            "last_user_intent_summary": self.last_user_intent_summary,
+            "last_assistant_action_summary": self.last_assistant_action_summary,
+            "current_likely_state": self.current_likely_state,
+            "router": self.router.to_dict(),
+            "recent_turns": list(self.recent_turns),
         }
 
 
@@ -361,6 +454,339 @@ def iter_session_events_from_offset(
             if barrier is not None:
                 event = barrier.redact_dict(event)
             yield event, handle.tell()
+
+
+def _unique_sorted_ints(values: list[int]) -> tuple[int, ...]:
+    return tuple(sorted(dict.fromkeys(values)))
+
+
+def _unique_sorted_strings(values: list[str]) -> tuple[str, ...]:
+    return tuple(sorted(dict.fromkeys(v for v in values if v)))
+
+
+def _extract_pr_mentions(text: str) -> list[int]:
+    mentions: list[int] = []
+    for match in _PR_RE.finditer(text):
+        try:
+            mentions.append(int(match.group(1)))
+        except (TypeError, ValueError):
+            continue
+    return mentions
+
+
+def _extract_file_mentions(text: str) -> list[str]:
+    return [match.group(1) for match in _FILE_RE.finditer(text)]
+
+
+def _extract_branch_mentions(text: str) -> list[str]:
+    return [match.group(0) for match in _BRANCH_RE.finditer(text)]
+
+
+def _message_role(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return "unknown"
+    role = payload.get("role")
+    return str(role) if role else "unknown"
+
+
+def _summarize_intent(
+    *,
+    role: str,
+    text: str,
+    pr_mentions: tuple[int, ...],
+    file_mentions: tuple[str, ...],
+    branch_mentions: tuple[str, ...],
+) -> str:
+    lower = text.lower()
+    parts: list[str] = []
+    if any(keyword in lower for keyword in _SETTLE_KEYWORDS):
+        parts.append("settlement or merge request")
+    if any(keyword in lower for keyword in _WATCH_KEYWORDS):
+        parts.append("watch/check-status request")
+    if any(keyword in lower for keyword in _REVIEW_KEYWORDS):
+        parts.append("review request")
+    if any(keyword in lower for keyword in _REPAIR_KEYWORDS):
+        parts.append("repair request")
+    if any(keyword in lower for keyword in _BROAD_BUILD_KEYWORDS):
+        parts.append("build/implementation request")
+    if pr_mentions:
+        parts.append("mentions " + ", ".join(f"PR #{n}" for n in pr_mentions[:5]))
+    if file_mentions:
+        parts.append(f"mentions {len(file_mentions)} file path(s)")
+    if branch_mentions:
+        parts.append(f"mentions {len(branch_mentions)} branch token(s)")
+    if parts:
+        return f"{role} " + "; ".join(parts)
+    if text:
+        return f"{role} message present; raw transcript text redacted"
+    return f"no {role} message found"
+
+
+def _recommended_prompt(
+    *,
+    category: str,
+    pr_mentions: tuple[int, ...],
+    files_mentioned: tuple[str, ...],
+    queue_pressure_high: bool,
+) -> str:
+    pr_part = ", ".join(f"#{n}" for n in pr_mentions[:4]) or "<target PR>"
+    file_part = ", ".join(files_mentioned[:3]) or "<changed files>"
+    if category == "pause":
+        return (
+            "Stop new implementation. Start from live repo truth, report current task state, "
+            "open PR pressure, and any active lane overlap; do not edit files or open PRs."
+        )
+    if category == "watch":
+        return (
+            f"Start from live repo truth. Watch {pr_part} only: pin current head, report CI/"
+            "merge-packet state, and stop without edits, labels, mark-ready, or merge."
+        )
+    if category == "review":
+        return (
+            f"Start from live repo truth. Review {pr_part} only at exact head; read changed "
+            "files, post or report a concise no-dissent/blocker verdict, and do not mutate "
+            "anything else."
+        )
+    if category == "settle":
+        return (
+            f"Start from live repo truth. Settle {pr_part} only at exact-head: rerun review-queue "
+            "merge-packet, merge only if admin_squash_allowed=true and not_ready=[], record "
+            "receipt, and stop on any drift."
+        )
+    if category == "repair":
+        return (
+            f"Start from live repo truth. Repair one bounded lane only for {pr_part}; touch "
+            f"only {file_part}, validate narrowly, push only the existing branch, and stop on "
+            "head drift."
+        )
+    suffix = " Queue pressure is high, so prefer read-only routing." if queue_pressure_high else ""
+    return (
+        "Paste the last 2-4 turns or provide the exact session name/PR, because the local "
+        f"redacted session record does not contain enough safe signal.{suffix}"
+    )
+
+
+def _route_session(
+    *,
+    all_text: str,
+    has_user_signal: bool,
+    has_assistant_signal: bool,
+    pr_mentions: tuple[int, ...],
+    files_mentioned: tuple[str, ...],
+    repo_context: dict[str, Any] | None,
+) -> PromptRoute:
+    context = repo_context or {}
+    try:
+        open_pr_count = int(context.get("open_pr_count") or 0)
+    except (TypeError, ValueError):
+        open_pr_count = 0
+    queue_pressure_high = open_pr_count >= _QUEUE_PRESSURE_OPEN_PR_THRESHOLD
+    lower = all_text.lower()
+
+    if not has_user_signal and not has_assistant_signal and not pr_mentions and not files_mentioned:
+        category = "paste-needed"
+        reason = "no safe recent user or assistant signal found"
+    elif queue_pressure_high and any(keyword in lower for keyword in _BROAD_BUILD_KEYWORDS):
+        category = "pause"
+        reason = f"open PR pressure is high ({open_pr_count}) and session looks build-oriented"
+    elif any(keyword in lower for keyword in _REPAIR_KEYWORDS):
+        category = "repair"
+        reason = "recent turns mention repair/conflict/rebase work"
+    elif any(keyword in lower for keyword in _SETTLE_KEYWORDS):
+        category = "settle"
+        reason = "recent turns mention settlement/merge/receipt work"
+    elif any(keyword in lower for keyword in _WATCH_KEYWORDS):
+        category = "watch"
+        reason = "recent turns mention CI/check/watch state"
+    elif any(keyword in lower for keyword in _REVIEW_KEYWORDS):
+        category = "review"
+        reason = "recent turns mention review/audit work"
+    elif queue_pressure_high:
+        category = "pause"
+        reason = f"open PR pressure is high ({open_pr_count}); defaulting to queue-drain posture"
+    else:
+        category = "paste-needed"
+        reason = "redacted local signal is ambiguous"
+
+    if category not in _PROMPT_CATEGORIES:
+        category = "paste-needed"
+        reason = "router produced an unknown category"
+    return PromptRoute(
+        category=category,
+        reason=reason,
+        recommended_next_prompt=_recommended_prompt(
+            category=category,
+            pr_mentions=pr_mentions,
+            files_mentioned=files_mentioned,
+            queue_pressure_high=queue_pressure_high,
+        ),
+    )
+
+
+def _state_from_route(route: PromptRoute) -> str:
+    if route.category == "pause":
+        return "likely too broad or duplicate-prone; pause and re-ground"
+    if route.category == "watch":
+        return "likely waiting on CI/head/merge-packet evidence"
+    if route.category == "review":
+        return "likely needs exact-head read-only review"
+    if route.category == "settle":
+        return "likely ready for exact-head settlement gate"
+    if route.category == "repair":
+        return "likely needs bounded one-PR repair"
+    return "insufficient redacted local signal; paste excerpt needed"
+
+
+def build_session_brief(
+    thread: ThreadSummary,
+    *,
+    include_last_turns: int = 0,
+    repo_context: dict[str, Any] | None = None,
+    max_events: int = 2000,
+) -> SessionBrief:
+    """Build a redacted operator briefing for one Codex Desktop thread.
+
+    The scan may read raw rollout JSONL locally to extract safe structured
+    tokens (PR numbers, path-like file mentions, branch names), but raw
+    transcript text is never returned.
+    """
+    include_last_turns = max(0, int(include_last_turns))
+    pr_values: list[int] = []
+    file_values: list[str] = []
+    branch_values: list[str] = []
+    turn_summaries: list[dict[str, Any]] = []
+    all_text_parts: list[str] = []
+    last_user_summary = "no user message found"
+    last_assistant_summary = "no assistant action found"
+    has_user_signal = False
+    has_assistant_signal = False
+    tool_names: list[str] = []
+    scanned = 0
+
+    for event in iter_jsonl(thread.rollout_path, strict=False):
+        if scanned >= max_events:
+            break
+        scanned += 1
+        payload = event.get("payload") or {}
+        event_type = str(event.get("type") or "")
+        text = _extract_text(payload)
+        if text:
+            all_text_parts.append(text)
+            pr_values.extend(_extract_pr_mentions(text))
+            file_values.extend(_extract_file_mentions(text))
+            branch_values.extend(_extract_branch_mentions(text))
+
+        if isinstance(payload, dict):
+            tool_name = payload.get("tool_name") or payload.get("name")
+            tool_call = payload.get("tool_call")
+            if not tool_name and isinstance(tool_call, dict):
+                tool_name = tool_call.get("name")
+            if isinstance(tool_name, str) and tool_name:
+                tool_names.append(tool_name)
+
+        if event_type == "agent_message":
+            role = _message_role(payload)
+            turn_prs = _unique_sorted_ints(_extract_pr_mentions(text))
+            turn_files = _unique_sorted_strings(_extract_file_mentions(text))
+            turn_branches = _unique_sorted_strings(_extract_branch_mentions(text))
+            summary = _summarize_intent(
+                role=role,
+                text=text,
+                pr_mentions=turn_prs,
+                file_mentions=turn_files,
+                branch_mentions=turn_branches,
+            )
+            if role == "user":
+                has_user_signal = bool(text)
+                last_user_summary = summary
+            elif role == "assistant":
+                has_assistant_signal = bool(text)
+                last_assistant_summary = summary
+            turn_summaries.append(
+                {
+                    "timestamp": event.get("timestamp"),
+                    "role": role,
+                    "summary": summary,
+                    "pr_mentions": list(turn_prs),
+                    "files_mentioned": list(turn_files),
+                    "branches_mentioned": list(turn_branches),
+                }
+            )
+
+    pr_mentions = _unique_sorted_ints(pr_values)
+    files_mentioned = _unique_sorted_strings(file_values)
+    branches_mentioned = _unique_sorted_strings(
+        branch_values + ([thread.git_branch] if thread.git_branch else [])
+    )
+    if tool_names and not has_assistant_signal:
+        names = ", ".join(sorted(dict.fromkeys(tool_names))[:5])
+        last_assistant_summary = f"assistant used tools: {names}"
+        has_assistant_signal = True
+
+    all_text = "\n".join(all_text_parts)
+    route = _route_session(
+        all_text=all_text,
+        has_user_signal=has_user_signal,
+        has_assistant_signal=has_assistant_signal,
+        pr_mentions=pr_mentions,
+        files_mentioned=files_mentioned,
+        repo_context=repo_context,
+    )
+    now = datetime.now(UTC)
+    age_seconds = max(0, int((now - thread.updated_at).total_seconds()))
+    recent_turns = tuple(turn_summaries[-include_last_turns:]) if include_last_turns else ()
+    return SessionBrief(
+        id=thread.id,
+        title=thread.title,
+        cwd=thread.cwd,
+        branch=thread.git_branch,
+        sha=thread.git_sha,
+        rollout_path=thread.rollout_path,
+        updated_at=thread.updated_at,
+        age_seconds=age_seconds,
+        age=humanize_ago(thread.updated_at, now=now),
+        pr_mentions=pr_mentions,
+        files_mentioned=files_mentioned,
+        branches_mentioned=branches_mentioned,
+        last_user_intent_summary=last_user_summary,
+        last_assistant_action_summary=last_assistant_summary,
+        current_likely_state=_state_from_route(route),
+        router=route,
+        recent_turns=recent_turns,
+    )
+
+
+def paste_needed_brief(session_id: str) -> SessionBrief:
+    """Return a synthetic brief for a requested session not visible locally."""
+    route = PromptRoute(
+        category="paste-needed",
+        reason="session id/prefix is not visible in Codex Desktop local state",
+        recommended_next_prompt=_recommended_prompt(
+            category="paste-needed",
+            pr_mentions=(),
+            files_mentioned=(),
+            queue_pressure_high=False,
+        ),
+    )
+    return SessionBrief(
+        id=session_id,
+        title="(session not found)",
+        cwd="",
+        branch=None,
+        sha=None,
+        rollout_path=None,
+        updated_at=None,
+        age_seconds=None,
+        age=None,
+        pr_mentions=(),
+        files_mentioned=(),
+        branches_mentioned=(),
+        last_user_intent_summary="session not visible",
+        last_assistant_action_summary="session not visible",
+        current_likely_state=_state_from_route(route),
+        router=route,
+        recent_turns=(),
+    )
 
 
 def summarize_session(

--- a/tests/codex/test_cli_codex_sessions.py
+++ b/tests/codex/test_cli_codex_sessions.py
@@ -39,8 +39,9 @@ def test_cli_codex_sessions_parent_prints_help(capsys: pytest.CaptureFixture[str
 
     assert args.func(args) == 2
     out = capsys.readouterr().out
-    assert "List, summarize, or tail Codex Desktop sessions" in out
+    assert "List, brief, summarize, or tail Codex Desktop sessions" in out
     assert "list" in out
+    assert "brief" in out
     assert "show" in out
 
 
@@ -310,6 +311,133 @@ def test_cli_show_unknown_target(fake_codex_home, capsys: pytest.CaptureFixture[
     )
     assert rc == 1
     assert "could not resolve" in capsys.readouterr().err
+
+
+# -- brief --------------------------------------------------------------------
+
+
+def _append_rollout_event(path: Path, event: dict) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event) + "\n")
+
+
+def test_cli_brief_json_redacts_raw_transcript(
+    fake_codex_home, capsys: pytest.CaptureFixture[str]
+) -> None:  # type: ignore[no-untyped-def]
+    _append_rollout_event(
+        fake_codex_home.recent_rollout,
+        {
+            "timestamp": "2026-05-16T13:54:00.000Z",
+            "type": "agent_message",
+            "payload": {
+                "role": "user",
+                "content": "Tell Codex B to watch #7283 with sk-proj-FAKE-BRIEF-SECRET",
+            },
+        },
+    )
+
+    rc = cli.cmd_codex_sessions_brief(
+        _args(
+            since="4h",
+            include_archived=False,
+            limit=50,
+            include_last_turns=0,
+            group_by=None,
+            session=None,
+            repo_root=None,
+            json=True,
+        )
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["schema"] == "aragora-codex-sessions-brief/1.0"
+    assert payload["count"] >= 1
+    assert "Tell Codex B" not in out
+    assert "sk-proj-FAKE-BRIEF-SECRET" not in out
+    assert any(7283 in row["pr_mentions"] for row in payload["briefs"])
+
+
+def test_cli_brief_include_last_turns_stays_summary_only(
+    fake_codex_home, capsys: pytest.CaptureFixture[str]
+) -> None:  # type: ignore[no-untyped-def]
+    _append_rollout_event(
+        fake_codex_home.recent_rollout,
+        {
+            "timestamp": "2026-05-16T13:54:00.000Z",
+            "type": "agent_message",
+            "payload": {
+                "role": "assistant",
+                "content": "I reviewed #7285 and saw Bearer ghp_FAKELEAK12345678901234",
+            },
+        },
+    )
+
+    rc = cli.cmd_codex_sessions_brief(
+        _args(
+            since="4h",
+            include_archived=False,
+            limit=50,
+            include_last_turns=2,
+            group_by=None,
+            session=fake_codex_home.recent_thread_id[:13],
+            repo_root=None,
+            json=True,
+        )
+    )
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+
+    assert rc == 0
+    assert payload["count"] == 1
+    assert payload["briefs"][0]["recent_turns"]
+    assert "I reviewed #7285" not in out
+    assert "ghp_FAKELEAK12345678901234" not in out
+
+
+def test_cli_brief_groups_by_branch(fake_codex_home, capsys: pytest.CaptureFixture[str]) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_brief(
+        _args(
+            since="4h",
+            include_archived=False,
+            limit=50,
+            include_last_turns=0,
+            group_by="branch",
+            session=None,
+            repo_root=None,
+            json=True,
+        )
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["group_by"] == "branch"
+    assert "main" in payload["groups"]
+    assert fake_codex_home.recent_thread_id in payload["groups"]["main"]
+
+
+def test_cli_brief_unknown_session_is_paste_needed(
+    fake_codex_home, capsys: pytest.CaptureFixture[str]
+) -> None:  # type: ignore[no-untyped-def]
+    rc = cli.cmd_codex_sessions_brief(
+        _args(
+            since="4h",
+            include_archived=False,
+            limit=50,
+            include_last_turns=0,
+            group_by=None,
+            session="ffffffffabcd",
+            repo_root=None,
+            json=True,
+        )
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["count"] == 1
+    assert payload["briefs"][0]["router"]["category"] == "paste-needed"
+    assert "Paste the last 2-4 turns" in payload["briefs"][0]["router"]["recommended_next_prompt"]
 
 
 def test_cli_tail_rejects_non_positive_interval(

--- a/tests/codex/test_cli_codex_sessions.py
+++ b/tests/codex/test_cli_codex_sessions.py
@@ -440,6 +440,95 @@ def test_cli_brief_unknown_session_is_paste_needed(
     assert "Paste the last 2-4 turns" in payload["briefs"][0]["router"]["recommended_next_prompt"]
 
 
+def test_cli_brief_compact_awaiting_prompts_filters_and_redacts(
+    fake_codex_home, capsys: pytest.CaptureFixture[str]
+) -> None:  # type: ignore[no-untyped-def]
+    _append_rollout_event(
+        fake_codex_home.recent_rollout,
+        {
+            "timestamp": "2026-05-16T13:55:00.000Z",
+            "type": "agent_message",
+            "payload": {
+                "role": "assistant",
+                "content": "Finished review of #7286 with sk-proj-FAKE-COMPACT-SECRET.",
+            },
+        },
+    )
+
+    rc = cli.cmd_codex_sessions_brief(
+        _args(
+            since="4h",
+            include_archived=False,
+            limit=50,
+            include_last_turns=0,
+            group_by=None,
+            session=fake_codex_home.recent_thread_id[:13],
+            repo_root=None,
+            compact=True,
+            awaiting_prompts=True,
+            json=True,
+        )
+    )
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+
+    assert rc == 0
+    assert payload["compact"] is True
+    assert payload["awaiting_prompts"] is True
+    assert payload["count"] == 1
+    row = payload["briefs"][0]
+    assert set(row) >= {
+        "id",
+        "title_summary",
+        "prompt_needed",
+        "prompt_needed_reason",
+        "route",
+        "conflict_risk",
+        "recommended_next_prompt",
+    }
+    assert row["prompt_needed"] is True
+    assert row["prompt_needed_reason"] == "assistant_final_recent"
+    assert "Finished review" not in out
+    assert "sk-proj-FAKE-COMPACT-SECRET" not in out
+
+
+def test_collect_repo_context_reads_active_lane_records_from_registry(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    registry = repo / ".aragora" / "agent-bridge" / "lanes.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "released",
+                    "owner_session": "codex-old",
+                    "status": "released",
+                    "branch": "old",
+                },
+                {
+                    "lane_id": "Q04-cross-agent-collision-control",
+                    "owner_session": "codex-q04",
+                    "status": "active",
+                    "branch": "codex/cross-agent-collision-control-20260517",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    context = cli._collect_repo_context(str(repo))
+
+    assert context["active_lanes"] == ["Q04-cross-agent-collision-control"]
+    assert context["active_lane_records"] == [
+        {
+            "lane_id": "Q04-cross-agent-collision-control",
+            "owner_session": "codex-q04",
+            "status": "active",
+            "branch": "codex/cross-agent-collision-control-20260517",
+        }
+    ]
+
+
 def test_cli_tail_rejects_non_positive_interval(
     fake_codex_home, capsys: pytest.CaptureFixture[str]
 ) -> None:  # type: ignore[no-untyped-def]

--- a/tests/codex/test_desktop_inspector.py
+++ b/tests/codex/test_desktop_inspector.py
@@ -357,6 +357,35 @@ def test_build_session_brief_last_turns_are_safe_summaries(
     assert "ghp_FAKELEAK12345678901234" not in serialized
 
 
+def test_build_session_brief_redacts_extracted_file_and_branch_tokens(
+    fake_codex_home,
+) -> None:  # type: ignore[no-untyped-def]
+    _append_rollout_event(
+        fake_codex_home.recent_rollout,
+        {
+            "timestamp": "2026-05-16T13:54:45.000Z",
+            "type": "agent_message",
+            "payload": {
+                "role": "user",
+                "content": (
+                    "Repair docs/sk-proj-FAKE-BRIEF-SECRET.md on "
+                    "codex/sk-or-v1-abcdefghijklmnopqrstuvwxyz"
+                ),
+            },
+        },
+    )
+    thread = inspector.find_thread(fake_codex_home.recent_thread_id)
+    assert thread is not None
+
+    brief = inspector.build_session_brief(thread, include_last_turns=2)
+    payload = brief.to_dict()
+    serialized = json.dumps(payload)
+
+    assert "sk-proj-FAKE-BRIEF-SECRET" not in serialized
+    assert "sk-or-v1-abcdefghijklmnopqrstuvwxyz" not in serialized
+    assert "[REDACTED]" in serialized
+
+
 def test_build_session_brief_routes_ambiguous_session_to_paste_needed(
     fake_codex_home,
 ) -> None:  # type: ignore[no-untyped-def]

--- a/tests/codex/test_desktop_inspector.py
+++ b/tests/codex/test_desktop_inspector.py
@@ -282,6 +282,120 @@ def test_iter_session_events_opt_out_returns_raw(fake_codex_home) -> None:  # ty
     assert "sk-proj-FAKE-LEAK-12345" in serialized
 
 
+# -- redacted briefing / prompt router ---------------------------------------
+
+
+def _append_rollout_event(path: Path, event: dict) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event) + "\n")
+
+
+def test_build_session_brief_redacts_raw_transcript_and_extracts_safe_tokens(
+    fake_codex_home,
+) -> None:  # type: ignore[no-untyped-def]
+    _append_rollout_event(
+        fake_codex_home.recent_rollout,
+        {
+            "timestamp": "2026-05-16T13:54:00.000Z",
+            "type": "agent_message",
+            "payload": {
+                "role": "user",
+                "content": (
+                    "Please settle PR #7283 and inspect scripts/apply_operator_decisions.py "
+                    "with sk-proj-FAKE-BRIEF-SECRET"
+                ),
+            },
+        },
+    )
+    thread = inspector.find_thread(fake_codex_home.recent_thread_id)
+    assert thread is not None
+
+    brief = inspector.build_session_brief(
+        thread,
+        include_last_turns=0,
+        repo_context={"open_pr_count": 14, "active_lanes": []},
+    )
+    payload = brief.to_dict()
+    serialized = json.dumps(payload)
+
+    assert payload["pr_mentions"] == [7283]
+    assert "scripts/apply_operator_decisions.py" in payload["files_mentioned"]
+    assert payload["router"]["category"] == "settle"
+    assert "exact-head" in payload["router"]["recommended_next_prompt"]
+    assert "Please settle PR" not in serialized
+    assert "sk-proj-FAKE-BRIEF-SECRET" not in serialized
+
+
+def test_build_session_brief_last_turns_are_safe_summaries(
+    fake_codex_home,
+) -> None:  # type: ignore[no-untyped-def]
+    _append_rollout_event(
+        fake_codex_home.recent_rollout,
+        {
+            "timestamp": "2026-05-16T13:54:30.000Z",
+            "type": "agent_message",
+            "payload": {
+                "role": "assistant",
+                "content": (
+                    "I posted a review comment on #7285 and read "
+                    "aragora/codex/desktop_inspector.py with ghp_FAKELEAK12345678901234"
+                ),
+            },
+        },
+    )
+    thread = inspector.find_thread(fake_codex_home.recent_thread_id)
+    assert thread is not None
+
+    brief = inspector.build_session_brief(thread, include_last_turns=2)
+    payload = brief.to_dict()
+    serialized = json.dumps(payload)
+
+    assert payload["recent_turns"]
+    assert "assistant" in {turn["role"] for turn in payload["recent_turns"]}
+    assert "review" in serialized
+    assert "I posted a review comment" not in serialized
+    assert "ghp_FAKELEAK12345678901234" not in serialized
+
+
+def test_build_session_brief_routes_ambiguous_session_to_paste_needed(
+    fake_codex_home,
+) -> None:  # type: ignore[no-untyped-def]
+    thread = inspector.find_thread(fake_codex_home.secret_titled_thread_id)
+    assert thread is not None
+
+    brief = inspector.build_session_brief(thread, include_last_turns=2)
+
+    assert brief.router.category == "paste-needed"
+    assert "Paste the last 2-4 turns" in brief.router.recommended_next_prompt
+
+
+def test_router_prefers_pause_for_broad_build_when_queue_pressure_is_high(
+    fake_codex_home,
+) -> None:  # type: ignore[no-untyped-def]
+    _append_rollout_event(
+        fake_codex_home.recent_rollout,
+        {
+            "timestamp": "2026-05-16T13:55:00.000Z",
+            "type": "agent_message",
+            "payload": {
+                "role": "user",
+                "content": "Please build a new broad feature and open another PR.",
+            },
+        },
+    )
+    thread = inspector.find_thread(fake_codex_home.recent_thread_id)
+    assert thread is not None
+
+    brief = inspector.build_session_brief(
+        thread,
+        include_last_turns=0,
+        repo_context={"open_pr_count": 20, "active_lanes": []},
+    )
+
+    assert brief.router.category == "pause"
+    assert "Stop new implementation" in brief.router.recommended_next_prompt
+
+
 # -- find_thread --------------------------------------------------------------
 
 

--- a/tests/codex/test_desktop_inspector.py
+++ b/tests/codex/test_desktop_inspector.py
@@ -425,6 +425,74 @@ def test_router_prefers_pause_for_broad_build_when_queue_pressure_is_high(
     assert "Stop new implementation" in brief.router.recommended_next_prompt
 
 
+def test_build_session_brief_marks_assistant_final_as_prompt_needed(
+    fake_codex_home,
+) -> None:  # type: ignore[no-untyped-def]
+    _append_rollout_event(
+        fake_codex_home.recent_rollout,
+        {
+            "timestamp": "2026-05-16T13:55:15.000Z",
+            "type": "agent_message",
+            "payload": {
+                "role": "assistant",
+                "content": "I finished reviewing #7286 and am waiting for next instruction.",
+            },
+        },
+    )
+    thread = inspector.find_thread(fake_codex_home.recent_thread_id)
+    assert thread is not None
+
+    brief = inspector.build_session_brief(
+        thread,
+        include_last_turns=0,
+        repo_context={"open_pr_count": 12, "active_lane_records": []},
+    )
+
+    assert brief.prompt_needed is True
+    assert brief.prompt_needed_reason == "assistant_final_recent"
+
+
+def test_build_session_brief_marks_matching_active_lane_not_prompt_needed(
+    fake_codex_home,
+) -> None:  # type: ignore[no-untyped-def]
+    _append_rollout_event(
+        fake_codex_home.recent_rollout,
+        {
+            "timestamp": "2026-05-16T13:55:30.000Z",
+            "type": "agent_message",
+            "payload": {
+                "role": "assistant",
+                "content": "Continuing the active lane for #7245.",
+            },
+        },
+    )
+    thread = inspector.find_thread(fake_codex_home.recent_thread_id)
+    assert thread is not None
+
+    brief = inspector.build_session_brief(
+        thread,
+        include_last_turns=0,
+        repo_context={
+            "open_pr_count": 12,
+            "active_lane_records": [
+                {
+                    "lane_id": "Q02-repair-7245-conflict",
+                    "owner_session": "codex-q02",
+                    "status": "active",
+                    "branch": "main",
+                    "pr_number": 7245,
+                }
+            ],
+        },
+    )
+    payload = brief.to_dict()
+
+    assert payload["prompt_needed"] is False
+    assert payload["prompt_needed_reason"] == "active_lane_owned"
+    assert payload["active_lane"]["lane_id"] == "Q02-repair-7245-conflict"
+    assert payload["conflict_risk"] == "active-lane-overlap"
+
+
 # -- find_thread --------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Adds `aragora codex sessions brief` for read-only, redacted Codex Desktop session briefings.
- Extracts only safe structured tokens (PR numbers, repo file paths, branches) and never emits raw transcript text by default.
- Adds conservative prompt-router categories: pause, watch, review, settle, repair, paste-needed.
- Integrates live repo context from open PR truth, agent bridge summary, active-session overlap script, and lane registry when `--repo-root` is enabled.

## Validation
- `python3 -m pytest tests/codex/test_cli_codex_sessions.py tests/codex/test_desktop_inspector.py -q` -> 63 passed
- `python3 -m ruff check aragora/cli/commands/codex_sessions.py aragora/codex/desktop_inspector.py aragora/cli/parser.py tests/codex/test_cli_codex_sessions.py tests/codex/test_desktop_inspector.py` -> passed
- `python3 -m ruff format --check aragora/cli/commands/codex_sessions.py aragora/codex/desktop_inspector.py aragora/cli/parser.py tests/codex/test_cli_codex_sessions.py tests/codex/test_desktop_inspector.py` -> passed
- `python3 -m mypy aragora/cli/commands/codex_sessions.py aragora/codex/desktop_inspector.py aragora/cli/parser.py tests/codex/test_cli_codex_sessions.py tests/codex/test_desktop_inspector.py --ignore-missing-imports --no-incremental` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok
- Live smoke: `codex sessions brief --since 4h --include-last-turns 2 --json` -> schema ok, 49 briefs, 12 open PRs, 0 active lanes

## Notes
- Draft because this is queue-routing infrastructure and should be reviewed before it becomes an operator default.
- Claude/Factory/browser sessions still need pasted excerpts until they emit compatible local session records.
