### PR TITLE
feat(scripts): add noninteractive Droid bridge exec

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -7,6 +7,7 @@ inventory from agent_bridge_sessions.py (PR #5306).
 Usage:
   python3 scripts/agent_bridge.py sessions [--json]
   python3 scripts/agent_bridge.py launch --name codex-review --agent codex --cwd .worktrees/review --file /tmp/prompt.md
+  python3 scripts/agent_bridge.py exec --agent droid --auto high --cwd . --file /tmp/prompt.md
   python3 scripts/agent_bridge.py send <name> "Fix the LOC ratchet"
   python3 scripts/agent_bridge.py send <name> --file /tmp/prompt.md
   python3 scripts/agent_bridge.py approve <name>
@@ -37,6 +38,13 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.agent_bridge.exceptions import TransportError
+from aragora.swarm.agent_bridge.harnesses import create_transport
+
 try:
     # When run as `python3 scripts/agent_bridge.py`, Python adds scripts/ to
     # sys.path automatically, so this direct import works.  For package-style
@@ -57,7 +65,6 @@ SESSION_SNAPSHOT_FILE = AGENT_BRIDGE_DIR / "sessions.json"
 LANE_REGISTRY_FILE = AGENT_BRIDGE_DIR / "lanes.json"
 TMUX_SESSIONS_DIR = Path.home() / ".aragora" / "tmux-sessions"
 TMUX_SESSION = "aragora"
-REPO_ROOT = Path(__file__).resolve().parents[1]
 CANONICAL_REPO_ROOT = REPO_ROOT
 if agent_bridge_sessions is not None:
     try:
@@ -997,6 +1004,28 @@ def cmd_launch(args: argparse.Namespace) -> int:
     if not launch_cwd.is_dir():
         print(f"Launch cwd does not exist or is not a directory: {launch_cwd}", file=sys.stderr)
         return 1
+    if agent in {"droid", "factory"} and getattr(args, "autonomous", False):
+        message = (
+            "Interactive Droid/Factory tmux sessions cannot be made autonomous. "
+            "Use `python3 scripts/agent_bridge.py exec --agent droid --auto high ...` "
+            "or `python3 scripts/agent_bridge_broker.py` for non-interactive Droid evidence."
+        )
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "name": args.name,
+                        "agent": agent,
+                        "cwd": str(launch_cwd),
+                        "error": message,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(message, file=sys.stderr)
+        return 1
 
     launcher = CANONICAL_REPO_ROOT / "scripts" / "tmux_session_launcher.sh"
     cmd = [
@@ -1051,6 +1080,86 @@ def cmd_launch(args: argparse.Namespace) -> int:
             print(result.stderr, end="", file=sys.stderr)
 
     return result.returncode
+
+
+def cmd_exec(args: argparse.Namespace) -> int:
+    """Run one non-interactive harness turn through the bridge transport layer."""
+    agent = str(args.agent or "droid").strip()
+    if agent not in {"codex", "claude", "droid", "factory"}:
+        print("Unsupported agent. Use codex, claude, droid, or factory.", file=sys.stderr)
+        return 1
+    launch_cwd = Path(args.cwd).expanduser() if args.cwd else Path.cwd()
+    try:
+        launch_cwd = launch_cwd.resolve()
+    except OSError as exc:
+        print(f"Invalid exec cwd: {exc}", file=sys.stderr)
+        return 1
+    if not launch_cwd.is_dir():
+        print(f"Exec cwd does not exist or is not a directory: {launch_cwd}", file=sys.stderr)
+        return 1
+
+    prompt = Path(args.file).read_text("utf-8") if args.file else " ".join(args.prompt or [])
+    if not prompt:
+        print("No prompt. Use text args or --file", file=sys.stderr)
+        return 1
+
+    harness_options: dict[str, Any] = {}
+    auto_mode = str(args.auto or "").strip()
+    if auto_mode:
+        harness_options["auto"] = auto_mode
+    elif agent in {"droid", "factory"}:
+        harness_options["auto"] = "high"
+    allowed_roles = set(args.allowed_role or ["reviewer"])
+
+    try:
+        transport = create_transport(
+            agent,
+            cwd=launch_cwd,
+            model=str(args.model).strip() if args.model else None,
+            harness_options=harness_options,
+        )
+        result = transport.launch(prompt, allowed_roles=allowed_roles)
+    except (TransportError, OSError, ValueError) as exc:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "agent": agent,
+                        "cwd": str(launch_cwd),
+                        "error": str(exc),
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Exec failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        footer = result.parsed_turn.footer.to_dict() if result.parsed_turn.footer else None
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "agent": agent,
+                    "cwd": str(launch_cwd),
+                    "session_id": result.session_id,
+                    "command": result.command,
+                    "exit_code": result.exit_code,
+                    "message_text": result.message_text,
+                    "parse_status": result.parsed_turn.parse_status,
+                    "footer": footer,
+                    "parse_errors": list(result.parsed_turn.parse_errors),
+                    "usage": result.usage,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    print(result.message_text)
+    return 0
 
 
 def cmd_send(args: argparse.Namespace) -> int:
@@ -1570,6 +1679,25 @@ def main() -> int:
     )
     launch_p.add_argument("--timeout-seconds", type=int, default=120)
 
+    exec_p = sub.add_parser(
+        "exec",
+        parents=[json_parent],
+        help="Run one non-interactive harness turn",
+    )
+    exec_p.add_argument("--agent", default="droid", choices=("codex", "claude", "droid", "factory"))
+    exec_p.add_argument(
+        "--cwd",
+        help=(
+            "Working directory/worktree for the exec harness "
+            "(defaults to the caller's current directory)"
+        ),
+    )
+    exec_p.add_argument("--model", help="Model id to pass to the harness")
+    exec_p.add_argument("--auto", choices=("low", "medium", "high"), help="Droid autonomy level")
+    exec_p.add_argument("--allowed-role", action="append", help="Allowed bridge footer role")
+    exec_p.add_argument("prompt", nargs="*")
+    exec_p.add_argument("--file", help="Prompt file")
+
     send_p = sub.add_parser("send", parents=[json_parent], help="Send prompt to session")
     send_p.add_argument("name")
     send_p.add_argument("prompt", nargs="*")
@@ -1653,6 +1781,7 @@ def main() -> int:
     cmds = {
         "sessions": cmd_sessions,
         "launch": cmd_launch,
+        "exec": cmd_exec,
         "send": cmd_send,
         "approve": cmd_approve,
         "read": cmd_read,

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -898,6 +898,126 @@ def test_cmd_launch_invokes_tmux_launcher_for_droid(
     ]
 
 
+def test_cmd_launch_rejects_autonomous_droid_tmux(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    review_worktree = tmp_path / "review-worktree"
+    review_worktree.mkdir()
+    monkeypatch.setattr(mod, "CANONICAL_REPO_ROOT", repo_root)
+
+    def _unexpected_run(*_args, **_kwargs):
+        raise AssertionError("interactive droid tmux launcher should not run")
+
+    monkeypatch.setattr(mod.subprocess, "run", _unexpected_run)
+
+    rc = mod.cmd_launch(
+        argparse.Namespace(
+            name="factory-review",
+            agent="droid",
+            prompt=["review", "#7292"],
+            file=None,
+            cwd=str(review_worktree),
+            autonomous=True,
+            timeout_seconds=10,
+            json=True,
+        )
+    )
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["agent"] == "droid"
+    assert "cannot be made autonomous" in payload["error"]
+    assert "agent_bridge.py exec --agent droid --auto high" in payload["error"]
+
+
+def test_cmd_exec_droid_uses_transport_auto_high(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import agent_bridge as mod
+    from aragora.swarm.agent_bridge.harnesses.droid import DroidTransport
+
+    fixture = (
+        Path(__file__).resolve().parents[2]
+        / "tests"
+        / "fixtures"
+        / "agent_bridge"
+        / "droid_start.json"
+    ).read_text(encoding="utf-8")
+    captured: dict[str, object] = {}
+    commands: list[list[str]] = []
+
+    def _fake_runner(command: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout=fixture, stderr="")
+
+    def _fake_create_transport(agent, *, cwd, model, harness_options):
+        captured.update(
+            {
+                "agent": agent,
+                "cwd": cwd,
+                "model": model,
+                "harness_options": harness_options,
+            }
+        )
+        return DroidTransport(
+            cwd=cwd,
+            model=model,
+            harness_options=harness_options,
+            runner=_fake_runner,
+            binary_resolver=lambda _: "/usr/bin/droid",
+        )
+
+    monkeypatch.setattr(mod, "create_transport", _fake_create_transport)
+
+    rc = mod.cmd_exec(
+        argparse.Namespace(
+            agent="droid",
+            cwd=str(tmp_path),
+            model=None,
+            auto="high",
+            allowed_role=["reviewer"],
+            file=None,
+            prompt=["Review", "#7292"],
+            json=True,
+        )
+    )
+
+    assert rc == 0
+    assert captured == {
+        "agent": "droid",
+        "cwd": tmp_path.resolve(),
+        "model": None,
+        "harness_options": {"auto": "high"},
+    }
+    assert commands == [
+        [
+            "droid",
+            "exec",
+            "--auto",
+            "high",
+            "--output-format",
+            "json",
+            "--cwd",
+            str(tmp_path.resolve()),
+            "Review #7292",
+        ]
+    ]
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["command"] == commands[0]
+    assert payload["message_text"].startswith("Synthesized the review findings.")
+    assert payload["parse_status"] == "ok"
+
+
 def test_write_session_snapshot_falls_back_to_state_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/test_agent_bridge_broker.py
+++ b/tests/scripts/test_agent_bridge_broker.py
@@ -176,6 +176,17 @@ def test_cli_healthcheck_failure_returns_6() -> None:
     )
 
 
+def test_parse_actors_sets_droid_auto_high() -> None:
+    module = _load_script_module()
+
+    registry = module._parse_actors(["reviewer:droid:claude-opus-4-7"])
+    session = registry.sessions["reviewer"]
+
+    assert session.harness == "droid"
+    assert session.model == "claude-opus-4-7"
+    assert session.harness_options == {"auto": "high"}
+
+
 def test_cli_success_returns_0_and_emits_json(capsys) -> None:
     module = _load_script_module()
 


### PR DESCRIPTION
## Summary
- add `agent_bridge.py exec` for one-shot transport-backed agent missions
- default Droid/Factory exec missions to `--auto high` through `DroidTransport`
- reject `agent_bridge.py launch --agent droid --autonomous` with a diagnostic pointing to exec/broker routes

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/swarm/agent_bridge/test_harnesses_droid.py tests/scripts/test_agent_bridge_broker.py tests/scripts/test_agent_bridge.py -q -p no:cacheprovider` -> 47 passed
- `python3 -m ruff check scripts/agent_bridge.py scripts/agent_bridge_broker.py tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_broker.py tests/swarm/agent_bridge/test_harnesses_droid.py` -> passed
- `python3 -m ruff format --check scripts/agent_bridge.py tests/scripts/test_agent_bridge.py tests/scripts/test_agent_bridge_broker.py` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Scope
No #7292 branch/code mutation, dependency PR changes, automation.toml, launchd, cleanup, or root generated metrics changes.