### PR TITLE
fix(scripts): harden operator decision replay

### DIFF
--- a/scripts/apply_operator_decisions.py
+++ b/scripts/apply_operator_decisions.py
@@ -30,6 +30,9 @@ trail is recoverable from any PR thread:
 
 Defaults to ``--dry-run`` so the first invocation never mutates state.
 ``--apply`` is required to actually call ``gh``.
+Apply mode also refuses draft/closed/merged PR targets and skips a
+decision when the same payload/receipt binding footer is already present
+on the PR, making replay idempotent.
 
 Hard-coded hold list: PRs explicitly marked as operator-only / held
 elsewhere in this repo are hard-skipped regardless of the receipt's
@@ -133,6 +136,16 @@ class EntryResult:
     status: str
     reason: str
     gh_command: list[str] | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class LivePrState:
+    """Minimal live PR state required before mutating GitHub."""
+
+    head_sha: str
+    is_draft: bool
+    state: str
+    binding_footer_present: bool
 
 
 class PayloadValidationError(ValueError):
@@ -359,10 +372,43 @@ def build_comment_body(entry: DecisionEntry, payload: OperatorDecisionsPayload) 
     return (main + footer) if main else footer.lstrip("\n")
 
 
-def _gh_view_head(pr_number: int, *, repo: str) -> tuple[str | None, str]:
-    """Return the current ``headRefOid`` for ``pr_number`` (or ``(None, err)``)."""
+def _binding_footer_marker(payload: OperatorDecisionsPayload) -> str:
+    return (
+        f"Applied from operator-decisions {_short_sha(payload.payload_sha256)} "
+        f"bound to packet {_short_sha(payload.receipt_sha256)}"
+    )
 
-    cmd = ["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", "headRefOid"]
+
+def _body_collection_contains_marker(value: Any, marker: str) -> bool:
+    if not isinstance(value, list):
+        return False
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        body = item.get("body")
+        if isinstance(body, str) and marker in body:
+            return True
+    return False
+
+
+def _gh_view_pr_state(
+    pr_number: int,
+    *,
+    repo: str,
+    binding_footer_marker: str,
+) -> tuple[LivePrState | None, str]:
+    """Return live PR state required before mutation, or ``(None, err)``."""
+
+    cmd = [
+        "gh",
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        repo,
+        "--json",
+        "headRefOid,isDraft,state,comments,reviews",
+    ]
     try:
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
     except subprocess.CalledProcessError as exc:
@@ -375,7 +421,21 @@ def _gh_view_head(pr_number: int, *, repo: str) -> tuple[str | None, str]:
     head = data.get("headRefOid")
     if not head or not isinstance(head, str):
         return None, f"gh pr view #{pr_number} returned no headRefOid"
-    return head, ""
+    is_draft = data.get("isDraft")
+    if not isinstance(is_draft, bool):
+        return None, f"gh pr view #{pr_number} returned no isDraft boolean"
+    state = data.get("state")
+    if not isinstance(state, str) or not state:
+        return None, f"gh pr view #{pr_number} returned no state"
+    binding_present = _body_collection_contains_marker(
+        data.get("comments"), binding_footer_marker
+    ) or _body_collection_contains_marker(data.get("reviews"), binding_footer_marker)
+    return LivePrState(
+        head_sha=head,
+        is_draft=is_draft,
+        state=state,
+        binding_footer_present=binding_present,
+    ), ""
 
 
 def _plan_action(entry: DecisionEntry, body: str, *, repo: str) -> list[str] | None:
@@ -454,20 +514,45 @@ def process_entry(
             gh_command=cmd,
         )
 
-    live_head, err = _gh_view_head(entry.pr_number, repo=payload.receipt_repo)
-    if live_head is None:
+    live_state, err = _gh_view_pr_state(
+        entry.pr_number,
+        repo=payload.receipt_repo,
+        binding_footer_marker=_binding_footer_marker(payload),
+    )
+    if live_state is None:
         return EntryResult(
             pr_number=entry.pr_number,
             decision=entry.decision,
             status=STATUS_FAILED,
             reason=err or "gh pr view failed",
         )
-    if live_head != entry.head_sha:
+    if live_state.binding_footer_present:
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_SKIPPED,
+            reason="binding footer already present; refusing duplicate apply",
+        )
+    if live_state.state != "OPEN":
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_FAILED,
+            reason=f"PR state is {live_state.state}; refusing mutation",
+        )
+    if live_state.is_draft:
+        return EntryResult(
+            pr_number=entry.pr_number,
+            decision=entry.decision,
+            status=STATUS_FAILED,
+            reason="PR is draft; refusing mutation",
+        )
+    if live_state.head_sha != entry.head_sha:
         return EntryResult(
             pr_number=entry.pr_number,
             decision=entry.decision,
             status=STATUS_DRIFTED,
-            reason=(f"HEAD DRIFT: expected {entry.head_sha[:10]}, got {live_head[:10]}"),
+            reason=(f"HEAD DRIFT: expected {entry.head_sha[:10]}, got {live_state.head_sha[:10]}"),
         )
 
     try:

--- a/tests/scripts/test_apply_operator_decisions.py
+++ b/tests/scripts/test_apply_operator_decisions.py
@@ -96,6 +96,14 @@ def write_payload(
     return p
 
 
+def binding_marker_for_payload(path: Path) -> str:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return (
+        f"Applied from operator-decisions {payload['payload_sha256'][:10]} "
+        f"bound to packet {payload['receipt_sha256'][:10]}"
+    )
+
+
 def write_receipt(tmp_path: Path, body: bytes = _RECEIPT_BODY) -> Path:
     p = tmp_path / "settlement-receipt.json"
     p.write_bytes(body)
@@ -119,9 +127,17 @@ class FakeGh:
         self,
         *,
         head_oid: str = _HEAD_SHA_DEFAULT,
+        is_draft: bool = False,
+        state: str = "OPEN",
+        comments: list[dict[str, str]] | None = None,
+        reviews: list[dict[str, str]] | None = None,
         apply_succeeds: bool = True,
     ) -> None:
         self.head_oid = head_oid
+        self.is_draft = is_draft
+        self.state = state
+        self.comments = comments or []
+        self.reviews = reviews or []
         self.apply_succeeds = apply_succeeds
         self.calls: list[list[str]] = []
 
@@ -131,7 +147,15 @@ class FakeGh:
             return subprocess.CompletedProcess(
                 args=cmd,
                 returncode=0,
-                stdout=json.dumps({"headRefOid": self.head_oid}),
+                stdout=json.dumps(
+                    {
+                        "headRefOid": self.head_oid,
+                        "isDraft": self.is_draft,
+                        "state": self.state,
+                        "comments": self.comments,
+                        "reviews": self.reviews,
+                    }
+                ),
                 stderr="",
             )
         if not self.apply_succeeds:
@@ -610,6 +634,86 @@ def test_head_drift_skips_entry(
     out = capsys.readouterr().out
     assert "DRIFT" in out
     assert "HEAD DRIFT" in out
+
+
+def test_apply_refuses_draft_pr_before_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake = FakeGh(is_draft=True)
+    monkeypatch.setattr(aod.subprocess, "run", fake.run)
+    monkeypatch.setattr(
+        aod.shutil, "which", lambda exe: "/usr/local/bin/gh" if exe == "gh" else None
+    )
+    p = write_payload(tmp_path, [make_entry(100, "approve_tier")])
+
+    rc = aod.main(apply_args(tmp_path, p))
+
+    assert rc == 1
+    assert len(fake.calls) == 1
+    assert fake.calls[0][:3] == ["gh", "pr", "view"]
+    assert fake.review_calls() == []
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+    assert "draft" in out
+
+
+@pytest.mark.parametrize("state", ["CLOSED", "MERGED"])
+def test_apply_refuses_non_open_pr_before_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    state: str,
+) -> None:
+    fake = FakeGh(state=state)
+    monkeypatch.setattr(aod.subprocess, "run", fake.run)
+    monkeypatch.setattr(
+        aod.shutil, "which", lambda exe: "/usr/local/bin/gh" if exe == "gh" else None
+    )
+    p = write_payload(tmp_path, [make_entry(100, "reject")])
+
+    rc = aod.main(apply_args(tmp_path, p))
+
+    assert rc == 1
+    assert len(fake.calls) == 1
+    assert fake.calls[0][:3] == ["gh", "pr", "view"]
+    assert fake.close_calls() == []
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+    assert state in out
+
+
+@pytest.mark.parametrize(
+    ("decision", "collection_name"),
+    [("approve_tier", "reviews"), ("reject", "comments")],
+)
+def test_apply_skips_duplicate_binding_replay_before_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    decision: str,
+    collection_name: str,
+) -> None:
+    p = write_payload(tmp_path, [make_entry(100, decision)])
+    marker = binding_marker_for_payload(p)
+    fake_kwargs: dict[str, Any] = {collection_name: [{"body": f"prior run\n{marker}"}]}
+    fake = FakeGh(**fake_kwargs)
+    monkeypatch.setattr(aod.subprocess, "run", fake.run)
+    monkeypatch.setattr(
+        aod.shutil, "which", lambda exe: "/usr/local/bin/gh" if exe == "gh" else None
+    )
+
+    rc = aod.main(apply_args(tmp_path, p))
+
+    assert rc == 0
+    assert len(fake.calls) == 1
+    assert fake.calls[0][:3] == ["gh", "pr", "view"]
+    assert fake.review_calls() == []
+    assert fake.close_calls() == []
+    out = capsys.readouterr().out
+    assert "SKIP" in out
+    assert "duplicate apply" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fail closed before mutation when live PR targets are draft, closed, or merged
- skip duplicate operator-decisions replay when the same payload/receipt binding footer already exists on PR comments or reviews
- add focused regressions for draft/non-open refusal and duplicate replay idempotence

## Validation
- python3 -m pytest tests/scripts/test_apply_operator_decisions.py -q
- python3 -m ruff check scripts/apply_operator_decisions.py tests/scripts/test_apply_operator_decisions.py
- python3 -m ruff format --check scripts/apply_operator_decisions.py tests/scripts/test_apply_operator_decisions.py
- python3 -m mypy scripts/apply_operator_decisions.py tests/scripts/test_apply_operator_decisions.py --ignore-missing-imports --no-incremental
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Follow-up for post-merge #7279 review findings only.