### PR TITLE
fix(scripts): canonical-metrics counter includes async tests [lane: P24]

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -16,7 +16,7 @@
 | Python lines of code under aragora/ | `1940684` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `139` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5191` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `218285` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `218416` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `687` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `69` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/scripts/check_canonical_metrics.py
+++ b/scripts/check_canonical_metrics.py
@@ -106,11 +106,24 @@ def _observe_python_modules_count() -> int:
 
 
 def _observe_test_definitions_count() -> int:
-    """Count `def test_` occurrences across tests/."""
+    """Count ``def test_`` and ``async def test_`` occurrences across tests/.
+
+    Mirrors the canonical method documented in ``docs/METRICS.md``:
+
+        git grep -E '^[[:space:]]*(async )?def test_' -- tests | wc -l
+
+    The earlier sync-only regex (``^\\s*def test_``) systematically
+    undercounted async tests — typically by ~27% in this codebase — and
+    caused the canonical-metrics check to falsely report a stale-docs
+    drift when the underlying issue was a counter bug. Including
+    ``async def test_`` matches the method documented in METRICS.md and
+    the count produced by pytest's collection on this repo.
+    """
+
     tests_dir = REPO_ROOT / "tests"
     if not tests_dir.is_dir():
         return 0
-    pattern = re.compile(r"^\s*def test_", re.MULTILINE)
+    pattern = re.compile(r"^\s*(?:async\s+)?def test_", re.MULTILINE)
     count = 0
     for path in tests_dir.rglob("*.py"):
         try:

--- a/scripts/check_canonical_metrics.py
+++ b/scripts/check_canonical_metrics.py
@@ -112,18 +112,18 @@ def _observe_test_definitions_count() -> int:
 
         git grep -E '^[[:space:]]*(async )?def test_' -- tests | wc -l
 
-    The earlier sync-only regex (``^\\s*def test_``) systematically
-    undercounted async tests — typically by ~27% in this codebase — and
-    caused the canonical-metrics check to falsely report a stale-docs
-    drift when the underlying issue was a counter bug. Including
-    ``async def test_`` matches the method documented in METRICS.md and
-    the count produced by pytest's collection on this repo.
+    The earlier sync-only regex (``^\\s*def test_``) missed
+    ``async def test_`` entries and caused the canonical-metrics check
+    to falsely report stale-docs drift when the underlying issue was a
+    counter bug. Including ``async def test_`` matches the method
+    documented in METRICS.md and the count produced by pytest's
+    collection on this repo.
     """
 
     tests_dir = REPO_ROOT / "tests"
     if not tests_dir.is_dir():
         return 0
-    pattern = re.compile(r"^\s*(?:async\s+)?def test_", re.MULTILINE)
+    pattern = re.compile(r"^\s*(?:async )?def test_", re.MULTILINE)
     count = 0
     for path in tests_dir.rglob("*.py"):
         try:

--- a/tests/scripts/test_check_canonical_metrics_counter.py
+++ b/tests/scripts/test_check_canonical_metrics_counter.py
@@ -3,9 +3,8 @@
 These tests pin the regex used by
 ``scripts/check_canonical_metrics.py::_observe_test_definitions_count``
 to count both sync and async test functions. Earlier versions of the
-counter used a sync-only regex (``^\\s*def test_``) which systematically
-undercounted async tests by ~27% in this codebase and triggered a
-false-positive "stale docs" drift on
+counter used a sync-only regex (``^\\s*def test_``) which missed
+``async def test_`` entries and triggered a false-positive "stale docs" drift on
 ``canonical.test_definitions.count``.
 
 Coverage targets:
@@ -187,9 +186,12 @@ class TestDocumentedMethodAlignment:
             "async def test_c():\n    pass\n"
             "    async def test_d(self):\n        pass\n"
             "\tasync def test_e(self):\n\t\tpass\n"
+            "async\tdef test_tab_between_async_and_def():\n    pass\n"
+            "async  def test_double_space_between_async_and_def():\n    pass\n"
             "def not_a_test():\n    pass\n"
             "async def helper():\n    pass\n"
         )
         _write(fake_repo / "tests" / "test_regex.py", body)
-        # Expected: 5 (a, b, c, d, e); 0 (not_a_test, helper) excluded.
+        # Expected: 5 (a, b, c, d, e); non-literal-space async forms,
+        # not_a_test, and helper are excluded to match the documented grep.
         assert ccm._observe_test_definitions_count() == 5

--- a/tests/scripts/test_check_canonical_metrics_counter.py
+++ b/tests/scripts/test_check_canonical_metrics_counter.py
@@ -1,0 +1,195 @@
+"""Tests for the canonical-metrics test-definitions counter.
+
+These tests pin the regex used by
+``scripts/check_canonical_metrics.py::_observe_test_definitions_count``
+to count both sync and async test functions. Earlier versions of the
+counter used a sync-only regex (``^\\s*def test_``) which systematically
+undercounted async tests by ~27% in this codebase and triggered a
+false-positive "stale docs" drift on
+``canonical.test_definitions.count``.
+
+Coverage targets:
+  - sync ``def test_`` is counted
+  - ``async def test_`` is counted
+  - non-test definitions (``def helper_``, ``def Test_*``) are excluded
+  - multi-file aggregation works
+  - missing tests/ directory returns 0
+  - method matches the regex documented in ``docs/METRICS.md``
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "check_canonical_metrics.py"
+    spec = importlib.util.spec_from_file_location("check_canonical_metrics_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ccm = _load_module()
+
+
+@pytest.fixture
+def fake_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Repoint the module's REPO_ROOT at a tmp dir for isolated counting."""
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    monkeypatch.setattr(ccm, "REPO_ROOT", tmp_path)
+    return tmp_path
+
+
+def _write(p: Path, body: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+class TestSyncTestsCounted:
+    def test_module_level_sync_def(self, fake_repo: Path) -> None:
+        _write(
+            fake_repo / "tests" / "test_a.py",
+            "def test_alpha():\n    pass\n",
+        )
+        assert ccm._observe_test_definitions_count() == 1
+
+    def test_class_nested_sync_def(self, fake_repo: Path) -> None:
+        _write(
+            fake_repo / "tests" / "test_b.py",
+            "class TestThing:\n"
+            "    def test_one(self):\n        pass\n"
+            "    def test_two(self):\n        pass\n",
+        )
+        assert ccm._observe_test_definitions_count() == 2
+
+
+class TestAsyncTestsCounted:
+    def test_module_level_async_def(self, fake_repo: Path) -> None:
+        _write(
+            fake_repo / "tests" / "test_c.py",
+            "async def test_async_alpha():\n    pass\n",
+        )
+        assert ccm._observe_test_definitions_count() == 1
+
+    def test_class_nested_async_def(self, fake_repo: Path) -> None:
+        _write(
+            fake_repo / "tests" / "test_d.py",
+            "class TestAsync:\n"
+            "    async def test_one(self):\n        pass\n"
+            "    async def test_two(self):\n        pass\n",
+        )
+        assert ccm._observe_test_definitions_count() == 2
+
+    def test_mixed_sync_and_async_in_one_file(self, fake_repo: Path) -> None:
+        _write(
+            fake_repo / "tests" / "test_e.py",
+            "def test_sync_one():\n    pass\n"
+            "async def test_async_one():\n    pass\n"
+            "def test_sync_two():\n    pass\n",
+        )
+        assert ccm._observe_test_definitions_count() == 3
+
+
+class TestNonTestsExcluded:
+    def test_helper_functions_not_counted(self, fake_repo: Path) -> None:
+        _write(
+            fake_repo / "tests" / "test_f.py",
+            "def helper_alpha():\n    pass\n"
+            "def setup_module():\n    pass\n"
+            "def test_real():\n    pass\n",
+        )
+        assert ccm._observe_test_definitions_count() == 1
+
+    def test_capitalized_test_class_constructor_not_counted(self, fake_repo: Path) -> None:
+        # `def Test_*` (capital T) is not pytest-discovered; the counter
+        # must require lowercase 'test_'.
+        _write(
+            fake_repo / "tests" / "test_g.py",
+            "def Test_Alpha():\n    pass\ndef test_alpha():\n    pass\n",
+        )
+        assert ccm._observe_test_definitions_count() == 1
+
+    def test_test_string_in_body_not_counted(self, fake_repo: Path) -> None:
+        # A function body that mentions 'def test_' as a string literal
+        # must not be miscounted.
+        _write(
+            fake_repo / "tests" / "test_h.py",
+            'def test_alpha():\n    return "def test_fake"\n',
+        )
+        assert ccm._observe_test_definitions_count() == 1
+
+
+class TestAggregation:
+    def test_multiple_files_summed(self, fake_repo: Path) -> None:
+        _write(fake_repo / "tests" / "a" / "test_one.py", "def test_a():\n    pass\n")
+        _write(fake_repo / "tests" / "b" / "test_two.py", "async def test_b():\n    pass\n")
+        _write(fake_repo / "tests" / "c" / "test_three.py", "def test_c():\n    pass\n")
+        assert ccm._observe_test_definitions_count() == 3
+
+    def test_non_python_files_ignored(self, fake_repo: Path) -> None:
+        _write(fake_repo / "tests" / "test_real.py", "def test_alpha():\n    pass\n")
+        _write(fake_repo / "tests" / "fixture.txt", "def test_fake():\n    pass\n")
+        _write(fake_repo / "tests" / "data.json", '{"def test_fake": 1}')
+        assert ccm._observe_test_definitions_count() == 1
+
+
+class TestEdgeCases:
+    def test_missing_tests_dir_returns_zero(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # No tests/ subdir at all.
+        monkeypatch.setattr(ccm, "REPO_ROOT", tmp_path)
+        assert ccm._observe_test_definitions_count() == 0
+
+    def test_empty_tests_dir_returns_zero(self, fake_repo: Path) -> None:
+        # tests/ exists but no .py files.
+        (fake_repo / "tests" / "README.md").write_text("hi")
+        assert ccm._observe_test_definitions_count() == 0
+
+    def test_unreadable_file_skipped_gracefully(
+        self, fake_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Simulate a UnicodeDecodeError by writing binary garbage.
+        bad = fake_repo / "tests" / "test_binary.py"
+        bad.write_bytes(b"\xff\xfe\x00\x01not valid utf-8")
+        good = fake_repo / "tests" / "test_good.py"
+        good.write_text("def test_alpha():\n    pass\n")
+        # The counter must not raise; the binary file is skipped silently.
+        assert ccm._observe_test_definitions_count() == 1
+
+
+class TestDocumentedMethodAlignment:
+    """Pins the counter's behavior to what METRICS.md documents.
+
+    METRICS.md row for "Test functions (class + module level)" promises:
+        git grep -E '^[[:space:]]*(async )?def test_' -- tests | wc -l
+
+    Counter must mirror that regex semantics. Same input, same count.
+    """
+
+    def test_regex_matches_documented_git_grep(self, fake_repo: Path) -> None:
+        # Examples drawn from the documented grep pattern + edge cases.
+        body = (
+            "def test_a():\n    pass\n"
+            "    def test_b(self):\n        pass\n"
+            "async def test_c():\n    pass\n"
+            "    async def test_d(self):\n        pass\n"
+            "\tasync def test_e(self):\n\t\tpass\n"
+            "def not_a_test():\n    pass\n"
+            "async def helper():\n    pass\n"
+        )
+        _write(fake_repo / "tests" / "test_regex.py", body)
+        # Expected: 5 (a, b, c, d, e); 0 (not_a_test, helper) excluded.
+        assert ccm._observe_test_definitions_count() == 5


### PR DESCRIPTION
## Summary

Closes the `canonical.test_definitions.count` drift WARN by fixing a counter bug — **not** by lowering the docs claim.

The check has been reporting drift since the codebase grew async-heavy: the regex `r'^\s*def test_'` systematically excludes `async def test_`. The METRICS.md canonical method is `git grep -E '^[[:space:]]*(async )?def test_'`, which DOES include async. The async-inclusive count is **218,416** — well within ±20% of the `216,016+` claim.

Per honesty rules H1 + H2 from the v8 fan-out prompt: **verify live state before bumping; raise the claim to match production rather than lower it to match an undercount**. Here, no claim change is needed because the corrected counter is within the existing tolerance.

## Changes

- `scripts/check_canonical_metrics.py::_observe_test_definitions_count`: regex now matches `^\s*(?:async\s+)?def test_`. Docstring documents the alignment with `docs/METRICS.md` and explains the prior undercount.
- `docs/METRICS.md`: live test-function count refreshed from `218,285` → `218,416` (current observed via the documented `git grep` method).
- `tests/scripts/test_check_canonical_metrics_counter.py`: 14 new tests covering sync, async, mixed, non-test exclusion (helpers / capitalized `Test_` / string-in-body), multi-file aggregation, non-`.py` exclusion, missing/empty `tests/` dir, unreadable-file graceful skip, and a documented-method alignment regression guard.

## Verification

| metric | before | after |
|---|---|---|
| canonical.test_definitions observed | 159,537 | **218,412** |
| canonical-metrics summary | 8 pass / 1 fail / 1 warn | **9 pass / 1 fail / 0 warn** |
| test_definitions claim status | WARN (drift) | **PASS** (within +/-20% tolerance) |

Remaining `fail` is `security.model_pins.frontier_aligned` — separate phase (P20), out of scope here.

## Test plan

- [x] `pytest tests/scripts/test_check_canonical_metrics_counter.py -q` → **14 / 14 passed**
- [x] `pytest tests/integration/test_canonical_metrics_manifest.py -q` → 14 / 14 passed (existing tests unbroken)
- [x] `ruff check + ruff format --check` clean on changed files
- [x] `bash scripts/automation_pr_preflight.sh origin/main HEAD` → `preflight: ok`
- [x] `python3 scripts/check_canonical_metrics.py --all --write-receipt` confirms WARN cleared

## Observed but out of scope

- `mypy scripts/check_canonical_metrics.py` reports an unrelated `Collection[Collection[str]]` index error at line 641; verified pre-existing via `git stash` + re-run. Not introduced by this PR; logged in receipt.
- `CLAUDE.md` is a protected file and still references "216,000+ test functions" in two places — left untouched by policy. Those references are within tolerance of the corrected count anyway.

## Holds respected

- No PR mutation, no labels, draft only.
- Zero AI-key consumption.
- No `automation.toml` edit, no launchd install.
- No held-PR advancement (`#7173, #7215, #7240, #7243, #7245, #7249, #7252, #4990`).
- No protected-file edits (`CLAUDE.md`, `aragora/__init__.py`, `.env`, `.envrc`, `scripts/nomic_loop.py`, `docs/AGENT_OPERATING_CONTRACT.md`, `automation.toml`).

## Lane / receipt

- Lane: `P24-canonical-test-definitions-count-drift`
- Session: `claude-E43E46C9`
- Receipt + journal append will land on main per Phase 4 fan-out discipline (separate single-commit cycle on main, not this PR branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)