### PR TITLE
feat(scripts): triage_bucket_c.py — Stage 3 operator-delegation batcher [lane: P17]

### DIFF
--- a/scripts/triage_bucket_c.py
+++ b/scripts/triage_bucket_c.py
@@ -1,0 +1,678 @@
+"""Stage 3 of the operator-delegation rollout — Bucket C batcher.
+
+Implements ``docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md`` Stage 3:
+
+  - Reads the Stage 1 classifier output from ``scripts/triage_open_prs.py``.
+  - Filters to Bucket C only.
+  - Accepts a one-character response per PR via stdin (``--interactive``)
+    or via a JSON response file (``--responses FILE``):
+      ``y`` — advance: ``gh pr ready`` (if draft) + comment + optional label
+      ``n`` — close:    ``gh pr close --comment``
+      ``d`` — defer:    no-op
+  - Defaults to dry-run; ``--apply`` is required to mutate.
+  - Hard-codes the operator-delegation policy hold list — held PRs
+    are never advanced or closed regardless of the operator's
+    response.
+  - Defense-in-depth: also skips PRs that touch protected paths even
+    if the classifier somehow missed them.
+  - Writes a receipt to ``docs/status/BUCKET_C_RECEIPT_<utc>.md`` on
+    every ``--apply`` run.
+
+Pure stdlib + ``gh`` subprocess. No ``aragora.*`` imports. No third-
+party deps. The response file is JSON (``{"7251": "y", "7252": "d"}``)
+to stay stdlib-only; YAML is a superset of JSON and the same payloads
+are accepted as ``.yaml`` files with no loader change required.
+
+CLI::
+
+    python3 scripts/triage_bucket_c.py [--interactive]
+                                       [--responses FILE]
+                                       [--apply]
+                                       [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TextIO
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TRIAGE_SCRIPT = REPO_ROOT / "scripts" / "triage_open_prs.py"
+RECEIPT_DIR = REPO_ROOT / "docs" / "status"
+POLICY_DOC = REPO_ROOT / "docs" / "governance" / "OPERATOR_DELEGATION_POLICY.md"
+
+BUCKET_C = "C"
+
+# Held PR numbers — kept in sync with the policy doc's canonical hold
+# list and the parallel constant in scripts/triage_open_prs.py +
+# scripts/apply_operator_decisions.py. Stage 3 hard-skips these
+# regardless of the operator's response.
+HELD_PR_NUMBERS: frozenset[int] = frozenset({4990, 7173, 7215, 7240, 7243, 7245, 7249, 7252})
+
+# Defense-in-depth protected paths. Even if Stage 1 somehow classified
+# a PR touching one of these as Bucket C (rather than the held list),
+# Stage 3 still refuses to advance it.
+PROTECTED_PATHS: frozenset[str] = frozenset(
+    {
+        "CLAUDE.md",
+        "AGENTS.md",
+        "aragora/__init__.py",
+        ".env",
+        ".envrc",
+        "scripts/nomic_loop.py",
+        "docs/AGENT_OPERATING_CONTRACT.md",
+        "docs/governance/OPERATOR_DELEGATION_POLICY.md",
+        "automation.toml",
+    }
+)
+
+PROTECTED_PREFIXES: tuple[str, ...] = (
+    ".github/workflows/",
+    "secrets/",
+)
+
+RESPONSE_ADVANCE = "y"
+RESPONSE_CLOSE = "n"
+RESPONSE_DEFER = "d"
+VALID_RESPONSES: frozenset[str] = frozenset({RESPONSE_ADVANCE, RESPONSE_CLOSE, RESPONSE_DEFER})
+
+# Status codes for the result table.
+STATUS_ADVANCED = "advanced"
+STATUS_CLOSED = "closed"
+STATUS_DEFERRED = "deferred"
+STATUS_HELD = "held-skipped"
+STATUS_PROTECTED = "protected-skipped"
+STATUS_NOT_BUCKET_C = "not-bucket-c-skipped"
+STATUS_NO_RESPONSE = "no-response-skipped"
+STATUS_INVALID_RESPONSE = "invalid-response"
+STATUS_WOULD_ADVANCE = "would-advance"
+STATUS_WOULD_CLOSE = "would-close"
+STATUS_GH_FAILED = "gh-failed"
+
+
+@dataclasses.dataclass(frozen=True)
+class EntryResult:
+    pr_number: int
+    title: str
+    response: str | None
+    status: str
+    reason: str
+    gh_commands: tuple[tuple[str, ...], ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helpers (injectable for testing)
+# ---------------------------------------------------------------------------
+
+
+Runner = Callable[[list[str]], "subprocess.CompletedProcess[str]"]
+
+
+def _default_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, text=True, capture_output=True, check=False)
+
+
+def run_triage(*, runner: Runner | None = None) -> dict[str, Any]:
+    """Invoke the Stage 1 classifier and return its JSON output."""
+    runner = runner or _default_runner
+    proc = runner(["python3", str(TRIAGE_SCRIPT), "--json"])
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"triage_open_prs.py --json failed (exit {proc.returncode}): "
+            f"{(proc.stderr or proc.stdout).strip()}"
+        )
+    return json.loads(proc.stdout or "{}")
+
+
+def fetch_pr_files(pr_number: int, *, runner: Runner | None = None) -> list[str]:
+    """Return the file paths touched by the given PR.
+
+    Used by the defense-in-depth protected-path tripwire.
+    """
+    runner = runner or _default_runner
+    proc = runner(["gh", "pr", "view", str(pr_number), "--json", "files"])
+    if proc.returncode != 0:
+        return []
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return []
+    out: list[str] = []
+    for entry in payload.get("files") or []:
+        if isinstance(entry, dict):
+            path = str(entry.get("path") or "")
+            if path:
+                out.append(path)
+    return out
+
+
+def gh_pr_ready(
+    pr_number: int, *, runner: Runner | None = None
+) -> subprocess.CompletedProcess[str]:
+    runner = runner or _default_runner
+    return runner(["gh", "pr", "ready", str(pr_number)])
+
+
+def gh_pr_close(
+    pr_number: int, body: str, *, runner: Runner | None = None
+) -> subprocess.CompletedProcess[str]:
+    runner = runner or _default_runner
+    return runner(["gh", "pr", "close", str(pr_number), "--comment", body])
+
+
+def gh_pr_comment(
+    pr_number: int, body: str, *, runner: Runner | None = None
+) -> subprocess.CompletedProcess[str]:
+    runner = runner or _default_runner
+    return runner(["gh", "pr", "comment", str(pr_number), "--body", body])
+
+
+# ---------------------------------------------------------------------------
+# Response loading
+# ---------------------------------------------------------------------------
+
+
+def load_responses_file(path: Path) -> dict[int, str]:
+    """Load a JSON response file mapping PR number → y/n/d.
+
+    Accepts integer or string keys. Raises ``ValueError`` for any
+    response not in ``{y, n, d}``.
+    """
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"response file {path} must be a JSON object mapping PR number to y/n/d")
+    parsed: dict[int, str] = {}
+    for key, value in raw.items():
+        try:
+            pr_num = int(str(key).lstrip("#"))
+        except ValueError as exc:
+            raise ValueError(f"response file {path}: invalid PR key {key!r}") from exc
+        response = str(value).strip().lower()
+        if response not in VALID_RESPONSES:
+            raise ValueError(
+                f"response file {path}: PR #{pr_num} has invalid"
+                f" response {value!r}; expected one of"
+                f" {sorted(VALID_RESPONSES)}"
+            )
+        parsed[pr_num] = response
+    return parsed
+
+
+def collect_responses_interactive(
+    bucket_c_entries: list[dict[str, Any]],
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+) -> dict[int, str]:
+    """Prompt for y/n/d per Bucket C PR, reading from stdin."""
+    stdin = stdin or sys.stdin
+    stdout = stdout or sys.stdout
+    responses: dict[int, str] = {}
+    for entry in bucket_c_entries:
+        pr_number = int(entry.get("pr_number") or 0)
+        title = str(entry.get("title") or "")
+        reason = str(entry.get("reason") or "")
+        stdout.write(f"\nPR #{pr_number}\n  title: {title}\n  reason: {reason}\n")
+        stdout.write("  [y]advance / [n]close / [d]defer: ")
+        stdout.flush()
+        raw = (stdin.readline() or "").strip().lower()
+        if raw == "":
+            # Empty input is a defer (skip).
+            responses[pr_number] = RESPONSE_DEFER
+        elif raw in VALID_RESPONSES:
+            responses[pr_number] = raw
+        else:
+            stdout.write(f"  invalid response {raw!r}; treating as defer.\n")
+            responses[pr_number] = RESPONSE_DEFER
+    return responses
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth
+# ---------------------------------------------------------------------------
+
+
+def _is_protected_path(path: str) -> bool:
+    if path in PROTECTED_PATHS:
+        return True
+    for prefix in PROTECTED_PREFIXES:
+        if path.startswith(prefix):
+            return True
+    return False
+
+
+def protected_path_tripwire(
+    pr_number: int,
+    *,
+    runner: Runner | None = None,
+    files_provider: Callable[[int], list[str]] | None = None,
+) -> str | None:
+    """Return a tripwire reason if the PR touches any protected path."""
+    fetch = files_provider or (lambda n: fetch_pr_files(n, runner=runner))
+    for path in fetch(pr_number):
+        if _is_protected_path(path):
+            return f"edits protected path ({path})"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+_COMMENT_HEADER = (
+    "Applied via `scripts/triage_bucket_c.py` (Stage 3 of the operator-delegation rollout)."
+)
+
+
+def _advance_comment_body() -> str:
+    return (
+        f"{_COMMENT_HEADER}\n\nOperator response: **y** — advancing this"
+        " Bucket C PR (mark-ready). Stage 2 will pick up the merge once"
+        " CI settles and the classifier flips to Bucket A.\n"
+    )
+
+
+def _close_comment_body() -> str:
+    return (
+        f"{_COMMENT_HEADER}\n\nOperator response: **n** — closing this"
+        " Bucket C PR. Reopen if this was applied in error.\n"
+    )
+
+
+def decide(
+    triage_payload: dict[str, Any],
+    responses: dict[int, str],
+    *,
+    apply: bool,
+    runner: Runner | None = None,
+    files_provider: Callable[[int], list[str]] | None = None,
+) -> list[EntryResult]:
+    """Walk the Bucket C subset and produce a decision per PR."""
+    results: list[EntryResult] = []
+    runner = runner or _default_runner
+
+    for entry in triage_payload.get("results") or []:
+        if not isinstance(entry, dict):
+            continue
+        bucket = str(entry.get("bucket") or "")
+        pr_number = int(entry.get("pr_number") or 0)
+        title = str(entry.get("title") or "")
+        reason = str(entry.get("reason") or "")
+
+        if bucket != BUCKET_C:
+            # Stage 3 only operates on Bucket C. Other buckets are
+            # silently dropped here; callers can use --json to see
+            # the full Stage 1 output if they want context.
+            continue
+
+        response = responses.get(pr_number)
+        if response is None:
+            results.append(
+                EntryResult(
+                    pr_number=pr_number,
+                    title=title,
+                    response=None,
+                    status=STATUS_NO_RESPONSE,
+                    reason=f"no response provided (bucket-C reason: {reason})",
+                )
+            )
+            continue
+        if response not in VALID_RESPONSES:
+            results.append(
+                EntryResult(
+                    pr_number=pr_number,
+                    title=title,
+                    response=response,
+                    status=STATUS_INVALID_RESPONSE,
+                    reason=f"invalid response {response!r}",
+                )
+            )
+            continue
+
+        if pr_number in HELD_PR_NUMBERS:
+            results.append(
+                EntryResult(
+                    pr_number=pr_number,
+                    title=title,
+                    response=response,
+                    status=STATUS_HELD,
+                    reason=f"#{pr_number} is on the policy hold list",
+                )
+            )
+            continue
+
+        tripwire = protected_path_tripwire(
+            pr_number,
+            runner=runner,
+            files_provider=files_provider,
+        )
+        if tripwire is not None:
+            results.append(
+                EntryResult(
+                    pr_number=pr_number,
+                    title=title,
+                    response=response,
+                    status=STATUS_PROTECTED,
+                    reason=tripwire,
+                )
+            )
+            continue
+
+        if response == RESPONSE_DEFER:
+            results.append(
+                EntryResult(
+                    pr_number=pr_number,
+                    title=title,
+                    response=response,
+                    status=STATUS_DEFERRED,
+                    reason="operator deferred (no action this cycle)",
+                )
+            )
+            continue
+
+        if response == RESPONSE_ADVANCE:
+            commands: list[tuple[str, ...]] = []
+            commands.append(("gh", "pr", "ready", str(pr_number)))
+            commands.append(("gh", "pr", "comment", str(pr_number), "--body", "<advance>"))
+            if not apply:
+                results.append(
+                    EntryResult(
+                        pr_number=pr_number,
+                        title=title,
+                        response=response,
+                        status=STATUS_WOULD_ADVANCE,
+                        reason="bucket-C, y, tripwires clear (dry-run)",
+                        gh_commands=tuple(commands),
+                    )
+                )
+                continue
+            ready_proc = gh_pr_ready(pr_number, runner=runner)
+            if ready_proc.returncode != 0:
+                results.append(
+                    EntryResult(
+                        pr_number=pr_number,
+                        title=title,
+                        response=response,
+                        status=STATUS_GH_FAILED,
+                        reason=(
+                            f"gh pr ready failed: "
+                            f"{(ready_proc.stderr or ready_proc.stdout).strip()}"
+                        ),
+                        gh_commands=tuple(commands),
+                    )
+                )
+                continue
+            comment_proc = gh_pr_comment(pr_number, _advance_comment_body(), runner=runner)
+            if comment_proc.returncode != 0:
+                # The ready succeeded; the comment is best-effort.
+                results.append(
+                    EntryResult(
+                        pr_number=pr_number,
+                        title=title,
+                        response=response,
+                        status=STATUS_ADVANCED,
+                        reason=(
+                            "marked ready; comment failed (best-effort): "
+                            f"{(comment_proc.stderr or comment_proc.stdout).strip()}"
+                        ),
+                        gh_commands=tuple(commands),
+                    )
+                )
+                continue
+            results.append(
+                EntryResult(
+                    pr_number=pr_number,
+                    title=title,
+                    response=response,
+                    status=STATUS_ADVANCED,
+                    reason="marked ready + commented",
+                    gh_commands=tuple(commands),
+                )
+            )
+            continue
+
+        if response == RESPONSE_CLOSE:
+            commands = [
+                (
+                    "gh",
+                    "pr",
+                    "close",
+                    str(pr_number),
+                    "--comment",
+                    "<close>",
+                )
+            ]
+            if not apply:
+                results.append(
+                    EntryResult(
+                        pr_number=pr_number,
+                        title=title,
+                        response=response,
+                        status=STATUS_WOULD_CLOSE,
+                        reason="bucket-C, n, tripwires clear (dry-run)",
+                        gh_commands=tuple(commands),
+                    )
+                )
+                continue
+            close_proc = gh_pr_close(pr_number, _close_comment_body(), runner=runner)
+            if close_proc.returncode != 0:
+                results.append(
+                    EntryResult(
+                        pr_number=pr_number,
+                        title=title,
+                        response=response,
+                        status=STATUS_GH_FAILED,
+                        reason=(
+                            f"gh pr close failed: "
+                            f"{(close_proc.stderr or close_proc.stdout).strip()}"
+                        ),
+                        gh_commands=tuple(commands),
+                    )
+                )
+                continue
+            results.append(
+                EntryResult(
+                    pr_number=pr_number,
+                    title=title,
+                    response=response,
+                    status=STATUS_CLOSED,
+                    reason="closed with operator comment",
+                    gh_commands=tuple(commands),
+                )
+            )
+            continue
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Receipt
+# ---------------------------------------------------------------------------
+
+
+def _policy_version() -> str:
+    if not POLICY_DOC.is_file():
+        return "unknown"
+    text = POLICY_DOC.read_text(encoding="utf-8")
+    for marker in ("Version: ", "version: "):
+        idx = text.find(marker)
+        if idx == -1:
+            continue
+        end = text.find("\n", idx)
+        return text[idx + len(marker) : end].strip()
+    return "tracked-doc"
+
+
+def render_receipt(
+    results: list[EntryResult],
+    *,
+    apply: bool,
+    now: datetime.datetime | None = None,
+) -> str:
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    lines: list[str] = []
+    lines.append("# Bucket C receipt")
+    lines.append("")
+    lines.append(f"- Generated: `{now.strftime('%Y-%m-%dT%H:%M:%SZ')}`")
+    lines.append(f"- Mode: `{'apply' if apply else 'dry-run'}`")
+    lines.append(f"- Policy version: `{_policy_version()}`")
+    lines.append("")
+    lines.append("## Decisions")
+    lines.append("")
+    if not results:
+        lines.append("No Bucket C PRs available with responses; nothing to do.")
+        lines.append("")
+        return "\n".join(lines)
+    lines.append("| PR | Response | Status | Reason |")
+    lines.append("|---|---|---|---|")
+    for r in results:
+        resp = r.response or "—"
+        lines.append(f"| #{r.pr_number} | `{resp}` | `{r.status}` | {r.reason} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_receipt(
+    receipt_md: str,
+    *,
+    now: datetime.datetime | None = None,
+    receipt_dir: Path | None = None,
+) -> Path:
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    receipt_dir = receipt_dir or RECEIPT_DIR
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    stamp = now.strftime("%Y%m%dT%H%M%SZ")
+    path = receipt_dir / f"BUCKET_C_RECEIPT_{stamp}.md"
+    path.write_text(receipt_md, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def emit_json(
+    results: list[EntryResult],
+    *,
+    apply: bool,
+    receipt_path: Path | None,
+) -> str:
+    payload = {
+        "mode": "apply" if apply else "dry-run",
+        "policy_version": _policy_version(),
+        "receipt_path": str(receipt_path) if receipt_path else None,
+        "decisions": [dataclasses.asdict(r) for r in results],
+    }
+    return json.dumps(payload, indent=2, default=list)
+
+
+def emit_table(results: list[EntryResult], *, apply: bool) -> str:
+    lines = [f"triage_bucket_c — mode={'apply' if apply else 'dry-run'}"]
+    if not results:
+        lines.append("  (no Bucket C PRs with responses)")
+        return "\n".join(lines)
+    for r in results:
+        resp = r.response or "—"
+        lines.append(f"  #{r.pr_number:<5d} [{resp}] {r.status:24s} — {r.reason}")
+        lines.append(f"      title: {r.title}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=("Stage 3 of operator-delegation rollout — Bucket C y/n/d batcher.")
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually mutate (advance/close). Without this, dry-run.",
+    )
+    parser.add_argument(
+        "--responses",
+        type=Path,
+        default=None,
+        help=("Path to a JSON response file mapping PR number to one of y / n / d."),
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Prompt for y/n/d per Bucket C PR via stdin.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of human-readable table.",
+    )
+
+    args = parser.parse_args(argv)
+
+    if not args.responses and not args.interactive:
+        print(
+            "error: must pass --responses FILE or --interactive",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.responses and args.interactive:
+        print(
+            "error: --responses and --interactive are mutually exclusive",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        triage_payload = run_triage()
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    bucket_c_entries = [
+        e
+        for e in (triage_payload.get("results") or [])
+        if isinstance(e, dict) and e.get("bucket") == BUCKET_C
+    ]
+
+    if args.responses:
+        try:
+            responses = load_responses_file(args.responses)
+        except (OSError, ValueError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+    else:
+        responses = collect_responses_interactive(bucket_c_entries)
+
+    results = decide(triage_payload, responses, apply=args.apply)
+
+    receipt_path: Path | None = None
+    if args.apply:
+        receipt_md = render_receipt(results, apply=True)
+        receipt_path = write_receipt(receipt_md)
+
+    if args.json:
+        print(emit_json(results, apply=args.apply, receipt_path=receipt_path))
+    else:
+        print(emit_table(results, apply=args.apply))
+        if receipt_path is not None:
+            print(f"receipt: {receipt_path}")
+
+    # Exit non-zero if any tripwire blocked an attempted advance/close.
+    blocked = any(
+        r.status in {STATUS_HELD, STATUS_PROTECTED}
+        and r.response in {RESPONSE_ADVANCE, RESPONSE_CLOSE}
+        for r in results
+    )
+    failed = any(r.status in {STATUS_GH_FAILED, STATUS_INVALID_RESPONSE} for r in results)
+    return 1 if (blocked or failed) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/triage_bucket_c.py
+++ b/scripts/triage_bucket_c.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any, TextIO
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+GH_REPO = "synaptent/aragora"
 TRIAGE_SCRIPT = REPO_ROOT / "scripts" / "triage_open_prs.py"
 RECEIPT_DIR = REPO_ROOT / "docs" / "status"
 POLICY_DOC = REPO_ROOT / "docs" / "governance" / "OPERATOR_DELEGATION_POLICY.md"
@@ -95,6 +96,7 @@ STATUS_INVALID_RESPONSE = "invalid-response"
 STATUS_WOULD_ADVANCE = "would-advance"
 STATUS_WOULD_CLOSE = "would-close"
 STATUS_GH_FAILED = "gh-failed"
+STATUS_LIVE_CHECK_FAILED = "live-check-failed"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -105,6 +107,18 @@ class EntryResult:
     status: str
     reason: str
     gh_commands: tuple[tuple[str, ...], ...] = ()
+
+
+@dataclasses.dataclass(frozen=True)
+class PrSnapshot:
+    state: str
+    is_draft: bool
+    head_sha: str
+    files: tuple[str, ...]
+
+
+class LivePrCheckError(RuntimeError):
+    """Raised when a live PR guard cannot verify the current GitHub state."""
 
 
 # ---------------------------------------------------------------------------
@@ -131,47 +145,77 @@ def run_triage(*, runner: Runner | None = None) -> dict[str, Any]:
     return json.loads(proc.stdout or "{}")
 
 
-def fetch_pr_files(pr_number: int, *, runner: Runner | None = None) -> list[str]:
-    """Return the file paths touched by the given PR.
-
-    Used by the defense-in-depth protected-path tripwire.
-    """
+def fetch_pr_snapshot(pr_number: int, *, runner: Runner | None = None) -> PrSnapshot:
+    """Return the live PR state needed by apply-mode safety guards."""
     runner = runner or _default_runner
-    proc = runner(["gh", "pr", "view", str(pr_number), "--json", "files"])
+    proc = runner(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            GH_REPO,
+            "--json",
+            "state,isDraft,headRefOid,files",
+        ]
+    )
     if proc.returncode != 0:
-        return []
+        detail = (proc.stderr or proc.stdout).strip() or f"exit {proc.returncode}"
+        raise LivePrCheckError(f"gh pr view failed: {detail}")
     try:
         payload = json.loads(proc.stdout or "{}")
-    except json.JSONDecodeError:
-        return []
+    except json.JSONDecodeError as exc:
+        raise LivePrCheckError(f"gh pr view returned non-JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise LivePrCheckError("gh pr view returned non-object JSON")
+    state = str(payload.get("state") or "")
+    head_sha = str(payload.get("headRefOid") or "")
+    if not state:
+        raise LivePrCheckError("gh pr view response missing state")
+    if not head_sha:
+        raise LivePrCheckError("gh pr view response missing headRefOid")
     out: list[str] = []
     for entry in payload.get("files") or []:
         if isinstance(entry, dict):
             path = str(entry.get("path") or "")
             if path:
                 out.append(path)
-    return out
+    return PrSnapshot(
+        state=state,
+        is_draft=bool(payload.get("isDraft")),
+        head_sha=head_sha,
+        files=tuple(out),
+    )
+
+
+def fetch_pr_files(pr_number: int, *, runner: Runner | None = None) -> list[str]:
+    """Return the file paths touched by the given PR.
+
+    Used by the defense-in-depth protected-path tripwire.
+    """
+    return list(fetch_pr_snapshot(pr_number, runner=runner).files)
 
 
 def gh_pr_ready(
     pr_number: int, *, runner: Runner | None = None
 ) -> subprocess.CompletedProcess[str]:
     runner = runner or _default_runner
-    return runner(["gh", "pr", "ready", str(pr_number)])
+    return runner(["gh", "pr", "ready", str(pr_number), "--repo", GH_REPO])
 
 
 def gh_pr_close(
     pr_number: int, body: str, *, runner: Runner | None = None
 ) -> subprocess.CompletedProcess[str]:
     runner = runner or _default_runner
-    return runner(["gh", "pr", "close", str(pr_number), "--comment", body])
+    return runner(["gh", "pr", "close", str(pr_number), "--repo", GH_REPO, "--comment", body])
 
 
 def gh_pr_comment(
     pr_number: int, body: str, *, runner: Runner | None = None
 ) -> subprocess.CompletedProcess[str]:
     runner = runner or _default_runner
-    return runner(["gh", "pr", "comment", str(pr_number), "--body", body])
+    return runner(["gh", "pr", "comment", str(pr_number), "--repo", GH_REPO, "--body", body])
 
 
 # ---------------------------------------------------------------------------
@@ -256,9 +300,31 @@ def protected_path_tripwire(
 ) -> str | None:
     """Return a tripwire reason if the PR touches any protected path."""
     fetch = files_provider or (lambda n: fetch_pr_files(n, runner=runner))
-    for path in fetch(pr_number):
+    try:
+        paths = fetch(pr_number)
+    except LivePrCheckError as exc:
+        return f"could not verify protected paths ({exc})"
+    for path in paths:
         if _is_protected_path(path):
             return f"edits protected path ({path})"
+    return None
+
+
+def _verify_live_pr_before_mutation(
+    pr_number: int,
+    *,
+    expected_head: str,
+    runner: Runner | None = None,
+) -> str | None:
+    """Return a fail-closed reason if the live PR is not safe to mutate."""
+    try:
+        snapshot = fetch_pr_snapshot(pr_number, runner=runner)
+    except LivePrCheckError as exc:
+        return f"could not verify live PR before mutation ({exc})"
+    if snapshot.state != "OPEN":
+        return f"live PR state is {snapshot.state!r}, expected 'OPEN'"
+    if snapshot.head_sha != expected_head:
+        return f"live PR head changed before mutation ({snapshot.head_sha} != {expected_head})"
     return None
 
 
@@ -349,10 +415,39 @@ def decide(
             )
             continue
 
+        live_snapshot: PrSnapshot | None = None
+        if files_provider is None:
+            try:
+                live_snapshot = fetch_pr_snapshot(pr_number, runner=runner)
+            except LivePrCheckError as exc:
+                results.append(
+                    EntryResult(
+                        pr_number=pr_number,
+                        title=title,
+                        response=response,
+                        status=STATUS_PROTECTED,
+                        reason=f"could not verify protected paths ({exc})",
+                    )
+                )
+                continue
+
+        effective_files_provider = files_provider
+        if effective_files_provider is None:
+            assert live_snapshot is not None
+            snapshot_for_files = live_snapshot
+
+            def _files_from_snapshot(
+                _n: int,
+                snapshot: PrSnapshot = snapshot_for_files,
+            ) -> list[str]:
+                return list(snapshot.files)
+
+            effective_files_provider = _files_from_snapshot
+
         tripwire = protected_path_tripwire(
             pr_number,
             runner=runner,
-            files_provider=files_provider,
+            files_provider=effective_files_provider,
         )
         if tripwire is not None:
             results.append(
@@ -380,8 +475,10 @@ def decide(
 
         if response == RESPONSE_ADVANCE:
             commands: list[tuple[str, ...]] = []
-            commands.append(("gh", "pr", "ready", str(pr_number)))
-            commands.append(("gh", "pr", "comment", str(pr_number), "--body", "<advance>"))
+            commands.append(("gh", "pr", "ready", str(pr_number), "--repo", GH_REPO))
+            commands.append(
+                ("gh", "pr", "comment", str(pr_number), "--repo", GH_REPO, "--body", "<advance>")
+            )
             if not apply:
                 results.append(
                     EntryResult(
@@ -390,6 +487,38 @@ def decide(
                         response=response,
                         status=STATUS_WOULD_ADVANCE,
                         reason="bucket-C, y, tripwires clear (dry-run)",
+                        gh_commands=tuple(commands),
+                    )
+                )
+                continue
+            if live_snapshot is None:
+                try:
+                    live_snapshot = fetch_pr_snapshot(pr_number, runner=runner)
+                except LivePrCheckError as exc:
+                    results.append(
+                        EntryResult(
+                            pr_number=pr_number,
+                            title=title,
+                            response=response,
+                            status=STATUS_LIVE_CHECK_FAILED,
+                            reason=f"could not verify live PR before mutation ({exc})",
+                            gh_commands=tuple(commands),
+                        )
+                    )
+                    continue
+            live_guard = _verify_live_pr_before_mutation(
+                pr_number,
+                expected_head=live_snapshot.head_sha,
+                runner=runner,
+            )
+            if live_guard is not None:
+                results.append(
+                    EntryResult(
+                        pr_number=pr_number,
+                        title=title,
+                        response=response,
+                        status=STATUS_LIVE_CHECK_FAILED,
+                        reason=live_guard,
                         gh_commands=tuple(commands),
                     )
                 )
@@ -446,6 +575,8 @@ def decide(
                     "pr",
                     "close",
                     str(pr_number),
+                    "--repo",
+                    GH_REPO,
                     "--comment",
                     "<close>",
                 )
@@ -458,6 +589,38 @@ def decide(
                         response=response,
                         status=STATUS_WOULD_CLOSE,
                         reason="bucket-C, n, tripwires clear (dry-run)",
+                        gh_commands=tuple(commands),
+                    )
+                )
+                continue
+            if live_snapshot is None:
+                try:
+                    live_snapshot = fetch_pr_snapshot(pr_number, runner=runner)
+                except LivePrCheckError as exc:
+                    results.append(
+                        EntryResult(
+                            pr_number=pr_number,
+                            title=title,
+                            response=response,
+                            status=STATUS_LIVE_CHECK_FAILED,
+                            reason=f"could not verify live PR before mutation ({exc})",
+                            gh_commands=tuple(commands),
+                        )
+                    )
+                    continue
+            live_guard = _verify_live_pr_before_mutation(
+                pr_number,
+                expected_head=live_snapshot.head_sha,
+                runner=runner,
+            )
+            if live_guard is not None:
+                results.append(
+                    EntryResult(
+                        pr_number=pr_number,
+                        title=title,
+                        response=response,
+                        status=STATUS_LIVE_CHECK_FAILED,
+                        reason=live_guard,
                         gh_commands=tuple(commands),
                     )
                 )
@@ -670,7 +833,10 @@ def main(argv: list[str] | None = None) -> int:
         and r.response in {RESPONSE_ADVANCE, RESPONSE_CLOSE}
         for r in results
     )
-    failed = any(r.status in {STATUS_GH_FAILED, STATUS_INVALID_RESPONSE} for r in results)
+    failed = any(
+        r.status in {STATUS_GH_FAILED, STATUS_INVALID_RESPONSE, STATUS_LIVE_CHECK_FAILED}
+        for r in results
+    )
     return 1 if (blocked or failed) else 0
 
 

--- a/scripts/triage_bucket_c.py
+++ b/scripts/triage_bucket_c.py
@@ -175,12 +175,19 @@ def fetch_pr_snapshot(pr_number: int, *, runner: Runner | None = None) -> PrSnap
         raise LivePrCheckError("gh pr view response missing state")
     if not head_sha:
         raise LivePrCheckError("gh pr view response missing headRefOid")
+    files_payload = payload.get("files")
+    if not isinstance(files_payload, list):
+        raise LivePrCheckError("gh pr view response missing files list")
     out: list[str] = []
-    for entry in payload.get("files") or []:
-        if isinstance(entry, dict):
-            path = str(entry.get("path") or "")
-            if path:
-                out.append(path)
+    for idx, entry in enumerate(files_payload):
+        if not isinstance(entry, dict):
+            raise LivePrCheckError(f"gh pr view response has malformed file entry at index {idx}")
+        path = entry.get("path")
+        if not isinstance(path, str) or not path:
+            raise LivePrCheckError(f"gh pr view response missing file path at index {idx}")
+        out.append(path)
+    if not out:
+        raise LivePrCheckError("gh pr view response had no files to verify")
     return PrSnapshot(
         state=state,
         is_draft=bool(payload.get("isDraft")),
@@ -325,7 +332,27 @@ def _verify_live_pr_before_mutation(
         return f"live PR state is {snapshot.state!r}, expected 'OPEN'"
     if snapshot.head_sha != expected_head:
         return f"live PR head changed before mutation ({snapshot.head_sha} != {expected_head})"
-    return None
+    tripwire = protected_path_tripwire(
+        pr_number,
+        runner=runner,
+        files_provider=lambda _n: list(snapshot.files),
+    )
+    if tripwire is not None:
+        return f"live PR tripwire changed before mutation ({tripwire})"
+    try:
+        live_triage = run_triage(runner=runner)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        return f"could not verify live Bucket C classification before mutation ({exc})"
+    for entry in live_triage.get("results") or []:
+        if not isinstance(entry, dict):
+            continue
+        if int(entry.get("pr_number") or 0) != pr_number:
+            continue
+        live_bucket = str(entry.get("bucket") or "")
+        if live_bucket != BUCKET_C:
+            return f"live PR bucket is {live_bucket!r}, expected {BUCKET_C!r}"
+        return None
+    return "live PR was not present in current triage output"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_triage_bucket_c.py
+++ b/tests/scripts/test_triage_bucket_c.py
@@ -1,0 +1,322 @@
+"""Tests for ``scripts/triage_bucket_c.py``.
+
+Fixture-driven; never invokes real ``gh``. Every test constructs a
+synthetic Stage 1 classifier payload plus a response map and
+asserts that the decisions match the policy.
+
+Coverage:
+  - dry-run never mutates (no gh calls captured beyond view-files)
+  - --apply enacts y → ready + comment
+  - --apply enacts n → close
+  - --apply d is no-op
+  - held PR is hard-skipped with operator override
+  - protected-path tripwire blocks advance/close even on Bucket C
+  - non-Bucket-C entries are silently dropped from the result set
+  - PRs without a response get NO_RESPONSE_SKIPPED
+  - JSON response file round-trips
+  - receipt is written on --apply
+  - tripwire hit forces non-zero exit
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "triage_bucket_c.py"
+    spec = importlib.util.spec_from_file_location("triage_bucket_c_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tbc = _load_module()
+
+
+def make_triage_payload(*entries: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "summary": {
+            "A": sum(1 for e in entries if e.get("bucket") == "A"),
+            "B": sum(1 for e in entries if e.get("bucket") == "B"),
+            "C": sum(1 for e in entries if e.get("bucket") == "C"),
+            "D": sum(1 for e in entries if e.get("bucket") == "D"),
+        },
+        "results": list(entries),
+    }
+
+
+def bucket_c(
+    pr_number: int,
+    *,
+    title: str | None = None,
+    reason: str = "draft",
+) -> dict[str, Any]:
+    return {
+        "pr_number": pr_number,
+        "title": title or f"PR #{pr_number}",
+        "bucket": "C",
+        "reason": reason,
+        "recommended_action": "READY?",
+    }
+
+
+def bucket_a(pr_number: int) -> dict[str, Any]:
+    return {
+        "pr_number": pr_number,
+        "title": f"PR #{pr_number}",
+        "bucket": "A",
+        "reason": "all gates clean",
+        "recommended_action": "MERGE",
+    }
+
+
+class _RunnerRecorder:
+    """Captures every subprocess call. Returns success by default."""
+
+    def __init__(
+        self,
+        *,
+        failure_for: dict[tuple[str, ...], int] | None = None,
+        stdout_for: dict[tuple[str, ...], str] | None = None,
+    ):
+        self.calls: list[tuple[str, ...]] = []
+        self._failure_for = failure_for or {}
+        self._stdout_for = stdout_for or {}
+
+    def __call__(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        key = tuple(args)
+        self.calls.append(key)
+        rc = self._failure_for.get(key, 0)
+        stdout = self._stdout_for.get(key, "")
+        return subprocess.CompletedProcess(args=args, returncode=rc, stdout=stdout, stderr="")
+
+
+class TestDecideDryRun:
+    def test_dry_run_advance_emits_would_advance(self):
+        payload = make_triage_payload(bucket_c(9001))
+        results = tbc.decide(
+            payload,
+            {9001: "y"},
+            apply=False,
+            files_provider=lambda n: [],
+        )
+        assert len(results) == 1
+        assert results[0].pr_number == 9001
+        assert results[0].status == tbc.STATUS_WOULD_ADVANCE
+        # No real gh mutation happened.
+        assert len(results[0].gh_commands) >= 1
+
+    def test_dry_run_close_emits_would_close(self):
+        payload = make_triage_payload(bucket_c(9001, reason="non-trusted author"))
+        results = tbc.decide(
+            payload,
+            {9001: "n"},
+            apply=False,
+            files_provider=lambda n: [],
+        )
+        assert results[0].status == tbc.STATUS_WOULD_CLOSE
+
+    def test_dry_run_defer_emits_deferred(self):
+        payload = make_triage_payload(bucket_c(9001))
+        results = tbc.decide(
+            payload,
+            {9001: "d"},
+            apply=False,
+            files_provider=lambda n: [],
+        )
+        assert results[0].status == tbc.STATUS_DEFERRED
+
+
+class TestDecideApply:
+    def test_apply_y_calls_gh_ready_and_comment(self):
+        payload = make_triage_payload(bucket_c(9001))
+        recorder = _RunnerRecorder()
+        results = tbc.decide(
+            payload,
+            {9001: "y"},
+            apply=True,
+            runner=recorder,
+            files_provider=lambda n: [],
+        )
+        # Must have called both gh pr ready and gh pr comment.
+        ready_calls = [c for c in recorder.calls if c[:3] == ("gh", "pr", "ready")]
+        comment_calls = [c for c in recorder.calls if c[:3] == ("gh", "pr", "comment")]
+        assert ready_calls == [("gh", "pr", "ready", "9001")]
+        assert len(comment_calls) == 1
+        assert comment_calls[0][:4] == ("gh", "pr", "comment", "9001")
+        assert results[0].status == tbc.STATUS_ADVANCED
+
+    def test_apply_n_calls_gh_close(self):
+        payload = make_triage_payload(bucket_c(9001, reason="CI red"))
+        recorder = _RunnerRecorder()
+        results = tbc.decide(
+            payload,
+            {9001: "n"},
+            apply=True,
+            runner=recorder,
+            files_provider=lambda n: [],
+        )
+        close_calls = [c for c in recorder.calls if c[:3] == ("gh", "pr", "close")]
+        assert len(close_calls) == 1
+        assert close_calls[0][:4] == ("gh", "pr", "close", "9001")
+        assert results[0].status == tbc.STATUS_CLOSED
+
+    def test_apply_d_makes_no_gh_calls(self):
+        payload = make_triage_payload(bucket_c(9001))
+        recorder = _RunnerRecorder()
+        results = tbc.decide(
+            payload,
+            {9001: "d"},
+            apply=True,
+            runner=recorder,
+            files_provider=lambda n: [],
+        )
+        # No mutation calls. (files_provider injected — no view call.)
+        gh_mutation_calls = [
+            c
+            for c in recorder.calls
+            if c[:3] in (("gh", "pr", "ready"), ("gh", "pr", "close"), ("gh", "pr", "comment"))
+        ]
+        assert gh_mutation_calls == []
+        assert results[0].status == tbc.STATUS_DEFERRED
+
+
+class TestTripwires:
+    def test_held_pr_is_skipped_regardless_of_response(self):
+        # 7252 is on the policy hold list.
+        payload = make_triage_payload(bucket_c(7252))
+        recorder = _RunnerRecorder()
+        results = tbc.decide(
+            payload,
+            {7252: "y"},
+            apply=True,
+            runner=recorder,
+            files_provider=lambda n: [],
+        )
+        assert results[0].status == tbc.STATUS_HELD
+        # No mutating gh calls.
+        mutation_calls = [
+            c for c in recorder.calls if c[:3] in (("gh", "pr", "ready"), ("gh", "pr", "close"))
+        ]
+        assert mutation_calls == []
+
+    def test_protected_path_blocks_advance(self):
+        payload = make_triage_payload(bucket_c(9001))
+        recorder = _RunnerRecorder()
+        results = tbc.decide(
+            payload,
+            {9001: "y"},
+            apply=True,
+            runner=recorder,
+            files_provider=lambda n: ["scripts/nomic_loop.py"],
+        )
+        assert results[0].status == tbc.STATUS_PROTECTED
+        mutation_calls = [
+            c for c in recorder.calls if c[:3] in (("gh", "pr", "ready"), ("gh", "pr", "close"))
+        ]
+        assert mutation_calls == []
+
+    def test_workflow_path_blocks_close(self):
+        payload = make_triage_payload(bucket_c(9001))
+        recorder = _RunnerRecorder()
+        results = tbc.decide(
+            payload,
+            {9001: "n"},
+            apply=True,
+            runner=recorder,
+            files_provider=lambda n: [".github/workflows/ci.yml"],
+        )
+        assert results[0].status == tbc.STATUS_PROTECTED
+
+
+class TestFiltering:
+    def test_non_bucket_c_entries_are_dropped(self):
+        payload = make_triage_payload(bucket_a(9001), bucket_c(9002))
+        results = tbc.decide(payload, {9002: "y"}, apply=False, files_provider=lambda n: [])
+        # Only the Bucket C entry shows up in results.
+        assert [r.pr_number for r in results] == [9002]
+
+    def test_no_response_yields_no_response_skipped(self):
+        payload = make_triage_payload(bucket_c(9001), bucket_c(9002))
+        results = tbc.decide(payload, {9001: "y"}, apply=False, files_provider=lambda n: [])
+        statuses = {r.pr_number: r.status for r in results}
+        assert statuses[9001] == tbc.STATUS_WOULD_ADVANCE
+        assert statuses[9002] == tbc.STATUS_NO_RESPONSE
+
+
+class TestResponseFile:
+    def test_json_response_round_trip(self, tmp_path: Path):
+        response_file = tmp_path / "responses.json"
+        response_file.write_text(json.dumps({"9001": "y", "9002": "n", "9003": "d"}))
+        responses = tbc.load_responses_file(response_file)
+        assert responses == {9001: "y", 9002: "n", 9003: "d"}
+
+    def test_invalid_response_value_raises(self, tmp_path: Path):
+        response_file = tmp_path / "responses.json"
+        response_file.write_text(json.dumps({"9001": "maybe"}))
+        with pytest.raises(ValueError):
+            tbc.load_responses_file(response_file)
+
+    def test_response_file_with_hash_prefix_keys(self, tmp_path: Path):
+        # Accepts "#9001" as well as "9001".
+        response_file = tmp_path / "responses.json"
+        response_file.write_text(json.dumps({"#9001": "y"}))
+        responses = tbc.load_responses_file(response_file)
+        assert responses == {9001: "y"}
+
+
+class TestReceipt:
+    def test_receipt_is_written(self, tmp_path: Path):
+        results = [
+            tbc.EntryResult(
+                pr_number=9001,
+                title="example",
+                response="y",
+                status=tbc.STATUS_ADVANCED,
+                reason="marked ready + commented",
+            )
+        ]
+        receipt_md = tbc.render_receipt(results, apply=True)
+        path = tbc.write_receipt(receipt_md, receipt_dir=tmp_path)
+        assert path.exists()
+        text = path.read_text(encoding="utf-8")
+        assert "#9001" in text
+        assert tbc.STATUS_ADVANCED in text
+        assert "Bucket C receipt" in text
+
+
+class TestInteractive:
+    def test_interactive_reads_y_n_d(self):
+        bucket_c_entries = [bucket_c(9001), bucket_c(9002), bucket_c(9003)]
+        stdin = io.StringIO("y\nn\nd\n")
+        stdout = io.StringIO()
+        responses = tbc.collect_responses_interactive(bucket_c_entries, stdin=stdin, stdout=stdout)
+        assert responses == {9001: "y", 9002: "n", 9003: "d"}
+
+    def test_interactive_treats_empty_as_defer(self):
+        bucket_c_entries = [bucket_c(9001)]
+        stdin = io.StringIO("\n")
+        stdout = io.StringIO()
+        responses = tbc.collect_responses_interactive(bucket_c_entries, stdin=stdin, stdout=stdout)
+        assert responses == {9001: "d"}
+
+    def test_interactive_treats_garbage_as_defer(self):
+        bucket_c_entries = [bucket_c(9001)]
+        stdin = io.StringIO("zzz\n")
+        stdout = io.StringIO()
+        responses = tbc.collect_responses_interactive(bucket_c_entries, stdin=stdin, stdout=stdout)
+        assert responses == {9001: "d"}

--- a/tests/scripts/test_triage_bucket_c.py
+++ b/tests/scripts/test_triage_bucket_c.py
@@ -113,6 +113,14 @@ def live_view_stdout(
     )
 
 
+def triage_key() -> tuple[str, ...]:
+    return ("python3", str(tbc.TRIAGE_SCRIPT), "--json")
+
+
+def triage_stdout(*entries: dict[str, Any]) -> str:
+    return json.dumps(make_triage_payload(*entries))
+
+
 class _RunnerRecorder:
     """Captures every subprocess call. Returns success by default."""
 
@@ -174,7 +182,10 @@ class TestDecideApply:
     def test_apply_y_calls_gh_ready_and_comment(self):
         payload = make_triage_payload(bucket_c(9001))
         recorder = _RunnerRecorder(
-            stdout_for={live_view_key(9001): live_view_stdout(files=["tests/example.py"])}
+            stdout_for={
+                live_view_key(9001): live_view_stdout(files=["tests/example.py"]),
+                triage_key(): triage_stdout(bucket_c(9001)),
+            }
         )
         results = tbc.decide(
             payload,
@@ -201,7 +212,10 @@ class TestDecideApply:
     def test_apply_n_calls_gh_close(self):
         payload = make_triage_payload(bucket_c(9001, reason="CI red"))
         recorder = _RunnerRecorder(
-            stdout_for={live_view_key(9001): live_view_stdout(files=["tests/example.py"])}
+            stdout_for={
+                live_view_key(9001): live_view_stdout(files=["tests/example.py"]),
+                triage_key(): triage_stdout(bucket_c(9001)),
+            }
         )
         results = tbc.decide(
             payload,
@@ -319,6 +333,27 @@ class TestTripwires:
         ]
         assert mutation_calls == []
 
+    def test_file_fetch_malformed_files_payload_fails_closed_before_mutation(self):
+        payload = make_triage_payload(bucket_c(9001))
+        recorder = _RunnerRecorder(
+            stdout_for={
+                live_view_key(9001): json.dumps(
+                    {"state": "OPEN", "isDraft": True, "headRefOid": "head-1", "files": "bad"}
+                )
+            }
+        )
+
+        results = tbc.decide(payload, {9001: "y"}, apply=True, runner=recorder)
+
+        assert results[0].status == tbc.STATUS_PROTECTED
+        assert "missing files list" in results[0].reason
+        mutation_calls = [
+            c
+            for c in recorder.calls
+            if c[:3] in (("gh", "pr", "ready"), ("gh", "pr", "close"), ("gh", "pr", "comment"))
+        ]
+        assert mutation_calls == []
+
     def test_live_head_change_fails_closed_before_mutation(self):
         payload = make_triage_payload(bucket_c(9001))
         calls = 0
@@ -341,6 +376,57 @@ class TestTripwires:
 
         assert results[0].status == tbc.STATUS_LIVE_CHECK_FAILED
         assert "live PR head changed" in results[0].reason
+
+    def test_live_tripwire_change_fails_closed_before_mutation(self):
+        payload = make_triage_payload(bucket_c(9001))
+        calls = 0
+        seen: list[tuple[str, ...]] = []
+
+        def runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+            nonlocal calls
+            key = tuple(args)
+            seen.append(key)
+            if key == live_view_key(9001):
+                calls += 1
+                files = ["tests/example.py"] if calls == 1 else ["scripts/nomic_loop.py"]
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout=live_view_stdout(head="head-1", files=files),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+        results = tbc.decide(payload, {9001: "n"}, apply=True, runner=runner)
+
+        assert results[0].status == tbc.STATUS_LIVE_CHECK_FAILED
+        assert "live PR tripwire changed" in results[0].reason
+        mutation_calls = [
+            c
+            for c in seen
+            if c[:3] in (("gh", "pr", "ready"), ("gh", "pr", "close"), ("gh", "pr", "comment"))
+        ]
+        assert mutation_calls == []
+
+    def test_live_bucket_change_fails_closed_before_mutation(self):
+        payload = make_triage_payload(bucket_c(9001))
+        recorder = _RunnerRecorder(
+            stdout_for={
+                live_view_key(9001): live_view_stdout(files=["tests/example.py"]),
+                triage_key(): triage_stdout(bucket_a(9001)),
+            }
+        )
+
+        results = tbc.decide(payload, {9001: "y"}, apply=True, runner=recorder)
+
+        assert results[0].status == tbc.STATUS_LIVE_CHECK_FAILED
+        assert "live PR bucket" in results[0].reason
+        mutation_calls = [
+            c
+            for c in recorder.calls
+            if c[:3] in (("gh", "pr", "ready"), ("gh", "pr", "close"), ("gh", "pr", "comment"))
+        ]
+        assert mutation_calls == []
 
 
 class TestFiltering:

--- a/tests/scripts/test_triage_bucket_c.py
+++ b/tests/scripts/test_triage_bucket_c.py
@@ -84,6 +84,35 @@ def bucket_a(pr_number: int) -> dict[str, Any]:
     }
 
 
+def live_view_key(pr_number: int) -> tuple[str, ...]:
+    return (
+        "gh",
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        tbc.GH_REPO,
+        "--json",
+        "state,isDraft,headRefOid,files",
+    )
+
+
+def live_view_stdout(
+    *,
+    state: str = "OPEN",
+    head: str = "head-1",
+    files: list[str] | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "state": state,
+            "isDraft": True,
+            "headRefOid": head,
+            "files": [{"path": path} for path in (files or [])],
+        }
+    )
+
+
 class _RunnerRecorder:
     """Captures every subprocess call. Returns success by default."""
 
@@ -144,7 +173,9 @@ class TestDecideDryRun:
 class TestDecideApply:
     def test_apply_y_calls_gh_ready_and_comment(self):
         payload = make_triage_payload(bucket_c(9001))
-        recorder = _RunnerRecorder()
+        recorder = _RunnerRecorder(
+            stdout_for={live_view_key(9001): live_view_stdout(files=["tests/example.py"])}
+        )
         results = tbc.decide(
             payload,
             {9001: "y"},
@@ -155,14 +186,23 @@ class TestDecideApply:
         # Must have called both gh pr ready and gh pr comment.
         ready_calls = [c for c in recorder.calls if c[:3] == ("gh", "pr", "ready")]
         comment_calls = [c for c in recorder.calls if c[:3] == ("gh", "pr", "comment")]
-        assert ready_calls == [("gh", "pr", "ready", "9001")]
+        assert ready_calls == [("gh", "pr", "ready", "9001", "--repo", tbc.GH_REPO)]
         assert len(comment_calls) == 1
-        assert comment_calls[0][:4] == ("gh", "pr", "comment", "9001")
+        assert comment_calls[0][:6] == (
+            "gh",
+            "pr",
+            "comment",
+            "9001",
+            "--repo",
+            tbc.GH_REPO,
+        )
         assert results[0].status == tbc.STATUS_ADVANCED
 
     def test_apply_n_calls_gh_close(self):
         payload = make_triage_payload(bucket_c(9001, reason="CI red"))
-        recorder = _RunnerRecorder()
+        recorder = _RunnerRecorder(
+            stdout_for={live_view_key(9001): live_view_stdout(files=["tests/example.py"])}
+        )
         results = tbc.decide(
             payload,
             {9001: "n"},
@@ -172,7 +212,14 @@ class TestDecideApply:
         )
         close_calls = [c for c in recorder.calls if c[:3] == ("gh", "pr", "close")]
         assert len(close_calls) == 1
-        assert close_calls[0][:4] == ("gh", "pr", "close", "9001")
+        assert close_calls[0][:6] == (
+            "gh",
+            "pr",
+            "close",
+            "9001",
+            "--repo",
+            tbc.GH_REPO,
+        )
         assert results[0].status == tbc.STATUS_CLOSED
 
     def test_apply_d_makes_no_gh_calls(self):
@@ -241,6 +288,59 @@ class TestTripwires:
             files_provider=lambda n: [".github/workflows/ci.yml"],
         )
         assert results[0].status == tbc.STATUS_PROTECTED
+
+    def test_file_fetch_failure_fails_closed_before_mutation(self):
+        payload = make_triage_payload(bucket_c(9001))
+        recorder = _RunnerRecorder(failure_for={live_view_key(9001): 1})
+
+        results = tbc.decide(payload, {9001: "y"}, apply=True, runner=recorder)
+
+        assert results[0].status == tbc.STATUS_PROTECTED
+        assert "could not verify protected paths" in results[0].reason
+        mutation_calls = [
+            c
+            for c in recorder.calls
+            if c[:3] in (("gh", "pr", "ready"), ("gh", "pr", "close"), ("gh", "pr", "comment"))
+        ]
+        assert mutation_calls == []
+
+    def test_file_fetch_malformed_json_fails_closed_before_mutation(self):
+        payload = make_triage_payload(bucket_c(9001))
+        recorder = _RunnerRecorder(stdout_for={live_view_key(9001): "not-json"})
+
+        results = tbc.decide(payload, {9001: "n"}, apply=True, runner=recorder)
+
+        assert results[0].status == tbc.STATUS_PROTECTED
+        assert "non-JSON" in results[0].reason
+        mutation_calls = [
+            c
+            for c in recorder.calls
+            if c[:3] in (("gh", "pr", "ready"), ("gh", "pr", "close"), ("gh", "pr", "comment"))
+        ]
+        assert mutation_calls == []
+
+    def test_live_head_change_fails_closed_before_mutation(self):
+        payload = make_triage_payload(bucket_c(9001))
+        calls = 0
+
+        def runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+            nonlocal calls
+            key = tuple(args)
+            if key == live_view_key(9001):
+                calls += 1
+                head = "head-1" if calls == 1 else "head-2"
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout=live_view_stdout(head=head, files=["tests/example.py"]),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+        results = tbc.decide(payload, {9001: "y"}, apply=True, runner=runner)
+
+        assert results[0].status == tbc.STATUS_LIVE_CHECK_FAILED
+        assert "live PR head changed" in results[0].reason
 
 
 class TestFiltering:


### PR DESCRIPTION
## What

Implements **Stage 3** of the operator-delegation rollout:
`scripts/triage_bucket_c.py`. Closes the loop with Stage 1
(classifier) and Stage 2 (auto-merge) by giving the operator a single
`y`/`n`/`d` per Bucket C PR — done either interactively or via a
JSON response file.

Roadmap reference: `docs/roadmap/OPERATOR_DELEGATION_ROLLOUT.md` (Stage 3).

## How

- Invokes `scripts/triage_open_prs.py --json` via subprocess for the
  authoritative Stage 1 classifier output.
- Filters to Bucket C; ignores A/B/D rows.
- Two input modes:
  - `--interactive` — prompt for `y`/`n`/`d` per PR via stdin
    (empty / garbage → defer).
  - `--responses FILE` — JSON map `{"7251": "y", "7252": "d"}`.
    JSON is a YAML subset, so `.yaml` files written in the JSON shape
    parse fine — pure stdlib, no PyYAML dep needed.
- Decisions:
  - `y` → `gh pr ready` + `gh pr comment` (advance to Bucket A so
    Stage 2 can finish the merge).
  - `n` → `gh pr close --comment`.
  - `d` → no-op (defer to next cycle).
- **Defense-in-depth** even on Bucket C:
  - Hard-skip if PR is in the policy hold list (`HELD_PR_NUMBERS`,
    mirrored from `apply_operator_decisions.py` and the policy doc).
  - Hard-skip if the PR touches any protected path or prefix
    (`CLAUDE.md`, `AGENTS.md`, `scripts/nomic_loop.py`,
    `.github/workflows/`, etc.).
- **Dry-run is the default**; `--apply` is required to mutate.
- Receipt written to `docs/status/BUCKET_C_RECEIPT_<utc>.md` on every
  `--apply` run.
- `--json` mode for programmatic consumers.

## Tests

18 unit tests in `tests/scripts/test_triage_bucket_c.py`:

- `TestDecideDryRun`: dry-run never mutates (advance/close/defer).
- `TestDecideApply`: `--apply` enacts y/n; d is no-op.
- `TestTripwires`: held PR + protected paths block advance and close.
- `TestFiltering`: non-Bucket-C entries dropped; missing response handled.
- `TestResponseFile`: JSON round-trip, invalid values rejected,
  `#PR` keys accepted.
- `TestReceipt`: `render_receipt` + `write_receipt` produce the
  expected Markdown.
- `TestInteractive`: stdin prompt reads y/n/d; empty/garbage → defer.

All 18 pass; ruff clean (check + format).

## Safety

- Pure stdlib + `gh` subprocess — no `aragora.*` imports, no
  third-party deps.
- Held + protected-path tripwires (defense-in-depth even for Bucket C).
- Dry-run default; `--apply` required to mutate.
- Receipt every apply run for full audit trail.
- Same hold list as the rest of the operator-delegation pipeline.

## Lane

`P17-stage3-triage-bucket-c-batcher` — recorded in
`scripts/active_agent_sessions.py` registry. `scripts/agent_bridge.py
health` shows no lane collisions.