### PR TITLE
fix(agent-bridge): count repo-local active lanes in snapshot

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -95,6 +95,23 @@ def _bridge_file_for_read(default_path: Path) -> Path:
     return default_path
 
 
+def _bridge_files_for_lane_read() -> list[Path]:
+    """Return all lane-registry locations that can contain live claims."""
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for path in (LANE_REGISTRY_FILE, _state_root_bridge_dir() / LANE_REGISTRY_FILE.name):
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if path.exists():
+            paths.append(path)
+    return paths or [LANE_REGISTRY_FILE]
+
+
 def _bridge_file_for_write(default_path: Path) -> Path:
     try:
         _assert_writable_dir(default_path.parent)
@@ -388,16 +405,46 @@ def _is_current_session(session: Session) -> bool:
 
 
 def _load_lane_registry() -> list[LaneRecord]:
-    registry_file = _bridge_file_for_read(LANE_REGISTRY_FILE)
-    if not registry_file.exists():
-        return []
-    try:
-        payload = json.loads(registry_file.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return []
-    if not isinstance(payload, list):
-        return []
-    return [LaneRecord.from_dict(item) for item in payload if isinstance(item, dict)]
+    merged: dict[str, tuple[LaneRecord, int]] = {}
+    anonymous: list[LaneRecord] = []
+
+    for source_index, registry_file in enumerate(_bridge_files_for_lane_read()):
+        if not registry_file.exists():
+            continue
+        try:
+            payload = json.loads(registry_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, list):
+            continue
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            record = LaneRecord.from_dict(item)
+            if not record.lane_id:
+                anonymous.append(record)
+                continue
+            current = merged.get(record.lane_id)
+            if current is None or _prefer_lane_record(record, source_index, current):
+                merged[record.lane_id] = (record, source_index)
+
+    return anonymous + [record for record, _source_index in merged.values()]
+
+
+def _prefer_lane_record(
+    candidate: LaneRecord,
+    candidate_source_index: int,
+    current: tuple[LaneRecord, int],
+) -> bool:
+    current_record, current_source_index = current
+    candidate_ts = _parse_timestamp(candidate.updated_at)
+    current_ts = _parse_timestamp(current_record.updated_at)
+    if candidate_ts is not None and current_ts is not None and candidate_ts != current_ts:
+        return candidate_ts > current_ts
+    # Later sources are repo-local fallbacks; prefer them when timestamps are
+    # missing or tied so claim_active_agent_lane.py writes cannot be shadowed by
+    # stale user-level bridge state.
+    return candidate_source_index >= current_source_index
 
 
 def _write_lane_registry(records: list[LaneRecord]) -> None:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -26,6 +26,7 @@ def _patch_bridge_paths(mod, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(mod, "AGENT_BRIDGE_DIR", bridge_dir)
     monkeypatch.setattr(mod, "SESSION_SNAPSHOT_FILE", bridge_dir / "sessions.json")
     monkeypatch.setattr(mod, "LANE_REGISTRY_FILE", bridge_dir / "lanes.json")
+    monkeypatch.setattr(mod, "CANONICAL_REPO_ROOT", tmp_path / "repo")
 
 
 def test_send_tmux_multiline_uses_delete_on_paste_buffer_transport(
@@ -419,6 +420,69 @@ def test_operator_snapshot_summary_only_json_omits_records(
     assert payload["process_census"] == {"ok": True, "total": 0, "by_role": {}}
     assert payload["health"] == {"ok": True, "issues": []}
     assert discover_include_summaries == [False]
+
+
+def test_operator_snapshot_summary_counts_repo_local_lane_when_user_registry_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    user_bridge_dir = tmp_path / "user-bridge"
+    repo_root = tmp_path / "repo"
+    repo_bridge_dir = repo_root / ".aragora" / "agent-bridge"
+    user_bridge_dir.mkdir(parents=True)
+    repo_bridge_dir.mkdir(parents=True)
+    monkeypatch.delenv("ARAGORA_AUTOMATION_STATE_ROOT", raising=False)
+    monkeypatch.setattr(mod, "AGENT_BRIDGE_DIR", user_bridge_dir)
+    monkeypatch.setattr(mod, "SESSION_SNAPSHOT_FILE", user_bridge_dir / "sessions.json")
+    monkeypatch.setattr(mod, "LANE_REGISTRY_FILE", user_bridge_dir / "lanes.json")
+    monkeypatch.setattr(mod, "CANONICAL_REPO_ROOT", repo_root)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "stale-user-lane",
+                    "owner_session": "codex-old",
+                    "status": "completed",
+                    "updated_at": "2026-05-18T12:00:00Z",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (repo_bridge_dir / "lanes.json").write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "repo-local-active",
+                    "owner_session": "codex-active",
+                    "status": "active",
+                    "updated_at": "2026-05-18T12:10:00Z",
+                    "branch": "codex/repo-local-active",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 0,
+            "by_role": {},
+        },
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "lanes" not in payload
+    assert payload["summary"]["active_lanes"] == 1
 
 
 def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(


### PR DESCRIPTION
Fixes operator-snapshot summary parity with repo-local active lane registry. See validation notes.