### PR TITLE
P53: claim-helper env-var auto-populate (Phase E)

### DIFF
--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -63,6 +63,21 @@ To release a lane, write a ``--status released`` claim with the same
 ``lane_id`` and ``owner_session``. To mark a conflict, write a
 ``--status conflict --conflict-session <other> --conflict-reason <text>``
 claim.
+
+Env-var fallbacks for identity fields (Phase E of the agent-steering
+primitive): when these CLI flags are omitted, the helper auto-populates
+them from canonical env vars at claim time. CLI flags always win when
+both are supplied; env vars are pure fallback. Mapping:
+
+================= =========================  =============================
+Env var           CLI flag (precedence)      LaneRecord field
+================= =========================  =============================
+CODEX_THREAD_ID         --codex-thread-id         codex_thread_id
+CODEX_ROLLOUT_PATH      --codex-rollout-path      codex_rollout_path
+CLAUDE_SESSION_ID       --session-title           session_title (fallback)
+FACTORY_DROID_SESSION   --desktop-label           desktop_label (fallback)
+ARAGORA_SESSION_ID      --owner-session           (already required CLI)
+================= =========================  =============================
 """
 
 from __future__ import annotations
@@ -382,6 +397,33 @@ def claim_lane(
         return normalized
 
 
+def _identity_fields_from_env() -> dict[str, str | None]:
+    """Auto-populate richer identity fields from canonical env vars when
+    the operator/agent left them off the CLI.
+
+    Mapping (env var -> argparse attribute -> LaneRecord field):
+
+    - ``CODEX_THREAD_ID``       -> ``codex_thread_id``    -> ``codex_thread_id``
+    - ``CODEX_ROLLOUT_PATH``    -> ``codex_rollout_path`` -> ``codex_rollout_path``
+    - ``CLAUDE_SESSION_ID``     -> ``session_title``      -> ``session_title`` (fallback)
+    - ``FACTORY_DROID_SESSION`` -> ``desktop_label``      -> ``desktop_label`` (fallback)
+
+    ``ARAGORA_SESSION_ID`` is intentionally not handled here: it is the
+    operator-facing primary identifier already passed via ``--owner-session``
+    (which is a required CLI flag), so an env-var fallback would create a
+    silent default that defeats the explicit-claim contract.
+
+    Returns a dict keyed by argparse attribute name so the caller can merge
+    the mapping into ``args`` without having to translate flag names.
+    """
+    return {
+        "codex_thread_id": os.environ.get("CODEX_THREAD_ID") or None,
+        "codex_rollout_path": os.environ.get("CODEX_ROLLOUT_PATH") or None,
+        "session_title": os.environ.get("CLAUDE_SESSION_ID") or None,
+        "desktop_label": os.environ.get("FACTORY_DROID_SESSION") or None,
+    }
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--lane-id", default="")
@@ -477,6 +519,10 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    env_fields = _identity_fields_from_env()
+    for cli_arg, value in env_fields.items():
+        if value and not getattr(args, cli_arg, None):
+            setattr(args, cli_arg, value)
     registry_path = resolve_registry_path(
         repo_root=args.repo_root,
         explicit=args.registry_path,

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -584,3 +584,248 @@ def test_explicit_registry_path_wins(tmp_path: Path) -> None:
     override = tmp_path / "override.json"
     actual = claim_module.resolve_registry_path(repo_root=repo_root, explicit=override)
     assert actual == override
+
+
+# --- Phase E: env-var auto-populate for identity fields -------------------
+
+ENV_IDENTITY_VARS = (
+    "CODEX_THREAD_ID",
+    "CODEX_ROLLOUT_PATH",
+    "CLAUDE_SESSION_ID",
+    "FACTORY_DROID_SESSION",
+)
+
+
+@pytest.fixture()
+def clean_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip the identity-fallback env vars so each test starts from a
+    known baseline. Tests then set only the env vars they exercise."""
+    for name in ENV_IDENTITY_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_env_codex_thread_id_populates_field(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_identity_env: None,
+) -> None:
+    """CODEX_THREAD_ID env var is auto-applied to codex_thread_id when
+    the --codex-thread-id CLI flag is absent."""
+    registry = tmp_path / "lanes.json"
+    monkeypatch.setenv("CODEX_THREAD_ID", "env-thread-uuid-aaa")
+
+    rc = claim_module.main(
+        [
+            "--lane-id",
+            "phase-env-1",
+            "--owner-session",
+            "owner-env-1",
+            "--registry-path",
+            str(registry),
+            "--status",
+            "active",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    assert payload[0]["codex_thread_id"] == "env-thread-uuid-aaa"
+
+
+def test_cli_codex_thread_id_wins_over_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_identity_env: None,
+) -> None:
+    """When both --codex-thread-id and CODEX_THREAD_ID are supplied, the
+    CLI flag wins. Env vars are pure fallback."""
+    registry = tmp_path / "lanes.json"
+    monkeypatch.setenv("CODEX_THREAD_ID", "env-loses")
+
+    rc = claim_module.main(
+        [
+            "--lane-id",
+            "phase-env-2",
+            "--owner-session",
+            "owner-env-2",
+            "--registry-path",
+            str(registry),
+            "--codex-thread-id",
+            "cli-wins",
+            "--status",
+            "active",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    assert payload[0]["codex_thread_id"] == "cli-wins"
+
+
+def test_missing_env_and_cli_leaves_codex_thread_id_unset(
+    tmp_path: Path,
+    clean_identity_env: None,
+) -> None:
+    """When neither the env var nor the CLI flag supplies a value, the
+    identity field stays absent from the persisted row (the schema
+    normalizer drops empty/None values)."""
+    registry = tmp_path / "lanes.json"
+    rc = claim_module.main(
+        [
+            "--lane-id",
+            "phase-env-3",
+            "--owner-session",
+            "owner-env-3",
+            "--registry-path",
+            str(registry),
+            "--status",
+            "active",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    assert "codex_thread_id" not in payload[0]
+
+
+def test_factory_droid_session_populates_desktop_label(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_identity_env: None,
+) -> None:
+    """FACTORY_DROID_SESSION env var falls back into desktop_label when
+    --desktop-label is absent."""
+    registry = tmp_path / "lanes.json"
+    monkeypatch.setenv("FACTORY_DROID_SESSION", "Droid-A")
+
+    rc = claim_module.main(
+        [
+            "--lane-id",
+            "phase-env-4",
+            "--owner-session",
+            "owner-env-4",
+            "--registry-path",
+            str(registry),
+            "--status",
+            "active",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    assert payload[0]["desktop_label"] == "Droid-A"
+
+
+def test_cli_desktop_label_wins_over_factory_droid_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_identity_env: None,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    monkeypatch.setenv("FACTORY_DROID_SESSION", "Droid-loses")
+
+    rc = claim_module.main(
+        [
+            "--lane-id",
+            "phase-env-5",
+            "--owner-session",
+            "owner-env-5",
+            "--registry-path",
+            str(registry),
+            "--desktop-label",
+            "CLI-wins",
+            "--status",
+            "active",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    assert payload[0]["desktop_label"] == "CLI-wins"
+
+
+def test_claude_session_id_populates_session_title_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_identity_env: None,
+) -> None:
+    """CLAUDE_SESSION_ID env var falls back into session_title when
+    --session-title is absent."""
+    registry = tmp_path / "lanes.json"
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "claude-fallback-title")
+
+    rc = claim_module.main(
+        [
+            "--lane-id",
+            "phase-env-6",
+            "--owner-session",
+            "owner-env-6",
+            "--registry-path",
+            str(registry),
+            "--status",
+            "active",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    assert payload[0]["session_title"] == "claude-fallback-title"
+
+
+def test_codex_rollout_path_env_populates_field(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_identity_env: None,
+) -> None:
+    registry = tmp_path / "lanes.json"
+    monkeypatch.setenv("CODEX_ROLLOUT_PATH", "/Users/armand/.codex/sessions/env-rollout.jsonl")
+
+    rc = claim_module.main(
+        [
+            "--lane-id",
+            "phase-env-7",
+            "--owner-session",
+            "owner-env-7",
+            "--registry-path",
+            str(registry),
+            "--status",
+            "active",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    assert payload[0]["codex_rollout_path"].endswith("env-rollout.jsonl")
+
+
+def test_identity_fields_from_env_helper_returns_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    clean_identity_env: None,
+) -> None:
+    """Direct unit test of the helper: each env var should map to the
+    matching argparse attribute name, with absent vars producing None."""
+    monkeypatch.setenv("CODEX_THREAD_ID", "t-uuid")
+    monkeypatch.setenv("FACTORY_DROID_SESSION", "Droid-X")
+    # CODEX_ROLLOUT_PATH and CLAUDE_SESSION_ID intentionally unset
+
+    mapping = claim_module._identity_fields_from_env()
+    assert mapping["codex_thread_id"] == "t-uuid"
+    assert mapping["desktop_label"] == "Droid-X"
+    assert mapping["codex_rollout_path"] is None
+    assert mapping["session_title"] is None
+
+
+def test_existing_claim_flow_unaffected_when_env_unset(
+    tmp_registry: Path,
+    clean_identity_env: None,
+) -> None:
+    """Regression: with all identity env vars unset, the original
+    programmatic claim_lane() flow still produces the same shape as before
+    (no spurious identity fields injected by the helper)."""
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="regression-lane",
+        owner_session="owner-regression",
+        goal="g",
+        source="s",
+        status="active",
+    )
+    payload = json.loads(tmp_registry.read_text(encoding="utf-8"))
+    assert payload[0]["lane_id"] == "regression-lane"
+    assert "codex_thread_id" not in payload[0]
+    assert "desktop_label" not in payload[0]
+    assert "session_title" not in payload[0]
+    assert "codex_rollout_path" not in payload[0]


### PR DESCRIPTION
## Summary
- Phase E of the agent-steering primitive: `scripts/claim_active_agent_lane.py` now auto-populates identity fields from canonical env vars when the matching CLI flags are omitted.
- Mapping (env -> CLI -> LaneRecord field):
  - `CODEX_THREAD_ID` -> `--codex-thread-id` -> `codex_thread_id`
  - `CODEX_ROLLOUT_PATH` -> `--codex-rollout-path` -> `codex_rollout_path`
  - `CLAUDE_SESSION_ID` -> `--session-title` -> `session_title` (fallback)
  - `FACTORY_DROID_SESSION` -> `--desktop-label` -> `desktop_label` (fallback)
- `ARAGORA_SESSION_ID` intentionally has no env fallback: it is the operator-facing primary identifier already passed via the required `--owner-session` flag.

## Constraints honored
- Additive only: CLI flags retain precedence; env vars are pure fallback.
- No lane registry schema change.
- No change to the atomic-write path.
- Pure stdlib; no new imports (uses existing `os`).
- Single-file production edit (`scripts/claim_active_agent_lane.py`); tests extend the existing module.

## Test plan
- [x] `python3 -m pytest tests/scripts/test_claim_active_agent_lane.py -q` (37 passed, was 28)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy scripts/claim_active_agent_lane.py` clean
- [x] `bash scripts/automation_pr_preflight.sh origin/main HEAD` clean
- [x] Smoke test: `CODEX_THREAD_ID=test-thread-uuid` invocation produces `codex_thread_id = test-thread-uuid` in the persisted row

## Tests added
- `test_env_codex_thread_id_populates_field` — env -> field when CLI absent
- `test_cli_codex_thread_id_wins_over_env` — CLI precedence over env
- `test_missing_env_and_cli_leaves_codex_thread_id_unset` — neither -> field stays absent (normalized out)
- `test_factory_droid_session_populates_desktop_label` — `FACTORY_DROID_SESSION` -> `desktop_label`
- `test_cli_desktop_label_wins_over_factory_droid_session` — CLI precedence for desktop_label
- `test_claude_session_id_populates_session_title_fallback` — `CLAUDE_SESSION_ID` -> `session_title`
- `test_codex_rollout_path_env_populates_field` — `CODEX_ROLLOUT_PATH` -> `codex_rollout_path`
- `test_identity_fields_from_env_helper_returns_mapping` — direct unit test of the helper
- `test_existing_claim_flow_unaffected_when_env_unset` — regression: nothing injected when all env vars are unset

## Out of scope
- `scripts/agent_bridge.py` (codex P47 lane)
- `scripts/identify_lane_owner.py`, `scripts/send_operator_steering.py` (Phases A/B frozen)
- `docs/AGENT_STEERING.md` (Phase D / P52 ships the canonical doc)

[lane: P53-claim-helper-env-var-auto-populate]