### PR TITLE
[AGT-05] Add DisputeWindowGate — settlement dispute-window enforcement (SD-4)

### DIFF
--- a/aragora/reputation/dispute_window.py
+++ b/aragora/reputation/dispute_window.py
@@ -1,0 +1,151 @@
+"""AGT-05 dispute-window gate — settlement step 4 (issue #6066).
+
+Per-domain dispute windows control when an agent may file a counter-attestation
+against a resolved claim.  Filings inside the window produce a
+:class:`DisputeRecord`; filings outside are rejected (settlement is final).
+
+Default windows (hours): prediction_market 72 | debate_position 48 | code_pr 24
+  crux_resolution 48 | km_contribution 24 | epistemic_claim 48
+
+Gate: ``ARAGORA_DISPUTE_WINDOW_ENABLED`` (default OFF).  No queue mutation.
+Advances: AGT-05 #6066 SD-4.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from aragora.reputation.types import (
+    DOMAIN_CODE_PR,
+    DOMAIN_CRUX_RESOLUTION,
+    DOMAIN_DEBATE_POSITION,
+    DOMAIN_EPISTEMIC_CLAIM,
+    DOMAIN_KM_CONTRIBUTION,
+    DOMAIN_PREDICTION_MARKET,
+    KNOWN_DOMAINS,
+)
+
+_FLAG = "ARAGORA_DISPUTE_WINDOW_ENABLED"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+DEFAULT_WINDOW_HOURS: dict[str, float] = {
+    DOMAIN_PREDICTION_MARKET: 72.0,
+    DOMAIN_DEBATE_POSITION: 48.0,
+    DOMAIN_CODE_PR: 24.0,
+    DOMAIN_CRUX_RESOLUTION: 48.0,
+    DOMAIN_KM_CONTRIBUTION: 24.0,
+    DOMAIN_EPISTEMIC_CLAIM: 48.0,
+}
+
+
+class DisputeWindowGateDisabledError(RuntimeError):
+    """Raised when the feature flag is off."""
+
+
+class UnknownDomainError(ValueError):
+    """Raised for domain strings not in :data:`~aragora.reputation.types.KNOWN_DOMAINS`."""
+
+
+@dataclass(frozen=True)
+class DisputeWindowPolicy:
+    """Per-domain window configuration; absent domains fall back to defaults."""
+
+    windows_hours: dict[str, float] = field(default_factory=dict)
+
+    def window_for(self, domain: str) -> float:
+        if domain not in KNOWN_DOMAINS:
+            raise UnknownDomainError(
+                f"unknown domain: {domain!r}; expected one of {sorted(KNOWN_DOMAINS)}"
+            )
+        return self.windows_hours.get(domain, DEFAULT_WINDOW_HOURS[domain])
+
+    @classmethod
+    def default(cls) -> "DisputeWindowPolicy":
+        return cls()
+
+
+@dataclass(frozen=True)
+class DisputeRecord:
+    """Eligibility result.  ``within_window=True`` → eligible for reversal path."""
+
+    claim_id: str
+    domain: str
+    resolved_at: str
+    filed_at: str
+    window_hours: float
+    elapsed_hours: float
+    within_window: bool
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            "domain": self.domain,
+            "resolved_at": self.resolved_at,
+            "filed_at": self.filed_at,
+            "window_hours": round(self.window_hours, 4),
+            "elapsed_hours": round(self.elapsed_hours, 4),
+            "within_window": self.within_window,
+            "evidence": dict(self.evidence),
+        }
+
+
+def dispute_window_enabled() -> bool:
+    return os.environ.get(_FLAG, "").strip().lower() in _TRUTHY
+
+
+def _parse_iso(ts: str) -> datetime:
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"cannot parse timestamp {ts!r}: {exc}") from exc
+    return dt.astimezone(UTC)
+
+
+class DisputeWindowGate:
+    """Flag-gated gate: checks whether a dispute filing is within the allowed window."""
+
+    def __init__(self, policy: DisputeWindowPolicy | None = None) -> None:
+        self._policy = policy or DisputeWindowPolicy.default()
+
+    def check(
+        self,
+        *,
+        claim_id: str,
+        domain: str,
+        resolved_at: str,
+        filed_at: str,
+        evidence: dict[str, Any] | None = None,
+    ) -> DisputeRecord:
+        if not dispute_window_enabled():
+            raise DisputeWindowGateDisabledError(
+                f"dispute window gate is disabled; set {_FLAG}=1 to enable"
+            )
+        window_hours = self._policy.window_for(domain)
+        resolved_dt = _parse_iso(resolved_at)
+        filed_dt = _parse_iso(filed_at)
+        elapsed = (filed_dt - resolved_dt) / timedelta(hours=1)
+        return DisputeRecord(
+            claim_id=claim_id,
+            domain=domain,
+            resolved_at=resolved_at,
+            filed_at=filed_at,
+            window_hours=window_hours,
+            elapsed_hours=elapsed,
+            within_window=elapsed <= window_hours,
+            evidence=dict(evidence or {}),
+        )
+
+
+__all__ = [
+    "DEFAULT_WINDOW_HOURS",
+    "DisputeRecord",
+    "DisputeWindowGate",
+    "DisputeWindowGateDisabledError",
+    "DisputeWindowPolicy",
+    "UnknownDomainError",
+    "dispute_window_enabled",
+]

--- a/tests/reputation/test_dispute_window.py
+++ b/tests/reputation/test_dispute_window.py
@@ -50,8 +50,10 @@ def test_check_raises_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(_FLAG, raising=False)
     with pytest.raises(DisputeWindowGateDisabledError, match=_FLAG):
         DisputeWindowGate().check(
-            claim_id=_CLAIM, domain=DOMAIN_PREDICTION_MARKET,
-            resolved_at=_RESOLVED, filed_at=_t(12),
+            claim_id=_CLAIM,
+            domain=DOMAIN_PREDICTION_MARKET,
+            resolved_at=_RESOLVED,
+            filed_at=_t(12),
         )
 
 
@@ -84,22 +86,28 @@ def gate(monkeypatch: pytest.MonkeyPatch) -> DisputeWindowGate:
     return DisputeWindowGate()
 
 
-@pytest.mark.parametrize("domain,filed_h", [
-    (DOMAIN_PREDICTION_MARKET, 36),
-    (DOMAIN_PREDICTION_MARKET, 72),   # boundary inclusive
-    (DOMAIN_CODE_PR, 10),
-    (DOMAIN_CRUX_RESOLUTION, 1),
-])
+@pytest.mark.parametrize(
+    "domain,filed_h",
+    [
+        (DOMAIN_PREDICTION_MARKET, 36),
+        (DOMAIN_PREDICTION_MARKET, 72),  # boundary inclusive
+        (DOMAIN_CODE_PR, 10),
+        (DOMAIN_CRUX_RESOLUTION, 1),
+    ],
+)
 def test_within_window(gate: DisputeWindowGate, domain: str, filed_h: float) -> None:
     r = gate.check(claim_id=_CLAIM, domain=domain, resolved_at=_RESOLVED, filed_at=_t(filed_h))
     assert r.within_window is True
 
 
-@pytest.mark.parametrize("domain,filed_h", [
-    (DOMAIN_PREDICTION_MARKET, 73),
-    (DOMAIN_CODE_PR, 25),
-    (DOMAIN_KM_CONTRIBUTION, 25),
-])
+@pytest.mark.parametrize(
+    "domain,filed_h",
+    [
+        (DOMAIN_PREDICTION_MARKET, 73),
+        (DOMAIN_CODE_PR, 25),
+        (DOMAIN_KM_CONTRIBUTION, 25),
+    ],
+)
 def test_outside_window(gate: DisputeWindowGate, domain: str, filed_h: float) -> None:
     r = gate.check(claim_id=_CLAIM, domain=domain, resolved_at=_RESOLVED, filed_at=_t(filed_h))
     assert r.within_window is False
@@ -107,23 +115,34 @@ def test_outside_window(gate: DisputeWindowGate, domain: str, filed_h: float) ->
 
 def test_negative_elapsed_is_within(gate: DisputeWindowGate) -> None:
     r = gate.check(
-        claim_id=_CLAIM, domain=DOMAIN_PREDICTION_MARKET,
-        resolved_at=_RESOLVED, filed_at=_t(-1),
+        claim_id=_CLAIM,
+        domain=DOMAIN_PREDICTION_MARKET,
+        resolved_at=_RESOLVED,
+        filed_at=_t(-1),
     )
     assert r.within_window is True and r.elapsed_hours < 0
 
 
 def test_record_fields_and_to_dict(gate: DisputeWindowGate) -> None:
     r = gate.check(
-        claim_id="clm_xyz", domain=DOMAIN_CODE_PR,
-        resolved_at=_RESOLVED, filed_at=_t(10), evidence={"src": "oracle"},
+        claim_id="clm_xyz",
+        domain=DOMAIN_CODE_PR,
+        resolved_at=_RESOLVED,
+        filed_at=_t(10),
+        evidence={"src": "oracle"},
     )
     assert r.claim_id == "clm_xyz"
     assert abs(r.elapsed_hours - 10.0) < 0.01
     assert r.evidence["src"] == "oracle"
     assert set(r.to_dict()) == {
-        "claim_id", "domain", "resolved_at", "filed_at",
-        "window_hours", "elapsed_hours", "within_window", "evidence",
+        "claim_id",
+        "domain",
+        "resolved_at",
+        "filed_at",
+        "window_hours",
+        "elapsed_hours",
+        "within_window",
+        "evidence",
     }
 
 
@@ -131,18 +150,23 @@ def test_custom_narrow_window_rejects(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(_FLAG, "1")
     gate = DisputeWindowGate(DisputeWindowPolicy({DOMAIN_PREDICTION_MARKET: 1.0}))
     assert not gate.check(
-        claim_id=_CLAIM, domain=DOMAIN_PREDICTION_MARKET,
-        resolved_at=_RESOLVED, filed_at=_t(2),
+        claim_id=_CLAIM,
+        domain=DOMAIN_PREDICTION_MARKET,
+        resolved_at=_RESOLVED,
+        filed_at=_t(2),
     ).within_window
 
 
 def test_unknown_domain_through_gate(gate: DisputeWindowGate) -> None:
     with pytest.raises(UnknownDomainError):
-        gate.check(claim_id=_CLAIM, domain="bad_domain",
-                   resolved_at=_RESOLVED, filed_at=_t(1))
+        gate.check(claim_id=_CLAIM, domain="bad_domain", resolved_at=_RESOLVED, filed_at=_t(1))
 
 
 def test_malformed_timestamp_raises(gate: DisputeWindowGate) -> None:
     with pytest.raises(ValueError, match="cannot parse"):
-        gate.check(claim_id=_CLAIM, domain=DOMAIN_PREDICTION_MARKET,
-                   resolved_at="not-a-date", filed_at=_t(1))
+        gate.check(
+            claim_id=_CLAIM,
+            domain=DOMAIN_PREDICTION_MARKET,
+            resolved_at="not-a-date",
+            filed_at=_t(1),
+        )

--- a/tests/reputation/test_dispute_window.py
+++ b/tests/reputation/test_dispute_window.py
@@ -1,0 +1,148 @@
+"""Tests for aragona.reputation.dispute_window (AGT-05 #6066 SD-4)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.reputation.dispute_window import (
+    DEFAULT_WINDOW_HOURS,
+    DisputeWindowGate,
+    DisputeWindowGateDisabledError,
+    DisputeWindowPolicy,
+    UnknownDomainError,
+    dispute_window_enabled,
+)
+from aragora.reputation.types import (
+    DOMAIN_CODE_PR,
+    DOMAIN_CRUX_RESOLUTION,
+    DOMAIN_KM_CONTRIBUTION,
+    DOMAIN_PREDICTION_MARKET,
+    KNOWN_DOMAINS,
+)
+
+_FLAG = "ARAGORA_DISPUTE_WINDOW_ENABLED"
+_BASE = datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC)
+_RESOLVED = "2026-05-01T00:00:00Z"
+_CLAIM = "clm_test_abc123"
+
+
+def _t(hours: float) -> str:
+    return (_BASE + timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --- Flag gating ---
+
+
+def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    assert not dispute_window_enabled()
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_truthy_values_enable(monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+    monkeypatch.setenv(_FLAG, val)
+    assert dispute_window_enabled()
+
+
+def test_check_raises_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_FLAG, raising=False)
+    with pytest.raises(DisputeWindowGateDisabledError, match=_FLAG):
+        DisputeWindowGate().check(
+            claim_id=_CLAIM, domain=DOMAIN_PREDICTION_MARKET,
+            resolved_at=_RESOLVED, filed_at=_t(12),
+        )
+
+
+# --- Policy ---
+
+
+def test_default_policy_covers_all_known_domains() -> None:
+    policy = DisputeWindowPolicy.default()
+    for d in KNOWN_DOMAINS:
+        assert policy.window_for(d) > 0
+
+
+def test_custom_policy_overrides_and_falls_back() -> None:
+    policy = DisputeWindowPolicy(windows_hours={DOMAIN_PREDICTION_MARKET: 12.0})
+    assert policy.window_for(DOMAIN_PREDICTION_MARKET) == 12.0
+    assert policy.window_for(DOMAIN_CODE_PR) == DEFAULT_WINDOW_HOURS[DOMAIN_CODE_PR]
+
+
+def test_unknown_domain_raises() -> None:
+    with pytest.raises(UnknownDomainError, match="unknown domain"):
+        DisputeWindowPolicy.default().window_for("not_a_domain")
+
+
+# --- Gate checks ---
+
+
+@pytest.fixture
+def gate(monkeypatch: pytest.MonkeyPatch) -> DisputeWindowGate:
+    monkeypatch.setenv(_FLAG, "1")
+    return DisputeWindowGate()
+
+
+@pytest.mark.parametrize("domain,filed_h", [
+    (DOMAIN_PREDICTION_MARKET, 36),
+    (DOMAIN_PREDICTION_MARKET, 72),   # boundary inclusive
+    (DOMAIN_CODE_PR, 10),
+    (DOMAIN_CRUX_RESOLUTION, 1),
+])
+def test_within_window(gate: DisputeWindowGate, domain: str, filed_h: float) -> None:
+    r = gate.check(claim_id=_CLAIM, domain=domain, resolved_at=_RESOLVED, filed_at=_t(filed_h))
+    assert r.within_window is True
+
+
+@pytest.mark.parametrize("domain,filed_h", [
+    (DOMAIN_PREDICTION_MARKET, 73),
+    (DOMAIN_CODE_PR, 25),
+    (DOMAIN_KM_CONTRIBUTION, 25),
+])
+def test_outside_window(gate: DisputeWindowGate, domain: str, filed_h: float) -> None:
+    r = gate.check(claim_id=_CLAIM, domain=domain, resolved_at=_RESOLVED, filed_at=_t(filed_h))
+    assert r.within_window is False
+
+
+def test_negative_elapsed_is_within(gate: DisputeWindowGate) -> None:
+    r = gate.check(
+        claim_id=_CLAIM, domain=DOMAIN_PREDICTION_MARKET,
+        resolved_at=_RESOLVED, filed_at=_t(-1),
+    )
+    assert r.within_window is True and r.elapsed_hours < 0
+
+
+def test_record_fields_and_to_dict(gate: DisputeWindowGate) -> None:
+    r = gate.check(
+        claim_id="clm_xyz", domain=DOMAIN_CODE_PR,
+        resolved_at=_RESOLVED, filed_at=_t(10), evidence={"src": "oracle"},
+    )
+    assert r.claim_id == "clm_xyz"
+    assert abs(r.elapsed_hours - 10.0) < 0.01
+    assert r.evidence["src"] == "oracle"
+    assert set(r.to_dict()) == {
+        "claim_id", "domain", "resolved_at", "filed_at",
+        "window_hours", "elapsed_hours", "within_window", "evidence",
+    }
+
+
+def test_custom_narrow_window_rejects(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_FLAG, "1")
+    gate = DisputeWindowGate(DisputeWindowPolicy({DOMAIN_PREDICTION_MARKET: 1.0}))
+    assert not gate.check(
+        claim_id=_CLAIM, domain=DOMAIN_PREDICTION_MARKET,
+        resolved_at=_RESOLVED, filed_at=_t(2),
+    ).within_window
+
+
+def test_unknown_domain_through_gate(gate: DisputeWindowGate) -> None:
+    with pytest.raises(UnknownDomainError):
+        gate.check(claim_id=_CLAIM, domain="bad_domain",
+                   resolved_at=_RESOLVED, filed_at=_t(1))
+
+
+def test_malformed_timestamp_raises(gate: DisputeWindowGate) -> None:
+    with pytest.raises(ValueError, match="cannot parse"):
+        gate.check(claim_id=_CLAIM, domain=DOMAIN_PREDICTION_MARKET,
+                   resolved_at="not-a-date", filed_at=_t(1))


### PR DESCRIPTION
## Slice

Adds `aragora/reputation/dispute_window.py` — a flag-gated gate implementing the "time is part of settlement" doctrine from `docs/plans/SKIN_IN_THE_GAME_REPUTATION.md`. Per-domain dispute windows (prediction_market 72 h, debate_position 48 h, code_pr / km_contribution 24 h, crux_resolution / epistemic_claim 48 h) determine whether a counter-attestation filing is eligible for the reversal path or rejected because the settlement is final.

## Gating

- Default: **OFF** (flag: `ARAGORA_DISPUTE_WINDOW_ENABLED`)
- Live queue effect: **none** — pure in-memory eligibility check; no writes to any store, no dispatch mutation, no queue mutation
- Advances issue: #6066 (AGT-05 — skin-in-the-game reputation flow), sub-deliverable 4 — settlement-window enforcement

## Tests

- `test_disabled_by_default` — flag absent → gate disabled
- `test_truthy_values_enable[1/true/yes/on]` — all four truthy values activate
- `test_check_raises_when_disabled` — `DisputeWindowGateDisabledError` raised with flag name in message
- `test_default_policy_covers_all_known_domains` — every `KNOWN_DOMAINS` entry has a positive window
- `test_custom_policy_overrides_and_falls_back` — custom window applies; other domains fall back to defaults
- `test_unknown_domain_raises` — `UnknownDomainError` for unrecognised domain string
- `test_within_window[4 parametrized cases]` — within boundary + exactly at boundary treated as eligible
- `test_outside_window[3 parametrized cases]` — past-window filings produce `within_window=False`
- `test_negative_elapsed_is_within` — filing before resolution is always eligible
- `test_record_fields_and_to_dict` — `claim_id`, `elapsed_hours`, `evidence`, and `to_dict` keys verified
- `test_custom_narrow_window_rejects` — tight custom policy overrides generous default
- `test_unknown_domain_through_gate` — gate propagates `UnknownDomainError` from policy
- `test_malformed_timestamp_raises` — `ValueError` with "cannot parse" for bad ISO strings

## Validation

- `pytest tests/reputation/test_dispute_window.py --noconftest` — **21 passed**
- `ruff check aragora/reputation/dispute_window.py tests/reputation/test_dispute_window.py` — clean
- `mypy aragora/reputation/dispute_window.py tests/reputation/test_dispute_window.py --ignore-missing-imports` — clean
- Net diff: **299 LOC** (151-line implementation + 148-line test file)

## Out of scope

- Persisting `DisputeRecord` to disk or any store — deferred; callers own the record
- Executing the actual reversal (step 7 — handled by `ReputationStore.reverse_delta`, already on main via the `agt-05-claim-verifier-bridge-followup` branch)
- Network calls or HTTP attestation verification — deferred to the oracle wiring slice
- Hard slashing policy — remains soft (downweight) until an explicit operator decision enables it

Labels: `vision-layer`

---
_Generated by [Claude Code](https://claude.ai/code/session_011zFj45dGqeQHShCZ16BF4W)_