### PR TITLE
feat(scripts): smart harvest merge detection [lane: P42]

### DIFF
--- a/scripts/codex_worktree_value_inventory.py
+++ b/scripts/codex_worktree_value_inventory.py
@@ -17,12 +17,14 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
 from collections import Counter
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
 
@@ -97,6 +99,7 @@ class GitInfo:
     behind: int | None = None
     dirty: bool = False
     patch_equivalent_to_base: bool = False
+    smart_merge_equivalent_to_base: bool = False
     lookup_failed: bool = False
     lookup_errors: list[str] = field(default_factory=list)
 
@@ -136,6 +139,8 @@ class InventoryContext:
     git_timeout: int
     gh_timeout: int
     patch_timeout: int
+    smart_merge_detection: bool = False
+    smart_merge_main_subjects: list[str] = field(default_factory=list)
 
 
 def utc_now() -> datetime:
@@ -402,6 +407,79 @@ def git_ahead_behind(
         return None, None, True, f"unexpected ahead/behind output: {proc.stdout!r}"
 
 
+def normalize_commit_subject(subject: str) -> str:
+    """Normalize commit/PR titles for loose squash-merge equivalence checks."""
+
+    value = subject.lower()
+    value = re.sub(r"\s+\(#\d+\)\s*$", "", value)
+    value = re.sub(r"\s+\[lane:[^\]]+\]\s*$", "", value)
+    value = re.sub(r"[^a-z0-9]+", " ", value)
+    return " ".join(value.split())
+
+
+def commit_subject_matches_recent_main(
+    subject: str,
+    recent_main_subjects: list[str],
+    *,
+    threshold: float = 0.80,
+) -> bool:
+    normalized = normalize_commit_subject(subject)
+    if not normalized:
+        return False
+    for recent_subject in recent_main_subjects:
+        recent = normalize_commit_subject(recent_subject)
+        if not recent:
+            continue
+        if normalized in recent or recent in normalized:
+            return True
+        if SequenceMatcher(None, normalized, recent).ratio() >= threshold:
+            return True
+    return False
+
+
+def recent_main_commit_subjects(repo: Path, base: str, *, timeout: int) -> list[str]:
+    proc = run_git(["log", base, "--since=60 days", "--pretty=format:%s"], repo, timeout=timeout)
+    if proc.returncode != 0:
+        return []
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def branch_unique_commit_subjects(
+    repo_path: Path,
+    base: str,
+    rev: str,
+    *,
+    timeout: int,
+) -> list[str] | None:
+    proc = run_git(
+        ["log", "--no-merges", f"{base}..{rev}", "--pretty=format:%s"],
+        repo_path,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        return None
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def branch_subjects_match_recent_main(
+    repo_path: Path,
+    base: str,
+    rev: str,
+    recent_main_subjects: list[str],
+    *,
+    timeout: int,
+) -> tuple[bool, list[str]]:
+    subjects = branch_unique_commit_subjects(repo_path, base, rev, timeout=timeout)
+    if not subjects:
+        return False, []
+    matched = [
+        subject
+        for subject in subjects
+        if commit_subject_matches_recent_main(subject, recent_main_subjects)
+    ]
+    return len(matched) == len(subjects), matched
+
+
 def lookup_open_prs(
     repo: Path, branch: str | None, *, timeout: int, skip_gh: bool
 ) -> tuple[list[dict[str, Any]], bool, str | None]:
@@ -636,6 +714,24 @@ def classify_candidate(
             if patch_equivalent:
                 classification = "patch_equivalent_or_merged"
                 proof.append("branch is patch-equivalent to base")
+            elif context.smart_merge_detection:
+                smart_equivalent, matched_subjects = branch_subjects_match_recent_main(
+                    repo_path,
+                    context.base,
+                    rev or "HEAD",
+                    context.smart_merge_main_subjects,
+                    timeout=context.patch_timeout,
+                )
+                git.smart_merge_equivalent_to_base = smart_equivalent
+                if smart_equivalent:
+                    classification = "patch_equivalent_or_merged"
+                    proof.append(
+                        "all unique commit subjects match recent main squash-merge subjects"
+                    )
+                    links["smart_merge_matched_subjects"] = matched_subjects
+                else:
+                    classification = "unique_unharvested"
+                    proof.append("branch has unique commits or diff ahead of base")
             else:
                 classification = "unique_unharvested"
                 proof.append("branch has unique commits or diff ahead of base")
@@ -868,6 +964,7 @@ def inventory(
     git_timeout: int,
     gh_timeout: int,
     patch_timeout: int,
+    smart_merge_detection: bool = False,
 ) -> dict[str, Any]:
     repo = resolve_repo(repo)
     base_sha = resolve_ref(repo, base, timeout=git_timeout)
@@ -901,6 +998,12 @@ def inventory(
         git_timeout=git_timeout,
         gh_timeout=gh_timeout,
         patch_timeout=patch_timeout,
+        smart_merge_detection=smart_merge_detection,
+        smart_merge_main_subjects=(
+            recent_main_commit_subjects(repo, base, timeout=git_timeout)
+            if smart_merge_detection
+            else []
+        ),
     )
     candidates = [
         classify_candidate(
@@ -921,6 +1024,7 @@ def inventory(
         "base": base,
         "base_sha": base_sha,
         "size_mode": size_mode,
+        "smart_merge_detection": smart_merge_detection,
         "limit": limit,
         "summary": build_summary(candidates),
         "candidates": [asdict(candidate) for candidate in candidates],
@@ -1002,6 +1106,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--gh-timeout", type=int, default=30)
     parser.add_argument("--patch-timeout", type=int, default=45)
     parser.add_argument("--skip-gh", action="store_true")
+    parser.add_argument(
+        "--smart-merge-detection",
+        action="store_true",
+        help=(
+            "Reclassify ahead branches as patch_equivalent_or_merged when every "
+            "unique commit subject loosely matches a recent main squash-merge "
+            "subject. Default off to preserve legacy inventory behavior."
+        ),
+    )
     parser.add_argument("--write-ledger", action="store_true")
     parser.add_argument("--dry-run", action="store_true", help="Suppress ledger writes.")
     parser.add_argument("--json", action="store_true")
@@ -1027,6 +1140,7 @@ def main(argv: list[str] | None = None) -> int:
         git_timeout=args.git_timeout,
         gh_timeout=args.gh_timeout,
         patch_timeout=args.patch_timeout,
+        smart_merge_detection=args.smart_merge_detection,
     )
     if args.write_ledger and not args.dry_run:
         payload["ledger_written"] = write_ledger(args.ledger_root, payload)

--- a/tests/scripts/test_codex_worktree_value_inventory.py
+++ b/tests/scripts/test_codex_worktree_value_inventory.py
@@ -365,6 +365,152 @@ def test_patch_equivalent_ahead_work_is_cleanup_candidate(
     assert candidate.cleanup_candidate is True
 
 
+def test_smart_merge_detection_default_off_preserves_unique_harvest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_subjects_match_recent_main",
+        lambda *_args, **_kwargs: pytest.fail("smart detector should be opt-in"),
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=False,
+            smart_merge_main_subjects=["feat(scripts): already merged"],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.decision == "harvest_candidate"
+
+
+def test_smart_merge_detection_reclassifies_matching_subjects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_unique_commit_subjects",
+        lambda *_args, **_kwargs: [
+            "feat(scripts): list active sessions [lane: P42]",
+            "docs(status): inventory receipt [lane: P42]",
+        ],
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=[
+                "feat(scripts): list active sessions (#7260)",
+                "docs(status): inventory receipt (#7258)",
+            ],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "patch_equivalent_or_merged"
+    assert candidate.cleanup_candidate is True
+    assert candidate.git.smart_merge_equivalent_to_base is True
+    assert "all unique commit subjects match recent main squash-merge subjects" in candidate.proof
+    assert candidate.links["smart_merge_matched_subjects"] == [
+        "feat(scripts): list active sessions [lane: P42]",
+        "docs(status): inventory receipt [lane: P42]",
+    ]
+
+
+def test_smart_merge_detection_keeps_unmatched_subjects_harvestable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
+    monkeypatch.setattr(
+        mod,
+        "branch_unique_commit_subjects",
+        lambda *_args, **_kwargs: [
+            "feat(scripts): list active sessions",
+            "fix(swarm): new unmerged behavior",
+        ],
+    )
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=["feat(scripts): list active sessions (#7260)"],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.cleanup_candidate is False
+    assert candidate.git.smart_merge_equivalent_to_base is False
+
+
+def test_smart_merge_detection_log_failure_keeps_candidate_harvestable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_value_inventory as mod
+
+    root = _candidate(tmp_path)
+    _stub_clean_git(monkeypatch, ahead=2, patch_equivalent=False)
+    monkeypatch.setattr(mod, "branch_unique_commit_subjects", lambda *_args, **_kwargs: None)
+
+    candidate = mod.classify_candidate(
+        root,
+        context=_context(
+            tmp_path,
+            smart_merge_detection=True,
+            smart_merge_main_subjects=["feat(scripts): list active sessions (#7260)"],
+        ),
+        size_bytes=1024,
+        size_lookup_failed=False,
+    )
+
+    assert candidate.classification == "unique_unharvested"
+    assert candidate.decision == "harvest_candidate"
+
+
+def test_commit_subject_matching_is_loose_but_not_unbounded() -> None:
+    import codex_worktree_value_inventory as mod
+
+    main_subjects = [
+        "feat(scripts): list active sessions (#7260)",
+        "docs(status): inventory receipt (#7258)",
+    ]
+
+    assert mod.commit_subject_matches_recent_main(
+        "feat(scripts): list active sessions [lane: P42]",
+        main_subjects,
+    )
+    assert mod.commit_subject_matches_recent_main(
+        "docs(status): inventory receipt",
+        main_subjects,
+    )
+    assert not mod.commit_subject_matches_recent_main(
+        "fix(swarm): unrelated dispatch behavior",
+        main_subjects,
+    )
+
+
 def test_lookup_failure_preserves_candidate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -596,3 +742,12 @@ def test_build_parser_root_omitted_yields_none(tmp_path: Path) -> None:
     args = parser.parse_args([])
 
     assert args.root is None
+
+
+def test_build_parser_smart_merge_detection_default_off() -> None:
+    import codex_worktree_value_inventory as mod
+
+    parser = mod.build_parser()
+
+    assert parser.parse_args([]).smart_merge_detection is False
+    assert parser.parse_args(["--smart-merge-detection"]).smart_merge_detection is True


### PR DESCRIPTION
## Summary

Adds opt-in `--smart-merge-detection` to `scripts/codex_worktree_value_inventory.py` so squash-merged worktree branches can be reclassified from `unique_unharvested` to `patch_equivalent_or_merged` when every unique commit subject loosely matches recent `origin/main` squash-merge subjects.

Default behavior remains unchanged unless the new flag is passed.

## Dogfood Evidence

Ran against current canonical worktree inventory root:

```bash
python3 scripts/codex_worktree_value_inventory.py --repo /Users/armand/Development/aragora --root /Users/armand/Development/aragora/.worktrees/codex-auto --skip-gh --size-mode none --git-timeout 5 --patch-timeout 10 --json > /tmp/p42-inventory-baseline.json
python3 scripts/codex_worktree_value_inventory.py --repo /Users/armand/Development/aragora --root /Users/armand/Development/aragora/.worktrees/codex-auto --skip-gh --size-mode none --git-timeout 5 --patch-timeout 10 --smart-merge-detection --json > /tmp/p42-inventory-smart.json
```

Observed delta:

- Baseline: `harvest=36 cleanup=7 patch_equiv=4`
- Smart flag: `harvest=33 cleanup=10 patch_equiv=7`
- Reclassified 3 candidates, including known squash-merge false positives `droid/phase2-worktree-value-inventory-20260516v2` and `droid/phase3-list-active-agent-sessions-20260516`.

## Validation

```bash
python3 -m pytest tests/scripts/test_codex_worktree_value_inventory.py -q
python3 -m ruff check scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py
python3 -m ruff format --check scripts/codex_worktree_value_inventory.py tests/scripts/test_codex_worktree_value_inventory.py
python3 -m mypy scripts/codex_worktree_value_inventory.py --config-file=pyproject.toml
bash scripts/automation_pr_preflight.sh origin/main HEAD
```

All passed.

## Scope Control

- No worktree deletion.
- No branch deletion.
- No behavior change unless `--smart-merge-detection` is passed.
- No third-party dependency added.
