### PR TITLE
feat(scripts): send_operator_steering.py — Phase B steering-mailbox writer [lane: P29]

### DIFF
--- a/scripts/send_operator_steering.py
+++ b/scripts/send_operator_steering.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Atomic steering-message writer for operator → agent-session inbox.
+
+Phase B of the agent-steering primitive (ships under lane id
+``P29-steering-mailbox-writer`` because the original P28-B namespace
+was contested by concurrent P28-* worktree-inventory work — see
+journal rows 29-31).
+
+Writes one JSON message file per invocation into a per-recipient
+mailbox dir:
+
+    .aragora/operator-steering/<to_session>/<utc-ts>-<short-uuid>.json
+
+Each message follows the frozen v1.0 schema documented inline and
+honoured by Phase A's ``scripts/identify_lane_owner.py``
+``steering_inbox_for()`` reader. The recipient session sees the count
+in that consolidator's ``pending_message_count`` field next time it
+runs Phase 0 of the fan-out prompt. Phase C
+(``operator-snapshot`` extension) will also surface the count directly
+in the agent_bridge snapshot once it ships.
+
+Atomic write: tempfile + ``os.replace`` so partial writes don't
+appear in the inbox glob even under SIGINT. Each message is its own
+file — no shared-file lock contention.
+
+Pure stdlib. No ``aragora.*`` imports. NEVER touches GitHub, the lane
+registry, or any path outside ``.aragora/operator-steering/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import secrets
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STEERING_INBOX_ROOT_DEFAULT = REPO_ROOT / ".aragora" / "operator-steering"
+
+SCHEMA_VERSION = "aragora-operator-steering/1.0"
+SUBJECT_MAX_CHARS = 80
+PRIORITY_CHOICES = ("low", "normal", "high", "blocking")
+SHORT_UUID_BYTES = 4  # 8 hex chars; collision risk negligible per-second
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_utc_iso() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _filename_timestamp(iso: str) -> str:
+    """Make an ISO timestamp safe for a filesystem filename."""
+
+    return iso.replace(":", "-").replace(".", "-")
+
+
+def canonical_json(value: Any) -> str:
+    """Canonical JSON matching the TS-side helper (sort_keys, no whitespace, UTF-8)."""
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def derive_subject(body: str, *, max_chars: int = SUBJECT_MAX_CHARS) -> str:
+    """First line of body, truncated to ``max_chars``."""
+
+    first_line = body.strip().splitlines()[0] if body.strip() else ""
+    return first_line[:max_chars]
+
+
+def build_message(
+    *,
+    to_session: str,
+    body: str,
+    from_label: str = "operator",
+    lane_id_hint: str | None = None,
+    pr_hint: int | None = None,
+    priority: str = "normal",
+    sent_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Compose the v1.0 message envelope and stamp the binding sha256."""
+
+    ts = sent_at_utc if sent_at_utc is not None else _now_utc_iso()
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "to_session": to_session,
+        "from": from_label,
+        "sent_at_utc": ts,
+        "lane_id_hint": lane_id_hint,
+        "pr_hint": pr_hint,
+        "priority": priority,
+        "subject": derive_subject(body),
+        "body": body,
+    }
+    canonical = canonical_json(payload)
+    payload["message_sha256"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return payload
+
+
+def verify_message_sha256(message: dict[str, Any]) -> tuple[str, str, bool]:
+    """Re-derive the message's sha256 and compare to the stored value."""
+
+    claimed = str(message.get("message_sha256", ""))
+    verify_copy = {k: v for k, v in message.items() if k != "message_sha256"}
+    recomputed = hashlib.sha256(canonical_json(verify_copy).encode("utf-8")).hexdigest()
+    return claimed, recomputed, claimed == recomputed
+
+
+def _mailbox_filename(sent_at_utc: str) -> str:
+    return f"{_filename_timestamp(sent_at_utc)}-{secrets.token_hex(SHORT_UUID_BYTES)}.json"
+
+
+def write_message(
+    message: dict[str, Any],
+    *,
+    steering_inbox_root: Path = STEERING_INBOX_ROOT_DEFAULT,
+) -> Path:
+    """Atomically persist ``message`` into the recipient's mailbox.
+
+    Creates the recipient dir on first message (idempotent). Writes
+    to a tempfile in the same dir, then ``os.replace`` to the final
+    path so partial writes never appear under the inbox glob.
+
+    Returns the absolute path of the written message.
+    """
+
+    to_session = str(message.get("to_session") or "")
+    if not to_session:
+        raise ValueError("message.to_session must be a non-empty string")
+    inbox = steering_inbox_root / to_session
+    inbox.mkdir(parents=True, exist_ok=True)
+    final_name = _mailbox_filename(str(message.get("sent_at_utc") or _now_utc_iso()))
+    final_path = inbox / final_name
+    body_text = json.dumps(message, indent=2, sort_keys=True)
+
+    # Atomic write: tmp in same dir, then rename.
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".tmp-",
+        suffix=".json",
+        dir=str(inbox),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body_text)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, final_path)
+    except Exception:
+        # Clean up tempfile on failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return final_path
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="send_operator_steering.py",
+        description=(
+            "Write an operator → agent-session steering message into the "
+            "atomic mailbox under .aragora/operator-steering/<to_session>/."
+        ),
+    )
+    parser.add_argument(
+        "--to",
+        required=True,
+        metavar="OWNER_SESSION",
+        help="Target owner_session identifier (e.g., codex-p19-repair-7292).",
+    )
+    parser.add_argument(
+        "--lane-id",
+        default=None,
+        help="Optional lane_id hint (passed through to message.lane_id_hint).",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Optional PR number hint (passed through to message.pr_hint).",
+    )
+    parser.add_argument(
+        "--from",
+        dest="from_label",
+        default="operator",
+        metavar="OPERATOR_NAME",
+        help="Sender label (default: 'operator').",
+    )
+    parser.add_argument(
+        "--priority",
+        choices=PRIORITY_CHOICES,
+        default="normal",
+        help="Message priority (default: normal).",
+    )
+    body_group = parser.add_mutually_exclusive_group(required=True)
+    body_group.add_argument(
+        "--body",
+        default=None,
+        help="Inline message body (markdown).",
+    )
+    body_group.add_argument(
+        "--body-file",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Read message body from a file (markdown).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the written record + final path as JSON to stdout.",
+    )
+    parser.add_argument(
+        "--steering-inbox-root",
+        type=Path,
+        default=STEERING_INBOX_ROOT_DEFAULT,
+        help="Override the steering inbox root (used by tests).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = _build_parser().parse_args(argv)
+    except SystemExit as exc:
+        # argparse exits 2 on bad args; preserve that contract.
+        return int(exc.code) if isinstance(exc.code, int) else 2
+
+    # Validate / resolve body.
+    body_text: str
+    if args.body is not None:
+        body_text = args.body
+    else:
+        body_path: Path = args.body_file
+        if not body_path.exists():
+            print(f"ERROR: --body-file not found: {body_path}", file=sys.stderr)
+            return 2
+        try:
+            body_text = body_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"ERROR: cannot read --body-file: {exc}", file=sys.stderr)
+            return 2
+
+    if not body_text.strip():
+        print("ERROR: message body is empty", file=sys.stderr)
+        return 2
+
+    message = build_message(
+        to_session=args.to,
+        body=body_text,
+        from_label=args.from_label,
+        lane_id_hint=args.lane_id,
+        pr_hint=args.pr,
+        priority=args.priority,
+    )
+
+    try:
+        written_path = write_message(message, steering_inbox_root=args.steering_inbox_root)
+    except OSError as exc:
+        print(f"ERROR: failed to write message: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        out = dict(message)
+        out["_written_path"] = str(written_path)
+        print(json.dumps(out, indent=2, sort_keys=True))
+    else:
+        print(
+            f"wrote {written_path}  "
+            f"(sha256 {message['message_sha256'][:10]}…, "
+            f"priority={message['priority']})"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/send_operator_steering.py
+++ b/scripts/send_operator_steering.py
@@ -124,6 +124,29 @@ def verify_message_sha256(message: dict[str, Any]) -> tuple[str, str, bool]:
     return claimed, recomputed, claimed == recomputed
 
 
+def validate_to_session(to_session: str, *, steering_inbox_root: Path) -> Path:
+    """Return the bounded inbox path for a safe session identifier."""
+
+    if not to_session:
+        raise ValueError("message.to_session must be a non-empty string")
+    if to_session != to_session.strip():
+        raise ValueError("message.to_session must not have leading or trailing whitespace")
+    if "/" in to_session or "\\" in to_session:
+        raise ValueError("message.to_session must not contain path separators")
+
+    session_path = Path(to_session)
+    if session_path.is_absolute() or to_session in {".", ".."} or ".." in session_path.parts:
+        raise ValueError("message.to_session must be a plain session identifier")
+
+    root = steering_inbox_root.resolve(strict=False)
+    inbox = (root / to_session).resolve(strict=False)
+    try:
+        inbox.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("message.to_session resolves outside the steering inbox root") from exc
+    return inbox
+
+
 def _mailbox_filename(sent_at_utc: str) -> str:
     return f"{_filename_timestamp(sent_at_utc)}-{secrets.token_hex(SHORT_UUID_BYTES)}.json"
 
@@ -143,9 +166,7 @@ def write_message(
     """
 
     to_session = str(message.get("to_session") or "")
-    if not to_session:
-        raise ValueError("message.to_session must be a non-empty string")
-    inbox = steering_inbox_root / to_session
+    inbox = validate_to_session(to_session, steering_inbox_root=steering_inbox_root)
     inbox.mkdir(parents=True, exist_ok=True)
     final_name = _mailbox_filename(str(message.get("sent_at_utc") or _now_utc_iso()))
     final_path = inbox / final_name
@@ -282,7 +303,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         written_path = write_message(message, steering_inbox_root=args.steering_inbox_root)
-    except OSError as exc:
+    except (OSError, ValueError) as exc:
         print(f"ERROR: failed to write message: {exc}", file=sys.stderr)
         return 2
 

--- a/tests/scripts/test_send_operator_steering.py
+++ b/tests/scripts/test_send_operator_steering.py
@@ -193,6 +193,21 @@ class TestArgValidation:
 
 
 class TestRecipientPathSafety:
+    def test_empty_recipient_fails_before_writing(self, tmp_path: Path) -> None:
+        rc = sos.main(
+            [
+                "--to",
+                "",
+                "--body",
+                "must not write",
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+        assert rc == 2
+        assert not (tmp_path / "inbox").exists()
+        assert list(tmp_path.rglob("*.json")) == []
+
     @pytest.mark.parametrize(
         "recipient",
         [

--- a/tests/scripts/test_send_operator_steering.py
+++ b/tests/scripts/test_send_operator_steering.py
@@ -1,0 +1,416 @@
+"""Tests for ``scripts/send_operator_steering.py`` — Phase B mailbox writer.
+
+Fixture-driven; never touches the real
+``.aragora/operator-steering/`` directory. All writes go to
+``tmp_path`` via the ``--steering-inbox-root`` override.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "send_operator_steering.py"
+    spec = importlib.util.spec_from_file_location("send_operator_steering_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sos = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _inbox_dir(tmp_path: Path, recipient: str) -> Path:
+    return tmp_path / recipient
+
+
+def _list_messages(tmp_path: Path, recipient: str) -> list[Path]:
+    inbox = _inbox_dir(tmp_path, recipient)
+    if not inbox.is_dir():
+        return []
+    return sorted(inbox.glob("*.json"))
+
+
+# ---------------------------------------------------------------------------
+# Schema + sha256 round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaShape:
+    def test_happy_path_writes_v1_schema_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = sos.main(
+            [
+                "--to",
+                "fixture-session-1",
+                "--body",
+                "first steering message",
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 0
+        msgs = _list_messages(tmp_path, "fixture-session-1")
+        assert len(msgs) == 1
+        payload = json.loads(msgs[0].read_text(encoding="utf-8"))
+        assert payload["schema_version"] == "aragora-operator-steering/1.0"
+        assert payload["to_session"] == "fixture-session-1"
+        assert payload["from"] == "operator"
+        assert payload["priority"] == "normal"
+        assert payload["subject"] == "first steering message"
+        assert payload["body"] == "first steering message"
+        assert payload["lane_id_hint"] is None
+        assert payload["pr_hint"] is None
+        assert payload["message_sha256"]
+        assert len(payload["message_sha256"]) == 64
+
+    def test_message_sha256_round_trips(self, tmp_path: Path) -> None:
+        sos.main(
+            [
+                "--to",
+                "fixture-roundtrip",
+                "--body",
+                "verify the binding sha",
+                "--from",
+                "operator-test",
+                "--priority",
+                "high",
+                "--lane-id",
+                "P29-fixture",
+                "--pr",
+                "9999",
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        msgs = _list_messages(tmp_path, "fixture-roundtrip")
+        assert len(msgs) == 1
+        payload = json.loads(msgs[0].read_text(encoding="utf-8"))
+        claimed, recomputed, matches = sos.verify_message_sha256(payload)
+        assert claimed == payload["message_sha256"]
+        assert recomputed == claimed
+        assert matches is True
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestArgValidation:
+    def test_missing_to_exits_2(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = sos.main(["--body", "no recipient", "--steering-inbox-root", str(tmp_path)])
+        assert rc == 2
+
+    def test_missing_body_exits_2(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = sos.main(["--to", "x", "--steering-inbox-root", str(tmp_path)])
+        assert rc == 2
+
+    def test_both_body_and_body_file_exits_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "body.md"
+        body_file.write_text("from file")
+        rc = sos.main(
+            [
+                "--to",
+                "x",
+                "--body",
+                "from inline",
+                "--body-file",
+                str(body_file),
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 2
+
+    def test_missing_body_file_exits_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = sos.main(
+            [
+                "--to",
+                "x",
+                "--body-file",
+                str(tmp_path / "absent.md"),
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 2
+        assert "not found" in capsys.readouterr().err
+
+    def test_empty_body_exits_2(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = sos.main(
+            [
+                "--to",
+                "x",
+                "--body",
+                "   \n   ",  # whitespace-only
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 2
+        assert "empty" in capsys.readouterr().err
+
+    def test_invalid_priority_exits_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = sos.main(
+            [
+                "--to",
+                "x",
+                "--body",
+                "hi",
+                "--priority",
+                "URGENT",  # not in PRIORITY_CHOICES
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# Subject derivation + body-file path
+# ---------------------------------------------------------------------------
+
+
+class TestSubjectAndBodyFile:
+    def test_subject_is_first_80_chars(self, tmp_path: Path) -> None:
+        long_body = "x" * 200
+        sos.main(
+            [
+                "--to",
+                "subj-fixture",
+                "--body",
+                long_body,
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        msg = json.loads(_list_messages(tmp_path, "subj-fixture")[0].read_text())
+        assert len(msg["subject"]) == 80
+        assert msg["subject"] == "x" * 80
+        assert msg["body"] == "x" * 200
+
+    def test_subject_is_first_line_only(self, tmp_path: Path) -> None:
+        body = "single-line subject\nbody line 2\nbody line 3"
+        sos.main(
+            [
+                "--to",
+                "subj-multi",
+                "--body",
+                body,
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        msg = json.loads(_list_messages(tmp_path, "subj-multi")[0].read_text())
+        assert msg["subject"] == "single-line subject"
+        assert msg["body"] == body  # full body preserved
+
+    def test_body_file_is_read(self, tmp_path: Path) -> None:
+        body_file = tmp_path / "msg.md"
+        body_file.write_text("# Heading\n\nfile body content\n", encoding="utf-8")
+        sos.main(
+            [
+                "--to",
+                "body-file-fixture",
+                "--body-file",
+                str(body_file),
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        msg = json.loads(_list_messages(tmp_path, "body-file-fixture")[0].read_text())
+        assert msg["body"] == "# Heading\n\nfile body content\n"
+        assert msg["subject"] == "# Heading"
+
+
+# ---------------------------------------------------------------------------
+# Ordering + directory creation
+# ---------------------------------------------------------------------------
+
+
+class TestOrderingAndDir:
+    def test_dir_auto_created_for_new_recipient(self, tmp_path: Path) -> None:
+        # Recipient dir does NOT exist beforehand.
+        assert not (tmp_path / "new-recipient").exists()
+        sos.main(
+            [
+                "--to",
+                "new-recipient",
+                "--body",
+                "first message ever",
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        assert (tmp_path / "new-recipient").is_dir()
+        assert len(_list_messages(tmp_path, "new-recipient")) == 1
+
+    def test_idempotent_on_rerun_same_recipient(self, tmp_path: Path) -> None:
+        # Two writes in succession both succeed; both messages persist.
+        for body in ("msg-A", "msg-B"):
+            sos.main(
+                [
+                    "--to",
+                    "rerun-fixture",
+                    "--body",
+                    body,
+                    "--steering-inbox-root",
+                    str(tmp_path),
+                ]
+            )
+        msgs = _list_messages(tmp_path, "rerun-fixture")
+        assert len(msgs) == 2
+        bodies = sorted(json.loads(m.read_text())["body"] for m in msgs)
+        assert bodies == ["msg-A", "msg-B"]
+
+    def test_multi_message_ordering_filenames_strictly_increasing(self, tmp_path: Path) -> None:
+        # The filename starts with the message's sent_at_utc; messages
+        # written later should sort after messages written earlier.
+        for i in range(3):
+            sos.main(
+                [
+                    "--to",
+                    "ordering-fixture",
+                    "--body",
+                    f"message-{i}",
+                    "--steering-inbox-root",
+                    str(tmp_path),
+                ]
+            )
+            time.sleep(0.005)  # ensure distinct sent_at_utc timestamps
+        msgs = _list_messages(tmp_path, "ordering-fixture")
+        assert len(msgs) == 3
+        # Sorted by filename should match sorted by sent_at_utc inside
+        # each message. zip without strict because adjacent-pair count
+        # is naturally len(msgs)-1.
+        for prev, curr in zip(msgs, msgs[1:]):
+            prev_payload = json.loads(prev.read_text())
+            curr_payload = json.loads(curr.read_text())
+            assert prev_payload["sent_at_utc"] <= curr_payload["sent_at_utc"]
+
+    def test_tmp_files_do_not_appear_in_glob(self, tmp_path: Path) -> None:
+        sos.main(
+            [
+                "--to",
+                "tmp-leak-fixture",
+                "--body",
+                "atomic-write check",
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        inbox = _inbox_dir(tmp_path, "tmp-leak-fixture")
+        # Real consumers do `glob("*.json")` — only completed messages
+        # should match. The atomic-write tmp prefix starts with '.tmp-'
+        # which neither matches *.json nor pollutes a glob.
+        completed = list(inbox.glob("*.json"))
+        assert len(completed) == 1
+        leftover_tmp = list(inbox.glob(".tmp-*"))
+        assert leftover_tmp == []
+
+
+# ---------------------------------------------------------------------------
+# --json output
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutput:
+    def test_json_includes_written_path_and_full_record(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = sos.main(
+            [
+                "--to",
+                "json-fixture",
+                "--body",
+                "json mode body",
+                "--from",
+                "operator-test",
+                "--lane-id",
+                "P29-fixture",
+                "--pr",
+                "9000",
+                "--priority",
+                "high",
+                "--json",
+                "--steering-inbox-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["schema_version"] == "aragora-operator-steering/1.0"
+        assert parsed["to_session"] == "json-fixture"
+        assert parsed["from"] == "operator-test"
+        assert parsed["lane_id_hint"] == "P29-fixture"
+        assert parsed["pr_hint"] == 9000
+        assert parsed["priority"] == "high"
+        assert parsed["_written_path"].endswith(".json")
+        # The written file should match the JSON-mode output (sans the
+        # injected _written_path field).
+        written_file = Path(parsed["_written_path"])
+        assert written_file.is_file()
+        on_disk = json.loads(written_file.read_text())
+        for k in (
+            "schema_version",
+            "to_session",
+            "from",
+            "lane_id_hint",
+            "pr_hint",
+            "priority",
+            "body",
+            "subject",
+            "message_sha256",
+        ):
+            assert on_disk[k] == parsed[k]
+
+
+# ---------------------------------------------------------------------------
+# Build / verify helpers exposed for downstream callers
+# ---------------------------------------------------------------------------
+
+
+class TestBuildVerifyHelpers:
+    def test_build_message_stamps_canonical_sha(self) -> None:
+        msg = sos.build_message(
+            to_session="target",
+            body="hello canonical",
+            sent_at_utc="2026-05-18T05:00:00.000Z",
+        )
+        verify_copy = {k: v for k, v in msg.items() if k != "message_sha256"}
+        expected = hashlib.sha256(sos.canonical_json(verify_copy).encode("utf-8")).hexdigest()
+        assert msg["message_sha256"] == expected
+
+    def test_verify_detects_tampered_message(self) -> None:
+        msg = sos.build_message(to_session="t", body="original body")
+        msg["body"] = "tampered body"
+        claimed, recomputed, matches = sos.verify_message_sha256(msg)
+        assert matches is False
+        assert claimed != recomputed

--- a/tests/scripts/test_send_operator_steering.py
+++ b/tests/scripts/test_send_operator_steering.py
@@ -192,6 +192,44 @@ class TestArgValidation:
         assert rc == 2
 
 
+class TestRecipientPathSafety:
+    @pytest.mark.parametrize(
+        "recipient",
+        [
+            "../escape",
+            "nested/session",
+            "nested\\session",
+            "/tmp/escape",
+            ".",
+            "..",
+            " session-with-space-prefix",
+            "session-with-space-suffix ",
+        ],
+    )
+    def test_unsafe_recipients_fail_before_writing(self, tmp_path: Path, recipient: str) -> None:
+        rc = sos.main(
+            [
+                "--to",
+                recipient,
+                "--body",
+                "must not escape",
+                "--steering-inbox-root",
+                str(tmp_path / "inbox"),
+            ]
+        )
+        assert rc == 2
+        assert not (tmp_path / "escape").exists()
+        assert not (tmp_path / "inbox").exists()
+        assert list(tmp_path.rglob("*.json")) == []
+
+    def test_validator_rejects_resolving_outside_root(self, tmp_path: Path) -> None:
+        root = tmp_path / "inbox"
+        with pytest.raises(ValueError, match="path separators|plain session identifier|outside"):
+            sos.validate_to_session("../escape", steering_inbox_root=root)
+        assert not root.exists()
+        assert not (tmp_path / "escape").exists()
+
+
 # ---------------------------------------------------------------------------
 # Subject derivation + body-file path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ships Phase B of the agent-steering primitive — atomic per-recipient mailbox writer. Renumbered from P28-B → P29 mid-session to dodge live P28-* worktree-inventory collisions (droid-3D81079C / codex-6B2B5435 both held active P28-* lanes when I tried to claim P28-B).

Atomic write of one message file per invocation:

\`\`\`
.aragora/operator-steering/<to_session>/<utc-ts>-<short-uuid>.json
\`\`\`

Each message follows the frozen v1.0 schema that Phase A's \`identify_lane_owner.py\` already reads via \`steering_inbox_for()\`.

## End-to-end loop confirmed

Smoke-tested live:

\`\`\`
step 1: send_operator_steering.py --to claude-86616832 --body "..." \
        --steering-inbox-root /tmp/p29-smoke
        → wrote 2026-05-18T05-17-56-328Z-5c052788.json

step 2: identify_lane_owner.py --lane-id P29-steering-mailbox-writer \
        --steering-inbox-root /tmp/p29-smoke
        → pending_message_count = 1
        → owner_session = claude-86616832
\`\`\`

The agent-steering pipeline is now write-side complete. Phase C will extend \`operator-snapshot\` to surface \`pending_steering_messages\` automatically in every fan-out session's Phase 0.

## CLI

\`\`\`
python3 scripts/send_operator_steering.py
    --to OWNER_SESSION
    [--lane-id ID] [--pr N]
    [--from OPERATOR_NAME]            # default "operator"
    [--priority {low,normal,high,blocking}]
    (--body BODY | --body-file PATH)
    [--json]
    [--steering-inbox-root PATH]      # test override
\`\`\`

Exit codes: \`0\` written; \`2\` bad args / missing body / missing file / write failure.

## Atomicity

- Tempfile (\`.tmp-...json\`) created in same dir as final path
- \`os.fsync\` before \`os.replace\`
- Partial writes never appear under \`glob(\"*.json\")\` even on SIGINT
- Test \`test_tmp_files_do_not_appear_in_glob\` asserts this

## Schema (frozen v1.0)

\`\`\`json
{
  "schema_version": "aragora-operator-steering/1.0",
  "to_session": "<owner_session>",
  "from": "<operator_label>",
  "sent_at_utc": "<iso8601>",
  "lane_id_hint": "<lane id>" | null,
  "pr_hint": <int> | null,
  "priority": "low"|"normal"|"high"|"blocking",
  "subject": "<first 80 chars of body>",
  "body": "<full markdown>",
  "message_sha256": "<sha256 of canonical-JSON payload sans this field>"
}
\`\`\`

## Tests (18 fixture-driven, all green — ≥6 required)

| Group | # | Coverage |
|---|---|---|
| TestSchemaShape | 2 | happy path writes v1.0; message_sha256 round-trip |
| TestArgValidation | 6 | missing --to; missing body; --body + --body-file mutex; missing --body-file; empty body; invalid priority |
| TestSubjectAndBodyFile | 3 | subject capped at 80; first line only; --body-file read |
| TestOrderingAndDir | 4 | dir auto-created; idempotent on rerun; filename timestamps strictly increasing; .tmp-* not in glob |
| TestJsonOutput | 1 | --json includes _written_path matching on-disk |
| TestBuildVerifyHelpers | 2 | build_message stamps correct sha; verify detects tampering |

## Validation

- \`pytest tests/scripts/test_send_operator_steering.py -q\` → **18 passed**
- \`ruff check\` + \`ruff format --check\` clean on both files
- \`mypy scripts/send_operator_steering.py\` clean
- \`bash scripts/automation_pr_preflight.sh origin/main HEAD\` → \`preflight: ok\`
- End-to-end smoke (above) — confirmed P29-B writer + P28-A reader integration

## Holds respected

- No PR mutation, no labels, draft only
- Zero AI-key consumption
- No held-PR advancement (#7173, #7215, #7240, #7243, #7245, #7249, #7252, #4990)
- No \`automation.toml\` edit, no launchd install, no protected-file edits
- Does NOT touch operator-snapshot output shape (that's Phase C)
- Does NOT touch identify_lane_owner.py (that's Phase A — PR #7308)
- Does NOT touch P19/P20/P24/P28-A/P28-worktree-inventory worktrees or PRs

## Receipt + lane

- Lane: \`P29-steering-mailbox-writer\` (renumbered from P28-B mid-session)
- Session: \`claude-86616832\`
- Phase 4 receipt + lane-release commit on \`main\` per fan-out discipline (separate from this PR branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)