### PR TITLE
R01: contact_method + contact_payload on LaneRecord (reach plan Phase 1)

### DIFF
--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -180,12 +180,17 @@ class LaneRecord:
     codex_thread_id: str = ""
     codex_rollout_path: str = ""
     session_title: str = ""
+    contact_method: str = ""
+    contact_payload: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v not in ("", None)}
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "LaneRecord":
+        contact_payload = payload.get("contact_payload")
+        if not isinstance(contact_payload, dict):
+            contact_payload = None
         return cls(
             lane_id=str(payload.get("lane_id", "")),
             owner_session=str(payload.get("owner_session", "")),
@@ -203,6 +208,8 @@ class LaneRecord:
             codex_thread_id=str(payload.get("codex_thread_id", "")),
             codex_rollout_path=str(payload.get("codex_rollout_path", "")),
             session_title=str(payload.get("session_title", "")),
+            contact_method=str(payload.get("contact_method", "")),
+            contact_payload=contact_payload,
         )
 
 

--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -73,6 +73,7 @@ from contextlib import contextmanager
 import datetime as dt
 import json
 import os
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -115,6 +116,8 @@ LANE_RECORD_KEYS = (
     "codex_thread_id",
     "codex_rollout_path",
     "session_title",
+    "contact_method",
+    "contact_payload",
 )
 
 
@@ -127,6 +130,76 @@ ACTIVE_STATUSES = {"active", "running", "pending", "queued", "claimed"}
 
 def _utc_now_iso() -> str:
     return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_contact_payload(raw: str) -> dict[str, Any] | None:
+    """Parse `--contact-payload` JSON string. Returns None when empty or invalid.
+
+    Phase 1 reach-plan helper. Strict-mode JSON: malformed input raises
+    `ValueError` so CLI users see the error rather than silently dropping
+    backend-specific dispatch detail.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"--contact-payload must be valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"--contact-payload must decode to a JSON object, got {type(parsed).__name__}"
+        )
+    return parsed
+
+
+def _detect_tmux_contact_method() -> str:
+    """Phase 1 reach-plan helper: auto-derive `contact_method=tmux:<name>`
+    when this claim is being made from inside a tmux pane in the aragora
+    session.
+
+    Returns an empty string when:
+    - Not running inside tmux (no `TMUX` env var)
+    - tmux binary unavailable
+    - `tmux display-message` fails for any reason
+    - The detected session is not `aragora` (we only auto-populate for the
+      canonical aragora tmux session — other sessions can pass the flag
+      explicitly to override)
+
+    Returns `tmux:<window-name>` when detection succeeds. Designed to be
+    pure observation: no environment mutation, no side effects, no
+    timeouts longer than 1 second (so a stuck tmux server can't block
+    claim_lane). Fully overridden by explicit `--contact-method` CLI flag
+    or `contact_method=` kwarg.
+    """
+    if not os.environ.get("TMUX"):
+        return ""
+    pane_id = os.environ.get("TMUX_PANE", "").strip()
+    if not pane_id:
+        return ""
+    try:
+        # Use #S\t#W format so we can verify session name AND get window name
+        result = subprocess.run(
+            ["tmux", "display-message", "-t", pane_id, "-p", "#S\t#W"],
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    parts = result.stdout.strip().split("\t", 1)
+    if len(parts) != 2:
+        return ""
+    session_name, window_name = parts[0].strip(), parts[1].strip()
+    # Only auto-populate when in the canonical aragora session; foreign
+    # sessions must pass --contact-method explicitly.
+    if session_name != "aragora":
+        return ""
+    if not window_name:
+        return ""
+    return f"tmux:{window_name}"
 
 
 def resolve_registry_path(
@@ -328,6 +401,8 @@ def claim_lane(
     codex_thread_id: str = "",
     codex_rollout_path: str = "",
     session_title: str = "",
+    contact_method: str = "",
+    contact_payload: dict[str, Any] | None = None,
     force: bool = False,
     allow_resource_conflicts: bool = False,
     updated_at: str | None = None,
@@ -339,6 +414,17 @@ def claim_lane(
         raise ValueError("owner_session must not be empty")
     if status not in ALLOWED_STATUSES:
         raise ValueError(f"status {status!r} is not in {sorted(ALLOWED_STATUSES)}")
+
+    # Phase 1 reach-plan auto-populate: if no contact_method given and the
+    # claim is being made from inside a tmux pane in the aragora session,
+    # derive contact_method=tmux:<window-name> so downstream dispatchers
+    # (wake_agent.sh, Phase 2 PR) can reach this lane's owner via the
+    # already-shipped tmux_send_prompt.sh backend. Pure env-var + subprocess;
+    # no new imports.
+    if not contact_method:
+        detected = _detect_tmux_contact_method()
+        if detected:
+            contact_method = detected
 
     with _registry_write_lock(registry_path):
         rows = _read_existing(registry_path)
@@ -361,6 +447,8 @@ def claim_lane(
             "codex_thread_id": codex_thread_id,
             "codex_rollout_path": codex_rollout_path,
             "session_title": session_title,
+            "contact_method": contact_method,
+            "contact_payload": contact_payload,
         }
         normalized = _normalize_row(new_row)
 
@@ -438,6 +526,26 @@ def build_parser() -> argparse.ArgumentParser:
         "--session-title",
         default="",
         help="Optional visible or inferred session title for operator display.",
+    )
+    parser.add_argument(
+        "--contact-method",
+        default="",
+        help=(
+            "Phase 1 reach-plan backend identifier. Format: "
+            "'tmux:<window-name>', 'osascript:codex-desktop:<thread-id>', "
+            "'osascript:droid-cli:<window-title>', 'factory-api:<session>', "
+            "or 'mailbox-only'. When omitted inside a tmux pane on the "
+            "aragora session, auto-populates from the live tmux window name."
+        ),
+    )
+    parser.add_argument(
+        "--contact-payload",
+        default="",
+        help=(
+            "Optional JSON-encoded dict with backend-specific dispatch detail "
+            'e.g. \'{"pane": "claude-p52", "log": "~/.aragora/tmux-sessions/claude-p52.log"}\'. '
+            "Parsed and stored as a dict in the lane registry."
+        ),
     )
     parser.add_argument(
         "--force",
@@ -526,6 +634,8 @@ def main(argv: list[str] | None = None) -> int:
                 codex_thread_id=args.codex_thread_id,
                 codex_rollout_path=args.codex_rollout_path,
                 session_title=args.session_title,
+                contact_method=args.contact_method,
+                contact_payload=_parse_contact_payload(args.contact_payload),
                 force=args.force,
                 allow_resource_conflicts=args.allow_resource_conflicts,
                 updated_at=args.updated_at,

--- a/tests/scripts/test_agent_bridge.py
+++ b/tests/scripts/test_agent_bridge.py
@@ -88,6 +88,68 @@ def test_lane_record_preserves_desktop_identity_metadata() -> None:
     assert payload["session_title"] == "Review #7286"
 
 
+def test_lane_record_roundtrips_contact_method_and_payload() -> None:
+    """Phase R01: LaneRecord persists + restores contact_method + contact_payload."""
+    import agent_bridge as mod
+
+    record = mod.LaneRecord.from_dict(
+        {
+            "lane_id": "claude-reach-1",
+            "owner_session": "claude-A",
+            "status": "active",
+            "contact_method": "tmux:claude-p52",
+            "contact_payload": {
+                "pane": "claude-p52",
+                "log": "~/.aragora/tmux-sessions/claude-p52.log",
+            },
+        }
+    )
+
+    assert record.contact_method == "tmux:claude-p52"
+    assert record.contact_payload == {
+        "pane": "claude-p52",
+        "log": "~/.aragora/tmux-sessions/claude-p52.log",
+    }
+    payload = record.to_dict()
+    assert payload["contact_method"] == "tmux:claude-p52"
+    assert payload["contact_payload"]["pane"] == "claude-p52"
+
+
+def test_lane_record_omits_unset_contact_fields() -> None:
+    """When contact_method='' and contact_payload=None, both keys absent from to_dict()."""
+    import agent_bridge as mod
+
+    record = mod.LaneRecord.from_dict(
+        {
+            "lane_id": "claude-reach-2",
+            "owner_session": "claude-A",
+            "status": "active",
+        }
+    )
+
+    payload = record.to_dict()
+    assert "contact_method" not in payload
+    assert "contact_payload" not in payload
+
+
+def test_lane_record_rejects_non_dict_contact_payload() -> None:
+    """Malformed contact_payload (string, list, scalar) coerces to None to avoid mid-pipeline crash."""
+    import agent_bridge as mod
+
+    record = mod.LaneRecord.from_dict(
+        {
+            "lane_id": "claude-reach-3",
+            "owner_session": "claude-A",
+            "status": "active",
+            "contact_method": "mailbox-only",
+            "contact_payload": "not-a-dict-value",  # legacy/malformed
+        }
+    )
+
+    assert record.contact_payload is None
+    assert record.contact_method == "mailbox-only"
+
+
 def test_cmd_approve_droid_uses_enter_menu_selection(monkeypatch: pytest.MonkeyPatch) -> None:
     import agent_bridge as mod
 

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -666,3 +666,246 @@ def test_worktree_collision_detected_across_trailing_slash(
 
     assert "worktree=" in str(excinfo.value)
     assert str(worktree.resolve()) in str(excinfo.value)
+
+
+# --- Phase R01 reach-plan: contact_method + contact_payload fields --------
+
+
+def test_claim_lane_records_explicit_contact_method(tmp_registry: Path) -> None:
+    """Explicit `contact_method=` kwarg round-trips through the persisted row."""
+    row = claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="reach-1",
+        owner_session="claude-A",
+        contact_method="tmux:claude-p52",
+    )
+    assert row["contact_method"] == "tmux:claude-p52"
+
+    payload = json.loads(tmp_registry.read_text())
+    assert payload[0]["contact_method"] == "tmux:claude-p52"
+
+
+def test_claim_lane_records_explicit_contact_payload(tmp_registry: Path) -> None:
+    """Explicit `contact_payload=` dict round-trips through the persisted row."""
+    payload_dict = {"pane": "claude-p52", "log": "~/.aragora/tmux-sessions/claude-p52.log"}
+    row = claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="reach-2",
+        owner_session="claude-A",
+        contact_method="tmux:claude-p52",
+        contact_payload=payload_dict,
+    )
+    assert row["contact_payload"] == payload_dict
+
+    persisted = json.loads(tmp_registry.read_text())
+    assert persisted[0]["contact_payload"] == payload_dict
+
+
+def test_claim_lane_omits_contact_fields_when_unset(
+    tmp_registry: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When neither --contact-method nor TMUX env is set, neither key persists."""
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+
+    row = claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="reach-3",
+        owner_session="claude-A",
+    )
+    assert "contact_method" not in row
+    assert "contact_payload" not in row
+
+    persisted = json.loads(tmp_registry.read_text())
+    assert "contact_method" not in persisted[0]
+    assert "contact_payload" not in persisted[0]
+
+
+def test_parse_contact_payload_valid_json() -> None:
+    """JSON object string decodes to a dict."""
+    assert claim_module._parse_contact_payload('{"k": "v"}') == {"k": "v"}
+
+
+def test_parse_contact_payload_empty_returns_none() -> None:
+    """Empty string returns None (not-set sentinel)."""
+    assert claim_module._parse_contact_payload("") is None
+
+
+def test_parse_contact_payload_invalid_json_raises() -> None:
+    """Malformed JSON raises ValueError so CLI users see it."""
+    with pytest.raises(ValueError, match="must be valid JSON"):
+        claim_module._parse_contact_payload("{not-json")
+
+
+def test_parse_contact_payload_non_object_raises() -> None:
+    """JSON arrays/scalars are rejected — must be an object."""
+    with pytest.raises(ValueError, match="must decode to a JSON object"):
+        claim_module._parse_contact_payload("[1, 2, 3]")
+    with pytest.raises(ValueError, match="must decode to a JSON object"):
+        claim_module._parse_contact_payload('"just a string"')
+
+
+def test_detect_tmux_returns_empty_without_tmux_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-detect short-circuits when TMUX env var is unset."""
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+    assert claim_module._detect_tmux_contact_method() == ""
+
+
+def test_detect_tmux_returns_empty_when_pane_id_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When TMUX is set but TMUX_PANE is missing, no auto-detect."""
+    monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,1234,0")
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+    assert claim_module._detect_tmux_contact_method() == ""
+
+
+def test_detect_tmux_returns_empty_for_non_aragora_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the canonical 'aragora' session triggers auto-populate."""
+    monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,1234,0")
+    monkeypatch.setenv("TMUX_PANE", "%0")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="other-session\tsomeagent\n", stderr=""
+        )
+
+    monkeypatch.setattr(claim_module.subprocess, "run", fake_run)
+    assert claim_module._detect_tmux_contact_method() == ""
+
+
+def test_detect_tmux_returns_window_name_for_aragora_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aragora-session pane produces `tmux:<window-name>`."""
+    monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,1234,0")
+    monkeypatch.setenv("TMUX_PANE", "%3")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="aragora\tclaude-p52\n", stderr=""
+        )
+
+    monkeypatch.setattr(claim_module.subprocess, "run", fake_run)
+    assert claim_module._detect_tmux_contact_method() == "tmux:claude-p52"
+
+
+def test_detect_tmux_returns_empty_when_tmux_binary_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If tmux is not installed, fall back to empty (no exception leak)."""
+    monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,1234,0")
+    monkeypatch.setenv("TMUX_PANE", "%0")
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("tmux not on PATH")
+
+    monkeypatch.setattr(claim_module.subprocess, "run", fake_run)
+    assert claim_module._detect_tmux_contact_method() == ""
+
+
+def test_explicit_contact_method_overrides_tmux_auto_detect(
+    tmp_registry: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit kwarg beats tmux env auto-detect — no surprise overwrite."""
+    monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,1234,0")
+    monkeypatch.setenv("TMUX_PANE", "%0")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="aragora\tauto-detected\n", stderr=""
+        )
+
+    monkeypatch.setattr(claim_module.subprocess, "run", fake_run)
+    row = claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="reach-explicit",
+        owner_session="claude-A",
+        contact_method="mailbox-only",
+    )
+    assert row["contact_method"] == "mailbox-only"
+
+
+def test_cli_contact_method_flag_via_subprocess(tmp_registry: Path) -> None:
+    """End-to-end: --contact-method CLI flag persists to the registry."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--lane-id",
+            "reach-cli-1",
+            "--owner-session",
+            "claude-cli",
+            "--registry-path",
+            str(tmp_registry),
+            "--contact-method",
+            "osascript:codex-desktop:thread-0abc",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin"},
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["contact_method"] == "osascript:codex-desktop:thread-0abc"
+
+
+def test_cli_contact_payload_flag_via_subprocess(tmp_registry: Path) -> None:
+    """End-to-end: --contact-payload JSON flag persists as a dict."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--lane-id",
+            "reach-cli-2",
+            "--owner-session",
+            "claude-cli",
+            "--registry-path",
+            str(tmp_registry),
+            "--contact-method",
+            "tmux:claude-p99",
+            "--contact-payload",
+            '{"pane": "claude-p99", "log": "/tmp/p99.log"}',
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin"},
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["contact_payload"] == {
+        "pane": "claude-p99",
+        "log": "/tmp/p99.log",
+    }
+
+
+def test_cli_invalid_contact_payload_exits_with_error(tmp_registry: Path) -> None:
+    """Malformed --contact-payload JSON exits non-zero with a clear error."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--lane-id",
+            "reach-cli-bad",
+            "--owner-session",
+            "claude-cli",
+            "--registry-path",
+            str(tmp_registry),
+            "--contact-payload",
+            "{not-json",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin"},
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "must be valid JSON" in result.stderr


### PR DESCRIPTION
## Summary

Phase 1 of the agent-dispatch reach plan introduced in PR #7327. Adds two additive fields to `LaneRecord` that name the backend each lane's owner can be reached through:

- `contact_method: str = ""` — e.g. `tmux:claude-p52`, `osascript:codex-desktop:<thread-id>`, `mailbox-only`
- `contact_payload: dict | None = None` — backend-specific dispatch detail

Tracked in lane registry under `R01-reach-plan-contact-method-field` (claimed by `claude-B061F80D`).

## Scope

- `scripts/agent_bridge.py` — `LaneRecord` dataclass gains the two fields. `from_dict` coerces malformed `contact_payload` (string/list/scalar) to `None` to prevent mid-pipeline crashes when legacy rows surface.
- `scripts/claim_active_agent_lane.py` — `LANE_RECORD_KEYS` extends, `claim_lane()` gets new kwargs, `--contact-method` and `--contact-payload` CLI flags added.
- **Auto-populate**: when `--contact-method` is omitted and the claim runs from inside a tmux pane on the canonical `aragora` tmux session, `contact_method` derives from `tmux display-message -p '#W'` and persists as `tmux:<window-name>`. Explicit flag overrides auto-detect.

## Why this matters

This is the smallest unblocker for Phase 2 (unified `scripts/wake_agent.sh`). Without `contact_method` on the record, the dispatcher can't know whether to reach a lane's owner via `tmux_send_prompt.sh` (tmux pane), `osascript` (Codex Desktop / Droid CLI), `send_operator_steering.py` (mailbox), or factory API. With this field, the dispatcher becomes one switch statement over a string.

## Tests

19 new tests across the two suites (50 + 36 = 86 total passing in the two affected files):

- explicit `contact_method` + `contact_payload` round-trip via `claim_lane()`
- absence when neither flag/env set
- JSON parse: valid object, empty, malformed → `ValueError`, scalar/list → `ValueError`
- tmux auto-detect: missing TMUX env, missing TMUX_PANE, non-aragora session, aragora-session happy path, tmux binary missing
- explicit flag overrides tmux auto-detect
- CLI subprocess round-trip for both flags
- CLI rejects malformed JSON with clear error
- `LaneRecord.to_dict()` omits unset contact fields
- `LaneRecord.from_dict()` coerces non-dict `contact_payload` to `None`

## Validation

```
$ python3 -m pytest tests/scripts/test_agent_bridge.py tests/scripts/test_claim_active_agent_lane.py -q
86 passed in 3.14s

$ python3 -m ruff check scripts/claim_active_agent_lane.py scripts/agent_bridge.py tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_agent_bridge.py
All checks passed!

$ python3 -m mypy scripts/claim_active_agent_lane.py scripts/agent_bridge.py
Success: no issues found in 2 source files

$ bash scripts/automation_pr_preflight.sh origin/main HEAD
preflight: ok
```

## Discipline

- Schema-additive only. Legacy rows lack the fields; `_normalize_row` filters None/empty values, so they continue to round-trip unchanged.
- Pure stdlib. One new import (`subprocess` in `claim_active_agent_lane.py`) per plan doc constraint.
- No protected files touched (no `CLAUDE.md`, no `aragora/__init__.py`, no `docs/AGENT_OPERATING_CONTRACT.md`).
- Draft. No labels. No merges. No automation config edits.
- Follow-on lane R02 (Phase 2 `wake_agent.sh`) depends on this PR landing first.

## Test plan
- [ ] Pull this branch, run `python3 -m pytest tests/scripts/test_claim_active_agent_lane.py tests/scripts/test_agent_bridge.py -q`
- [ ] Inside the `aragora` tmux session, run `python3 scripts/claim_active_agent_lane.py --lane-id smoke-r01 --owner-session test --json` and confirm `contact_method` auto-populates to `tmux:<your-window>`
- [ ] Confirm `python3 scripts/claim_active_agent_lane.py --lane-id smoke-r01 --owner-session test --contact-method mailbox-only --json` overrides the auto-detect

🤖 Generated with [Claude Code](https://claude.com/claude-code)