### PR TITLE
feat(automation): detect active lane identity collisions

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -159,6 +159,10 @@ class LaneRecord:
     pr_number: int | None = None
     conflict_session: str = ""
     conflict_reason: str = ""
+    desktop_label: str = ""
+    codex_thread_id: str = ""
+    codex_rollout_path: str = ""
+    session_title: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v not in ("", None)}
@@ -178,6 +182,10 @@ class LaneRecord:
             pr_number=payload.get("pr_number"),
             conflict_session=str(payload.get("conflict_session", "")),
             conflict_reason=str(payload.get("conflict_reason", "")),
+            desktop_label=str(payload.get("desktop_label", "")),
+            codex_thread_id=str(payload.get("codex_thread_id", "")),
+            codex_rollout_path=str(payload.get("codex_rollout_path", "")),
+            session_title=str(payload.get("session_title", "")),
         )
 
 

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -472,6 +472,48 @@ def _is_repo_root_path(path: str) -> bool:
         return False
 
 
+def _lane_identity_values(record: "LaneRecord") -> list[tuple[str, str]]:
+    values: list[tuple[str, str]] = []
+    if record.pr_number is not None:
+        values.append(("pr_number", str(record.pr_number)))
+    if record.branch:
+        values.append(("branch", record.branch))
+    if record.worktree:
+        values.append(("worktree", record.worktree))
+    return values
+
+
+def _active_lane_identity_conflicts(records: list["LaneRecord"]) -> list[dict[str, Any]]:
+    buckets: dict[tuple[str, str], list[LaneRecord]] = {}
+    for record in records:
+        if record.status not in ACTIVE_LANE_STATUSES:
+            continue
+        for key in _lane_identity_values(record):
+            buckets.setdefault(key, []).append(record)
+
+    conflicts: list[dict[str, Any]] = []
+    for (kind, value), grouped in buckets.items():
+        owners = sorted({record.owner_session for record in grouped if record.owner_session})
+        if len(owners) <= 1:
+            continue
+        lane_ids = sorted({record.lane_id for record in grouped if record.lane_id})
+        conflicts.append(
+            {
+                "type": "lane_identity_conflict",
+                "key_kind": kind,
+                "key_value": value,
+                "lane_ids": lane_ids,
+                "owner_sessions": owners,
+                "detail": (
+                    f"active lanes share {kind}={value}: "
+                    f"lanes={', '.join(lane_ids)} owners={', '.join(owners)}"
+                ),
+            }
+        )
+    conflicts.sort(key=lambda row: (row["key_kind"], row["key_value"]))
+    return conflicts
+
+
 def _collect_health_issues(
     sessions: list[Session], records: list[LaneRecord]
 ) -> list[dict[str, str]]:
@@ -542,6 +584,15 @@ def _collect_health_issues(
                     "detail": f"lane '{r.lane_id}' in conflict with {r.conflict_session}: {r.conflict_reason}",
                 }
             )
+
+    for conflict in _active_lane_identity_conflicts(records):
+        issues.append(
+            {
+                "type": str(conflict["type"]),
+                "session": ", ".join(conflict["owner_sessions"]),
+                "detail": str(conflict["detail"]),
+            }
+        )
 
     return issues
 
@@ -1201,6 +1252,13 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     records = _sync_lane_records(_load_lane_registry(), sessions)
 
     issues = _collect_health_issues(sessions, records)
+    lane_conflicts = _active_lane_identity_conflicts(records)
+    computed_conflict_lane_ids = {
+        lane_id
+        for conflict in lane_conflicts
+        for lane_id in conflict.get("lane_ids", [])
+        if isinstance(lane_id, str)
+    }
     process_census = _collect_agent_process_census(
         include_records=not summary_only,
         record_limit=50,
@@ -1211,6 +1269,7 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         "sessions": [s.to_dict() for s in sessions],
         "broker_runs": broker_runs,
         "lanes": [r.to_dict() for r in records],
+        "lane_conflicts": lane_conflicts,
         "process_census": process_census,
         "health": {"ok": len(issues) == 0, "issues": issues},
         "summary": {
@@ -1225,7 +1284,8 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
                 1 for run in broker_runs if run.get("status") in {"running", "awaiting_human"}
             ),
             "active_lanes": sum(1 for r in records if r.status in ACTIVE_LANE_STATUSES),
-            "conflict_lanes": sum(1 for r in records if r.status == "conflict"),
+            "conflict_lanes": sum(1 for r in records if r.status == "conflict")
+            + len(computed_conflict_lane_ids),
             "health_issues": len(issues),
             "active_processes": int(process_census.get("total", 0)),
             "active_process_roles": sorted(process_census.get("by_role", {}).keys()),

--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -29,16 +29,19 @@ bootstraps and from any agent):
   reader picks it up without modification: ``lane_id``, ``owner_session``,
   ``goal``, ``source``, ``status``, ``next_action``, ``updated_at``,
   ``branch``, ``worktree``, ``pr_number``, ``conflict_session``,
-  ``conflict_reason``.
+  ``conflict_reason``, and optional Desktop identity metadata
+  (``desktop_label``, ``codex_thread_id``, ``codex_rollout_path``,
+  ``session_title``).
 - A claim with the same ``lane_id`` from the same ``owner_session``
   overwrites the existing row (idempotent refresh). A claim with the
   same ``lane_id`` from a *different* ``owner_session`` is rejected
   unless ``--force`` is supplied; the helper exits 2 and prints a
   conflict hint so the caller can pick a different lane name or wait.
-- A mutating active claim is also rejected when a different active
-  owner already claims the same ``pr_number``, ``branch``, or
-  ``worktree``. Different lane IDs cannot silently duplicate work on
-  the same PR or branch.
+- A mutating active claim is also rejected when a different active owner
+  already claims the same ``pr_number``, ``branch``, or ``worktree``.
+  Different lane IDs cannot silently duplicate work on the same PR or branch.
+  Read-only observers can opt into report-only claim creation with
+  ``--allow-resource-conflicts``.
 - Never deletes rows. Never writes a lane row with a missing
   ``lane_id`` or empty ``owner_session``.
 - Never invokes git, gh, or any network call.
@@ -108,6 +111,10 @@ LANE_RECORD_KEYS = (
     "pr_number",
     "conflict_session",
     "conflict_reason",
+    "desktop_label",
+    "codex_thread_id",
+    "codex_rollout_path",
+    "session_title",
 )
 
 
@@ -298,7 +305,12 @@ def claim_lane(
     pr_number: int | None = None,
     conflict_session: str = "",
     conflict_reason: str = "",
+    desktop_label: str = "",
+    codex_thread_id: str = "",
+    codex_rollout_path: str = "",
+    session_title: str = "",
     force: bool = False,
+    allow_resource_conflicts: bool = False,
     updated_at: str | None = None,
 ) -> dict[str, Any]:
     """Write or refresh a single lane claim, returning the persisted row."""
@@ -326,6 +338,10 @@ def claim_lane(
             "pr_number": pr_number,
             "conflict_session": conflict_session,
             "conflict_reason": conflict_reason,
+            "desktop_label": desktop_label,
+            "codex_thread_id": codex_thread_id,
+            "codex_rollout_path": codex_rollout_path,
+            "session_title": session_title,
         }
         normalized = _normalize_row(new_row)
 
@@ -334,7 +350,7 @@ def claim_lane(
             normalized=normalized,
             owner_session=owner_session,
         )
-        if identity_conflict is not None and not force:
+        if identity_conflict is not None and not allow_resource_conflicts and not force:
             existing, kind, value = identity_conflict
             raise ClaimError(
                 f"{kind}={value!r} already claimed by "
@@ -385,9 +401,38 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--conflict-session", default="")
     parser.add_argument("--conflict-reason", default="")
     parser.add_argument(
+        "--desktop-label",
+        default="",
+        help='Operator-visible Desktop label, e.g. "Boss Codex", "Codex B", or "Review".',
+    )
+    parser.add_argument(
+        "--codex-thread-id",
+        default="",
+        help="Optional Codex Desktop thread id for the visible session.",
+    )
+    parser.add_argument(
+        "--codex-rollout-path",
+        default="",
+        help="Optional Codex rollout JSONL path for the visible session.",
+    )
+    parser.add_argument(
+        "--session-title",
+        default="",
+        help="Optional visible or inferred session title for operator display.",
+    )
+    parser.add_argument(
         "--force",
         action="store_true",
         help="Overwrite an existing claim or identity conflict owned by a different session.",
+    )
+    parser.add_argument(
+        "--allow-resource-conflicts",
+        action="store_true",
+        help=(
+            "Allow a claim even if another active owner claims the same "
+            "pr_number, branch, or worktree. Default is fail-closed for "
+            "mutating lane ownership."
+        ),
     )
     parser.add_argument(
         "--release-stale",
@@ -458,7 +503,12 @@ def main(argv: list[str] | None = None) -> int:
                 pr_number=args.pr_number,
                 conflict_session=args.conflict_session,
                 conflict_reason=args.conflict_reason,
+                desktop_label=args.desktop_label,
+                codex_thread_id=args.codex_thread_id,
+                codex_rollout_path=args.codex_rollout_path,
+                session_title=args.session_title,
                 force=args.force,
+                allow_resource_conflicts=args.allow_resource_conflicts,
                 updated_at=args.updated_at,
             )
     except ClaimError as exc:

--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -35,6 +35,10 @@ bootstraps and from any agent):
   same ``lane_id`` from a *different* ``owner_session`` is rejected
   unless ``--force`` is supplied; the helper exits 2 and prints a
   conflict hint so the caller can pick a different lane name or wait.
+- A mutating active claim is also rejected when a different active
+  owner already claims the same ``pr_number``, ``branch``, or
+  ``worktree``. Different lane IDs cannot silently duplicate work on
+  the same PR or branch.
 - Never deletes rows. Never writes a lane row with a missing
   ``lane_id`` or empty ``owner_session``.
 - Never invokes git, gh, or any network call.
@@ -111,6 +115,9 @@ class ClaimError(Exception):
     """Raised when a lane claim would conflict with an existing row."""
 
 
+ACTIVE_STATUSES = {"active", "running", "pending", "queued", "claimed"}
+
+
 def _utc_now_iso() -> str:
     return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -178,6 +185,105 @@ def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _parse_utc_timestamp(value: object) -> dt.datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    try:
+        if raw.endswith("Z"):
+            return dt.datetime.fromisoformat(raw[:-1] + "+00:00")
+        parsed = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def _identity_claims(row: dict[str, Any]) -> list[tuple[str, str]]:
+    claims: list[tuple[str, str]] = []
+    pr_number = row.get("pr_number")
+    if isinstance(pr_number, int):
+        claims.append(("pr_number", str(pr_number)))
+    branch = str(row.get("branch") or "").strip()
+    if branch:
+        claims.append(("branch", branch))
+    worktree = str(row.get("worktree") or "").strip()
+    if worktree:
+        claims.append(("worktree", worktree))
+    return claims
+
+
+def _active_identity_conflict(
+    *,
+    rows: list[dict[str, Any]],
+    normalized: dict[str, Any],
+    owner_session: str,
+) -> tuple[dict[str, Any], str, str] | None:
+    requested = set(_identity_claims(normalized))
+    if not requested or str(normalized.get("status") or "") not in ACTIVE_STATUSES:
+        return None
+    for existing in rows:
+        if str(existing.get("status") or "") not in ACTIVE_STATUSES:
+            continue
+        existing_owner = str(existing.get("owner_session") or "")
+        if not existing_owner or existing_owner == owner_session:
+            continue
+        overlap = requested.intersection(_identity_claims(existing))
+        if not overlap:
+            continue
+        kind, value = sorted(overlap)[0]
+        return existing, kind, value
+    return None
+
+
+def release_stale_claims(
+    *,
+    registry_path: Path,
+    owner_session: str,
+    ttl_minutes: float,
+    updated_at: str | None = None,
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    """Release stale active claims owned by ``owner_session``."""
+    if not owner_session:
+        raise ValueError("owner_session must not be empty")
+    if ttl_minutes < 0:
+        raise ValueError("ttl_minutes must be non-negative")
+
+    with _registry_write_lock(registry_path):
+        rows = _read_existing(registry_path)
+        timestamp = updated_at or _utc_now_iso()
+        now_dt = (now or dt.datetime.now(dt.UTC)).astimezone(dt.UTC)
+        cutoff = now_dt - dt.timedelta(minutes=ttl_minutes)
+        released: list[str] = []
+        out_rows: list[dict[str, Any]] = []
+        for row in rows:
+            row = dict(row)
+            if str(row.get("owner_session") or "") != owner_session:
+                out_rows.append(row)
+                continue
+            if str(row.get("status") or "") not in ACTIVE_STATUSES:
+                out_rows.append(row)
+                continue
+            parsed = _parse_utc_timestamp(row.get("updated_at"))
+            if parsed is None or parsed > cutoff:
+                out_rows.append(row)
+                continue
+            row["status"] = "released"
+            row["updated_at"] = timestamp
+            released.append(str(row.get("lane_id") or ""))
+            out_rows.append(_normalize_row(row))
+
+        _atomic_write(registry_path, out_rows)
+        return {
+            "owner_session": owner_session,
+            "released_count": len(released),
+            "released_lane_ids": released,
+            "registry_path": str(registry_path),
+        }
+
+
 def claim_lane(
     *,
     registry_path: Path,
@@ -223,6 +329,20 @@ def claim_lane(
         }
         normalized = _normalize_row(new_row)
 
+        identity_conflict = _active_identity_conflict(
+            rows=rows,
+            normalized=normalized,
+            owner_session=owner_session,
+        )
+        if identity_conflict is not None and not force:
+            existing, kind, value = identity_conflict
+            raise ClaimError(
+                f"{kind}={value!r} already claimed by "
+                f"lane_id={existing.get('lane_id')!r} "
+                f"owner_session={existing.get('owner_session')!r}; refusing to "
+                "create overlapping active lane (use --force to override)"
+            )
+
         out_rows: list[dict[str, Any]] = []
         replaced = False
         for existing in rows:
@@ -248,7 +368,7 @@ def claim_lane(
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--lane-id", required=True)
+    parser.add_argument("--lane-id", default="")
     parser.add_argument("--owner-session", required=True)
     parser.add_argument("--goal", default="")
     parser.add_argument("--source", default="")
@@ -267,7 +387,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--force",
         action="store_true",
-        help="Overwrite an existing claim owned by a different session.",
+        help="Overwrite an existing claim or identity conflict owned by a different session.",
+    )
+    parser.add_argument(
+        "--release-stale",
+        action="store_true",
+        help="Release stale active claims for --owner-session instead of claiming a lane.",
+    )
+    parser.add_argument(
+        "--ttl-minutes",
+        type=float,
+        default=240.0,
+        help="Age threshold for --release-stale (default: 240).",
     )
     parser.add_argument(
         "--registry-path",
@@ -306,22 +437,30 @@ def main(argv: list[str] | None = None) -> int:
         explicit=args.registry_path,
     )
     try:
-        row = claim_lane(
-            registry_path=registry_path,
-            lane_id=args.lane_id,
-            owner_session=args.owner_session,
-            goal=args.goal,
-            source=args.source,
-            status=args.status,
-            next_action=args.next_action,
-            branch=args.branch,
-            worktree=args.worktree,
-            pr_number=args.pr_number,
-            conflict_session=args.conflict_session,
-            conflict_reason=args.conflict_reason,
-            force=args.force,
-            updated_at=args.updated_at,
-        )
+        if args.release_stale:
+            row = release_stale_claims(
+                registry_path=registry_path,
+                owner_session=args.owner_session,
+                ttl_minutes=float(args.ttl_minutes),
+                updated_at=args.updated_at,
+            )
+        else:
+            row = claim_lane(
+                registry_path=registry_path,
+                lane_id=args.lane_id,
+                owner_session=args.owner_session,
+                goal=args.goal,
+                source=args.source,
+                status=args.status,
+                next_action=args.next_action,
+                branch=args.branch,
+                worktree=args.worktree,
+                pr_number=args.pr_number,
+                conflict_session=args.conflict_session,
+                conflict_reason=args.conflict_reason,
+                force=args.force,
+                updated_at=args.updated_at,
+            )
     except ClaimError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -331,6 +470,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.json:
         print(json.dumps(row, indent=2, sort_keys=True))
+    elif args.release_stale:
+        print(
+            f"released {row['released_count']} stale lane(s) for "
+            f"owner={row['owner_session']} registry={registry_path}"
+        )
     else:
         print(
             f"claimed lane_id={row['lane_id']} owner={row['owner_session']} "

--- a/scripts/list_active_agent_sessions.py
+++ b/scripts/list_active_agent_sessions.py
@@ -21,13 +21,14 @@ Inputs (each optional, never errors on missing sources):
 - ``~/.codex/sessions/**/*.jsonl`` for Codex CLI session files
 - ``scripts/agent_bridge.py processes --json --summary-only`` for live
   agent process census
-- ``~/.aragora/agent-bridge/lanes.json`` (and the in-repo
-  ``.aragora/agent-bridge/lanes.json`` fallback) for the cross-agent
+- in-repo ``.aragora/agent-bridge/lanes.json`` for the cross-agent
   lane registry maintained by ``scripts/agent_bridge.py``; lane
   branches, worktrees, and PR numbers are folded into the overlap
   detector so that an active lane claim collides with the matching
   git worktree, dispatch contract, automation outbox row, open PR, or
   another active lane claiming the same PR/branch/worktree
+  (legacy ``~/.aragora/agent-bridge/lanes.json`` fallback is available
+  only via ``--include-user-lane-registry``)
 - ``gh pr list --state open --json ...`` for open PRs (skippable via
   ``--skip-gh``)
 
@@ -65,7 +66,7 @@ DEFAULT_MAX_PR_FETCH = 30
 DEFAULT_GIT_TIMEOUT = 10
 DEFAULT_SUBPROCESS_TIMEOUT = 20
 DEFAULT_CODEX_SESSION_SCAN_LIMIT = 500
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 LANE_REGISTRY_RELATIVE_PATH = Path(".aragora") / "agent-bridge" / "lanes.json"
 LANE_REGISTRY_USER_PATH = Path.home() / ".aragora" / "agent-bridge" / "lanes.json"
@@ -386,18 +387,19 @@ def detect_agent_bridge_lanes(
     repo_root: Path,
     *,
     user_path: Path = LANE_REGISTRY_USER_PATH,
+    include_user_fallback: bool = False,
 ) -> list[dict[str, Any]]:
-    """Read the agent-bridge lane registry from repo-local state, then fallback.
+    """Read the agent-bridge lane registry from repo-local state.
 
     Repo-local state is authoritative when present. The user-home registry is
-    only a fallback for older checkouts and non-repo harnesses; mixing both can
-    make fixture tests and disposable worktrees inherit unrelated live lanes.
+    optional legacy fallback because mixing both can make fixture tests and
+    disposable worktrees inherit unrelated live lanes.
     """
     candidates: list[Path] = []
     repo_lane = repo_root / LANE_REGISTRY_RELATIVE_PATH
     if repo_lane.exists():
         candidates.append(repo_lane)
-    elif user_path.exists():
+    elif include_user_fallback and user_path.exists():
         candidates.append(user_path)
 
     out_by_id: dict[str, dict[str, Any]] = {}
@@ -435,6 +437,10 @@ def detect_agent_bridge_lanes(
                 "worktree",
                 "conflict_session",
                 "conflict_reason",
+                "desktop_label",
+                "codex_thread_id",
+                "codex_rollout_path",
+                "session_title",
             ):
                 value = entry.get(key)
                 if isinstance(value, str) and value:
@@ -761,6 +767,7 @@ def build_payload(
     skip_codex_desktop: bool = False,
     skip_process_census: bool = False,
     codex_session_scan_limit: int = DEFAULT_CODEX_SESSION_SCAN_LIMIT,
+    include_user_lane_registry: bool = False,
 ) -> dict[str, Any]:
     repo_root = repo_root.resolve()
     codex_home = codex_home.expanduser()
@@ -801,7 +808,10 @@ def build_payload(
     process_census: dict[str, Any] = {}
     if not skip_process_census:
         process_census = detect_agent_process_census(repo_root)
-    agent_bridge_lanes = detect_agent_bridge_lanes(repo_root)
+    agent_bridge_lanes = detect_agent_bridge_lanes(
+        repo_root,
+        include_user_fallback=include_user_lane_registry,
+    )
     open_prs: list[dict[str, Any]] = []
     if not skip_gh:
         open_prs = fetch_open_prs(limit=max_pr_fetch)
@@ -827,6 +837,7 @@ def build_payload(
         "skip_gh": skip_gh,
         "skip_codex_desktop": skip_codex_desktop,
         "skip_process_census": skip_process_census,
+        "include_user_lane_registry": include_user_lane_registry,
         "worktrees": worktrees,
         "dispatch_contracts": dispatch_contracts,
         "issue_claims": issue_claims,
@@ -946,7 +957,15 @@ def render_text(payload: dict[str, Any]) -> str:
                 flag = " [ACTIVE]"
             branch = row.get("branch") or "-"
             owner = row.get("owner_session") or "-"
-            lines.append(f"  - {row.get('lane_id')}{flag}  owner={owner}  branch={branch}")
+            label = row.get("desktop_label") or "-"
+            thread_id = str(row.get("codex_thread_id") or "")
+            thread = f"  thread={thread_id[:12]}" if thread_id else ""
+            title = row.get("session_title") or ""
+            title_text = f"  title={str(title)[:48]}" if title else ""
+            lines.append(
+                f"  - {row.get('lane_id')}{flag}  label={label}  "
+                f"owner={owner}{thread}  branch={branch}{title_text}"
+            )
         if len(lanes) > 20:
             lines.append(f"  ... ({len(lanes) - 20} more)")
         lines.append("")
@@ -1041,6 +1060,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--json", action="store_true")
     parser.add_argument(
+        "--include-user-lane-registry",
+        action="store_true",
+        help="Include legacy ~/.aragora/agent-bridge/lanes.json fallback when no repo registry exists.",
+    )
+    parser.add_argument(
         "--conflicts-only",
         action="store_true",
         help="Emit only active lane conflicts and agent-bridge overlaps.",
@@ -1059,6 +1083,7 @@ def main(argv: list[str] | None = None) -> int:
         skip_codex_desktop=bool(args.skip_codex_desktop),
         skip_process_census=bool(args.skip_process_census),
         codex_session_scan_limit=int(args.codex_session_scan_limit),
+        include_user_lane_registry=bool(args.include_user_lane_registry),
     )
     if args.conflicts_only:
         payload = build_conflicts_only_payload(payload)

--- a/scripts/list_active_agent_sessions.py
+++ b/scripts/list_active_agent_sessions.py
@@ -26,7 +26,8 @@ Inputs (each optional, never errors on missing sources):
   lane registry maintained by ``scripts/agent_bridge.py``; lane
   branches, worktrees, and PR numbers are folded into the overlap
   detector so that an active lane claim collides with the matching
-  git worktree, dispatch contract, automation outbox row, or open PR
+  git worktree, dispatch contract, automation outbox row, open PR, or
+  another active lane claiming the same PR/branch/worktree
 - ``gh pr list --state open --json ...`` for open PRs (skippable via
   ``--skip-gh``)
 
@@ -386,16 +387,17 @@ def detect_agent_bridge_lanes(
     *,
     user_path: Path = LANE_REGISTRY_USER_PATH,
 ) -> list[dict[str, Any]]:
-    """Read the agent-bridge lane registry from the repo + user-home paths.
+    """Read the agent-bridge lane registry from repo-local state, then fallback.
 
-    Lane rows are de-duplicated by ``lane_id``, repo-root wins ties so a
-    repo-local override masks the user-home record.
+    Repo-local state is authoritative when present. The user-home registry is
+    only a fallback for older checkouts and non-repo harnesses; mixing both can
+    make fixture tests and disposable worktrees inherit unrelated live lanes.
     """
     candidates: list[Path] = []
     repo_lane = repo_root / LANE_REGISTRY_RELATIVE_PATH
     if repo_lane.exists():
         candidates.append(repo_lane)
-    if user_path.exists() and user_path not in candidates:
+    elif user_path.exists():
         candidates.append(user_path)
 
     out_by_id: dict[str, dict[str, Any]] = {}
@@ -443,7 +445,74 @@ def detect_agent_bridge_lanes(
             row["is_active"] = row["status"] in ACTIVE_LANE_STATUSES
             row["is_conflict"] = row["status"] == "conflict"
             out_by_id[lane_id] = row
-    return sorted(out_by_id.values(), key=lambda r: r["lane_id"])
+    rows = sorted(out_by_id.values(), key=lambda r: r["lane_id"])
+    _mark_lane_identity_conflicts(rows)
+    return rows
+
+
+def _lane_identity_values(row: dict[str, Any]) -> list[tuple[str, str]]:
+    values: list[tuple[str, str]] = []
+    pr_number = row.get("pr_number")
+    if isinstance(pr_number, int):
+        values.append(("pr_number", str(pr_number)))
+    branch = str(row.get("branch") or "").strip()
+    if branch:
+        values.append(("branch", branch))
+    worktree = str(row.get("worktree") or "").strip()
+    if worktree:
+        values.append(("worktree", worktree))
+    return values
+
+
+def lane_identity_conflicts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    buckets: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        if not row.get("is_active"):
+            continue
+        for key in _lane_identity_values(row):
+            buckets[key].append(row)
+
+    conflicts: list[dict[str, Any]] = []
+    for (kind, value), grouped in buckets.items():
+        owners = sorted(
+            {str(row.get("owner_session") or "") for row in grouped if row.get("owner_session")}
+        )
+        if len(owners) <= 1:
+            continue
+        lane_ids = sorted({str(row.get("lane_id") or "") for row in grouped if row.get("lane_id")})
+        conflicts.append(
+            {
+                "type": "lane_identity_conflict",
+                "key_kind": kind,
+                "key_value": value,
+                "lane_ids": lane_ids,
+                "owner_sessions": owners,
+                "suggested_resolution": (
+                    "pause duplicate mutation; keep only the owner whose local "
+                    "HEAD matches the pushed PR/branch head, release the other lane"
+                ),
+            }
+        )
+    conflicts.sort(key=lambda row: (row["key_kind"], row["key_value"]))
+    return conflicts
+
+
+def _mark_lane_identity_conflicts(rows: list[dict[str, Any]]) -> None:
+    conflicts = lane_identity_conflicts(rows)
+    conflict_by_lane: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for conflict in conflicts:
+        for lane_id in conflict["lane_ids"]:
+            conflict_by_lane[lane_id].append(conflict)
+    for row in rows:
+        lane_id = str(row.get("lane_id") or "")
+        row_conflicts = conflict_by_lane.get(lane_id)
+        if not row_conflicts:
+            continue
+        row["is_conflict"] = True
+        row["identity_conflicts"] = row_conflicts
+        row["conflict_reason"] = "; ".join(
+            f"{conflict['key_kind']}={conflict['key_value']}" for conflict in row_conflicts
+        )
 
 
 def fetch_open_prs(
@@ -659,7 +728,12 @@ def build_overlap_report(
     for kind, bucket in signals.items():
         for value, (sources, details) in bucket.items():
             counts[kind] += 1
-            if len(sources) > 1:
+            lane_duplicate = (
+                kind in {"branch", "pr", "worktree_path"}
+                and "agent_bridge_lane" in sources
+                and len(details) > 1
+            )
+            if len(sources) > 1 or lane_duplicate:
                 overlaps.append(
                     {
                         "kind": kind,
@@ -741,6 +815,7 @@ def build_payload(
         open_prs=open_prs,
         agent_bridge_lanes=agent_bridge_lanes,
     )
+    lane_conflicts = lane_identity_conflicts(agent_bridge_lanes)
 
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
@@ -762,10 +837,43 @@ def build_payload(
         "codex_cli_sessions": codex_cli_sessions,
         "process_census": process_census,
         "agent_bridge_lanes": agent_bridge_lanes,
+        "lane_conflicts": lane_conflicts,
         "open_prs": open_prs,
         "overlap_report": overlap,
     }
     return payload
+
+
+def build_conflicts_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    overlap = payload.get("overlap_report") or {}
+    overlaps = [
+        row
+        for row in overlap.get("overlaps", [])
+        if "agent_bridge_lane" in set(row.get("sources") or [])
+    ]
+    conflict_lanes = [
+        row
+        for row in payload.get("agent_bridge_lanes", [])
+        if row.get("is_conflict") or row.get("identity_conflicts")
+    ]
+    lane_conflicts = payload.get("lane_conflicts") or []
+    return {
+        "schema_version": payload.get("schema_version"),
+        "generated_at": payload.get("generated_at"),
+        "repo_root": payload.get("repo_root"),
+        "conflict_count": len(lane_conflicts),
+        "conflict_lane_count": len(conflict_lanes),
+        "lane_conflicts": lane_conflicts,
+        "agent_bridge_lanes": conflict_lanes,
+        "overlap_report": {
+            "overlap_count": len(overlaps),
+            "overlaps": overlaps,
+        },
+        "suggested_owner_resolution": (
+            "For each conflict, pause duplicate mutation; compare local HEAD "
+            "to pushed PR/branch head; keep one owner and release the other lane."
+        ),
+    }
 
 
 def render_text(payload: dict[str, Any]) -> str:
@@ -856,6 +964,22 @@ def render_text(payload: dict[str, Any]) -> str:
     lines.append("")
 
     overlap = payload.get("overlap_report") or {}
+    lane_conflicts = payload.get("lane_conflicts")
+    if isinstance(lane_conflicts, list) and lane_conflicts:
+        lines.append(f"lane conflicts (count={len(lane_conflicts)}):")
+        for conflict in lane_conflicts:
+            if not isinstance(conflict, dict):
+                continue
+            lane_ids = conflict.get("lane_ids")
+            if not isinstance(lane_ids, list):
+                lane_ids = []
+            lines.append(
+                "  - "
+                f"{conflict.get('key_kind')}={conflict.get('key_value')} "
+                f"lanes={','.join(str(lane_id) for lane_id in lane_ids)}"
+            )
+        lines.append("")
+
     lines.append(f"overlap report (count={overlap.get('overlap_count', 0)}):")
     for ov in (overlap.get("overlaps") or [])[:20]:
         sources = "+".join(ov.get("sources") or [])
@@ -916,6 +1040,11 @@ def build_parser() -> argparse.ArgumentParser:
         f"(default: {DEFAULT_CODEX_SESSION_SCAN_LIMIT})",
     )
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--conflicts-only",
+        action="store_true",
+        help="Emit only active lane conflicts and agent-bridge overlaps.",
+    )
     return parser
 
 
@@ -931,6 +1060,8 @@ def main(argv: list[str] | None = None) -> int:
         skip_process_census=bool(args.skip_process_census),
         codex_session_scan_limit=int(args.codex_session_scan_limit),
     )
+    if args.conflicts_only:
+        payload = build_conflicts_only_payload(payload)
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True, default=str))
     else:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -93,6 +93,8 @@ def test_cmd_send_persists_lane_registry(tmp_path: Path, monkeypatch: pytest.Mon
     import agent_bridge as mod
 
     _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.LANE_REGISTRY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text("[]", encoding="utf-8")
     session = mod.Session(
         name="codex-strategic",
         agent="codex",
@@ -395,6 +397,57 @@ def test_operator_snapshot_summary_only_json_omits_records(
     assert payload["process_census"] == {"ok": True, "total": 0, "by_role": {}}
     assert payload["health"] == {"ok": True, "issues": []}
     assert discover_include_summaries == [False]
+
+
+def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-a",
+                    "owner_session": "codex-A",
+                    "status": "active",
+                    "pr_number": 7245,
+                    "branch": "worktree-codex-insights",
+                },
+                {
+                    "lane_id": "lane-b",
+                    "owner_session": "codex-B",
+                    "status": "active",
+                    "pr_number": 7245,
+                    "branch": "worktree-codex-insights",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 0,
+            "by_role": {},
+        },
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["conflict_lanes"] == 2
+    assert payload["lane_conflicts"][0]["key_kind"] == "branch"
+    assert payload["health"]["ok"] is False
+    assert payload["health"]["issues"][0]["type"] == "lane_identity_conflict"
 
 
 def test_collect_agent_process_census_redacts_commands_and_counts_roles() -> None:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -65,6 +65,28 @@ def test_send_tmux_multiline_uses_delete_on_paste_buffer_transport(
     ]
 
 
+def test_lane_record_preserves_desktop_identity_metadata() -> None:
+    import agent_bridge as mod
+
+    record = mod.LaneRecord.from_dict(
+        {
+            "lane_id": "codex-b-review",
+            "owner_session": "codex-B",
+            "status": "active",
+            "desktop_label": "Codex B",
+            "codex_thread_id": "019e-test-thread",
+            "codex_rollout_path": "/Users/armand/.codex/sessions/rollout.jsonl",
+            "session_title": "Review #7286",
+        }
+    )
+
+    payload = record.to_dict()
+    assert payload["desktop_label"] == "Codex B"
+    assert payload["codex_thread_id"] == "019e-test-thread"
+    assert payload["codex_rollout_path"].endswith("rollout.jsonl")
+    assert payload["session_title"] == "Review #7286"
+
+
 def test_cmd_approve_droid_uses_enter_menu_selection(monkeypatch: pytest.MonkeyPatch) -> None:
     import agent_bridge as mod
 

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -111,7 +111,7 @@ def test_force_overrides_owner_mismatch(tmp_registry: Path) -> None:
     assert payload[0]["owner_session"] == "claude-B"
 
 
-def test_different_lane_same_pr_is_rejected(tmp_registry: Path) -> None:
+def test_different_lane_same_pr_is_rejected_by_default(tmp_registry: Path) -> None:
     claim_module.claim_lane(
         registry_path=tmp_registry,
         lane_id="lane-a",
@@ -130,7 +130,27 @@ def test_different_lane_same_pr_is_rejected(tmp_registry: Path) -> None:
     assert "pr_number='7245' already claimed" in str(excinfo.value)
 
 
-def test_different_lane_same_branch_is_rejected(tmp_registry: Path) -> None:
+def test_different_lane_same_pr_can_be_allowed_when_requested(tmp_registry: Path) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        pr_number=7245,
+    )
+
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-b",
+        owner_session="codex-B",
+        pr_number=7245,
+        allow_resource_conflicts=True,
+    )
+
+    payload = json.loads(tmp_registry.read_text(encoding="utf-8"))
+    assert sorted(row["lane_id"] for row in payload) == ["lane-a", "lane-b"]
+
+
+def test_different_lane_same_branch_is_rejected_by_default(tmp_registry: Path) -> None:
     claim_module.claim_lane(
         registry_path=tmp_registry,
         lane_id="lane-a",
@@ -149,7 +169,9 @@ def test_different_lane_same_branch_is_rejected(tmp_registry: Path) -> None:
     assert "branch='worktree-codex-insights' already claimed" in str(excinfo.value)
 
 
-def test_different_lane_same_worktree_is_rejected(tmp_registry: Path) -> None:
+def test_different_lane_same_worktree_is_rejected_by_default(
+    tmp_registry: Path,
+) -> None:
     claim_module.claim_lane(
         registry_path=tmp_registry,
         lane_id="lane-a",
@@ -425,6 +447,24 @@ def test_persisted_schema_matches_lane_record_keys(tmp_registry: Path) -> None:
     assert keys.issubset(allowed)
 
 
+def test_desktop_identity_metadata_round_trips(tmp_registry: Path) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="codex-b-review",
+        owner_session="codex-B",
+        desktop_label="Codex B",
+        codex_thread_id="019e-test-thread",
+        codex_rollout_path="/Users/armand/.codex/sessions/rollout.jsonl",
+        session_title="Review #7286",
+    )
+
+    payload = json.loads(tmp_registry.read_text(encoding="utf-8"))
+    assert payload[0]["desktop_label"] == "Codex B"
+    assert payload[0]["codex_thread_id"] == "019e-test-thread"
+    assert payload[0]["codex_rollout_path"].endswith("rollout.jsonl")
+    assert payload[0]["session_title"] == "Review #7286"
+
+
 def test_cli_help_exits_zero() -> None:
     result = subprocess.run(
         [sys.executable, str(SCRIPT_PATH), "--help"],
@@ -447,6 +487,14 @@ def test_cli_writes_registry_via_subprocess(tmp_path: Path) -> None:
             "claude-cli",
             "--branch",
             "droid/phase-cli",
+            "--desktop-label",
+            "Codex C",
+            "--codex-thread-id",
+            "019e-cli-thread",
+            "--codex-rollout-path",
+            "/Users/armand/.codex/sessions/cli.jsonl",
+            "--session-title",
+            "CLI lane claim",
             "--status",
             "active",
             "--registry-path",
@@ -460,10 +508,14 @@ def test_cli_writes_registry_via_subprocess(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     payload_out = json.loads(result.stdout)
     assert payload_out["lane_id"] == "phase-cli"
+    assert payload_out["desktop_label"] == "Codex C"
     assert registry.exists()
     file_payload = json.loads(registry.read_text(encoding="utf-8"))
     assert len(file_payload) == 1
     assert file_payload[0]["lane_id"] == "phase-cli"
+    assert file_payload[0]["codex_thread_id"] == "019e-cli-thread"
+    assert file_payload[0]["codex_rollout_path"].endswith("cli.jsonl")
+    assert file_payload[0]["session_title"] == "CLI lane claim"
 
 
 def test_cli_conflict_returns_exit_code_2(tmp_path: Path) -> None:

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -16,6 +16,7 @@ in ``scripts/agent_bridge.py``. These tests cover:
 from __future__ import annotations
 
 import importlib
+import datetime as dt
 import json
 import subprocess
 import sys
@@ -108,6 +109,100 @@ def test_force_overrides_owner_mismatch(tmp_registry: Path) -> None:
     )
     payload = json.loads(tmp_registry.read_text(encoding="utf-8"))
     assert payload[0]["owner_session"] == "claude-B"
+
+
+def test_different_lane_same_pr_is_rejected(tmp_registry: Path) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        pr_number=7245,
+    )
+
+    with pytest.raises(claim_module.ClaimError) as excinfo:
+        claim_module.claim_lane(
+            registry_path=tmp_registry,
+            lane_id="lane-b",
+            owner_session="codex-B",
+            pr_number=7245,
+        )
+
+    assert "pr_number='7245' already claimed" in str(excinfo.value)
+
+
+def test_different_lane_same_branch_is_rejected(tmp_registry: Path) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        branch="worktree-codex-insights",
+    )
+
+    with pytest.raises(claim_module.ClaimError) as excinfo:
+        claim_module.claim_lane(
+            registry_path=tmp_registry,
+            lane_id="lane-b",
+            owner_session="codex-B",
+            branch="worktree-codex-insights",
+        )
+
+    assert "branch='worktree-codex-insights' already claimed" in str(excinfo.value)
+
+
+def test_different_lane_same_worktree_is_rejected(tmp_registry: Path) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        worktree="/tmp/aragora-pr7245",
+    )
+
+    with pytest.raises(claim_module.ClaimError) as excinfo:
+        claim_module.claim_lane(
+            registry_path=tmp_registry,
+            lane_id="lane-b",
+            owner_session="codex-B",
+            worktree="/tmp/aragora-pr7245",
+        )
+
+    assert "worktree='/tmp/aragora-pr7245' already claimed" in str(excinfo.value)
+
+
+def test_same_owner_can_refresh_same_pr_identity(tmp_registry: Path) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        pr_number=7245,
+    )
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-b",
+        owner_session="codex-A",
+        pr_number=7245,
+    )
+
+    payload = json.loads(tmp_registry.read_text(encoding="utf-8"))
+    assert sorted(row["lane_id"] for row in payload) == ["lane-a", "lane-b"]
+
+
+def test_released_lane_identity_does_not_block_new_owner(tmp_registry: Path) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        status="released",
+        pr_number=7245,
+    )
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-b",
+        owner_session="codex-B",
+        pr_number=7245,
+    )
+
+    payload = json.loads(tmp_registry.read_text(encoding="utf-8"))
+    assert len(payload) == 2
 
 
 def test_other_lanes_are_preserved_during_claim(tmp_registry: Path) -> None:
@@ -235,6 +330,47 @@ def test_released_status_round_trips(tmp_registry: Path) -> None:
     )
     payload = json.loads(tmp_registry.read_text(encoding="utf-8"))
     assert payload[0]["status"] == "released"
+
+
+def test_release_stale_claims_only_releases_old_owner_rows(tmp_registry: Path) -> None:
+    old = "2026-05-17T10:00:00Z"
+    fresh = "2026-05-17T11:59:00Z"
+    now = dt.datetime(2026, 5, 17, 12, 0, tzinfo=dt.UTC)
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="old-owned",
+        owner_session="codex-A",
+        status="active",
+        updated_at=old,
+    )
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="fresh-owned",
+        owner_session="codex-A",
+        status="active",
+        updated_at=fresh,
+    )
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="old-other",
+        owner_session="codex-B",
+        status="active",
+        updated_at=old,
+    )
+
+    result = claim_module.release_stale_claims(
+        registry_path=tmp_registry,
+        owner_session="codex-A",
+        ttl_minutes=30,
+        updated_at="2026-05-17T12:00:00Z",
+        now=now,
+    )
+
+    payload = {row["lane_id"]: row for row in json.loads(tmp_registry.read_text())}
+    assert result["released_lane_ids"] == ["old-owned"]
+    assert payload["old-owned"]["status"] == "released"
+    assert payload["fresh-owned"]["status"] == "active"
+    assert payload["old-other"]["status"] == "active"
 
 
 def test_invalid_status_is_rejected(tmp_registry: Path) -> None:

--- a/tests/scripts/test_list_active_agent_sessions.py
+++ b/tests/scripts/test_list_active_agent_sessions.py
@@ -456,6 +456,7 @@ def test_build_payload_assembles_top_level_keys(tmp_path: Path) -> None:
         "skip_gh",
         "skip_codex_desktop",
         "skip_process_census",
+        "include_user_lane_registry",
         "worktrees",
         "dispatch_contracts",
         "issue_claims",
@@ -473,6 +474,7 @@ def test_build_payload_assembles_top_level_keys(tmp_path: Path) -> None:
     assert payload["generated_at"] == "2026-05-17T12:00:00Z"
     assert payload["skip_gh"] is True
     assert payload["skip_process_census"] is True
+    assert payload["include_user_lane_registry"] is False
     assert payload["overlap_report"]["overlap_count"] == 0
 
 
@@ -629,7 +631,7 @@ def test_detect_agent_bridge_lanes_reads_repo_local_registry(tmp_path: Path) -> 
     assert phase4["conflict_session"] == "claude-X"
 
 
-def test_detect_agent_bridge_lanes_falls_back_to_user_home(tmp_path: Path) -> None:
+def test_detect_agent_bridge_lanes_does_not_read_user_home_by_default(tmp_path: Path) -> None:
     user_registry = tmp_path / "user-home" / "lanes.json"
     user_registry.parent.mkdir(parents=True)
     user_registry.write_text(
@@ -648,6 +650,34 @@ def test_detect_agent_bridge_lanes_falls_back_to_user_home(tmp_path: Path) -> No
     repo_root = tmp_path / "repo-without-aragora"
     repo_root.mkdir()
     out = detector.detect_agent_bridge_lanes(repo_root, user_path=user_registry)
+    assert out == []
+
+
+def test_detect_agent_bridge_lanes_falls_back_to_user_home_when_requested(
+    tmp_path: Path,
+) -> None:
+    user_registry = tmp_path / "user-home" / "lanes.json"
+    user_registry.parent.mkdir(parents=True)
+    user_registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "user-only-lane",
+                    "owner_session": "claude-C",
+                    "status": "running",
+                    "branch": "claude/user-only",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    repo_root = tmp_path / "repo-without-aragora"
+    repo_root.mkdir()
+    out = detector.detect_agent_bridge_lanes(
+        repo_root,
+        user_path=user_registry,
+        include_user_fallback=True,
+    )
     assert len(out) == 1
     assert out[0]["lane_id"] == "user-only-lane"
     assert out[0]["branch"] == "claude/user-only"
@@ -925,6 +955,10 @@ def test_build_payload_includes_agent_bridge_lanes(tmp_path: Path) -> None:
                     "owner_session": "claude-A",
                     "status": "active",
                     "branch": "droid/embedded",
+                    "desktop_label": "Codex B",
+                    "codex_thread_id": "019e-test-thread",
+                    "codex_rollout_path": "/Users/armand/.codex/sessions/rollout.jsonl",
+                    "session_title": "Cross-Agent Collision Control",
                 }
             ]
         ),
@@ -942,6 +976,10 @@ def test_build_payload_includes_agent_bridge_lanes(tmp_path: Path) -> None:
     assert "agent_bridge_lanes" in payload
     assert len(payload["agent_bridge_lanes"]) == 1
     assert payload["agent_bridge_lanes"][0]["lane_id"] == "droid/embedded"
+    assert payload["agent_bridge_lanes"][0]["desktop_label"] == "Codex B"
+    assert payload["agent_bridge_lanes"][0]["codex_thread_id"] == "019e-test-thread"
+    assert payload["agent_bridge_lanes"][0]["codex_rollout_path"].endswith("rollout.jsonl")
+    assert payload["agent_bridge_lanes"][0]["session_title"] == "Cross-Agent Collision Control"
 
 
 def test_render_text_includes_lane_section() -> None:
@@ -963,6 +1001,9 @@ def test_render_text_includes_lane_section() -> None:
                 "owner_session": "claude-A",
                 "status": "active",
                 "branch": "droid/phase3-20260517",
+                "desktop_label": "Codex B",
+                "codex_thread_id": "019e-test-thread",
+                "session_title": "Cross-Agent Collision Control",
                 "is_active": True,
                 "is_conflict": False,
             },
@@ -982,6 +1023,9 @@ def test_render_text_includes_lane_section() -> None:
     assert "agent_bridge lanes (2 total, 1 active, 1 conflict)" in text
     assert "[ACTIVE]" in text
     assert "[CONFLICT]" in text
+    assert "label=Codex B" in text
+    assert "thread=019e-test-th" in text
+    assert "title=Cross-Agent Collision Control" in text
     assert "droid/phase3" in text
     assert "droid/phase4" in text
 
@@ -1039,10 +1083,9 @@ def test_build_conflicts_only_payload_filters_to_lane_conflicts() -> None:
     assert out["overlap_report"]["overlap_count"] == 1
 
 
-def test_schema_version_bumped_for_lane_registry() -> None:
-    """The schema bump (1 -> 2) reflects the new ``agent_bridge_lanes`` top-
-    level key. Consumers that pinned to schema_version=1 should adapt."""
-    assert detector.SCHEMA_VERSION == 2
+def test_schema_version_bumped_for_lane_desktop_metadata() -> None:
+    """The schema bump reflects optional Desktop label/thread metadata on lanes."""
+    assert detector.SCHEMA_VERSION == 3
 
 
 def test_active_lane_statuses_match_agent_bridge() -> None:

--- a/tests/scripts/test_list_active_agent_sessions.py
+++ b/tests/scripts/test_list_active_agent_sessions.py
@@ -721,12 +721,81 @@ def test_detect_agent_bridge_lanes_skips_rows_without_lane_id(tmp_path: Path) ->
     assert [r["lane_id"] for r in out] == ["real-lane"]
 
 
+def test_detect_agent_bridge_lanes_marks_duplicate_active_pr_conflicts(tmp_path: Path) -> None:
+    registry = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-a",
+                    "owner_session": "codex-A",
+                    "status": "active",
+                    "pr_number": 7245,
+                    "branch": "worktree-codex-insights",
+                },
+                {
+                    "lane_id": "lane-b",
+                    "owner_session": "codex-B",
+                    "status": "active",
+                    "pr_number": 7245,
+                    "branch": "worktree-codex-insights",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out = detector.detect_agent_bridge_lanes(
+        tmp_path,
+        user_path=tmp_path / "missing.json",
+    )
+
+    assert {row["lane_id"] for row in out if row["is_conflict"]} == {"lane-a", "lane-b"}
+    assert detector.lane_identity_conflicts(out)[0]["key_kind"] == "branch"
+
+
+def test_detect_agent_bridge_lanes_does_not_conflict_released_lanes(tmp_path: Path) -> None:
+    registry = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-a",
+                    "owner_session": "codex-A",
+                    "status": "released",
+                    "pr_number": 7245,
+                    "branch": "worktree-codex-insights",
+                },
+                {
+                    "lane_id": "lane-b",
+                    "owner_session": "codex-B",
+                    "status": "active",
+                    "pr_number": 7245,
+                    "branch": "worktree-codex-insights",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out = detector.detect_agent_bridge_lanes(
+        tmp_path,
+        user_path=tmp_path / "missing.json",
+    )
+
+    assert detector.lane_identity_conflicts(out) == []
+    assert not any(row["is_conflict"] for row in out)
+
+
 def test_build_overlap_report_flags_lane_branch_against_worktree() -> None:
     report = detector.build_overlap_report(
         worktrees=[{"path": "/tmp/wt-a", "branch": "droid/phase3-20260517"}],
         dispatch_contracts=[],
         issue_claims=[],
         automation_outbox=[],
+        codex_cli_sessions=[],
         open_prs=[],
         agent_bridge_lanes=[
             {
@@ -764,6 +833,7 @@ def test_build_overlap_report_includes_conflict_lanes() -> None:
         dispatch_contracts=[],
         issue_claims=[],
         automation_outbox=[],
+        codex_cli_sessions=[],
         open_prs=[],
         agent_bridge_lanes=[
             {
@@ -781,6 +851,40 @@ def test_build_overlap_report_includes_conflict_lanes() -> None:
     assert "agent_bridge_lane" in overlaps_by_value["shared"]["sources"]
 
 
+def test_build_overlap_report_flags_duplicate_active_lane_pr() -> None:
+    report = detector.build_overlap_report(
+        worktrees=[],
+        dispatch_contracts=[],
+        issue_claims=[],
+        automation_outbox=[],
+        codex_cli_sessions=[],
+        open_prs=[],
+        agent_bridge_lanes=[
+            {
+                "lane_id": "lane-a",
+                "owner_session": "codex-A",
+                "status": "active",
+                "pr_number": 7245,
+                "is_active": True,
+                "is_conflict": True,
+            },
+            {
+                "lane_id": "lane-b",
+                "owner_session": "codex-B",
+                "status": "active",
+                "pr_number": 7245,
+                "is_active": True,
+                "is_conflict": True,
+            },
+        ],
+    )
+
+    overlaps_by_value = {ov["value"]: ov for ov in report["overlaps"]}
+    assert "7245" in overlaps_by_value
+    assert overlaps_by_value["7245"]["sources"] == ["agent_bridge_lane"]
+    assert overlaps_by_value["7245"]["details"] == ["lane-a", "lane-b"]
+
+
 def test_build_overlap_report_skips_released_lanes() -> None:
     """A released lane (no longer active and not in conflict) must not be
     folded into the overlap report so completed lanes don't keep blocking
@@ -790,6 +894,7 @@ def test_build_overlap_report_skips_released_lanes() -> None:
         dispatch_contracts=[],
         issue_claims=[],
         automation_outbox=[],
+        codex_cli_sessions=[],
         open_prs=[],
         agent_bridge_lanes=[
             {
@@ -879,6 +984,59 @@ def test_render_text_includes_lane_section() -> None:
     assert "[CONFLICT]" in text
     assert "droid/phase3" in text
     assert "droid/phase4" in text
+
+
+def test_build_conflicts_only_payload_filters_to_lane_conflicts() -> None:
+    payload = {
+        "schema_version": 2,
+        "generated_at": "2026-05-17T12:00:00Z",
+        "repo_root": "/repo",
+        "agent_bridge_lanes": [
+            {
+                "lane_id": "lane-a",
+                "owner_session": "codex-A",
+                "is_active": True,
+                "is_conflict": True,
+                "identity_conflicts": [{"key_kind": "pr_number", "key_value": "7245"}],
+            },
+            {
+                "lane_id": "lane-z",
+                "owner_session": "codex-Z",
+                "is_active": True,
+                "is_conflict": False,
+            },
+        ],
+        "lane_conflicts": [
+            {
+                "key_kind": "pr_number",
+                "key_value": "7245",
+                "lane_ids": ["lane-a", "lane-b"],
+            }
+        ],
+        "overlap_report": {
+            "overlaps": [
+                {
+                    "kind": "pr",
+                    "value": "7245",
+                    "sources": ["agent_bridge_lane"],
+                    "details": ["lane-a", "lane-b"],
+                },
+                {
+                    "kind": "branch",
+                    "value": "main",
+                    "sources": ["git_worktree"],
+                    "details": ["/repo"],
+                },
+            ]
+        },
+    }
+
+    out = detector.build_conflicts_only_payload(payload)
+
+    assert out["conflict_count"] == 1
+    assert out["conflict_lane_count"] == 1
+    assert [row["lane_id"] for row in out["agent_bridge_lanes"]] == ["lane-a"]
+    assert out["overlap_report"]["overlap_count"] == 1
 
 
 def test_schema_version_bumped_for_lane_registry() -> None:


### PR DESCRIPTION
## Summary
- surface active lane identity conflicts when different owners claim the same PR, branch, or worktree
- make claim_active_agent_lane.py reject overlapping active PR/branch/worktree claims unless --force is used
- add --release-stale support for owner-scoped stale active lane release
- add list_active_agent_sessions.py --conflicts-only for compact operator conflict checks

## Validation
- python3 -m pytest tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_list_active_agent_sessions.py tests/scripts/test_agent_bridge.py -q
- python3 -m ruff check scripts/agent_bridge.py scripts/list_active_agent_sessions.py scripts/claim_active_agent_lane.py tests/scripts/test_agent_bridge.py tests/scripts/test_list_active_agent_sessions.py tests/scripts/test_claim_active_agent_lane.py
- python3 -m ruff format --check scripts/agent_bridge.py scripts/list_active_agent_sessions.py scripts/claim_active_agent_lane.py tests/scripts/test_agent_bridge.py tests/scripts/test_list_active_agent_sessions.py tests/scripts/test_claim_active_agent_lane.py
- python3 -m mypy scripts/agent_bridge.py scripts/list_active_agent_sessions.py scripts/claim_active_agent_lane.py tests/scripts/test_agent_bridge.py tests/scripts/test_list_active_agent_sessions.py tests/scripts/test_claim_active_agent_lane.py --ignore-missing-imports --no-incremental
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- live smoke: list_active_agent_sessions.py --json --conflicts-only reports conflict_count=0 after the earlier #7245 duplicate resolved
