### PR TITLE
feat(scripts): operator-snapshot surfaces pending_steering_messages [lane: P30]

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -1241,6 +1241,107 @@ def cmd_health(args: argparse.Namespace) -> int:
     return 1
 
 
+def _collect_pending_steering_messages(
+    session_name: str | None,
+    steering_root: Path | None = None,
+) -> dict[str, Any]:
+    """Read the operator-steering mailbox(es) and surface pending counts.
+
+    Phase C of the agent-steering primitive. Reads only — never
+    mutates the mailbox. Companion to ``scripts/send_operator_steering.py``
+    (Phase B writer) and ``scripts/identify_lane_owner.py``
+    (Phase A consolidator) which both honour the same
+    ``aragora-operator-steering/1.0`` schema.
+
+    Scoping rules:
+      - ``session_name`` set     → return only that recipient's count
+                                   + latest_three.
+      - ``session_name`` falsy   → operator roll-up: count across all
+                                   recipient dirs + ``by_recipient``
+                                   map + latest_three newest across all.
+
+    Schema (stable for Phase D / future consumers):
+
+        scoped:
+          {count: int, latest_three: [{subject, sent_at_utc, priority,
+                                        lane_id_hint, pr_hint}]}
+        roll-up:
+          {count: int, by_recipient: {<session>: int}, latest_three: [...]}
+
+    Acknowledged messages live in the per-recipient ``_acked/`` subdir
+    (Phase D convention; the directory name starts with ``_`` so this
+    glob silently ignores it via ``*.json`` only matching the inbox
+    top level).
+    """
+
+    if steering_root is None:
+        steering_root = REPO_ROOT / ".aragora" / "operator-steering"
+    if not steering_root.is_dir():
+        if session_name:
+            return {"count": 0, "latest_three": []}
+        return {"count": 0, "by_recipient": {}, "latest_three": []}
+
+    def _summary_from(path: Path) -> dict[str, Any]:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {
+                "subject": "(unreadable)",
+                "sent_at_utc": "",
+                "priority": "",
+                "lane_id_hint": None,
+                "pr_hint": None,
+            }
+        if not isinstance(data, dict):
+            return {
+                "subject": "(invalid)",
+                "sent_at_utc": "",
+                "priority": "",
+                "lane_id_hint": None,
+                "pr_hint": None,
+            }
+        return {
+            "subject": str(data.get("subject") or ""),
+            "sent_at_utc": str(data.get("sent_at_utc") or ""),
+            "priority": str(data.get("priority") or ""),
+            "lane_id_hint": data.get("lane_id_hint"),
+            "pr_hint": data.get("pr_hint"),
+        }
+
+    def _inbox_files(dir_path: Path) -> list[Path]:
+        if not dir_path.is_dir():
+            return []
+        # Only count top-level *.json files — _acked/ subdir holds
+        # consumed messages per the Phase D convention.
+        return [p for p in dir_path.glob("*.json") if p.is_file()]
+
+    if session_name:
+        files = _inbox_files(steering_root / session_name)
+        summaries = sorted(
+            (_summary_from(p) for p in files),
+            key=lambda s: s["sent_at_utc"],
+            reverse=True,
+        )
+        return {"count": len(files), "latest_three": summaries[:3]}
+
+    # Roll-up across all recipient dirs.
+    by_recipient: dict[str, int] = {}
+    all_summaries: list[dict[str, Any]] = []
+    for child in sorted(steering_root.iterdir()):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        files = _inbox_files(child)
+        if files:
+            by_recipient[child.name] = len(files)
+            all_summaries.extend(_summary_from(p) for p in files)
+    all_summaries.sort(key=lambda s: s["sent_at_utc"], reverse=True)
+    return {
+        "count": sum(by_recipient.values()),
+        "by_recipient": by_recipient,
+        "latest_three": all_summaries[:3],
+    }
+
+
 def cmd_operator_snapshot(args: argparse.Namespace) -> int:
     """Output a unified operator snapshot combining sessions, lanes, and health."""
     summary_only = bool(getattr(args, "summary_only", False))
@@ -1272,6 +1373,15 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         record_limit=50,
     )
 
+    # Phase C: surface operator-steering mailbox counts for the
+    # current session (if ARAGORA_SESSION_ID set or
+    # --steering-recipient passed) or as a roll-up across all
+    # recipient dirs (operator view).
+    steering_recipient = getattr(args, "steering_recipient", None) or os.environ.get(
+        "ARAGORA_SESSION_ID"
+    )
+    pending_steering = _collect_pending_steering_messages(steering_recipient)
+
     snapshot: dict[str, Any] = {
         "timestamp": _now_iso(),
         "sessions": [s.to_dict() for s in sessions],
@@ -1280,6 +1390,7 @@ def cmd_operator_snapshot(args: argparse.Namespace) -> int:
         "lane_conflicts": lane_conflicts,
         "process_census": process_census,
         "health": {"ok": len(issues) == 0, "issues": issues},
+        "pending_steering_messages": pending_steering,
         "summary": {
             "total_sessions": len(sessions),
             "alive_sessions": sum(1 for s in sessions if s.status == "alive"),
@@ -1596,6 +1707,16 @@ def main() -> int:
         choices=("current", "all"),
         default="current",
         help="Snapshot scope. Default 'current' includes live bridge truth only.",
+    )
+    operator_snapshot_p.add_argument(
+        "--steering-recipient",
+        default=None,
+        metavar="SESSION",
+        help=(
+            "Scope pending_steering_messages lookup to one recipient "
+            "session. Default: env ARAGORA_SESSION_ID, then roll-up across "
+            "all recipient inbox dirs."
+        ),
     )
 
     args = parser.parse_args()

--- a/tests/scripts/test_agent_bridge_steering.py
+++ b/tests/scripts/test_agent_bridge_steering.py
@@ -1,0 +1,294 @@
+"""Tests for ``_collect_pending_steering_messages`` and the
+``pending_steering_messages`` field added to ``operator-snapshot``
+by Phase C of the agent-steering primitive.
+
+Fixture-driven; uses ``tmp_path`` for the steering inbox root and
+``monkeypatch`` for env vars. Never touches the live
+``.aragora/operator-steering/`` directory.
+
+Also includes a regression test that pins all pre-Phase-C top-level
+operator-snapshot keys so future changes can't silently drop them.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "agent_bridge.py"
+    spec = importlib.util.spec_from_file_location("agent_bridge_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ab = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mailbox fixture writer
+# ---------------------------------------------------------------------------
+
+
+def _write_message(
+    root: Path,
+    recipient: str,
+    *,
+    body: str,
+    priority: str = "normal",
+    lane_id_hint: str | None = None,
+    pr_hint: int | None = None,
+    sent_at_utc: str | None = None,
+    subject: str | None = None,
+    filename: str | None = None,
+) -> Path:
+    """Write one v1.0 schema mailbox file at ``root/recipient/<filename>``."""
+
+    inbox = root / recipient
+    inbox.mkdir(parents=True, exist_ok=True)
+    if sent_at_utc is None:
+        sent_at_utc = "2026-05-18T00:00:00.000Z"
+    payload = {
+        "schema_version": "aragora-operator-steering/1.0",
+        "to_session": recipient,
+        "from": "operator-test",
+        "sent_at_utc": sent_at_utc,
+        "lane_id_hint": lane_id_hint,
+        "pr_hint": pr_hint,
+        "priority": priority,
+        "subject": subject if subject is not None else body[:80],
+        "body": body,
+        "message_sha256": "0" * 64,  # not validated by Phase C reader
+    }
+    if filename is None:
+        filename = f"{sent_at_utc.replace(':', '-').replace('.', '-')}-fixture.json"
+    out = inbox / filename
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# _collect_pending_steering_messages — direct unit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestCollectPendingSteeringMessages:
+    def test_empty_mailbox_scoped(self, tmp_path: Path) -> None:
+        result = ab._collect_pending_steering_messages("fixture-a", steering_root=tmp_path)
+        assert result == {"count": 0, "latest_three": []}
+
+    def test_empty_mailbox_rollup(self, tmp_path: Path) -> None:
+        result = ab._collect_pending_steering_messages(None, steering_root=tmp_path)
+        assert result == {"count": 0, "by_recipient": {}, "latest_three": []}
+
+    def test_missing_dir_returns_zero(self, tmp_path: Path) -> None:
+        # Steering root does not exist at all.
+        result = ab._collect_pending_steering_messages(
+            "fixture", steering_root=tmp_path / "no-root"
+        )
+        assert result == {"count": 0, "latest_three": []}
+        result_rollup = ab._collect_pending_steering_messages(
+            None, steering_root=tmp_path / "no-root"
+        )
+        assert result_rollup == {"count": 0, "by_recipient": {}, "latest_three": []}
+
+    def test_single_message_scoped_surfaces_metadata(self, tmp_path: Path) -> None:
+        _write_message(
+            tmp_path,
+            "fixture-single",
+            body="hello world",
+            priority="high",
+            lane_id_hint="P30-fixture",
+            pr_hint=9000,
+            sent_at_utc="2026-05-18T01:00:00.000Z",
+        )
+        result = ab._collect_pending_steering_messages("fixture-single", steering_root=tmp_path)
+        assert result["count"] == 1
+        assert len(result["latest_three"]) == 1
+        first = result["latest_three"][0]
+        assert first["subject"] == "hello world"
+        assert first["sent_at_utc"] == "2026-05-18T01:00:00.000Z"
+        assert first["priority"] == "high"
+        assert first["lane_id_hint"] == "P30-fixture"
+        assert first["pr_hint"] == 9000
+
+    def test_five_messages_returns_top_three_newest(self, tmp_path: Path) -> None:
+        # Write 5 with strictly-increasing sent_at_utc.
+        for i in range(5):
+            _write_message(
+                tmp_path,
+                "fixture-five",
+                body=f"message-{i}",
+                sent_at_utc=f"2026-05-18T0{i}:00:00.000Z",
+                filename=f"msg-{i}.json",
+            )
+        result = ab._collect_pending_steering_messages("fixture-five", steering_root=tmp_path)
+        assert result["count"] == 5
+        assert len(result["latest_three"]) == 3
+        subjects = [m["subject"] for m in result["latest_three"]]
+        assert subjects == ["message-4", "message-3", "message-2"]
+
+    def test_rollup_across_multiple_recipients(self, tmp_path: Path) -> None:
+        _write_message(tmp_path, "alpha", body="a-only", sent_at_utc="2026-05-18T01:00:00.000Z")
+        _write_message(tmp_path, "alpha", body="a-second", sent_at_utc="2026-05-18T02:00:00.000Z")
+        _write_message(tmp_path, "beta", body="b-only", sent_at_utc="2026-05-18T03:00:00.000Z")
+        _write_message(tmp_path, "gamma", body="g-only", sent_at_utc="2026-05-18T04:00:00.000Z")
+        result = ab._collect_pending_steering_messages(None, steering_root=tmp_path)
+        assert result["count"] == 4
+        assert result["by_recipient"] == {"alpha": 2, "beta": 1, "gamma": 1}
+        # latest_three sorted newest first across all recipients
+        subjects = [m["subject"] for m in result["latest_three"]]
+        assert subjects == ["g-only", "b-only", "a-second"]
+
+    def test_acked_subdir_excluded(self, tmp_path: Path) -> None:
+        """Phase D ack convention: messages moved to _acked/ should NOT count."""
+        # One live message in inbox top-level
+        _write_message(tmp_path, "ack-fixture", body="live", sent_at_utc="2026-05-18T05:00:00.000Z")
+        # One acked message in _acked subdir (should be invisible)
+        acked_dir = tmp_path / "ack-fixture" / "_acked"
+        acked_dir.mkdir(parents=True)
+        (acked_dir / "old-msg.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "aragora-operator-steering/1.0",
+                    "to_session": "ack-fixture",
+                    "subject": "should-not-appear",
+                    "body": "acked",
+                    "sent_at_utc": "2026-05-18T06:00:00.000Z",
+                    "priority": "low",
+                    "lane_id_hint": None,
+                    "pr_hint": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = ab._collect_pending_steering_messages("ack-fixture", steering_root=tmp_path)
+        assert result["count"] == 1
+        assert result["latest_three"][0]["subject"] == "live"
+
+    def test_unreadable_message_safely_surfaces(self, tmp_path: Path) -> None:
+        inbox = tmp_path / "unreadable"
+        inbox.mkdir(parents=True)
+        (inbox / "broken.json").write_text("not valid json {{{", encoding="utf-8")
+        result = ab._collect_pending_steering_messages("unreadable", steering_root=tmp_path)
+        # Still counts the file but surfaces a sentinel summary.
+        assert result["count"] == 1
+        assert result["latest_three"][0]["subject"] == "(unreadable)"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — pending field appears in operator-snapshot --json output
+# ---------------------------------------------------------------------------
+
+
+REPO_ROOT_FOR_SUBPROCESS = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT_FOR_SUBPROCESS / "scripts" / "agent_bridge.py"
+
+
+def _run_snapshot(*extra_args: str, env: dict[str, str] | None = None) -> dict[str, Any]:
+    """Invoke `operator-snapshot --json` and parse stdout."""
+    import os as _os
+
+    full_env = _os.environ.copy()
+    if env:
+        full_env.update(env)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "operator-snapshot", "--json", *extra_args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=REPO_ROOT_FOR_SUBPROCESS,
+        env=full_env,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+class TestOperatorSnapshotIntegration:
+    """End-to-end CLI checks. Runs the script as a subprocess and
+    verifies the new field appears + all pre-Phase-C fields remain."""
+
+    def test_pre_phase_c_fields_still_present(self) -> None:
+        """Regression guard: existing top-level keys must keep their shape."""
+        snap = _run_snapshot()
+        expected_keys = {
+            "timestamp",
+            "sessions",
+            "broker_runs",
+            "lanes",
+            "lane_conflicts",
+            "process_census",
+            "health",
+            "summary",
+            # Phase C addition (will fail if Phase C ever silently removes it):
+            "pending_steering_messages",
+        }
+        assert expected_keys.issubset(set(snap.keys())), (
+            f"missing keys: {expected_keys - set(snap.keys())}"
+        )
+
+    def test_summary_subkeys_preserved(self) -> None:
+        snap = _run_snapshot()
+        summary = snap["summary"]
+        expected = {
+            "total_sessions",
+            "alive_sessions",
+            "live_sessions",
+            "dead_sessions",
+            "historical_sessions",
+            "active_broker_runs",
+            "active_lanes",
+            "conflict_lanes",
+            "health_issues",
+            "active_processes",
+            "active_process_roles",
+        }
+        assert expected.issubset(set(summary.keys()))
+
+    def test_pending_steering_messages_default_rollup_shape(self) -> None:
+        """Without ARAGORA_SESSION_ID, output is a roll-up across all recipients."""
+        # Ensure ARAGORA_SESSION_ID is NOT set in the subprocess env.
+        import os as _os
+
+        env = {k: v for k, v in _os.environ.items() if k != "ARAGORA_SESSION_ID"}
+        snap = _run_snapshot(env=env)
+        pending = snap["pending_steering_messages"]
+        assert "count" in pending
+        assert "by_recipient" in pending
+        assert "latest_three" in pending
+        assert isinstance(pending["latest_three"], list)
+
+    def test_pending_steering_messages_scoped_via_env(self) -> None:
+        snap = _run_snapshot(env={"ARAGORA_SESSION_ID": "no-such-session-fixture-xyz"})
+        pending = snap["pending_steering_messages"]
+        # Scoped output has count + latest_three but NOT by_recipient.
+        assert pending["count"] == 0
+        assert pending["latest_three"] == []
+        assert "by_recipient" not in pending
+
+    def test_steering_recipient_flag_overrides_env(self) -> None:
+        # Pass --steering-recipient with a no-such-session label;
+        # env ARAGORA_SESSION_ID would otherwise pick a different
+        # nonsense value. Both yield 0 here because neither recipient
+        # has a mailbox, but the assertion confirms the flag is wired.
+        snap = _run_snapshot(
+            "--steering-recipient",
+            "flag-fixture-xyz",
+            env={"ARAGORA_SESSION_ID": "env-fixture-xyz"},
+        )
+        pending = snap["pending_steering_messages"]
+        assert "by_recipient" not in pending  # scoped, not roll-up
+        assert pending["count"] == 0


### PR DESCRIPTION
## Summary

Ships Phase C of the agent-steering primitive — extends `scripts/agent_bridge.py operator-snapshot` to surface a new top-level `pending_steering_messages` field so every fan-out session sees its inbox automatically in Phase 0.

| Phase | PR | Status |
|---|---|---|
| Plan | merged in #7283 | ✓ |
| A — `identify_lane_owner.py` (read) | #7308 | draft, ready, BLOCKED on review |
| B — `send_operator_steering.py` (write) | #7310 | draft, ready, BLOCKED on review |
| **C — `operator-snapshot` extension (surface)** | **this PR** | **draft** |
| D — docs + ack convention | tracked | unclaimed |

## Implementation (single-file edit to `scripts/agent_bridge.py`)

### New helper

\`\`\`python
def _collect_pending_steering_messages(
    session_name: str | None,
    steering_root: Path | None = None,
) -> dict[str, Any]:
    \"\"\"Read .aragora/operator-steering/<recipient>/*.json mailboxes.
    
    Scoped (session_name set): {count, latest_three:[...]}
    Roll-up (session_name None): {count, by_recipient, latest_three}
    \"\"\"
\`\`\`

### Snapshot output gains one new top-level field

All 8 pre-existing keys preserved (regression-tested):
\`timestamp, sessions, broker_runs, lanes, lane_conflicts, process_census, health, summary\`

Added: \`pending_steering_messages\`

### CLI

\`\`\`
operator-snapshot ... [--steering-recipient SESSION]
\`\`\`

Precedence: \`--steering-recipient\` flag > env \`ARAGORA_SESSION_ID\` > roll-up.

## End-to-end loop A → B → C confirmed

\`\`\`
$ send_operator_steering.py --to smoke-c-fixture --body "..." --priority high \
    --lane-id P30-test --steering-inbox-root /tmp/p30-smoke
  wrote /tmp/p30-smoke/smoke-c-fixture/2026-05-18T05-41-45-326Z-c57b9621.json

$ _collect_pending_steering_messages('smoke-c-fixture', steering_root=/tmp/p30-smoke)
  → SCOPED: count=1 priority=high lane_hint=P30-test
  → ROLLUP: count=1 by_recipient={smoke-c-fixture: 1}
  END-TO-END A→B→C LOOP CONFIRMED.
\`\`\`

## Defense-in-depth + scope discipline

- **Read-only.** Never deletes, never acks, never moves files. Phase D will document the ack convention (move to \`_acked/\` subdir, gitignored).
- **\`_acked/\` already honored.** Top-level \`*.json\` glob naturally excludes the underscore-prefixed subdir. Test \`test_acked_subdir_excluded\` asserts this.
- **Pure additive.** No existing field shape changed. Regression test \`test_pre_phase_c_fields_still_present\` pins the pre-C schema.
- **Pure stdlib.** No new imports beyond what \`agent_bridge.py\` already had (\`json\`, \`os\`, \`Path\`).
- **Unreadable messages don't crash** the snapshot — fall back to sentinel \`subject="(unreadable)"\` summary. Test covers this.

## Tests (13 new, 32 regression — all green)

| Group | # | Coverage |
|---|---|---|
| TestCollectPendingSteeringMessages | 8 | empty scoped/rollup; missing root for both modes; single message metadata; five-message top-3 ordering; rollup across recipients; \`_acked\` subdir excluded; unreadable message safely surfaced |
| TestOperatorSnapshotIntegration | 5 | pre-Phase-C fields regression guard; summary subkeys preserved; rollup output shape; scoped via env var; \`--steering-recipient\` flag overrides env |

\`\`\`
$ pytest tests/scripts/test_agent_bridge_steering.py -q
.............                                                            [100%]
13 passed in 13.34s

$ pytest tests/scripts/test_agent_bridge.py -q
................................                                         [100%]
32 passed in 2.72s
\`\`\`

## Validation

- \`pytest tests/scripts/test_agent_bridge_steering.py -q\` → 13 / 13
- \`pytest tests/scripts/test_agent_bridge.py -q\` → 32 / 32 (existing tests still pass — REGRESSION GUARD)
- \`ruff check scripts/agent_bridge.py tests/scripts/test_agent_bridge_steering.py\` clean
- \`ruff format --check ...\` clean
- \`mypy scripts/agent_bridge.py\` clean
- \`bash scripts/automation_pr_preflight.sh origin/main HEAD\` → \`preflight: ok\`

## Holds respected

- No PR mutation, no labels, draft only
- Zero AI-key consumption
- No held-PR advancement (#7173, #7215, #7240, #7243, #7245, #7249, #7252, #4990)
- No \`automation.toml\` edit, no launchd install, no protected-file edits
- Stays clear of every active hotspot per Factory's coordination note: \`Q01-repair-7292-admin-merge\` (codex working #7292) and the stuck-active \`P28-refresh-worktree-value-inventory\` (codex-6B2B5435 — different scope)
- Does NOT touch \`scripts/auto_merge_bucket_a.py\`, \`.github/workflows/*\`, \`scripts/codex_worktree_value_inventory.py\`, \`scripts/identify_lane_owner.py\` (Phase A frozen), \`scripts/send_operator_steering.py\` (Phase B frozen)

## Receipt + lane

- Lane: \`P30-operator-snapshot-steering-messages\`
- Session: \`claude-7E0F63B3\`
- Phase 4 receipt + lane-release commit on \`main\` per fan-out discipline (separate from this PR branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)