### PR TITLE
[AGT-04] Repo visibility guard — publicly observable market repos (SD-7)

### DIFF
--- a/aragora/markets/repo_guard.py
+++ b/aragora/markets/repo_guard.py
@@ -1,0 +1,133 @@
+"""Public-repo visibility guard for synthetic prediction markets (AGT-04 SD-7).
+
+Limits market creation to publicly observable GitHub repositories so resolution
+events are derived from unambiguous public state rather than private API calls
+that may be unavailable, rate-limited differently, or misleading.
+
+Feature flag: ``ARAGORA_MARKET_REPO_GUARD_ENABLED`` (env var, default OFF).
+When the flag is off the guard is a transparent pass-through — all existing
+markets and tests are unaffected.
+
+Allowlist: ``ARAGORA_MARKET_REPO_ALLOWLIST`` — comma-separated ``owner/repo``
+entries.  The special token ``*`` allows any syntactically valid ``owner/repo``
+without explicit listing (trust-public-repos mode, useful for test environments
+and future network-backed visibility probing).
+
+Fail-closed rule: when the flag is ON and ``ARAGORA_MARKET_REPO_ALLOWLIST`` is
+empty or unset, the guard **denies all repos**.  Operators must explicitly list
+repos or set ``ARAGORA_MARKET_REPO_ALLOWLIST=*``.
+
+Does NOT call the GitHub API.  Network-backed public-visibility probing (e.g.
+checking ``repo.visibility`` via the REST API) is a follow-on slice that can be
+wired in by subclassing :class:`RepoVisibilityGuard` and overriding
+:meth:`is_allowed`.
+
+Advances: issue #6065 (AGT-04), sub-deliverable 7 — publicly observable repos.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+
+_FLAG = "ARAGORA_MARKET_REPO_GUARD_ENABLED"
+_ALLOWLIST_VAR = "ARAGORA_MARKET_REPO_ALLOWLIST"
+_WILDCARD = "*"
+
+# Accepts GitHub-style owner/repo with alphanumerics, dots, dashes, underscores.
+_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
+class RepoVisibilityError(ValueError):
+    """Raised when a market targets a repo not in the visibility allowlist."""
+
+
+def _guard_enabled() -> bool:
+    return os.environ.get(_FLAG, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_allowlist(raw: str) -> frozenset[str]:
+    """Parse a comma-separated allowlist string into a normalised frozenset.
+
+    The wildcard token ``*`` is kept as-is; all other tokens are lowercased
+    and stripped so comparisons are case-insensitive.
+    """
+    parts: set[str] = set()
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if token == _WILDCARD:
+            parts.add(_WILDCARD)
+        else:
+            parts.add(token.lower())
+    return frozenset(parts)
+
+
+@dataclass
+class RepoVisibilityGuard:
+    """Flag-gated allowlist guard for synthetic-market target repos.
+
+    Prefer :meth:`from_env` for production use.  Direct construction is
+    available so unit tests can build instances without touching the
+    process environment.
+
+    Attributes:
+        enabled: When ``False`` the guard is a transparent pass-through;
+            :meth:`is_allowed` always returns ``True``.
+        allowlist: Normalised ``owner/repo`` entries, or ``{"*"}`` for
+            wildcard mode.  Empty when ``enabled`` is ``False``.
+    """
+
+    enabled: bool = False
+    allowlist: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def from_env(cls) -> "RepoVisibilityGuard":
+        """Build a guard from the current process environment."""
+        if not _guard_enabled():
+            return cls(enabled=False, allowlist=frozenset())
+        raw = os.environ.get(_ALLOWLIST_VAR, "").strip()
+        return cls(enabled=True, allowlist=_parse_allowlist(raw))
+
+    def is_allowed(self, repo: str) -> bool:
+        """Return ``True`` if *repo* is permitted as a market target.
+
+        Always returns ``True`` when the guard is disabled.
+
+        In wildcard mode (``allowlist == {"*"}``), any syntactically valid
+        ``owner/repo`` string is accepted; malformed strings are rejected so
+        they fail cleanly before reaching the GitHub resolver.
+        """
+        if not self.enabled:
+            return True
+        if _WILDCARD in self.allowlist:
+            return bool(_REPO_RE.match(repo.strip()))
+        return repo.strip().lower() in self.allowlist
+
+    def require_allowed(self, repo: str) -> None:
+        """Raise :exc:`RepoVisibilityError` if *repo* is not permitted.
+
+        No-op when the guard is disabled.
+        """
+        if self.is_allowed(repo):
+            return
+        if not self.allowlist:
+            raise RepoVisibilityError(
+                f"Repo {repo!r} is not allowed: guard is enabled but "
+                f"{_ALLOWLIST_VAR} is empty (fail-closed). "
+                f"Set {_ALLOWLIST_VAR}=owner/repo or {_ALLOWLIST_VAR}=* "
+                "to permit repos."
+            )
+        raise RepoVisibilityError(
+            f"Repo {repo!r} is not in the market visibility allowlist. "
+            f"Add it to {_ALLOWLIST_VAR} or set {_ALLOWLIST_VAR}=* "
+            "to allow any syntactically valid repo."
+        )
+
+
+__all__ = [
+    "RepoVisibilityError",
+    "RepoVisibilityGuard",
+]

--- a/tests/markets/test_repo_guard.py
+++ b/tests/markets/test_repo_guard.py
@@ -1,0 +1,131 @@
+"""Tests for aragora.markets.repo_guard (AGT-04 SD-7).
+
+Flag gating, allowlist semantics, wildcard mode, fail-closed behaviour,
+from_env construction, require_allowed error messages.  No network calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.markets.repo_guard import (
+    RepoVisibilityError,
+    RepoVisibilityGuard,
+    _ALLOWLIST_VAR,
+    _FLAG,
+)
+
+
+class TestFlagGating:
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_FLAG, raising=False)
+        monkeypatch.delenv(_ALLOWLIST_VAR, raising=False)
+        assert not RepoVisibilityGuard.from_env().enabled
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+    def test_truthy_values_enable(self, val: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, val)
+        monkeypatch.setenv(_ALLOWLIST_VAR, "owner/repo")
+        assert RepoVisibilityGuard.from_env().enabled
+
+    @pytest.mark.parametrize("val", ["0", "false", ""])
+    def test_falsy_values_disable(self, val: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, val)
+        assert not RepoVisibilityGuard.from_env().enabled
+
+    def test_flag_off_any_repo_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_FLAG, raising=False)
+        guard = RepoVisibilityGuard.from_env()
+        assert guard.is_allowed("private-org/secret-repo")
+
+    def test_flag_off_require_allowed_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_FLAG, raising=False)
+        RepoVisibilityGuard.from_env().require_allowed("any/repo")  # must not raise
+
+
+class TestAllowlist:
+    def test_listed_repo_is_allowed(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"synaptent/aragora"}))
+        assert guard.is_allowed("synaptent/aragora")
+
+    def test_comparison_is_case_insensitive(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"owner/repo"}))
+        assert guard.is_allowed("Owner/Repo")
+
+    def test_unlisted_repo_denied(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"owner/repo"}))
+        assert not guard.is_allowed("other/project")
+
+    def test_empty_allowlist_denies_all(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset())
+        assert not guard.is_allowed("any/repo")
+
+    def test_multiple_repos_in_allowlist(self) -> None:
+        guard = RepoVisibilityGuard(
+            enabled=True, allowlist=frozenset({"owner/repo-a", "owner/repo-b"})
+        )
+        assert guard.is_allowed("owner/repo-a")
+        assert guard.is_allowed("owner/repo-b")
+        assert not guard.is_allowed("owner/repo-c")
+
+
+class TestWildcardMode:
+    def test_wildcard_allows_valid_owner_slash_repo(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"*"}))
+        assert guard.is_allowed("any-org/any-repo")
+        assert guard.is_allowed("synaptent/aragora")
+
+    def test_wildcard_rejects_missing_slash(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"*"}))
+        assert not guard.is_allowed("not-a-valid-repo-format")
+
+    def test_wildcard_rejects_bare_slash_or_empty_component(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"*"}))
+        assert not guard.is_allowed("owner/")
+        assert not guard.is_allowed("/repo")
+
+
+class TestRequireAllowed:
+    def test_raises_for_unlisted_repo(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"other/repo"}))
+        with pytest.raises(RepoVisibilityError, match="owner/repo"):
+            guard.require_allowed("owner/repo")
+
+    def test_raises_fail_closed_message_on_empty_allowlist(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset())
+        with pytest.raises(RepoVisibilityError, match="fail-closed"):
+            guard.require_allowed("any/repo")
+
+    def test_no_raise_for_listed_repo(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"owner/repo"}))
+        guard.require_allowed("owner/repo")  # must not raise
+
+    def test_no_raise_for_wildcard_valid_repo(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"*"}))
+        guard.require_allowed("any-org/any-project")  # must not raise
+
+    def test_raises_for_wildcard_invalid_format(self) -> None:
+        guard = RepoVisibilityGuard(enabled=True, allowlist=frozenset({"*"}))
+        with pytest.raises(RepoVisibilityError):
+            guard.require_allowed("not-a-repo")
+
+
+class TestFromEnv:
+    def test_reads_allowlist_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        monkeypatch.setenv(_ALLOWLIST_VAR, "owner/repo-a, owner/repo-b")
+        guard = RepoVisibilityGuard.from_env()
+        assert guard.is_allowed("owner/repo-a")
+        assert not guard.is_allowed("owner/repo-c")
+
+    def test_empty_allowlist_env_denies_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        monkeypatch.delenv(_ALLOWLIST_VAR, raising=False)
+        assert not RepoVisibilityGuard.from_env().is_allowed("any/repo")
+
+    def test_wildcard_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_FLAG, "1")
+        monkeypatch.setenv(_ALLOWLIST_VAR, "*")
+        guard = RepoVisibilityGuard.from_env()
+        assert guard.is_allowed("any-org/any-project")
+        assert not guard.is_allowed("bad-format")


### PR DESCRIPTION
## Slice

Adds `aragora/markets/repo_guard.py` — a flag-gated allowlist guard
(`RepoVisibilityGuard`) that limits synthetic-market creation to publicly
observable GitHub repositories. This is the last missing piece of AGT-04:
the existing schema, resolver, store, scoring, and credit-settlement modules
cover SDs 1–6; this PR closes SD-7 — "Limit to publicly observable repos
for unambiguous resolution."

## Gating

- Default: **OFF** (flag: `ARAGORA_MARKET_REPO_GUARD_ENABLED`)
- Allowlist: `ARAGORA_MARKET_REPO_ALLOWLIST` — comma-separated `owner/repo`
  entries or `*` for wildcard (any syntactically valid repo)
- **Fail-closed**: when flag is ON and allowlist is empty, all repos are denied
- Live queue effect: **none** — module is import-only; nothing in the live
  market creation, resolver, or boss-loop path imports it yet
- Advances issue: #6065 (AGT-04), sub-deliverable 7

## Tests

- `TestFlagGating` — disabled by default; all four truthy values activate;
  three falsy values keep guard off; pass-through when disabled
- `TestAllowlist` — listed repo allowed; case-insensitive comparison; unlisted
  denied; empty allowlist denies all; multi-repo allowlist
- `TestWildcardMode` — `*` accepts valid `owner/repo` format; rejects missing
  slash; rejects empty owner or repo component
- `TestRequireAllowed` — raises `RepoVisibilityError` with repo name in message
  for unlisted; raises with "fail-closed" in message on empty allowlist; no
  raise for listed; no raise for wildcard + valid format; raises for wildcard +
  invalid format
- `TestFromEnv` — reads comma-separated allowlist from env; empty env denies
  all; `*` from env enables wildcard mode

## Validation

- `pytest tests/markets/test_repo_guard.py --noconftest` — **26 passed**
- `ruff check aragora/markets/repo_guard.py tests/markets/test_repo_guard.py` — clean
- `mypy aragora/markets/repo_guard.py tests/markets/test_repo_guard.py --ignore-missing-imports` — clean
- Net diff: **264 LOC** (133-line implementation + 131-line test file)

## Out of scope

- Wiring the guard into `MarketStore.add_market()` — requires a separate
  operator decision once `ARAGORA_MARKET_REPO_GUARD_ENABLED` is cleared for
  the live path; the wiring PR can inject `RepoVisibilityGuard.from_env()` at
  store-construction time with one line
- Network-backed public-visibility probing (checking `repo.visibility` via
  REST API) — deferred; can be wired in by subclassing `RepoVisibilityGuard`
  and overriding `is_allowed`
- Per-market visibility override — deferred to a follow-on slice

Labels: `vision-layer`

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9D3GpMxM1HozwouZLcAEa)_