### PR TITLE
fix(automation): harden lane collision diagnostics

### DIFF
--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -226,7 +226,7 @@ def _active_identity_conflict(
     rows: list[dict[str, Any]],
     normalized: dict[str, Any],
     owner_session: str,
-) -> tuple[dict[str, Any], str, str] | None:
+) -> tuple[dict[str, Any], list[tuple[str, str]]] | None:
     requested = set(_identity_claims(normalized))
     if not requested or str(normalized.get("status") or "") not in ACTIVE_STATUSES:
         return None
@@ -239,8 +239,7 @@ def _active_identity_conflict(
         overlap = requested.intersection(_identity_claims(existing))
         if not overlap:
             continue
-        kind, value = sorted(overlap)[0]
-        return existing, kind, value
+        return existing, sorted(overlap)
     return None
 
 
@@ -351,9 +350,10 @@ def claim_lane(
             owner_session=owner_session,
         )
         if identity_conflict is not None and not allow_resource_conflicts and not force:
-            existing, kind, value = identity_conflict
+            existing, overlaps = identity_conflict
+            overlap_text = ", ".join(f"{kind}={value!r}" for kind, value in overlaps)
             raise ClaimError(
-                f"{kind}={value!r} already claimed by "
+                f"{overlap_text} already claimed by "
                 f"lane_id={existing.get('lane_id')!r} "
                 f"owner_session={existing.get('owner_session')!r}; refusing to "
                 "create overlapping active lane (use --force to override)"

--- a/scripts/list_active_agent_sessions.py
+++ b/scripts/list_active_agent_sessions.py
@@ -514,11 +514,20 @@ def _mark_lane_identity_conflicts(rows: list[dict[str, Any]]) -> None:
         row_conflicts = conflict_by_lane.get(lane_id)
         if not row_conflicts:
             continue
+        # ``is_conflict`` is true for either an explicit status=="conflict" row
+        # or a computed identity conflict between active lanes.
         row["is_conflict"] = True
         row["identity_conflicts"] = row_conflicts
-        row["conflict_reason"] = "; ".join(
-            f"{conflict['key_kind']}={conflict['key_value']}" for conflict in row_conflicts
-        )
+        reason_parts = [
+            part.strip()
+            for part in str(row.get("conflict_reason") or "").split(";")
+            if part.strip()
+        ]
+        for conflict in row_conflicts:
+            part = f"{conflict['key_kind']}={conflict['key_value']}"
+            if part not in reason_parts:
+                reason_parts.append(part)
+        row["conflict_reason"] = "; ".join(reason_parts)
 
 
 def fetch_open_prs(

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -472,6 +472,36 @@ def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(
     assert payload["health"]["issues"][0]["type"] == "lane_identity_conflict"
 
 
+def test_operator_snapshot_high_process_count_alone_is_not_conflict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 500,
+            "by_role": {"codex_app_server": 500},
+        },
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["active_processes"] == 500
+    assert payload["summary"]["conflict_lanes"] == 0
+    assert payload["health"]["ok"] is True
+
+
 def test_collect_agent_process_census_redacts_commands_and_counts_roles() -> None:
     import agent_bridge as mod
 

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -190,6 +190,34 @@ def test_different_lane_same_worktree_is_rejected_by_default(
     assert "worktree='/tmp/aragora-pr7245' already claimed" in str(excinfo.value)
 
 
+def test_different_lane_same_identity_reports_all_overlapping_keys(
+    tmp_registry: Path,
+) -> None:
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="lane-a",
+        owner_session="codex-A",
+        pr_number=7245,
+        branch="worktree-codex-insights",
+        worktree="/tmp/aragora-pr7245",
+    )
+
+    with pytest.raises(claim_module.ClaimError) as excinfo:
+        claim_module.claim_lane(
+            registry_path=tmp_registry,
+            lane_id="lane-b",
+            owner_session="codex-B",
+            pr_number=7245,
+            branch="worktree-codex-insights",
+            worktree="/tmp/aragora-pr7245",
+        )
+
+    message = str(excinfo.value)
+    assert "branch='worktree-codex-insights'" in message
+    assert "pr_number='7245'" in message
+    assert "worktree='/tmp/aragora-pr7245'" in message
+
+
 def test_same_owner_can_refresh_same_pr_identity(tmp_registry: Path) -> None:
     claim_module.claim_lane(
         registry_path=tmp_registry,
@@ -561,6 +589,14 @@ def test_module_imports_no_aragora_package() -> None:
     source = SCRIPT_PATH.read_text(encoding="utf-8")
     assert "import aragora" not in source
     assert "from aragora" not in source
+
+
+def test_active_lane_statuses_match_bridge_and_detector() -> None:
+    agent_bridge = importlib.import_module("agent_bridge")
+    detector = importlib.import_module("list_active_agent_sessions")
+
+    assert claim_module.ACTIVE_STATUSES == set(agent_bridge.ACTIVE_LANE_STATUSES)
+    assert claim_module.ACTIVE_STATUSES == set(detector.ACTIVE_LANE_STATUSES)
 
 
 def test_resolve_registry_path_prefers_repo_local(tmp_path: Path) -> None:

--- a/tests/scripts/test_list_active_agent_sessions.py
+++ b/tests/scripts/test_list_active_agent_sessions.py
@@ -782,7 +782,47 @@ def test_detect_agent_bridge_lanes_marks_duplicate_active_pr_conflicts(tmp_path:
     )
 
     assert {row["lane_id"] for row in out if row["is_conflict"]} == {"lane-a", "lane-b"}
+    lane_a = next(row for row in out if row["lane_id"] == "lane-a")
+    assert lane_a["status"] == "active"
+    assert lane_a["is_conflict"] is True
+    assert lane_a["conflict_reason"] == "branch=worktree-codex-insights; pr_number=7245"
     assert detector.lane_identity_conflicts(out)[0]["key_kind"] == "branch"
+
+
+def test_detect_agent_bridge_lanes_preserves_existing_identity_conflict_reason(
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-a",
+                    "owner_session": "codex-A",
+                    "status": "active",
+                    "pr_number": 7245,
+                    "conflict_reason": "manual operator note",
+                },
+                {
+                    "lane_id": "lane-b",
+                    "owner_session": "codex-B",
+                    "status": "active",
+                    "pr_number": 7245,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out = detector.detect_agent_bridge_lanes(
+        tmp_path,
+        user_path=tmp_path / "missing.json",
+    )
+
+    lane_a = next(row for row in out if row["lane_id"] == "lane-a")
+    assert lane_a["is_conflict"] is True
+    assert lane_a["conflict_reason"] == "manual operator note; pr_number=7245"
 
 
 def test_detect_agent_bridge_lanes_does_not_conflict_released_lanes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- keep active-lane status semantics test-enforced across agent_bridge, claim_active_agent_lane, and list_active_agent_sessions
- report every overlapping identity key when rejecting duplicate active lane claims
- preserve existing conflict_reason text while adding computed identity-conflict reasons and document computed is_conflict semantics

## Validation
- python3 -m pytest tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_list_active_agent_sessions.py tests/scripts/test_agent_bridge.py -q
- python3 -m ruff check scripts/agent_bridge.py scripts/claim_active_agent_lane.py scripts/list_active_agent_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_list_active_agent_sessions.py
- python3 -m ruff format --check scripts/agent_bridge.py scripts/claim_active_agent_lane.py scripts/list_active_agent_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_list_active_agent_sessions.py
- python3 -m mypy scripts/agent_bridge.py scripts/claim_active_agent_lane.py scripts/list_active_agent_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_list_active_agent_sessions.py --ignore-missing-imports --no-incremental
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- temp-only smoke: duplicate active claim with same PR/branch/worktree exits 2 and reports all three overlapping keys