### PR TITLE
feat(scripts): add canonical metrics json flag

### DIFF
--- a/scripts/check_canonical_metrics.py
+++ b/scripts/check_canonical_metrics.py
@@ -8,6 +8,7 @@ via the existing DIC-14 ClaimVerifier infrastructure.
 Usage:
     python3 scripts/check_canonical_metrics.py --claim <claim_id>
     python3 scripts/check_canonical_metrics.py --all
+    python3 scripts/check_canonical_metrics.py --all --json
 
 Exit codes:
     0  all requested claims pass (or are within tolerance)
@@ -600,6 +601,14 @@ def main() -> int:
     parser.add_argument("--claim", help="Verify a single claim by id")
     parser.add_argument("--all", action="store_true", help="Verify every claim")
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit the canonical metrics receipt JSON to stdout. This is the default "
+            "output format; the flag exists for fan-out tooling compatibility."
+        ),
+    )
+    parser.add_argument(
         "--write-receipt",
         action="store_true",
         help=("Also write a receipt file to docs/status/generated/canonical_metrics/latest.json"),
@@ -621,14 +630,15 @@ def main() -> int:
     else:
         results = [check() for check in CHECKS.values()]
 
+    summary = {
+        "pass": sum(1 for r in results if r.status == "pass"),
+        "warn": sum(1 for r in results if r.status == "warn"),
+        "fail": sum(1 for r in results if r.status == "fail"),
+    }
     payload = {
         "manifest_id": "canonical_metrics",
         "results": [asdict(r) for r in results],
-        "summary": {
-            "pass": sum(1 for r in results if r.status == "pass"),
-            "warn": sum(1 for r in results if r.status == "warn"),
-            "fail": sum(1 for r in results if r.status == "fail"),
-        },
+        "summary": summary,
     }
     print(json.dumps(payload, sort_keys=True, indent=2))
 
@@ -638,7 +648,7 @@ def main() -> int:
             json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8"
         )
 
-    if payload["summary"]["fail"] > 0:
+    if summary["fail"] > 0:
         return 1
     return 0
 

--- a/tests/integration/test_canonical_metrics_manifest.py
+++ b/tests/integration/test_canonical_metrics_manifest.py
@@ -100,11 +100,32 @@ class TestCheckScriptRunsEndToEnd:
         assert "summary" in payload
         assert len(payload["results"]) >= 1
 
+    def test_json_flag_all_claims_produces_receipt_schema(self) -> None:
+        rc, payload = _run_check("--all", "--json")
+        assert rc in {0, 1}
+        assert payload["manifest_id"] == "canonical_metrics"
+        assert set(payload) == {"manifest_id", "results", "summary"}
+        assert payload["summary"]["pass"] + payload["summary"]["warn"] + payload["summary"][
+            "fail"
+        ] == len(payload["results"])
+
     def test_single_claim_mode_isolates_one_result(self) -> None:
         rc, payload = _run_check("--claim", "canonical.version.matches_pyproject")
         assert rc in {0, 1}
         assert len(payload["results"]) == 1
         assert payload["results"][0]["claim_id"] == "canonical.version.matches_pyproject"
+
+    def test_json_flag_single_claim_isolates_one_result(self) -> None:
+        rc, payload = _run_check("--claim", "canonical.version.matches_pyproject", "--json")
+        assert rc in {0, 1}
+        assert payload["manifest_id"] == "canonical_metrics"
+        assert len(payload["results"]) == 1
+        assert payload["results"][0]["claim_id"] == "canonical.version.matches_pyproject"
+
+    def test_json_flag_does_not_replace_claim_or_all(self) -> None:
+        rc, payload = _run_check("--json")
+        assert rc == 2
+        assert payload == {}
 
     def test_unknown_claim_returns_usage_error(self) -> None:
         rc, payload = _run_check("--claim", "not_a_real_claim")


### PR DESCRIPTION
## Summary
- add an explicit `--json` compatibility flag to `scripts/check_canonical_metrics.py`
- keep existing stdout receipt JSON behavior unchanged
- cover `--all --json`, single-claim `--json`, and usage-error behavior

## Validation
- `python3 -m pytest tests/integration/test_canonical_metrics_manifest.py -q`
- `python3 -m ruff check scripts/check_canonical_metrics.py tests/integration/test_canonical_metrics_manifest.py`
- `python3 -m ruff format --check scripts/check_canonical_metrics.py tests/integration/test_canonical_metrics_manifest.py`
- `python3 -m mypy scripts/check_canonical_metrics.py tests/integration/test_canonical_metrics_manifest.py --ignore-missing-imports --no-incremental`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Lane: P22-check-canonical-metrics-json-flag
Session: codex-7FFAEAF0