### PR TITLE
ci(metrics): make drift advisory for ordinary PRs

### DIFF
--- a/.github/workflows/metrics-drift.yml
+++ b/.github/workflows/metrics-drift.yml
@@ -2,8 +2,11 @@ name: Metrics Drift
 
 # Validates docs/METRICS.md against ground truth. The script
 # scripts/regenerate_metrics.py recounts every canonical metric
-# (tests, LOC, OpenAPI paths, adapters, etc.) and fails if any value
-# drifts more than 0.5% from the committed doc.
+# (tests, LOC, OpenAPI paths, adapters, etc.). PRs that touch metrics
+# sources or public/canonical claim docs fail if any value drifts more
+# than 0.5% from the committed doc. Ordinary implementation PRs report
+# the same drift advisory-only so stale generated counts do not block
+# unrelated queue drain.
 #
 # Thesis alignment (Commitment 4: respect the limits): public numeric
 # claims must remain honest as the codebase grows. Silent staleness
@@ -25,7 +28,18 @@ on:
       - 'sdk/python/aragora_sdk/**'
       - 'sdk/typescript/src/**'
       - 'docs/api/openapi.json'
+      - 'docs/CANONICAL_GOALS.md'
+      - 'docs/CAPABILITY_MATRIX.md'
+      - 'docs/COMMERCIAL_OVERVIEW.md'
+      - 'docs/FEATURE_GAP_LIST.md'
+      - 'docs/GA_CHECKLIST.md'
+      - 'docs/HONEST_ASSESSMENT.md'
       - 'docs/METRICS.md'
+      - 'docs/ROADMAP_30_60_90.md'
+      - 'docs/STATUS.md'
+      - 'docs/status/claims/canonical_metrics.yaml'
+      - 'docs/status/generated/canonical_metrics/**'
+      - 'scripts/check_canonical_metrics.py'
       - 'scripts/regenerate_metrics.py'
       - '.mypy-baseline'
       - '.github/workflows/metrics-drift.yml'
@@ -49,7 +63,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -59,11 +73,36 @@ jobs:
       - name: Install ripgrep
         run: sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep
 
+      - name: Classify enforcement mode
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --name-only \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" \
+              > /tmp/metrics-changed-files.txt
+          else
+            : > /tmp/metrics-changed-files.txt
+          fi
+
+          python3 scripts/classify_metrics_drift_scope.py \
+            --event-name "${{ github.event_name }}" \
+            --changed-files /tmp/metrics-changed-files.txt \
+            --json \
+            | tee /tmp/metrics-scope.json
+
+          mode="$(python3 -c 'import json; print(json.load(open("/tmp/metrics-scope.json"))["mode"])')"
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+
       - name: Verify drift
         id: check
         shell: bash
         run: |
           set -euo pipefail
+          mode="${{ steps.scope.outputs.mode }}"
 
           # Snapshot the committed doc into a backup BEFORE any regeneration
           # so the post-check diff is unambiguous: committed-doc vs what-live-
@@ -72,8 +111,23 @@ jobs:
           # the committed state and current truth.
           cp docs/METRICS.md /tmp/metrics-committed.md
 
-          if ! python3 scripts/regenerate_metrics.py --check; then
-            echo "::error::docs/METRICS.md is stale. Run 'python3 scripts/regenerate_metrics.py' locally and commit the updated doc."
+          check_args=(--check)
+          if [ "$mode" = "advisory" ]; then
+            check_args+=(--advisory)
+          fi
+
+          set +e
+          python3 scripts/regenerate_metrics.py "${check_args[@]}" | tee /tmp/metrics-check.log
+          check_rc=${PIPESTATUS[0]}
+          set -e
+
+          if grep -q "Metrics drifted" /tmp/metrics-check.log; then
+            echo "drift_status=${mode}-drift" >> "$GITHUB_OUTPUT"
+            if [ "$mode" = "advisory" ]; then
+              echo "::warning::docs/METRICS.md is stale, but this PR is advisory-only for Metrics Drift."
+            else
+              echo "::error::docs/METRICS.md is stale. Run 'python3 scripts/regenerate_metrics.py' locally and commit the updated doc."
+            fi
             echo ""
             echo "=== DIFF: committed doc vs current ground truth ==="
             # Regenerate into a temp file without touching the tracked file,
@@ -83,7 +137,12 @@ jobs:
             diff -u /tmp/metrics-committed.md docs/METRICS.md | head -200 || true
             # Restore the committed doc so downstream steps see the original.
             cp /tmp/metrics-committed.md docs/METRICS.md
-            exit 1
+          else
+            echo "drift_status=clean" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$check_rc" -ne 0 ]; then
+            exit "$check_rc"
           fi
 
       - name: Emit summary
@@ -95,9 +154,17 @@ jobs:
               echo "## Metrics Drift Check"
               echo ""
               if [ "${{ job.status }}" = "success" ]; then
-                echo "- Status: passed (no metric drifted more than 0.5%)"
+                if [ "${{ steps.check.outputs.drift_status }}" = "advisory-drift" ]; then
+                  echo "- Status: passed with advisory drift"
+                  echo "- Enforcement: advisory for this PR"
+                  echo "- Action: refresh \`docs/METRICS.md\` in a dedicated metrics PR or wait for the weekly strict run"
+                else
+                  echo "- Status: passed (no metric drifted more than 0.5%)"
+                  echo "- Enforcement: ${{ steps.scope.outputs.mode }}"
+                fi
               else
                 echo "- Status: failed — \`docs/METRICS.md\` is stale"
+                echo "- Enforcement: ${{ steps.scope.outputs.mode }}"
                 echo ""
                 echo "Run locally:"
                 echo ""

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -6,6 +6,7 @@
 
 - **Regenerate:** `python scripts/regenerate_metrics.py`
 - **Verify (drift check):** `python scripts/regenerate_metrics.py --check`
+- **Advisory PR check:** `python scripts/regenerate_metrics.py --check --advisory`
 - **Timestamped JSON snapshot:** `python scripts/regenerate_metrics.py --json`
 
 ## Canonical numbers
@@ -13,11 +14,11 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4140` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1940684` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1941752` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `139` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5191` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `218416` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `687` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5197` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `218477` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `689` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `69` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +29,7 @@
 | Allowlisted agent types | `34` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `848` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `896` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `85` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3317` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 
@@ -51,9 +52,11 @@ The `--check` mode fails if any metric moved by more than 0.5% from the committe
 
 New metrics (present in the script but not in the committed doc) are reported as `NEW:` in the check output and force a refresh regardless of threshold.
 
+The GitHub workflow applies that strict failure mode to manual/weekly runs and to PRs that touch metrics generation, canonical metrics checks, `docs/METRICS.md`, or public/canonical claim docs. Ordinary implementation PRs that only move counted surfaces still run the same drift check, but in advisory mode: drift is reported loudly in the workflow output without failing the PR. This keeps public claims honest without forcing every unrelated branch to refresh generated counts before review.
+
 ## Related automation
 
-- `.github/workflows/metrics-drift.yml` runs this script on every PR that touches counted surfaces (`aragora/`, `tests/`, `sdk/`, `docs/api/openapi.json`, `.mypy-baseline`), and on a weekly Monday schedule. It invokes `--check` and fails the job if drift exceeds the threshold. The job does **not** auto-open a refresh PR; it fails loud and a human or follow-up automation decides whether to regenerate.
+- `.github/workflows/metrics-drift.yml` runs this script on every PR that touches counted surfaces (`aragora/`, `tests/`, `sdk/`, `docs/api/openapi.json`, `.mypy-baseline`) plus public/canonical claim paths, and on a weekly Monday schedule. It classifies PRs with `scripts/classify_metrics_drift_scope.py`: public-claim and metrics source changes are strict, while ordinary counted-surface changes are advisory. The job does **not** auto-open a refresh PR; strict failures stay loud and a human or follow-up automation decides whether to regenerate.
 - `tests/scripts/test_regenerate_metrics.py` holds external invariants (e.g. test count > 100K, python file count > 1K) so the bootstrap is not fully self-referential: even if the committed doc were wrong, the invariant tests would catch a gross break.
 - `scripts/reconcile_status.py` cross-references feature claims across CAPABILITY_MATRIX, GA_CHECKLIST, STATUS, ROADMAP.
 - `scripts/validate_openapi_routes.py` verifies OpenAPI paths against actual handler implementations.

--- a/scripts/classify_metrics_drift_scope.py
+++ b/scripts/classify_metrics_drift_scope.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Classify Metrics Drift enforcement mode for a workflow run.
+
+Pull requests that touch metrics/public-claim sources stay strict. Ordinary
+implementation PRs that merely move counted surfaces run advisory so stale
+generated counts do not block otherwise-valid work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+STRICT_EXACT_PATHS = frozenset(
+    {
+        ".github/workflows/metrics-drift.yml",
+        "docs/CANONICAL_GOALS.md",
+        "docs/CAPABILITY_MATRIX.md",
+        "docs/COMMERCIAL_OVERVIEW.md",
+        "docs/FEATURE_GAP_LIST.md",
+        "docs/GA_CHECKLIST.md",
+        "docs/HONEST_ASSESSMENT.md",
+        "docs/METRICS.md",
+        "docs/ROADMAP_30_60_90.md",
+        "docs/STATUS.md",
+        "docs/status/claims/canonical_metrics.yaml",
+        "scripts/check_canonical_metrics.py",
+        "scripts/regenerate_metrics.py",
+    }
+)
+
+STRICT_PREFIXES = ("docs/status/generated/canonical_metrics/",)
+
+COUNTED_EXACT_PATHS = frozenset(
+    {
+        ".mypy-baseline",
+        "docs/api/openapi.json",
+    }
+)
+
+COUNTED_PREFIXES = (
+    "aragora/",
+    "sdk/python/aragora_sdk/",
+    "sdk/typescript/src/",
+    "tests/",
+)
+
+
+def normalize_path(path: str) -> str:
+    """Normalize GitHub/Git path output into repo-relative POSIX paths."""
+    return path.strip().replace("\\", "/").removeprefix("./")
+
+
+def load_changed_paths(paths: list[str], changed_files: Path | None) -> list[str]:
+    loaded = list(paths)
+    if changed_files is not None:
+        loaded.extend(changed_files.read_text(encoding="utf-8").splitlines())
+    normalized = [normalize_path(path) for path in loaded]
+    return [path for path in normalized if path]
+
+
+def is_strict_path(path: str) -> bool:
+    return path in STRICT_EXACT_PATHS or path.startswith(STRICT_PREFIXES)
+
+
+def is_counted_path(path: str) -> bool:
+    return path in COUNTED_EXACT_PATHS or path.startswith(COUNTED_PREFIXES)
+
+
+def classify(event_name: str, changed_paths: list[str]) -> dict[str, object]:
+    """Return a JSON-serializable Metrics Drift enforcement classification."""
+    if event_name != "pull_request":
+        return {
+            "mode": "strict",
+            "event_name": event_name,
+            "reasons": ["non_pull_request_event"],
+            "changed_paths": changed_paths,
+            "strict_matches": [],
+            "counted_matches": [],
+        }
+
+    strict_matches = [path for path in changed_paths if is_strict_path(path)]
+    counted_matches = [path for path in changed_paths if is_counted_path(path)]
+    if strict_matches:
+        return {
+            "mode": "strict",
+            "event_name": event_name,
+            "reasons": ["strict_metrics_or_public_claim_path_changed"],
+            "changed_paths": changed_paths,
+            "strict_matches": strict_matches,
+            "counted_matches": counted_matches,
+        }
+
+    reasons = ["pull_request_without_strict_metrics_paths"]
+    if not changed_paths:
+        reasons.append("no_changed_paths_reported")
+    if counted_matches:
+        reasons.append("counted_surface_changed")
+
+    return {
+        "mode": "advisory",
+        "event_name": event_name,
+        "reasons": reasons,
+        "changed_paths": changed_paths,
+        "strict_matches": [],
+        "counted_matches": counted_matches,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--event-name",
+        required=True,
+        help="GitHub event name, for example pull_request or workflow_dispatch.",
+    )
+    parser.add_argument(
+        "--changed-files",
+        type=Path,
+        help="File containing one changed repo-relative path per line.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Accepted for explicitness; output is always JSON.",
+    )
+    parser.add_argument("paths", nargs="*", help="Changed repo-relative paths.")
+    args = parser.parse_args(argv)
+
+    changed_paths = load_changed_paths(args.paths, args.changed_files)
+    print(json.dumps(classify(args.event_name, changed_paths), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/regenerate_metrics.py
+++ b/scripts/regenerate_metrics.py
@@ -8,11 +8,13 @@ verify it by running the same command.
 Usage:
     python scripts/regenerate_metrics.py              # rewrite docs/METRICS.md
     python scripts/regenerate_metrics.py --check      # fail if drift > 0.5%
+    python scripts/regenerate_metrics.py --check --advisory  # warn but exit 0
     python scripts/regenerate_metrics.py --json       # emit JSON only
 
 Drift threshold is intentionally tight: claim-drift is a thesis-commitment
 violation (Commitment 4: respect the limits). A drifted metric should
-trigger a PR rather than a silent mismatch.
+trigger a PR rather than a silent mismatch. Advisory mode is for ordinary
+implementation PRs where the workflow should report drift without blocking.
 """
 
 from __future__ import annotations
@@ -465,6 +467,9 @@ def render_markdown(snapshot: MetricsSnapshot) -> str:
     lines.append("")
     lines.append("- **Regenerate:** `python scripts/regenerate_metrics.py`")
     lines.append("- **Verify (drift check):** `python scripts/regenerate_metrics.py --check`")
+    lines.append(
+        "- **Advisory PR check:** `python scripts/regenerate_metrics.py --check --advisory`"
+    )
     lines.append("- **Timestamped JSON snapshot:** `python scripts/regenerate_metrics.py --json`")
     lines.append("")
     lines.append("## Canonical numbers")
@@ -522,16 +527,29 @@ def render_markdown(snapshot: MetricsSnapshot) -> str:
         "regardless of threshold."
     )
     lines.append("")
+    lines.append(
+        "The GitHub workflow applies that strict failure mode to manual/weekly "
+        "runs and to PRs that touch metrics generation, canonical metrics "
+        "checks, `docs/METRICS.md`, or public/canonical claim docs. Ordinary "
+        "implementation PRs that only move counted surfaces still run the "
+        "same drift check, but in advisory mode: drift is reported loudly in "
+        "the workflow output without failing the PR. This keeps public claims "
+        "honest without forcing every unrelated branch to refresh generated "
+        "counts before review."
+    )
+    lines.append("")
     lines.append("## Related automation")
     lines.append("")
     lines.append(
         "- `.github/workflows/metrics-drift.yml` runs this script on every PR "
         "that touches counted surfaces (`aragora/`, `tests/`, `sdk/`, "
-        "`docs/api/openapi.json`, `.mypy-baseline`), and on a weekly Monday "
-        "schedule. It invokes `--check` and fails the job if drift exceeds "
-        "the threshold. The job does **not** auto-open a refresh PR; it "
-        "fails loud and a human or follow-up automation decides whether "
-        "to regenerate."
+        "`docs/api/openapi.json`, `.mypy-baseline`) plus public/canonical "
+        "claim paths, and on a weekly Monday schedule. It classifies PRs with "
+        "`scripts/classify_metrics_drift_scope.py`: public-claim and metrics "
+        "source changes are strict, while ordinary counted-surface changes "
+        "are advisory. The job does **not** auto-open a refresh PR; strict "
+        "failures stay loud and a human or follow-up automation decides "
+        "whether to regenerate."
     )
     lines.append(
         "- `tests/scripts/test_regenerate_metrics.py` holds external "
@@ -569,7 +587,11 @@ def parse_current_metrics(doc_path: Path) -> dict[str, int | str]:
     return result
 
 
-def check_drift(snapshot: MetricsSnapshot) -> tuple[bool, list[str]]:
+def check_drift(
+    snapshot: MetricsSnapshot,
+    *,
+    threshold: float = DRIFT_THRESHOLD,
+) -> tuple[bool, list[str]]:
     current = parse_current_metrics(METRICS_DOC)
     drifts: list[str] = []
     for m in snapshot.metrics:
@@ -582,7 +604,7 @@ def check_drift(snapshot: MetricsSnapshot) -> tuple[bool, list[str]]:
                 delta_pct = 1.0 if m.value != 0 else 0.0
             else:
                 delta_pct = abs(m.value - prev) / prev
-            if delta_pct > DRIFT_THRESHOLD:
+            if delta_pct > threshold:
                 drifts.append(f"DRIFT: {m.label} {prev} -> {m.value} ({delta_pct * 100:.1f}%)")
         else:
             if str(prev) != str(m.value):
@@ -598,11 +620,27 @@ def main() -> int:
         help="Exit non-zero if any metric drifted more than 0.5% from current doc.",
     )
     parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help="With --check, report drift but exit zero.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DRIFT_THRESHOLD,
+        help="Allowed fractional drift for integer metrics (default: 0.005).",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Print JSON snapshot to stdout instead of writing docs/METRICS.md.",
     )
     args = parser.parse_args()
+
+    if args.advisory and not args.check:
+        parser.error("--advisory requires --check")
+    if args.threshold < 0:
+        parser.error("--threshold must be non-negative")
 
     snapshot = gather_metrics()
 
@@ -611,18 +649,24 @@ def main() -> int:
         return 0
 
     if args.check:
-        drifted, drifts = check_drift(snapshot)
+        drifted, drifts = check_drift(snapshot, threshold=args.threshold)
         if drifted:
-            print("Metrics drifted:")
+            label = "Metrics drifted"
+            if args.advisory:
+                label += " (advisory)"
+            print(f"{label}:")
             for d in drifts:
                 print(f"  {d}")
             print()
+            if args.advisory:
+                print("Advisory mode: drift reported, but exit status remains zero.")
+                return 0
             print(
                 "Run `python scripts/regenerate_metrics.py` to refresh "
                 "docs/METRICS.md and commit the result."
             )
             return 1
-        print("No drift beyond 0.5% threshold.")
+        print(f"No drift beyond {args.threshold * 100:g}% threshold.")
         return 0
 
     # Regenerate the doc

--- a/tests/scripts/test_classify_metrics_drift_scope.py
+++ b/tests/scripts/test_classify_metrics_drift_scope.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "classify_metrics_drift_scope.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("classify_metrics_drift_scope", str(SCRIPT))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["classify_metrics_drift_scope"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_non_pull_request_events_are_strict():
+    mod = _load_module()
+
+    result = mod.classify("workflow_dispatch", [])
+
+    assert result["mode"] == "strict"
+    assert result["reasons"] == ["non_pull_request_event"]
+
+
+def test_public_claim_and_metrics_source_paths_are_strict():
+    mod = _load_module()
+
+    result = mod.classify(
+        "pull_request",
+        [
+            "aragora/example.py",
+            "docs/CANONICAL_GOALS.md",
+            "scripts/regenerate_metrics.py",
+        ],
+    )
+
+    assert result["mode"] == "strict"
+    assert result["strict_matches"] == [
+        "docs/CANONICAL_GOALS.md",
+        "scripts/regenerate_metrics.py",
+    ]
+    assert result["counted_matches"] == ["aragora/example.py"]
+
+
+def test_ordinary_counted_surface_prs_are_advisory():
+    mod = _load_module()
+
+    result = mod.classify(
+        "pull_request",
+        [
+            "tests/scripts/test_example.py",
+            "sdk/python/aragora_sdk/client.py",
+            "docs/api/openapi.json",
+            ".mypy-baseline",
+        ],
+    )
+
+    assert result["mode"] == "advisory"
+    assert "counted_surface_changed" in result["reasons"]
+    assert result["strict_matches"] == []
+
+
+def test_empty_pull_request_path_list_is_advisory():
+    mod = _load_module()
+
+    result = mod.classify("pull_request", [])
+
+    assert result["mode"] == "advisory"
+    assert "no_changed_paths_reported" in result["reasons"]
+
+
+def test_unknown_pull_request_paths_are_advisory_not_strict():
+    mod = _load_module()
+
+    result = mod.classify("pull_request", ["docs/random-note.md"])
+
+    assert result["mode"] == "advisory"
+    assert result["strict_matches"] == []
+    assert result["counted_matches"] == []

--- a/tests/scripts/test_regenerate_metrics.py
+++ b/tests/scripts/test_regenerate_metrics.py
@@ -194,3 +194,88 @@ def test_check_mode_is_idempotent(tmp_path, monkeypatch):
     snapshot_b = mod.gather_metrics()
     drifted, drifts = mod.check_drift(snapshot_b)
     assert not drifted, f"drift detected between two back-to-back regenerations: {drifts}"
+
+
+def _snapshot_with_metric(mod, value: int):
+    return mod.MetricsSnapshot(
+        generated_at="1970-01-01T00:00:00+00:00",
+        git_sha="deadbeef",
+        metrics=[
+            mod.Metric(
+                key="example",
+                label="Example metric",
+                value=value,
+                command="echo example",
+                source="test",
+            )
+        ],
+    )
+
+
+def _write_metrics_doc(path: Path, value: int) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "# Test Metrics",
+                "",
+                "| Metric | Value | Source | Command |",
+                "|---|---|---|---|",
+                f"| Example metric | `{value}` | `test` | `echo example` |",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_check_drift_default_threshold_is_unchanged(tmp_path, monkeypatch):
+    mod = _load_module()
+    metrics_doc = tmp_path / "METRICS.md"
+    _write_metrics_doc(metrics_doc, 1000)
+    monkeypatch.setattr(mod, "METRICS_DOC", metrics_doc)
+
+    drifted, drifts = mod.check_drift(_snapshot_with_metric(mod, 1005))
+    assert not drifted, drifts
+
+    drifted, drifts = mod.check_drift(_snapshot_with_metric(mod, 1006))
+    assert drifted, drifts
+
+    drifted, drifts = mod.check_drift(
+        _snapshot_with_metric(mod, 1006),
+        threshold=0.01,
+    )
+    assert not drifted, drifts
+
+
+def test_strict_check_exits_nonzero_on_drift(tmp_path, monkeypatch, capsys):
+    mod = _load_module()
+    metrics_doc = tmp_path / "METRICS.md"
+    _write_metrics_doc(metrics_doc, 100)
+    monkeypatch.setattr(mod, "METRICS_DOC", metrics_doc)
+    monkeypatch.setattr(mod, "gather_metrics", lambda: _snapshot_with_metric(mod, 200))
+    monkeypatch.setattr(sys, "argv", ["regenerate_metrics.py", "--check"])
+
+    assert mod.main() == 1
+    out = capsys.readouterr().out
+    assert "Metrics drifted:" in out
+    assert "Run `python scripts/regenerate_metrics.py`" in out
+
+
+def test_advisory_check_exits_zero_on_drift(tmp_path, monkeypatch, capsys):
+    mod = _load_module()
+    metrics_doc = tmp_path / "METRICS.md"
+    _write_metrics_doc(metrics_doc, 100)
+    original_doc = metrics_doc.read_text(encoding="utf-8")
+    monkeypatch.setattr(mod, "METRICS_DOC", metrics_doc)
+    monkeypatch.setattr(mod, "gather_metrics", lambda: _snapshot_with_metric(mod, 200))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["regenerate_metrics.py", "--check", "--advisory"],
+    )
+
+    assert mod.main() == 0
+    assert metrics_doc.read_text(encoding="utf-8") == original_doc
+    out = capsys.readouterr().out
+    assert "Metrics drifted (advisory):" in out
+    assert "Advisory mode: drift reported" in out


### PR DESCRIPTION
## Summary
- Adds a pure-stdlib Metrics Drift scope classifier so public/canonical metrics paths stay strict while ordinary counted-surface PRs become advisory.
- Adds `regenerate_metrics.py --check --advisory` plus threshold plumbing without changing the default 0.5% drift threshold.
- Updates the Metrics Drift workflow and generated `docs/METRICS.md` policy text to report advisory drift without blocking unrelated PRs.

## Test Plan
- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/scripts/test_regenerate_metrics.py tests/scripts/test_classify_metrics_drift_scope.py -p no:cacheprovider`
- [x] `python3 -m ruff check --no-cache scripts/regenerate_metrics.py scripts/classify_metrics_drift_scope.py tests/scripts/test_regenerate_metrics.py tests/scripts/test_classify_metrics_drift_scope.py`
- [x] `python3 -m ruff format --check scripts/regenerate_metrics.py scripts/classify_metrics_drift_scope.py tests/scripts/test_regenerate_metrics.py tests/scripts/test_classify_metrics_drift_scope.py`
- [x] `python3 scripts/regenerate_metrics.py --check`
- [x] `python3 scripts/regenerate_metrics.py --check --advisory`
- [x] `bash scripts/automation_pr_preflight.sh origin/main HEAD`