### PR TITLE
fix(scripts): classify more gh connectivity failures

### DIFF
--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -35,6 +35,8 @@ CONNECTIVITY_ERROR_TOKENS = (
     "network is unreachable",
     "connection timed out",
     "connection refused",
+    "connection reset by peer",
+    "dial tcp",
     "command timed out after",
     "context deadline exceeded",
     "i/o timeout",
@@ -46,6 +48,7 @@ CONNECTIVITY_ERROR_TOKENS = (
     "lookup github.com",
     "no such host",
     "no route to host",
+    "proxyconnect tcp",
 )
 
 

--- a/scripts/github_cli_health.py
+++ b/scripts/github_cli_health.py
@@ -36,7 +36,6 @@ CONNECTIVITY_ERROR_TOKENS = (
     "connection timed out",
     "connection refused",
     "connection reset by peer",
-    "dial tcp",
     "command timed out after",
     "context deadline exceeded",
     "i/o timeout",

--- a/tests/scripts/test_github_cli_health.py
+++ b/tests/scripts/test_github_cli_health.py
@@ -111,6 +111,12 @@ def test_github_connectivity_error_detects_dns_lookup_failures() -> None:
     assert mod.is_github_connectivity_error(
         'Get "https://api.github.com/rate_limit": dial tcp 140.82.112.6:443: connect: network is unreachable'
     )
+    assert mod.is_github_connectivity_error(
+        'Get "https://api.github.com/rate_limit": read: connection reset by peer'
+    )
+    assert mod.is_github_connectivity_error(
+        'Get "https://api.github.com/rate_limit": proxyconnect tcp: i/o timeout'
+    )
 
 
 def test_github_connectivity_error_detects_bounded_probe_timeouts() -> None:


### PR DESCRIPTION
Harvests the retained value from old swarm branch codex/swarm-848a8081-micro-2. Adds coverage for connection reset by peer and proxyconnect tcp errors in github_cli_health connectivity classification, while removing a duplicate dial tcp token after rebasing onto current main.\n\nValidation:\n- python3 -m pytest tests/scripts/test_github_cli_health.py -q\n- python3 -m ruff check scripts/github_cli_health.py tests/scripts/test_github_cli_health.py\n- python3 -m ruff format --check scripts/github_cli_health.py tests/scripts/test_github_cli_health.py\n- python3 -m mypy scripts/github_cli_health.py --ignore-missing-imports --no-incremental\n- git diff --check\n\nNon-touches: no #7292, no cleanup worktrees removed from this branch, no protected PRs, no labels/issues/merges.