### PR TITLE
R02: wake_agent.sh unified dispatch CLI (reach plan Phase 2)

### DIFF
--- a/scripts/wake_agent.sh
+++ b/scripts/wake_agent.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Unified agent-wake dispatcher (Phase 2 of agent-dispatch reach plan, R02).
+#
+# Reads the lane's `contact_method` (added to LaneRecord by R01 / PR #7336)
+# and dispatches a prompt to that lane's owner via the right backend:
+#   tmux:NAME       -> scripts/tmux_send_prompt.sh
+#   mailbox-only    -> scripts/send_operator_steering.py
+#   osascript:*     -> not yet implemented (R03+); falls back to --fallback
+#   factory-api:*   -> not yet implemented (R04 opt-in); falls back to --fallback
+#
+# Every dispatch writes a JSON delivery receipt to
+#   .aragora/dispatch-receipts/<utc>-<lane>-<sha8>.json
+# capturing the chosen backend, message SHA-256, and outcome.
+#
+# Usage:
+#   ./scripts/wake_agent.sh --lane LANE_ID \
+#       [--prompt TEXT | --prompt-file PATH] \
+#       [--priority {low,normal,high,blocking}] \
+#       [--dry-run | --apply] \
+#       [--fallback {mailbox-only,fail}] \
+#       [--json]
+#
+# Flags:
+#   --lane <id>           Required. Lane id whose owner should be woken.
+#   --prompt <text>       Inline prompt text.
+#   --prompt-file <path>  Path to a prompt file (read as-is, UTF-8).
+#   --priority <level>    Mailbox priority hint (default: normal).
+#   --dry-run             (Default.) Resolve lane, pick backend, write
+#                         receipt with `dispatch_attempted=false`, but do
+#                         NOT actually send. Idempotent and safe.
+#   --apply               Opt-in mutate — actually dispatch.
+#   --fallback <mode>     What to do if contact_method is missing / unknown:
+#                           mailbox-only (default) — fall back to mailbox.
+#                           fail — exit non-zero without dispatching.
+#   --json                Print the dispatch receipt to stdout.
+#
+# Exit codes:
+#   0   success (dispatched or dry-run resolved)
+#   1   usage error
+#   2   lane not found
+#   3   missing contact_method AND --fallback fail
+#   4   dispatch backend invocation failed
+#
+# Dependencies (all already shipped):
+#   - scripts/identify_lane_owner.py  (PR #7308, on main)
+#   - scripts/tmux_send_prompt.sh
+#   - scripts/send_operator_steering.py (PR #7310)
+#
+# Depends on R01 (PR #7336) for the `contact_method` field on LaneRecord
+# rows, but degrades gracefully when contact_method is absent (treats as
+# mailbox-only fallback).
+
+set -euo pipefail
+
+LANE_ID=""
+PROMPT_TEXT=""
+PROMPT_FILE=""
+PRIORITY="normal"
+MODE="dry-run"     # default fail-closed
+FALLBACK="mailbox-only"
+JSON_OUTPUT=0
+
+usage() {
+    cat <<'EOF'
+wake_agent.sh — unified dispatch CLI (reach plan Phase 2 / R02)
+
+Required:
+  --lane <id>           Lane id to wake.
+
+One of:
+  --prompt <text>       Inline prompt.
+  --prompt-file <path>  Read prompt from file.
+
+Optional:
+  --priority {low,normal,high,blocking}  (default: normal)
+  --dry-run            (default) Resolve + write receipt, do not send.
+  --apply              Opt-in: actually dispatch.
+  --fallback {mailbox-only,fail}         (default: mailbox-only)
+  --json               Emit JSON receipt to stdout.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --lane)         LANE_ID="$2"; shift 2 ;;
+        --prompt)       PROMPT_TEXT="$2"; shift 2 ;;
+        --prompt-file)  PROMPT_FILE="$2"; shift 2 ;;
+        --priority)     PRIORITY="$2"; shift 2 ;;
+        --dry-run)      MODE="dry-run"; shift ;;
+        --apply)        MODE="apply"; shift ;;
+        --fallback)     FALLBACK="$2"; shift 2 ;;
+        --json)         JSON_OUTPUT=1; shift ;;
+        -h|--help)      usage; exit 0 ;;
+        *)              echo "Unknown flag: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$LANE_ID" ]]; then
+    echo "error: --lane is required" >&2
+    exit 1
+fi
+if [[ -z "$PROMPT_TEXT" && -z "$PROMPT_FILE" ]]; then
+    echo "error: one of --prompt or --prompt-file is required" >&2
+    exit 1
+fi
+if [[ -n "$PROMPT_TEXT" && -n "$PROMPT_FILE" ]]; then
+    echo "error: --prompt and --prompt-file are mutually exclusive" >&2
+    exit 1
+fi
+case "$PRIORITY" in
+    low|normal|high|blocking) ;;
+    *) echo "error: --priority must be one of low|normal|high|blocking" >&2; exit 1 ;;
+esac
+case "$FALLBACK" in
+    mailbox-only|fail) ;;
+    *) echo "error: --fallback must be one of mailbox-only|fail" >&2; exit 1 ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/scripts"
+RECEIPT_DIR="$REPO_ROOT/.aragora/dispatch-receipts"
+mkdir -p "$RECEIPT_DIR"
+
+# Resolve prompt content + SHA-256 for receipt binding.
+if [[ -n "$PROMPT_FILE" ]]; then
+    if [[ ! -r "$PROMPT_FILE" ]]; then
+        echo "error: prompt file not readable: $PROMPT_FILE" >&2
+        exit 1
+    fi
+    PROMPT_CONTENT="$(cat "$PROMPT_FILE")"
+else
+    PROMPT_CONTENT="$PROMPT_TEXT"
+fi
+PROMPT_SHA="$(printf '%s' "$PROMPT_CONTENT" | shasum -a 256 | awk '{print $1}')"
+
+# Look up lane owner + contact_method via the canonical Phase A reader.
+# Falls back to direct registry parse if identify_lane_owner.py is absent
+# (e.g., legacy worktree predating PR #7308).
+LANE_JSON=""
+if [[ -x "$SCRIPTS_DIR/identify_lane_owner.py" || -r "$SCRIPTS_DIR/identify_lane_owner.py" ]]; then
+    LANE_JSON="$(python3 "$SCRIPTS_DIR/identify_lane_owner.py" --lane-id "$LANE_ID" --json 2>/dev/null || true)"
+fi
+if [[ -z "$LANE_JSON" || "$LANE_JSON" == "null" ]]; then
+    # Fallback: read the raw registry.
+    LANE_JSON="$(python3 -c "
+import json, sys
+from pathlib import Path
+for p in (Path('$REPO_ROOT/.aragora/agent-bridge/lanes.json'),
+          Path.home()/'.aragora'/'agent-bridge'/'lanes.json'):
+    if p.exists():
+        for row in json.loads(p.read_text() or '[]'):
+            if row.get('lane_id') == '$LANE_ID':
+                print(json.dumps(row))
+                sys.exit(0)
+" 2>/dev/null || true)"
+fi
+if [[ -z "$LANE_JSON" ]]; then
+    echo "error: lane not found: $LANE_ID" >&2
+    exit 2
+fi
+
+OWNER="$(printf '%s' "$LANE_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('owner_session','') or '')")"
+CONTACT_METHOD="$(printf '%s' "$LANE_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('contact_method','') or '')")"
+
+CHOSEN_BACKEND=""
+BACKEND_TARGET=""
+if [[ -z "$CONTACT_METHOD" ]]; then
+    if [[ "$FALLBACK" == "fail" ]]; then
+        echo "error: lane $LANE_ID has no contact_method and --fallback fail" >&2
+        exit 3
+    fi
+    CHOSEN_BACKEND="mailbox-only"
+    BACKEND_TARGET="$OWNER"
+elif [[ "$CONTACT_METHOD" == "mailbox-only"* ]]; then
+    CHOSEN_BACKEND="mailbox-only"
+    BACKEND_TARGET="$OWNER"
+elif [[ "$CONTACT_METHOD" == tmux:* ]]; then
+    CHOSEN_BACKEND="tmux"
+    BACKEND_TARGET="${CONTACT_METHOD#tmux:}"
+else
+    # Unknown / not-yet-implemented backend (osascript:* / factory-api:*).
+    if [[ "$FALLBACK" == "fail" ]]; then
+        echo "error: contact_method $CONTACT_METHOD not implemented and --fallback fail" >&2
+        exit 3
+    fi
+    CHOSEN_BACKEND="mailbox-only"
+    BACKEND_TARGET="$OWNER"
+fi
+
+UTC_TS="$(date -u +%Y%m%dT%H%M%SZ)"
+SHA_SHORT="${PROMPT_SHA:0:8}"
+RECEIPT_PATH="$RECEIPT_DIR/${UTC_TS}-${LANE_ID}-${SHA_SHORT}.json"
+DISPATCH_OUTCOME="dry-run-only"
+DISPATCH_ERROR=""
+
+if [[ "$MODE" == "apply" ]]; then
+    case "$CHOSEN_BACKEND" in
+        tmux)
+            # Build a tmp prompt file for the tmux script (handles multi-line correctly).
+            TMP_FILE="$(mktemp -t wake_agent_tmux.XXXXXX)"
+            printf '%s' "$PROMPT_CONTENT" > "$TMP_FILE"
+            if bash "$SCRIPTS_DIR/tmux_send_prompt.sh" \
+                    --name "$BACKEND_TARGET" \
+                    --prompt-file "$TMP_FILE" \
+                    --source "wake_agent.sh:$LANE_ID" >/dev/null 2>&1; then
+                DISPATCH_OUTCOME="dispatched"
+            else
+                DISPATCH_OUTCOME="failed"
+                DISPATCH_ERROR="tmux_send_prompt.sh exited non-zero"
+            fi
+            rm -f "$TMP_FILE"
+            ;;
+        mailbox-only)
+            if python3 "$SCRIPTS_DIR/send_operator_steering.py" \
+                    --to "$BACKEND_TARGET" \
+                    --body "$PROMPT_CONTENT" \
+                    --priority "$PRIORITY" \
+                    --lane-id "$LANE_ID" >/dev/null 2>&1; then
+                DISPATCH_OUTCOME="dispatched"
+            else
+                DISPATCH_OUTCOME="failed"
+                DISPATCH_ERROR="send_operator_steering.py exited non-zero"
+            fi
+            ;;
+    esac
+fi
+
+# Always write the receipt (idempotent, includes dry-run resolutions).
+python3 - "$RECEIPT_PATH" "$LANE_ID" "$OWNER" "$CONTACT_METHOD" "$CHOSEN_BACKEND" \
+        "$BACKEND_TARGET" "$MODE" "$DISPATCH_OUTCOME" "$DISPATCH_ERROR" \
+        "$PROMPT_SHA" "$PRIORITY" "$FALLBACK" <<'PYEOF'
+import json
+import sys
+from datetime import UTC, datetime
+
+(_, path, lane_id, owner, contact_method, chosen_backend, backend_target,
+ mode, outcome, err, prompt_sha, priority, fallback) = sys.argv
+receipt = {
+    "schema_version": "aragora-wake-agent-receipt/1.0",
+    "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "lane_id": lane_id,
+    "owner_session": owner,
+    "contact_method": contact_method or None,
+    "chosen_backend": chosen_backend,
+    "backend_target": backend_target,
+    "fallback_policy": fallback,
+    "mode": mode,
+    "dispatch_attempted": mode == "apply",
+    "dispatch_outcome": outcome,
+    "dispatch_error": err or None,
+    "priority": priority,
+    "prompt_sha256": prompt_sha,
+}
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(receipt, fh, indent=2, sort_keys=True)
+PYEOF
+
+if [[ "$JSON_OUTPUT" -eq 1 ]]; then
+    cat "$RECEIPT_PATH"
+else
+    echo "wake_agent: lane=$LANE_ID owner=$OWNER backend=$CHOSEN_BACKEND mode=$MODE outcome=$DISPATCH_OUTCOME receipt=$RECEIPT_PATH"
+fi
+
+if [[ "$DISPATCH_OUTCOME" == "failed" ]]; then
+    exit 4
+fi
+exit 0

--- a/tests/scripts/test_wake_agent.py
+++ b/tests/scripts/test_wake_agent.py
@@ -1,0 +1,315 @@
+"""Tests for ``scripts/wake_agent.sh`` (R02 — reach plan Phase 2).
+
+Pattern mirrors ``tests/scripts/test_tmux_transport_scripts.py`` — invoke
+the bash script with subprocess against a tmp HOME / repo-root scaffold,
+and assert on dispatch receipts + exit codes.
+
+R02 depends on R01's `contact_method` field but degrades gracefully when
+the field is absent (falls back to mailbox-only by default), so these
+tests do not require R01 to be on main.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WAKE_SCRIPT = REPO_ROOT / "scripts" / "wake_agent.sh"
+
+
+def _make_fake_repo(tmp_path: Path) -> Path:
+    """Build a minimal repo skeleton that mirrors what wake_agent.sh expects."""
+    fake_repo = tmp_path / "fake_repo"
+    (fake_repo / "scripts").mkdir(parents=True)
+    (fake_repo / ".aragora" / "agent-bridge").mkdir(parents=True)
+    (fake_repo / ".aragora" / "dispatch-receipts").mkdir(parents=True)
+
+    # Copy the script under test into the fake repo so REPO_ROOT resolves correctly.
+    target_script = fake_repo / "scripts" / "wake_agent.sh"
+    target_script.write_bytes(WAKE_SCRIPT.read_bytes())
+    target_script.chmod(target_script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return fake_repo
+
+
+def _write_lane(
+    fake_repo: Path, lane_id: str, *, owner: str, contact_method: str | None = None
+) -> None:
+    registry = fake_repo / ".aragora" / "agent-bridge" / "lanes.json"
+    row: dict[str, object] = {"lane_id": lane_id, "owner_session": owner, "status": "active"}
+    if contact_method is not None:
+        row["contact_method"] = contact_method
+    registry.write_text(json.dumps([row]), encoding="utf-8")
+
+
+def _write_fake_backend(fake_repo: Path, name: str, log_file: Path, *, exit_code: int = 0) -> None:
+    """Drop a fake backend script under the fake repo's scripts/ dir."""
+    script = fake_repo / "scripts" / name
+    script.write_text(
+        f"""#!/usr/bin/env bash
+echo "$@" >> "{log_file}"
+exit {exit_code}
+"""
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run(fake_repo: Path, *args: str, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["HOME"] = str(fake_repo.parent)  # so the user-registry fallback uses tmp
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(fake_repo / "scripts" / "wake_agent.sh"), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(fake_repo),
+        check=False,
+    )
+
+
+# ----- usage / arg validation -----
+
+
+def test_no_lane_flag_errors(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    result = _run(fake_repo, "--prompt", "hi")
+    assert result.returncode == 1
+    assert "--lane is required" in result.stderr
+
+
+def test_no_prompt_errors(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    result = _run(fake_repo, "--lane", "L1")
+    assert result.returncode == 1
+    assert "--prompt or --prompt-file is required" in result.stderr
+
+
+def test_both_prompt_forms_errors(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    pf = tmp_path / "p.txt"
+    pf.write_text("hi")
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "x", "--prompt-file", str(pf))
+    assert result.returncode == 1
+    assert "mutually exclusive" in result.stderr
+
+
+def test_invalid_priority_errors(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--priority", "bogus")
+    assert result.returncode == 1
+    assert "must be one of low|normal|high|blocking" in result.stderr
+
+
+def test_invalid_fallback_errors(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--fallback", "bogus")
+    assert result.returncode == 1
+    assert "must be one of mailbox-only|fail" in result.stderr
+
+
+# ----- lane resolution -----
+
+
+def test_lane_not_found_exits_2(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    # No lanes.json written.
+    result = _run(fake_repo, "--lane", "missing", "--prompt", "hi")
+    assert result.returncode == 2
+    assert "lane not found" in result.stderr
+
+
+# ----- dispatch backend selection -----
+
+
+def test_tmux_backend_dry_run_writes_receipt(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="claude-A", contact_method="tmux:claude-p52")
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--json")
+    assert result.returncode == 0, result.stderr
+    receipt = json.loads(result.stdout)
+    assert receipt["chosen_backend"] == "tmux"
+    assert receipt["backend_target"] == "claude-p52"
+    assert receipt["mode"] == "dry-run"
+    assert receipt["dispatch_attempted"] is False
+    assert receipt["dispatch_outcome"] == "dry-run-only"
+
+
+def test_mailbox_backend_dry_run_uses_owner(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="droid-X", contact_method="mailbox-only")
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--json")
+    assert result.returncode == 0
+    receipt = json.loads(result.stdout)
+    assert receipt["chosen_backend"] == "mailbox-only"
+    assert receipt["backend_target"] == "droid-X"
+
+
+def test_missing_contact_method_defaults_to_mailbox(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="codex-Y", contact_method=None)
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--json")
+    assert result.returncode == 0
+    receipt = json.loads(result.stdout)
+    assert receipt["chosen_backend"] == "mailbox-only"
+    assert receipt["backend_target"] == "codex-Y"
+
+
+def test_missing_contact_method_with_fail_fallback_exits_3(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="codex-Y", contact_method=None)
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--fallback", "fail")
+    assert result.returncode == 3
+    assert "no contact_method" in result.stderr
+
+
+def test_unknown_backend_falls_back_to_mailbox(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(
+        fake_repo, "L1", owner="codex-Z", contact_method="osascript:codex-desktop:thread-abc"
+    )
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--json")
+    assert result.returncode == 0
+    receipt = json.loads(result.stdout)
+    assert receipt["chosen_backend"] == "mailbox-only"
+    assert receipt["backend_target"] == "codex-Z"
+
+
+def test_unknown_backend_with_fail_fallback_exits_3(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="codex-Z", contact_method="factory-api:sess-1")
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--fallback", "fail")
+    assert result.returncode == 3
+    assert "not implemented" in result.stderr
+
+
+# ----- receipt schema -----
+
+
+def test_receipt_includes_sha256_of_prompt(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="claude-A", contact_method="tmux:claude-p52")
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--json")
+    receipt = json.loads(result.stdout)
+    # SHA256 of "hi" with no trailing newline
+    assert (
+        receipt["prompt_sha256"]
+        == "8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4"
+    )
+
+
+def test_receipt_schema_version(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="claude-A", contact_method="tmux:claude-p52")
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--json")
+    receipt = json.loads(result.stdout)
+    assert receipt["schema_version"] == "aragora-wake-agent-receipt/1.0"
+
+
+def test_receipt_persisted_to_dispatch_receipts_dir(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="claude-A", contact_method="tmux:claude-p52")
+    _run(fake_repo, "--lane", "L1", "--prompt", "hi")
+    receipts = list((fake_repo / ".aragora" / "dispatch-receipts").iterdir())
+    assert len(receipts) == 1
+    data = json.loads(receipts[0].read_text())
+    assert data["lane_id"] == "L1"
+
+
+# ----- apply mode (with fake backends) -----
+
+
+def test_apply_mode_invokes_tmux_backend(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="claude-A", contact_method="tmux:claude-p52")
+    log = tmp_path / "tmux.log"
+    _write_fake_backend(fake_repo, "tmux_send_prompt.sh", log)
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--apply", "--json")
+    assert result.returncode == 0
+    receipt = json.loads(result.stdout)
+    assert receipt["mode"] == "apply"
+    assert receipt["dispatch_attempted"] is True
+    assert receipt["dispatch_outcome"] == "dispatched"
+    assert log.read_text().strip()  # backend was called with some args
+
+
+def test_apply_mode_records_backend_failure(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="claude-A", contact_method="tmux:claude-p52")
+    log = tmp_path / "tmux.log"
+    _write_fake_backend(fake_repo, "tmux_send_prompt.sh", log, exit_code=7)
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--apply", "--json")
+    assert result.returncode == 4
+    receipt = json.loads(result.stdout)
+    assert receipt["dispatch_outcome"] == "failed"
+    assert "non-zero" in (receipt.get("dispatch_error") or "")
+
+
+def test_apply_mode_invokes_mailbox_backend(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="droid-X", contact_method="mailbox-only")
+    log = tmp_path / "mailbox.log"
+    # send_operator_steering.py is a Python script; emulate by writing a bash
+    # shim with the same name. wake_agent.sh shells out via `python3` so we
+    # need a real .py — instead make the .py file invoke a logger.
+    py_script = fake_repo / "scripts" / "send_operator_steering.py"
+    py_script.write_text(
+        f"""#!/usr/bin/env python3
+import sys
+with open("{log}", "a") as fh:
+    fh.write(" ".join(sys.argv[1:]) + "\\n")
+sys.exit(0)
+"""
+    )
+    py_script.chmod(py_script.stat().st_mode | stat.S_IXUSR)
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--apply", "--json")
+    assert result.returncode == 0
+    receipt = json.loads(result.stdout)
+    assert receipt["chosen_backend"] == "mailbox-only"
+    assert receipt["dispatch_outcome"] == "dispatched"
+    assert "droid-X" in log.read_text()
+
+
+# ----- priority + json wiring -----
+
+
+@pytest.mark.parametrize("priority", ["low", "normal", "high", "blocking"])
+def test_priority_round_trips(tmp_path: Path, priority: str) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="claude-A", contact_method="tmux:claude-p52")
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi", "--priority", priority, "--json")
+    receipt = json.loads(result.stdout)
+    assert receipt["priority"] == priority
+
+
+def test_non_json_output_is_human_readable(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="claude-A", contact_method="tmux:claude-p52")
+    result = _run(fake_repo, "--lane", "L1", "--prompt", "hi")
+    assert result.returncode == 0
+    assert "wake_agent:" in result.stdout
+    assert "lane=L1" in result.stdout
+    assert "backend=tmux" in result.stdout
+
+
+# ----- prompt-file path -----
+
+
+def test_prompt_file_is_read(tmp_path: Path) -> None:
+    fake_repo = _make_fake_repo(tmp_path)
+    _write_lane(fake_repo, "L1", owner="claude-A", contact_method="tmux:claude-p52")
+    pf = tmp_path / "prompt.txt"
+    pf.write_text("hello from file\nsecond line")
+    result = _run(fake_repo, "--lane", "L1", "--prompt-file", str(pf), "--json")
+    receipt = json.loads(result.stdout)
+    # SHA256 of "hello from file\nsecond line" (no trailing newline)
+    import hashlib
+
+    expected = hashlib.sha256(b"hello from file\nsecond line").hexdigest()
+    assert receipt["prompt_sha256"] == expected


### PR DESCRIPTION
## Summary

Phase 2 of the agent-dispatch reach plan (per #7327 P54). Adds \`scripts/wake_agent.sh\` — a single dispatch entry point that reads a lane's \`contact_method\` (R01 field, #7336) and routes the prompt to the right backend:

| contact_method | Backend | Status |
|---|---|---|
| \`tmux:NAME\` | \`scripts/tmux_send_prompt.sh\` | Shipped |
| \`mailbox-only\` | \`scripts/send_operator_steering.py\` | Shipped |
| \`osascript:codex-desktop:*\` | \`scripts/codex_desktop_inject.sh\` | R03 (future) — falls back to mailbox-only |
| \`osascript:droid-cli:*\` | \`scripts/droid_cli_inject.sh\` | R04 (future) — falls back |
| \`factory-api:*\` | \`scripts/factory_api_send.py\` | R04 opt-in — falls back |

## CLI

\`\`\`
./scripts/wake_agent.sh --lane LANE_ID \\
    [--prompt TEXT | --prompt-file PATH] \\
    [--priority {low,normal,high,blocking}] \\
    [--dry-run | --apply] \\
    [--fallback {mailbox-only,fail}] \\
    [--json]
\`\`\`

Default mode is \`--dry-run\` (fail-closed): resolves the backend, writes a JSON receipt with \`dispatch_attempted=false\`, exits 0. \`--apply\` opts into mutate.

## Dispatch receipt

Every invocation writes \`.aragora/dispatch-receipts/<utc>-<lane>-<sha8>.json\`:

\`\`\`json
{
  "schema_version": "aragora-wake-agent-receipt/1.0",
  "generated_at": "2026-05-19T03:30:00Z",
  "lane_id": "R02-test",
  "owner_session": "claude-A",
  "contact_method": "tmux:claude-p52",
  "chosen_backend": "tmux",
  "backend_target": "claude-p52",
  "fallback_policy": "mailbox-only",
  "mode": "apply",
  "dispatch_attempted": true,
  "dispatch_outcome": "dispatched",
  "dispatch_error": null,
  "priority": "normal",
  "prompt_sha256": "..."
}
\`\`\`

## Exit codes

- 0: success (dispatched or dry-run resolved)
- 1: usage error
- 2: lane not found
- 3: missing contact_method AND --fallback fail
- 4: dispatch backend invocation failed

## Tests

24 tests in \`tests/scripts/test_wake_agent.py\` covering:
- arg validation (5)
- lane resolution (1)
- backend selection per contact_method shape + fallback policy (6)
- receipt schema + SHA-256 binding + persistence (3)
- apply-mode success + failure for tmux + mailbox backends (3)
- priority round-trip parametrized over all 4 levels (4)
- human-readable output (1)
- prompt-file path with multi-line content (1)

\`\`\`
$ python3 -m pytest tests/scripts/test_wake_agent.py -q
24 passed in 6.59s
\`\`\`

Ruff/format clean. \`automation_pr_preflight.sh\`: ok.

## Discipline

- Pure bash + stdlib Python. No new pip deps.
- Depends on R01 (#7336) for the \`contact_method\` field but **degrades gracefully** if R01 hasn't merged yet: missing field is treated as \`mailbox-only\` fallback. So R02 ships independently.
- Default mode is \`--dry-run\` (fail-closed). No accidental dispatch.
- No protected files touched. No labels. No merges. No automation config edits.
- Draft.

## Test plan

- [ ] \`bash scripts/wake_agent.sh --help\` shows usage
- [ ] \`bash scripts/wake_agent.sh --lane <real-lane-id> --prompt hi --json\` resolves a known active lane and shows a receipt with chosen_backend + dry-run-only outcome
- [ ] \`python3 -m pytest tests/scripts/test_wake_agent.py -q\` → 24 passed

## Follow-on

R03 (\`codex_desktop_inject.sh\`) — wire \`osascript:codex-desktop:*\` to the official \`codex app-server proxy\` IPC layer documented in my comment on #7327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)