### PR TITLE
feat(scripts): stabilize agent ownership lookup

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -13,6 +13,7 @@ Usage:
   python3 scripts/agent_bridge.py read <name> [--lines 20]
   python3 scripts/agent_bridge.py read-all [--lines 3] [--json]
   python3 scripts/agent_bridge.py lanes [--json]
+  python3 scripts/agent_bridge.py owner --pr 7292 [--json]
   python3 scripts/agent_bridge.py processes [--json]
   python3 scripts/agent_bridge.py tmux-map
   python3 scripts/agent_bridge.py health [--json]
@@ -468,6 +469,148 @@ def _sync_lane_records(records: list[LaneRecord], sessions: list[Session]) -> li
             record.worktree = live.worktree
             record.pr_number = live.pr_number
     return records
+
+
+def _head_for_worktree(path: str | Path | None) -> str | None:
+    if not path:
+        return None
+    worktree = Path(path)
+    if not worktree.is_dir():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    head = result.stdout.strip()
+    return head or None
+
+
+def _worktree_matches(record_worktree: str, query_worktree: str | None) -> bool:
+    if not query_worktree:
+        return False
+    if record_worktree == query_worktree:
+        return True
+    try:
+        return Path(record_worktree).resolve() == Path(query_worktree).resolve()
+    except OSError:
+        return False
+
+
+def _record_matches_owner_query(
+    record: LaneRecord,
+    *,
+    pr_number: int | None,
+    branch: str | None,
+    worktree: str | None,
+) -> bool:
+    if record.status not in ACTIVE_LANE_STATUSES:
+        return False
+    if pr_number is not None and record.pr_number == pr_number:
+        return True
+    if branch and record.branch == branch:
+        return True
+    return bool(record.worktree and _worktree_matches(record.worktree, worktree))
+
+
+def _owner_action_for(record: LaneRecord) -> str:
+    return (
+        f"route mutation/comment work to owner_session {record.owner_session}; "
+        "non-owners should stop or request release"
+    )
+
+
+def _unowned_owner_payload(
+    *,
+    pr_number: int | None,
+    branch: str | None,
+    worktree: str | None,
+) -> dict[str, Any]:
+    return {
+        "owner_status": "unowned",
+        "active_owner": False,
+        "lane_id": None,
+        "owner_session": None,
+        "pr_number": pr_number,
+        "branch": branch,
+        "worktree": worktree,
+        "head": None,
+        "status": None,
+        "updated_at": None,
+        "recommended_operator_action": "no active owner found; claim the lane before mutation",
+    }
+
+
+def _owned_owner_payload(record: LaneRecord) -> dict[str, Any]:
+    return {
+        "owner_status": "owned",
+        "active_owner": True,
+        "lane_id": record.lane_id,
+        "owner_session": record.owner_session,
+        "pr_number": record.pr_number,
+        "branch": record.branch or None,
+        "worktree": record.worktree or None,
+        "head": _head_for_worktree(record.worktree),
+        "status": record.status,
+        "updated_at": record.updated_at or None,
+        "recommended_operator_action": _owner_action_for(record),
+    }
+
+
+def _conflicted_owner_payload(records: list[LaneRecord]) -> dict[str, Any]:
+    lane_ids = sorted({record.lane_id for record in records if record.lane_id})
+    owner_sessions = sorted({record.owner_session for record in records if record.owner_session})
+    branches = sorted({record.branch for record in records if record.branch})
+    worktrees = sorted({record.worktree for record in records if record.worktree})
+    pr_numbers = sorted({record.pr_number for record in records if record.pr_number is not None})
+    updated_values = sorted(
+        (record.updated_at for record in records if record.updated_at), reverse=True
+    )
+    return {
+        "owner_status": "conflict",
+        "active_owner": True,
+        "lane_id": ",".join(lane_ids) or None,
+        "owner_session": ",".join(owner_sessions) or None,
+        "pr_number": pr_numbers[0] if len(pr_numbers) == 1 else None,
+        "branch": branches[0] if len(branches) == 1 else None,
+        "worktree": worktrees[0] if len(worktrees) == 1 else None,
+        "head": None,
+        "status": "conflict",
+        "updated_at": updated_values[0] if updated_values else None,
+        "recommended_operator_action": (
+            "pause duplicate mutation; resolve active owner conflict before mutation"
+        ),
+    }
+
+
+def _active_owner_payload(
+    records: list[LaneRecord],
+    *,
+    pr_number: int | None,
+    branch: str | None,
+    worktree: str | None,
+) -> dict[str, Any]:
+    matches = [
+        record
+        for record in records
+        if _record_matches_owner_query(
+            record, pr_number=pr_number, branch=branch, worktree=worktree
+        )
+    ]
+    if not matches:
+        return _unowned_owner_payload(pr_number=pr_number, branch=branch, worktree=worktree)
+    owners = {record.owner_session for record in matches if record.owner_session}
+    if len(owners) > 1:
+        return _conflicted_owner_payload(matches)
+    matches.sort(key=lambda record: record.updated_at or "", reverse=True)
+    return _owned_owner_payload(matches[0])
 
 
 def _load_broker_run_summaries() -> list[dict[str, Any]]:
@@ -1200,6 +1343,44 @@ def cmd_lanes(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_owner(args: argparse.Namespace) -> int:
+    """Report the active lane owner for a PR, branch, or worktree."""
+    pr_number = getattr(args, "pr", None)
+    branch = str(getattr(args, "branch", "") or "").strip() or None
+    worktree = str(getattr(args, "worktree", "") or "").strip() or None
+    if pr_number is None and branch is None and worktree is None:
+        print("Provide at least one of --pr, --branch, or --worktree.", file=sys.stderr)
+        return 2
+
+    sessions, _broker_runs, _active_broker_ids = _discover_with_broker_state(
+        include_summaries=False,
+        include_historical=False,
+    )
+    _enrich_prs(sessions)
+    records = _sync_lane_records(_load_lane_registry(), sessions)
+    payload = _active_owner_payload(
+        records,
+        pr_number=pr_number,
+        branch=branch,
+        worktree=worktree,
+    )
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    if payload["owner_status"] == "unowned":
+        print(f"unowned: {payload['recommended_operator_action']}")
+        return 0
+    print(
+        f"{payload['owner_status']}: lane={payload['lane_id']} "
+        f"owner={payload['owner_session']} pr={payload['pr_number'] or '-'} "
+        f"branch={payload['branch'] or '-'} worktree={payload['worktree'] or '-'}"
+    )
+    print(payload["recommended_operator_action"])
+    return 0
+
+
 def cmd_processes(args: argparse.Namespace) -> int:
     """Report local agent/control-plane processes without exposing raw commands."""
     summary_only = bool(getattr(args, "summary_only", False))
@@ -1596,6 +1777,14 @@ def main() -> int:
     ra_p.add_argument("--lines", type=int, default=5)
 
     sub.add_parser("lanes", parents=[json_parent], help="Sessions + PR state")
+    owner_p = sub.add_parser(
+        "owner",
+        parents=[json_parent],
+        help="Find the active lane owner for a PR, branch, or worktree",
+    )
+    owner_p.add_argument("--pr", type=int, help="Pull request number to query")
+    owner_p.add_argument("--branch", help="Branch name to query")
+    owner_p.add_argument("--worktree", help="Worktree path to query")
     processes_p = sub.add_parser(
         "processes",
         parents=[json_parent],
@@ -1658,6 +1847,7 @@ def main() -> int:
         "read": cmd_read,
         "read-all": cmd_read_all,
         "lanes": cmd_lanes,
+        "owner": cmd_owner,
         "processes": cmd_processes,
         "tmux-map": cmd_tmux_map,
         "health": cmd_health,

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -426,8 +426,18 @@ def _load_lane_registry() -> list[LaneRecord]:
                 anonymous.append(record)
                 continue
             current = merged.get(record.lane_id)
-            if current is None or _prefer_lane_record(record, source_index, current):
+            if current is None:
                 merged[record.lane_id] = (record, source_index)
+            elif _prefer_lane_record(record, source_index, current):
+                merged[record.lane_id] = (
+                    _fill_sparse_lane_identity(record, current[0]),
+                    source_index,
+                )
+            else:
+                merged[record.lane_id] = (
+                    _fill_sparse_lane_identity(current[0], record),
+                    current[1],
+                )
 
     return anonymous + [record for record, _source_index in merged.values()]
 
@@ -448,6 +458,16 @@ def _prefer_lane_record(
     return candidate_source_index >= current_source_index
 
 
+def _fill_sparse_lane_identity(preferred: LaneRecord, fallback: LaneRecord) -> LaneRecord:
+    if not preferred.branch:
+        preferred.branch = fallback.branch
+    if not preferred.worktree:
+        preferred.worktree = fallback.worktree
+    if preferred.pr_number is None:
+        preferred.pr_number = fallback.pr_number
+    return preferred
+
+
 def _write_lane_registry(records: list[LaneRecord]) -> None:
     registry_file = _bridge_file_for_write(LANE_REGISTRY_FILE)
     _atomic_write_json(registry_file, [record.to_dict() for record in records])
@@ -465,9 +485,12 @@ def _sync_lane_records(records: list[LaneRecord], sessions: list[Session]) -> li
     for record in records:
         live = session_map.get(record.owner_session)
         if live is not None:
-            record.branch = live.branch
-            record.worktree = live.worktree
-            record.pr_number = live.pr_number
+            if live.branch:
+                record.branch = live.branch
+            if live.worktree:
+                record.worktree = live.worktree
+            if live.pr_number is not None:
+                record.pr_number = live.pr_number
     return records
 
 

--- a/scripts/list_active_agent_sessions.py
+++ b/scripts/list_active_agent_sessions.py
@@ -858,7 +858,7 @@ def build_payload(
 def build_conflicts_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
     overlap = payload.get("overlap_report") or {}
     overlaps = [
-        row
+        _operator_overlap_record(row)
         for row in overlap.get("overlaps", [])
         if "agent_bridge_lane" in set(row.get("sources") or [])
     ]
@@ -909,6 +909,28 @@ def _operator_lane_record(row: dict[str, Any]) -> dict[str, Any]:
         "desktop_label": row.get("desktop_label"),
         "session_title": row.get("session_title"),
     }
+
+
+def _operator_overlap_record(row: dict[str, Any]) -> dict[str, Any]:
+    details = sorted(
+        {
+            _operator_overlap_detail(str(detail))
+            for detail in row.get("details", [])
+            if str(detail).strip()
+        }
+    )
+    return {
+        "kind": row.get("kind"),
+        "value": row.get("value"),
+        "sources": row.get("sources") or [],
+        "details": details,
+    }
+
+
+def _operator_overlap_detail(detail: str) -> str:
+    if "rollout-" in detail or detail.endswith(".jsonl"):
+        return "codex_cli_session"
+    return detail
 
 
 def _operator_conflict_lane_record(row: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/list_active_agent_sessions.py
+++ b/scripts/list_active_agent_sessions.py
@@ -863,9 +863,14 @@ def build_conflicts_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
         if "agent_bridge_lane" in set(row.get("sources") or [])
     ]
     conflict_lanes = [
-        row
+        _operator_conflict_lane_record(row)
         for row in payload.get("agent_bridge_lanes", [])
         if row.get("is_conflict") or row.get("identity_conflicts")
+    ]
+    active_owner_records = [
+        _operator_lane_record(row)
+        for row in payload.get("agent_bridge_lanes", [])
+        if row.get("is_active")
     ]
     lane_conflicts = payload.get("lane_conflicts") or []
     return {
@@ -876,6 +881,7 @@ def build_conflicts_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "conflict_lane_count": len(conflict_lanes),
         "lane_conflicts": lane_conflicts,
         "agent_bridge_lanes": conflict_lanes,
+        "active_owner_records": active_owner_records,
         "overlap_report": {
             "overlap_count": len(overlaps),
             "overlaps": overlaps,
@@ -885,6 +891,37 @@ def build_conflicts_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "to pushed PR/branch head; keep one owner and release the other lane."
         ),
     }
+
+
+def _operator_lane_record(row: dict[str, Any]) -> dict[str, Any]:
+    """Return lane ownership fields safe for compact operator routing."""
+    return {
+        "lane_id": row.get("lane_id"),
+        "owner_session": row.get("owner_session"),
+        "status": row.get("status"),
+        "updated_at": row.get("updated_at"),
+        "branch": row.get("branch"),
+        "worktree": row.get("worktree"),
+        "pr_number": row.get("pr_number"),
+        "goal": row.get("goal"),
+        "source": row.get("source"),
+        "next_action": row.get("next_action"),
+        "desktop_label": row.get("desktop_label"),
+        "session_title": row.get("session_title"),
+    }
+
+
+def _operator_conflict_lane_record(row: dict[str, Any]) -> dict[str, Any]:
+    record = _operator_lane_record(row)
+    record["is_active"] = bool(row.get("is_active"))
+    record["is_conflict"] = bool(row.get("is_conflict"))
+    if row.get("identity_conflicts"):
+        record["identity_conflicts"] = row.get("identity_conflicts")
+    if row.get("conflict_session"):
+        record["conflict_session"] = row.get("conflict_session")
+    if row.get("conflict_reason"):
+        record["conflict_reason"] = row.get("conflict_reason")
+    return record
 
 
 def render_text(payload: dict[str, Any]) -> str:

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -536,6 +536,189 @@ def test_operator_snapshot_counts_active_duplicate_pr_lanes_as_conflicts(
     assert payload["health"]["issues"][0]["type"] == "lane_identity_conflict"
 
 
+def test_operator_snapshot_does_not_conflict_same_owner_refreshes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-a",
+                    "owner_session": "codex-owner",
+                    "status": "active",
+                    "pr_number": 7245,
+                    "branch": "worktree-codex-insights",
+                },
+                {
+                    "lane_id": "lane-b",
+                    "owner_session": "codex-owner",
+                    "status": "active",
+                    "pr_number": 7245,
+                    "branch": "worktree-codex-insights",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_collect_agent_process_census",
+        lambda *, include_records=True, record_limit=None, ps_lines=None: {
+            "ok": True,
+            "total": 400,
+            "by_role": {"codex_app_server": 400},
+        },
+    )
+
+    rc = mod.cmd_operator_snapshot(argparse.Namespace(json=True, summary_only=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["active_lanes"] == 2
+    assert payload["summary"]["conflict_lanes"] == 0
+    assert payload["lane_conflicts"] == []
+    assert payload["health"]["ok"] is True
+
+
+def test_cmd_owner_json_reports_active_pr_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    worktree = tmp_path / "owned-worktree"
+    worktree.mkdir()
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "q01-settle-7292",
+                    "owner_session": "codex-owner",
+                    "status": "active",
+                    "updated_at": "2026-05-18T17:00:00Z",
+                    "branch": "droid/P16-stage2",
+                    "worktree": str(worktree),
+                    "pr_number": 7292,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_head_for_worktree",
+        lambda path: "a" * 40 if str(path) == str(worktree) else None,
+    )
+
+    rc = mod.cmd_owner(argparse.Namespace(json=True, pr=7292, branch=None, worktree=None))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "owner_status": "owned",
+        "active_owner": True,
+        "lane_id": "q01-settle-7292",
+        "owner_session": "codex-owner",
+        "pr_number": 7292,
+        "branch": "droid/P16-stage2",
+        "worktree": str(worktree),
+        "head": "a" * 40,
+        "status": "active",
+        "updated_at": "2026-05-18T17:00:00Z",
+        "recommended_operator_action": "route mutation/comment work to owner_session codex-owner; non-owners should stop or request release",
+    }
+
+
+def test_cmd_owner_json_reports_unowned_pr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+
+    rc = mod.cmd_owner(argparse.Namespace(json=True, pr=7292, branch=None, worktree=None))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "owner_status": "unowned",
+        "active_owner": False,
+        "lane_id": None,
+        "owner_session": None,
+        "pr_number": 7292,
+        "branch": None,
+        "worktree": None,
+        "head": None,
+        "status": None,
+        "updated_at": None,
+        "recommended_operator_action": "no active owner found; claim the lane before mutation",
+    }
+
+
+def test_cmd_owner_json_reports_duplicate_pr_conflict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "lane-a",
+                    "owner_session": "codex-A",
+                    "status": "active",
+                    "updated_at": "2026-05-18T17:00:00Z",
+                    "branch": "feature/a",
+                    "pr_number": 7292,
+                },
+                {
+                    "lane_id": "lane-b",
+                    "owner_session": "codex-B",
+                    "status": "active",
+                    "updated_at": "2026-05-18T17:01:00Z",
+                    "branch": "feature/b",
+                    "pr_number": 7292,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+
+    rc = mod.cmd_owner(argparse.Namespace(json=True, pr=7292, branch=None, worktree=None))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["owner_status"] == "conflict"
+    assert payload["active_owner"] is True
+    assert payload["lane_id"] == "lane-a,lane-b"
+    assert payload["owner_session"] == "codex-A,codex-B"
+    assert payload["pr_number"] == 7292
+    assert payload["recommended_operator_action"] == (
+        "pause duplicate mutation; resolve active owner conflict before mutation"
+    )
+
+
 def test_collect_agent_process_census_redacts_commands_and_counts_roles() -> None:
     import agent_bridge as mod
 

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -640,6 +640,118 @@ def test_cmd_owner_json_reports_active_pr_owner(
     }
 
 
+def test_cmd_owner_preserves_registry_identity_when_live_session_is_sparse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    worktree = tmp_path / "owned-worktree"
+    worktree.mkdir()
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "q01-settle-7292",
+                    "owner_session": "codex-owner",
+                    "status": "active",
+                    "updated_at": "2026-05-18T17:00:00Z",
+                    "branch": "droid/P16-stage2",
+                    "worktree": str(worktree),
+                    "pr_number": 7292,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        mod,
+        "discover",
+        lambda **_kwargs: [
+            mod.Session(
+                name="codex-owner",
+                agent="codex",
+                status="alive",
+                lifecycle="live",
+            )
+        ],
+    )
+    monkeypatch.setattr(mod, "_enrich_prs", lambda _sessions: None)
+    monkeypatch.setattr(mod, "_head_for_worktree", lambda _path: "b" * 40)
+
+    rc = mod.cmd_owner(argparse.Namespace(json=True, pr=7292, branch=None, worktree=None))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["owner_status"] == "owned"
+    assert payload["lane_id"] == "q01-settle-7292"
+    assert payload["owner_session"] == "codex-owner"
+    assert payload["pr_number"] == 7292
+    assert payload["branch"] == "droid/P16-stage2"
+    assert payload["worktree"] == str(worktree)
+
+
+def test_cmd_owner_preserves_identity_when_newer_registry_row_is_sparse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    worktree = tmp_path / "owned-worktree"
+    worktree.mkdir()
+    _patch_bridge_paths(mod, tmp_path, monkeypatch)
+    mod.AGENT_BRIDGE_DIR.mkdir(parents=True, exist_ok=True)
+    repo_registry = mod.CANONICAL_REPO_ROOT / ".aragora" / "agent-bridge" / "lanes.json"
+    repo_registry.parent.mkdir(parents=True, exist_ok=True)
+    mod.LANE_REGISTRY_FILE.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "q01-settle-7292",
+                    "owner_session": "codex-owner",
+                    "status": "active",
+                    "updated_at": "2026-05-18T17:01:00Z",
+                    "worktree": str(worktree),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    repo_registry.write_text(
+        json.dumps(
+            [
+                {
+                    "lane_id": "q01-settle-7292",
+                    "owner_session": "codex-owner",
+                    "status": "active",
+                    "updated_at": "2026-05-18T17:00:00Z",
+                    "branch": "droid/P16-stage2",
+                    "worktree": str(worktree),
+                    "pr_number": 7292,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "discover", lambda **_kwargs: [])
+    monkeypatch.setattr(mod, "_head_for_worktree", lambda _path: "c" * 40)
+
+    rc = mod.cmd_owner(argparse.Namespace(json=True, pr=7292, branch=None, worktree=None))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["owner_status"] == "owned"
+    assert payload["lane_id"] == "q01-settle-7292"
+    assert payload["pr_number"] == 7292
+    assert payload["branch"] == "droid/P16-stage2"
+    assert payload["worktree"] == str(worktree)
+    assert payload["updated_at"] == "2026-05-18T17:01:00Z"
+
+
 def test_cmd_owner_json_reports_unowned_pr(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/test_list_active_agent_sessions.py
+++ b/tests/scripts/test_list_active_agent_sessions.py
@@ -1041,6 +1041,7 @@ def test_build_conflicts_only_payload_filters_to_lane_conflicts() -> None:
                 "owner_session": "codex-A",
                 "is_active": True,
                 "is_conflict": True,
+                "codex_rollout_path": "/Users/armand/.codex/sessions/raw.jsonl",
                 "identity_conflicts": [{"key_kind": "pr_number", "key_value": "7245"}],
             },
             {
@@ -1048,6 +1049,7 @@ def test_build_conflicts_only_payload_filters_to_lane_conflicts() -> None:
                 "owner_session": "codex-Z",
                 "is_active": True,
                 "is_conflict": False,
+                "codex_rollout_path": "/Users/armand/.codex/sessions/raw-z.jsonl",
             },
         ],
         "lane_conflicts": [
@@ -1080,7 +1082,54 @@ def test_build_conflicts_only_payload_filters_to_lane_conflicts() -> None:
     assert out["conflict_count"] == 1
     assert out["conflict_lane_count"] == 1
     assert [row["lane_id"] for row in out["agent_bridge_lanes"]] == ["lane-a"]
+    assert [row["lane_id"] for row in out["active_owner_records"]] == ["lane-a", "lane-z"]
+    assert "codex_rollout_path" not in out["active_owner_records"][0]
+    assert "raw.jsonl" not in json.dumps(out)
     assert out["overlap_report"]["overlap_count"] == 1
+
+
+def test_build_conflicts_only_payload_includes_active_owners_without_conflicts() -> None:
+    payload = {
+        "schema_version": 3,
+        "generated_at": "2026-05-18T17:00:00Z",
+        "repo_root": "/repo",
+        "agent_bridge_lanes": [
+            {
+                "lane_id": "q01-settle-7292",
+                "owner_session": "codex-owner",
+                "status": "active",
+                "is_active": True,
+                "is_conflict": False,
+                "pr_number": 7292,
+                "branch": "droid/P16-stage2",
+                "worktree": "/repo/.worktrees/p16",
+            }
+        ],
+        "lane_conflicts": [],
+        "overlap_report": {"overlaps": []},
+    }
+
+    out = detector.build_conflicts_only_payload(payload)
+
+    assert out["conflict_count"] == 0
+    assert out["conflict_lane_count"] == 0
+    assert out["agent_bridge_lanes"] == []
+    assert out["active_owner_records"] == [
+        {
+            "lane_id": "q01-settle-7292",
+            "owner_session": "codex-owner",
+            "status": "active",
+            "updated_at": None,
+            "branch": "droid/P16-stage2",
+            "worktree": "/repo/.worktrees/p16",
+            "pr_number": 7292,
+            "goal": None,
+            "source": None,
+            "next_action": None,
+            "desktop_label": None,
+            "session_title": None,
+        }
+    ]
 
 
 def test_schema_version_bumped_for_lane_desktop_metadata() -> None:

--- a/tests/scripts/test_list_active_agent_sessions.py
+++ b/tests/scripts/test_list_active_agent_sessions.py
@@ -1064,8 +1064,12 @@ def test_build_conflicts_only_payload_filters_to_lane_conflicts() -> None:
                 {
                     "kind": "pr",
                     "value": "7245",
-                    "sources": ["agent_bridge_lane"],
-                    "details": ["lane-a", "lane-b"],
+                    "sources": ["agent_bridge_lane", "codex_cli_session"],
+                    "details": [
+                        "lane-a",
+                        "lane-b",
+                        "2026/05/18/rollout-2026-05-18T11-54-20-secret.jsonl",
+                    ],
                 },
                 {
                     "kind": "branch",
@@ -1085,6 +1089,12 @@ def test_build_conflicts_only_payload_filters_to_lane_conflicts() -> None:
     assert [row["lane_id"] for row in out["active_owner_records"]] == ["lane-a", "lane-z"]
     assert "codex_rollout_path" not in out["active_owner_records"][0]
     assert "raw.jsonl" not in json.dumps(out)
+    assert "rollout-2026" not in json.dumps(out)
+    assert out["overlap_report"]["overlaps"][0]["details"] == [
+        "codex_cli_session",
+        "lane-a",
+        "lane-b",
+    ]
     assert out["overlap_report"]["overlap_count"] == 1
 
 


### PR DESCRIPTION
## Summary
- add `scripts/agent_bridge.py owner --pr/--branch/--worktree --json` for compact active-lane owner lookup
- keep same-owner lane refreshes non-conflicting while duplicate active owners for the same PR/branch/worktree remain conflicts
- include redacted `active_owner_records` in `list_active_agent_sessions.py --conflicts-only` so operators can see current owners even when there is no conflict

## Scope
This intentionally avoids #7292 mutation and avoids mailbox/steering implementation areas because adjacent steering lanes were active during this run. This PR only hardens ownership lookup and conflict visibility.

## Validation
- `python3 -m pytest tests/scripts/test_agent_bridge.py tests/scripts/test_list_active_agent_sessions.py -q`
- `python3 -m ruff check scripts/agent_bridge.py scripts/list_active_agent_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_list_active_agent_sessions.py`
- `python3 -m ruff format --check scripts/agent_bridge.py scripts/list_active_agent_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_list_active_agent_sessions.py`
- `python3 -m mypy scripts/agent_bridge.py scripts/list_active_agent_sessions.py tests/scripts/test_agent_bridge.py tests/scripts/test_list_active_agent_sessions.py --ignore-missing-imports --no-incremental`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- temp-only synthetic duplicate-lane smoke for `operator-snapshot --summary-only`, `owner --pr`, and `list_active_agent_sessions.py --conflicts-only`
