### PR TITLE
feat(work): surface active lane ownership in work board

### DIFF
--- a/aragora/work/board.py
+++ b/aragora/work/board.py
@@ -13,6 +13,7 @@ from aragora.work.sources import (
     collect_broker_runs,
     collect_github_prs,
     collect_mission_files,
+    enrich_with_agent_bridge_lanes,
 )
 
 
@@ -35,6 +36,8 @@ def collect_work_items(
         collected, source_health = collector(root)
         items.extend(collected)
         health.append(source_health)
+    items, lane_health = enrich_with_agent_bridge_lanes(root, items)
+    health.append(lane_health)
 
     if scope == "current":
         items = [item for item in items if item.scope == "current"]

--- a/aragora/work/scoring.py
+++ b/aragora/work/scoring.py
@@ -175,9 +175,17 @@ def score_work_item(item: WorkItem, *, now: datetime | None = None) -> WorkScore
         parallel_safety -= 0.12
 
     staleness = stale_factor(item.updated_at or item.created_at, now=now)
-    owner_clarity = 0.85 if item.owner or item.branch else 0.35
-    if item.owner or item.branch:
-        rationale.append("owner/branch is explicit")
+    if item.owner:
+        owner_clarity = 0.9
+        rationale.append("owner is explicit")
+    elif item.metadata.get("active_lane") and item.metadata.get("owner_session"):
+        owner_clarity = 0.86
+        rationale.append("active lane owner is explicit")
+    elif item.branch:
+        owner_clarity = 0.62
+        rationale.append("branch is explicit but owner is unknown")
+    else:
+        owner_clarity = 0.35
 
     tests = [path for path in files if str(path).startswith("tests/")]
     code = [path for path in files if str(path).startswith("aragora/")]

--- a/aragora/work/sources.py
+++ b/aragora/work/sources.py
@@ -12,6 +12,8 @@ from typing import Any
 from aragora.work.models import WorkItem
 from aragora.work.scoring import is_current_status, stale_factor
 
+_ACTIVE_LANE_STATUSES = {"active", "claimed", "in_progress", "in-progress", "running"}
+
 
 def _read_json(path: Path) -> dict[str, Any] | None:
     try:
@@ -42,6 +44,113 @@ def _read_jsonl(path: Path, *, limit: int = 200) -> list[dict[str, Any]]:
 
 def _health(source: str, status: str, detail: str, **extra: Any) -> dict[str, Any]:
     return {"source": source, "status": status, "detail": detail, **extra}
+
+
+def _read_agent_bridge_lane_rows(repo_root: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Read repo-local agent-bridge lane registry rows without mutating lane state."""
+    registry = repo_root / ".aragora" / "agent-bridge" / "lanes.json"
+    if not registry.exists():
+        return [], _health("agent_bridge_lane", "missing", f"{registry} not found")
+    try:
+        raw = json.loads(registry.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return [], _health("agent_bridge_lane", "degraded", f"lanes registry unreadable: {exc}")
+    if isinstance(raw, dict):
+        raw_rows = raw.get("lanes") or raw.get("items") or []
+    elif isinstance(raw, list):
+        raw_rows = raw
+    else:
+        return [], _health("agent_bridge_lane", "degraded", "lanes registry returned non-list")
+
+    rows = [row for row in raw_rows if isinstance(row, dict)]
+    return rows, _health("agent_bridge_lane", "ok", f"{len(rows)} lane row(s)")
+
+
+def _lane_is_active(row: dict[str, Any]) -> bool:
+    return str(row.get("status") or "").strip().lower() in _ACTIVE_LANE_STATUSES
+
+
+def _lane_sort_key(row: dict[str, Any]) -> tuple[int, str, str]:
+    return (
+        1 if _lane_is_active(row) else 0,
+        str(row.get("updated_at") or ""),
+        str(row.get("lane_id") or ""),
+    )
+
+
+def _best_lane(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=_lane_sort_key)
+
+
+def _lane_lookup_value(row: dict[str, Any], key: str) -> str | None:
+    value = row.get(key)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _apply_lane_metadata(item: WorkItem, lane: dict[str, Any]) -> None:
+    active = _lane_is_active(lane)
+    owner_session = _lane_lookup_value(lane, "owner_session")
+    metadata = {
+        "active_lane": active,
+        "lane_id": _lane_lookup_value(lane, "lane_id"),
+        "owner_session": owner_session,
+        "lane_worktree": _lane_lookup_value(lane, "worktree"),
+        "lane_status": _lane_lookup_value(lane, "status"),
+        "lane_updated_at": _lane_lookup_value(lane, "updated_at"),
+    }
+    item.metadata.update({key: value for key, value in metadata.items() if value is not None})
+    if active and owner_session and item.owner is None:
+        item.owner = owner_session
+
+
+def enrich_with_agent_bridge_lanes(
+    repo_root: Path, items: list[WorkItem]
+) -> tuple[list[WorkItem], dict[str, Any]]:
+    """Attach active/recent lane ownership to PR work items from repo-local lanes.json."""
+    rows, health = _read_agent_bridge_lane_rows(repo_root)
+    if not rows:
+        return items, health
+
+    by_pr: dict[int, list[dict[str, Any]]] = {}
+    by_branch: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        pr_number = row.get("pr_number")
+        if isinstance(pr_number, int):
+            by_pr.setdefault(pr_number, []).append(row)
+        elif isinstance(pr_number, str) and pr_number.isdigit():
+            by_pr.setdefault(int(pr_number), []).append(row)
+        branch = _lane_lookup_value(row, "branch")
+        if branch:
+            by_branch.setdefault(branch, []).append(row)
+
+    enriched = 0
+    active = 0
+    for item in items:
+        if item.source != "github_pr":
+            continue
+        number = item.metadata.get("number")
+        candidates: list[dict[str, Any]] = []
+        if isinstance(number, int):
+            candidates.extend(by_pr.get(number, []))
+        elif isinstance(number, str) and number.isdigit():
+            candidates.extend(by_pr.get(int(number), []))
+        if item.branch:
+            candidates.extend(by_branch.get(item.branch, []))
+        lane = _best_lane(candidates)
+        if lane is None:
+            continue
+        _apply_lane_metadata(item, lane)
+        enriched += 1
+        if item.metadata.get("active_lane"):
+            active += 1
+
+    health.update({"enriched": enriched, "active": active})
+    return items, health
 
 
 def _tier_from_labels(labels: list[str]) -> int | None:

--- a/tests/cli/test_work_board.py
+++ b/tests/cli/test_work_board.py
@@ -115,6 +115,177 @@ def test_work_robot_marks_tier_four_pr_human_gated(
     assert payload["recommendations"][0]["item"]["metadata"]["tier"] == 4
 
 
+def test_work_show_enriches_github_pr_with_active_lane_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: "/usr/bin/gh")
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "number": 7292,
+                        "title": "Stage 2 operator-delegation",
+                        "url": "https://github.com/synaptent/aragora/pull/7292",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "headRefName": "droid/P16-stage2-auto-merge-bucket-a",
+                        "headRefOid": "abc123",
+                        "updatedAt": _now_iso(),
+                        "createdAt": _now_iso(),
+                        "reviewDecision": "REVIEW_REQUIRED",
+                        "mergeStateStatus": "DIRTY",
+                        "labels": [],
+                        "assignees": [],
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr("aragora.work.sources.subprocess.run", fake_run)
+    registry = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "P16-repair-7292-stage2-guards",
+                    "owner_session": "codex-owner",
+                    "status": "active",
+                    "pr_number": 7292,
+                    "branch": "droid/P16-stage2-auto-merge-bucket-a",
+                    "worktree": "/repo/.worktrees/p16",
+                    "updated_at": "2026-05-18T02:12:13Z",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert cmd_work_show(_args(tmp_path, work_id="pr:7292")) == 0
+    payload = _capture_json(capsys)
+    item = payload["item"]
+
+    assert item["owner"] == "codex-owner"
+    assert item["metadata"]["active_lane"] is True
+    assert item["metadata"]["lane_id"] == "P16-repair-7292-stage2-guards"
+    assert item["metadata"]["owner_session"] == "codex-owner"
+    assert item["metadata"]["lane_worktree"] == "/repo/.worktrees/p16"
+    assert item["metadata"]["lane_status"] == "active"
+    assert item["metadata"]["lane_updated_at"] == "2026-05-18T02:12:13Z"
+
+
+def test_work_show_preserves_assignee_when_lane_is_released(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: "/usr/bin/gh")
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "number": 7292,
+                        "title": "Stage 2 operator-delegation",
+                        "url": "https://github.com/synaptent/aragora/pull/7292",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "headRefName": "droid/P16-stage2-auto-merge-bucket-a",
+                        "headRefOid": "abc123",
+                        "updatedAt": _now_iso(),
+                        "createdAt": _now_iso(),
+                        "reviewDecision": "REVIEW_REQUIRED",
+                        "mergeStateStatus": "DIRTY",
+                        "labels": [],
+                        "assignees": [{"login": "assigned-human"}],
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr("aragora.work.sources.subprocess.run", fake_run)
+    registry = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "P16-released",
+                    "owner_session": "old-owner",
+                    "status": "released",
+                    "pr_number": 7292,
+                    "branch": "droid/P16-stage2-auto-merge-bucket-a",
+                    "updated_at": "2026-05-18T02:12:13Z",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert cmd_work_show(_args(tmp_path, work_id="pr:7292")) == 0
+    payload = _capture_json(capsys)
+    item = payload["item"]
+
+    assert item["owner"] == "assigned-human"
+    assert item["metadata"]["active_lane"] is False
+    assert item["metadata"]["lane_id"] == "P16-released"
+    assert item["metadata"]["owner_session"] == "old-owner"
+    assert item["metadata"]["lane_status"] == "released"
+
+
+def test_work_robot_degrades_safely_on_malformed_lane_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setattr("aragora.work.sources.shutil.which", lambda name: "/usr/bin/gh")
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "number": 7292,
+                        "title": "Stage 2 operator-delegation",
+                        "url": "https://github.com/synaptent/aragora/pull/7292",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "headRefName": "droid/P16-stage2-auto-merge-bucket-a",
+                        "headRefOid": "abc123",
+                        "updatedAt": _now_iso(),
+                        "createdAt": _now_iso(),
+                        "reviewDecision": "REVIEW_REQUIRED",
+                        "mergeStateStatus": "DIRTY",
+                        "labels": [],
+                        "assignees": [],
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr("aragora.work.sources.subprocess.run", fake_run)
+    registry = tmp_path / ".aragora" / "agent-bridge" / "lanes.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text("{not json", encoding="utf-8")
+
+    assert cmd_work_robot(_args(tmp_path)) == 0
+    payload = _capture_json(capsys)
+
+    assert payload["recommendations"][0]["item"]["owner"] is None
+    assert any(
+        health["source"] == "agent_bridge_lane" and health["status"] == "degraded"
+        for health in payload["source_health"]
+    )
+
+
 def test_work_show_finds_historical_receipt_in_all_scope(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:

--- a/tests/work/test_work_scoring.py
+++ b/tests/work/test_work_scoring.py
@@ -28,6 +28,35 @@ def test_score_prefers_current_non_draft_pr_with_tests() -> None:
     assert 0.0 <= score.total <= 1.0
 
 
+def test_branch_only_has_less_owner_clarity_than_real_owner() -> None:
+    branch_only = WorkItem(
+        id="pr:1",
+        source="github_pr",
+        item_type="pull_request",
+        title="fix(queue): repair proof health",
+        status="open",
+        branch="codex/fix",
+    )
+    owned = WorkItem(
+        id="pr:2",
+        source="github_pr",
+        item_type="pull_request",
+        title="fix(queue): repair proof health",
+        status="open",
+        branch="codex/fix",
+        owner="codex-owner",
+    )
+
+    branch_score = score_work_item(branch_only)
+    owner_score = score_work_item(owned)
+
+    assert branch_score.owner_clarity == 0.62
+    assert owner_score.owner_clarity == 0.9
+    assert owner_score.owner_clarity > branch_score.owner_clarity
+    assert "branch is explicit but owner is unknown" in branch_score.rationale
+    assert "owner is explicit" in owner_score.rationale
+
+
 def test_score_penalizes_stale_terminal_bead() -> None:
     item = WorkItem(
         id="bead:old",


### PR DESCRIPTION
## Summary

Adds read-only Agent Flywheel owner enrichment for `aragora work` surfaces using the repo-local `.aragora/agent-bridge/lanes.json` registry.

Behavior:
- Enriches GitHub PR WorkItems by PR number and branch.
- Surfaces `active_lane`, `lane_id`, `owner_session`, `lane_worktree`, `lane_status`, and `lane_updated_at` in WorkItem metadata.
- Fills `owner` from `owner_session` only when an active lane exists and no GitHub assignee owner is present.
- Preserves released/stale lanes as non-active metadata with `active_lane=false`.
- Degrades safely when the lane registry is missing or malformed.
- Lowers branch-only owner clarity so a branch name is no longer treated as equivalent to real owner/session ownership.

This is read-only and repo-local lane-registry only. It performs no PR mutation, lane mutation, bridge send, issue/label mutation, launchd/automation change, or worktree cleanup. It does not implement broker mail, file leases, `work pick`, `work ready`, CASS indexing, auto-claiming, or any mutation API.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/test_work_board.py tests/work/test_work_scoring.py -q -p no:cacheprovider` -> 19 passed
- `ruff check aragora/work/sources.py aragora/work/board.py aragora/work/scoring.py tests/cli/test_work_board.py tests/work/test_work_scoring.py` -> passed
- `ruff format --check aragora/work/sources.py aragora/work/board.py aragora/work/scoring.py tests/cli/test_work_board.py tests/work/test_work_scoring.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- Live read-only smoke against `/Users/armand/Development/aragora` showed released lane metadata for `pr:7292` and branch-only owner clarity lowered to `0.62`.
