### PR TITLE
ADC-v0.2: lane-registry delegation-contract attachment

### DIFF
--- a/aragora/policy/__init__.py
+++ b/aragora/policy/__init__.py
@@ -52,6 +52,26 @@ from aragora.policy.tools import (
     ToolCapability,
     ToolRegistry,
 )
+from aragora.policy.delegation_contract import (
+    CONTRACT_SCHEMA_VERSION,
+    GOAL_SPEC_SCHEMA_VERSION,
+    AcceptanceCriterion,
+    AllowedSurfaces,
+    ContractBudget,
+    ContractValidationError,
+    DelegationContract,
+    GoalSpec,
+    make_root_contract,
+    narrow_for_child,
+)
+from aragora.policy.predicate_oracle import (
+    EVALUATORS,
+    PredicateParseError,
+    PredicateResult,
+    evaluate_all,
+    evaluate_predicate,
+    parse_predicate,
+)
 
 __all__ = [
     "PolicyEngine",
@@ -64,4 +84,22 @@ __all__ = [
     "RiskLevel",
     "BlastRadius",
     "RiskBudget",
+    # Delegation Contract v0.1
+    "DelegationContract",
+    "GoalSpec",
+    "AcceptanceCriterion",
+    "AllowedSurfaces",
+    "ContractBudget",
+    "ContractValidationError",
+    "CONTRACT_SCHEMA_VERSION",
+    "GOAL_SPEC_SCHEMA_VERSION",
+    "narrow_for_child",
+    "make_root_contract",
+    # Predicate oracle
+    "PredicateResult",
+    "PredicateParseError",
+    "EVALUATORS",
+    "parse_predicate",
+    "evaluate_predicate",
+    "evaluate_all",
 ]

--- a/aragora/policy/delegation_contract.py
+++ b/aragora/policy/delegation_contract.py
@@ -1,0 +1,699 @@
+"""Aragora Delegation Contract v0.1 — schema + validator.
+
+This module ships the smallest durable artifact of the Delegation Contract
+work: the dataclasses (DelegationContract, GoalSpec, AcceptanceCriterion,
+ContractBudget, AllowedSurfaces) plus a monotonic-narrowing validator at
+parent → child issue time.
+
+No autonomous worker behavior changes in v0.1. The lane registry hookup
+is Stage 2 (separate PR). The signing layer is v0.4. See
+``docs/governance/DELEGATION_CONTRACT_V0_1_SPEC.md`` for the full
+roadmap.
+
+Design influences (per spec doc):
+- Object-capability security: child scope ⊆ parent scope (enforced here)
+- Ethereum gas: ContractBudget composes existing RiskBudget + fan-out caps
+- AWS IAM AssumeRole with session policies: time-bounded delegation
+- Factory's review: deterministic predicate oracle separate from this
+  module so contract logic is itself testable without LLM dependencies
+
+Operator review notes:
+- codex: rename "Capability Certificate" → "Delegation Contract" for
+  v0.1 unless cryptographic signing ships in the same PR; v0.1 does
+  NOT ship signing, so the rename is honored.
+- Factory: predicate evaluation is a separate non-LLM oracle module
+  (``aragora.policy.predicate_oracle``); this module does not reach
+  into the oracle directly — the goal spec references predicate
+  strings and the caller evaluates them.
+
+Pure stdlib. No new pip deps.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Iterable, Literal
+
+from .risk import RiskBudget
+
+CONTRACT_SCHEMA_VERSION = "aragora-delegation-contract/0.1"
+GOAL_SPEC_SCHEMA_VERSION = "aragora-goal-spec/0.1"
+
+DestructivePolicy = Literal["deny", "human-only", "allow"]
+ProgressMetric = Literal["fraction_of_AC_satisfied", "all_AC_satisfied", "weighted_AC"]
+
+# Actions that ALWAYS require explicit human approval, regardless of contract
+# scope. v0.1 effectively forbids these because the contract format has no
+# "human_approval_token" carrier yet.
+DEFAULT_DESTRUCTIVE_ACTIONS: frozenset[str] = frozenset(
+    {
+        "force-push:*",
+        "delete:branch:*",
+        "delete:worktree:*",
+        "kill:process:*",
+        "merge:*",
+        "label:*",
+        "edit:protected:*",
+        "unshallow:*",
+        "gpg-bypass:*",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+class ContractValidationError(ValueError):
+    """Raised when a contract or a parent→child narrowing fails validation."""
+
+
+# ---------------------------------------------------------------------------
+# Sub-schemas
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AcceptanceCriterion:
+    """A single verifiable predicate for goal completion."""
+
+    ac_id: str
+    predicate: str  # predicate-oracle string, e.g. "pr_merged(7336)"
+    weight: float = 1.0
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class GoalSpec:
+    """The "why" — what we're trying to accomplish, expressed as
+    deterministically-verifiable predicates.
+
+    Separate from DelegationContract because:
+    - one goal may span multiple contracts (e.g. parent + multiple children
+      all working toward the same goal)
+    - goals are signed by humans; contracts can be issued by agents within
+      a delegation chain
+    """
+
+    goal_id: str
+    schema_version: str
+    owner: str  # human GitHub login or operator id
+    approved_at: str  # ISO-8601 UTC
+    description: str
+    acceptance_criteria: list[AcceptanceCriterion]
+    progress_metric: ProgressMetric = "fraction_of_AC_satisfied"
+    completion_predicate: str = ""  # oracle predicate; if empty, defaults
+    # to "all AC satisfied"
+    anti_signals: list[str] = field(default_factory=list)
+    max_delegation_depth: int = 3
+
+    def validate(self) -> None:
+        """Sanity-check the goal spec. Raises ContractValidationError."""
+        if not self.goal_id:
+            raise ContractValidationError("goal_id must not be empty")
+        if self.schema_version != GOAL_SPEC_SCHEMA_VERSION:
+            raise ContractValidationError(
+                f"unexpected schema_version: {self.schema_version!r}; expected "
+                f"{GOAL_SPEC_SCHEMA_VERSION!r}"
+            )
+        if not self.acceptance_criteria:
+            raise ContractValidationError(
+                "acceptance_criteria must not be empty — a goal with no verifiable "
+                "acceptance criteria cannot drive progress evaluation"
+            )
+        ac_ids = [ac.ac_id for ac in self.acceptance_criteria]
+        if len(set(ac_ids)) != len(ac_ids):
+            raise ContractValidationError(f"duplicate ac_id in goal: {ac_ids}")
+        if self.max_delegation_depth < 0:
+            raise ContractValidationError(
+                f"max_delegation_depth must be >= 0; got {self.max_delegation_depth}"
+            )
+
+
+@dataclass(frozen=True)
+class AllowedSurfaces:
+    """Scope dimensions: what surfaces this contract permits acting on.
+
+    Empty sets mean "no restriction beyond the action filter" — but if
+    the action requires a specific surface (e.g. write:branch:NAME) and
+    the surface is not allowed, the action is denied.
+    """
+
+    pr_numbers: frozenset[int] = frozenset()
+    branch_globs: frozenset[str] = frozenset()
+    worktree_globs: frozenset[str] = frozenset()
+    file_globs: frozenset[str] = frozenset()
+    deny_file_globs: frozenset[str] = frozenset()
+
+    def is_branch_allowed(self, branch: str) -> bool:
+        if not self.branch_globs:
+            return True
+        return any(fnmatch.fnmatchcase(branch, g) for g in self.branch_globs)
+
+    def is_file_allowed(self, path: str) -> bool:
+        # deny wins
+        if any(fnmatch.fnmatchcase(path, g) for g in self.deny_file_globs):
+            return False
+        if not self.file_globs:
+            return True
+        return any(fnmatch.fnmatchcase(path, g) for g in self.file_globs)
+
+
+@dataclass(frozen=True)
+class ContractBudget:
+    """The "how much" — gas dimension. Composes existing RiskBudget."""
+
+    risk_budget: RiskBudget
+    max_wall_clock_minutes: int = 60
+    max_subagents_spawned: int = 0
+    max_prs_opened: int = 1
+    max_commits_to_main: int = 0
+    max_api_dollars: float = 1.00
+    max_lane_claims: int = 1
+
+    def validate(self) -> None:
+        for field_name in (
+            "max_wall_clock_minutes",
+            "max_subagents_spawned",
+            "max_prs_opened",
+            "max_commits_to_main",
+            "max_lane_claims",
+        ):
+            value = getattr(self, field_name)
+            if value < 0:
+                raise ContractValidationError(
+                    f"ContractBudget.{field_name} must be >= 0; got {value}"
+                )
+        if self.max_api_dollars < 0:
+            raise ContractValidationError(
+                f"max_api_dollars must be >= 0; got {self.max_api_dollars}"
+            )
+        if self.risk_budget.total < 0 or self.risk_budget.spent < 0:
+            raise ContractValidationError("risk_budget total/spent must be >= 0")
+
+    def child_fits(self, child: "ContractBudget") -> tuple[bool, str]:
+        """Whether `child` budget fits within `self.remaining` capacity.
+
+        Returns (fits, reason). Used by parent→child narrowing validation.
+        """
+        # Wall clock + counts must each be ≤ parent's
+        for field_name in (
+            "max_wall_clock_minutes",
+            "max_subagents_spawned",
+            "max_prs_opened",
+            "max_commits_to_main",
+            "max_lane_claims",
+        ):
+            parent_v = getattr(self, field_name)
+            child_v = getattr(child, field_name)
+            if child_v > parent_v:
+                return (
+                    False,
+                    f"child.{field_name}={child_v} exceeds parent.{field_name}={parent_v}",
+                )
+        if child.max_api_dollars > self.max_api_dollars:
+            return (
+                False,
+                f"child.max_api_dollars={child.max_api_dollars} exceeds parent={self.max_api_dollars}",
+            )
+        # Risk budget: child's total must fit within parent's remaining.
+        if child.risk_budget.total > self.risk_budget.remaining:
+            return (
+                False,
+                f"child.risk_budget.total={child.risk_budget.total} exceeds "
+                f"parent.risk_budget.remaining={self.risk_budget.remaining}",
+            )
+        return (True, "ok")
+
+
+# ---------------------------------------------------------------------------
+# Delegation Contract
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DelegationContract:
+    """A signed-or-should-have-been-signed token of authority.
+
+    Tracks:
+    - WHO delegated WHAT to WHOM (delegator → delegatee)
+    - In service of WHICH goal (goal_id)
+    - Within WHAT scope (allowed_actions, allowed_surfaces)
+    - Under WHAT budget (ContractBudget)
+    - With WHAT lifetime (issued_at, expires_at)
+    - As PART OF which authority chain (root_intent_id, parent_contract_id)
+    - At WHAT delegation depth (max_depth: 0 = leaf)
+    """
+
+    # Identity
+    contract_id: str
+    schema_version: str
+
+    # Authority chain
+    root_intent_id: str
+    parent_contract_id: str | None
+    delegator: str
+    delegatee: str
+    max_depth: int
+
+    # Goal binding
+    goal_id: str
+
+    # Scope (ocap dimension)
+    allowed_actions: frozenset[str]
+    denied_actions: frozenset[str]
+    allowed_surfaces: AllowedSurfaces
+    destructive_action_policy: DestructivePolicy
+
+    # Budget (gas dimension)
+    budget: ContractBudget
+
+    # Lifecycle
+    issued_at: str
+    expires_at: str
+    revocation_check_uri: str | None
+
+    # Progress gating
+    progress_predicates: list[str]
+    stale_threshold_minutes: int
+
+    # v0.2 stub for v0.4 signing
+    signature: str | None = None
+
+    # -----------------------------------------------------------------------
+    # Self-validation
+    # -----------------------------------------------------------------------
+
+    def validate(self) -> None:
+        """Raise ContractValidationError if this contract is self-inconsistent."""
+        if not self.contract_id:
+            raise ContractValidationError("contract_id must not be empty")
+        if self.schema_version != CONTRACT_SCHEMA_VERSION:
+            raise ContractValidationError(
+                f"unexpected schema_version: {self.schema_version!r}; expected "
+                f"{CONTRACT_SCHEMA_VERSION!r}"
+            )
+        if not self.root_intent_id:
+            raise ContractValidationError("root_intent_id must not be empty")
+        if not self.delegator or not self.delegatee:
+            raise ContractValidationError("delegator and delegatee must not be empty")
+        if self.parent_contract_id is None and self.delegator != self.delegatee:
+            # Root contracts: human delegates to themselves OR to an agent;
+            # both are valid as long as the human signed it. v0.1 has no
+            # signing, so we only enforce non-empty.
+            pass
+        if self.max_depth < 0:
+            raise ContractValidationError(f"max_depth must be >= 0; got {self.max_depth}")
+        if not self.goal_id:
+            raise ContractValidationError("goal_id must not be empty")
+        # Time fields
+        _parse_utc(self.issued_at, "issued_at")
+        expires = _parse_utc(self.expires_at, "expires_at")
+        if expires <= _parse_utc(self.issued_at, "issued_at"):
+            raise ContractValidationError(
+                f"expires_at ({self.expires_at}) must be after issued_at ({self.issued_at})"
+            )
+        # Destructive policy in v0.1: cannot be "allow" — destructive actions
+        # always require a human gate that v0.1 doesn't carry.
+        if self.destructive_action_policy == "allow":
+            raise ContractValidationError(
+                "destructive_action_policy='allow' is not permitted in v0.1; "
+                "use 'deny' or 'human-only'"
+            )
+        # Destructive actions cannot appear in allowed_actions unless policy is
+        # "human-only" (in v0.1 the carrier for the human-approval-token
+        # doesn't exist, so effectively destructive actions always go through
+        # an out-of-band approval gate).
+        for action in self.allowed_actions:
+            if _is_destructive_action(action) and self.destructive_action_policy == "deny":
+                raise ContractValidationError(
+                    f"contract allows destructive action {action!r} but "
+                    f"destructive_action_policy='deny'"
+                )
+        # Budget sanity
+        self.budget.validate()
+        # Stale threshold
+        if self.stale_threshold_minutes < 1:
+            raise ContractValidationError(
+                f"stale_threshold_minutes must be >= 1; got {self.stale_threshold_minutes}"
+            )
+        # Signature must be None in v0.1
+        if self.signature is not None:
+            raise ContractValidationError("signature must be None in v0.1; signing ships in v0.4")
+
+    # -----------------------------------------------------------------------
+    # Time helpers
+    # -----------------------------------------------------------------------
+
+    def is_expired(self, *, now: datetime | None = None) -> bool:
+        moment = now if now is not None else datetime.now(UTC)
+        return _parse_utc(self.expires_at, "expires_at") <= moment
+
+    # -----------------------------------------------------------------------
+    # Action filter
+    # -----------------------------------------------------------------------
+
+    def permits_action(self, action: str) -> tuple[bool, str]:
+        """Whether this contract permits the given action string.
+
+        Returns (allowed, reason).
+
+        Order of operations:
+        1. Destructive action against destructive_action_policy=='deny'
+           → deny
+        2. Explicit denied_actions match → deny
+        3. allowed_actions match (or empty == any) → allow
+        4. else → deny
+        """
+        if _is_destructive_action(action) and self.destructive_action_policy == "deny":
+            return (False, f"action {action!r} is destructive and policy is 'deny'")
+        # destructive_action_policy == "human-only" means the action is allowed
+        # only if a human-approval-token is presented; v0.1 has no carrier so
+        # effectively we deny here too. The caller (lane registry / wake_agent)
+        # is responsible for surfacing the human-approval gate.
+        if _is_destructive_action(action) and self.destructive_action_policy == "human-only":
+            return (
+                False,
+                f"action {action!r} requires human approval; v0.1 has no carrier",
+            )
+        for pattern in self.denied_actions:
+            if _action_matches(action, pattern):
+                return (False, f"action {action!r} matches denied pattern {pattern!r}")
+        if not self.allowed_actions:
+            # Empty allowed set means "no positive grant"; v0.1 chooses deny-by-default.
+            return (False, "no allowed_actions match (deny by default)")
+        for pattern in self.allowed_actions:
+            if _action_matches(action, pattern):
+                return (True, f"matched allowed pattern {pattern!r}")
+        return (False, f"action {action!r} matches no allowed pattern")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_utc(value: str, field_name: str) -> datetime:
+    try:
+        if value.endswith("Z"):
+            return datetime.fromisoformat(value[:-1] + "+00:00")
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+    except ValueError as exc:
+        raise ContractValidationError(f"{field_name} is not valid ISO-8601 UTC: {value!r}") from exc
+
+
+def _action_matches(action: str, pattern: str) -> bool:
+    """fnmatch-style action matching. ':' is a literal separator; '*' is glob."""
+    return fnmatch.fnmatchcase(action, pattern)
+
+
+def _is_destructive_action(action: str) -> bool:
+    return any(_action_matches(action, pattern) for pattern in DEFAULT_DESTRUCTIVE_ACTIONS)
+
+
+# ---------------------------------------------------------------------------
+# Monotonic narrowing
+# ---------------------------------------------------------------------------
+
+
+def narrow_for_child(
+    parent: DelegationContract,
+    *,
+    child_contract_id: str,
+    child_delegatee: str,
+    child_allowed_actions: Iterable[str] | None = None,
+    child_denied_actions: Iterable[str] | None = None,
+    child_allowed_surfaces: AllowedSurfaces | None = None,
+    child_budget: ContractBudget | None = None,
+    child_expires_at: str | None = None,
+    child_destructive_policy: DestructivePolicy | None = None,
+    child_progress_predicates: list[str] | None = None,
+    child_stale_threshold_minutes: int | None = None,
+    issued_at: str | None = None,
+) -> DelegationContract:
+    """Issue a child contract narrowed from ``parent``.
+
+    Enforces monotonic narrowing rules from the v0.1 spec:
+    - child.goal_id == parent.goal_id
+    - child.max_depth == parent.max_depth - 1
+    - child.allowed_actions ⊆ parent.allowed_actions
+    - child.denied_actions ⊇ parent.denied_actions
+    - allowed_surfaces narrowed (or unchanged)
+    - destructive policy cannot widen
+    - budget ≤ parent.budget (each dimension, see ContractBudget.child_fits)
+    - expires_at ≤ parent.expires_at
+    - stale_threshold_minutes ≤ parent.stale_threshold_minutes
+
+    Any violation raises ContractValidationError. The caller is responsible
+    for actually persisting the child contract; this function only
+    constructs and validates it.
+
+    Defaults for omitted child fields inherit from parent (mostly — the
+    monotonic-narrowing semantic).
+    """
+    parent.validate()
+
+    if parent.max_depth <= 0:
+        raise ContractValidationError(
+            f"parent contract has max_depth={parent.max_depth}; cannot spawn children"
+        )
+
+    issued = issued_at if issued_at is not None else _now_utc_iso()
+
+    # Inherit unchanged where caller didn't override
+    allowed_actions = (
+        frozenset(child_allowed_actions)
+        if child_allowed_actions is not None
+        else parent.allowed_actions
+    )
+    denied_actions = (
+        frozenset(child_denied_actions)
+        if child_denied_actions is not None
+        else parent.denied_actions
+    )
+    allowed_surfaces = (
+        child_allowed_surfaces if child_allowed_surfaces is not None else parent.allowed_surfaces
+    )
+    budget = child_budget if child_budget is not None else parent.budget
+    expires_at = child_expires_at if child_expires_at is not None else parent.expires_at
+    destructive_policy = (
+        child_destructive_policy
+        if child_destructive_policy is not None
+        else parent.destructive_action_policy
+    )
+    progress_predicates = (
+        list(child_progress_predicates)
+        if child_progress_predicates is not None
+        else list(parent.progress_predicates)
+    )
+    stale_threshold = (
+        child_stale_threshold_minutes
+        if child_stale_threshold_minutes is not None
+        else parent.stale_threshold_minutes
+    )
+
+    # --- Enforce narrowing rules ---
+
+    # Actions: child ⊆ parent
+    extra_allowed = allowed_actions - parent.allowed_actions
+    if extra_allowed:
+        raise ContractValidationError(
+            f"child allowed_actions widen parent's: extra={sorted(extra_allowed)}"
+        )
+    # Denied: child ⊇ parent
+    missing_denied = parent.denied_actions - denied_actions
+    if missing_denied:
+        raise ContractValidationError(
+            f"child denied_actions narrow parent's: missing={sorted(missing_denied)}"
+        )
+
+    # Surfaces
+    _check_surfaces_narrowed(parent.allowed_surfaces, allowed_surfaces)
+
+    # Destructive policy: cannot widen
+    if destructive_policy == "allow" and parent.destructive_action_policy != "allow":
+        raise ContractValidationError("child destructive_action_policy widens parent's")
+    if destructive_policy == "human-only" and parent.destructive_action_policy == "deny":
+        raise ContractValidationError(
+            "child destructive_action_policy widens parent's (parent='deny', child='human-only')"
+        )
+
+    # Budget
+    fits, reason = parent.budget.child_fits(budget)
+    if not fits:
+        raise ContractValidationError(f"child budget exceeds parent: {reason}")
+
+    # Time
+    parent_expires = _parse_utc(parent.expires_at, "parent.expires_at")
+    child_expires_dt = _parse_utc(expires_at, "child.expires_at")
+    if child_expires_dt > parent_expires:
+        raise ContractValidationError(
+            f"child.expires_at ({expires_at}) is after parent.expires_at ({parent.expires_at})"
+        )
+
+    # Stale threshold (children fail faster)
+    if stale_threshold > parent.stale_threshold_minutes:
+        raise ContractValidationError(
+            f"child.stale_threshold_minutes={stale_threshold} exceeds "
+            f"parent.stale_threshold_minutes={parent.stale_threshold_minutes}"
+        )
+
+    # Issued-time sanity
+    issued_dt = _parse_utc(issued, "issued_at")
+    if issued_dt > child_expires_dt:
+        raise ContractValidationError(
+            f"issued_at ({issued}) is after child.expires_at ({expires_at})"
+        )
+
+    child = DelegationContract(
+        contract_id=child_contract_id,
+        schema_version=CONTRACT_SCHEMA_VERSION,
+        root_intent_id=parent.root_intent_id,
+        parent_contract_id=parent.contract_id,
+        delegator=parent.delegatee,
+        delegatee=child_delegatee,
+        max_depth=parent.max_depth - 1,
+        goal_id=parent.goal_id,
+        allowed_actions=allowed_actions,
+        denied_actions=denied_actions,
+        allowed_surfaces=allowed_surfaces,
+        destructive_action_policy=destructive_policy,
+        budget=budget,
+        issued_at=issued,
+        expires_at=expires_at,
+        revocation_check_uri=parent.revocation_check_uri,
+        progress_predicates=progress_predicates,
+        stale_threshold_minutes=stale_threshold,
+        signature=None,
+    )
+    child.validate()
+    return child
+
+
+def _check_surfaces_narrowed(parent: AllowedSurfaces, child: AllowedSurfaces) -> None:
+    """Each child surface set must be a subset of (or contained within)
+    the parent's, except for ``deny_file_globs`` which must be a superset."""
+    # PR numbers: empty parent means any; otherwise child ⊆ parent
+    if parent.pr_numbers and (child.pr_numbers - parent.pr_numbers):
+        raise ContractValidationError(
+            f"child allowed_surfaces.pr_numbers widens parent's: extra="
+            f"{sorted(child.pr_numbers - parent.pr_numbers)}"
+        )
+    # Globs: every child glob must be contained by at least one parent glob.
+    for kind, child_set, parent_set in (
+        ("branch_globs", child.branch_globs, parent.branch_globs),
+        ("worktree_globs", child.worktree_globs, parent.worktree_globs),
+        ("file_globs", child.file_globs, parent.file_globs),
+    ):
+        if not parent_set:
+            continue  # parent has no restriction, child may add any
+        for cg in child_set:
+            if not any(_glob_contains(pg, cg) for pg in parent_set):
+                raise ContractValidationError(
+                    f"child allowed_surfaces.{kind} glob {cg!r} is not contained "
+                    f"by any parent glob in {sorted(parent_set)}"
+                )
+    # Deny file globs: child ⊇ parent (child denies at least everything parent denies)
+    missing = parent.deny_file_globs - child.deny_file_globs
+    if missing:
+        raise ContractValidationError(
+            f"child allowed_surfaces.deny_file_globs is missing parent denies: {sorted(missing)}"
+        )
+
+
+def _glob_contains(parent_glob: str, child_glob: str) -> bool:
+    """Heuristic: does parent_glob's set ⊇ child_glob's set?
+
+    Exact-match is sufficient. For wildcards, we accept the conservative
+    rule: parent ends with '*' AND child starts with parent's stem, OR
+    parent == child.
+
+    This is intentionally simple in v0.1; the test suite documents the
+    accepted shapes. v0.2+ can swap in a full glob-containment algorithm
+    if needed.
+    """
+    if parent_glob == child_glob:
+        return True
+    if parent_glob == "*":
+        return True
+    if parent_glob.endswith("/*"):
+        prefix = parent_glob[:-2]
+        if child_glob == prefix:
+            return True
+        if child_glob.startswith(prefix + "/"):
+            return True
+        # child_glob is itself a glob — accept if it's strictly under prefix
+        if child_glob.startswith(prefix + "/") and child_glob.endswith("*"):
+            return True
+    if parent_glob.endswith("*"):
+        prefix = parent_glob[:-1]
+        return child_glob.startswith(prefix)
+    return False
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Convenience builder for tests / examples
+# ---------------------------------------------------------------------------
+
+
+def make_root_contract(
+    *,
+    contract_id: str,
+    root_intent_id: str,
+    delegator: str,
+    delegatee: str,
+    goal_id: str,
+    allowed_actions: Iterable[str] = ("read:*",),
+    denied_actions: Iterable[str] = (),
+    allowed_surfaces: AllowedSurfaces | None = None,
+    budget: ContractBudget | None = None,
+    max_depth: int = 3,
+    duration_minutes: int = 60,
+    stale_threshold_minutes: int = 30,
+    destructive_action_policy: DestructivePolicy = "deny",
+    progress_predicates: list[str] | None = None,
+    revocation_check_uri: str | None = None,
+) -> DelegationContract:
+    """Build and validate a root contract. Convenience for tests + example
+    docs; production callers should use a signed-issuance flow when v0.4
+    lands.
+    """
+    issued = _now_utc_iso()
+    expires_at = (datetime.now(UTC) + timedelta(minutes=duration_minutes)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    surfaces = allowed_surfaces if allowed_surfaces is not None else AllowedSurfaces()
+    contract_budget = budget if budget is not None else ContractBudget(risk_budget=RiskBudget())
+    contract = DelegationContract(
+        contract_id=contract_id,
+        schema_version=CONTRACT_SCHEMA_VERSION,
+        root_intent_id=root_intent_id,
+        parent_contract_id=None,
+        delegator=delegator,
+        delegatee=delegatee,
+        max_depth=max_depth,
+        goal_id=goal_id,
+        allowed_actions=frozenset(allowed_actions),
+        denied_actions=frozenset(denied_actions),
+        allowed_surfaces=surfaces,
+        destructive_action_policy=destructive_action_policy,
+        budget=contract_budget,
+        issued_at=issued,
+        expires_at=expires_at,
+        revocation_check_uri=revocation_check_uri,
+        progress_predicates=list(progress_predicates or []),
+        stale_threshold_minutes=stale_threshold_minutes,
+        signature=None,
+    )
+    contract.validate()
+    return contract

--- a/aragora/policy/predicate_oracle.py
+++ b/aragora/policy/predicate_oracle.py
@@ -1,0 +1,524 @@
+"""Deterministic non-LLM predicate oracle for Aragora Delegation Contract.
+
+Factory's review of the original Capability Certificate proposal flagged
+this as the single most important addition: **predicates must be evaluated
+by deterministic code, not by the agent itself or by spot-check models.**
+
+Without this, the Delegation Contract becomes "debugging-by-LLM all the
+way down" — every acceptance criterion would be evaluable only by another
+LLM, recreating the reward-hacking surface the contract is trying to
+close.
+
+This module is the trust kernel: its evaluators are small-surface,
+separately-versioned, and never invoke an LLM. Each evaluator is a
+direct shell-out to a deterministic tool (gh, pytest, git) or a stdlib
+filesystem check.
+
+Predicate string grammar (v0.1, intentionally narrow):
+
+    <predicate>          ::= <name> "(" <arg> ("," <arg>)* ")"
+    <name>               ::= identifier matching r"^[a-z][a-z_]*$"
+    <arg>                ::= integer | quoted_string | bare_token
+
+Supported predicates (v0.1):
+
+  pr_merged(N)           pr_open(N)            pr_state(N, state)
+  tests_pass(path)       file_exists(path)     dir_exists(path)
+  branch_exists(name)    commit_landed(sha)    issue_closed(N)
+
+Each evaluator returns a PredicateResult with explicit boolean +
+evidence string + error if the evaluator failed. Failures (e.g. gh
+unavailable) are NOT silently treated as `satisfied=False`; they
+propagate as `error != None` so the caller can distinguish
+"definitely-not-satisfied" from "couldn't-check."
+
+Pure stdlib + shell-out. No new pip deps. No network calls except via
+the already-installed `gh` and `git` binaries.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Callable
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PredicateResult:
+    """Outcome of evaluating a single predicate."""
+
+    predicate: str  # original string, e.g. "pr_merged(7336)"
+    satisfied: bool  # boolean outcome
+    evidence: str  # what was checked (e.g. "merged_at=2026-05-19T18:13:28Z")
+    evaluator: str  # which named evaluator ran it
+    evaluated_at: str = field(
+        default_factory=lambda: datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    error: str | None = None  # populated if the evaluator itself failed
+
+
+# ---------------------------------------------------------------------------
+# Predicate string parser
+# ---------------------------------------------------------------------------
+
+
+_PREDICATE_RE = re.compile(r"^([a-z][a-z_]*)\((.*)\)$")
+
+
+class PredicateParseError(ValueError):
+    """Raised when a predicate string is malformed."""
+
+
+def parse_predicate(predicate: str) -> tuple[str, list[str]]:
+    """Split a predicate string into (name, args).
+
+    >>> parse_predicate("pr_merged(7336)")
+    ('pr_merged', ['7336'])
+    >>> parse_predicate('tests_pass("tests/scripts/test_foo.py")')
+    ('tests_pass', ['tests/scripts/test_foo.py'])
+    """
+    text = predicate.strip()
+    match = _PREDICATE_RE.match(text)
+    if not match:
+        raise PredicateParseError(f"malformed predicate: {predicate!r}")
+    name = match.group(1)
+    args_blob = match.group(2).strip()
+    if not args_blob:
+        return name, []
+    args: list[str] = []
+    for raw in _split_args(args_blob):
+        raw = raw.strip()
+        if (raw.startswith('"') and raw.endswith('"')) or (
+            raw.startswith("'") and raw.endswith("'")
+        ):
+            args.append(raw[1:-1])
+        else:
+            args.append(raw)
+    return name, args
+
+
+def _split_args(text: str) -> list[str]:
+    """Split comma-separated args, honoring single/double-quoted strings."""
+    out: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    for ch in text:
+        if quote is None:
+            if ch in ('"', "'"):
+                quote = ch
+                buf.append(ch)
+            elif ch == ",":
+                out.append("".join(buf))
+                buf = []
+            else:
+                buf.append(ch)
+        else:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+    if buf:
+        out.append("".join(buf))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Evaluators
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd: list[str], *, timeout: float = 15.0) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess with capture + timeout. Never raises on non-zero."""
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def evaluate_pr_merged(predicate: str, args: list[str]) -> PredicateResult:
+    if len(args) != 1:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="pr_merged",
+            error=f"expected 1 arg, got {len(args)}",
+        )
+    try:
+        pr_num = int(args[0])
+    except ValueError:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="pr_merged",
+            error=f"arg must be int, got {args[0]!r}",
+        )
+    try:
+        result = _run(["gh", "pr", "view", str(pr_num), "--json", "mergedAt"], timeout=10.0)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="pr_merged",
+            error=f"gh unavailable: {exc!r}",
+        )
+    if result.returncode != 0:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence=result.stderr.strip()[:200],
+            evaluator="pr_merged",
+            error=f"gh exit {result.returncode}",
+        )
+    import json
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence=result.stdout.strip()[:200],
+            evaluator="pr_merged",
+            error=f"gh json decode failed: {exc!r}",
+        )
+    merged_at = payload.get("mergedAt")
+    return PredicateResult(
+        predicate=predicate,
+        satisfied=merged_at is not None and merged_at != "",
+        evidence=f"merged_at={merged_at!r}",
+        evaluator="pr_merged",
+    )
+
+
+def evaluate_pr_state(predicate: str, args: list[str]) -> PredicateResult:
+    if len(args) != 2:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="pr_state",
+            error=f"expected 2 args, got {len(args)}",
+        )
+    try:
+        pr_num = int(args[0])
+    except ValueError:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="pr_state",
+            error=f"first arg must be int, got {args[0]!r}",
+        )
+    expected_state = args[1].upper()
+    try:
+        result = _run(["gh", "pr", "view", str(pr_num), "--json", "state"], timeout=10.0)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="pr_state",
+            error=f"gh unavailable: {exc!r}",
+        )
+    if result.returncode != 0:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence=result.stderr.strip()[:200],
+            evaluator="pr_state",
+            error=f"gh exit {result.returncode}",
+        )
+    import json
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence=result.stdout.strip()[:200],
+            evaluator="pr_state",
+            error=f"gh json decode failed: {exc!r}",
+        )
+    actual = (payload.get("state") or "").upper()
+    return PredicateResult(
+        predicate=predicate,
+        satisfied=actual == expected_state,
+        evidence=f"state={actual!r} expected={expected_state!r}",
+        evaluator="pr_state",
+    )
+
+
+def evaluate_pr_open(predicate: str, args: list[str]) -> PredicateResult:
+    if len(args) != 1:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="pr_open",
+            error=f"expected 1 arg, got {len(args)}",
+        )
+    inner = evaluate_pr_state(predicate, [args[0], "OPEN"])
+    return PredicateResult(
+        predicate=inner.predicate,
+        satisfied=inner.satisfied,
+        evidence=inner.evidence,
+        evaluator="pr_open",
+        evaluated_at=inner.evaluated_at,
+        error=inner.error,
+    )
+
+
+def evaluate_tests_pass(predicate: str, args: list[str]) -> PredicateResult:
+    if len(args) != 1:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="tests_pass",
+            error=f"expected 1 arg, got {len(args)}",
+        )
+    path = args[0]
+    if not os.path.exists(path):
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence=f"path_missing={path!r}",
+            evaluator="tests_pass",
+        )
+    try:
+        result = _run(["python3", "-m", "pytest", path, "-q", "--tb=no"], timeout=300.0)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="tests_pass",
+            error=f"pytest unavailable or timed out: {exc!r}",
+        )
+    return PredicateResult(
+        predicate=predicate,
+        satisfied=result.returncode == 0,
+        evidence=f"pytest exit={result.returncode}; last_line={result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ''!r}",
+        evaluator="tests_pass",
+    )
+
+
+def evaluate_file_exists(predicate: str, args: list[str]) -> PredicateResult:
+    if len(args) != 1:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="file_exists",
+            error=f"expected 1 arg, got {len(args)}",
+        )
+    path = args[0]
+    exists = os.path.isfile(path)
+    return PredicateResult(
+        predicate=predicate,
+        satisfied=exists,
+        evidence=f"isfile({path!r})={exists}",
+        evaluator="file_exists",
+    )
+
+
+def evaluate_dir_exists(predicate: str, args: list[str]) -> PredicateResult:
+    if len(args) != 1:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="dir_exists",
+            error=f"expected 1 arg, got {len(args)}",
+        )
+    path = args[0]
+    exists = os.path.isdir(path)
+    return PredicateResult(
+        predicate=predicate,
+        satisfied=exists,
+        evidence=f"isdir({path!r})={exists}",
+        evaluator="dir_exists",
+    )
+
+
+def evaluate_branch_exists(predicate: str, args: list[str]) -> PredicateResult:
+    if len(args) != 1:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="branch_exists",
+            error=f"expected 1 arg, got {len(args)}",
+        )
+    name = args[0]
+    try:
+        local = _run(["git", "branch", "--list", name], timeout=5.0)
+        remote = _run(["git", "ls-remote", "--heads", "origin", name], timeout=10.0)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="branch_exists",
+            error=f"git unavailable: {exc!r}",
+        )
+    local_hit = bool(local.stdout.strip())
+    remote_hit = bool(remote.stdout.strip())
+    return PredicateResult(
+        predicate=predicate,
+        satisfied=local_hit or remote_hit,
+        evidence=f"local={local_hit} remote={remote_hit}",
+        evaluator="branch_exists",
+    )
+
+
+def evaluate_commit_landed(predicate: str, args: list[str]) -> PredicateResult:
+    if len(args) != 1:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="commit_landed",
+            error=f"expected 1 arg, got {len(args)}",
+        )
+    sha = args[0]
+    try:
+        result = _run(["git", "merge-base", "--is-ancestor", sha, "origin/main"], timeout=10.0)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="commit_landed",
+            error=f"git unavailable: {exc!r}",
+        )
+    # merge-base --is-ancestor exits 0 if ancestor, 1 if not.
+    return PredicateResult(
+        predicate=predicate,
+        satisfied=result.returncode == 0,
+        evidence=f"is_ancestor_of_origin_main={result.returncode == 0}",
+        evaluator="commit_landed",
+    )
+
+
+def evaluate_issue_closed(predicate: str, args: list[str]) -> PredicateResult:
+    if len(args) != 1:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="issue_closed",
+            error=f"expected 1 arg, got {len(args)}",
+        )
+    try:
+        issue_num = int(args[0])
+    except ValueError:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="issue_closed",
+            error=f"arg must be int, got {args[0]!r}",
+        )
+    try:
+        result = _run(["gh", "issue", "view", str(issue_num), "--json", "state"], timeout=10.0)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="issue_closed",
+            error=f"gh unavailable: {exc!r}",
+        )
+    if result.returncode != 0:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence=result.stderr.strip()[:200],
+            evaluator="issue_closed",
+            error=f"gh exit {result.returncode}",
+        )
+    import json
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence=result.stdout.strip()[:200],
+            evaluator="issue_closed",
+            error=f"gh json decode failed: {exc!r}",
+        )
+    state = (payload.get("state") or "").upper()
+    return PredicateResult(
+        predicate=predicate,
+        satisfied=state == "CLOSED",
+        evidence=f"state={state!r}",
+        evaluator="issue_closed",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry + dispatcher
+# ---------------------------------------------------------------------------
+
+
+EvaluatorFn = Callable[[str, list[str]], PredicateResult]
+
+EVALUATORS: dict[str, EvaluatorFn] = {
+    "pr_merged": evaluate_pr_merged,
+    "pr_open": evaluate_pr_open,
+    "pr_state": evaluate_pr_state,
+    "tests_pass": evaluate_tests_pass,
+    "file_exists": evaluate_file_exists,
+    "dir_exists": evaluate_dir_exists,
+    "branch_exists": evaluate_branch_exists,
+    "commit_landed": evaluate_commit_landed,
+    "issue_closed": evaluate_issue_closed,
+}
+
+
+def evaluate_predicate(
+    predicate: str, *, evaluators: dict[str, EvaluatorFn] | None = None
+) -> PredicateResult:
+    """Parse + dispatch a predicate string to its registered evaluator."""
+    registry = evaluators if evaluators is not None else EVALUATORS
+    try:
+        name, args = parse_predicate(predicate)
+    except PredicateParseError as exc:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="(none)",
+            error=str(exc),
+        )
+    fn = registry.get(name)
+    if fn is None:
+        return PredicateResult(
+            predicate=predicate,
+            satisfied=False,
+            evidence="",
+            evaluator="(none)",
+            error=f"unknown predicate name: {name!r}",
+        )
+    return fn(predicate, args)
+
+
+def evaluate_all(predicates: list[str]) -> list[PredicateResult]:
+    """Evaluate a batch of predicate strings in declared order."""
+    return [evaluate_predicate(p) for p in predicates]

--- a/docs/governance/DELEGATION_CONTRACT_V0_1_SPEC.md
+++ b/docs/governance/DELEGATION_CONTRACT_V0_1_SPEC.md
@@ -1,0 +1,327 @@
+# Aragora Delegation Contract v0.1 — Specification
+
+**Status:** draft v0.1 — schema-first, no autonomous behavior change yet.
+**Author:** claude-B061F80D (synthesis of operator + codex + Factory review)
+**Date:** 2026-05-19
+
+## Why this exists
+
+Today Aragora can spawn autonomous agents (tmux-managed Claude workers,
+Codex CLI workers, Droid CLI workers, Factory droid workers). Each spawn
+extends a chain of authority that ultimately roots in a human operator,
+but the chain itself is implicit: there's no machine-checkable artifact
+that says "this agent was authorized to do this action, in this scope,
+in service of this goal, for this much budget, by whom."
+
+Without that artifact, three failure modes are systemic rather than
+incidental:
+
+1. **Authority laundering.** Child agent inherits permissions parent
+   never had explicit operator approval to delegate.
+2. **Scope drift.** Operator authorized "ship the reach plan"; agent
+   spawns a chain of work that quietly expands to "refactor all of
+   `scripts/`."
+3. **Unbounded cascade.** Parent agent spawns child agents that spawn
+   their own children — no formal limit, no consolidated budget, no
+   way to revoke mid-cascade.
+
+The Anthropic-side classifier polarity addresses these reactively by
+denying actions that look risky. The Factory-side auto-mode polarity
+addresses these by trusting the agent and counting dollars after the
+fact. **Neither is sufficient: scope (what) and budget (how much) are
+two independent dimensions, and a real protocol needs both.**
+
+The Delegation Contract makes scope + budget + goal + chain auditable
+as a single signed-or-shouldhavebeensigned artifact that flows with
+each lane claim and each subagent dispatch.
+
+## Design influences
+
+This v0.1 synthesizes:
+
+- **Object-capability security** (E lang, KeyKOS, Genode): authority
+  as unforgeable tokens passed explicitly; child scope must be subset
+  of parent scope.
+- **Ethereum gas**: per-op cost, bounded budget, atomic revert.
+- **AWS IAM AssumeRole with session policies**: production-proven
+  cert narrowing across permission boundaries.
+- **SLSA / in-toto**: cryptographic provenance attestations along the
+  build chain (deferred to a later contract version; v0.1 is
+  schema-only).
+- **OAuth 2.0 scopes**: scope-set + expiry + audience model.
+- **Aragora's existing `RiskBudget` / `ToolCapability` / `Policy`
+  primitives**: this contract composes them rather than replacing
+  them.
+
+Operator review notes that shaped v0.1:
+
+- **codex**: "extend existing surfaces, not invent a parallel
+  certificate/orchestration stack"; "schema-first and enforceable at
+  lane-claim/dispatch boundaries"; "rename 'Capability Certificate'
+  to 'Delegation Contract' for v0.1 unless cryptographic signing is
+  actually implemented in the same PR."
+- **Factory**: "the orthogonality of ocap (scope) and gas (budget) is
+  the protocol's most important contribution"; "predicate oracle
+  decoupling — the largest unaddressed gap"; "trust-adjusted budgets
+  via ELO"; "continuous adversarial verification instead of periodic
+  spot-checks"; "cross-family cert bridging"; "three-tier
+  reversibility: pause / halt / revoke".
+
+## v0.1 Schema
+
+### `DelegationContract`
+
+```python
+@dataclass(frozen=True)
+class DelegationContract:
+    # --- Identity ---
+    contract_id: str              # ULID-like, monotonic
+    schema_version: str           # "aragora-delegation-contract/0.1"
+
+    # --- Authority chain ---
+    root_intent_id: str           # The original human-rooted intent
+    parent_contract_id: str | None  # None iff root; else MUST resolve to
+                                    # a contract whose scope contains
+                                    # this one's
+    delegator: str                # session id of issuer
+    delegatee: str                # session id of subject
+    max_depth: int                # subagents this can issue must have
+                                  # max_depth = this.max_depth - 1; 0
+                                  # means leaf, cannot spawn
+
+    # --- Goal binding ---
+    goal_id: str                  # Resolves to a GoalSpec
+
+    # --- Scope (ocap dimension) ---
+    allowed_actions: frozenset[str]
+        # e.g. {"read:*", "write:branch:claude/*",
+        #       "write:draft-pr:*", "spawn:subagent"}
+    denied_actions: frozenset[str]
+        # explicit deny list; takes precedence over allowed
+    allowed_surfaces: AllowedSurfaces
+        # PRs, branches, worktrees, file globs
+    destructive_action_policy: Literal["deny", "human-only", "allow"]
+        # default "human-only" — destructive actions require explicit
+        # human approval regardless of any other field
+
+    # --- Budget (gas dimension) ---
+    budget: ContractBudget        # see below
+
+    # --- Lifecycle ---
+    issued_at: str                # ISO-8601 UTC
+    expires_at: str               # ISO-8601 UTC, must be in future at
+                                  # issue time
+    revocation_check_uri: str | None
+        # Where to check liveness; v0.1 uses local file path
+
+    # --- Progress gating ---
+    progress_predicates: list[str]
+        # References into the predicate oracle namespace (R01-style)
+    stale_threshold_minutes: int  # No-progress-for-N halt threshold
+
+    # --- v0.1 stub for v0.2 signing ---
+    signature: str | None         # Always None in v0.1; reserved for
+                                  # HMAC/ed25519 in v0.2
+```
+
+### `AllowedSurfaces`
+
+```python
+@dataclass(frozen=True)
+class AllowedSurfaces:
+    pr_numbers: frozenset[int]          # specific PRs (empty = any in branches)
+    branch_globs: frozenset[str]        # e.g. {"claude/*", "claude/R*"}
+    worktree_globs: frozenset[str]      # e.g. {".worktrees/codex-auto/claude-*"}
+    file_globs: frozenset[str]          # e.g. {"scripts/wake_agent.sh", "tests/scripts/test_wake_agent.py"}
+    deny_file_globs: frozenset[str]     # e.g. {"CLAUDE.md", "aragora/__init__.py"}
+```
+
+### `ContractBudget`
+
+Composes Aragora's existing `RiskBudget` with additional fan-out and
+artifact-output caps:
+
+```python
+@dataclass(frozen=True)
+class ContractBudget:
+    risk_budget: RiskBudget           # existing aragora.policy.risk primitive
+    max_wall_clock_minutes: int       # hard real-time cap
+    max_subagents_spawned: int        # cascade fan-out cap
+    max_prs_opened: int               # output cap
+    max_commits_to_main: int          # main-branch write cap
+    max_api_dollars: float            # spend cap
+    max_lane_claims: int              # registry-write cap
+```
+
+### `GoalSpec`
+
+```python
+@dataclass(frozen=True)
+class GoalSpec:
+    goal_id: str
+    schema_version: str               # "aragora-goal-spec/0.1"
+    owner: str                        # human GitHub login or operator id
+    approved_at: str                  # ISO-8601 UTC
+    description: str                  # human-readable summary
+    acceptance_criteria: list[AcceptanceCriterion]
+    progress_metric: Literal[
+        "fraction_of_AC_satisfied",
+        "all_AC_satisfied",
+        "weighted_AC",
+    ]
+    completion_predicate: str         # oracle predicate; must be true to
+                                      # consider goal done
+    anti_signals: list[str]           # named anti-signal evaluators
+    max_delegation_depth: int         # ceiling for any contract issued
+                                      # under this goal
+```
+
+### `AcceptanceCriterion`
+
+```python
+@dataclass(frozen=True)
+class AcceptanceCriterion:
+    ac_id: str                    # e.g. "AC1"
+    predicate: str                # oracle string, e.g. "pr_merged(7336)"
+    weight: float = 1.0           # for weighted_AC metric
+    description: str = ""         # human-readable
+```
+
+## Monotonic narrowing rules
+
+When `parent_contract` issues `child_contract`, ALL of the following
+must hold; violations are rejected at issue time:
+
+| Rule | Constraint |
+|---|---|
+| Goal | `child.goal_id == parent.goal_id` (same intent) |
+| Depth | `child.max_depth == parent.max_depth - 1` |
+| Actions | `child.allowed_actions ⊆ parent.allowed_actions` |
+| Actions | `child.denied_actions ⊇ parent.denied_actions` (child denies at least everything parent denies) |
+| Surface PRs | `child.allowed_surfaces.pr_numbers ⊆ parent.allowed_surfaces.pr_numbers` (or both empty) |
+| Surface branches | every glob in `child.allowed_surfaces.branch_globs` is contained by some glob in `parent.allowed_surfaces.branch_globs` |
+| Surface worktrees | analogous |
+| Surface files | analogous; `child.deny_file_globs ⊇ parent.deny_file_globs` |
+| Destructive | `child.destructive_action_policy` is "deny" or matches parent (cannot widen) |
+| Budget | every field of `child.budget` ≤ corresponding field of `parent.budget.remaining` (budget is debited from parent, not duplicated) |
+| Wall clock | `child.expires_at ≤ parent.expires_at` |
+| Stale threshold | `child.stale_threshold_minutes ≤ parent.stale_threshold_minutes` (children fail faster than parents) |
+
+These are enforced by `DelegationContract.narrow_for_child(...)` at
+issue time. v0.1 ships the validator + tests; the actual lane-registry
+hookup is Stage 2.
+
+## Predicate oracle
+
+The single biggest insight from Factory's review: **predicates must be
+evaluated by deterministic non-LLM code, not by the agent itself or by
+spot-check models.**
+
+Without this, ACAP becomes "debugging-by-LLM all the way down."
+
+v0.1 ships a small predicate oracle with explicit named evaluators:
+
+| Predicate | Implementation |
+|---|---|
+| `pr_merged(N)` | `gh pr view N --json mergedAt --jq '.mergedAt'` → non-null |
+| `pr_open(N)` | `gh pr view N --json state` → state == "OPEN" |
+| `tests_pass(path)` | `pytest path -q --tb=no` exits 0 |
+| `file_exists(path)` | `os.path.exists(path)` |
+| `branch_exists(name)` | `git branch --list name` non-empty OR `git ls-remote --heads origin name` non-empty |
+| `commit_landed(sha)` | `git merge-base --is-ancestor sha origin/main` returns 0 |
+| `issue_closed(N)` | `gh issue view N --json state` → state == "CLOSED" |
+
+Each predicate has a deterministic Python implementation in
+`aragora/policy/predicate_oracle.py`. The oracle returns:
+
+```python
+@dataclass(frozen=True)
+class PredicateResult:
+    predicate: str               # the original string
+    satisfied: bool              # boolean outcome
+    evidence: str                # what was checked (e.g. "merged_at=2026-05-19T18:13:28Z")
+    evaluated_at: str            # ISO-8601 UTC
+    evaluator: str               # which evaluator ran it
+    error: str | None            # if the oracle failed (e.g. gh unavailable)
+```
+
+**Non-oracle predicates are not acceptance criteria.** If a desired
+outcome cannot be reduced to a deterministic check, it goes in the
+human-review notes section of the goal spec, not in
+`acceptance_criteria`.
+
+## Destructive-action policy (always human-only in v0.1)
+
+Regardless of any other field, the following action classes ALWAYS
+require explicit human approval in v0.1:
+
+- `force-push:*`
+- `delete:branch:*`
+- `delete:worktree:*` (the canonical helper paths are allowed; raw `rm -rf` is not)
+- `kill:process:*`
+- `merge:*`
+- `label:*`
+- `edit:protected:*` (see CLAUDE.md "Protected Files" list)
+- `unshallow:*`
+- `gpg-bypass:*`
+
+These are encoded in `DEFAULT_DESTRUCTIVE_ACTIONS` and a contract
+cannot weaken them (the validator rejects any contract whose
+`allowed_actions` includes a destructive action without
+`destructive_action_policy == "human-only"` + an explicit
+`human_approval_token` field, which v0.1 does NOT ship — so v0.1
+effectively forbids destructive actions across the board).
+
+## What v0.1 does NOT include
+
+Explicit non-goals for this PR:
+
+- HMAC / ed25519 signing of contracts (deferred to v0.2)
+- Lane-registry integration (`delegation_contract_id` column on
+  LaneRecord) — that's Stage 2, separate PR
+- Continuous adversarial spot-check execution — Stage 4
+- ELO trust-multiplier on budget — Stage 4 (requires receipt feedback
+  loop)
+- Cross-family adapter (`--parent-cert` flag on `launch_lane.sh`) —
+  Stage 4
+- Three-tier reversibility orchestration (pause / halt / revoke) —
+  Stage 3
+- Push-revocation kill-switch file watcher — Stage 3
+
+v0.1 ships ONLY: the spec doc, the joint dataclass module, the
+predicate oracle, and tests. No autonomous worker behavior change.
+
+## Path to v0.2+
+
+| Version | Adds |
+|---|---|
+| v0.1 (this PR) | Schema + validator + predicate oracle + tests; no behavior change |
+| v0.2 | Lane registry `delegation_contract_id` field; `claim_active_agent_lane.py --parent-contract` enforcement |
+| v0.3 | Progress-ledger periodic predicate evaluation; stall-detection thresholds |
+| v0.4 | HMAC signing via existing `aragora.security.context_signing`; receipt schema references contract_id |
+| v0.5 | Continuous adversarial check (Haiku-tier model alongside worker); debate panel escalation via existing Arena |
+| v0.6 | ELO trust multiplier on effective budget |
+| v0.7 | Three-tier reversibility (pause / halt / revoke) with push-revocation kill switch |
+| v0.8 | Cross-family adapter for Factory / Codex / Droid harnesses |
+| v1.0 | All of the above hardened, audited, default-on for new lanes |
+
+Each stage is a separately-reviewable PR. v0.1 must be visible and
+tested before any of v0.2+ is meaningful.
+
+## Open questions for v0.2+ review
+
+1. **Where does the goal spec live?** `docs/goals/<goal-id>.yaml` (tracked in repo) or `.aragora/goals/<goal-id>.json` (operator-local)? v0.2 needs to decide; v0.1 is schema-only so it doesn't matter yet.
+2. **Predicate caching.** Some predicates (e.g. `pr_merged`) are expensive. v0.3 progress ledger needs a cache policy.
+3. **Identity verification.** v0.1 takes `delegator` / `delegatee` as plain strings; v0.4 signing makes them verifiable.
+4. **Cross-family delegator naming.** Factory worker spawned by Claude session — what's the delegator? The Claude session or the Factory harness? v0.8 needs to settle this.
+
+## References
+
+- `aragora/policy/risk.py` — `RiskBudget`, `RiskLevel`, `BlastRadius`, `RiskActionRecord`
+- `aragora/policy/tools.py` — `ToolCapability`, `ToolCategory`
+- `aragora/policy/engine.py` — `Policy`, `PolicyEngine`, `PolicyDecision`, `PolicyResult`
+- `aragora/security/context_signing.py` — HMAC signing primitives (deferred to v0.4)
+- `aragora/ranking/elo.py` — agent skill ELO (deferred to v0.6 trust multiplier)
+- `scripts/claim_active_agent_lane.py` — lane registry mutation surface (v0.2 integration point)
+- `docs/AGENT_OPERATING_CONTRACT.md` — protected, but defines current operator authority model
+- `PR #7327` — agent-dispatch reach plan; depends on this contract for v0.8 cross-family bridging

--- a/scripts/claim_active_agent_lane.py
+++ b/scripts/claim_active_agent_lane.py
@@ -115,6 +115,12 @@ LANE_RECORD_KEYS = (
     "codex_thread_id",
     "codex_rollout_path",
     "session_title",
+    # Delegation Contract v0.2 — authority chain attached to each lane.
+    # All three optional; backward-compatible with pre-v0.2 lanes (None
+    # values are filtered by _normalize_row).
+    "delegation_contract_id",
+    "parent_contract_id",
+    "root_intent_id",
 )
 
 
@@ -328,21 +334,69 @@ def claim_lane(
     codex_thread_id: str = "",
     codex_rollout_path: str = "",
     session_title: str = "",
+    delegation_contract_id: str = "",
+    parent_contract_id: str = "",
+    root_intent_id: str = "",
     force: bool = False,
     allow_resource_conflicts: bool = False,
     updated_at: str | None = None,
 ) -> dict[str, Any]:
-    """Write or refresh a single lane claim, returning the persisted row."""
+    """Write or refresh a single lane claim, returning the persisted row.
+
+    Delegation Contract v0.2: when ``delegation_contract_id`` is supplied,
+    the three contract fields (delegation_contract_id, parent_contract_id,
+    root_intent_id) are persisted on the row so the authority chain is
+    visible at lane-registry queries. v0.2 does NOT yet verify the
+    contract against a stored DelegationContract JSON file — that
+    verification step lands in v0.4 (signing) and v0.5 (lane-time
+    enforcement). v0.2 ships only the schema attachment + monotonic-
+    narrowing rule when both ``delegation_contract_id`` and
+    ``parent_contract_id`` are set: ``parent_contract_id`` must match
+    the ``delegation_contract_id`` of an existing row in the registry.
+    """
     if not lane_id:
         raise ValueError("lane_id must not be empty")
     if not owner_session:
         raise ValueError("owner_session must not be empty")
     if status not in ALLOWED_STATUSES:
         raise ValueError(f"status {status!r} is not in {sorted(ALLOWED_STATUSES)}")
+    if parent_contract_id and not delegation_contract_id:
+        raise ValueError(
+            "parent_contract_id provided without delegation_contract_id; "
+            "every lane referencing a parent must also have its own contract id"
+        )
 
     with _registry_write_lock(registry_path):
         rows = _read_existing(registry_path)
         timestamp = updated_at or _utc_now_iso()
+
+        # Delegation Contract v0.2 monotonic-narrowing check:
+        # if parent_contract_id is set, it must resolve to an existing
+        # contract id in the registry (proving the parent claim exists +
+        # is part of the same chain).
+        if parent_contract_id:
+            parent_found = any(
+                str(r.get("delegation_contract_id") or "") == parent_contract_id for r in rows
+            )
+            if not parent_found and not force:
+                raise ClaimError(
+                    f"parent_contract_id={parent_contract_id!r} does not match any "
+                    f"existing delegation_contract_id in the lane registry; "
+                    f"parent contract must be claimed before child can chain to it "
+                    f"(use --force to override)"
+                )
+            # When a parent is referenced, root_intent_id must match the parent's
+            # root_intent_id if the parent declared one.
+            if root_intent_id:
+                for r in rows:
+                    if str(r.get("delegation_contract_id") or "") == parent_contract_id:
+                        parent_root = str(r.get("root_intent_id") or "")
+                        if parent_root and parent_root != root_intent_id:
+                            raise ClaimError(
+                                f"root_intent_id mismatch: child={root_intent_id!r} "
+                                f"parent={parent_root!r}; authority chains must share "
+                                f"a single root intent (use --force to override)"
+                            )
 
         new_row: dict[str, Any] = {
             "lane_id": lane_id,
@@ -361,6 +415,9 @@ def claim_lane(
             "codex_thread_id": codex_thread_id,
             "codex_rollout_path": codex_rollout_path,
             "session_title": session_title,
+            "delegation_contract_id": delegation_contract_id,
+            "parent_contract_id": parent_contract_id,
+            "root_intent_id": root_intent_id,
         }
         normalized = _normalize_row(new_row)
 
@@ -438,6 +495,34 @@ def build_parser() -> argparse.ArgumentParser:
         "--session-title",
         default="",
         help="Optional visible or inferred session title for operator display.",
+    )
+    parser.add_argument(
+        "--delegation-contract-id",
+        default="",
+        help=(
+            "Delegation Contract v0.2: contract id binding this lane to a "
+            "specific authority grant. See "
+            "docs/governance/DELEGATION_CONTRACT_V0_1_SPEC.md."
+        ),
+    )
+    parser.add_argument(
+        "--parent-contract-id",
+        default="",
+        help=(
+            "Delegation Contract v0.2: contract id of the parent contract "
+            "in the authority chain. If set, the parent must already exist "
+            "in the registry (use --force to override). Requires "
+            "--delegation-contract-id."
+        ),
+    )
+    parser.add_argument(
+        "--root-intent-id",
+        default="",
+        help=(
+            "Delegation Contract v0.2: id of the root human-rooted intent "
+            "this lane derives from. When --parent-contract-id is set and "
+            "parent has root_intent_id, child's value must match."
+        ),
     )
     parser.add_argument(
         "--force",
@@ -526,6 +611,9 @@ def main(argv: list[str] | None = None) -> int:
                 codex_thread_id=args.codex_thread_id,
                 codex_rollout_path=args.codex_rollout_path,
                 session_title=args.session_title,
+                delegation_contract_id=args.delegation_contract_id,
+                parent_contract_id=args.parent_contract_id,
+                root_intent_id=args.root_intent_id,
                 force=args.force,
                 allow_resource_conflicts=args.allow_resource_conflicts,
                 updated_at=args.updated_at,

--- a/tests/policy/test_delegation_contract.py
+++ b/tests/policy/test_delegation_contract.py
@@ -1,0 +1,409 @@
+"""Tests for ``aragora.policy.delegation_contract`` — Delegation Contract v0.1.
+
+Covers per the spec:
+- root-contract validation (self-consistency)
+- monotonic narrowing rules for parent→child issuance
+- scope-widening rejection
+- budget-debit math
+- max-depth rejection
+- destructive-action human gate (v0.1 effectively denies destructive)
+- expires_at narrowing
+- surface containment
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.policy import (
+    CONTRACT_SCHEMA_VERSION,
+    GOAL_SPEC_SCHEMA_VERSION,
+    AcceptanceCriterion,
+    AllowedSurfaces,
+    ContractBudget,
+    ContractValidationError,
+    DelegationContract,
+    GoalSpec,
+    RiskBudget,
+    make_root_contract,
+    narrow_for_child,
+)
+
+
+# ---------- helpers ----------
+
+
+def _now_iso(offset_minutes: int = 0) -> str:
+    return (datetime.now(UTC) + timedelta(minutes=offset_minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _make_simple_parent(**overrides) -> DelegationContract:
+    defaults = dict(
+        contract_id="root-1",
+        root_intent_id="intent-1",
+        delegator="an0mium",
+        delegatee="claude-A",
+        goal_id="G-foo",
+        allowed_actions=("read:*", "write:branch:claude/*", "spawn:subagent"),
+        max_depth=3,
+        duration_minutes=120,
+        stale_threshold_minutes=30,
+        destructive_action_policy="deny",
+    )
+    defaults.update(overrides)
+    return make_root_contract(**defaults)
+
+
+# ---------- root validation ----------
+
+
+def test_root_contract_validates() -> None:
+    c = _make_simple_parent()
+    c.validate()
+    assert c.schema_version == CONTRACT_SCHEMA_VERSION
+    assert c.parent_contract_id is None
+    assert c.max_depth == 3
+
+
+def test_root_contract_requires_goal_id() -> None:
+    with pytest.raises(ContractValidationError, match="goal_id"):
+        _make_simple_parent(goal_id="")
+
+
+def test_root_contract_requires_future_expiry() -> None:
+    with pytest.raises(ContractValidationError, match="expires_at"):
+        _make_simple_parent(duration_minutes=-1)
+
+
+def test_root_contract_rejects_destructive_policy_allow() -> None:
+    with pytest.raises(ContractValidationError, match="'allow' is not permitted"):
+        _make_simple_parent(destructive_action_policy="allow")
+
+
+def test_root_contract_rejects_v01_signature() -> None:
+    parent = _make_simple_parent()
+    forged = DelegationContract(
+        **{**parent.__dict__, "signature": "deadbeef"},
+    )
+    with pytest.raises(ContractValidationError, match="signature must be None in v0.1"):
+        forged.validate()
+
+
+# ---------- monotonic narrowing — actions ----------
+
+
+def test_child_actions_subset_ok() -> None:
+    parent = _make_simple_parent(
+        allowed_actions=("read:*", "write:branch:claude/*", "spawn:subagent")
+    )
+    child = narrow_for_child(
+        parent,
+        child_contract_id="child-1",
+        child_delegatee="claude-B-worker",
+        child_allowed_actions=("read:*",),
+    )
+    assert "read:*" in child.allowed_actions
+    assert "write:branch:claude/*" not in child.allowed_actions
+
+
+def test_child_actions_widening_rejected() -> None:
+    parent = _make_simple_parent(allowed_actions=("read:*",))
+    with pytest.raises(ContractValidationError, match="widen parent"):
+        narrow_for_child(
+            parent,
+            child_contract_id="child-1",
+            child_delegatee="claude-B",
+            child_allowed_actions=("read:*", "write:branch:claude/*"),
+        )
+
+
+def test_child_denied_actions_narrowing_rejected() -> None:
+    parent = _make_simple_parent(
+        allowed_actions=("read:*",),
+    )
+    parent = DelegationContract(**{**parent.__dict__, "denied_actions": frozenset({"merge:*"})})
+    with pytest.raises(ContractValidationError, match="missing"):
+        narrow_for_child(
+            parent,
+            child_contract_id="child-1",
+            child_delegatee="claude-B",
+            child_denied_actions=frozenset(),  # tries to remove parent's deny
+        )
+
+
+# ---------- monotonic narrowing — depth ----------
+
+
+def test_child_depth_decrements_by_one() -> None:
+    parent = _make_simple_parent(max_depth=2)
+    child = narrow_for_child(parent, child_contract_id="c1", child_delegatee="claude-B")
+    assert child.max_depth == 1
+
+
+def test_leaf_parent_cannot_spawn() -> None:
+    parent = _make_simple_parent(max_depth=0)
+    with pytest.raises(ContractValidationError, match="cannot spawn children"):
+        narrow_for_child(parent, child_contract_id="c1", child_delegatee="claude-B")
+
+
+# ---------- monotonic narrowing — budget ----------
+
+
+def test_child_budget_within_parent_ok() -> None:
+    parent_budget = ContractBudget(
+        risk_budget=RiskBudget(total=100),
+        max_wall_clock_minutes=120,
+        max_subagents_spawned=4,
+        max_prs_opened=6,
+        max_api_dollars=5.00,
+    )
+    parent = _make_simple_parent(budget=parent_budget)
+    child = narrow_for_child(
+        parent,
+        child_contract_id="c1",
+        child_delegatee="claude-B",
+        child_budget=ContractBudget(
+            risk_budget=RiskBudget(total=20),
+            max_wall_clock_minutes=30,
+            max_subagents_spawned=0,
+            max_prs_opened=1,
+            max_api_dollars=0.50,
+        ),
+    )
+    assert child.budget.max_wall_clock_minutes == 30
+    assert child.budget.risk_budget.total == 20
+
+
+def test_child_budget_exceeding_parent_rejected() -> None:
+    parent = _make_simple_parent()
+    with pytest.raises(ContractValidationError, match="exceeds parent"):
+        narrow_for_child(
+            parent,
+            child_contract_id="c1",
+            child_delegatee="claude-B",
+            child_budget=ContractBudget(
+                risk_budget=RiskBudget(total=10),
+                max_wall_clock_minutes=parent.budget.max_wall_clock_minutes + 1,
+                max_subagents_spawned=0,
+                max_prs_opened=1,
+                max_api_dollars=0.50,
+            ),
+        )
+
+
+def test_child_api_dollars_exceeds_parent_rejected() -> None:
+    parent = _make_simple_parent(
+        budget=ContractBudget(risk_budget=RiskBudget(), max_api_dollars=1.0)
+    )
+    with pytest.raises(ContractValidationError, match="max_api_dollars"):
+        narrow_for_child(
+            parent,
+            child_contract_id="c1",
+            child_delegatee="claude-B",
+            child_budget=ContractBudget(risk_budget=RiskBudget(total=10), max_api_dollars=2.0),
+        )
+
+
+def test_child_risk_total_exceeds_parent_remaining_rejected() -> None:
+    parent_rb = RiskBudget(total=10, spent=5)  # remaining = 5
+    parent = _make_simple_parent(budget=ContractBudget(risk_budget=parent_rb))
+    with pytest.raises(ContractValidationError, match="risk_budget.total"):
+        narrow_for_child(
+            parent,
+            child_contract_id="c1",
+            child_delegatee="claude-B",
+            child_budget=ContractBudget(risk_budget=RiskBudget(total=6)),
+        )
+
+
+# ---------- monotonic narrowing — destructive policy ----------
+
+
+def test_child_destructive_policy_widening_rejected_deny_to_human_only() -> None:
+    parent = _make_simple_parent(destructive_action_policy="deny")
+    with pytest.raises(ContractValidationError, match="destructive_action_policy"):
+        narrow_for_child(
+            parent,
+            child_contract_id="c1",
+            child_delegatee="claude-B",
+            child_destructive_policy="human-only",
+        )
+
+
+def test_child_destructive_policy_unchanged_ok() -> None:
+    parent = _make_simple_parent(destructive_action_policy="deny")
+    child = narrow_for_child(
+        parent,
+        child_contract_id="c1",
+        child_delegatee="claude-B",
+        child_destructive_policy="deny",
+    )
+    assert child.destructive_action_policy == "deny"
+
+
+# ---------- monotonic narrowing — surfaces ----------
+
+
+def test_child_branch_glob_inside_parent_ok() -> None:
+    parent = _make_simple_parent(
+        allowed_surfaces=AllowedSurfaces(branch_globs=frozenset({"claude/*"}))
+    )
+    child = narrow_for_child(
+        parent,
+        child_contract_id="c1",
+        child_delegatee="claude-B",
+        child_allowed_surfaces=AllowedSurfaces(branch_globs=frozenset({"claude/R*"})),
+    )
+    assert "claude/R*" in child.allowed_surfaces.branch_globs
+
+
+def test_child_branch_glob_outside_parent_rejected() -> None:
+    parent = _make_simple_parent(
+        allowed_surfaces=AllowedSurfaces(branch_globs=frozenset({"claude/*"}))
+    )
+    with pytest.raises(ContractValidationError, match="branch_globs"):
+        narrow_for_child(
+            parent,
+            child_contract_id="c1",
+            child_delegatee="claude-B",
+            child_allowed_surfaces=AllowedSurfaces(branch_globs=frozenset({"codex/*"})),
+        )
+
+
+def test_child_deny_file_globs_must_include_parent_denies() -> None:
+    parent = _make_simple_parent(
+        allowed_surfaces=AllowedSurfaces(
+            deny_file_globs=frozenset({"CLAUDE.md", "aragora/__init__.py"})
+        )
+    )
+    with pytest.raises(ContractValidationError, match="deny_file_globs"):
+        narrow_for_child(
+            parent,
+            child_contract_id="c1",
+            child_delegatee="claude-B",
+            child_allowed_surfaces=AllowedSurfaces(
+                deny_file_globs=frozenset({"CLAUDE.md"})  # missing aragora/__init__.py
+            ),
+        )
+
+
+# ---------- monotonic narrowing — time ----------
+
+
+def test_child_expires_after_parent_rejected() -> None:
+    parent = _make_simple_parent(duration_minutes=30)
+    later = _now_iso(offset_minutes=60)
+    with pytest.raises(ContractValidationError, match="expires_at"):
+        narrow_for_child(
+            parent,
+            child_contract_id="c1",
+            child_delegatee="claude-B",
+            child_expires_at=later,
+        )
+
+
+def test_child_stale_threshold_widening_rejected() -> None:
+    parent = _make_simple_parent(stale_threshold_minutes=30)
+    with pytest.raises(ContractValidationError, match="stale_threshold_minutes"):
+        narrow_for_child(
+            parent,
+            child_contract_id="c1",
+            child_delegatee="claude-B",
+            child_stale_threshold_minutes=60,
+        )
+
+
+# ---------- chain semantics ----------
+
+
+def test_child_inherits_root_intent_and_goal() -> None:
+    parent = _make_simple_parent()
+    child = narrow_for_child(parent, child_contract_id="c1", child_delegatee="claude-B")
+    assert child.root_intent_id == parent.root_intent_id
+    assert child.goal_id == parent.goal_id
+    assert child.parent_contract_id == parent.contract_id
+
+
+def test_grandchild_depth_chain() -> None:
+    parent = _make_simple_parent(max_depth=3)
+    child = narrow_for_child(parent, child_contract_id="c1", child_delegatee="claude-B")
+    grandchild = narrow_for_child(child, child_contract_id="c2", child_delegatee="claude-C")
+    assert grandchild.max_depth == 1
+    assert grandchild.parent_contract_id == child.contract_id
+    # Eventually max_depth=0 means leaf
+    leaf = narrow_for_child(grandchild, child_contract_id="c3", child_delegatee="claude-D")
+    assert leaf.max_depth == 0
+    with pytest.raises(ContractValidationError, match="cannot spawn"):
+        narrow_for_child(leaf, child_contract_id="c4", child_delegatee="claude-E")
+
+
+# ---------- action filter (permits_action) ----------
+
+
+def test_permits_action_matches_allowed() -> None:
+    c = _make_simple_parent(allowed_actions=("read:*", "write:branch:claude/*"))
+    allowed, _ = c.permits_action("read:file")
+    assert allowed
+    allowed, _ = c.permits_action("write:branch:claude/R02-xxx")
+    assert allowed
+
+
+def test_permits_action_rejects_outside_allowed() -> None:
+    c = _make_simple_parent(allowed_actions=("read:*",))
+    allowed, reason = c.permits_action("write:branch:claude/foo")
+    assert not allowed
+    assert "no allowed pattern" in reason
+
+
+def test_permits_action_denied_takes_precedence() -> None:
+    parent = _make_simple_parent(allowed_actions=("read:*", "write:branch:claude/*"))
+    contract = DelegationContract(
+        **{**parent.__dict__, "denied_actions": frozenset({"write:branch:claude/main"})}
+    )
+    allowed, reason = contract.permits_action("write:branch:claude/main")
+    assert not allowed
+    assert "denied pattern" in reason
+
+
+def test_permits_action_destructive_with_deny_policy_blocked() -> None:
+    """A clean contract under deny policy must block destructive actions at
+    permits_action time too (defense in depth: validator catches them at
+    construction, permits_action catches them at evaluation)."""
+    c = _make_simple_parent(
+        allowed_actions=("read:*",),
+        destructive_action_policy="deny",
+    )
+    allowed, reason = c.permits_action("force-push:branch:foo")
+    assert not allowed
+    assert "destructive" in reason
+
+
+def test_root_contract_rejects_destructive_in_allowed_under_deny_policy() -> None:
+    with pytest.raises(ContractValidationError, match="destructive"):
+        _make_simple_parent(
+            allowed_actions=("force-push:branch:claude/foo",),
+            destructive_action_policy="deny",
+        )
+
+
+def test_empty_allowed_actions_denies_by_default() -> None:
+    c = _make_simple_parent(allowed_actions=())
+    allowed, reason = c.permits_action("read:file")
+    assert not allowed
+    assert "deny by default" in reason
+
+
+# ---------- expiry ----------
+
+
+def test_is_expired_future() -> None:
+    c = _make_simple_parent(duration_minutes=10)
+    assert not c.is_expired()
+
+
+def test_is_expired_with_past_time() -> None:
+    c = _make_simple_parent(duration_minutes=10)
+    future = datetime.now(UTC) + timedelta(minutes=20)
+    assert c.is_expired(now=future)

--- a/tests/policy/test_predicate_oracle.py
+++ b/tests/policy/test_predicate_oracle.py
@@ -1,0 +1,339 @@
+"""Tests for ``aragora.policy.predicate_oracle``.
+
+Covers:
+- predicate-string parsing
+- each evaluator's happy-path and error paths (with subprocess mocked)
+- dispatcher behavior for unknown predicates and parse errors
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aragora.policy import (
+    EVALUATORS,
+    PredicateParseError,
+    PredicateResult,
+    evaluate_all,
+    evaluate_predicate,
+    parse_predicate,
+)
+from aragora.policy import predicate_oracle as oracle_module
+
+
+# ---------- parse_predicate ----------
+
+
+def test_parse_simple_int_arg() -> None:
+    assert parse_predicate("pr_merged(7336)") == ("pr_merged", ["7336"])
+
+
+def test_parse_quoted_string_arg() -> None:
+    assert parse_predicate('tests_pass("tests/foo.py")') == (
+        "tests_pass",
+        ["tests/foo.py"],
+    )
+
+
+def test_parse_two_args() -> None:
+    assert parse_predicate("pr_state(7336, OPEN)") == ("pr_state", ["7336", "OPEN"])
+
+
+def test_parse_zero_args() -> None:
+    assert parse_predicate("status()") == ("status", [])
+
+
+def test_parse_invalid_raises() -> None:
+    with pytest.raises(PredicateParseError):
+        parse_predicate("not a predicate")
+    with pytest.raises(PredicateParseError):
+        parse_predicate("missing_close_paren(")
+
+
+# ---------- evaluate_file_exists / dir_exists (pure stdlib, no mock needed) ----------
+
+
+def test_file_exists_true(tmp_path: Path) -> None:
+    target = tmp_path / "real.txt"
+    target.write_text("x")
+    result = evaluate_predicate(f"file_exists({target})")
+    assert result.satisfied is True
+    assert result.error is None
+    assert "isfile" in result.evidence
+
+
+def test_file_exists_false(tmp_path: Path) -> None:
+    result = evaluate_predicate(f"file_exists({tmp_path / 'missing.txt'})")
+    assert result.satisfied is False
+    assert result.error is None
+
+
+def test_file_exists_wrong_arg_count() -> None:
+    result = evaluate_predicate("file_exists()")
+    assert result.satisfied is False
+    assert result.error and "expected 1 arg" in result.error
+
+
+def test_dir_exists_true(tmp_path: Path) -> None:
+    result = evaluate_predicate(f"dir_exists({tmp_path})")
+    assert result.satisfied is True
+    assert result.error is None
+
+
+def test_dir_exists_false_for_file(tmp_path: Path) -> None:
+    target = tmp_path / "afile"
+    target.write_text("x")
+    result = evaluate_predicate(f"dir_exists({target})")
+    assert result.satisfied is False  # isfile, not isdir
+
+
+# ---------- evaluate_pr_merged (mock subprocess) ----------
+
+
+def _fake_proc(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_pr_merged_when_gh_reports_mergedAt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        oracle_module,
+        "_run",
+        lambda cmd, timeout=15.0: _fake_proc(
+            0, stdout=json.dumps({"mergedAt": "2026-05-19T18:13:28Z"})
+        ),
+    )
+    result = evaluate_predicate("pr_merged(7336)")
+    assert result.satisfied is True
+    assert result.error is None
+    assert "merged_at" in result.evidence
+
+
+def test_pr_merged_when_mergedAt_null(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        oracle_module,
+        "_run",
+        lambda cmd, timeout=15.0: _fake_proc(0, stdout=json.dumps({"mergedAt": None})),
+    )
+    result = evaluate_predicate("pr_merged(7336)")
+    assert result.satisfied is False
+    assert result.error is None
+
+
+def test_pr_merged_when_gh_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd, timeout=15.0):
+        raise FileNotFoundError("gh missing")
+
+    monkeypatch.setattr(oracle_module, "_run", fake_run)
+    result = evaluate_predicate("pr_merged(7336)")
+    assert result.satisfied is False
+    assert result.error and "gh unavailable" in result.error
+
+
+def test_pr_merged_when_gh_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        oracle_module, "_run", lambda cmd, timeout=15.0: _fake_proc(1, stderr="not found")
+    )
+    result = evaluate_predicate("pr_merged(99999)")
+    assert result.satisfied is False
+    assert result.error and "gh exit" in result.error
+
+
+def test_pr_merged_non_int_arg(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = evaluate_predicate("pr_merged(foo)")
+    assert result.satisfied is False
+    assert result.error and "must be int" in result.error
+
+
+# ---------- evaluate_pr_open / pr_state ----------
+
+
+def test_pr_open_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        oracle_module,
+        "_run",
+        lambda cmd, timeout=15.0: _fake_proc(0, stdout=json.dumps({"state": "OPEN"})),
+    )
+    result = evaluate_predicate("pr_open(7327)")
+    assert result.satisfied is True
+    assert result.evaluator == "pr_open"
+
+
+def test_pr_state_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        oracle_module,
+        "_run",
+        lambda cmd, timeout=15.0: _fake_proc(0, stdout=json.dumps({"state": "MERGED"})),
+    )
+    result = evaluate_predicate("pr_state(7327, MERGED)")
+    assert result.satisfied is True
+
+
+def test_pr_state_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        oracle_module,
+        "_run",
+        lambda cmd, timeout=15.0: _fake_proc(0, stdout=json.dumps({"state": "OPEN"})),
+    )
+    result = evaluate_predicate("pr_state(7327, MERGED)")
+    assert result.satisfied is False
+
+
+# ---------- evaluate_branch_exists ----------
+
+
+def test_branch_exists_local_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, timeout=15.0):
+        calls.append(list(cmd))
+        if "branch" in cmd:
+            return _fake_proc(0, stdout="  main\n")
+        return _fake_proc(0, stdout="")
+
+    monkeypatch.setattr(oracle_module, "_run", fake_run)
+    result = evaluate_predicate("branch_exists(main)")
+    assert result.satisfied is True
+
+
+def test_branch_exists_remote_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd, timeout=15.0):
+        if cmd[1] == "branch":
+            return _fake_proc(0, stdout="")
+        return _fake_proc(0, stdout="abc123\trefs/heads/foo\n")
+
+    monkeypatch.setattr(oracle_module, "_run", fake_run)
+    result = evaluate_predicate("branch_exists(foo)")
+    assert result.satisfied is True
+
+
+def test_branch_exists_neither(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oracle_module, "_run", lambda cmd, timeout=15.0: _fake_proc(0, stdout=""))
+    result = evaluate_predicate("branch_exists(missing)")
+    assert result.satisfied is False
+
+
+# ---------- evaluate_commit_landed ----------
+
+
+def test_commit_landed_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oracle_module, "_run", lambda cmd, timeout=15.0: _fake_proc(0))
+    result = evaluate_predicate("commit_landed(abc123)")
+    assert result.satisfied is True
+
+
+def test_commit_landed_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oracle_module, "_run", lambda cmd, timeout=15.0: _fake_proc(1))
+    result = evaluate_predicate("commit_landed(deadbeef)")
+    assert result.satisfied is False
+
+
+# ---------- evaluate_issue_closed ----------
+
+
+def test_issue_closed_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        oracle_module,
+        "_run",
+        lambda cmd, timeout=15.0: _fake_proc(0, stdout=json.dumps({"state": "CLOSED"})),
+    )
+    result = evaluate_predicate("issue_closed(123)")
+    assert result.satisfied is True
+
+
+def test_issue_closed_when_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        oracle_module,
+        "_run",
+        lambda cmd, timeout=15.0: _fake_proc(0, stdout=json.dumps({"state": "OPEN"})),
+    )
+    result = evaluate_predicate("issue_closed(123)")
+    assert result.satisfied is False
+
+
+# ---------- evaluate_tests_pass ----------
+
+
+def test_tests_pass_path_missing(tmp_path: Path) -> None:
+    result = evaluate_predicate(f"tests_pass({tmp_path / 'nope.py'})")
+    assert result.satisfied is False
+    assert result.error is None  # not an oracle error, just unsatisfied
+    assert "path_missing" in result.evidence
+
+
+def test_tests_pass_pytest_exit_zero(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    target = tmp_path / "test_x.py"
+    target.write_text("def test_x():\n    assert True\n")
+    monkeypatch.setattr(
+        oracle_module, "_run", lambda cmd, timeout=300.0: _fake_proc(0, stdout="1 passed")
+    )
+    result = evaluate_predicate(f"tests_pass({target})")
+    assert result.satisfied is True
+
+
+def test_tests_pass_pytest_exit_nonzero(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    target = tmp_path / "test_x.py"
+    target.write_text("def test_x():\n    assert False\n")
+    monkeypatch.setattr(
+        oracle_module, "_run", lambda cmd, timeout=300.0: _fake_proc(1, stdout="1 failed")
+    )
+    result = evaluate_predicate(f"tests_pass({target})")
+    assert result.satisfied is False
+
+
+# ---------- dispatcher ----------
+
+
+def test_unknown_predicate_returns_error() -> None:
+    result = evaluate_predicate("does_not_exist(x)")
+    assert result.satisfied is False
+    assert result.error and "unknown predicate" in result.error
+
+
+def test_malformed_predicate_returns_error() -> None:
+    result = evaluate_predicate("not a predicate")
+    assert result.satisfied is False
+    assert result.error is not None
+
+
+def test_evaluate_all_preserves_order(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    f1 = tmp_path / "a.txt"
+    f1.write_text("x")
+    results = evaluate_all(
+        [
+            f"file_exists({f1})",
+            f"file_exists({tmp_path / 'missing'})",
+        ]
+    )
+    assert len(results) == 2
+    assert results[0].satisfied is True
+    assert results[1].satisfied is False
+
+
+def test_registry_lists_all_evaluators() -> None:
+    expected = {
+        "pr_merged",
+        "pr_open",
+        "pr_state",
+        "tests_pass",
+        "file_exists",
+        "dir_exists",
+        "branch_exists",
+        "commit_landed",
+        "issue_closed",
+    }
+    assert expected.issubset(EVALUATORS.keys())
+
+
+def test_predicate_result_is_frozen() -> None:
+    r = PredicateResult(
+        predicate="x",
+        satisfied=True,
+        evidence="",
+        evaluator="t",
+    )
+    with pytest.raises(Exception):  # frozen dataclasses raise FrozenInstanceError
+        r.satisfied = False  # type: ignore[misc]

--- a/tests/scripts/test_claim_active_agent_lane.py
+++ b/tests/scripts/test_claim_active_agent_lane.py
@@ -666,3 +666,212 @@ def test_worktree_collision_detected_across_trailing_slash(
 
     assert "worktree=" in str(excinfo.value)
     assert str(worktree.resolve()) in str(excinfo.value)
+
+
+# --- Delegation Contract v0.2 — lane-registry authority-chain attachment ---
+
+
+def test_v02_contract_fields_round_trip(tmp_registry: Path) -> None:
+    """delegation_contract_id, parent_contract_id, root_intent_id persist."""
+    row = claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="L1",
+        owner_session="claude-A",
+        delegation_contract_id="root-contract-1",
+        root_intent_id="intent-1",
+    )
+    assert row["delegation_contract_id"] == "root-contract-1"
+    assert row["root_intent_id"] == "intent-1"
+    persisted = json.loads(tmp_registry.read_text())[0]
+    assert persisted["delegation_contract_id"] == "root-contract-1"
+    assert persisted["root_intent_id"] == "intent-1"
+
+
+def test_v02_parent_contract_id_requires_own_contract_id(tmp_registry: Path) -> None:
+    """parent_contract_id without delegation_contract_id is rejected."""
+    with pytest.raises(ValueError, match="parent_contract_id provided"):
+        claim_module.claim_lane(
+            registry_path=tmp_registry,
+            lane_id="L1",
+            owner_session="claude-A",
+            parent_contract_id="some-parent",
+            # delegation_contract_id intentionally absent
+        )
+
+
+def test_v02_child_must_match_existing_parent(tmp_registry: Path) -> None:
+    """parent_contract_id must match an existing row's delegation_contract_id."""
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="L-root",
+        owner_session="claude-A",
+        delegation_contract_id="root-1",
+    )
+    # Child references root-1 — should succeed
+    child_row = claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="L-child",
+        owner_session="claude-B",
+        delegation_contract_id="child-1",
+        parent_contract_id="root-1",
+    )
+    assert child_row["parent_contract_id"] == "root-1"
+
+
+def test_v02_child_with_missing_parent_rejected(tmp_registry: Path) -> None:
+    """parent_contract_id pointing to a non-existent parent is rejected."""
+    with pytest.raises(claim_module.ClaimError, match="does not match any existing"):
+        claim_module.claim_lane(
+            registry_path=tmp_registry,
+            lane_id="L1",
+            owner_session="claude-A",
+            delegation_contract_id="child-1",
+            parent_contract_id="never-existed",
+        )
+
+
+def test_v02_child_with_missing_parent_force_overrides(tmp_registry: Path) -> None:
+    """--force bypasses the missing-parent check."""
+    row = claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="L1",
+        owner_session="claude-A",
+        delegation_contract_id="child-1",
+        parent_contract_id="never-existed",
+        force=True,
+    )
+    assert row["parent_contract_id"] == "never-existed"
+
+
+def test_v02_child_root_intent_must_match_parent(tmp_registry: Path) -> None:
+    """When parent has root_intent_id, child's root_intent_id must match."""
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="L-root",
+        owner_session="claude-A",
+        delegation_contract_id="root-1",
+        root_intent_id="intent-1",
+    )
+    # Child with conflicting root_intent_id should fail
+    with pytest.raises(claim_module.ClaimError, match="root_intent_id mismatch"):
+        claim_module.claim_lane(
+            registry_path=tmp_registry,
+            lane_id="L-child",
+            owner_session="claude-B",
+            delegation_contract_id="child-1",
+            parent_contract_id="root-1",
+            root_intent_id="DIFFERENT-INTENT",
+        )
+
+
+def test_v02_child_with_matching_root_intent_ok(tmp_registry: Path) -> None:
+    """Child whose root_intent_id matches parent's persists cleanly."""
+    claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="L-root",
+        owner_session="claude-A",
+        delegation_contract_id="root-1",
+        root_intent_id="intent-1",
+    )
+    child_row = claim_module.claim_lane(
+        registry_path=tmp_registry,
+        lane_id="L-child",
+        owner_session="claude-B",
+        delegation_contract_id="child-1",
+        parent_contract_id="root-1",
+        root_intent_id="intent-1",
+    )
+    assert child_row["root_intent_id"] == "intent-1"
+
+
+def test_v02_legacy_rows_unchanged_when_no_contract_supplied(tmp_registry: Path) -> None:
+    """A claim without contract fields persists without contract keys (legacy)."""
+    row = claim_module.claim_lane(
+        registry_path=tmp_registry, lane_id="L1", owner_session="claude-A"
+    )
+    assert "delegation_contract_id" not in row
+    assert "parent_contract_id" not in row
+    assert "root_intent_id" not in row
+
+
+def test_v02_cli_flags_via_subprocess(tmp_registry: Path) -> None:
+    """End-to-end: --delegation-contract-id + --parent-contract-id + --root-intent-id flow through."""
+    # First seed the root contract
+    seed_result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--lane-id",
+            "L-root",
+            "--owner-session",
+            "claude-root",
+            "--registry-path",
+            str(tmp_registry),
+            "--delegation-contract-id",
+            "root-1",
+            "--root-intent-id",
+            "intent-1",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin"},
+        check=True,
+    )
+    seed = json.loads(seed_result.stdout)
+    assert seed["delegation_contract_id"] == "root-1"
+    # Now claim child
+    child_result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--lane-id",
+            "L-child",
+            "--owner-session",
+            "claude-child",
+            "--registry-path",
+            str(tmp_registry),
+            "--delegation-contract-id",
+            "child-1",
+            "--parent-contract-id",
+            "root-1",
+            "--root-intent-id",
+            "intent-1",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin"},
+        check=True,
+    )
+    child = json.loads(child_result.stdout)
+    assert child["delegation_contract_id"] == "child-1"
+    assert child["parent_contract_id"] == "root-1"
+    assert child["root_intent_id"] == "intent-1"
+
+
+def test_v02_cli_orphan_parent_exits_nonzero(tmp_registry: Path) -> None:
+    """CLI invocation with orphan parent_contract_id exits non-zero with clear error."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--lane-id",
+            "L-child",
+            "--owner-session",
+            "claude-child",
+            "--registry-path",
+            str(tmp_registry),
+            "--delegation-contract-id",
+            "child-1",
+            "--parent-contract-id",
+            "missing-root",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin"},
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "does not match any existing" in result.stderr


### PR DESCRIPTION
## Summary

Phase 2 of Aragora Delegation Contract. Makes the v0.1 schema load-bearing for real lane claims by attaching the three authority-chain fields to every `LaneRecord` row.

**Depends on #7357 (v0.1).** Targeting v0.1's branch as base so the depends-on chain is explicit.

## Schema (additive)

`LANE_RECORD_KEYS` now includes:
- `delegation_contract_id` — id of the contract granting this lane's authority
- `parent_contract_id` — id of the parent contract in the authority chain (None for roots)
- `root_intent_id` — id of the original human-rooted intent

Pre-v0.2 rows round-trip unchanged (`_normalize_row` filters None/empty).

## Monotonic narrowing at claim time

1. `parent_contract_id` without `delegation_contract_id` → **reject** (every chained lane must have its own contract id).
2. `parent_contract_id` must match some existing row's `delegation_contract_id` → **reject** otherwise (`--force` overrides for emergencies).
3. When parent has `root_intent_id`, child's `root_intent_id` must match → **reject** mismatch (authority chains share a single root intent).

## CLI

```bash
python3 scripts/claim_active_agent_lane.py \\
  --lane-id L1 --owner-session ... \\
  --delegation-contract-id root-1 \\
  --root-intent-id intent-1

# Child of root-1:
python3 scripts/claim_active_agent_lane.py \\
  --lane-id L2 --owner-session ... \\
  --delegation-contract-id child-1 \\
  --parent-contract-id root-1 \\
  --root-intent-id intent-1
```

## What v0.2 does NOT include

- Verifying contract content against a stored DelegationContract JSON (v0.5)
- Verifying signature (v0.4)
- Budget enforcement at claim time (v0.5)
- Goal-spec resolution (v0.3)

v0.2 ships only the schema attachment + parent-existence check + root-intent monotonicity. The contract object itself (v0.1) and the predicate oracle (v0.1) are visible but not yet hooked into runtime enforcement.

## Tests

10 new tests covering: roundtrip persistence, orphan-parent rejection, --force override, root-intent mismatch, root-intent matching, legacy-row preservation, end-to-end CLI flow, CLI exit-nonzero on orphan parent.

```
$ python3 -m pytest tests/scripts/test_claim_active_agent_lane.py -q
44 passed in 1.77s  (34 original + 10 new v0.2)
```

ruff / format / mypy / preflight all clean.

## Parallel droid missions

- **ADC-v0.3 progress ledger** — dispatched via `droid exec` as parallel background work; uses v0.1's predicate oracle to evaluate goal-spec acceptance criteria periodically and write per-tick boolean ledgers.
- **ADC-v0.4 HMAC signing** — dispatched via `droid exec` as parallel background work; reuses `aragora.security.context_signing` to sign DelegationContract + receipt payloads.

Both droid missions branch off v0.1's PR head and are independent of this v0.2 PR — they can ship in any order.

## Test plan

- [ ] `python3 -m pytest tests/scripts/test_claim_active_agent_lane.py -q` → 44 passed
- [ ] Live smoke: claim a root contract + a child + verify the registry shows both with correct `parent_contract_id` link
- [ ] Try orphan claim → confirm exit code 2 + clear error
- [ ] Confirm a pre-v0.2 row (no contract fields) still round-trips when refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)